### PR TITLE
Fix 2-player link desync from held buttons lost on rollback rebase (#79)

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
+import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memento.Originator
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
@@ -26,6 +27,14 @@ class Session(
     console?.setGameboy(null)
     eventBus.close()
   }
+
+  // held buttons live outside the memento (the joypad keeps physical input across a
+  // single-player rewind); netplay snapshots them separately so a held button survives a rebase
+  var heldButtons: Set<Button>
+    get() = gameboy.pressedButtons
+    set(value) {
+      gameboy.setPressedButtons(value)
+    }
 
   override fun saveToMemento(): Memento<Session> {
     return SessionMemento(gameboy.saveToMemento(), serialEndpoint.saveToMemento())

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -66,6 +66,8 @@ class LinkedController(
 
   @VisibleForTesting internal val stateHistory: StateHistory = StateHistory()
 
+  @VisibleForTesting internal fun mainHeldButtons() = mainSession?.heldButtons ?: emptySet()
+
   @Volatile private var doStop = false
 
   private val mainSerialEndpoint = Peer2PeerSerialEndpoint()
@@ -177,9 +179,11 @@ class LinkedController(
       val head = stateHistory.getHead()
       if (mainSession != null && head.mainMemento != null) {
         mainSession.restoreFromMemento(head.mainMemento)
+        mainSession.heldButtons = head.mainButtons
       }
       if (peerSession != null && head.peerMemento != null) {
         peerSession.restoreFromMemento(head.peerMemento)
+        peerSession.heldButtons = head.peerButtons
       }
       frame = head.frame
       LOG.atDebug().log("State merged to {}", frame)
@@ -188,22 +192,29 @@ class LinkedController(
     val input = currentInput ?: Input(emptyList(), emptyList())
     val effectiveInput = if (input != lastInput) input else Input(emptyList(), emptyList())
     lastInput = input
-    if (mainSession != null) {
-      effectiveInput.send(mainSession.eventBus)
-    }
     currentInput = null
 
-    if (!effectiveInput.isEmpty() || lastSync.elapsedNow() > 5.seconds) {
-      eventBus.postAsync(LocalButtonStateEvent(frame, effectiveInput))
-      lastSync = TimeSource.Monotonic.markNow()
-    }
-
+    // Snapshot BEFORE applying this frame's input, exactly like StateHistory.merge does, so a
+    // later rebase that restores this state and replays effectiveInput reproduces the frame
+    // bit-for-bit. The held-button sets are captured too because the joypad keeps them out of
+    // the memento - without them a button held before the rebase base frame is lost (#79).
     stateHistory.addState(
         frame,
         effectiveInput,
         mainSession?.saveToMemento(),
         peerSession?.saveToMemento(),
+        mainSession?.heldButtons ?: emptySet(),
+        peerSession?.heldButtons ?: emptySet(),
     )
+
+    if (mainSession != null) {
+      effectiveInput.send(mainSession.eventBus)
+    }
+
+    if (!effectiveInput.isEmpty() || lastSync.elapsedNow() > 5.seconds) {
+      eventBus.postAsync(LocalButtonStateEvent(frame, effectiveInput))
+      lastSync = TimeSource.Monotonic.markNow()
+    }
 
     repeat(TICKS_PER_FRAME) {
       mainSession?.gameboy?.tick()
@@ -285,7 +296,7 @@ class LinkedController(
 
     var peerFrame = frame
     while (this.frame > peerFrame) {
-      stateHistory.setPeerState(peerFrame, peerSession.saveToMemento())
+      stateHistory.setPeerState(peerFrame, peerSession.saveToMemento(), peerSession.heldButtons)
       repeat(TICKS_PER_FRAME) { peerSession.gameboy.tick() }
       peerFrame++
     }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -32,8 +32,10 @@ class StateHistory() {
       mainInput: Input,
       mainMemento: Memento<Session>?,
       peerMemento: Memento<Session>?,
+      mainButtons: Set<Button>,
+      peerButtons: Set<Button>,
   ) {
-    states.add(State(frame, mainInput, mainMemento, peerMemento))
+    states.add(State(frame, mainInput, mainMemento, peerMemento, mainButtons, peerButtons))
     LOG.atDebug().log("Adding state on frame {}; state size {}", frame, states.size)
     while (states.size > 60 * 5) {
       states.removeFirst()
@@ -93,9 +95,13 @@ class StateHistory() {
         }
     if (mainSession != null && baseState.mainMemento != null) {
       mainSession.restoreFromMemento(baseState.mainMemento)
+      // the joypad's held-button set is not in the memento; restore it explicitly or a button
+      // held before the base frame would be lost for the whole rebase (issue #79 desync)
+      mainSession.heldButtons = baseState.mainButtons
     }
     if (peerSession != null && baseState.peerMemento != null) {
       peerSession.restoreFromMemento(baseState.peerMemento)
+      peerSession.heldButtons = baseState.peerButtons
     }
 
     states.clear()
@@ -103,7 +109,15 @@ class StateHistory() {
 
     for (i in (baseFrame..toFrame + 1)) {
       val mainInput = mainInputs[i] ?: Input(emptyList(), emptyList())
-      states.add(State(i, mainInput, mainSession?.saveToMemento(), peerSession?.saveToMemento()))
+      states.add(
+          State(
+              i,
+              mainInput,
+              mainSession?.saveToMemento(),
+              peerSession?.saveToMemento(),
+              mainSession?.heldButtons ?: emptySet(),
+              peerSession?.heldButtons ?: emptySet(),
+          ))
 
       if (i <= toFrame) {
         mainInput.send(mainEventBus)
@@ -129,12 +143,12 @@ class StateHistory() {
 
   fun getHead() = states.last()
 
-  fun setPeerState(peerFrame: Long, peerState: Memento<Session>) {
+  fun setPeerState(peerFrame: Long, peerState: Memento<Session>, peerButtons: Set<Button>) {
     val index = states.indexOfFirst { it.frame == peerFrame }
     if (index == -1) {
       return
     }
-    states[index] = states[index].copy(peerMemento = peerState)
+    states[index] = states[index].copy(peerMemento = peerState, peerButtons = peerButtons)
   }
 
   data class State(
@@ -142,6 +156,8 @@ class StateHistory() {
       val mainInput: Input,
       val mainMemento: Memento<Session>?,
       val peerMemento: Memento<Session>?,
+      val mainButtons: Set<Button> = emptySet(),
+      val peerButtons: Set<Button> = emptySet(),
   )
 
   private data class Patch(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -11,10 +11,12 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
 import org.junit.Test
 import java.nio.file.Paths
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class LinkedControllerTest {
 
@@ -60,6 +62,34 @@ class LinkedControllerTest {
     val actualButtons = buttons.toList()
 
     assertJoypadEventsEqual(expectedButtons, actualButtons)
+  }
+
+  @Test
+  fun heldButtonSurvivesRebasePastThePress() {
+    // Issue #79: a button held from before a rebase's base frame must not be dropped. The
+    // joypad keeps its held-button set out of the memento (so single-player rewind preserves
+    // physical input), and the recorded per-frame Input only carries changes - so unless the
+    // rebase restores the held-button set explicitly, a held button vanishes for the whole
+    // re-simulation, desyncing the two linked machines.
+    val eventBus = EventBusImpl()
+    val sut = LinkedController(eventBus, EmulatorProperties(), null)
+    sut.timingTicker.disabled = true
+    eventBus.post(LoadRomEvent(ROM))
+    eventBus.post(PeerLoadedGameEvent(ROM_BYTES, null, null, GAMEBOY_TYPE, BOOTSTRAP_MODE, 0))
+
+    // establish the sessions, then press and HOLD A (never released)
+    repeat(5) { sut.runFrame() }
+    eventBus.post(ButtonPressEvent(Button.A))
+    repeat(11) { sut.runFrame() } // frame ~5 processes the press; A is held through frame ~15
+    assertTrue(sut.mainHeldButtons().contains(Button.A), "A should be held before the rebase")
+
+    // a remote patch for a frame well past the press forces a rebase whose base frame is after
+    // the press was recorded
+    eventBus.post(LinkedController.RemoteButtonStateEvent(10, Input(emptyList(), emptyList())))
+    sut.runFrame()
+
+    assertTrue(
+        sut.mainHeldButtons().contains(Button.A), "held button A was lost across the rebase")
   }
 
   @Test

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -350,6 +350,18 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         return paused;
     }
 
+    /**
+     * Held-button state, snapshotted separately from the memento by rollback netplay so a held
+     * button survives a rebase (the joypad deliberately keeps it out of the memento).
+     */
+    public java.util.Set<eu.rekawek.coffeegb.core.joypad.Button> getPressedButtons() {
+        return joypad.getPressedButtons();
+    }
+
+    public void setPressedButtons(java.util.Collection<eu.rekawek.coffeegb.core.joypad.Button> pressed) {
+        joypad.setPressedButtons(pressed);
+    }
+
     @Override
     public Memento<Gameboy> saveToMemento() {
         return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -69,6 +69,20 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         buttons.remove(button);
     }
 
+    /**
+     * The set of currently-held buttons. Intentionally not part of the memento (see
+     * {@link #saveToMemento()}); rollback netplay snapshots and restores it separately so a
+     * held button survives a rebase whose base frame is past the original press.
+     */
+    public Set<Button> getPressedButtons() {
+        return new java.util.HashSet<>(buttons);
+    }
+
+    public void setPressedButtons(java.util.Collection<Button> pressed) {
+        buttons.clear();
+        buttons.addAll(pressed);
+    }
+
     public void tick() {
         tick++;
     }


### PR DESCRIPTION
Addresses #79 (Mario Tennis 2-player link: one peer's background graphics corrupt).

## Diagnosis

I reproduced the link path headlessly and ruled out the obvious suspects:
- **Core emulation is deterministic** — a single-Game-Boy memento round-trip re-simulates bit-for-bit (500 frames).
- **The serial link is correct** — two Game Boys wired through `Peer2PeerSerialEndpoint` play a full linked tennis match with zero corruption on both sides.
- **The serial-connected rollback is bit-perfect** — snapshotting both Game Boys + both serial cables mid-match and restoring into a fresh pair reproduces exactly.

That left the **netplay layer**. `LinkedController` predicts remote input and rebases via `StateHistory.merge` when the real input arrives. Two bugs corrupted the re-simulation of a serial-linked game:

1. **Held buttons were dropped on rebase.** `Joypad.saveToMemento()` deliberately excludes the held-button set (so a single-player rewind keeps whatever is physically held), and the recorded per-frame `Input` only carries *changes*. So a button held from before the rebase's base frame vanished for the whole re-simulation. Because the two machines rebase at different frames (network timing), they dropped held buttons at *different* points and their shared `game1 + game2 + cable` simulations diverged — one peer's background VRAM ends up garbled while the score stays in sync, exactly the reported symptom.
2. **`runFrame` snapshotted after applying input, but `merge` snapshots before** — so a `runFrame` state baked the input in, and a later rebase that used it as a base re-applied the input on top.

## Fix

- Snapshot the held-button set alongside each netplay state and restore it on rebase (`Session.heldButtons`, exposed via `Gameboy`/`Joypad`, kept out of the memento so single-player rewind is unchanged).
- Reorder `runFrame` to snapshot *before* applying input, matching `merge`.

## Tests

New `heldButtonSurvivesRebasePastThePress` holds A across a rebase whose base frame is past the press and asserts it survives — it fails without the fix (`held button A was lost across the rebase`) and passes with it. All existing `LinkedController` tests (3) and core unit tests (50) still pass.

Full end-to-end confirmation ideally wants a real two-machine network session; the mechanism and the unit test pin down the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)