### PR TITLE
Emulate the CGB infrared port and the Full Changer (#94)

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
@@ -50,6 +50,7 @@ class EmulatorProperties() {
     SoundEnabled("sound.enabled"),
     RomDirectory("rom.directory"),
     DatelSlotRom("datel.slot.rom"),
+    FullChangerCharacter("fullchanger.character"),
   }
 
   private companion object {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -65,6 +65,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     private final SerialPort serialPort;
 
+    private final eu.rekawek.coffeegb.core.ir.InfraredPort infraredPort;
+
     private final Joypad joypad;
 
     private final SpeedMode speedMode;
@@ -127,6 +129,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         sound = new Sound(timer, speedMode, gbc);
         joypad = new Joypad(interruptManager, sgbBus, sgb);
         serialPort = new SerialPort(interruptManager, timer, gbc, speedMode);
+        infraredPort = new eu.rekawek.coffeegb.core.ir.InfraredPort(gbc, speedMode);
 
         if (configuration.batteryData != null) {
             cartridge = new Cartridge(configuration.rom, new MemoryBattery(configuration.batteryData));
@@ -159,6 +162,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         if (gbc) {
             mmu.addAddressSpace(speedMode);
             mmu.addAddressSpace(hdma);
+            mmu.addAddressSpace(infraredPort);
         }
         mmu.indexSpaces();
         mmu.setBusListener(cartridge.getSachenMmc());
@@ -257,6 +261,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         display.init(eventBus);
         sound.init(eventBus);
         serialPort.init(serialEndpoint);
+        infraredPort.init(eventBus);
         background.init(eventBus);
         sgbDisplay.init(eventBus);
         gameGenie.init(eventBus);
@@ -362,6 +367,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         dma.tick();
         sound.tick();
         serialPort.tick();
+        infraredPort.tick();
         joypad.tick();
         Mode mode = gpu.tick();
         statRegister.tick();
@@ -429,7 +435,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled);
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled);
     }
 
     @Override
@@ -451,6 +457,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         display.restoreFromMemento(mem.displayMemento());
         sound.restoreFromMemento(mem.soundMemento());
         serialPort.restoreFromMemento(mem.serialPortMemento());
+        infraredPort.restoreFromMemento(mem.infraredPortMemento());
         joypad.restoreFromMemento(mem.joypadMemento());
         speedMode.restoreFromMemento(mem.speedModeMemento());
         superGameboy.restoreFromMemento(mem.superGameboyMemento());
@@ -477,6 +484,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<InterruptManager> interruptManagerMemento, Memento<Timer> timerMemento,
                                   Memento<Dma> dmaMemento, Memento<Hdma> hdmaMemento, Memento<Display> displayMemento,
                                   Memento<Sound> soundMemento, Memento<SerialPort> serialPortMemento,
