### PR TITLE
Datel: boot the game through an Action Replay Online (#66)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
@@ -119,6 +119,15 @@ public class Datel implements MemoryController {
         return (regs[5] & 0x10) != 0;
     }
 
+    // hand the bus to the slot game for good and warm-reset the console to a clean
+    // post-boot state (the machine state both launch stubs reconstruct by hand)
+    private void launch() {
+        launched = true;
+        if (eventBus != null) {
+            eventBus.post(new LaunchEvent(slotNonCgb));
+        }
+    }
+
     private int bank(int reg) {
         return regs[reg] % romBanks8k;
     }
@@ -143,21 +152,30 @@ public class Datel implements MemoryController {
         }
         if (address >= 0x7fe0 && address <= 0x7fe7) {
             regs[address - 0x7fe0] = value;
+            if (address == 0x7fe6 && value == 0x07 && regs[7] == 0x02 && slot != null) {
+                // the "run launch" stub (Action Replay Online's path, copied to 0xFF80):
+                // it routes the bus to the slot with 0x7FE7=02 + 0x7FE6=07, restores the
+                // boot IO itself and jumps straight into the game (no console reset). We
+                // model the handoff as a warm reset to a clean post-boot state - the same
+                // machine state the stub reconstructs by hand - and hand the bus over.
+                launch();
+            }
             return;
         }
         if (address >= 0x7ff0 && address <= 0x7ff7) {
             regsB[address - 0x7ff0] = value;
             if (address == 0x7ff4 && (regs[4] & 0x01) != 0 && slot != null) {
-                // the restart stub's final write hands the bus to the game: emulate the
-                // console reset the software performs here, and leave the bus for good
-                launched = true;
-                if (eventBus != null) {
-                    eventBus.post(new LaunchEvent(slotNonCgb));
-                }
+                // the "reset launch" stub (the Xtreme's path): 0x7FE4 bit 0 latches the
+                // slot and the final 0x7FF4 write pulses the console reset line - the boot
+                // ROM re-runs against the game cartridge (the logo-swap trick).
+                launch();
             }
             return;
         }
-        if (slotPeek()) {
+        if (slotPeek() || (regs[5] & 0x01) != 0) {
+            // 0x7FE5 bit 0 is a write-through mode: before the genuine launch the boot
+            // pre-sets the slot game's MBC bank register through it (0x7FE5=01,
+            // LD (2000),A, 0x7FE5=00) without exposing the slot for reads
             if (slot != null) {
                 slot.setByte(address, value);
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DatelTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DatelTest.java
@@ -43,6 +43,22 @@ public class DatelTest {
         return rom;
     }
 
+    /** An MBC5 slot game with a distinct marker byte in each 16 KB bank. */
+    private static byte[] mbcGameRom() {
+        byte[] rom = new byte[0x40000]; // 256 KB, 16 banks
+        int[] logo = {0xCE, 0xED, 0x66, 0x66};
+        for (int i = 0; i < logo.length; i++) {
+            rom[0x104 + i] = (byte) logo[i];
+        }
+        rom[0x134] = 'G';
+        rom[0x147] = 0x19; // MBC5
+        rom[0x148] = 0x04; // 256 KB
+        for (int bank = 0; bank < 16; bank++) {
+            rom[bank * 0x4000 + 0x0100] = (byte) (0xB0 + bank);
+        }
+        return rom;
+    }
+
     private static Cartridge build() throws IOException {
         return new Cartridge(new Rom(datelRom()), Battery.NULL_BATTERY);
     }
@@ -125,6 +141,56 @@ public class DatelTest {
         assertEquals(0xCE, cart.getByte(0x0104));
         assertEquals('G', cart.getByte(0x0134));
         assertEquals(0x5a, cart.getByte(0x7fe1)); // the game's ROM there, not the AR reg (0x02)
+    }
+
+    @Test
+    public void runLaunchHandsOffTheBusForGood() throws IOException {
+        // the Action Replay Online "run launch" path: the 0xFF80 stub routes the bus with
+        // 0x7FE7=02 then 0x7FE6=07 and jumps into the game without a console reset. (The
+        // Xtreme's cart uses the 0x7FF4 reset path instead; both must hand off.)
+        Cartridge cart = build();
+        Cartridge game = new Cartridge(new Rom(gameRom()), Battery.NULL_BATTERY);
+        cart.getDatel().setSlotCartridge(game.getMemoryController(), false);
+        eu.rekawek.coffeegb.core.events.EventBusImpl bus =
+                new eu.rekawek.coffeegb.core.events.EventBusImpl(null, null, false);
+        cart.init(bus);
+        java.util.concurrent.atomic.AtomicInteger launches = new java.util.concurrent.atomic.AtomicInteger();
+        bus.register(e -> launches.incrementAndGet(), eu.rekawek.coffeegb.core.memory.cart.type.Datel.LaunchEvent.class);
+
+        assertEquals(0x44, cart.getByte(0x0104)); // the AR's fake logo, pre-launch
+
+        // 0x7FE6=07 only routes the bus once 0x7FE7 already holds 02
+        cart.setByte(0x7fe6, 0x07);
+        assertEquals(0, launches.get());
+        cart.setByte(0x7fe7, 0x02);
+        cart.setByte(0x7fe6, 0x07);
+        assertEquals(1, launches.get());
+
+        // the game now owns the whole bus
+        assertEquals(0xCE, cart.getByte(0x0104));
+        assertEquals('G', cart.getByte(0x0134));
+        assertEquals(0x5a, cart.getByte(0x7fe1));
+    }
+
+    @Test
+    public void slotBankRegisterWriteThrough() throws IOException {
+        // 0x7FE5 bit 0 is a write-through: the boot pre-sets the slot game's MBC bank
+        // register through it without exposing the slot for reads
+        Cartridge cart = build();
+        Cartridge game = new Cartridge(new Rom(mbcGameRom()), Battery.NULL_BATTERY);
+        cart.getDatel().setSlotCartridge(game.getMemoryController(), false);
+
+        cart.setByte(0x7fe5, 0x01);      // enable write-through
+        cart.setByte(0x2000, 0x03);      // MBC5 low-bank register -> the game's bank 3
+        cart.setByte(0x7fe5, 0x00);      // back to normal
+        // reads still serve the AR (its fake logo), not the slot
+        assertEquals(0x44, cart.getByte(0x0104));
+
+        // peek the slot: the write reached the game's mapper, so its 0x4000 window maps
+        // bank 3 (open the peek window, then close it)
+        cart.setByte(0x7fe5, 0x10);
+        assertEquals(0xB3, cart.getByte(0x4100)); // bank-3 marker
+        cart.setByte(0x7fe5, 0x00);
     }
 
     @Test


### PR DESCRIPTION
## What
The Orbit V2 mapper only recognised the **Action Replay Xtreme**'s launch, which pulses the console reset line (`0x7FE4` bit 0 + a final `0x7FF4` write — the logo-swap trick). The general **Action Replay Online** cart uses a different launch stub (copied to `0xFF80`): it routes the bus to the slot with `0x7FE7=02` then `0x7FE6=07`, restores the boot IO by hand and jumps straight into the game **without a reset**.

We ignored that handoff, so an Action Replay Online with a game in its slot **hung on the Datel logo forever** instead of booting the game.

This recognises the "run launch" too, unifying both stubs into one `launch()` (a warm reset to the clean post-boot state the stub otherwise reconstructs by hand — posting the LaunchEvent is required, a bare bus-latch leaves the game stuck in its early boot loop). It also honours the `0x7FE5` bit 0 **write-through** the boot uses to pre-set the slot game's MBC bank register without exposing the slot for reads.

**Result:** Pokémon Crystal now boots and plays in full colour through an Action Replay Online, matching the Xtreme.

## Tests
`DatelTest` +2 (`runLaunchHandsOffTheBusForGood`, `slotBankRegisterWriteThrough`) → 9 cases; `DatelSlotCheatTest` still green.

## Note on the on-cart menu
While investigating "how do I show the Action Replay code-entry menu", I confirmed the menu UI (Main Menu / Codes / New Code / Game Trainer) *is* in the ROM, but on the Action Replay Online it is only reachable through the cart's **dongle upgrade** (a serial download of Datel's code database, which their now-dead server provided and no dump contains). A virtual dongle completes the `3A → C5/CE` handshake and reaches "Downloading:", but there is no valid data to send — the same data wall documented for the on-cart cheat DB. This PR is just the launch fix; the on-cart menu remains gated behind that upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8