### PR TITLE
Blank the first DMG frame after LCD enable

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -28,13 +28,12 @@ public class Display implements Serializable, Originator<Display> {
 
     private boolean enabled = true;
 
-    // On the CGB the first frame after the LCD is switched back on is not shown: real
-    // hardware puts out a garbage/incomplete frame while the PPU re-locks to the line grid,
-    // so the previous frame is repeated for one frame instead (SameBoy's frame_skip_state /
-    // GB_VBLANK_TYPE_REPEAT). Games that swap BG buffers behind a brief mid-frame LCD-off
-    // (e.g. A Bug's Life every 7 frames) would otherwise flash the transient enable-frame
-    // render, flickering once per swap.
-    private transient boolean repeatFrame;
+    // The first frame after the LCD is switched back on is not shown while the PPU re-locks
+    // to the line grid. A CGB repeats the previous frame; a DMG outputs a blank frame.
+    // SameBoy models these as the two GB_FRAMESKIP_LCD_TURNED_ON paths. Exposing the
+    // incomplete DMG frame leaves fragments of the old screen behind during transitions
+    // (Hitori de Dekirumon, issue #126).
+    private transient boolean firstFrameAfterLcdEnable;
 
     public Display(boolean gbc) {
         this.gbc = gbc;
@@ -45,7 +44,7 @@ public class Display implements Serializable, Originator<Display> {
     }
 
     void putDmgPixel(int color) {
-        if (!enabled || repeatFrame) {
+        if (!enabled || firstFrameAfterLcdEnable) {
             return;
         }
         if (i >= buffer.length) {
@@ -55,7 +54,7 @@ public class Display implements Serializable, Originator<Display> {
     }
 
     void putColorPixel(int gbcRgb) {
-        if (!enabled || repeatFrame) {
+        if (!enabled || firstFrameAfterLcdEnable) {
             return;
         }
         if (i >= buffer.length) {
@@ -66,10 +65,17 @@ public class Display implements Serializable, Originator<Display> {
 
     public void frameIsReady() {
         i = 0;
-        if (repeatFrame) {
-            // discard the just-rendered enable frame; re-show the previous complete frame
-            repeatFrame = false;
-            eventBus.post(gbc ? new GbcFrameReadyEvent(lastFrame) : new DmgFrameReadyEvent(lastFrame));
+        if (firstFrameAfterLcdEnable) {
+            firstFrameAfterLcdEnable = false;
+            if (gbc) {
+                // The CGB keeps the previous complete frame on its panel.
+                eventBus.post(new GbcFrameReadyEvent(lastFrame));
+            } else {
+                // The DMG drives a blank frame instead of exposing the incomplete render.
+                Arrays.fill(buffer, 0);
+                System.arraycopy(buffer, 0, lastFrame, 0, buffer.length);
+                eventBus.post(new DmgFrameReadyEvent(buffer));
+            }
             return;
         }
         System.arraycopy(buffer, 0, lastFrame, 0, buffer.length);
@@ -86,9 +92,7 @@ public class Display implements Serializable, Originator<Display> {
     public void enableLcd() {
         i = 0;
         enabled = true;
-        if (gbc) {
-            repeatFrame = true;
-        }
+        firstFrameAfterLcdEnable = true;
     }
 
     public void disableLcd() {
@@ -104,8 +108,8 @@ public class Display implements Serializable, Originator<Display> {
 
     /** Emits a blank frame while the LCD stays off (a sustained off blanks the screen). */
     public void blankFrame() {
-        // a deliberate blank overrides any pending enable-frame repeat
-        repeatFrame = false;
+        // a deliberate blank overrides any pending enable-frame skip
+        firstFrameAfterLcdEnable = false;
         Arrays.fill(buffer, 0);
         i = 0;
         frameIsReady();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
@@ -1,0 +1,71 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class DisplayTest {
+
+    private static final int PIXELS = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
+
+    @Test
+    public void dmgBlanksFirstFrameAfterLcdEnable() {
+        Display display = new Display(false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.pixels().clone()), Display.DmgFrameReadyEvent.class);
+        display.init(eventBus);
+
+        fillDmg(display, 3);
+        display.frameIsReady();
+
+        display.disableLcd();
+        display.enableLcd();
+        fillDmg(display, 2);
+        display.frameIsReady();
+
+        assertArrayEquals(new int[PIXELS], frame.get());
+
+        int[] expected = new int[PIXELS];
+        java.util.Arrays.fill(expected, 1);
+        fillDmg(display, 1);
+        display.frameIsReady();
+        assertArrayEquals(expected, frame.get());
+    }
+
+    @Test
+    public void cgbRepeatsPreviousFrameAfterLcdEnable() {
+        Display display = new Display(true);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.pixels().clone()), Display.GbcFrameReadyEvent.class);
+        display.init(eventBus);
+
+        int[] expected = new int[PIXELS];
+        java.util.Arrays.fill(expected, 0x1234);
+        fillCgb(display, 0x1234);
+        display.frameIsReady();
+
+        display.disableLcd();
+        display.enableLcd();
+        fillCgb(display, 0x4321);
+        display.frameIsReady();
+
+        assertArrayEquals(expected, frame.get());
+    }
+
+    private static void fillDmg(Display display, int color) {
+        for (int i = 0; i < PIXELS; i++) {
+            display.putDmgPixel(color);
+        }
+    }
+
+    private static void fillCgb(Display display, int color) {
+        for (int i = 0; i < PIXELS; i++) {
+            display.putColorPixel(color);
+        }
+    }
+}


### PR DESCRIPTION
DMG hardware outputs a blank first frame while the PPU settles after LCDC is re-enabled. Coffee GB previously exposed that incomplete render, leaving fragments of the prior screen during transitions. CGB behavior remains unchanged: it repeats the previous complete frame.

Adds focused DMG and CGB display regressions. Verified with 103 core unit tests, 98 Mooneye tests, 9 Daid tests, 71 SameSuite tests, and 24 Mealybug PPU tests.