### PR TITLE
Support BHGOS multicart banking

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -49,6 +49,8 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             addressSpace = new Mani32kMulticart(rom);
         } else if (isDuzMulticart(rom)) {
             addressSpace = new DuzMulticart(rom, battery);
+        } else if (isBhgosMulticart(rom)) {
+            addressSpace = new BhgosMulticart(rom, battery);
         } else if (sachenType(rom) >= 0) {
             addressSpace = new SachenMmc(rom, sachenType(rom) == 2);
         } else if (isCookedSachen(rom)) {
@@ -207,6 +209,17 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             }
         }
         return false;
+    }
+
+    /**
+     * Blue Hippo's Game Boy Operating System multicarts keep the menu's MBC5 header but
+     * add a register that relocates the complete 32 KiB cartridge window to a selected
+     * embedded game. A standalone 32 KiB copy of the menu needs no special mapping.
+     */
+    private static boolean isBhgosMulticart(Rom rom) {
+        return "MultiCart".equals(rom.getTitle())
+                && rom.getType().isMbc5()
+                && rom.getRom().length > 0x8000;
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
@@ -1,0 +1,118 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+import java.util.Arrays;
+
+/**
+ * Blue Hippo's Game Boy Operating System multicart mapper. Its menu is followed by
+ * unmodified games aligned to 32 KiB boundaries. The second write to 0x6000-0x7FFF
+ * selects one of those blocks and relocates both ROM windows; bank writes made by the
+ * selected game are then relative to that block.
+ */
+public class BhgosMulticart implements MemoryController {
+
+    private final int[] rom;
+
+    private final int romBanks;
+
+    private final int[] ram = new int[4 * 0x2000];
+
+    private final Battery battery;
+
+    private int selectedRomBank = 1;
+
+    private int selectedRamBank;
+
+    private int baseRomBank;
+
+    private int blockSelectWrites;
+
+    private boolean ramUpdated;
+
+    public BhgosMulticart(Rom rom, Battery battery) {
+        this.rom = rom.getRom();
+        this.romBanks = Math.max(2, (this.rom.length + 0x3fff) / 0x4000);
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (address >= 0x2000 && address < 0x4000) {
+            selectedRomBank = value == 0 ? 1 : value;
+        } else if (address >= 0x4000 && address < 0x6000) {
+            selectedRamBank = value & 0x03;
+        } else if (address >= 0x6000 && address < 0x8000) {
+            blockSelectWrites++;
+            if (blockSelectWrites == 2) {
+                baseRomBank = (value * 2) % romBanks;
+                selectedRomBank = 1;
+            }
+        } else if (address >= 0xa000 && address < 0xc000) {
+            ram[selectedRamBank * 0x2000 + address - 0xa000] = value;
+            ramUpdated = true;
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x4000) {
+            return getRomByte(baseRomBank, address);
+        } else if (address >= 0x4000 && address < 0x8000) {
+            return getRomByte(baseRomBank + selectedRomBank, address - 0x4000);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ram[selectedRamBank * 0x2000 + address - 0xa000];
+        }
+        throw new IllegalArgumentException(Integer.toHexString(address));
+    }
+
+    private int getRomByte(int bank, int address) {
+        int offset = (bank % romBanks) * 0x4000 + address;
+        return offset < rom.length ? rom[offset] : 0xff;
+    }
+
+    @Override
+    public void flushRam() {
+        if (ramUpdated) {
+            battery.saveRam(ram);
+            battery.flush();
+        }
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new BhgosMulticartMemento(battery.saveToMemento(), ram.clone(), selectedRomBank,
+                selectedRamBank, baseRomBank, blockSelectWrites, ramUpdated);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof BhgosMulticartMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        battery.restoreFromMemento(mem.batteryMemento);
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        selectedRomBank = mem.selectedRomBank;
+        selectedRamBank = mem.selectedRamBank;
+        baseRomBank = mem.baseRomBank;
+        blockSelectWrites = mem.blockSelectWrites;
+        ramUpdated = mem.ramUpdated;
+    }
+
+    private record BhgosMulticartMemento(Memento<Battery> batteryMemento, int[] ram,
+                                         int selectedRomBank, int selectedRamBank,
+                                         int baseRomBank, int blockSelectWrites,
+                                         boolean ramUpdated) implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticartTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticartTest.java
@@ -1,0 +1,65 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BhgosMulticartTest {
+
+    @Test
+    public void detectsMulticartAndRelocatesBothRomWindows() throws IOException {
+        Cartridge cartridge = new Cartridge(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        MemoryController mapper = cartridge.getMemoryController();
+
+        assertTrue(mapper instanceof BhgosMulticart);
+        assertEquals(0, mapper.getByte(0x0000));
+
+        // The menu can inspect all appended banks before choosing a game.
+        mapper.setByte(0x2000, 5);
+        assertEquals(5, mapper.getByte(0x4000));
+
+        mapper.setByte(0x6100, 0xd0); // unlock write
+        mapper.setByte(0x6000, 2);    // second embedded 32 KiB block
+        mapper.setByte(0x6000, 0);    // menu's final latch write
+
+        assertEquals(4, mapper.getByte(0x0000));
+        assertEquals(5, mapper.getByte(0x4000));
+
+        // Bank requests made by the embedded game are relative to its new bank 0.
+        mapper.setByte(0x2000, 2);
+        assertEquals(6, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void providesFourAlwaysWritableRamBanks() throws IOException {
+        MemoryController mapper = new BhgosMulticart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x4000, 3);
+        mapper.setByte(0xa123, 0x5a);
+        assertEquals(0x5a, mapper.getByte(0xa123));
+
+        mapper.setByte(0x4000, 0);
+        assertEquals(0xff, mapper.getByte(0xa123));
+    }
+
+    private static byte[] multicartRom() {
+        byte[] data = new byte[8 * 0x4000];
+        for (int bank = 0; bank < 8; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        byte[] title = "MultiCart".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x134, title.length);
+        data[0x143] = (byte) 0x80;
+        data[0x147] = 0x1a; // MBC5 + RAM
+        data[0x148] = 0x00; // the menu only declares its own 32 KiB
+        return data;
+    }
+}


### PR DESCRIPTION
Closes #114.

BHGOS images keep the menu MBC5 header but use an extra register sequence to relocate the complete 32 KiB ROM window to an embedded game. Add a dedicated controller that exposes the appended banks to the menu, handles the second 0x6000-0x7fff write as the block selector, makes subsequent bank requests relative to that block, and provides the four always-writable RAM banks used by the format.

Verification:
- Overclocked Combo menu renders both entries correctly
- First entry launches Tetris
- Second entry launches MMX / MEGAMAN.X
- Core unit tests: 103 passed
- Mooneye: 98 passed
- Daid: 9 passed
- SameSuite: 71 passed