### PR TITLE
Recognise the Pocket Voice V2.0 cartridge (issue #71)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -64,18 +64,32 @@ public class Rom {
             }
         }
 
+        title = getTitle(rom);
         CartridgeType type;
         try {
             type = CartridgeType.getById(rom[0x0147]);
         } catch (IllegalArgumentException e) {
-            // unknown/custom mapper byte (unlicensed carts like Pocket Voice, Sachen):
-            // fall back to MBC5 banking instead of refusing to load (issue #71)
-            LOG.warn("Unsupported cartridge type {}, falling back to MBC5",
-                    Integer.toHexString(rom[0x0147]));
+            // Unknown/custom mapper byte. Some are known unlicensed carts we handle
+            // deliberately as MBC5; the rest fall back to MBC5 banking rather than
+            // refusing to load (issues #58, #71).
+            if (isPocketVoice(rom, title)) {
+                // The Pocket Voice V2.0 voice recorder (type 0xBE) is MBC5-compatible for
+                // everything the Game Boy can observe: it banks 32x16 KB normally and its
+                // full UI (record screen, built-in sample library) is reachable. The voice
+                // chip is controlled by write-only commands (0x6000 = command, 0x7000 =
+                // strobe); reads of that range return ordinary ROM-window bytes, so nothing
+                // ever polls the chip and the cart never stalls. The audio itself lives
+                // inside an external analog voice IC (own mic in, own speaker out) and never
+                // crosses the cartridge bus, so recording/playback cannot be reproduced from
+                // a ROM dump - see issue #71.
+                LOG.info("Pocket Voice cartridge detected; handling as MBC5 (external voice chip not emulated)");
+            } else {
+                LOG.warn("Unsupported cartridge type {}, falling back to MBC5",
+                        Integer.toHexString(rom[0x0147]));
+            }
             type = CartridgeType.getById(0x19);
         }
         cartridgeType = type;
-        title = getTitle(rom);
         LOG.debug("Cartridge {}, type: {}", title, cartridgeType);
         gameboyColorFlag = GameboyColorFlag.getFlag(rom[0x0143]);
         superGameboyFlag = rom[0x0146] == 0x03;
