### PR TITLE
Fix SameSuite hardware timing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,6 +43,8 @@ jobs:
       run: mvn -B -pl core test -Ptest-mbc30
     - name: RTC3 tests
       run: mvn -B -pl core test -Ptest-rtc3
+    - name: SameSuite tests
+      run: mvn -B -pl core test -Ptest-samesuite
     - name: dmg-acid2
       run: mvn -B -pl core test -Ptest-dmgacid2
     - name: cgbacid2

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -177,10 +177,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         interruptManager.disableInterrupts(false);
         if (configuration.bootstrapMode != BootstrapMode.SKIP) {
             // at power-on the LCD is off; the boot ROM enables it, anchoring the PPU
-            // line grid to that write; the divider has counted a few cycles more on
-            // the CGB by the time the CPU starts, and the revision 0 CGB adds
-            // another 512 T (boot_div-cgbABCDE, boot_div-cgb0)
-            timer.presetDiv(gbc ? (configuration.cgb0Revision ? 536 : 12) : 4);
+            // line grid to that write; the CGB divider phase accounts for the boot
+            // ROM's accurately paced HDMA, and revision 0 adds another 512 T
+            // (boot_div-cgbABCDE, boot_div-cgb0)
+            timer.presetDiv(gbc ? (configuration.cgb0Revision ? 518 : 0xfffa) : 4);
             gpu.setByte(0xff40, 0x00);
         }
         boolean bootTimedOut = false;
@@ -373,6 +373,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         if (!speedSwitching) {
             timer.tick();
         }
+        sound.tickFrameSequencer();
         if (speedSwitching) {
             // A CGB speed switch pauses the CPU and DIV, but the PPU keeps running.
             cpu.tick();
@@ -383,6 +384,9 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             hdma.tick();
         } else {
             cpu.tick();
+        }
+        if (timer.isDivResetPending()) {
+            sound.tickFrameSequencer();
         }
         dma.tick();
         sound.tick();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -203,7 +203,17 @@ public class Cpu implements Serializable, Originator<Cpu> {
                     } else if (opcode1 == 0x76) {
                         // committing a pending EI happens even when entering halt, so
                         // "ei; halt" halts with IME=1 (no halt bug, wake dispatches)
+                        boolean imeBeforeHalt = interruptManager.isIme();
+                        boolean interruptPendingBeforeHalt = interruptManager.isInterruptRequested();
                         interruptManager.onInstructionFinished();
+                        if (!imeBeforeHalt && interruptPendingBeforeHalt && interruptManager.isIme()) {
+                            // HALT was fetched while EI's delayed enable was still pending.
+                            // The interrupt is accepted at instruction completion, but hardware
+                            // pushes HALT's address so RETI executes it again.
+                            registers.setPC((registers.getPC() - 1) & 0xffff);
+                            state = State.OPCODE;
+                            return;
+                        }
                         if (interruptManager.isHaltBug()) {
                             state = State.OPCODE;
                             haltBugMode = true;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -44,7 +44,11 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         this.sgbBus = sgbBus;
         sgbBus.register(event -> {
             players = event.getMultiplayerControl();
-            currentPlayer = currentPlayer & players;
+            if (players == 2) {
+                currentPlayer = currentPlayer == 1 || currentPlayer == 2 ? 2 : 0;
+            } else {
+                currentPlayer = currentPlayer & players;
+            }
             LOG.atDebug().log("Players: {}, current player: {}", players, currentPlayer);
         }, Commands.MltReqCmd.class);
     }
@@ -122,7 +126,7 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
                 }
             }
         }
