### PR TITLE
Run Green Beret (PD): don't gate MBC5 RAM writes on non-battery carts (#65)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -27,6 +27,13 @@ public class Mbc5 implements MemoryController {
 
     private boolean ramUpdated;
 
+    // Non-battery cart RAM is volatile scratch with no save to protect, so the RAM-enable
+    // handshake serves no purpose there. Some homebrew built for flash carts (Bung/EMS, whose
+    // SRAM is always accessible) use it - e.g. as a stack - without ever enabling it, and would
+    // otherwise crash (Green Beret PD, #65). Battery carts keep the gate so a defensive write
+    // to disabled RAM can't corrupt the save.
+    private final boolean gateRamWrites;
+
     public Mbc5(Rom rom, Battery battery) {
         this.cartridge = rom.getRom();
         this.romBanks = rom.getRomBanks();
@@ -34,6 +41,7 @@ public class Mbc5 implements MemoryController {
         this.ram = new int[0x2000 * Math.max(this.ramBanks, 1)];
         Arrays.fill(ram, 0xff);
         this.battery = battery;
+        this.gateRamWrites = rom.getType().isBattery();
         battery.loadRam(ram);
     }
 
@@ -55,7 +63,7 @@ public class Mbc5 implements MemoryController {
             if (bank < ramBanks) {
                 selectedRamBank = bank;
             }
-        } else if (address >= 0xa000 && address < 0xc000 && ramWriteEnabled) {
+        } else if (address >= 0xa000 && address < 0xc000 && (ramWriteEnabled || !gateRamWrites)) {
             int ramAddress = getRamAddress(address);
             if (ramAddress < ram.length) {
                 ram[ramAddress] = value;


### PR DESCRIPTION
Re: #65. The reporter noted these homebrew work on Gearboy and a real Bung flash cart. I investigated **Green Beret (PD) [C]** (attached to the issue).

## Diagnosis

It's a standard MBC5+RAM cart (type `0x1A`), not a special mapper — but it **crashes into an RST 38 loop** (permanent blank screen) shortly after boot. Tracing it: the game puts its **stack in cart RAM** (SP ≈ 0xBFFC) but **never runs the RAM-enable handshake**. On a strict MBC5, coffee-gb dropped the stack pushes, so the first `RET` read `0xFF 0xFF` → jumped to `0xFFFF` → RST 38 loop.

It was written for a **Bung/EMS flash cart, whose SRAM is always accessible**, which is why it runs on the reporter's real cart and on Gearboy but not on hardware-accurate emulation (SameBoy fails it too — it doesn't emulate always-on flash SRAM).

## Fix

The RAM-enable gate only exists to stop a stray write from corrupting a **battery save** during a power transition. A **non-battery** cart's RAM is volatile scratch with nothing to protect, so gating it serves no purpose. Only gate cart-RAM writes when the cart is battery-backed (reads already ignored the flag). Battery carts are completely unchanged, so saves stay protected.

## Verification

Green Beret now boots to its title screen and advances through its intro screens (it's a beta homebrew — "only 3 levels complete"). Core unit (50), blargg (46), and mooneye (98) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)