### PR TITLE
Bank oversized "ROM only" carts as MBC1 (#76)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -68,9 +68,14 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             addressSpace = new Datel(rom, battery);
         } else if (rom.getRom().length >= 0x20000) {
             // "ROM only" carts of 128 KB and more are Wisdom Tree style unlicensed
-            // mappers with a single switchable 32 KB window (issue #61); smaller
-            // oversized type-0 dumps are treated as plain 32 KB ROMs like on hardware
+            // mappers with a single switchable 32 KB window (issue #61)
             addressSpace = new WisdomTree(rom);
+        } else if (rom.getRom().length > 0x8000) {
+            // a "ROM only" header on a cart bigger than the 32 KB a no-MBC cart can address
+            // is wrong (common in homebrew, e.g. Dimensionless Sample, #76): bank it as MBC1
+            // like BGB does. MBC1's power-on mapping is identical to a plain 32 KB ROM, so
+            // this never breaks a genuinely 32 KB-addressable dump.
+            addressSpace = new Mbc1(rom, battery);
         } else {
             addressSpace = new BasicRom(rom);
         }


### PR DESCRIPTION
Closes #76.

Dimensionless Sample runs as a full top-down overworld on BGB, but coffee-gb showed garbage. It's a 64 KB dump with a `ROM only` (type `0x00`) header — but a cart with no MBC can't address past 32 KB, so the header is wrong (common in homebrew). coffee-gb mapped it as a plain 32 KB `BasicRom`, leaving the upper half unreachable.

## Fix

Treat a type-0 cart between 32 KB and 128 KB as **MBC1**, matching BGB. MBC1's power-on mapping is identical to a plain 32 KB ROM (bank 0 + bank 1 = the first 32 KB), so this can never break a genuinely 32 KB-addressable dump — it only adds the banking these carts actually need. 128 KB+ type-0 carts keep the existing Wisdom Tree path (#61); bad-logo oversized carts keep the Datel path (#66).

## Verification

The unmodified ROM now boots into the overworld matching the BGB screenshot in #76 (confirmed MBC1 vs the previous garbage, and MBC1/3/5 all render identically). Core unit (50), blargg (46), and mooneye still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)