### PR TITLE
Find system SDL2 on macOS so game controllers work there (#78)

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
@@ -4,12 +4,15 @@ import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.joypad.Button;
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent;
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent;
+import com.sun.jna.NativeLibrary;
 import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
 import io.github.libsdl4j.api.gamecontroller.SDL_GameController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import static io.github.libsdl4j.api.Sdl.SDL_Init;
@@ -30,6 +33,11 @@ import static io.github.libsdl4j.api.joystick.SdlJoystick.SDL_NumJoysticks;
  *
  * <p>The MBC5 rumble carts' motor (issue #93) is forwarded to the controller's force
  * feedback when it has any.
+ *
+ * <p>libsdl4j bundles the SDL2 native only for Linux and Windows. On macOS SDL2 must be
+ * installed separately ({@code brew install sdl2}); this looks it up in Homebrew's lib
+ * directories, which JNA does not search by default, and otherwise degrades to
+ * keyboard-only input with a hint in the log.
  */
 public class SwingGamepad implements Runnable {
 
@@ -64,13 +72,23 @@ public class SwingGamepad implements Runnable {
 
     @Override
     public void run() {
+        locateSystemSdl();
         try {
             if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
                 LOG.info("Game controllers unavailable: {}", SDL_GetError());
                 return;
             }
+        } catch (UnsatisfiedLinkError e) {
+            // no SDL2 library on this machine - keyboard input still works. libsdl4j
+            // bundles the native only for Linux and Windows; macOS must supply its own.
+            if (isMac()) {
+                LOG.warn("Game controllers need SDL2, which macOS builds don't bundle. "
+                        + "Install it with 'brew install sdl2' and restart. Keyboard input still works.");
+            } else {
+                LOG.info("Game controllers unavailable (no SDL2 native): {}", e.getMessage());
+            }
+            return;
         } catch (Throwable e) {
-            // no SDL native for this platform - keyboard input still works
             LOG.info("Game controllers unavailable: {}", e.toString());
             return;
         }
@@ -93,6 +111,25 @@ public class SwingGamepad implements Runnable {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;
+            }
+        }
+    }
+
+    private static boolean isMac() {
+        return System.getProperty("os.name", "").toLowerCase().contains("mac");
+    }
+
+    // libsdl4j ships the native only for Linux and Windows; on macOS SDL2 comes from a
+    // system install (Homebrew). JNA's default dlopen search misses Homebrew's dirs - the
+    // Apple-Silicon prefix /opt/homebrew/lib especially - so add them explicitly for the
+    // "SDL2" library JNA will look up.
+    private static void locateSystemSdl() {
+        if (!isMac()) {
+            return;
+        }
+        for (String dir : List.of("/opt/homebrew/lib", "/usr/local/lib")) {
+            if (new File(dir, "libSDL2.dylib").exists()) {
+                NativeLibrary.addSearchPath("SDL2", dir);
             }
         }
     }


### PR DESCRIPTION
Fixes the macOS half of #78, reported after the merge:

```
Game controllers unavailable: java.lang.UnsatisfiedLinkError: Unable to load library 'SDL2'
Native library (darwin-aarch64/libSDL2.dylib) not found in resource path (...)
```

## Cause
libsdl4j 2.28.4-1.6 bundles the SDL2 native only for **Linux and Windows** — there is no macOS dylib in the jar (my original PR blurb wrongly said otherwise). macOS gets SDL2 from Homebrew, but JNA's default `dlopen` search never looks in Homebrew's directories — notably the Apple-Silicon prefix `/opt/homebrew/lib` (the failing trace tries `/usr/local/lib` but not `/opt/homebrew/lib`).

## Fix
- Before init on macOS, register `/opt/homebrew/lib` and `/usr/local/lib` as JNA search paths for the `SDL2` library when `libSDL2.dylib` is actually present there. So the whole fix for a Mac user is **`brew install sdl2`** (Intel or Apple Silicon), then restart.
- If SDL2 still isn't loadable, catch the `UnsatisfiedLinkError` and log a single actionable line (`Install it with 'brew install sdl2'`) instead of the dlopen wall. Keyboard input is unaffected, as before.
- Linux/Windows behaviour is unchanged (the helper is a no-op off macOS).

## Verified
- Forcing the macOS path on a machine without SDL2 now logs the `brew install sdl2` hint and does not crash (keyboard play continues).
- Linux still loads the bundled native and runs normally.

The class javadoc now documents the macOS requirement. (I can't build/sign a macOS dylib to bundle from CI here; the Homebrew route is the standard approach for JNA-based SDL on macOS.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1wLWscyUGS7CFwc3CjJR8