### PR TITLE
Fix Bomberman audio DC filtering

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -38,11 +38,10 @@ public class AudioSystemSound implements Runnable {
     private static final int VOLUME_SCALE = 62;
 
     /**
-     * One-pole DC-blocking high-pass (~7 Hz at 44.1 kHz), mirroring the console's analog
-     * output path: an idle-but-enabled DAC parks a constant offset on the line which the
-     * speaker never sees, but its master-volume modulation (PCM speech) passes through.
+     * The console's output capacitor has a cutoff of about 28 Hz. It removes the
+     * baseline steps caused by channel routing while preserving master-volume PCM.
      */
-    private static final double HIGHPASS = 0.999;
+    private static final double HIGHPASS_CUTOFF = 28.0;
 
     private static final double TICKS_PER_SAMPLE = (double) Gameboy.TICKS_PER_SEC / SAMPLE_RATE;
 
@@ -68,7 +67,9 @@ public class AudioSystemSound implements Runnable {
 
     private int cnt, prevCnt;
 
-    private double hpInL, hpInR, hpOutL, hpOutR;
+    private final DcBlocker dcBlockerL = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
+
+    private final DcBlocker dcBlockerR = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
 
     public AudioSystemSound(SoundProperties properties, EventBus eventBus, String callerId) {
         enabled = properties.getSoundEnabled();
@@ -148,12 +149,10 @@ public class AudioSystemSound implements Runnable {
                 int total = prevCnt + cnt;
                 double rawL = (double) (prevSumL + sumL) / total;
                 double rawR = (double) (prevSumR + sumR) / total;
-                hpOutL = rawL - hpInL + HIGHPASS * hpOutL;
-                hpOutR = rawR - hpInR + HIGHPASS * hpOutR;
-                hpInL = rawL;
-                hpInR = rawR;
-                int left = enabled ? (int) (hpOutL * VOLUME_SCALE) : 0;
-                int right = enabled ? (int) (hpOutR * VOLUME_SCALE) : 0;
+                double filteredL = dcBlockerL.filter(rawL);
+                double filteredR = dcBlockerR.filter(rawR);
+                int left = enabled ? (int) (filteredL * VOLUME_SCALE) : 0;
+                int right = enabled ? (int) (filteredR * VOLUME_SCALE) : 0;
                 out[j++] = (byte) left;
                 out[j++] = (byte) (left >> 8);
                 out[j++] = (byte) right;

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DcBlocker.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DcBlocker.java
@@ -1,0 +1,21 @@
+package eu.rekawek.coffeegb.swing.io;
+
+final class DcBlocker {
+
+    private final double pole;
+
+    private double previousInput;
+
+    private double previousOutput;
+
+    DcBlocker(double sampleRate, double cutoff) {
+        pole = Math.exp(-2.0 * Math.PI * cutoff / sampleRate);
+    }
+
+    double filter(double input) {
+        double output = input - previousInput + pole * previousOutput;
+        previousInput = input;
+        previousOutput = output;
+        return output;
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DcBlockerTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DcBlockerTest.java
@@ -1,0 +1,44 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DcBlockerTest {
+
+    private static final int SAMPLE_RATE = 44_100;
+
+    private static final double CUTOFF = 28.0;
+
+    @Test
+    public void dcStepDecaysByOneTimeConstant() {
+        DcBlocker filter = new DcBlocker(SAMPLE_RATE, CUTOFF);
+        int timeConstantSamples = (int) Math.round(SAMPLE_RATE / (2.0 * Math.PI * CUTOFF));
+
+        double output = 0;
+        for (int i = 0; i < timeConstantSamples; i++) {
+            output = filter.filter(1.0);
+        }
+
+        assertEquals(Math.exp(-1), output, 0.002);
+    }
+
+    @Test
+    public void preservesMasterVolumePcmFrequencies() {
+        DcBlocker filter = new DcBlocker(SAMPLE_RATE, CUTOFF);
+        double inputEnergy = 0;
+        double outputEnergy = 0;
+        int warmup = SAMPLE_RATE / 10;
+
+        for (int i = 0; i < SAMPLE_RATE; i++) {
+            double input = Math.sin(2.0 * Math.PI * 200.0 * i / SAMPLE_RATE);
+            double output = filter.filter(input);
+            if (i >= warmup) {
+                inputEnergy += input * input;
+                outputEnergy += output * output;
+            }
+        }
+
+        assertEquals(1.0, Math.sqrt(outputEnergy / inputEnergy), 0.02);
+    }
+}


### PR DESCRIPTION
Fixes #122.

Bomberman GB 2 rapidly changes NR51 routing during the Mode A tutorial. The previous 7 Hz DC blocker retained those normal DAC baseline steps as an audible buzz. This changes the output capacitor model to the hardware/reference rate of about 28 Hz.

The filter recurrence is extracted into DcBlocker and covered by tests which verify:
- a DC step decays by one time constant at 28 Hz
- 200 Hz master-volume PCM remains intact

Validation:
- exact Bomber Man Collection Mode A tutorial replay compared with SameBoy
- /opt/maven/bin/mvn -q test