### PR TITLE
Cover SGB LCD re-enable blanking

### DIFF
--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/SgbDisplayLcdTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/SgbDisplayLcdTest.java
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SgbDisplayLcdTest {
+
+    private static final int PIXELS = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
+
+    @Test
+    public void lcdReenableFrameIsBlankBeforeSgbColorization() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        SgbDisplay sgbDisplay = new SgbDisplay(testRom(), sgbBus, true, false);
+        sgbDisplay.init(eventBus);
+
+        Display display = new Display(false);
+        display.init(eventBus);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(
+                event -> frame.set(event.buffer().clone()), SgbDisplay.SgbFrameReadyEvent.class);
+
+        fill(display, 3);
+        display.frameIsReady();
+        int nonBlankColor = frame.get()[0];
+
+        display.disableLcd();
+        display.enableLcd();
+        fill(display, 2);
+        display.frameIsReady();
+
+        int blankColor = frame.get()[0];
+        assertNotEquals(nonBlankColor, blankColor);
+        for (int pixel : frame.get()) {
+            assertEquals(blankColor, pixel);
+        }
+    }
+
+    private static Rom testRom() throws IOException {
+        byte[] bytes = new byte[0x8000];
+        bytes[0x147] = 0x00;
+        return new Rom(bytes);
+    }
+
+    private static void fill(Display display, int color) {
+        for (int i = 0; i < PIXELS; i++) {
+            display.putDmgPixel(color);
+        }
+    }
+}


### PR DESCRIPTION
Konami GB Collection uses the DMG PPU through the Super Game Boy path, so it depends on the first-frame blanking fix in #132. This stacked PR adds an end-to-end regression proving that the blank DMG frame is colorized as a uniform SGB frame rather than leaking tiles from the previous screen.

Verified with the focused regression and all 104 core unit tests.