+                                  Memento<eu.rekawek.coffeegb.core.ir.InfraredPort> infraredPortMemento,
                                   Memento<Joypad> joypadMemento, Memento<SpeedMode> speedModeMemento,
                                   Memento<SuperGameboy> superGameboyMemento, Memento<Background> backgroundMemento,
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
@@ -1,0 +1,132 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memento.Originator;
+
+import java.io.Serializable;
+
+/**
+ * The Full Changer, the IR toy bundled with Zok Zok Heroes (issue #94). The player
+ * "draws" a Cosmic Character by waving it, then holds it to the GBC's IR port; the toy
+ * transmits the character as a series of light pulses and the game transforms the hero.
+ *
+ * <p>Protocol (reverse-engineered by Shonumi for GBE+): 18 ON/OFF pulse pairs. The game
+ * busy-polls RP and counts loop iterations for each ON+OFF pair as one delay byte. The
+ * first pulse is a long sync (delay &gt; 0x20). The next 16 pulses carry two bytes,
+ * LSB-first: a short pulse (&le; 0x13) is a 0 bit, a long pulse (0x14-0x20) a 1 bit.
+ * Byte 1 is the character ID, byte 2 its complement (their sum must be 0xFF); the 18th
+ * pulse is required but unused. Pulse durations below are GBE+'s calibrated cycle counts
+ * (in double-speed cycles): the first ON pulse takes 74 + 20*(len-2), later ON pulses
+ * 78 + 20*(len-2), OFF pulses 38 + 20*(len-2), where the ON and OFF lens of a pair sum
+ * to the delay byte the game should measure.
+ *
+ * <p>There are 70 Cosmic Characters, IDs 0x01-0x46.
+ */
+public class FullChanger implements Serializable, Originator<FullChanger> {
+
+    /** The player finished drawing a Cosmic Character and pointed the toy at the IR port. */
+    public record TransformEvent(int characterId) implements Event {
+    }
+
+    public static final int CHARACTERS = 70;
+
+    // total delay bytes the game should measure: a long sync, data bits and the final pulse
+    private static final int SYNC_DELAY = 0x2e;
+
+    private static final int LONG_DELAY = 0x1a; // a 1 bit
+
+    private static final int SHORT_DELAY = 0x0a; // a 0 bit
+
+    // alternating ON/OFF durations in double-speed cycles; empty = nothing to send
+    private int[] schedule = new int[0];
+
+    // a transformation waits for the game to poll RP before the light fires, so the
+    // measuring loop sees the first pulse from its start
+    private boolean armed;
+
+    private boolean running;
+
+    private int index;
+
+    private int remaining;
+
+    /** Queues the transmission of the given Cosmic Character (1-70). */
+    public void transform(int characterId) {
+        if (characterId < 1 || characterId > CHARACTERS) {
+            throw new IllegalArgumentException("Cosmic Character ID out of range: " + characterId);
+        }
+        schedule = buildSchedule(characterId);
+        armed = true;
+        running = false;
+    }
+
+    void onRpRead() {
+        if (armed) {
+            armed = false;
+            running = true;
+            index = 0;
+            remaining = schedule[0];
+        }
+    }
+
+    void tick(int cycles) {
+        if (!running) {
+            return;
+        }
+        remaining -= cycles;
+        while (remaining <= 0) {
+            if (++index >= schedule.length) {
+                running = false;
+                return;
+            }
+            remaining += schedule[index];
+        }
+    }
+
+    boolean isLightOn() {
+        return running && (index & 1) == 0; // even entries are the ON periods
+    }
+
+    private static int[] buildSchedule(int characterId) {
+        int[] delays = new int[18];
+        delays[0] = SYNC_DELAY;
+        int checksum = characterId & 0xff; // byte 1 + byte 2 = 0xFF
+        int data = (~characterId) & 0xff; // the ID is transmitted complemented
+        for (int bit = 0; bit < 8; bit++) {
+            delays[1 + bit] = ((checksum >> bit) & 1) != 0 ? LONG_DELAY : SHORT_DELAY;
+            delays[9 + bit] = ((data >> bit) & 1) != 0 ? LONG_DELAY : SHORT_DELAY;
+        }
+        delays[17] = SHORT_DELAY; // required by the software, not part of the data
+
+        int[] schedule = new int[36];
+        for (int i = 0; i < 18; i++) {
+            int on = delays[i] / 2;
+            int off = delays[i] - on;
+            schedule[2 * i] = (i == 0 ? 74 : 78) + 20 * (on - 2);
+            schedule[2 * i + 1] = 38 + 20 * (off - 2);
+        }
+        return schedule;
+    }
+
+    @Override
+    public Memento<FullChanger> saveToMemento() {
+        return new FullChangerMemento(schedule.clone(), armed, running, index, remaining);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<FullChanger> memento) {
+        if (!(memento instanceof FullChangerMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        this.schedule = mem.schedule.clone();
+        this.armed = mem.armed;
+        this.running = mem.running;
+        this.index = mem.index;
+        this.remaining = mem.remaining;
+    }
+
+    private record FullChangerMemento(int[] schedule, boolean armed, boolean running, int index, int remaining)
+            implements Memento<FullChanger> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -1,0 +1,90 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memento.Originator;
+
+import java.io.Serializable;
+
+/**
+ * The CGB infrared port - the RP register at 0xFF56 (issue #94).
+ *
+ * <p>Bit 0 drives the console's own IR LED (write). Bit 1 reads the light sensor,
+ * inverted: 0 means IR light is being received. The sensor only reports light while both
+ * read-enable bits 6-7 are set; otherwise bit 1 reads 1. The register does not exist in
+ * DMG-compatibility mode (reads 0xFF), matching the other CGB-only registers.
+ *
+ * <p>Received light comes from a pluggable external device; the only one emulated so far
+ * is the {@link FullChanger} (Zok Zok Heroes).
+ */
+public class InfraredPort implements AddressSpace, Serializable, Originator<InfraredPort> {
+
+    private final boolean gbc;
+
+    private final SpeedMode speedMode;
+
+    private final FullChanger fullChanger = new FullChanger();
+
+    // the written bits of RP: bit 0 (own LED) and bits 6-7 (read enable)
+    private int rp;
+
+    public InfraredPort(boolean gbc, SpeedMode speedMode) {
+        this.gbc = gbc;
+        this.speedMode = speedMode;
+    }
+
+    public void init(EventBus eventBus) {
+        eventBus.register(e -> fullChanger.transform(e.characterId()), FullChanger.TransformEvent.class);
+    }
+
+    public void tick() {
+        // the pulse timings are defined in double-speed cycles; advance twice as fast in
+        // double speed so a game sees the same delays regardless of its speed setting
+        fullChanger.tick(speedMode.getSpeedMode());
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return address == 0xff56;
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        rp = value & 0xc1;
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (!gbc || speedMode.isDmgCompat()) {
+            return 0xff;
+        }
+        // an armed device starts transmitting at a poll of the register, so the polling
+        // loop observes the first pulse from its beginning
+        fullChanger.onRpRead();
+        int result = rp | 0x3c | 0x02;
+        if ((rp & 0xc0) == 0xc0 && fullChanger.isLightOn()) {
+            result &= ~0x02;
+        }
+        return result;
+    }
+
+    @Override
+    public Memento<InfraredPort> saveToMemento() {
+        return new InfraredPortMemento(rp, fullChanger.saveToMemento());
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<InfraredPort> memento) {
+        if (!(memento instanceof InfraredPortMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        this.rp = mem.rp;
+        fullChanger.restoreFromMemento(mem.fullChangerMemento);
+    }
+
+    private record InfraredPortMemento(int rp, Memento<FullChanger> fullChangerMemento)
+            implements Memento<InfraredPort> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/FullChangerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/FullChangerTest.java
@@ -1,0 +1,154 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The CGB IR port and the Full Changer (issue #94). The decoding test replicates the
+ * measurement loop Zok Zok Heroes runs: it busy-polls RP (0xFF56) and counts loop
+ * iterations for each ON+OFF light pulse, building 18 delay bytes that carry a sync
+ * pulse, a checksum byte and the complemented Cosmic Character ID (LSB-first; short
+ * pulse = 0 bit, long pulse = 1 bit).
+ */
+public class FullChangerTest {
+
+    // one iteration of the game's polling loop costs ~20 double-speed cycles - the
+    // constant GBE+'s calibrated pulse timings are built around
+    private static final int LOOP_CYCLES = 20;
+
+    private final SpeedMode speedMode = new SpeedMode(true);
+
+    private final InfraredPort port = new InfraredPort(true, speedMode);
+
+    private int readRp() {
+        int value = port.getByte(0xff56);
+        for (int i = 0; i < LOOP_CYCLES; i++) {
+            port.tick();
+        }
+        return value;
+    }
+
+    /** Replicates the game's capture: waits for light, then measures 18 ON+OFF delays. */
+    private int[] captureDelays() {
+        int timeout = 0xffff;
+        while ((readRp() & 0x02) != 0) {
+            if (--timeout == 0) {
+                throw new AssertionError("IR light never came on");
+            }
+        }
+        int[] delays = new int[18];
+        for (int pulse = 0; pulse < 18; pulse++) {
+            int length = 0;
+            while ((readRp() & 0x02) == 0) { // light on
+                length++;
+                assertTrue("ON pulse too long", length < 0x100);
+            }
+            while ((readRp() & 0x02) != 0) { // light off
+                length++;
+                if (pulse == 17 && length > 0x30) {
+                    break; // transmission over; the final off period just ends
+                }
+                assertTrue("OFF pulse too long", length < 0x100);
+            }
+            delays[pulse] = length;
+        }
+        return delays;
+    }
+
+    private int decodeByte(int[] delays, int offset) {
+        int value = 0;
+        for (int bit = 0; bit < 8; bit++) {
+            int delay = delays[offset + bit];
+            assertTrue("delay out of range: " + delay, delay <= 0x20);
+            if (delay >= 0x14) {
+                value |= 1 << bit;
+            }
+        }
+        return value;
+    }
+
+    private void transformAndVerify(int id) {
+        port.setByte(0xff56, 0xc0); // read enable
+        new FullChangerTrigger(port).transform(id);
+        int[] delays = captureDelays();
+        assertTrue("sync pulse must be long, got " + delays[0], delays[0] > 0x20);
+        int checksum = decodeByte(delays, 1);
+        int data = decodeByte(delays, 9);
+        assertEquals("checksum", 0xff, (checksum + data) & 0xff);
+        assertEquals("character ID", id, (~data) & 0xff);
+    }
+
+    // posts the event the same way the UI does
+    private record FullChangerTrigger(InfraredPort port) {
+        void transform(int id) {
+            EventBusImpl bus = new EventBusImpl(null, null, false);
+            port.init(bus);
+            bus.post(new FullChanger.TransformEvent(id));
+        }
+    }
+
+    @Test
+    public void decodesFirstCharacter() {
+        transformAndVerify(0x01);
+    }
+
+    @Test
+    public void decodesLastCharacter() {
+        transformAndVerify(FullChanger.CHARACTERS);
+    }
+
+    @Test
+    public void decodesAllCharacters() {
+        for (int id = 1; id <= FullChanger.CHARACTERS; id++) {
+            transformAndVerify(id);
+        }
+    }
+
+    @Test
+    public void sensorGatedByReadEnable() {
+        new FullChangerTrigger(port).transform(1);
+        port.setByte(0xff56, 0x00); // read disabled: bit 1 always 1
+        port.getByte(0xff56); // arms + starts the transmission
+        boolean sawLight = false;
+        for (int i = 0; i < 10000; i++) {
+            port.tick();
+            if ((port.getByte(0xff56) & 0x02) == 0) {
+                sawLight = true;
+            }
+        }
+        assertEquals(false, sawLight);
+    }
+
+    @Test
+    public void writtenBitsReadBack() {
+        port.setByte(0xff56, 0xc1);
+        assertEquals(0xff, port.getByte(0xff56)); // 0x3c pulled + bit1 (no light) + written c1
+        port.setByte(0xff56, 0x00);
+        assertEquals(0x3e, port.getByte(0xff56));
+    }
+
+    @Test
+    public void mementoRoundTrip() {
+        port.setByte(0xff56, 0xc0);
+        new FullChangerTrigger(port).transform(5);
+        port.getByte(0xff56); // start transmitting
+        for (int i = 0; i < 30; i++) {
+            port.tick();
+        }
+        Memento<InfraredPort> memento = port.saveToMemento();
+
+        InfraredPort other = new InfraredPort(true, speedMode);
+        other.restoreFromMemento(memento);
+        // both ports continue the same pulse train in lockstep
+        for (int i = 0; i < 5000; i++) {
+            assertEquals(port.getByte(0xff56), other.getByte(0xff56));
+            port.tick();
+            other.tick();
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -28,6 +28,7 @@ import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.DmgGames
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.genie.AddPatches
+import eu.rekawek.coffeegb.core.ir.FullChanger
 import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera
 import eu.rekawek.coffeegb.swing.io.WebcamCameraSource
 import eu.rekawek.coffeegb.core.genie.PatchFactory
@@ -293,6 +294,29 @@ class SwingMenu(
     arClear.addActionListener {
       properties.setProperty(EmulatorProperties.Key.DatelSlotRom, "")
       arGame.text = arGameLabel()
+    }
+
+    // the Full Changer, the IR toy of Zok Zok Heroes: picking a Cosmic Character sends
+    // its transformation over the CGB infrared port (issue #94)
+    val fullChanger = JMenuItem("Full Changer transformation...")
+    peripheralsMenu.add(fullChanger)
+    fullChanger.isEnabled = false
+    enableWhenEmulationActive(fullChanger)
+    fullChanger.addActionListener {
+      val choice =
+          JOptionPane.showInputDialog(
+              window,
+              "Cosmic Character to transform into:",
+              "Full Changer",
+              JOptionPane.PLAIN_MESSAGE,
+              null,
+              COSMIC_CHARACTERS,
+              properties.getProperty(EmulatorProperties.Key.FullChangerCharacter, COSMIC_CHARACTERS[0]),
+          )
+      if (choice != null) {
+        properties.setProperty(EmulatorProperties.Key.FullChangerCharacter, choice as String)
+        eventBus.post(FullChanger.TransformEvent(COSMIC_CHARACTERS.indexOf(choice) + 1))
+      }
     }
 
     val barcodeMenu = JMenu("Barcode Boy")
@@ -568,6 +592,81 @@ class SwingMenu(
   }
 
   private companion object {
+    // the 70 Cosmic Characters of Zok Zok Heroes, in Full Changer ID order (1-70)
+    val COSMIC_CHARACTERS =
+        arrayOf(
+            "01 \u3042 Alkaline Powered",
+            "02 \u3044 In Water",
+            "03 \u3046 Ultra Runner",
+            "04 \u3048 Aero Power",
+            "05 \u304a Ochaapa",
+            "06 \u304b Kaizer Edge",
+            "07 \u304d King Batter",
+            "08 \u304f Crash Car",
+            "09 \u3051 Cellphone Tiger",
+            "10 \u3053 Cup Ace",
+            "11 \u3055 Sakanard",
+            "12 \u3057 Thin Delta",
+            "13 \u3059 Skateboard Rider",
+            "14 \u305b Celery Star",
+            "15 \u305d Cleaning Killer",
+            "16 \u305f Takoyaki Kid",
+            "17 \u3061 Chinkoman",
+            "18 \u3064 Tsukai Stater",
+            "19 \u3066 Teppangar",
+            "20 \u3068 Tongararin",
+            "21 \u306a Nagashiman",
+            "22 \u306b Ninja",
+            "23 \u306c Plushy-chan",
+            "24 \u306d Screw Razor",
+            "25 \u306e Nobel Brain",
+            "26 \u306f Hard Hammer",
+            "27 \u3072 Heat Man",
+            "28 \u3075 Flame Gourmet",
+            "29 \u3078 Hercules Army",
+            "30 \u307b Hot Card",
+            "31 \u307e Mr. Muscle",
+            "32 \u307f Mist Water",
+            "33 \u3080 Mushimushi Man",
+            "34 \u3081 Megaaten",
+            "35 \u3082 Mobile Robot X",
+            "36 \u3084 Yaki Bird",
+            "37 \u3086 Utron",
+            "38 \u3088 Yo-Yo Mask",
+            "39 \u3089 Radial Road",
+            "40 \u308a Remote-Control Man",
+            "41 \u308b Ruby Hook",
+            "42 \u308c Retro Sounder",
+            "43 \u308d Rocket Bastard",
+            "44 \u308f Wild Sword",
+            "45 \u304c Guts Lago",
+            "46 \u304e Giniun",
+            "47 \u3050 Great Fire",
+            "48 \u3052 Gamemark",
+            "49 \u3054 Gorilla Killa",
+            "50 \u3056 The Climber",
+            "51 \u3058 G Shark",
+            "52 \u305a Zoom Laser",
+            "53 \u305c Zenmai",
+            "54 \u305e Elephant Shower",
+            "55 \u3060 Diamond Mall",
+            "56 \u3062 Digronyan",
+            "57 \u3065 Ziza One",
+            "58 \u3067 Danger Red",
+            "59 \u3069 Dohatsuten",
+            "60 \u3070 Balloon",
+            "61 \u3073 Videoja",
+            "62 \u3076 Boo Boo",
+            "63 \u3079 Belt Jain",
+            "64 \u307c Boat Ron",
+            "65 \u3071 Perfect Sun",
+            "66 \u3074 Pinspawn",
+            "67 \u3077 Press Arm",
+            "68 \u307a Pegasus Boy",
+            "69 \u307d Pop Thunder",
+            "70 \u3093 Ndjamenas",
+        )
+
     val KEY_MODIFIER: Int =
         if (System.getProperty("os.name").contains("mac", ignoreCase = true)) {
           KeyEvent.META_DOWN_MASK


### PR DESCRIPTION
Addresses #94.

## What
Adds the **CGB infrared port** — the RP register at `0xFF56` (bit 0 = LED, bit 1 = light sensor, inverted, gated by read-enable bits 6-7; absent in DMG-compatibility mode) — with the **Full Changer** as its first device: the IR toy bundled with Zok Zok Heroes, required to progress past an early story point.

The transmission implements [Shonumi's reverse engineering](https://shonumi.github.io/articles/art8.html) ([technical doc](https://github.com/shonumi/gbe-plus/blob/master/src/docs/technical/Full_Changer.txt)) done for GBE+: 18 ON/OFF pulse pairs that the game measures as busy-poll loop counts — a long sync pulse, then two bytes LSB-first (short pulse = 0 bit, long = 1): the Cosmic Character ID and its complement as checksum. Pulse durations use GBE+'s calibrated cycle counts and advance at double rate in CGB double speed, so the game measures identical delays in either speed mode.

**UI:** Peripherals → *Full Changer transformation…* lists all 70 Cosmic Characters (ID + kana + translated name); the choice is remembered in the emulator properties. The transmission arms on the game's next RP poll, so it can be selected before (or while) the game listens.

## Validation
`FullChangerTest` replicates the game's documented capture loop (busy-polling RP, counting iterations per pulse, thresholding short/long) and verifies:
- all **70 characters** decode to the right ID with a valid checksum,
- the sync pulse is long, delays stay in the game's accepted ranges,
- the read-enable gate (bits 6-7 clear → sensor always reads 1),
- written-bit read-back and the memento round-trip.

Full battery green (core 85, controller 13).

Note: I could not script a blind playthrough deep enough into the (Japanese) story to reach the mandatory transformation prompt, so the in-game verification is protocol-level — the test mirrors the exact polling loop GBE+ documented from the game's own code. If someone with a save near the story gate can try it, even better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8