### PR TITLE
Cover SGB character transfer timing

### DIFF
--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
@@ -32,6 +32,28 @@ public class SuperGameboyTest {
         assertEquals(3, transfer.get().dataTransfer[0]);
     }
 
+    @Test
+    public void characterTransferAlsoCapturesThirdFrameAfterPacket() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        new SuperGameboy(sgbBus);
+        AtomicReference<Commands.ChrTrnCmd> transfer = new AtomicReference<>();
+        sgbBus.register(transfer::set, Commands.ChrTrnCmd.class);
+
+        int[] packet = new int[16];
+        packet[0] = (0x13 << 3) | 1; // one-packet CHR_TRN
+        packet[1] = 1; // upper tile half
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(packet));
+
+        postFrame(sgbBus, 1);
+        assertNull(transfer.get());
+        postFrame(sgbBus, 2);
+        assertNull(transfer.get());
+        postFrame(sgbBus, 3);
+
+        assertEquals(0x80, transfer.get().getTileOffset());
+        assertEquals(3, transfer.get().dataTransfer[0]);
+    }
+
     private static void postFrame(EventBusImpl sgbBus, int value) {
         int[] frame = new int[0x1000];
         Arrays.fill(frame, value);


### PR DESCRIPTION
Wild Snake uses the same SGB border upload path corrected in #134. This separate stacked PR adds CHR_TRN coverage, verifying that character data—like PCT_TRN map data—is captured on the third frame and that upper-half tile selection is preserved.

Verified with the focused transfer regression.