### PR TITLE
Correct invalid cartridge header checksums on load (#76)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -47,6 +47,23 @@ public class Rom {
             rom[i] = romByteArray[i] & 0xFF;
         }
 
+        // Correct an invalid header checksum (0x14D) so the authentic boot ROM does not lock
+        // up. The real DMG/CGB boot ROM verifies the checksum over 0x134-0x14C and hangs on
+        // the logo screen if it is wrong; some homebrew/PD dumps ship a bad one (e.g.
+        // Dimensionless Sample, #76 - it renders past a SKIP boot but hangs the boot ROM).
+        // BGB, SameBoy and real flashcarts silently fix it; only touches already-invalid ROMs.
+        if (rom.length > 0x014D) {
+            int headerChecksum = 0;
+            for (int a = 0x0134; a <= 0x014C; a++) {
+                headerChecksum = (headerChecksum - rom[a] - 1) & 0xFF;
+            }
+            if (rom[0x014D] != headerChecksum) {
+                LOG.warn("Correcting invalid header checksum {} -> {}",
+                        Integer.toHexString(rom[0x014D]), Integer.toHexString(headerChecksum));
+                rom[0x014D] = headerChecksum;
+            }
+        }
+
         CartridgeType type;
         try {
             type = CartridgeType.getById(rom[0x0147]);


### PR DESCRIPTION
Follow-up to #85. With #85 merged, Dimensionless Sample renders correctly under a **SKIP** boot, but on the Swing app (which runs the real boot ROM via FAST_FORWARD/NORMAL) it shows the boot logo then a black screen.

## Cause

The dump's header checksum byte (`0x14D`) is wrong — `0x00`, should be `0x07`. The authentic DMG/CGB boot ROM verifies the checksum over `0x134`–`0x14C` and **locks up on the logo screen** when it fails, so the game never starts. SKIP boot bypasses the check, which is why the headless test worked but the GUI didn't.

## Fix

Recompute and fix `0x14D` on load when it's invalid — exactly what BGB, SameBoy and real flashcarts do. It only rewrites an *already-wrong* checksum, so valid ROMs are untouched.

## Verification

Reproduced: SKIP → overworld, FAST_FORWARD → black, NORMAL → stuck on "GAME BOY Nintendo®". After the fix, **both FAST_FORWARD and NORMAL boot into the overworld**. Core unit (50), mooneye (98, including all `boot_*` tests), and blargg all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)