### PR TITLE
Fix MBC3 real-time clock behavior

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,8 @@ jobs:
       run: mvn -B -pl core test -Ptest-daid
     - name: MBC30 tests
       run: mvn -B -pl core test -Ptest-mbc30
+    - name: RTC3 tests
+      run: mvn -B -pl core test -Ptest-rtc3
     - name: dmg-acid2
       run: mvn -B -pl core test -Ptest-dmgacid2
     - name: Mealybug Tearoom (baseline-guarded)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -15,6 +15,8 @@ import eu.rekawek.coffeegb.core.memory.*;
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import eu.rekawek.coffeegb.core.serial.SerialPort;
 import eu.rekawek.coffeegb.core.sgb.Background;
@@ -132,9 +134,11 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         infraredPort = new eu.rekawek.coffeegb.core.ir.InfraredPort(gbc, speedMode);
 
         if (configuration.batteryData != null) {
-            cartridge = new Cartridge(configuration.rom, new MemoryBattery(configuration.batteryData));
+            cartridge = new Cartridge(configuration.rom, new MemoryBattery(configuration.batteryData),
+                    configuration.rtcTimeSource);
         } else {
-            cartridge = new Cartridge(configuration.rom, configuration.supportBatterySave);
+            cartridge = new Cartridge(configuration.rom, configuration.supportBatterySave,
+                    configuration.rtcTimeSource);
         }
         if (configuration.slotRom != null && cartridge.getDatel() != null) {
             // the game cartridge in the Action Replay's pass-through slot
@@ -529,6 +533,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
         private boolean cgb0Revision;
 
+        private TimeSource rtcTimeSource = new SystemTimeSource();
+
         public GameboyConfiguration(File romFile) throws IOException {
             this(new Rom(romFile));
         }
@@ -590,6 +596,11 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             return this;
         }
 
