### PR TITLE
Game-controller support via SDL2 (#78)

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -8,6 +10,10 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import java.util.Arrays;
 
 public class Mbc5 implements MemoryController {
+
+    /** The rumble carts' motor turning on or off (issue #93). */
+    public record RumbleEvent(boolean on) implements Event {
+    }
 
     private final int romBanks;
 
@@ -27,6 +33,14 @@ public class Mbc5 implements MemoryController {
 
     private boolean ramUpdated;
 
+    // rumble carts (types 0x1C-0x1E) wire bit 3 of the RAM-bank register to the motor,
+    // leaving bits 0-2 for the bank select
+    private final boolean rumble;
+
+    private boolean motorOn;
+
+    private transient EventBus eventBus;
+
     // Non-battery cart RAM is volatile scratch with no save to protect, so the RAM-enable
     // handshake serves no purpose there. Some homebrew built for flash carts (Bung/EMS, whose
     // SRAM is always accessible) use it - e.g. as a stack - without ever enabling it, and would
@@ -42,7 +56,13 @@ public class Mbc5 implements MemoryController {
         Arrays.fill(ram, 0xff);
         this.battery = battery;
         this.gateRamWrites = rom.getType().isBattery();
+        this.rumble = rom.getType().isRumble();
         battery.loadRam(ram);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus;
     }
 
     @Override
@@ -59,7 +79,16 @@ public class Mbc5 implements MemoryController {
         } else if (address >= 0x3000 && address < 0x4000) {
             selectedRomBank = (selectedRomBank & 0x0ff) | ((value & 1) << 8);
         } else if (address >= 0x4000 && address < 0x6000) {
-            int bank = value & 0x0f;
+            if (rumble) {
+                boolean on = (value & 0x08) != 0;
+                if (on != motorOn) {
+                    motorOn = on;
+                    if (eventBus != null) {
+                        eventBus.post(new RumbleEvent(on));
+                    }
+                }
+            }
+            int bank = value & (rumble ? 0x07 : 0x0f);
             if (bank < ramBanks) {
                 selectedRamBank = bank;
             }
@@ -114,7 +143,7 @@ public class Mbc5 implements MemoryController {
 
     @Override
     public Memento<MemoryController> saveToMemento() {
-        return new Mbc5Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated);
+        return new Mbc5Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated, motorOn);
     }
 
     @Override
@@ -131,9 +160,11 @@ public class Mbc5 implements MemoryController {
         this.selectedRomBank = mem.selectedRomBank;
         this.ramWriteEnabled = mem.ramWriteEnabled;
         this.ramUpdated = mem.ramUpdated;
+        this.motorOn = mem.motorOn;
     }
 
     private record Mbc5Memento(Memento<Battery> batteryMemento, int[] ram, int selectedRamBank, int selectedRomBank,
-                               boolean ramWriteEnabled, boolean ramUpdated) implements Memento<MemoryController> {
+                               boolean ramWriteEnabled, boolean ramUpdated,
+                               boolean motorOn) implements Memento<MemoryController> {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
@@ -1,0 +1,75 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The MBC5 rumble motor (issue #93): on rumble carts (types 0x1C-0x1E) bit 3 of the
+ * RAM-bank register drives the vibration motor, leaving bits 0-2 for the bank select.
+ */
+public class Mbc5RumbleTest {
+
+    private static byte[] rom(int type) {
+        byte[] rom = new byte[0x40000]; // 256 KB, 16 banks
+        rom[0x147] = (byte) type;
+        rom[0x148] = 0x04; // 256 KB
+        rom[0x149] = 0x03; // 4 RAM banks
+        for (int bank = 0; bank < 16; bank++) {
+            rom[bank * 0x4000 + 0x0100] = (byte) (0xB0 + bank);
+        }
+        return rom;
+    }
+
+    private static Mbc5 build(int type, List<Boolean> motorLog) throws IOException {
+        Mbc5 mbc = new Mbc5(new Rom(rom(type)), Battery.NULL_BATTERY);
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        bus.register(e -> motorLog.add(e.on()), Mbc5.RumbleEvent.class);
+        mbc.init(bus);
+        return mbc;
+    }
+
+    @Test
+    public void motorBitPostsEvents() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1c, log); // ROM_MBC5_RUMBLE
+
+        mbc.setByte(0x4000, 0x08); // motor on
+        mbc.setByte(0x4000, 0x08); // idempotent - no duplicate event
+        mbc.setByte(0x4000, 0x00); // motor off
+        assertEquals(List.of(true, false), log);
+    }
+
+    @Test
+    public void motorBitIsNotPartOfTheRamBank() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1e, log); // ROM_MBC5_RUMBLE_SRAM_BATTERY
+
+        // select RAM bank 3 with the motor running: bit 3 must not leak into the bank
+        mbc.setByte(0x0000, 0x0a); // enable RAM
+        mbc.setByte(0x4000, 0x0b); // bank 3 (0b011) + motor (0b1000)
+        mbc.setByte(0xa000, 0x77);
+        // read it back from bank 3 with the motor off
+        mbc.setByte(0x4000, 0x03);
+        assertEquals(0x77, mbc.getByte(0xa000));
+        assertEquals(List.of(true, false), log);
+    }
+
+    @Test
+    public void nonRumbleCartTreatsBit3AsBankBits() throws IOException {
+        List<Boolean> log = new ArrayList<>();
+        Mbc5 mbc = build(0x1a, log); // ROM_MBC5_RAM, no rumble
+
+        // without rumble, bit 3 is an ordinary RAM-bank bit and posts no motor event
+        mbc.setByte(0x0000, 0x0a);
+        mbc.setByte(0x4000, 0x08);
+        assertEquals(List.of(), log);
+    }
+}

--- a/swing/pom.xml
+++ b/swing/pom.xml
@@ -66,5 +66,13 @@
             <artifactId>opencv</artifactId>
             <version>4.9.0-0</version>
         </dependency>
+        <!-- SDL2 via JNA with bundled natives (Linux / Windows / macOS incl. arm64) for
+             game-controller input: SDL's mapping database covers PS3/PS4/PS5, Xbox,
+             Switch Pro and most generic pads, plus force feedback for the rumble carts. -->
+        <dependency>
+            <groupId>io.github.libsdl4j</groupId>
+            <artifactId>libsdl4j</artifactId>
+            <version>2.28.4-1.6</version>
+        </dependency>
     </dependencies>
 </project>

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -13,6 +13,7 @@ import eu.rekawek.coffeegb.swing.io.SwingAccelerometer
 import eu.rekawek.coffeegb.swing.io.SwingTiltKeys
 import eu.rekawek.coffeegb.swing.io.SwingDisplay
 import eu.rekawek.coffeegb.swing.io.SwingJoypad
+import eu.rekawek.coffeegb.swing.io.SwingGamepad
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -24,6 +25,7 @@ class SwingEmulator(
 ) {
   private val display: SwingDisplay
   private val joypad: SwingJoypad
+  private val gamepad: SwingGamepad
   private val sound: AudioSystemSound
   private val accelerometer: SwingAccelerometer
 
@@ -39,6 +41,7 @@ class SwingEmulator(
     display = SwingDisplay(properties.display, eventBus, "main")
     sound = AudioSystemSound(properties.sound, eventBus, "main")
     joypad = SwingJoypad(properties.controllerMapping, eventBus)
+    gamepad = SwingGamepad(eventBus)
     accelerometer = SwingAccelerometer(eventBus, display.preferredSize)
     tiltKeys = SwingTiltKeys(eventBus)
     printer = SwingPrinter(eventBus)
@@ -46,6 +49,7 @@ class SwingEmulator(
 
     Thread(display).start()
     Thread(sound).start()
+    Thread(gamepad, "gamepad").apply { isDaemon = true }.start()
 
     controller = BasicController(eventBus, properties, console).also { it.startController() }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -50,6 +50,12 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private GameboyType gameboyType;
 
+    // the rumble carts' motor (issue #93): while it runs, the picture is jiggled by a
+    // pixel each frame - a dependency-free stand-in for a vibrating console
+    private volatile boolean rumbling;
+
+    private int rumblePhase;
+
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
         this.eventBus = eventBus;
@@ -64,6 +70,7 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> setBlending(e.blending), SetBlendingEvent.class);
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
+        eventBus.register(e -> this.rumbling = e.on(), eu.rekawek.coffeegb.core.memory.cart.type.Mbc5.RumbleEvent.class, callerId);
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());
         setBlending(properties.getBlending());
@@ -157,6 +164,10 @@ public class SwingDisplay extends JPanel implements Runnable {
         Graphics2D g2d = (Graphics2D) g.create();
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+        if (rumbling) {
+            rumblePhase++;
+            g2d.translate((rumblePhase & 2) == 0 ? 1 : -1, (rumblePhase & 1) == 0 ? 1 : -1);
+        }
         switch (rotation) {
             case 90 -> {
                 g2d.translate(h, 0);

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
@@ -1,0 +1,159 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent;
+import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent;
+import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
+import io.github.libsdl4j.api.gamecontroller.SDL_GameController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static io.github.libsdl4j.api.Sdl.SDL_Init;
+import static io.github.libsdl4j.api.SdlSubSystemConst.SDL_INIT_GAMECONTROLLER;
+import static io.github.libsdl4j.api.error.SdlError.SDL_GetError;
+import static io.github.libsdl4j.api.gamecontroller.SDL_GameControllerAxis.SDL_CONTROLLER_AXIS_LEFTX;
+import static io.github.libsdl4j.api.gamecontroller.SDL_GameControllerAxis.SDL_CONTROLLER_AXIS_LEFTY;
+import static io.github.libsdl4j.api.gamecontroller.SDL_GameControllerButton.*;
+import static io.github.libsdl4j.api.gamecontroller.SdlGamecontroller.*;
+import static io.github.libsdl4j.api.joystick.SdlJoystick.SDL_NumJoysticks;
+
+/**
+ * Game-controller input via SDL2 (issue #78): any pad SDL recognizes - PS3/PS4/PS5,
+ * Xbox, Switch Pro, generic HID - works out of the box through SDL's built-in mapping
+ * database. The first connected controller drives the joypad: d-pad or left stick for
+ * the directions, A/B for the buttons, Start, and Back/Select for select. Hotplug is
+ * handled by rescanning while no controller is open.
+ *
+ * <p>The MBC5 rumble carts' motor (issue #93) is forwarded to the controller's force
+ * feedback when it has any.
+ */
+public class SwingGamepad implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SwingGamepad.class);
+
+    private static final int POLL_MS = 8;
+
+    // half of the axis range: the left stick acts as a digital d-pad past this deflection
+    private static final int AXIS_THRESHOLD = 16384;
+
+    private final EventBus eventBus;
+
+    private volatile boolean doStop;
+
+    // written by the event bus, applied on the SDL thread
+    private volatile boolean rumbleRequested;
+
+    private SDL_GameController controller;
+
+    private final Set<Button> pressed = EnumSet.noneOf(Button.class);
+
+    private boolean rumbleActive;
+
+    public SwingGamepad(EventBus eventBus) {
+        this.eventBus = eventBus;
+        eventBus.register(e -> rumbleRequested = e.on(), Mbc5.RumbleEvent.class);
+    }
+
+    public void stop() {
+        doStop = true;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
+                LOG.info("Game controllers unavailable: {}", SDL_GetError());
+                return;
+            }
+        } catch (Throwable e) {
+            // no SDL native for this platform - keyboard input still works
+            LOG.info("Game controllers unavailable: {}", e.toString());
+            return;
+        }
+        while (!doStop) {
+            SDL_GameControllerUpdate();
+            if (controller == null) {
+                openFirstController();
+            } else if (!SDL_GameControllerGetAttached(controller)) {
+                LOG.info("Game controller disconnected");
+                SDL_GameControllerClose(controller);
+                controller = null;
+                releaseAll();
+            }
+            if (controller != null) {
+                pollButtons();
+                applyRumble();
+            }
+            try {
+                Thread.sleep(POLL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private void openFirstController() {
+        int joysticks = SDL_NumJoysticks();
+        for (int i = 0; i < joysticks; i++) {
+            if (SDL_IsGameController(i)) {
+                controller = SDL_GameControllerOpen(i);
+                if (controller != null) {
+                    LOG.info("Game controller connected: {}", SDL_GameControllerName(controller));
+                    return;
+                }
+            }
+        }
+    }
+
+    private void pollButtons() {
+        int x = SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX);
+        int y = SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY);
+        update(Button.UP, isDown(SDL_CONTROLLER_BUTTON_DPAD_UP) || y < -AXIS_THRESHOLD);
+        update(Button.DOWN, isDown(SDL_CONTROLLER_BUTTON_DPAD_DOWN) || y > AXIS_THRESHOLD);
+        update(Button.LEFT, isDown(SDL_CONTROLLER_BUTTON_DPAD_LEFT) || x < -AXIS_THRESHOLD);
+        update(Button.RIGHT, isDown(SDL_CONTROLLER_BUTTON_DPAD_RIGHT) || x > AXIS_THRESHOLD);
+        update(Button.A, isDown(SDL_CONTROLLER_BUTTON_A));
+        update(Button.B, isDown(SDL_CONTROLLER_BUTTON_B) || isDown(SDL_CONTROLLER_BUTTON_X));
+        update(Button.START, isDown(SDL_CONTROLLER_BUTTON_START));
+        update(Button.SELECT, isDown(SDL_CONTROLLER_BUTTON_BACK));
+    }
+
+    private boolean isDown(int button) {
+        return SDL_GameControllerGetButton(controller, button) != 0;
+    }
+
+    private void update(Button button, boolean down) {
+        if (down && pressed.add(button)) {
+            eventBus.post(new ButtonPressEvent(button));
+        } else if (!down && pressed.remove(button)) {
+            eventBus.post(new ButtonReleaseEvent(button));
+        }
+    }
+
+    private void releaseAll() {
+        for (Button button : pressed) {
+            eventBus.post(new ButtonReleaseEvent(button));
+        }
+        pressed.clear();
+    }
+
+    private void applyRumble() {
+        boolean requested = rumbleRequested;
+        if (requested == rumbleActive) {
+            return;
+        }
+        rumbleActive = requested;
+        if (SDL_GameControllerHasRumble(controller)) {
+            // the cart holds the motor line for as long as it rumbles; refresh with a
+            // generous duration and cut it on the off transition
+            SDL_GameControllerRumble(controller,
+                    (short) (requested ? 0xffff : 0), (short) (requested ? 0xffff : 0),
+                    requested ? 60_000 : 0);
+        }
+    }
+}


### PR DESCRIPTION
Addresses #78 (and the force-feedback half of #93).

## What
Adds game-controller input to the Swing emulator via **SDL2** ([libsdl4j](https://github.com/libsdl4j/libsdl4j) from Maven Central — SDL2 through JNA with bundled natives for Linux, Windows and macOS incl. arm64, same spirit as the bundled-natives OpenCV dep already used for the webcam).

- **Any pad SDL recognizes works out of the box** — PS3/PS4/PS5, Xbox, Switch Pro, and most generic HID pads — through SDL's built-in controller-mapping database.
- Mapping: d-pad **or** left stick → directions, A/B (X doubles as B), Start, Back/Select → select. Keyboard input stays fully functional alongside.
- **Hotplug**: connect/disconnect any time; the backend rescans while no controller is open and releases held buttons on disconnect.
- **Rumble**: the MBC5 rumble carts' motor (#93) is forwarded to the controller's force feedback when the pad has any (Pokémon Pinball buzzes your DualShock).
- Graceful degradation: on platforms without an SDL native the backend logs once and the emulator runs as before.

## Notes
- Stacked on #96 (contains its commit — the `RumbleEvent` this forwards); merging #96 first reduces this to one commit.
- Verified headless: `SDL_Init(SDL_INIT_GAMECONTROLLER)` succeeds without a display server and with zero controllers connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8