### PR TITLE
Fixed typo in Hdma.java

### DIFF
--- a/src/main/java/eu/rekawek/coffeegb/memory/Hdma.java
+++ b/src/main/java/eu/rekawek/coffeegb/memory/Hdma.java
@@ -69,7 +69,7 @@ public class Hdma implements AddressSpace {
         if (hdma1234.accepts(address)) {
             hdma1234.setByte(address, value);
         } else if (address == HDMA5) {
-            if (transferInProgress && (address & (1 << 7)) == 0) {
+            if (transferInProgress && (value & (1 << 7)) == 0) {
                 stopTransfer();
             } else {
                 startTransfer(value);


### PR DESCRIPTION
Hey, I was browsing through the source code of your emulator, when I noticed that you had a small typo in the file for the **HDMA** stuff. Instead of checking the 7th bit in the value being written to the **HDMA5** register, you were accidentally checking the 7th bit of the address variable. To refresh yourself on how this all works, consult the stuff [here](https://gbdev.io/pandocs/CGB_Registers.html?highlight=hdma#ff55--hdma5-cgb-mode-only-vram-dma-lengthmodestart).