### PR TITLE
Fix BullyGB hardware checks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,8 @@ jobs:
       run: mvn -B -pl core test -Ptest-blargg-individual
     - name: Daid tests (baseline-guarded)
       run: mvn -B -pl core test -Ptest-daid
+    - name: BullyGB tests
+      run: mvn -B -pl core test -Ptest-bullygb
     - name: dmg-acid2
       run: mvn -B -pl core test -Ptest-dmgacid2
     - name: Mealybug Tearoom (baseline-guarded)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -167,7 +167,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         mmu.indexSpaces();
         mmu.setBusListener(cartridge.getSachenMmc());
 
-        cpu = new Cpu(getAddressSpace(), interruptManager, gpu, speedMode, display);
+        cpu = new Cpu(new DmaCpuAddressSpace(getAddressSpace(), dma, gbc),
+                interruptManager, gpu, speedMode, display);
 
         interruptManager.disableInterrupts(false);
         if (configuration.bootstrapMode != BootstrapMode.SKIP) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -67,6 +67,32 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
         return restarted || (transferInProgress && ticks >= 5);
     }
 
+    public boolean isCpuAccessBlocked(int address, boolean gbc) {
+        if (!isOamBlocked() || address == 0xff46 || (address >= 0xfe00 && address < 0xff00)
+                || (address >= 0xff80 && address < 0xffff)) {
+            return false;
+        }
+        int cpuBus = getBus(address, gbc);
+        return cpuBus >= 0 && cpuBus == getBus(from, gbc);
+    }
+
+    public int getCpuBusValue() {
+        int byteIndex = Math.max(0, Math.min(0x9f, (ticks - 5) / 4));
+        return addressSpace.getByte(from + byteIndex);
+    }
+
+    private static int getBus(int address, boolean gbc) {
+        if (address < 0x8000 || (address >= 0xa000 && address < 0xc000)) {
+            return 0; // cartridge
+        } else if (address >= 0x8000 && address < 0xa000) {
+            return 1; // VRAM
+        } else if (address >= 0xc000 && address < 0xfe00) {
+            return gbc ? 2 : 0; // WRAM has its own bus only on CGB
+        } else {
+            return -1; // OAM, I/O and HRAM are not on a DMA source bus
+        }
+    }
+
     @Override
     public Memento<Dma> saveToMemento() {
         return new DmaMemento(transferInProgress, restarted, from, ticks, regValue);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
@@ -1,0 +1,41 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+
+import java.io.Serializable;
+
+/** Applies OAM DMA bus conflicts to memory accesses made by the CPU. */
+public class DmaCpuAddressSpace implements AddressSpace, Serializable {
+
+    private final AddressSpace addressSpace;
+
+    private final Dma dma;
+
+    private final boolean gbc;
+
+    public DmaCpuAddressSpace(AddressSpace addressSpace, Dma dma, boolean gbc) {
+        this.addressSpace = addressSpace;
+        this.dma = dma;
+        this.gbc = gbc;
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return true;
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (!dma.isCpuAccessBlocked(address, gbc)) {
+            addressSpace.setByte(address, value);
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (dma.isCpuAccessBlocked(address, gbc)) {
+            return dma.getCpuBusValue();
+        }
+        return addressSpace.getByte(address);
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -31,6 +31,7 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
 
     public void setSpeedMode(eu.rekawek.coffeegb.core.cpu.SpeedMode speedMode) {
         gbcRam.setSpeedMode(speedMode);
+        undocumentedGbcRegisters.setSpeedMode(speedMode);
     }
 
     private final UndocumentedGbcRegisters undocumentedGbcRegisters = new UndocumentedGbcRegisters();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegisters.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegisters.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -13,10 +14,15 @@ public class UndocumentedGbcRegisters implements AddressSpace, Serializable, Ori
 
     private int xff6c;
 
+    private SpeedMode speedMode;
+
     public UndocumentedGbcRegisters() {
         xff6c = 0xfe;
-        ram.setByte(0xff74, 0xff);
         ram.setByte(0xff75, 0x8f);
+    }
+
+    public void setSpeedMode(SpeedMode speedMode) {
+        this.speedMode = speedMode;
     }
 
     @Override
@@ -33,8 +39,13 @@ public class UndocumentedGbcRegisters implements AddressSpace, Serializable, Ori
 
             case 0xff72:
             case 0xff73:
-            case 0xff74:
                 ram.setByte(address, value);
+                break;
+
+            case 0xff74:
+                if (speedMode == null || !speedMode.isDmgCompat()) {
+                    ram.setByte(address, value);
+                }
                 break;
 
             case 0xff75:
@@ -46,6 +57,8 @@ public class UndocumentedGbcRegisters implements AddressSpace, Serializable, Ori
     public int getByte(int address) {
         if (address == 0xff6c) {
             return xff6c;
+        } else if (address == 0xff74 && speedMode != null && speedMode.isDmgCompat()) {
+            return 0xff;
         } else if (ram.accepts(address)) {
             return ram.getByte(address);
         } else {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/BullyGbTestRunner.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/BullyGbTestRunner.java
@@ -28,7 +28,7 @@ public class BullyGbTestRunner {
     public BullyGbTestRunner(File romFile, GameboyType gameboyType) throws IOException {
         EventBus eventBus = new EventBusImpl();
         gb = new Gameboy.GameboyConfiguration(romFile)
-                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
                 .setGameboyType(gameboyType)
                 .setSupportBatterySave(false)
                 .build();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
@@ -1,0 +1,83 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DmaCpuAddressSpaceTest {
+
+    @Test
+    public void dmgSharesTheCartridgeAndWramBusButNotVram() {
+        Fixture fixture = new Fixture(false, 0x12);
+
+        assertEquals(0x42, fixture.cpu.getByte(0x0100));
+        assertEquals(0x42, fixture.cpu.getByte(0xc001));
+        assertEquals(0x55, fixture.cpu.getByte(0x8000));
+        assertEquals(0x33, fixture.cpu.getByte(0xff80));
+
+        fixture.cpu.setByte(0xc001, 0x99);
+        fixture.cpu.setByte(0xff80, 0x99);
+        assertEquals(0x22, fixture.memory.getByte(0xc001));
+        assertEquals(0x99, fixture.memory.getByte(0xff80));
+    }
+
+    @Test
+    public void cgbBlocksOnlyTheCartridgeBusDuringRomDma() {
+        Fixture fixture = new Fixture(true, 0x12);
+
+        assertEquals(0x42, fixture.cpu.getByte(0x0100));
+        assertEquals(0x22, fixture.cpu.getByte(0xc001));
+    }
+
+    @Test
+    public void cgbCanUseTheCartridgeBusDuringWramDma() {
+        Fixture fixture = new Fixture(true, 0xc0);
+
+        assertEquals(0x11, fixture.cpu.getByte(0x0100));
+        assertEquals(0x42, fixture.cpu.getByte(0xc001));
+    }
+
+    private static class Fixture {
+
+        private final TestAddressSpace memory = new TestAddressSpace();
+
+        private final DmaCpuAddressSpace cpu;
+
+        private Fixture(boolean gbc, int sourceHigh) {
+            memory.setByte(0x0100, 0x11);
+            memory.setByte(0x8000, 0x55);
+            memory.setByte(0xc001, 0x22);
+            memory.setByte(0xff80, 0x33);
+            memory.setByte(sourceHigh << 8, 0x42);
+
+            Dma dma = new Dma(memory, new Ram(0xfe00, 0xa0), new SpeedMode(gbc));
+            cpu = new DmaCpuAddressSpace(memory, dma, gbc);
+            dma.setByte(0xff46, sourceHigh);
+            for (int i = 0; i < 5; i++) {
+                dma.tick();
+            }
+        }
+    }
+
+    private static class TestAddressSpace implements AddressSpace {
+
+        private final int[] data = new int[0x10000];
+
+        @Override
+        public boolean accepts(int address) {
+            return true;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            data[address] = value;
+        }
+
+        @Override
+        public int getByte(int address) {
+            return data[address];
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegistersTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegistersTest.java
@@ -1,0 +1,44 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UndocumentedGbcRegistersTest {
+
+    @Test
+    public void hasCgbPowerOnValues() {
+        UndocumentedGbcRegisters registers = new UndocumentedGbcRegisters();
+
+        assertEquals(0x00, registers.getByte(0xff72));
+        assertEquals(0x00, registers.getByte(0xff73));
+        assertEquals(0x00, registers.getByte(0xff74));
+        assertEquals(0x8f, registers.getByte(0xff75));
+    }
+
+    @Test
+    public void undocumentedStorageRegistersRemainWritable() {
+        UndocumentedGbcRegisters registers = new UndocumentedGbcRegisters();
+
+        registers.setByte(0xff72, 0xff);
+        registers.setByte(0xff73, 0xff);
+        registers.setByte(0xff74, 0xff);
+
+        assertEquals(0xff, registers.getByte(0xff72));
+        assertEquals(0xff, registers.getByte(0xff73));
+        assertEquals(0xff, registers.getByte(0xff74));
+    }
+
+    @Test
+    public void ff74IsDisabledInDmgCompatibilityMode() {
+        UndocumentedGbcRegisters registers = new UndocumentedGbcRegisters();
+        SpeedMode speedMode = new SpeedMode(true);
+        speedMode.setDmgCompat(true);
+        registers.setSpeedMode(speedMode);
+
+        assertEquals(0xff, registers.getByte(0xff74));
+        registers.setByte(0xff74, 0x42);
+        assertEquals(0xff, registers.getByte(0xff74));
+    }
+}


### PR DESCRIPTION
## Summary
- model CPU-visible OAM DMA bus conflicts on DMG and CGB
- use native boot state in the BullyGB runner and correct FF74 behavior by compatibility mode
- run BullyGB in GitHub Actions

## Verification
- core unit tests: 94 passed
- BullyGB: DMG and CGB passed
- Mooneye: 98 passed