### PR TITLE
Fix CGB full-screen window shearing diagonally (#80)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -42,6 +42,10 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
 
     private long outputTicks;
 
+    // pixels of the current line popped towards the LCD, for the window-activation rewind
+    // bookkeeping (mirrors DmgPixelFifo); reset at startLine
+    private int linePixels;
+
     public ColorPixelFifo(
             Display display, Lcdc lcdc, ColorPalette bgPalette, ColorPalette oamPalette,
             GpuRegisterValues r, SpeedMode speedMode) {
@@ -60,11 +64,34 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
 
     @Override
     public void putPixelToScreen() {
+        linePixels++;
         int entry = popEntry();
         int tail = (delayHead + delaySize) & 7;
         delayEntry[tail] = entry;
         delayStamp[tail] = outputTicks;
         delaySize++;
+    }
+
+    @Override
+    public void startLine() {
+        linePixels = 0;
+    }
+
+    @Override
+    public void rewindOnePixel() {
+        // the CGB window-activation rollback (a pending WX match whose position advanced)
+        // steps the LCD x back one pixel: without this the popped pixel stays in the output
+        // and every window line drifts right by one, shearing a full-screen window into a
+        // diagonal (issue #80). Mirrors DmgPixelFifo.
+        if (linePixels == 0) {
+            return;
+        }
+        linePixels--;
+        if (delaySize > 0) {
+            delaySize--;
+        } else {
+            display.rewindPixel();
+        }
     }
 
     // pack bg pixel (2b), bg palette (3b), bg priority (1b), sprite pixel (2b),
@@ -195,7 +222,8 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
                 delayStamp.clone(),
                 delayHead,
                 delaySize,
-                outputTicks);
+                outputTicks,
+                linePixels);
     }
 
     @Override
@@ -214,6 +242,7 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
             delayHead = mem.delayHead;
             delaySize = mem.delaySize;
             outputTicks = mem.outputTicks;
+            linePixels = mem.linePixels;
         } else {
             delayHead = 0;
             delaySize = 0;
@@ -229,7 +258,8 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
             long[] delayStamp,
             int delayHead,
             int delaySize,
-            long outputTicks)
+            long outputTicks,
+            int linePixels)
             implements Memento<ColorPixelFifo> {
     }
 }


### PR DESCRIPTION
Closes #80.

The reporter's reference screenshot showed the Color Panel Demo should render **vertical** colour panels, but coffee-gb sheared them into diagonals. I confirmed the demo's VRAM data is correct (a straightforward render of coffee-gb's own tilemap/tiles/attributes reproduces the vertical panels) — so the PPU was mis-rendering it, with an exact **1 pixel/scanline** horizontal drift.

## Cause

`ColorPixelFifo` never implemented `rewindOnePixel()` — it inherited the empty `PixelFifo` default, whereas `DmgPixelFifo` implements it. That method is called by the window-activation rollback in `PixelTransfer`: a pending `WX` match commits one T-cycle late, and if a pixel popped during that tick the fetch position is rolled back and the popped pixel must be un-emitted. On DMG this removes the leaked output pixel; on CGB the no-op left it in the delay line, so every window line emitted one extra pixel and the LCD x wrapped one dot late. For a full-screen window (`WY=0`, `WX=7`) that accumulates 1px per scanline → the diagonal shear.

## Fix

Implement `rewindOnePixel()` in `ColorPixelFifo` (plus the `linePixels`/`startLine` bookkeeping it needs, and the memento field), mirroring `DmgPixelFifo`.

## Verification

- The demo now renders the vertical panels matching the reference in #80.
- Full battery green: core unit (50), dmg-acid2, mooneye (98), mealybug (24 threshold tests, incl. the CGB window cases like `m2_win_en_toggle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)