### PR TITLE
Remove SLF4J-Simple binding (Issue #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The emulator can be build with [Maven](https://maven.apache.org/):
 
     mvn clean package
 
-The jar file will be available in the `./target` directory.
+The coffee-gb-*-complete.jar executable file will be available in the `./target` directory.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
           <appendAssemblyId>false</appendAssemblyId>
+          <finalName>${project.name}-${project.version}-complete</finalName>
         </configuration>
         <executions>
           <execution>
@@ -110,6 +111,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.16</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Use a different name for the fat jar, so that the original, dependency-less library is available too. Mark the slf4j-simple as a runtime dependency, so it's included in the fat jar, but not necessarily in other projects relying on coffee-gb.