### PR TITLE
Fix SGB transfer capture timing

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
@@ -39,7 +39,7 @@ public class SuperGameboy implements Originator<SuperGameboy> {
     }
 
     private void handleVBlank(int[] buffer) {
-        if (waitingTransferCommand != null && transferCountdown-- == 0) {
+        if (waitingTransferCommand != null && --transferCountdown == 0) {
             waitingTransferCommand.setDataTransfer(buffer.clone());
             LOG.atInfo().log("Transfer command: {}", waitingTransferCommand);
             sgbBus.post(waitingTransferCommand);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
@@ -1,0 +1,40 @@
+package eu.rekawek.coffeegb.core.sgb;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.VRamTransfer;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SuperGameboyTest {
+
+    @Test
+    public void transferCommandCapturesThirdFrameAfterPacket() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        new SuperGameboy(sgbBus);
+        AtomicReference<Commands.PctTrnCmd> transfer = new AtomicReference<>();
+        sgbBus.register(transfer::set, Commands.PctTrnCmd.class);
+
+        int[] packet = new int[16];
+        packet[0] = (0x14 << 3) | 1; // one-packet PCT_TRN
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(packet));
+
+        postFrame(sgbBus, 1);
+        assertNull(transfer.get());
+        postFrame(sgbBus, 2);
+        assertNull(transfer.get());
+        postFrame(sgbBus, 3);
+
+        assertEquals(3, transfer.get().dataTransfer[0]);
+    }
+
+    private static void postFrame(EventBusImpl sgbBus, int value) {
+        int[] frame = new int[0x1000];
+        Arrays.fill(frame, value);
+        sgbBus.post(new VRamTransfer.VRamTransferComplete(frame));
+    }
+}


### PR DESCRIPTION
Fixes #123.

SGB VRAM transfer commands capture the third frame after their packet. Coffee GB used a post-decrement countdown and captured the fourth frame instead. Bomberman Collection has restored gameplay by then, so its gameplay tiles were decoded as border data.

The countdown now matches SameBoy and captures the third VBlank. A focused PCT_TRN timing regression was added. Verified with 103 core unit tests and all 71 SameSuite tests.