### PR TITLE
Fix Joust & Defender trainer screen

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -56,6 +56,12 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
         fillWithGarbage(ramC000, 0xc000, 0x1000, garbage);
         fillWithGarbage(ramD000, 0xd000, 0x1000, garbage);
         gbcRam.fillWithGarbage(garbage);
+        // The fixed garbage pattern must still contain zero runs. Older GBDK font
+        // code uses this block as a lazy-init sentinel (issue #111), while the
+        // following block remains nonzero for Minesweeper's seed (issue #48).
+        for (int address = 0xc0f8; address < 0xc100; address++) {
+            ramC000.setByte(address, 0);
+        }
 
         addAddressSpace(ramC000);
         if (gbc) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/MmuPowerOnTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/MmuPowerOnTest.java
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MmuPowerOnTest {
+
+    @Test
+    public void powerOnWramContainsBothZeroSentinelsAndEntropy() {
+        Mmu mmu = new Mmu(true);
+        mmu.indexSpaces();
+
+        // Older GBDK font code lazily initializes this BSS block (issue #111).
+        for (int address = 0xc0f8; address < 0xc100; address++) {
+            assertEquals(0, mmu.getByte(address));
+        }
+
+        // Minesweeper seeds its LFSR from this otherwise-uninitialized block (issue #48).
+        boolean hasNonZeroSeed = false;
+        for (int address = 0xc100; address < 0xc110; address++) {
+            hasNonZeroSeed |= mmu.getByte(address) != 0;
+        }
+        assertTrue(hasNonZeroSeed);
+    }
+}


### PR DESCRIPTION
Closes #111.

The fixed pseudo-random WRAM image left the old GBDK font BSS sentinel at C0F8-C0FF nonzero, so the trainer skipped initialization and rendered corrupted glyphs. Add a small zero run there while preserving nonzero entropy in C100-C10F for the Minesweeper behavior covered by #48.

Verification:
- Coffee GB output at frame 120 is pixel-identical to PyBoy (0 differing pixels)
- Core unit tests: 102 passed
- Mooneye: 98 passed
- Daid: 9 passed
- SameSuite: 71 passed