### PR TITLE
Add MBC30 banking support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,8 @@ jobs:
       run: mvn -B -pl core test -Ptest-blargg-individual
     - name: Daid tests (baseline-guarded)
       run: mvn -B -pl core test -Ptest-daid
+    - name: MBC30 tests
+      run: mvn -B -pl core test -Ptest-mbc30
     - name: dmg-acid2
       run: mvn -B -pl core test -Ptest-dmgacid2
     - name: Mealybug Tearoom (baseline-guarded)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -19,6 +19,8 @@ public class Mbc3 implements MemoryController {
 
     private final Battery battery;
 
+    private final boolean mbc30;
+
     private int selectedRamBank;
 
     private int selectedRomBank = 1;
@@ -35,6 +37,7 @@ public class Mbc3 implements MemoryController {
         Arrays.fill(ram, 0xff);
         this.clock = new RealTimeClock(new SystemTimeSource());
         this.battery = battery;
+        this.mbc30 = rom.getRomBanks() > 128 || rom.getRamBanks() > 4;
 
         long[] clockData = new long[12];
         battery.loadRamWithClock(ram, clockData);
@@ -51,7 +54,7 @@ public class Mbc3 implements MemoryController {
         if (address >= 0x0000 && address < 0x2000) {
             ramWriteEnabled = (value & 0b1010) != 0;
         } else if (address >= 0x2000 && address < 0x4000) {
-            int bank = value & 0b01111111;
+            int bank = value & (mbc30 ? 0xff : 0x7f);
             selectRomBank(bank);
         } else if (address >= 0x4000 && address < 0x6000) {
             selectedRamBank = value;
@@ -66,7 +69,7 @@ public class Mbc3 implements MemoryController {
                 }
             }
             latchClockReg = value;
-        } else if (address >= 0xa000 && address < 0xc000 && ramWriteEnabled && selectedRamBank < 4) {
+        } else if (address >= 0xa000 && address < 0xc000 && ramWriteEnabled && isRamBankSelected()) {
             int ramAddress = getRamAddress(address);
             if (ramAddress < ram.length) {
                 ram[ramAddress] = value;
@@ -95,7 +98,7 @@ public class Mbc3 implements MemoryController {
             return getRomByte(0, address);
         } else if (address >= 0x4000 && address < 0x8000) {
             return getRomByte(selectedRomBank, address - 0x4000);
-        } else if (address >= 0xa000 && address < 0xc000 && selectedRamBank < 4) {
+        } else if (address >= 0xa000 && address < 0xc000 && isRamBankSelected()) {
             int ramAddress = getRamAddress(address);
             if (ramAddress < ram.length) {
                 return ram[ramAddress];
@@ -120,6 +123,10 @@ public class Mbc3 implements MemoryController {
 
     private int getRamAddress(int address) {
         return selectedRamBank * 0x2000 + (address - 0xa000);
+    }
+
+    private boolean isRamBankSelected() {
+        return selectedRamBank < (mbc30 ? 8 : 4);
     }
 
     private int getTimer() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3Test.java
@@ -1,0 +1,61 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class Mbc3Test {
+
+    private static Mbc3 buildMbc3() throws IOException {
+        byte[] data = new byte[0x200000];
+        data[0x147] = 0x13; // MBC3 + RAM + battery
+        data[0x148] = 0x06; // 2 MiB / 128 ROM banks
+        data[0x149] = 0x03; // 32 KiB / four RAM banks
+        data[0x4000] = 0x24;
+        return new Mbc3(new Rom(data), Battery.NULL_BATTERY);
+    }
+
+    private static Mbc3 buildMbc30() throws IOException {
+        byte[] data = new byte[0x400000];
+        data[0x147] = 0x13; // MBC3 + RAM + battery
+        data[0x148] = 0x07; // 4 MiB / 256 ROM banks
+        data[0x149] = 0x05; // 64 KiB / eight RAM banks
+        data[0x80 * 0x4000] = 0x42;
+        return new Mbc3(new Rom(data), Battery.NULL_BATTERY);
+    }
+
+    @Test
+    public void mbc30UsesEightBitRomBankNumbers() throws IOException {
+        Mbc3 mbc30 = buildMbc30();
+
+        mbc30.setByte(0x2000, 0x80);
+
+        assertEquals(0x42, mbc30.getByte(0x4000));
+    }
+
+    @Test
+    public void regularMbc3IgnoresTheEighthRomBankBit() throws IOException {
+        Mbc3 mbc3 = buildMbc3();
+
+        mbc3.setByte(0x2000, 0x80);
+
+        assertEquals(0x24, mbc3.getByte(0x4000));
+    }
+
+    @Test
+    public void mbc30CanSelectAllEightRamBanks() throws IOException {
+        Mbc3 mbc30 = buildMbc30();
+        mbc30.setByte(0x0000, 0x0a);
+
+        mbc30.setByte(0x4000, 7);
+        mbc30.setByte(0xa000, 0x42);
+        mbc30.setByte(0x4000, 3);
+        assertEquals(0xff, mbc30.getByte(0xa000));
+        mbc30.setByte(0x4000, 7);
+        assertEquals(0x42, mbc30.getByte(0xa000));
+    }
+}


### PR DESCRIPTION
## Summary
- enable the eighth ROM bank bit for MBC30-sized cartridges
- expose all eight MBC30 SRAM banks while preserving regular MBC3 masking
- add mapper regression coverage and run the MBC30 suite in GitHub Actions

## Verification
- Core unit suite: 91 tests pass
- MBC30 integration profile: passes