+        public GameboyConfiguration setRtcTimeSource(TimeSource rtcTimeSource) {
+            this.rtcTimeSource = rtcTimeSource;
+            return this;
+        }
+
         /**
          * A copy of this configuration that skips the boot sequence, for building a
          * Gameboy whose state is immediately overwritten by a memento restore. With
@@ -605,6 +616,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             copy.supportBatterySave = supportBatterySave;
             copy.displaySgbBorder = displaySgbBorder;
             copy.cgb0Revision = cgb0Revision;
+            copy.rtcTimeSource = rtcTimeSource;
             return copy;
         }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -6,6 +6,8 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.type.*;
 import org.apache.commons.io.FilenameUtils;
 
@@ -19,12 +21,22 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
     private final Battery battery;
 
     public Cartridge(Rom rom, boolean supportBatterySaves) {
-        this(rom, supportBatterySaves && rom.getFile() != null ? createBattery(rom) : Battery.NULL_BATTERY);
+        this(rom, supportBatterySaves && rom.getFile() != null ? createBattery(rom) : Battery.NULL_BATTERY,
+                new SystemTimeSource());
     }
 
     private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B, 0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
 
     public Cartridge(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource());
+    }
+
+    public Cartridge(Rom rom, boolean supportBatterySaves, TimeSource rtcTimeSource) {
+        this(rom, supportBatterySaves && rom.getFile() != null ? createBattery(rom) : Battery.NULL_BATTERY,
+                rtcTimeSource);
+    }
+
+    public Cartridge(Rom rom, Battery battery, TimeSource rtcTimeSource) {
         this.battery = battery;
 
         var type = rom.getType();
@@ -54,7 +66,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         } else if (type.isMbc2()) {
             addressSpace = new Mbc2(rom, battery);
         } else if (type.isMbc3()) {
-            addressSpace = new Mbc3(rom, battery);
+            addressSpace = new Mbc3(rom, battery, rtcTimeSource);
         } else if (type.isMbc5()) {
             addressSpace = new Mbc5(rom, battery);
         } else if (type.isMbc6()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
@@ -7,157 +7,246 @@ import java.io.Serializable;
 
 public class RealTimeClock implements Serializable, Originator<RealTimeClock> {
 
+    private static final long SECONDS_PER_DAY = 24 * 60 * 60;
+
+    private static final long SECONDS_PER_CYCLE = 512 * SECONDS_PER_DAY;
+
     private final TimeSource timeSource;
 
-    private long offsetSec;
+    private int seconds;
 
-    private long clockStart;
+    private int minutes;
+
+    private int hours;
+
+    private int days;
 
     private boolean halt;
 
-    private long latchStart;
+    private boolean counterOverflow;
 
-    private int haltSeconds;
+    private long lastUpdateMillis;
 
-    private int haltMinutes;
+    private int subSecondMillis;
 
-    private int haltHours;
+    private boolean latched;
 
-    private int haltDays;
+    private int latchedSeconds;
+
+    private int latchedMinutes;
+
+    private int latchedHours;
+
+    private int latchedDays;
+
+    private boolean latchedHalt;
+
+    private boolean latchedCounterOverflow;
 
     public RealTimeClock(TimeSource timeSource) {
         this.timeSource = timeSource;
-        this.clockStart = timeSource.currentTimeMillis();
+        this.lastUpdateMillis = timeSource.currentTimeMillis();
     }
 
     public void latch() {
-        latchStart = timeSource.currentTimeMillis();
+        updateClock();
+        latchedSeconds = seconds;
+        latchedMinutes = minutes;
+        latchedHours = hours;
+        latchedDays = days;
+        latchedHalt = halt;
+        latchedCounterOverflow = counterOverflow;
+        latched = true;
     }
 
     public void unlatch() {
-        latchStart = 0;
+        latched = false;
     }
 
     public int getSeconds() {
-        return (int) (clockTimeInSec() % 60);
+        updateClock();
+        return latched ? latchedSeconds : seconds;
     }
 
     public int getMinutes() {
-        return (int) ((clockTimeInSec() % (60 * 60)) / 60);
+        updateClock();
+        return latched ? latchedMinutes : minutes;
     }
 
     public int getHours() {
-        return (int) ((clockTimeInSec() % (60 * 60 * 24)) / (60 * 60));
+        updateClock();
+        return latched ? latchedHours : hours;
     }
 
     public int getDayCounter() {
-        return (int) (clockTimeInSec() % (60 * 60 * 24 * 512) / (60 * 60 * 24));
+        updateClock();
+        return latched ? latchedDays : days;
     }
 
     public boolean isHalt() {
-        return halt;
+        updateClock();
+        return latched ? latchedHalt : halt;
     }
 
     public boolean isCounterOverflow() {
-        return clockTimeInSec() >= 60 * 60 * 24 * 512;
+        updateClock();
+        return latched ? latchedCounterOverflow : counterOverflow;
     }
 
     public void setSeconds(int seconds) {
-        if (!halt) {
-            return;
-        }
-        haltSeconds = seconds;
+        updateClock();
+        this.seconds = seconds & 0x3f;
+        subSecondMillis = 0;
     }
 
     public void setMinutes(int minutes) {
-        if (!halt) {
-            return;
-        }
-        haltMinutes = minutes;
+        updateClock();
+        this.minutes = minutes & 0x3f;
     }
 
     public void setHours(int hours) {
-        if (!halt) {
-            return;
-        }
-        haltHours = hours;
+        updateClock();
+        this.hours = hours & 0x1f;
     }
 
     public void setDayCounter(int dayCounter) {
-        if (!halt) {
-            return;
-        }
-        haltDays = dayCounter;
+        updateClock();
+        this.days = dayCounter & 0x1ff;
+    }
+
+    public void setDayCounterLow(int value) {
+        updateClock();
+        days = (days & 0x100) | (value & 0xff);
+    }
+
+    public void setDayCounterHigh(int value) {
+        updateClock();
+        days = (days & 0xff) | ((value & 1) << 8);
     }
 
     public void setHalt(boolean halt) {
-        if (halt && !this.halt) {
-            latch();
-            haltSeconds = getSeconds();
-            haltMinutes = getMinutes();
-            haltHours = getHours();
-            haltDays = getDayCounter();
-            unlatch();
-        } else if (!halt && this.halt) {
-            offsetSec =
-                    haltSeconds
-                            + haltMinutes * 60L
-                            + (long) haltHours * 60 * 60
-                            + (long) haltDays * 60 * 60 * 24;
-            clockStart = timeSource.currentTimeMillis();
-        }
+        updateClock();
         this.halt = halt;
     }
 
+    public void setCounterOverflow(boolean counterOverflow) {
+        updateClock();
+        this.counterOverflow = counterOverflow;
+    }
+
     public void clearCounterOverflow() {
-        while (isCounterOverflow()) {
-            offsetSec -= 60 * 60 * 24 * 512;
+        setCounterOverflow(false);
+    }
+
+    private void updateClock() {
+        long now = timeSource.currentTimeMillis();
+        long elapsedMillis = Math.max(0, now - lastUpdateMillis);
+        lastUpdateMillis = now;
+        if (halt || elapsedMillis == 0) {
+            return;
+        }
+
+        long elapsedWithRemainder = elapsedMillis + subSecondMillis;
+        subSecondMillis = (int) (elapsedWithRemainder % 1000);
+        advanceSeconds(elapsedWithRemainder / 1000);
+    }
+
+    private void advanceSeconds(long count) {
+        while (count > 0 && (seconds > 59 || minutes > 59 || hours > 23)) {
+            tickSecond();
+            count--;
+        }
+        if (count == 0) {
+            return;
+        }
+
+        long total = days * SECONDS_PER_DAY + hours * 3600L + minutes * 60L + seconds + count;
+        if (total >= SECONDS_PER_CYCLE) {
+            counterOverflow = true;
+        }
+        total %= SECONDS_PER_CYCLE;
+        days = (int) (total / SECONDS_PER_DAY);
+        total %= SECONDS_PER_DAY;
+        hours = (int) (total / 3600);
+        total %= 3600;
+        minutes = (int) (total / 60);
+        seconds = (int) (total % 60);
+    }
+
+    private void tickSecond() {
+        if (seconds == 59) {
+            seconds = 0;
+            tickMinute();
+        } else if (seconds == 63) {
+            seconds = 0;
+        } else {
+            seconds = (seconds + 1) & 0x3f;
         }
     }
 
-    private long clockTimeInSec() {
-        long now;
-        if (latchStart == 0) {
-            now = timeSource.currentTimeMillis();
+    private void tickMinute() {
+        if (minutes == 59) {
+            minutes = 0;
+            tickHour();
+        } else if (minutes == 63) {
+            minutes = 0;
         } else {
-            now = latchStart;
+            minutes = (minutes + 1) & 0x3f;
         }
-        return (now - clockStart) / 1000 + offsetSec;
+    }
+
+    private void tickHour() {
+        if (hours == 23) {
+            hours = 0;
+            if (++days == 512) {
+                days = 0;
+                counterOverflow = true;
+            }
+        } else if (hours == 31) {
+            hours = 0;
+        } else {
+            hours = (hours + 1) & 0x1f;
+        }
     }
 
     public void deserialize(long[] clockData) {
-        long seconds = clockData[0];
-        long minutes = clockData[1];
-        long hours = clockData[2];
-        long days = clockData[3];
-        long daysHigh = clockData[4];
-        long timestamp = clockData[10];
+        seconds = (int) clockData[0] & 0x3f;
+        minutes = (int) clockData[1] & 0x3f;
+        hours = (int) clockData[2] & 0x1f;
+        int control = (int) clockData[4];
+        days = ((control & 1) << 8) | ((int) clockData[3] & 0xff);
+        halt = (control & 0x40) != 0;
+        counterOverflow = (control & 0x80) != 0;
+        latched = false;
+        subSecondMillis = 0;
 
-        this.clockStart = timestamp * 1000;
-        this.offsetSec =
-                seconds
-                        + minutes * 60
-                        + hours * 60 * 60
-                        + days * 24 * 60 * 60
-                        + daysHigh * 256 * 24 * 60 * 60;
+        long now = timeSource.currentTimeMillis();
+        lastUpdateMillis = now;
+        long timestampMillis = clockData[10] * 1000;
+        if (!halt && timestampMillis > 0 && now > timestampMillis) {
+            advanceSeconds((now - timestampMillis) / 1000);
+        }
     }
 
     public long[] serialize() {
+        updateClock();
+        long control = ((days >> 8) & 1) | (halt ? 0x40 : 0) | (counterOverflow ? 0x80 : 0);
         long[] clockData = new long[11];
-        latch();
-        clockData[0] = clockData[5] = getSeconds();
-        clockData[1] = clockData[6] = getMinutes();
-        clockData[2] = clockData[7] = getHours();
-        clockData[3] = clockData[8] = getDayCounter() % 256;
-        clockData[4] = clockData[9] = getDayCounter() / 256;
-        clockData[10] = latchStart / 1000;
-        unlatch();
+        clockData[0] = clockData[5] = seconds;
+        clockData[1] = clockData[6] = minutes;
+        clockData[2] = clockData[7] = hours;
+        clockData[3] = clockData[8] = days & 0xff;
+        clockData[4] = clockData[9] = control;
+        clockData[10] = timeSource.currentTimeMillis() / 1000;
         return clockData;
     }
 
     @Override
     public Memento<RealTimeClock> saveToMemento() {
-        return new RealTimeClockMemento(offsetSec, clockStart, halt, latchStart, haltSeconds, haltMinutes, haltHours, haltDays);
+        updateClock();
+        return new RealTimeClockMemento(seconds, minutes, hours, days, halt, counterOverflow, lastUpdateMillis,
+                subSecondMillis, latched, latchedSeconds, latchedMinutes, latchedHours, latchedDays, latchedHalt,
+                latchedCounterOverflow);
     }
 
     @Override
@@ -165,18 +254,27 @@ public class RealTimeClock implements Serializable, Originator<RealTimeClock> {
         if (!(memento instanceof RealTimeClockMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");
         }
-        this.offsetSec = mem.offsetSec;
-        this.clockStart = mem.clockStart;
-        this.halt = mem.halt;
-        this.latchStart = mem.latchStart;
-        this.haltSeconds = mem.haltSeconds;
-        this.haltMinutes = mem.haltMinutes;
-        this.haltHours = mem.haltHours;
-        this.haltDays = mem.haltDays;
+        seconds = mem.seconds;
+        minutes = mem.minutes;
+        hours = mem.hours;
+        days = mem.days;
+        halt = mem.halt;
+        counterOverflow = mem.counterOverflow;
+        lastUpdateMillis = mem.lastUpdateMillis;
+        subSecondMillis = mem.subSecondMillis;
+        latched = mem.latched;
+        latchedSeconds = mem.latchedSeconds;
+        latchedMinutes = mem.latchedMinutes;
+        latchedHours = mem.latchedHours;
+        latchedDays = mem.latchedDays;
+        latchedHalt = mem.latchedHalt;
+        latchedCounterOverflow = mem.latchedCounterOverflow;
     }
 
-    private record RealTimeClockMemento(long offsetSec, long clockStart, boolean halt, long latchStart, int haltSeconds,
-                                        int haltMinutes, int haltHours,
-                                        int haltDays) implements Memento<RealTimeClock> {
+    private record RealTimeClockMemento(int seconds, int minutes, int hours, int days, boolean halt,
+                                        boolean counterOverflow, long lastUpdateMillis, int subSecondMillis,
+                                        boolean latched, int latchedSeconds, int latchedMinutes, int latchedHours,
+                                        int latchedDays, boolean latchedHalt,
+                                        boolean latchedCounterOverflow) implements Memento<RealTimeClock> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 
 import java.util.Arrays;
 
@@ -32,10 +33,14 @@ public class Mbc3 implements MemoryController {
     private boolean clockLatched;
 
     public Mbc3(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource());
+    }
+
+    public Mbc3(Rom rom, Battery battery, TimeSource timeSource) {
         this.cartridge = rom.getRom();
         this.ram = new int[0x2000 * Math.max(rom.getRamBanks(), 1)];
         Arrays.fill(ram, 0xff);
-        this.clock = new RealTimeClock(new SystemTimeSource());
+        this.clock = new RealTimeClock(timeSource);
         this.battery = battery;
         this.mbc30 = rom.getRomBanks() > 128 || rom.getRamBanks() > 4;
 
@@ -60,13 +65,8 @@ public class Mbc3 implements MemoryController {
             selectedRamBank = value;
         } else if (address >= 0x6000 && address < 0x8000) {
             if (value == 0x01 && latchClockReg == 0x00) {
-                if (clockLatched) {
-                    clock.unlatch();
-                    clockLatched = false;
-                } else {
-                    clock.latch();
-                    clockLatched = true;
-                }
+                clock.latch();
+                clockLatched = true;
             }
             latchClockReg = value;
         } else if (address >= 0xa000 && address < 0xc000 && ramWriteEnabled && isRamBankSelected()) {
@@ -153,7 +153,6 @@ public class Mbc3 implements MemoryController {
     }
 
     private void setTimer(int value) {
-        int dayCounter = clock.getDayCounter();
         switch (selectedRamBank) {
             case 0x08:
                 clock.setSeconds(value);
@@ -168,15 +167,13 @@ public class Mbc3 implements MemoryController {
                 break;
 
             case 0x0b:
-                clock.setDayCounter((dayCounter & 0x100) | (value & 0xff));
+                clock.setDayCounterLow(value);
                 break;
 
             case 0x0c:
-                clock.setDayCounter((dayCounter & 0xff) | ((value & 1) << 8));
+                clock.setDayCounterHigh(value);
                 clock.setHalt((value & (1 << 6)) != 0);
-                if ((value & (1 << 7)) == 0) {
-                    clock.clearCounterOverflow();
-                }
+                clock.setCounterOverflow((value & (1 << 7)) != 0);
                 break;
         }
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/Rtc3TestRunner.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/Rtc3TestRunner.java
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.GameboyType;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 
 import java.io.File;
@@ -29,12 +30,15 @@ public class Rtc3TestRunner {
 
     private final AddressSpace memory;
 
+    private final EmulatedTimeSource rtcTimeSource = new EmulatedTimeSource();
+
     public Rtc3TestRunner(File romFile) throws IOException {
         EventBus eventBus = new EventBusImpl();
         gb = new Gameboy.GameboyConfiguration(romFile)
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setGameboyType(GameboyType.DMG)
                 .setSupportBatterySave(false)
+                .setRtcTimeSource(rtcTimeSource)
                 .build();
         gb.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
         memory = gb.getAddressSpace();
@@ -56,7 +60,7 @@ public class Rtc3TestRunner {
             if (++ticks > MAX_TEST_TICKS) {
                 return new TestResult(false, "RTC3Test timed out\n" + dumpScreen());
             }
-            gb.tick();
+            tick();
         }
 
         return new TestResult(!hasFailedResult(), dumpScreen());
@@ -73,8 +77,13 @@ public class Rtc3TestRunner {
 
     private void runTicks(long ticks) {
         while (ticks-- > 0) {
-            gb.tick();
+            tick();
         }
+    }
+
+    private void tick() {
+        rtcTimeSource.tick();
+        gb.tick();
     }
 
     private boolean hasReturnLabel() {
@@ -165,6 +174,20 @@ public class Rtc3TestRunner {
 
         public String getOutput() {
             return output;
+        }
+    }
+
+    private static class EmulatedTimeSource implements TimeSource {
+
+        private long ticks;
+
+        @Override
+        public long currentTimeMillis() {
+            return ticks * 1000 / Gameboy.TICKS_PER_SEC;
+        }
+
+        private void tick() {
+            ticks++;
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/rtc/RealTimeTimeSourceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/rtc/RealTimeTimeSourceTest.java
@@ -78,6 +78,68 @@ public class RealTimeTimeSourceTest {
         assertClockEquals(12, 18, 23, 34);
     }
 
+    @Test
+    public void writesAreMaskedAndAllowedWhileRunning() {
+        rtc.setSeconds(0xff);
+        rtc.setMinutes(0xff);
+        rtc.setHours(0xff);
+        rtc.setDayCounter(0x3ff);
+        rtc.setCounterOverflow(true);
+
+        assertClockEquals(511, 31, 63, 63);
+        assertTrue(rtc.isCounterOverflow());
+    }
+
+    @Test
+    public void secondsWriteResetsOnlyTheSubSecondCounter() {
+        clock.forward(600, TimeUnit.MILLISECONDS);
+        rtc.setMinutes(12);
+        clock.forward(399, TimeUnit.MILLISECONDS);
+        assertClockEquals(0, 0, 12, 0);
+        clock.forward(1, TimeUnit.MILLISECONDS);
+        assertClockEquals(0, 0, 12, 1);
+
+        clock.forward(600, TimeUnit.MILLISECONDS);
+        rtc.setSeconds(20);
+        clock.forward(999, TimeUnit.MILLISECONDS);
+        assertClockEquals(0, 0, 12, 20);
+        clock.forward(1, TimeUnit.MILLISECONDS);
+        assertClockEquals(0, 0, 12, 21);
+    }
+
+    @Test
+    public void haltPreservesTheSubSecondCounter() {
+        clock.forward(600, TimeUnit.MILLISECONDS);
+        rtc.setHalt(true);
+        clock.forward(10, TimeUnit.SECONDS);
+        rtc.setHalt(false);
+
+        clock.forward(399, TimeUnit.MILLISECONDS);
+        assertEquals(0, rtc.getSeconds());
+        clock.forward(1, TimeUnit.MILLISECONDS);
+        assertEquals(1, rtc.getSeconds());
+    }
+
+    @Test
+    public void invalidRegisterValuesUseHardwareRolloverRules() {
+        rtc.setMinutes(10);
+        rtc.setSeconds(63);
+        clock.forward(1, TimeUnit.SECONDS);
+        assertClockEquals(0, 0, 10, 0);
+
+        rtc.setHours(5);
+        rtc.setMinutes(63);
+        rtc.setSeconds(59);
+        clock.forward(1, TimeUnit.SECONDS);
+        assertClockEquals(0, 5, 0, 0);
+
+        rtc.setHours(31);
+        rtc.setMinutes(59);
+        rtc.setSeconds(59);
+        clock.forward(1, TimeUnit.SECONDS);
+        assertClockEquals(0, 0, 0, 0);
+    }
+
     private void forward(int days, int hours, int minutes, int seconds) {
         clock.forward(days, TimeUnit.DAYS);
         clock.forward(hours, TimeUnit.HOURS);


### PR DESCRIPTION
## Summary
- model writable and masked MBC3 RTC registers with hardware rollover behavior
- preserve sub-second phase across non-seconds writes and halt cycles
- make RTC3 timing deterministic and run the suite in GitHub Actions

## Verification
- core unit tests: 95 passed
- MBC30: passed
- RTC3: all 3 menus passed