### PR TITLE
Emulate the MBC5 rumble motor (#93)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -8,6 +10,10 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import java.util.Arrays;
 
 public class Mbc5 implements MemoryController {
+
+    /** The rumble carts' motor turning on or off (issue #93). */
+    public record RumbleEvent(boolean on) implements Event {
+    }
 
     private final int romBanks;
 
@@ -27,6 +33,14 @@ public class Mbc5 implements MemoryController {
 
     private boolean ramUpdated;
 
+    // rumble carts (types 0x1C-0x1E) wire bit 3 of the RAM-bank register to the motor,
+    // leaving bits 0-2 for the bank select
+    private final boolean rumble;
+
+    private boolean motorOn;
+
+    private transient EventBus eventBus;
+
     // Non-battery cart RAM is volatile scratch with no save to protect, so the RAM-enable
     // handshake serves no purpose there. Some homebrew built for flash carts (Bung/EMS, whose
     // SRAM is always accessible) use it - e.g. as a stack - without ever enabling it, and would
@@ -42,7 +56,13 @@ public class Mbc5 implements MemoryController {
         Arrays.fill(ram, 0xff);
         this.battery = battery;
         this.gateRamWrites = rom.getType().isBattery();
+        this.rumble = rom.getType().isRumble();
         battery.loadRam(ram);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus;
     }
 
     @Override
@@ -59,7 +79,16 @@ public class Mbc5 implements MemoryController {
         } else if (address >= 0x3000 && address < 0x4000) {
             selectedRomBank = (selectedRomBank & 0x0ff) | ((value & 1) << 8);
         } else if (address >= 0x4000 && address < 0x6000) {
-            int bank = value & 0x0f;
+            if (rumble) {
+                boolean on = (value & 0x08) != 0;
+                if (on != motorOn) {
+                    motorOn = on;
+                    if (eventBus != null) {
+                        eventBus.post(new RumbleEvent(on));
+                    }
+                }
+            }
+            int bank = value & (rumble ? 0x07 : 0x0f);
             if (bank < ramBanks) {
                 selectedRamBank = bank;
             }
@@ -114,7 +143,7 @@ public class Mbc5 implements MemoryController {
 
     @Override
     public Memento<MemoryController> saveToMemento() {
-        return new Mbc5Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated);
+        return new Mbc5Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated, motorOn);
     }
 
     @Override
@@ -131,9 +160,11 @@ public class Mbc5 implements MemoryController {
         this.selectedRomBank = mem.selectedRomBank;
         this.ramWriteEnabled = mem.ramWriteEnabled;
         this.ramUpdated = mem.ramUpdated;
+        this.motorOn = mem.motorOn;
     }
 
     private record Mbc5Memento(Memento<Battery> batteryMemento, int[] ram, int selectedRamBank, int selectedRomBank,
-                               boolean ramWriteEnabled, boolean ramUpdated) implements Memento<MemoryController> {
+                               boolean ramWriteEnabled, boolean ramUpdated,
+                               boolean motorOn) implements Memento<MemoryController> {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
@@ -1,0 +1,75 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The MBC5 rumble motor (issue #93): on rumble carts (types 0x1C-0x1E) bit 3 of the
+ * RAM-bank register drives the vibration motor, leaving bits 0-2 for the bank select.
+ */
+public class Mbc5RumbleTest {
+
+    private static byte[] rom(int type) {
+        byte[] rom = new byte[0x40000]; // 256 KB, 16 banks
+        rom[0x147] = (byte) type;
+        rom[0x148] = 0x04; // 256 KB
+        rom[0x149] = 0x03; // 4 RAM banks
+        for (int bank = 0; bank < 16; bank++) {
+            rom[bank * 0x4000 + 0x0100] = (byte) (0xB0 + bank);
+        }
+        return rom;
+    }
+
+    private static Mbc5 build(int type, List<Boolean> motorLog) throws IOException {
+        Mbc5 mbc = new Mbc5(new Rom(rom(type)), Battery.NULL_BATTERY);
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        bus.register(e -> motorLog.add(e.on()), Mbc5.RumbleEvent.class);
+        mbc.init(bus);
+        return mbc;
+    }
+
+    @Test
+    public void motorBitPostsEvents() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1c, log); // ROM_MBC5_RUMBLE
+
+        mbc.setByte(0x4000, 0x08); // motor on
+        mbc.setByte(0x4000, 0x08); // idempotent - no duplicate event
+        mbc.setByte(0x4000, 0x00); // motor off
+        assertEquals(List.of(true, false), log);
+    }
+
+    @Test
+    public void motorBitIsNotPartOfTheRamBank() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1e, log); // ROM_MBC5_RUMBLE_SRAM_BATTERY
+
+        // select RAM bank 3 with the motor running: bit 3 must not leak into the bank
+        mbc.setByte(0x0000, 0x0a); // enable RAM
+        mbc.setByte(0x4000, 0x0b); // bank 3 (0b011) + motor (0b1000)
+        mbc.setByte(0xa000, 0x77);
+        // read it back from bank 3 with the motor off
+        mbc.setByte(0x4000, 0x03);
+        assertEquals(0x77, mbc.getByte(0xa000));
+        assertEquals(List.of(true, false), log);
+    }
+
+    @Test
+    public void nonRumbleCartTreatsBit3AsBankBits() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1a, log); // ROM_MBC5_RAM, no rumble
+
+        // without rumble, bit 3 is an ordinary RAM-bank bit and posts no motor event
+        mbc.setByte(0x0000, 0x0a);
+        mbc.setByte(0x4000, 0x08);
+        assertEquals(List.of(), log);
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -50,6 +50,12 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private GameboyType gameboyType;
 
+    // the rumble carts' motor (issue #93): while it runs, the picture is jiggled by a
+    // pixel each frame - a dependency-free stand-in for a vibrating console
+    private volatile boolean rumbling;
+
+    private int rumblePhase;
+
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
         this.eventBus = eventBus;
@@ -64,6 +70,7 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> setBlending(e.blending), SetBlendingEvent.class);
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
+        eventBus.register(e -> this.rumbling = e.on(), eu.rekawek.coffeegb.core.memory.cart.type.Mbc5.RumbleEvent.class, callerId);
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());
         setBlending(properties.getBlending());
@@ -157,6 +164,10 @@ public class SwingDisplay extends JPanel implements Runnable {
         Graphics2D g2d = (Graphics2D) g.create();
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+        if (rumbling) {
+            rumblePhase++;
+            g2d.translate((rumblePhase & 2) == 0 ? 1 : -1, (rumblePhase & 1) == 0 ? 1 : -1);
+        }
         switch (rotation) {
             case 90 -> {
                 g2d.translate(h, 0);


### PR DESCRIPTION
Addresses the cartridge half of #93.

## What
The rumble carts (types `0x1C`-`0x1E`: Pokémon Pinball, Perfect Dark, …) wire **bit 3 of the RAM-bank register** to a vibration motor, leaving bits 0-2 for the bank select. This decodes the bit, keeps it out of the bank number (previously a rumble game selecting "bank 8+n" could alias into a wrong RAM bank), and posts a `RumbleEvent` on each motor transition.

The Swing display reacts by jiggling the picture one pixel per frame while the motor runs — a dependency-free stand-in for a vibrating console. The event is designed as the hook for real force feedback once game-controller support (#78) lands.

## Tests
`Mbc5RumbleTest`: motor transitions post events (idempotent), the motor bit doesn't leak into the RAM bank (write/read-back across banks), non-rumble MBC5 types keep bit 3 as a bank bit and post nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8