### PR TITLE
Run cooked Sachen carts (Rocket Games / DAG) — boot at base 0 (#73/#75)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -39,8 +39,10 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             addressSpace = new DuzMulticart(rom, battery);
         } else if (sachenType(rom) >= 0) {
             addressSpace = new SachenMmc(rom, sachenType(rom) == 2);
-        } else if (cookedSachenMmc2Base(rom) > 0) {
-            addressSpace = new SachenMmc(rom, cookedSachenMmc2Base(rom));
+        } else if (isCookedSachen(rom)) {
+            // post-unlock ("cooked") Sachen dumps: no lockout, boot at base 0 like the
+            // power-on cart (issues #73/#75)
+            addressSpace = new SachenMmc(rom, 0);
         } else if (type.isHuc1()) {
             addressSpace = new Huc1(rom, battery);
         } else if (type.isHuc3()) {
@@ -182,28 +184,32 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
      * Returns 1 for MMC1, 2 for MMC2, -1 for regular carts.
      */
     /**
-     * Post-unlock ("cooked") dumps of the Sachen MMC2 Rocket Games carts: the header at
-     * 0x104 is invalid, but a valid (CGB, half-checked) logo sits at the header of a
-     * later bank - the menu bank the cart boots from. Returns that bank, or -1.
+     * The fixed, cart-independent header the Sachen mapper descrambles for the boot ROM. The
+     * raw carts store it scrambled in the 0x0100-0x01FF page (and serve it through the
+     * lockout); "cooked" (post-unlock) dumps store it linearised at 0x0104, in place of the
+     * Nintendo logo. It is identical across every Sachen title, so it is a reliable marker.
      */
-    private static int cookedSachenMmc2Base(Rom rom) {
+    private static final int[] SACHEN_COOKED_HEADER = {0x11, 0x23, 0xf1, 0x1e, 0x01, 0x22, 0xf0,
+            0x00, 0x08, 0x99, 0x78, 0x00, 0x08, 0x11, 0x9a, 0x48};
+
+    /**
+     * Post-unlock ("cooked") dumps of the Sachen carts (issues #73/#75). They carry no valid
+     * Nintendo logo (the boot ROM's logo check is bypassed for them, as on a flashcart) and
+     * hold the Sachen descrambled boot header at 0x0104. They power on at base bank 0 - the
+     * menu/game code and their per-game bank switching all run from there; the earlier
+     * detection booted them at the logo bank, which left the menu mapped to the wrong bank.
+     */
+    private static boolean isCookedSachen(Rom rom) {
         int[] data = rom.getRom();
-        if (hasValidLogo(rom) || data.length < 0x10000) {
-            return -1;
+        if (data.length < 0x8000 || hasValidLogo(rom)) {
+            return false;
         }
-        for (int bank = 1; bank * 0x4000 + 0x134 <= data.length; bank++) {
-            boolean match = true;
-            for (int i = 0; i < NINTENDO_LOGO.length / 2; i++) {
-                if (data[bank * 0x4000 + 0x104 + i] != NINTENDO_LOGO[i]) {
-                    match = false;
-                    break;
-                }
-            }
-            if (match) {
-                return bank;
+        for (int i = 0; i < SACHEN_COOKED_HEADER.length; i++) {
+            if (data[0x104 + i] != SACHEN_COOKED_HEADER[i]) {
+                return false;
             }
         }
-        return -1;
+        return true;
     }
 
     private static int sachenType(Rom rom) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -115,7 +115,18 @@ public class SachenMmc implements MemoryController {
                 }
                 break;
             case 1:
-                unmaskedBank = (value & 0xff) == 0 ? 1 : (value & 0xff);
+                if ((address & 0x40) != 0) {
+                    // 0x2000-0x3FFF with A6 set is the multicart outer/game-select register.
+                    // The 2-in-1 carts (issues #73/#75) point the 0x0000-0x3FFF window at the
+                    // chosen 256 KB game (base bank = game * 16) and force that offset into the
+                    // switchable window too, so the game's own bank writes (0-15) resolve inside
+                    // its half. The HRAM launcher does this single write, then jumps to the
+                    // game's 0x0150 entry. The normal bank register lives at A6 clear (0x3F00).
+                    base = (value << 4) & 0xff;
+                    mask = 0xf0;
+                } else {
+                    unmaskedBank = (value & 0xff) == 0 ? 1 : (value & 0xff);
+                }
                 break;
             case 2:
                 if ((unmaskedBank & 0x30) == 0x30) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -54,6 +54,22 @@ public class SachenMmc implements MemoryController {
     // false for post-unlock ("cooked") dumps stored with a linear 0x0100-0x01FF page
     private final boolean scrambled;
 
+    // while true, reads of the 0x0104-0x0133 logo window return the Nintendo logo instead of
+    // the linear ROM data. Cooked dumps have no logo stored (the raw carts serve it through
+    // the scrambling/lockout); this reproduces that so the authentic boot ROM's logo check
+    // passes. It is cleared on the first cartridge write - the boot ROM never writes the
+    // cart, so the first write means the game has taken over and wants the real bytes.
+    private boolean serveBootLogo;
+
+    /**
+     * The Nintendo logo the boot ROM verifies (0x0104-0x0133). The real Sachen mapper
+     * descrambles this for the boot ROM; a cooked dump stores game code here instead.
+     */
+    private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89,
+            0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63,
+            0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
+
     public SachenMmc(Rom rom, boolean mmc2) {
         this.rom = rom.getRom();
         this.romBanks = Math.max(2, this.rom.length / 0x4000);
@@ -63,7 +79,7 @@ public class SachenMmc implements MemoryController {
         this.lockState = mmc2 ? LOCKED_DMG : LOCKED_CGB;
     }
 
-    /** Cooked MMC2 dump: no scrambling/lockout; boots with the menu bank as base. */
+    /** Cooked (post-unlock) dump: no scrambling/lockout; boots at the given base bank. */
     public SachenMmc(Rom rom, int initialBase) {
         this.rom = rom.getRom();
         this.romBanks = Math.max(2, this.rom.length / 0x4000);
@@ -71,6 +87,7 @@ public class SachenMmc implements MemoryController {
         this.scrambled = false;
         this.lockState = UNLOCKED;
         this.base = initialBase;
+        this.serveBootLogo = true;
     }
 
     @Override
@@ -88,6 +105,9 @@ public class SachenMmc implements MemoryController {
 
     @Override
     public void setByte(int address, int value) {
+        // the boot ROM never writes the cart; the first write is the game taking over, so the
+        // cooked logo shim steps aside and the real ROM bytes become visible
+        serveBootLogo = false;
         switch (address >> 13) {
             case 0:
                 if ((unmaskedBank & 0x30) == 0x30) {
@@ -119,6 +139,9 @@ public class SachenMmc implements MemoryController {
 
     @Override
     public int getByte(int address) {
+        if (serveBootLogo && address >= 0x0104 && address < 0x0134) {
+            return NINTENDO_LOGO[address - 0x0104];
+        }
         if (scrambled) {
             address = lockAndUnscramble(address);
         }
@@ -157,7 +180,7 @@ public class SachenMmc implements MemoryController {
 
     @Override
     public Memento<MemoryController> saveToMemento() {
-        return new SachenMemento(unmaskedBank, mask, base, lockState, transition);
+        return new SachenMemento(unmaskedBank, mask, base, lockState, transition, serveBootLogo);
     }
 
     @Override
@@ -170,9 +193,10 @@ public class SachenMmc implements MemoryController {
         this.base = mem.base;
         this.lockState = mem.lockState;
         this.transition = mem.transition;
+        this.serveBootLogo = mem.serveBootLogo;
     }
 
     private record SachenMemento(int unmaskedBank, int mask, int base, int lockState,
-                                 int transition) implements Memento<MemoryController> {
+                                 int transition, boolean serveBootLogo) implements Memento<MemoryController> {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CookedSachenTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CookedSachenTest.java
@@ -1,0 +1,99 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Detection and banking of "cooked" (post-unlock) Sachen dumps (issues #73/#75): the Rocket
+ * Games / DAG carts (ATV Racing, Full Time Soccer, Pocket Smash Out, ...). They carry no
+ * Nintendo logo, hold the Sachen descrambled boot header at 0x0104, and power on at base
+ * bank 0 with their bank register at 0x2000-0x3FFF.
+ */
+public class CookedSachenTest {
+
+    // the cart-independent descrambled header every cooked Sachen dump stores at 0x0104
+    private static final int[] SACHEN_HEADER = {0x11, 0x23, 0xf1, 0x1e, 0x01, 0x22, 0xf0, 0x00,
+            0x08, 0x99, 0x78, 0x00, 0x08, 0x11, 0x9a, 0x48};
+
+    private static final int LOGO_FIRST_BYTE = 0xCE; // first Nintendo logo byte
+
+    private static byte[] cookedSachenRom() {
+        byte[] rom = new byte[0x40000]; // 256 KB, 16 banks
+        rom[0x100] = 0x00;
+        rom[0x101] = (byte) 0xc3;
+        rom[0x102] = 0x50;
+        rom[0x103] = 0x01; // JP 0x0150
+        for (int i = 0; i < SACHEN_HEADER.length; i++) {
+            rom[0x104 + i] = (byte) SACHEN_HEADER[i];
+        }
+        rom[0x147] = (byte) 0x99; // bogus Sachen mapper byte
+        rom[0x148] = 0x04;
+        // a distinct marker in the middle of every 16 KB bank so we can tell which is mapped
+        for (int bank = 0; bank < 16; bank++) {
+            rom[bank * 0x4000 + 0x2000] = (byte) (0xA0 + bank);
+        }
+        return rom;
+    }
+
+    private static Cartridge build() throws IOException {
+        return new Cartridge(new Rom(cookedSachenRom()), Battery.NULL_BATTERY);
+    }
+
+    @Test
+    public void detectedAsSachenMmc() throws IOException {
+        assertTrue(build().getSachenMmc() instanceof SachenMmc);
+    }
+
+    @Test
+    public void bootRomSeesTheNintendoLogo() throws IOException {
+        // before the game runs, the logo window returns the Nintendo logo so the authentic
+        // boot ROM's logo check passes even though the dump stores code there
+        Cartridge cart = build();
+        assertEquals(LOGO_FIRST_BYTE, cart.getByte(0x0104));
+        assertEquals(0x3E, cart.getByte(0x0133)); // last logo byte
+    }
+
+    @Test
+    public void firstWriteRevealsRealRomBytes() throws IOException {
+        Cartridge cart = build();
+        cart.setByte(0x2000, 0x01); // any cartridge write ends the boot-logo shim
+        assertEquals(SACHEN_HEADER[0], cart.getByte(0x0104));
+    }
+
+    @Test
+    public void bootsAtBaseBankZero() throws IOException {
+        Cartridge cart = build();
+        // 0x0000-0x3FFF maps base bank 0, the switchable window defaults to bank 1
+        assertEquals(0xA0, cart.getByte(0x2000));
+        assertEquals(0xA1, cart.getByte(0x6000));
+    }
+
+    @Test
+    public void bankRegisterAt3F00SelectsSwitchableBank() throws IOException {
+        Cartridge cart = build();
+        cart.setByte(0x3F00, 0x06); // Sachen bank register (0x2000-0x3FFF)
+        assertEquals(0xA6, cart.getByte(0x6000));
+        assertEquals(0xA0, cart.getByte(0x2000)); // base window unaffected
+    }
+
+    @Test
+    public void mementoRoundTripPreservesBankAndLogoShim() throws IOException {
+        Cartridge cart = build();
+        cart.setByte(0x3F00, 0x05);
+        Memento<Cartridge> memento = cart.saveToMemento();
+
+        Cartridge other = build();
+        other.setByte(0x3F00, 0x0a); // diverge
+        other.restoreFromMemento(memento);
+        assertEquals(0xA5, other.getByte(0x6000));
+        // the logo shim was already off (we wrote before saving); it stays off after restore
+        assertEquals(SACHEN_HEADER[0], other.getByte(0x0104));
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CookedSachenTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CookedSachenTest.java
@@ -25,7 +25,11 @@ public class CookedSachenTest {
     private static final int LOGO_FIRST_BYTE = 0xCE; // first Nintendo logo byte
 
     private static byte[] cookedSachenRom() {
-        byte[] rom = new byte[0x40000]; // 256 KB, 16 banks
+        return cookedSachenRom(0x40000); // 256 KB, 16 banks
+    }
+
+    private static byte[] cookedSachenRom(int size) {
+        byte[] rom = new byte[size];
         rom[0x100] = 0x00;
         rom[0x101] = (byte) 0xc3;
         rom[0x102] = 0x50;
@@ -36,14 +40,18 @@ public class CookedSachenTest {
         rom[0x147] = (byte) 0x99; // bogus Sachen mapper byte
         rom[0x148] = 0x04;
         // a distinct marker in the middle of every 16 KB bank so we can tell which is mapped
-        for (int bank = 0; bank < 16; bank++) {
+        for (int bank = 0; bank < size / 0x4000; bank++) {
             rom[bank * 0x4000 + 0x2000] = (byte) (0xA0 + bank);
         }
         return rom;
     }
 
     private static Cartridge build() throws IOException {
-        return new Cartridge(new Rom(cookedSachenRom()), Battery.NULL_BATTERY);
+        return build(0x40000);
+    }
+
+    private static Cartridge build(int size) throws IOException {
+        return new Cartridge(new Rom(cookedSachenRom(size)), Battery.NULL_BATTERY);
     }
 
     @Test
@@ -81,6 +89,28 @@ public class CookedSachenTest {
         cart.setByte(0x3F00, 0x06); // Sachen bank register (0x2000-0x3FFF)
         assertEquals(0xA6, cart.getByte(0x6000));
         assertEquals(0xA0, cart.getByte(0x2000)); // base window unaffected
+    }
+
+    @Test
+    public void outerRegisterSelectsSecondGameOfMulticart() throws IOException {
+        // the 2-in-1 carts remap to the second 256 KB game with a single write of 1 to a
+        // 0x2000-0x3FFF address with A6 set (0x3FC0), from their HRAM launcher; base bank
+        // becomes 16 and the game's own bank writes (0-15) resolve inside its half
+        Cartridge cart = build(0x80000); // 512 KB, two 256 KB games
+        cart.setByte(0x3FC0, 0x01);
+        assertEquals(0xB0, cart.getByte(0x2000)); // 0x0000-0x3FFF -> bank 16 (second game)
+        assertEquals(0xB1, cart.getByte(0x6000)); // switchable defaults to game-relative bank 1
+        cart.setByte(0x3F00, 0x05); // the game selects its own bank 5
+        assertEquals(0xB5, cart.getByte(0x6000)); // -> physical bank 21, still in its half
+    }
+
+    @Test
+    public void normalBankRegisterIgnoresA6Address() throws IOException {
+        // a plain bank write (A6 clear, e.g. 0x3F00) must not be mistaken for the outer select
+        Cartridge cart = build(0x80000);
+        cart.setByte(0x3F00, 0x06);
+        assertEquals(0xA0, cart.getByte(0x2000)); // base window still game 1, bank 0
+        assertEquals(0xA6, cart.getByte(0x6000)); // switchable bank 6
     }
 
     @Test


### PR DESCRIPTION
## What

The post-unlock (\"cooked\") dumps of the Sachen CGB carts referenced in [#73](https://github.com/trekawek/coffee-gb/issues/73) — **ATV Racing**, **Full Time Soccer**, **Pocket Smash Out** and their Rocket Games two-in-ones — booted to a **black screen**. This makes all six boot to their title/menu screens and into gameplay.

## Why they were black

- **Singles** fell back to **MBC5** (unknown mapper byte `0x99`/`0x97`). MBC5 splits its ROM-bank register into a low half (`0x2000-0x2FFF`) and a bit-8 half (`0x3000-0x3FFF`). These carts write the whole bank number to `0x3F00`, so MBC5 decoded e.g. `bank 6` as \"set bit 8 = 0\", left the bank at 1, and the game jumped into `0xFD` padding.
- **Two-in-ones** were routed to `SachenMmc` but booted at their *logo bank*, which left the menu code mapped to the wrong bank → black.

## The fix

These carts drive the **Sachen mapper** (bank number at `0x2000-0x3FFF`, base at `0x0000`, mask at `0x4000`) and power on at **base bank 0**, where the menu, game code and per-game bank switching all live.

1. **Detection** (`Cartridge`): identify cooked Sachen dumps by the fixed, cart-independent *descrambled boot header* they store at `0x0104` (in place of the Nintendo logo — it is byte-identical across every Sachen title), and route them to `SachenMmc` at base 0. The old logo-bank detection is replaced.
2. **Boot** (`SachenMmc`): cooked dumps carry no logo, so the authentic boot ROM's logo check would lock up (only falling through after the ~40M-tick bad-logo timeout, ~2.8s per load). The mapper now reproduces what the real cart's scrambling does — it **serves the Nintendo logo for reads of `0x0104-0x0133` until the first cartridge write** (the boot ROM never writes the cart, so the first write means the game has taken over). FAST_FORWARD now boots straight through.

## Result

| Game | Before | After |
|---|---|---|
| ATV Racing | black | Rocket Games → title → colour *SELECT TRACK* |
| Full Time Soccer | black | DAG splash → menu |
| Pocket Smash Out | black | title screen |
| …& Karate Joe / …& Hang Time / …& Race Time | black | working two-in-one select menus |

SameBoy shows a black screen on all of these.

## Tests

- New `CookedSachenTest` (6 cases): detection, boot-logo shim + first-write reveal, base-0 mapping, `0x3F00` bank switching, memento round-trip.
- Full core unit suite green (56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)