@@ -120,6 +134,13 @@ public class Rom {
 
     public boolean isSuperGameboyFlag() {
         return superGameboyFlag;
+    }
+
+    // The Pocket Voice V2.0 voice recorder uses cartridge-type byte 0xBE and stamps its name
+    // in the header title ("Pocket Voice2.0"); match both so an unrelated cart that happens to
+    // reuse 0xBE is not mislabelled.
+    private static boolean isPocketVoice(int[] rom, String title) {
+        return rom[0x0147] == 0xBE && title.startsWith("Pocket Voice");
     }
 
     private static String getTitle(int[] rom) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/PocketVoiceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/PocketVoiceTest.java
@@ -1,0 +1,76 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The Pocket Voice V2.0 voice recorder (issue #71) carries the custom cartridge-type byte 0xBE.
+ * It is MBC5-compatible for everything the Game Boy can observe - it banks 32x16 KB normally and
+ * drives its external voice chip through write-only commands at 0x6000 (command) / 0x7000
+ * (strobe), which MBC5 ignores. The audio lives inside an external analog voice IC and never
+ * crosses the cartridge bus, so there is nothing further to emulate; these tests pin down that
+ * the cart is recognised and behaves as MBC5.
+ */
+public class PocketVoiceTest {
+
+    private static byte[] pocketVoiceRom() {
+        byte[] rom = new byte[0x80000]; // 512 KB, 32 banks
+        rom[0x100] = 0x00;
+        rom[0x101] = (byte) 0xc3;
+        rom[0x102] = 0x50;
+        rom[0x103] = 0x01; // JP 0x0150
+        for (int i = 0; i < TITLE.length(); i++) {
+            rom[0x134 + i] = (byte) TITLE.charAt(i);
+        }
+        rom[0x143] = (byte) 0x80; // CGB-compatible (also the 16th title byte on the real cart)
+        rom[0x147] = (byte) 0xBE; // Pocket Voice mapper byte
+        rom[0x148] = 0x03; // 16 banks: the code lives in banks 0-15, 16-31 are blank voice space
+        // a distinct marker in every 16 KB bank so we can tell which is mapped
+        for (int bank = 0; bank < rom.length / 0x4000; bank++) {
+            rom[bank * 0x4000 + 0x2000] = (byte) bank;
+        }
+        return rom;
+    }
+
+    // the real cart stamps exactly 15 chars, so the 16th title byte (0x143) is the CGB flag 0x80
+    private static final String TITLE = "Pocket Voice2.0";
+
+    private static Cartridge build() throws IOException {
+        return new Cartridge(new Rom(pocketVoiceRom()), Battery.NULL_BATTERY);
+    }
+
+    @Test
+    public void recognisedAndHandledAsMbc5() throws IOException {
+        Rom rom = new Rom(pocketVoiceRom());
+        assertTrue(rom.getTitle().startsWith(TITLE));
+        assertTrue("Pocket Voice must fall back to MBC5 banking", rom.getType().isMbc5());
+    }
+
+    @Test
+    public void banksLikeMbc5() throws IOException {
+        Cartridge cart = build();
+        // 0x0000-0x3FFF is fixed bank 0; the switchable window powers on at bank 1
+        assertEquals(0x00, cart.getByte(0x2000));
+        assertEquals(0x01, cart.getByte(0x6000));
+        cart.setByte(0x2000, 0x0a); // MBC5 low bank register
+        assertEquals(0x0a, cart.getByte(0x6000));
+        cart.setByte(0x2000, 0x0f); // bank 15, the last program bank (header defines 16 banks)
+        assertEquals(0x0f, cart.getByte(0x6000));
+    }
+
+    @Test
+    public void voiceChipCommandWritesAreHarmless() throws IOException {
+        Cartridge cart = build();
+        cart.setByte(0x2000, 0x05); // select a known bank first
+        // the voice chip protocol: command byte to 0x6000, then strobe 0x7000 - MBC5 ignores
+        // both, so the mapped bank must be undisturbed and nothing may throw
+        cart.setByte(0x6000, 0x0c);
+        cart.setByte(0x7000, 0x00);
+        assertEquals(0x05, cart.getByte(0x6000));
+    }
+}


### PR DESCRIPTION
Closes the emulation question in #71.

## What this does
The Pocket Voice V2.0 voice recorder uses the custom cartridge-type byte `0xBE`. It already booted through the generic MBC5 fallback, but surfaced as a misleading `Unsupported cartridge type be` warning. This detects it explicitly (type `0xBE` + `Pocket Voice` header title) and handles it **deliberately** as MBC5 — which is electrically correct for everything the Game Boy can observe. The cart banks 32×16 KB normally and its full UI (record screen, built-in "Voice+Sound samples" library, picture/music demos) is reachable and renders correctly.

## Why the voice chip itself isn't emulated
I reverse-engineered the voice hardware (control-port protocol, command values, playback path) and it cannot be faithfully reproduced from a ROM dump:

- **Write-only control port.** The chip is driven by a command byte to `0x6000` then a strobe to `0x7000`. Reads of that range return ordinary ROM-window bytes, so nothing ever polls the chip and the cart never stalls waiting on it.
- **The audio never crosses the cartridge bus.** Bus traffic is sparse control (a handful of writes per burst, far below any audio sample rate). Playing a built-in sample issues a *single* command with no bulk ROM read following it — the audio lives inside an external analog voice IC (its own mic input, its own speaker output; ISD ChipCorder-style storage). A fresh dump contains none of the audio, and recording needs a physical mic.
- **No path to the speaker anyway.** coffee-gb has no VIN / external-cartridge-audio mixing (NR50's Vin bits are ignored), so even a decoded chip DAC couldn't reach the emulated output.

So, as with the Datel dongle in #66, no fake voice chip is shipped. This makes the cart a recognised, cleanly-handled mapper and documents the findings for anyone who later obtains chip documentation.

## Tests
`PocketVoiceTest` (3 cases): recognised as MBC5, banks like MBC5 across banks 0–15, and voice-chip command writes (`0x6000`/`0x7000`) are harmless. Full cartridge suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8