### PR TITLE
Don't use threads in dmg-acid2 test.

### DIFF
--- a/src/main/java/eu/rekawek/coffeegb/Gameboy.java
+++ b/src/main/java/eu/rekawek/coffeegb/Gameboy.java
@@ -166,7 +166,7 @@ public class Gameboy implements Runnable {
         tickListeners.forEach(Runnable::run);
     }
 
-    public Gpu.Mode tickSubsystems() {
+    private Gpu.Mode tickSubsystems() {
         timer.tick();
         if (hdma.isTransferInProgress()) {
             hdma.tick();

--- a/src/test/java/eu/rekawek/coffeegb/integration/dmgacid2/DmgAcid2RomTest.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/dmgacid2/DmgAcid2RomTest.java
@@ -15,7 +15,6 @@ public class DmgAcid2RomTest {
         testRomWithImage(getPath("dmg-acid2.gb"));
     }
 
-
     private static Path getPath(String name) {
         return Paths.get("src/test/resources/roms/dmg-acid2", name);
     }

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/MemoryTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/MemoryTestRunner.java
@@ -37,7 +37,7 @@ public class MemoryTestRunner {
         int status = 0x80;
         int divider = 0;
         while(status == 0x80 && !SerialTestRunner.isInfiniteLoop(gb)) {
-            gb.tickSubsystems();
+            gb.tick();
             if (++divider >= (gb.getSpeedMode().getSpeedMode() == 2 ? 1 : 4)) {
                 status = getTestResult(gb);
                 divider = 0;

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/MemoryTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/MemoryTestRunner.java
@@ -37,7 +37,7 @@ public class MemoryTestRunner {
         int status = 0x80;
         int divider = 0;
         while(status == 0x80 && !SerialTestRunner.isInfiniteLoop(gb)) {
-            gb.tick();
+            gb.tickSubsystems();
             if (++divider >= (gb.getSpeedMode().getSpeedMode() == 2 ? 1 : 4)) {
                 status = getTestResult(gb);
                 divider = 0;

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/MooneyeTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/MooneyeTestRunner.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static eu.rekawek.coffeegb.integration.support.RomTestUtils.isByteSequenceAtPc;
+
 public class MooneyeTestRunner {
 
     private final Gameboy gb;
@@ -52,8 +54,8 @@ public class MooneyeTestRunner {
 
     public boolean runTest() throws IOException {
         int divider = 0;
-        while(!isByteSequenceAtPc(0x00, 0x18, 0xfd)) { // infinite loop
-            gb.tick();
+        while(!isByteSequenceAtPc(gb, 0x00, 0x18, 0xfd)) { // infinite loop
+            gb.tickSubsystems();
             if (++divider >= (gb.getSpeedMode().getSpeedMode() == 2 ? 1 : 4)) {
                 displayProgress();
                 divider = 0;
@@ -67,25 +69,8 @@ public class MooneyeTestRunner {
             if (regs.getA() != 0) {
                 os.write(regs.getA());
             }
-        } else if (isByteSequenceAtPc(0x7d, 0xe6, 0x1f, 0xee, 0x1f)) {
+        } else if (isByteSequenceAtPc(gb, 0x7d, 0xe6, 0x1f, 0xee, 0x1f)) {
             os.write('\n');
         }
     }
-
-    private boolean isByteSequenceAtPc(int... seq) {
-        if (cpu.getState() != Cpu.State.OPCODE) {
-            return false;
-        }
-
-        int i = regs.getPC();
-        boolean found = true;
-        for (int v : seq) {
-            if (mem.getByte(i++) != v) {
-                found = false;
-                break;
-            }
-        }
-        return found;
-    }
-
 }

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/MooneyeTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/MooneyeTestRunner.java
@@ -55,7 +55,7 @@ public class MooneyeTestRunner {
     public boolean runTest() throws IOException {
         int divider = 0;
         while(!isByteSequenceAtPc(gb, 0x00, 0x18, 0xfd)) { // infinite loop
-            gb.tickSubsystems();
+            gb.tick();
             if (++divider >= (gb.getSpeedMode().getSpeedMode() == 2 ? 1 : 4)) {
                 displayProgress();
                 divider = 0;

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/RomTestUtils.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/RomTestUtils.java
@@ -1,9 +1,11 @@
 package eu.rekawek.coffeegb.integration.support;
 
+import eu.rekawek.coffeegb.Gameboy;
+import eu.rekawek.coffeegb.cpu.Cpu;
+
+import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -30,12 +32,31 @@ public final class RomTestUtils {
         System.out.println("\n### Running test rom " + romPath.getFileName() + " ###");
         ImageTestRunner runner = new ImageTestRunner(romPath.toFile());
         ImageTestRunner.TestResult result = runner.runTest();
-        assertArrayEquals(result.getErrorMessage(),result.getExpectedRGB(),result.getResultRGB());
+
+        File resultFile = File.createTempFile(romPath.getFileName().toString(), "-result.png");
+        result.writeResultToFile(resultFile);
+        assertArrayEquals("The result image is different from expected: " + resultFile, result.getExpectedRGB(), result.getResultRGB());
     }
 
     public static void testMooneyeRom(Path romPath) throws IOException {
         System.out.println("\n### Running test rom " + romPath.getFileName() + " ###");
         MooneyeTestRunner runner = new MooneyeTestRunner(romPath.toFile(), System.out);
         assertTrue(runner.runTest());
+    }
+
+    static boolean isByteSequenceAtPc(Gameboy gameboy, int... seq) {
+        if (gameboy.getCpu().getState() != Cpu.State.OPCODE) {
+            return false;
+        }
+
+        int i = gameboy.getCpu().getRegisters().getPC();
+        boolean found = true;
+        for (int v : seq) {
+            if (gameboy.getAddressSpace().getByte(i++) != v) {
+                found = false;
+                break;
+            }
+        }
+        return found;
     }
 }

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/SerialTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/SerialTestRunner.java
@@ -34,10 +34,10 @@ public class SerialTestRunner implements SerialEndpoint {
         this.os = os;
     }
 
-    public String runTest() throws IOException {
+    public String runTest() {
         int divider = 0;
         while (true) {
-            gb.tickSubsystems();
+            gb.tick();
             if (++divider == 4) {
                 if (isInfiniteLoop(gb)) {
                     break;

--- a/src/test/java/eu/rekawek/coffeegb/integration/support/SerialTestRunner.java
+++ b/src/test/java/eu/rekawek/coffeegb/integration/support/SerialTestRunner.java
@@ -37,7 +37,7 @@ public class SerialTestRunner implements SerialEndpoint {
     public String runTest() throws IOException {
         int divider = 0;
         while (true) {
-            gb.tick();
+            gb.tickSubsystems();
             if (++divider == 4) {
                 if (isInfiniteLoop(gb)) {
                     break;


### PR DESCRIPTION
Refactored the dmg-acid2 test to look for a specific condition rather than running emulation for a few seconds.

I had to extract another `tick()` method in the Gameboy class, which will also call display and HDMA callbacks.