-        if (players > 0 && !BitUtils.getBit(p1, 5) && BitUtils.getBit(value, 5)) {
+        if (players > 0 && players != 2 && !BitUtils.getBit(p1, 5) && BitUtils.getBit(value, 5)) {
             currentPlayer++;
             if (currentPlayer > players) {
                 currentPlayer = 0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -58,6 +58,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         }
         src = (src + 0x10) & 0xffff;
         dst = (dst + 0x10) & 0xffff;
+        tick = 0;
         if (length-- == 0) {
             transferInProgress = false;
             length = 0x7f;
@@ -83,7 +84,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                 break;
             case HDMA5:
                 if (transferInProgress && (value & (1 << 7)) == 0) {
-                    stopTransfer();
+                    stopTransfer(value);
                 } else {
                     startTransfer(value);
                 }
@@ -110,7 +111,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
     public boolean isTransferInProgress() {
         if (!transferInProgress) {
             return false;
-        } else if (hblankTransfer && (gpuMode == Mode.HBlank || !lcdEnabled)) {
+        } else if (hblankTransfer && gpuMode == Mode.HBlank) {
             return true;
         } else return !hblankTransfer;
     }
@@ -119,10 +120,17 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         hblankTransfer = (reg & (1 << 7)) != 0;
         length = reg & 0x7f;
         transferInProgress = true;
+        tick = 0;
+        if (hblankTransfer && !lcdEnabled) {
+            // With the LCD off, starting HDMA copies one block immediately. There are
+            // no subsequent HBlanks, so the transfer then remains paused.
+            gpuMode = Mode.HBlank;
+        }
     }
 
-    private void stopTransfer() {
+    private void stopTransfer(int reg) {
         transferInProgress = false;
+        length = reg & 0x7f;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/AbstractSoundMode.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/AbstractSoundMode.java
@@ -28,6 +28,12 @@ public abstract class AbstractSoundMode implements AddressSpace, Serializable, O
 
     public abstract int tick();
 
+    public int tick(boolean divReset) {
+        return tick();
+    }
+
+    public abstract int getCurrentOutput();
+
     protected abstract void trigger();
 
     public void tickLength() {
@@ -49,6 +55,9 @@ public abstract class AbstractSoundMode implements AddressSpace, Serializable, O
     }
 
     public void tickEnvelope() {
+    }
+
+    public void tickEnvelopeClock(int frameSequencerStep) {
     }
 
     public void tickSweep() {
@@ -213,4 +222,3 @@ public abstract class AbstractSoundMode implements AddressSpace, Serializable, O
                                             Memento<LengthCounter> lengthMemento) implements Memento<AbstractSoundMode> {
     }
 }
-

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/FrameSequencer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/FrameSequencer.java
@@ -20,6 +20,8 @@ public class FrameSequencer implements Serializable, Originator<FrameSequencer> 
 
     private boolean previousBit;
 
+    private boolean skipNextEdge;
+
     /**
      * @param divCounter the current value of the internal 16-bit divider
      * @param apuEnabled whether the APU is powered on
@@ -27,11 +29,15 @@ public class FrameSequencer implements Serializable, Originator<FrameSequencer> 
      * @return the fired step, or -1
      */
     public int tick(int divCounter, boolean apuEnabled, boolean doubleSpeed) {
-        boolean bit = (divCounter & (doubleSpeed ? DIV_BIT << 2 : DIV_BIT)) != 0;
+        boolean bit = (divCounter & (doubleSpeed ? DIV_BIT << 1 : DIV_BIT)) != 0;
         int firedStep = -1;
         if (previousBit && !bit && apuEnabled) {
-            firedStep = step;
-            step = (step + 1) & 7;
+            if (skipNextEdge) {
+                skipNextEdge = false;
+            } else {
+                firedStep = step;
+                step = (step + 1) & 7;
+            }
         }
         previousBit = bit;
         return firedStep;
@@ -42,16 +48,27 @@ public class FrameSequencer implements Serializable, Originator<FrameSequencer> 
      * Writing NRx4 in this phase causes the extra length clocking.
      */
     public boolean isFirstHalfOfLengthPeriod() {
-        return (step & 1) == 1;
+        return skipNextEdge || (step & 1) == 1;
     }
 
     public void reset() {
         step = 0;
+        skipNextEdge = false;
+    }
+
+    /**
+     * Powers the divider down/up. If the selected DIV bit is already high, CGB hardware
+     * suppresses the first falling edge after power-on.
+     */
+    public void reset(int divCounter, boolean doubleSpeed) {
+        step = 0;
+        previousBit = (divCounter & (doubleSpeed ? DIV_BIT << 1 : DIV_BIT)) != 0;
+        skipNextEdge = previousBit;
     }
 
     @Override
     public Memento<FrameSequencer> saveToMemento() {
-        return new FrameSequencerMemento(step, previousBit);
+        return new FrameSequencerMemento(step, previousBit, skipNextEdge);
     }
 
     @Override
@@ -61,8 +78,10 @@ public class FrameSequencer implements Serializable, Originator<FrameSequencer> 
         }
         this.step = mem.step;
         this.previousBit = mem.previousBit;
+        this.skipNextEdge = mem.skipNextEdge;
     }
 
-    private record FrameSequencerMemento(int step, boolean previousBit) implements Memento<FrameSequencer> {
+    private record FrameSequencerMemento(int step, boolean previousBit,
+                                         boolean skipNextEdge) implements Memento<FrameSequencer> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/FrequencySweep.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/FrequencySweep.java
@@ -25,20 +25,37 @@ public class FrequencySweep implements Serializable, Originator<FrequencySweep> 
 
     private boolean negging;
 
+    /**
+     * The overflow check following a sweep calculation is performed by a 1 MHz
+     * ripple counter, rather than in the frame-sequencer callback itself.
+     */
+    private int calculationDelay;
+
+    private boolean unshiftedCalculation;
+
+    private int restartHold;
+
     public void start() {
         counterEnabled = false;
+        calculationDelay = 0;
+        unshiftedCalculation = false;
+        restartHold = 0;
     }
 
-    public void trigger() {
+    public void trigger(boolean wasActive, boolean lowFrequencyPhase, boolean gbc) {
         this.negging = false;
         this.overflow = false;
 
         this.shadowFreq = nr13 | ((nr14 & 0b111) << 8);
         this.timer = period == 0 ? 8 : period;
         this.counterEnabled = period != 0 || shift != 0;
-
-        if (shift > 0) {
-            calculate();
+        // The sweep adder holds its pre-restart input while the trigger pipeline drains.
+        // CGB hardware keeps that hold for two additional stages.
+        restartHold = (4 - (lowFrequencyPhase ? 1 : 0) + (gbc ? 2 : 0)) * 2;
+        if (shift == 0) {
+            cancelCalculation();
+        } else {
+            scheduleCalculation(shift + (wasActive ? 2 : 3), false);
         }
     }
 
@@ -57,9 +74,6 @@ public class FrequencySweep implements Serializable, Originator<FrequencySweep> 
 
     public void setNr14(int value) {
         this.nr14 = value;
-        if ((value & (1 << 7)) != 0) {
-            trigger();
-        }
     }
 
     public int getNr13() {
@@ -77,15 +91,48 @@ public class FrequencySweep implements Serializable, Originator<FrequencySweep> 
         if (--timer == 0) {
             timer = period == 0 ? 8 : period;
             if (period != 0) {
-                int newFreq = calculate();
-                if (!overflow && shift != 0) {
-                    shadowFreq = newFreq;
-                    nr13 = shadowFreq & 0xff;
-                    nr14 = (shadowFreq & 0x700) >> 8;
-                    calculate();
+                if (shift == 0) {
+                    if (restartHold == 0) {
+                        scheduleCalculation(1, true);
+                    } else {
+                        cancelCalculation();
+                    }
+                } else {
+                    int newFreq = calculate();
+                    if (!overflow) {
+                        shadowFreq = newFreq;
+                        nr13 = shadowFreq & 0xff;
+                        nr14 = (shadowFreq & 0x700) >> 8;
+                        scheduleCalculation(shift + 1, false);
+                    }
                 }
             }
         }
+    }
+
+    /** Advances the delayed sweep calculation by one CPU T-cycle. */
+    public void tick() {
+        if (restartHold > 0) {
+            restartHold--;
+        }
+        // A zero shift disconnects the calculation counter until NR10 enables it again.
+        if (calculationDelay == 0 || (shift == 0 && !unshiftedCalculation)) {
+            return;
+        }
+        if (--calculationDelay == 0) {
+            calculate();
+            unshiftedCalculation = false;
+        }
+    }
+
+    private void scheduleCalculation(int oneMhzTicks, boolean unshifted) {
+        calculationDelay = oneMhzTicks * 4;
+        unshiftedCalculation = unshifted;
+    }
+
+    private void cancelCalculation() {
+        calculationDelay = 0;
+        unshiftedCalculation = false;
     }
 
     private int calculate() {
@@ -108,7 +155,8 @@ public class FrequencySweep implements Serializable, Originator<FrequencySweep> 
 
     @Override
     public Memento<FrequencySweep> saveToMemento() {
-        return new FrequencySweepMemento(period, negate, shift, timer, shadowFreq, nr13, nr14, overflow, counterEnabled, negging);
+        return new FrequencySweepMemento(period, negate, shift, timer, shadowFreq, nr13, nr14, overflow,
+                counterEnabled, negging, calculationDelay, unshiftedCalculation, restartHold);
     }
 
     @Override
@@ -126,10 +174,14 @@ public class FrequencySweep implements Serializable, Originator<FrequencySweep> 
         this.overflow = mem.overflow;
         this.counterEnabled = mem.counterEnabled;
         this.negging = mem.negging;
+        this.calculationDelay = mem.calculationDelay;
+        this.unshiftedCalculation = mem.unshiftedCalculation;
+        this.restartHold = mem.restartHold;
     }
 
     private record FrequencySweepMemento(int period, boolean negate, int shift, int timer, int shadowFreq, int nr13,
                                          int nr14, boolean overflow, boolean counterEnabled,
-                                         boolean negging) implements Memento<FrequencySweep> {
+                                         boolean negging, int calculationDelay,
+                                         boolean unshiftedCalculation, int restartHold) implements Memento<FrequencySweep> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Lfsr.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Lfsr.java
@@ -26,7 +26,7 @@ public class Lfsr implements Serializable, Originator<Lfsr> {
         lfsr = lfsr >> 1;
         lfsr = lfsr | (x ? (1 << 14) : 0);
         if (widthMode7) {
-            lfsr = lfsr | (x ? (1 << 6) : 0);
+            lfsr = (lfsr & ~(1 << 6)) | (x ? (1 << 6) : 0);
         }
         return 1 & ~lfsr;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/PolynomialCounter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/PolynomialCounter.java
@@ -7,65 +7,99 @@ import java.io.Serializable;
 
 public class PolynomialCounter implements Serializable, Originator<PolynomialCounter> {
 
-    private int shiftedDivisor;
+    private static final int[] RELOAD_ALIGNMENT_OFFSETS = {2, 1, 0, 3};
 
-    private int i;
+    private int nr43;
+
+    // The noise generator uses a prescaler feeding a free-running 14-bit counter;
+    // the NR43 shift selects which rising counter edge clocks the LFSR.
+    private int counter;
+
+    // Expressed in fixed 2 MHz APU cycles.
+    private int counterCountdown;
+
+    private boolean clock2Mhz;
+
+    private int alignment;
+
+    private boolean backgroundActive;
+
+    private boolean countdownReloaded;
+
+    public void start() {
+        nr43 = 0;
+        counter = 0;
+        counterCountdown = 0;
+        clock2Mhz = false;
+        alignment = 0;
+        backgroundActive = false;
+        countdownReloaded = false;
+    }
+
+    public void stop() {
+        start();
+    }
 
     public void setNr43(int value) {
-        int clockShift = value >> 4;
-        int divisor;
-        switch (value & 0b111) {
-            case 0:
-                divisor = 8;
-                break;
-
-            case 1:
-                divisor = 16;
-                break;
-
-            case 2:
-                divisor = 32;
-                break;
-
-            case 3:
-                divisor = 48;
-                break;
-
-            case 4:
-                divisor = 64;
-                break;
-
-            case 5:
-                divisor = 80;
-                break;
-
-            case 6:
-                divisor = 96;
-                break;
-
-            case 7:
-                divisor = 112;
-                break;
-
-            default:
-                throw new IllegalStateException();
+        if (countdownReloaded) {
+            int divisor = (value & 0b111) << 2;
+            if (divisor == 0) {
+                divisor = 2;
+            }
+            counterCountdown = divisor + (divisor == 2 ? 0 : RELOAD_ALIGNMENT_OFFSETS[alignment]);
         }
-        shiftedDivisor = divisor << clockShift;
-        i = 1;
+        nr43 = value;
+    }
+
+    public void trigger() {
+        int divisor = nr43 & 0b111;
+        counterCountdown = divisor == 0 ? 6 : divisor * 4 + 6;
+        if (divisor == 0) {
+            if ((alignment & 1) != 0) {
+                counterCountdown += backgroundActive ? -1 : 1;
+            }
+        } else {
+            if (alignment == 2) {
+                counterCountdown -= 2;
+            } else if (alignment == 0 && divisor > 1) {
+                counterCountdown -= 4;
+            }
+        }
+        backgroundActive = true;
+        countdownReloaded = false;
     }
 
     public boolean tick() {
-        if (--i == 0) {
-            i = shiftedDivisor;
-            return true;
-        } else {
+        clock2Mhz = !clock2Mhz;
+        if (!clock2Mhz) {
             return false;
         }
+
+        alignment = (alignment + 1) & 3;
+        if (!backgroundActive) {
+            return false;
+        }
+
+        if (--counterCountdown > 0) {
+            countdownReloaded = false;
+            return false;
+        }
+
+        int divisor = (nr43 & 0b111) << 2;
+        counterCountdown = divisor == 0 ? 2 : divisor;
+
+        int mask = 1 << (nr43 >> 4);
+        boolean oldBit = (counter & mask) != 0;
+        counter = (counter + 1) & 0x3fff;
+        boolean newBit = (counter & mask) != 0;
+        countdownReloaded = true;
+        return !oldBit && newBit;
     }
 
     @Override
     public Memento<PolynomialCounter> saveToMemento() {
-        return new PolynomialCounterMemento(shiftedDivisor, i);
+        return new PolynomialCounterMemento(nr43, counter, counterCountdown, clock2Mhz, alignment, backgroundActive,
+                countdownReloaded);
     }
 
     @Override
@@ -73,10 +107,17 @@ public class PolynomialCounter implements Serializable, Originator<PolynomialCou
         if (!(memento instanceof PolynomialCounterMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");
         }
-        this.shiftedDivisor = mem.shiftedDivisor;
-        this.i = mem.i;
+        this.nr43 = mem.nr43;
+        this.counter = mem.counter;
+        this.counterCountdown = mem.counterCountdown;
+        this.clock2Mhz = mem.clock2Mhz;
+        this.alignment = mem.alignment;
+        this.backgroundActive = mem.backgroundActive;
+        this.countdownReloaded = mem.countdownReloaded;
     }
 
-    private record PolynomialCounterMemento(int shiftedDivisor, int i) implements Memento<PolynomialCounter> {
+    private record PolynomialCounterMemento(int nr43, int counter, int counterCountdown, boolean clock2Mhz,
+                                             int alignment, boolean backgroundActive,
+                                             boolean countdownReloaded) implements Memento<PolynomialCounter> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -64,28 +64,16 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
     }
 
     public void tick() {
-        int firedStep = frameSequencer.tick(timer.getDivCounter(), enabled, speedMode.getSpeedMode() == 2);
+        boolean divReset = timer.consumeDivReset();
         if (!enabled) {
             play(0, 0);
             return;
         }
 
-        if (firedStep >= 0) {
-            if ((firedStep & 1) == 0) {
-                for (AbstractSoundMode m : allModes) m.tickLength();
-            }
-            if (firedStep == 2 || firedStep == 6) {
-                for (AbstractSoundMode m : allModes) m.tickSweep();
-            }
-            if (firedStep == 7) {
-                for (AbstractSoundMode m : allModes) m.tickEnvelope();
-            }
-        }
-
-        channels[0] = allModes[0].tick();
-        channels[1] = allModes[1].tick();
-        channels[2] = allModes[2].tick();
-        channels[3] = allModes[3].tick();
+        channels[0] = allModes[0].tick(divReset);
+        channels[1] = allModes[1].tick(divReset);
+        channels[2] = allModes[2].tick(divReset);
+        channels[3] = allModes[3].tick(divReset);
 
         int selection = r.getByte(0xff25);
         int left = 0;
@@ -114,6 +102,26 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         right *= (volumes & 0b111) + 1;
 
         play(left, right);
+    }
+
+    /**
+     * Updates DIV-APU independently of channel sampling. It is called both before the
+     * CPU (for natural DIV edges) and after it (for an edge caused by an FF04 write).
+     */
+    public void tickFrameSequencer() {
+        int firedStep = frameSequencer.tick(timer.getDivCounter(), enabled, speedMode.getSpeedMode() == 2);
+        if (firedStep >= 0) {
+            for (AbstractSoundMode m : allModes) m.tickEnvelopeClock(firedStep);
+            if ((firedStep & 1) == 0) {
+                for (AbstractSoundMode m : allModes) m.tickLength();
+            }
+            if (firedStep == 2 || firedStep == 6) {
+                for (AbstractSoundMode m : allModes) m.tickSweep();
+            }
+            if (firedStep == 7) {
+                for (AbstractSoundMode m : allModes) m.tickEnvelope();
+            }
+        }
     }
 
     private void play(int left, int right) {
@@ -167,19 +175,21 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         if (!enabled && address < 0xff30) {
             // while the APU is off, the only writable register bits are the DMG length
             // counters (and NR52 handled above); everything else is ignored
-            switch (address) {
-                case 0xff11:
-                    allModes[0].writeLengthWhileOff(value);
-                    break;
-                case 0xff16:
-                    allModes[1].writeLengthWhileOff(value);
-                    break;
-                case 0xff1b:
-                    allModes[2].writeLengthWhileOff(value);
-                    break;
-                case 0xff20:
-                    allModes[3].writeLengthWhileOff(value);
-                    break;
+            if (!gbc) {
+                switch (address) {
+                    case 0xff11:
+                        allModes[0].writeLengthWhileOff(value);
+                        break;
+                    case 0xff16:
+                        allModes[1].writeLengthWhileOff(value);
+                        break;
+                    case 0xff1b:
+                        allModes[2].writeLengthWhileOff(value);
+                        break;
+                    case 0xff20:
+                        allModes[3].writeLengthWhileOff(value);
+                        break;
+                }
             }
             return;
         }
@@ -202,9 +212,11 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
             }
             result |= enabled ? (1 << 7) : 0;
         } else if (address == 0xff76) {
-            return channels[0] | (channels[1] << 4);
+            return (allModes[0].isEnabled() ? allModes[0].getCurrentOutput() : 0)
+                    | (allModes[1].isEnabled() ? allModes[1].getCurrentOutput() << 4 : 0);
         } else if (address == 0xff77) {
-            return channels[2] | (channels[3] << 4);
+            return (allModes[2].isEnabled() ? allModes[2].getCurrentOutput() : 0)
+                    | (allModes[3].isEnabled() ? allModes[3].getCurrentOutput() << 4 : 0);
         } else {
             result = getUnmaskedByte(address);
         }
@@ -224,7 +236,7 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         for (AbstractSoundMode m : allModes) {
             m.start();
         }
-        frameSequencer.reset();
+        frameSequencer.reset(timer.getDivCounter(), speedMode.getSpeedMode() == 2);
     }
 
     private void stop() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
@@ -10,6 +10,16 @@ public class SoundMode1 extends AbstractSoundMode {
 
     private int i;
 
+    private boolean sampleSuppressed;
+
+    private boolean activeBeforeTrigger;
+
+    private boolean clock2Mhz;
+
+    private boolean lowFrequencyPhase;
+
+    private int justReloadedTicks;
+
     private final FrequencySweep frequencySweep;
 
     private final VolumeEnvelope volumeEnvelope;
@@ -23,6 +33,10 @@ public class SoundMode1 extends AbstractSoundMode {
     @Override
     public void start() {
         i = 0;
+        sampleSuppressed = true;
+        clock2Mhz = false;
+        lowFrequencyPhase = true;
+        justReloadedTicks = 0;
         if (gbc) {
             length.reset();
         }
@@ -35,6 +49,10 @@ public class SoundMode1 extends AbstractSoundMode {
         super.stop();
         i = 0;
         lastOutput = 0;
+        sampleSuppressed = true;
+        clock2Mhz = false;
+        lowFrequencyPhase = true;
+        justReloadedTicks = 0;
         frequencySweep.setNr10(0);
         frequencySweep.setNr13(0);
         frequencySweep.setNr14(0);
@@ -44,7 +62,18 @@ public class SoundMode1 extends AbstractSoundMode {
     @Override
     public void trigger() {
         // the duty position is not changed by the trigger, only the timer is reloaded
-        resetFreqDivider();
+        int triggerDelay = activeBeforeTrigger ? 4 : 6;
+        if (activeBeforeTrigger && justReloadedTicks == 1) {
+            // A trigger on the trailing T-cycle of a pulse reload must not charge
+            // that same 2 MHz edge to the newly loaded divider.
+            triggerDelay++;
+        }
+        freqDivider = (getFrequency() - 1) * 2 + triggerDelay - (lowFrequencyPhase ? 1 : 0);
+        if (!activeBeforeTrigger) {
+            sampleSuppressed = true;
+            lastOutput = 0;
+        }
+        frequencySweep.trigger(activeBeforeTrigger, lowFrequencyPhase, gbc);
         volumeEnvelope.trigger();
     }
 
@@ -54,12 +83,31 @@ public class SoundMode1 extends AbstractSoundMode {
     }
 
     @Override
+    public void tickEnvelopeClock(int frameSequencerStep) {
+        volumeEnvelope.apuClockTick(frameSequencerStep);
+    }
+
+    @Override
     public void tickSweep() {
         frequencySweep.clockTick();
     }
 
     @Override
     public int tick() {
+        return tick(false);
+    }
+
+    @Override
+    public int tick(boolean divReset) {
+        clock2Mhz = !clock2Mhz;
+        frequencySweep.tick();
+        if (justReloadedTicks > 0) {
+            justReloadedTicks--;
+        }
+        if (clock2Mhz) {
+            lowFrequencyPhase = !lowFrequencyPhase;
+        }
+
         boolean e;
         e = updateLength();
         e = updateSweep() && e;
@@ -68,12 +116,21 @@ public class SoundMode1 extends AbstractSoundMode {
             return 0;
         }
 
-        if (--freqDivider == 0) {
+        // FF04 writes are handled before this post-CPU channel tick. The APU phase
+        // still advances, but charging this edge again would double-count it.
+        if (clock2Mhz && !divReset && freqDivider-- == 0) {
             resetFreqDivider();
-            lastOutput = ((getDuty() & (1 << i)) >> i);
             i = (i + 1) % 8;
+            lastOutput = ((getDuty() & (1 << i)) >> i);
+            sampleSuppressed = false;
+            justReloadedTicks = 4;
         }
-        return lastOutput * volumeEnvelope.getVolume();
+        return getCurrentOutput();
+    }
+
+    @Override
+    public int getCurrentOutput() {
+        return (sampleSuppressed ? 0 : lastOutput) * volumeEnvelope.getVolume();
     }
 
     @Override
@@ -91,7 +148,7 @@ public class SoundMode1 extends AbstractSoundMode {
     @Override
     protected void setNr2(int value) {
         super.setNr2(value);
-        volumeEnvelope.setNr2(value);
+        volumeEnvelope.setNr2(value, channelEnabled);
         dacEnabled = (value & 0b11111000) != 0;
         channelEnabled &= dacEnabled;
     }
@@ -100,12 +157,19 @@ public class SoundMode1 extends AbstractSoundMode {
     protected void setNr3(int value) {
         super.setNr3(value);
         frequencySweep.setNr13(value);
+        if (justReloadedTicks > 0) {
+            resetFreqDivider();
+        }
     }
 
     @Override
     protected void setNr4(int value) {
-        super.setNr4(value);
+        activeBeforeTrigger = channelEnabled;
         frequencySweep.setNr14(value);
+        super.setNr4(value);
+        if ((value & (1 << 7)) == 0 && justReloadedTicks > 0) {
+            resetFreqDivider();
+        }
     }
 
     @Override
@@ -121,11 +185,11 @@ public class SoundMode1 extends AbstractSoundMode {
     private int getDuty() {
         switch (getNr1() >> 6) {
             case 0:
-                return 0b00000001;
+                return 0b10000000;
             case 1:
                 return 0b10000001;
             case 2:
-                return 0b10000111;
+                return 0b11100001;
             case 3:
                 return 0b01111110;
             default:
@@ -134,7 +198,7 @@ public class SoundMode1 extends AbstractSoundMode {
     }
 
     private void resetFreqDivider() {
-        freqDivider = getFrequency() * 4;
+        freqDivider = (getFrequency() - 1) * 2 + 1;
     }
 
     protected boolean updateSweep() {
@@ -146,7 +210,9 @@ public class SoundMode1 extends AbstractSoundMode {
 
     @Override
     public Memento<AbstractSoundMode> saveToMemento() {
-        return new SoundMode1Memento(super.saveToMemento(), freqDivider, lastOutput, i, frequencySweep.saveToMemento(), volumeEnvelope.saveToMemento());
+        return new SoundMode1Memento(super.saveToMemento(), freqDivider, lastOutput, i, sampleSuppressed,
+                activeBeforeTrigger, clock2Mhz, lowFrequencyPhase, frequencySweep.saveToMemento(),
+                justReloadedTicks, volumeEnvelope.saveToMemento());
     }
 
     @Override
@@ -158,12 +224,20 @@ public class SoundMode1 extends AbstractSoundMode {
         this.freqDivider = mem.freqDivider;
         this.lastOutput = mem.lastOutput;
         this.i = mem.i;
+        this.sampleSuppressed = mem.sampleSuppressed;
+        this.activeBeforeTrigger = mem.activeBeforeTrigger;
+        this.clock2Mhz = mem.clock2Mhz;
+        this.lowFrequencyPhase = mem.lowFrequencyPhase;
+        this.justReloadedTicks = mem.justReloadedTicks;
         this.frequencySweep.restoreFromMemento(mem.frequencySweepMemento);
         this.volumeEnvelope.restoreFromMemento(mem.volumeEnvelopeMemento);
     }
 
     private record SoundMode1Memento(Memento<AbstractSoundMode> abstractSoundMemento, int freqDivider, int lastOutput,
-                                     int i, Memento<FrequencySweep> frequencySweepMemento,
+                                     int i, boolean sampleSuppressed, boolean activeBeforeTrigger,
+                                     boolean clock2Mhz, boolean lowFrequencyPhase,
+                                     Memento<FrequencySweep> frequencySweepMemento,
+                                     int justReloadedTicks,
                                      Memento<VolumeEnvelope> volumeEnvelopeMemento) implements Memento<AbstractSoundMode> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode2.java
@@ -10,6 +10,16 @@ public class SoundMode2 extends AbstractSoundMode {
 
     private int i;
 
+    private boolean sampleSuppressed;
+
+    private boolean activeBeforeTrigger;
+
+    private boolean clock2Mhz;
+
+    private boolean lowFrequencyPhase;
+
+    private int justReloadedTicks;
+
     private final VolumeEnvelope volumeEnvelope;
 
     public SoundMode2(FrameSequencer frameSequencer, boolean gbc) {
@@ -20,6 +30,10 @@ public class SoundMode2 extends AbstractSoundMode {
     @Override
     public void start() {
         i = 0;
+        sampleSuppressed = true;
+        clock2Mhz = false;
+        lowFrequencyPhase = true;
+        justReloadedTicks = 0;
         if (gbc) {
             length.reset();
         }
@@ -31,13 +45,22 @@ public class SoundMode2 extends AbstractSoundMode {
         super.stop();
         i = 0;
         lastOutput = 0;
+        sampleSuppressed = true;
+        clock2Mhz = false;
+        lowFrequencyPhase = true;
+        justReloadedTicks = 0;
         volumeEnvelope.setNr2(0);
     }
 
     @Override
     public void trigger() {
         // the duty position is not changed by the trigger, only the timer is reloaded
-        resetFreqDivider();
+        int triggerDelay = activeBeforeTrigger ? 4 : 6;
+        freqDivider = (getFrequency() - 1) * 2 + triggerDelay - (lowFrequencyPhase ? 1 : 0);
+        if (!activeBeforeTrigger) {
+            sampleSuppressed = true;
+            lastOutput = 0;
+        }
         volumeEnvelope.trigger();
     }
 
@@ -47,7 +70,25 @@ public class SoundMode2 extends AbstractSoundMode {
     }
 
     @Override
+    public void tickEnvelopeClock(int frameSequencerStep) {
+        volumeEnvelope.apuClockTick(frameSequencerStep);
+    }
+
+    @Override
     public int tick() {
+        return tick(false);
+    }
+
+    @Override
+    public int tick(boolean divReset) {
+        clock2Mhz = !clock2Mhz;
+        if (justReloadedTicks > 0) {
+            justReloadedTicks--;
+        }
+        if (clock2Mhz) {
+            lowFrequencyPhase = !lowFrequencyPhase;
+        }
+
         boolean e;
         e = updateLength();
         e = dacEnabled && e;
@@ -55,12 +96,21 @@ public class SoundMode2 extends AbstractSoundMode {
             return 0;
         }
 
-        if (--freqDivider == 0) {
+        // FF04 writes are handled before this post-CPU channel tick. The APU phase
+        // still advances, but charging this edge again would double-count it.
+        if (clock2Mhz && !divReset && freqDivider-- == 0) {
             resetFreqDivider();
-            lastOutput = ((getDuty() & (1 << i)) >> i);
             i = (i + 1) % 8;
+            lastOutput = ((getDuty() & (1 << i)) >> i);
+            sampleSuppressed = false;
+            justReloadedTicks = 4;
         }
-        return lastOutput * volumeEnvelope.getVolume();
+        return getCurrentOutput();
+    }
+
+    @Override
+    public int getCurrentOutput() {
+        return (sampleSuppressed ? 0 : lastOutput) * volumeEnvelope.getVolume();
     }
 
     @Override
@@ -77,19 +127,36 @@ public class SoundMode2 extends AbstractSoundMode {
     @Override
     protected void setNr2(int value) {
         super.setNr2(value);
-        volumeEnvelope.setNr2(value);
+        volumeEnvelope.setNr2(value, channelEnabled);
         dacEnabled = (value & 0b11111000) != 0;
         channelEnabled &= dacEnabled;
+    }
+
+    @Override
+    protected void setNr3(int value) {
+        super.setNr3(value);
+        if (justReloadedTicks > 0) {
+            resetFreqDivider();
+        }
+    }
+
+    @Override
+    protected void setNr4(int value) {
+        activeBeforeTrigger = channelEnabled;
+        super.setNr4(value);
+        if ((value & (1 << 7)) == 0 && justReloadedTicks > 0) {
+            resetFreqDivider();
+        }
     }
 
     private int getDuty() {
         switch (getNr1() >> 6) {
             case 0:
-                return 0b00000001;
+                return 0b10000000;
             case 1:
                 return 0b10000001;
             case 2:
-                return 0b10000111;
+                return 0b11100001;
             case 3:
                 return 0b01111110;
             default:
@@ -98,12 +165,14 @@ public class SoundMode2 extends AbstractSoundMode {
     }
 
     private void resetFreqDivider() {
-        freqDivider = getFrequency() * 4;
+        freqDivider = (getFrequency() - 1) * 2 + 1;
     }
 
     @Override
     public Memento<AbstractSoundMode> saveToMemento() {
-        return new SoundMode2Memento(super.saveToMemento(), freqDivider, lastOutput, i, volumeEnvelope.saveToMemento());
+        return new SoundMode2Memento(super.saveToMemento(), freqDivider, lastOutput, i, sampleSuppressed,
+                activeBeforeTrigger, clock2Mhz, lowFrequencyPhase, volumeEnvelope.saveToMemento(),
+                justReloadedTicks);
     }
 
     @Override
@@ -115,12 +184,19 @@ public class SoundMode2 extends AbstractSoundMode {
         this.freqDivider = mem.freqDivider;
         this.lastOutput = mem.lastOutput;
         this.i = mem.i;
+        this.sampleSuppressed = mem.sampleSuppressed;
+        this.activeBeforeTrigger = mem.activeBeforeTrigger;
+        this.clock2Mhz = mem.clock2Mhz;
+        this.lowFrequencyPhase = mem.lowFrequencyPhase;
+        this.justReloadedTicks = mem.justReloadedTicks;
         this.volumeEnvelope.restoreFromMemento(mem.volumeEnvelopeMemento);
     }
 
     private record SoundMode2Memento(Memento<AbstractSoundMode> abstractSoundMemento, int freqDivider, int lastOutput,
-                                     int i,
-                                     Memento<VolumeEnvelope> volumeEnvelopeMemento) implements Memento<AbstractSoundMode> {
+                                     int i, boolean sampleSuppressed, boolean activeBeforeTrigger,
+                                     boolean clock2Mhz, boolean lowFrequencyPhase,
+                                     Memento<VolumeEnvelope> volumeEnvelopeMemento,
+                                     int justReloadedTicks) implements Memento<AbstractSoundMode> {
     }
 
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
@@ -38,6 +38,9 @@ public class SoundMode3 extends AbstractSoundMode {
 
     private boolean triggered;
 
+    // CH3 is clocked by the APU's fixed 2 MHz clock, independently of CPU speed.
+    private boolean clock2Mhz;
+
     public SoundMode3(FrameSequencer frameSequencer, Timer timer, boolean gbc) {
         super(0xff1a, 256, frameSequencer, gbc);
         this.timer = timer;
@@ -97,6 +100,14 @@ public class SoundMode3 extends AbstractSoundMode {
     }
 
     @Override
+    protected void setNr2(int value) {
+        super.setNr2(value);
+        if (channelEnabled) {
+            lastOutput = getBufferedOutput();
+        }
+    }
+
+    @Override
     protected void setNr3(int value) {
         super.setNr3(value);
     }
@@ -124,6 +135,7 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     public void start() {
         i = 0;
+        clock2Mhz = false;
         if (gbc) {
             length.reset();
         }
@@ -151,13 +163,17 @@ public class SoundMode3 extends AbstractSoundMode {
         freqDivider = getFrequency() + 3;
         triggered = !gbc;
         if (gbc) {
-            getWaveEntry();
+            // CGB wave-RAM access is redirected to the current byte immediately,
+            // but the sample buffer itself is not refreshed by a trigger.
+            lastReadAddr = 0xff30;
+            ticksSinceRead = 0;
         }
     }
 
     @Override
     public int tick() {
         ticksSinceRead++;
+        clock2Mhz = !clock2Mhz;
         if (!channelEnabled) {
             return lastOutput;
         }
@@ -165,7 +181,7 @@ public class SoundMode3 extends AbstractSoundMode {
             return 0;
         }
 
-        if ((timer.getDivCounter() & 1) == 0 && --freqDivider == 0) {
+        if (clock2Mhz && --freqDivider == 0) {
             resetFreqDivider();
             i = (i + 1) % 32;
             int stale = (buffer >> 4) & 0x0f;
@@ -178,6 +194,11 @@ public class SoundMode3 extends AbstractSoundMode {
         return lastOutput;
     }
 
+    @Override
+    public int getCurrentOutput() {
+        return lastOutput;
+    }
+
     private int getVolume() {
         return (getNr2() >> 5) & 0b11;
     }
@@ -186,6 +207,10 @@ public class SoundMode3 extends AbstractSoundMode {
         ticksSinceRead = 0;
         lastReadAddr = 0xff30 + i / 2;
         buffer = waveRam.getByte(lastReadAddr);
+        return getBufferedOutput();
+    }
+
+    private int getBufferedOutput() {
         int b = buffer;
         if (i % 2 == 0) {
             b = (b >> 4) & 0x0f;
@@ -212,7 +237,7 @@ public class SoundMode3 extends AbstractSoundMode {
 
     @Override
     public Memento<AbstractSoundMode> saveToMemento() {
-        return new SoundMode3Memento(super.saveToMemento(), waveRam.saveToMemento(), freqDivider, lastOutput, i, ticksSinceRead, lastReadAddr, buffer, triggered);
+        return new SoundMode3Memento(super.saveToMemento(), waveRam.saveToMemento(), freqDivider, lastOutput, i, ticksSinceRead, lastReadAddr, buffer, triggered, clock2Mhz);
     }
 
     @Override
@@ -229,10 +254,12 @@ public class SoundMode3 extends AbstractSoundMode {
         this.lastReadAddr = mem.lastReadAddr;
         this.buffer = mem.buffer;
         this.triggered = mem.triggered;
+        this.clock2Mhz = mem.clock2Mhz;
     }
 
     private record SoundMode3Memento(Memento<AbstractSoundMode> abstractSoundMemento, Memento<Ram> waveRamMemento,
                                      int freqDivider, int lastOutput, int i, int ticksSinceRead, int lastReadAddr,
-                                     int buffer, boolean triggered) implements Memento<AbstractSoundMode> {
+                                     int buffer, boolean triggered,
+                                     boolean clock2Mhz) implements Memento<AbstractSoundMode> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java
@@ -24,6 +24,7 @@ public class SoundMode4 extends AbstractSoundMode {
             length.reset();
         }
         lfsr.start();
+        polynomialCounter.start();
         volumeEnvelope.start();
     }
 
@@ -32,12 +33,14 @@ public class SoundMode4 extends AbstractSoundMode {
         super.stop();
         lastResult = 0;
         volumeEnvelope.setNr2(0);
-        polynomialCounter.setNr43(0);
+        polynomialCounter.stop();
     }
 
     @Override
     public void trigger() {
         lfsr.reset();
+        lastResult = 0;
+        polynomialCounter.trigger();
         volumeEnvelope.trigger();
     }
 
@@ -47,7 +50,13 @@ public class SoundMode4 extends AbstractSoundMode {
     }
 
     @Override
+    public void tickEnvelopeClock(int frameSequencerStep) {
+        volumeEnvelope.apuClockTick(frameSequencerStep);
+    }
+
+    @Override
     public int tick() {
+        boolean stepLfsr = polynomialCounter.tick();
         if (!updateLength()) {
             return 0;
         }
@@ -55,9 +64,14 @@ public class SoundMode4 extends AbstractSoundMode {
             return 0;
         }
 
-        if (polynomialCounter.tick()) {
+        if (stepLfsr) {
             lastResult = lfsr.nextBit((nr3 & (1 << 3)) != 0);
         }
+        return getCurrentOutput();
+    }
+
+    @Override
+    public int getCurrentOutput() {
         return lastResult * volumeEnvelope.getVolume();
     }
 
@@ -70,7 +84,7 @@ public class SoundMode4 extends AbstractSoundMode {
     @Override
     protected void setNr2(int value) {
         super.setNr2(value);
-        volumeEnvelope.setNr2(value);
+        volumeEnvelope.setNr2(value, channelEnabled);
         dacEnabled = (value & 0b11111000) != 0;
         channelEnabled &= dacEnabled;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/VolumeEnvelope.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/VolumeEnvelope.java
@@ -19,10 +19,26 @@ public class VolumeEnvelope implements Serializable, Originator<VolumeEnvelope> 
 
     private boolean finished;
 
+    private boolean pendingEnvelopeClock;
+
     public void setNr2(int register) {
+        setNr2(register, false);
+    }
+
+    public void setNr2(int register, boolean channelActive) {
+        int oldSweep = sweep;
+        int oldDirection = envelopeDirection;
+        if (channelActive) {
+            applyWriteGlitch(register, oldSweep, oldDirection);
+        }
         this.initialVolume = register >> 4;
         this.envelopeDirection = (register & (1 << 3)) == 0 ? -1 : 1;
         this.sweep = register & 0b111;
+        if (channelActive && oldSweep == 0 && sweep != 0 && !finished) {
+            pendingEnvelopeClock = true;
+        } else if (sweep == 0) {
+            pendingEnvelopeClock = false;
+        }
     }
 
     public boolean isEnabled() {
@@ -31,12 +47,14 @@ public class VolumeEnvelope implements Serializable, Originator<VolumeEnvelope> 
 
     public void start() {
         finished = true;
+        pendingEnvelopeClock = false;
     }
 
     public void trigger() {
         volume = initialVolume;
         timer = sweep == 0 ? 8 : sweep;
         finished = false;
+        pendingEnvelopeClock = false;
     }
 
     public void clockTick() {
@@ -52,21 +70,63 @@ public class VolumeEnvelope implements Serializable, Originator<VolumeEnvelope> 
         }
         if (--timer <= 0) {
             timer = sweep;
-            volume += envelopeDirection;
+            clockVolume();
         }
     }
 
-    public int getVolume() {
-        if (isEnabled()) {
-            return volume;
-        } else {
-            return initialVolume;
+    public void apuClockTick(int frameSequencerStep) {
+        // The frame sequencer numbers the power-on edge as step 0, while the
+        // envelope's secondary latch observes the opposite half of that phase.
+        if (pendingEnvelopeClock && (frameSequencerStep & 1) == 1) {
+            pendingEnvelopeClock = false;
+            timer = sweep;
+            clockVolume();
         }
+    }
+
+    private void applyWriteGlitch(int register, int oldSweep, int oldDirection) {
+        int oldLow = oldSweep | (oldDirection == 1 ? 0b1000 : 0);
+        int newLow = register & 0b1111;
+        boolean locked = finished;
+        boolean shouldTick = (newLow & 0b111) != 0 && oldSweep == 0 && !locked;
+        boolean shouldInvert = ((newLow ^ oldLow) & 0b1000) != 0;
+
+        if (newLow == 0b1000 && oldLow == 0b1000 && !locked) {
+            shouldTick = true;
+        }
+        if (shouldInvert) {
+            if ((newLow & 0b1000) != 0) {
+                if (oldSweep == 0 && !locked) {
+                    volume ^= 0b1111;
+                } else {
+                    volume = (14 - volume) & 0b1111;
+                }
+                shouldTick = false;
+            } else {
+                volume = (16 - volume) & 0b1111;
+            }
+        }
+        if (shouldTick) {
+            volume = (volume + ((newLow & 0b1000) != 0 ? 1 : -1)) & 0b1111;
+        }
+    }
+
+    private void clockVolume() {
+        if ((volume == 0 && envelopeDirection == -1) || (volume == 15 && envelopeDirection == 1)) {
+            finished = true;
+            return;
+        }
+        volume += envelopeDirection;
+    }
+
+    public int getVolume() {
+        return volume;
     }
 
     @Override
     public Memento<VolumeEnvelope> saveToMemento() {
-        return new VolumeEnvelopeMemento(initialVolume, envelopeDirection, sweep, volume, timer, finished);
+        return new VolumeEnvelopeMemento(initialVolume, envelopeDirection, sweep, volume, timer, finished,
+                pendingEnvelopeClock);
     }
 
     @Override
@@ -80,10 +140,11 @@ public class VolumeEnvelope implements Serializable, Originator<VolumeEnvelope> 
         this.volume = mem.volume;
         this.timer = mem.timer;
         this.finished = mem.finished;
+        this.pendingEnvelopeClock = mem.pendingEnvelopeClock;
     }
 
     private record VolumeEnvelopeMemento(int initialVolume, int envelopeDirection, int sweep, int volume, int timer,
-                                         boolean finished) implements Memento<VolumeEnvelope> {
+                                         boolean finished, boolean pendingEnvelopeClock) implements Memento<VolumeEnvelope> {
     }
 
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -28,6 +28,8 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
 
     private int ticksSinceOverflow;
 
+    private boolean divReset;
+
     public Timer(InterruptManager interruptManager, SpeedMode speedMode) {
         this.speedMode = speedMode;
         this.interruptManager = interruptManager;
@@ -42,6 +44,7 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
     }
 
     public void tick() {
+        divReset = false;
         updateDiv((div + speedMode.getSpeedMode()) & 0xffff);
         if (overflow) {
             ticksSinceOverflow++;
@@ -89,6 +92,7 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
         switch (address) {
             case 0xff04:
                 updateDiv(0);
+                divReset = true;
                 break;
 
             case 0xff05:
@@ -107,6 +111,16 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
                 tac = value;
                 break;
         }
+    }
+
+    public boolean consumeDivReset() {
+        boolean result = divReset;
+        divReset = false;
+        return result;
+    }
+
+    public boolean isDivResetPending() {
+        return divReset;
     }
 
     @Override
@@ -129,7 +143,7 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
 
     @Override
     public Memento<Timer> saveToMemento() {
-        return new TimerMemento(div, tac, tma, tima, previousBit, overflow, ticksSinceOverflow);
+        return new TimerMemento(div, tac, tma, tima, previousBit, overflow, ticksSinceOverflow, divReset);
     }
 
     @Override
@@ -144,10 +158,11 @@ public class Timer implements AddressSpace, Serializable, Originator<Timer> {
         this.previousBit = mem.previousBit;
         this.overflow = mem.overflow;
         this.ticksSinceOverflow = mem.ticksSinceOverflow;
+        this.divReset = mem.divReset;
     }
 
     public record TimerMemento(int div, int tac, int tma, int tima, boolean previousBit, boolean overflow,
-                               int ticksSinceOverflow) implements Memento<Timer> {
+                               int ticksSinceOverflow, boolean divReset) implements Memento<Timer> {
     }
 
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/daid/DaidRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/daid/DaidRomTest.java
@@ -50,12 +50,13 @@ public class DaidRomTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                // Correct palette patterns, currently phased 4 DMG / 5 CGB dots early.
+                // Correct palette patterns, currently phased 4 DMG / 7 CGB dots early.
+                // The CGB phase includes the boot ROM's full 32-dot GDMA block stalls.
                 {"ppu_scanline_bgp (DMG)", "ppu_scanline_bgp.gb", GameboyType.DMG,
                         new String[]{"ppu_scanline_bgp_0.dmg.png", "ppu_scanline_bgp_1.dmg.png",
                                 "ppu_scanline_bgp_2.dmg.png"}, 2192},
                 {"ppu_scanline_bgp (CGB)", "ppu_scanline_bgp.gb", GameboyType.CGB,
-                        new String[]{"ppu_scanline_bgp.gbc.png"}, 2880},
+                        new String[]{"ppu_scanline_bgp.gbc.png"}, 4032},
                 {"stop_instr (DMG)", "stop_instr.gb", GameboyType.DMG,
                         new String[]{"stop_instr.dmg.png"}, 0},
                 {"stop_instr (CGB)", "stop_instr.gb", GameboyType.CGB,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/mooneye/GeneralTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/mooneye/GeneralTest.java
@@ -24,7 +24,7 @@ public class GeneralTest {
         this.romPath = romPath;
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void test() throws IOException {
         RomTestUtils.testMooneyeRom(romPath);
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SweepTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SweepTest.java
@@ -33,12 +33,14 @@ public class SweepTest {
         wregNR(10, 0x01);
         wregNR(13, 0xff);
         wregNR(14, 0xc7);
+        delaySweepCalculation(4);
         shouldBeOff();
 
         begin();
         wregNR(10, 0x11);
         wregNR(13, 0xff);
         wregNR(14, 0xc7);
+        delaySweepCalculation(4);
         shouldBeOff();
     }
 
@@ -113,6 +115,7 @@ public class SweepTest {
         wregNR(10, 0x02);
         wregNR(13, 0x67);
         wregNR(14, 0xc6);
+        delaySweepCalculation(5);
         shouldBeOff();
     }
 
@@ -323,6 +326,7 @@ public class SweepTest {
             if (firedStep == 2 || firedStep == 6) {
                 sweep.clockTick();
             }
+            sweep.tick();
         }
     }
 
@@ -338,6 +342,9 @@ public class SweepTest {
 
             case 14:
                 sweep.setNr14(value);
+                if ((value & 0x80) != 0) {
+                    sweep.trigger(false, false, false);
+                }
                 break;
 
             default:
@@ -351,6 +358,13 @@ public class SweepTest {
             if (firedStep == 2 || firedStep == 6) {
                 sweep.clockTick();
             }
+            sweep.tick();
+        }
+    }
+
+    private void delaySweepCalculation(int oneMhzTicks) {
+        for (int i = 0; i < oneMhzTicks * 4; i++) {
+            sweep.tick();
         }
     }
 }


### PR DESCRIPTION
## Summary

- make all 71 SameSuite ROMs pass by correcting DIV/APU sequencing, channel timing, sweep/envelope behavior, and live PCM output
- fix the EI/HALT, SGB joypad, and HDMA edge cases exercised by the suite
- preserve Mooneye boot timing with accurate HDMA pacing and a non-flaky bootstrap timeout
- add SameSuite as its own GitHub Actions step

## Validation

- core unit tests: 101 passed
- SameSuite: 71 passed
- Mooneye: 98 passed
- BullyGB: 2 passed
- RTC3: 3 passed
- Blargg aggregate: 8 passed
- Blargg individual: 46 passed