### PR TITLE
Add screen rotation display option (#81)

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
@@ -16,4 +16,7 @@ class DisplayProperties(private val properties: EmulatorProperties) {
   val colorCorrection
     get() =
         properties.getProperty(EmulatorProperties.Key.DisplayColorCorrection, "false").toBoolean()
+
+  val rotation
+    get() = properties.getProperty(EmulatorProperties.Key.DisplayRotation, "0").toInt()
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
@@ -45,6 +45,7 @@ class EmulatorProperties() {
     DisplayGrayscale("display.grayscale"),
     DisplayBlending("display.blending"),
     DisplayColorCorrection("display.colorCorrection"),
+    DisplayRotation("display.rotation"),
     ShowSgbBorder("display.showSgbBorder"),
     SoundEnabled("sound.enabled"),
     RomDirectory("rom.directory"),

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -89,6 +89,12 @@ class SwingEmulator(
 
     eventBus.register<SwingDisplay.DisplaySizeUpdatedEvent> {
       mainPanel.preferredSize = it.preferredSize
+      // Setting preferredSize doesn't invalidate, and a pack() that leaves the frame the
+      // same size (e.g. re-selecting the current scale, or a rotation that preserves the
+      // dimensions) never triggers the reshape that refreshes the window's cached preferred
+      // size - after which every later pack() reads the stale size and stops resizing.
+      // Invalidating up from the panel clears the cache at each level so pack() recomputes.
+      mainPanel.invalidate()
       jFrame.pack()
     }
   }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -36,6 +36,7 @@ import eu.rekawek.coffeegb.core.sound.Sound
 import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetBlendingEvent
 import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetColorCorrectionEvent
 import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetGrayscaleEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetRotationEvent
 import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetScaleEvent
 import java.awt.event.KeyEvent
 import java.io.File
@@ -309,6 +310,20 @@ class SwingMenu(
         properties.setProperty(EmulatorProperties.Key.DisplayScale, s.toString())
       }
       scale.add(item)
+    }
+
+    val rotate = JMenu("Rotate")
+    screenMenu.add(rotate)
+
+    for (deg in mutableListOf(0, 90, 180, 270)) {
+      val label = if (deg == 0) "None" else "$deg°"
+      val item = JCheckBoxMenuItem(label, deg == properties.display.rotation)
+      item.addActionListener {
+        eventBus.post(SetRotationEvent(deg))
+        uncheckAllBut(rotate, item)
+        properties.setProperty(EmulatorProperties.Key.DisplayRotation, deg.toString())
+      }
+      rotate.add(item)
     }
 
     val grayscale = JCheckBoxMenuItem("DMG grayscale", properties.display.grayscale)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -44,6 +44,8 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private boolean colorCorrection;
 
+    private int rotation;
+
     private int[] previousFrame;
 
     private GameboyType gameboyType;
@@ -61,7 +63,9 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> this.grayscale = e.grayscale, SetGrayscaleEvent.class);
         eventBus.register(e -> setBlending(e.blending), SetBlendingEvent.class);
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
+        eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
         this.grayscale = properties.getGrayscale();
+        this.rotation = normalizeRotation(properties.getRotation());
         setBlending(properties.getBlending());
         setColorCorrection(properties.getColorCorrection());
         setScale(properties.getScale());
@@ -120,8 +124,27 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private synchronized void setScale(int scale) {
         this.scale = scale;
-        setPreferredSize(new Dimension(getDisplayWidth() * scale, getDisplayHeight() * scale));
+        setPreferredSize(rotatedPreferredSize());
         eventBus.post(new DisplaySizeUpdatedEvent(getPreferredSize()));
+    }
+
+    private synchronized void setRotation(int degrees) {
+        this.rotation = normalizeRotation(degrees);
+        setPreferredSize(rotatedPreferredSize());
+        eventBus.post(new DisplaySizeUpdatedEvent(getPreferredSize()));
+        repaint();
+    }
+
+    private static int normalizeRotation(int degrees) {
+        int r = ((degrees % 360) + 360) % 360;
+        // snap to the four quarter turns the display supports
+        return (r / 90) * 90;
+    }
+
+    private Dimension rotatedPreferredSize() {
+        int w = getDisplayWidth() * scale;
+        int h = getDisplayHeight() * scale;
+        return (rotation == 90 || rotation == 270) ? new Dimension(h, w) : new Dimension(w, h);
     }
 
     @Override
@@ -129,10 +152,28 @@ public class SwingDisplay extends JPanel implements Runnable {
         super.paintComponent(g);
 
         int localScale = scale;
+        int w = getDisplayWidth() * localScale;
+        int h = getDisplayHeight() * localScale;
         Graphics2D g2d = (Graphics2D) g.create();
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
-        g2d.drawImage(img, 0, 0, getDisplayWidth() * localScale, getDisplayHeight() * localScale, null);
+        switch (rotation) {
+            case 90 -> {
+                g2d.translate(h, 0);
+                g2d.rotate(Math.PI / 2);
+            }
+            case 180 -> {
+                g2d.translate(w, h);
+                g2d.rotate(Math.PI);
+            }
+            case 270 -> {
+                g2d.translate(0, w);
+                g2d.rotate(3 * Math.PI / 2);
+            }
+            default -> {
+            }
+        }
+        g2d.drawImage(img, 0, 0, w, h, null);
         g2d.dispose();
     }
 
@@ -222,6 +263,9 @@ public class SwingDisplay extends JPanel implements Runnable {
     }
 
     public record SetColorCorrectionEvent(boolean colorCorrection) implements Event {
+    }
+
+    public record SetRotationEvent(int rotation) implements Event {
     }
 
     public record SetBlendingEvent(boolean blending) implements Event {


### PR DESCRIPTION
Closes #81.

Ninety (PD) and other homebrew meant to be played with the Game Boy held sideways need the screen rotated. This adds a **Screen > Rotate** submenu offering None / 90° / 180° / 270°.

## Changes
- `SwingDisplay`: applies the quarter-turn as an `AffineTransform` in `paintComponent`, and swaps the preferred width/height for 90°/270° so the window becomes portrait and re-packs.
- New `display.rotation` property (persisted like the other display options).
- `SwingMenu`: the Rotate submenu, mirroring the existing Scale submenu.

Purely a display concern — the emulated frame, timing and input are untouched.

## Verification
Rendered the Ninety title screen through the identical transform at each angle; 90° produces the expected 144×160 portrait frame with the "90" logo correctly rotated. `swing` compiles clean.