### PR TITLE
Show the Crazy Castle 3 trainer

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -93,7 +93,15 @@ public class Rom {
         }
         cartridgeType = type;
         LOG.debug("Cartridge {}, type: {}", title, cartridgeType);
-        gameboyColorFlag = GameboyColorFlag.getFlag(rom[0x0143]);
+        GameboyColorFlag colorFlag = GameboyColorFlag.getFlag(rom[0x0143]);
+        if (isDmgOnlyCrazyCastleTrainer(rom, title)) {
+            // This trainer advertises CGB compatibility but only initializes the DMG
+            // BGP/OBP registers. Native CGB startup therefore renders its menu entirely
+            // white and also leaves HRAM in a state the trainer does not expect.
+            LOG.info("DMG-only Crazy Castle 3 trainer detected; ignoring its CGB flag");
+            colorFlag = GameboyColorFlag.NON_CGB;
+        }
+        gameboyColorFlag = colorFlag;
         superGameboyFlag = rom[0x0146] == 0x03;
         romBanks = getRomBanks(rom[0x0148], rom.length);
         int ramSize = getRamSize(rom[0x0149]);
@@ -148,6 +156,20 @@ public class Rom {
     // reuse 0xBE is not mislabelled.
     private static boolean isPocketVoice(int[] rom, String title) {
         return rom[0x0147] == 0xBE && title.startsWith("Pocket Voice");
+    }
+
+    private static boolean isDmgOnlyCrazyCastleTrainer(int[] rom, String title) {
+        int[] entryStub = {0xf5, 0x3e, 0x03, 0xea, 0x00, 0x21, 0xf1, 0xc3, 0x00, 0x68};
+        if (rom.length != 0x100000 || !"BUGS CC3 CRACK".equals(title)
+                || rom[0x0143] != 0x80 || rom[0x0147] != 0x19) {
+            return false;
+        }
+        for (int i = 0; i < entryStub.length; i++) {
+            if (rom[0x00e0 + i] != entryStub[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String getTitle(int[] rom) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CrazyCastleTrainerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CrazyCastleTrainerTest.java
@@ -1,0 +1,45 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.GameboyType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class CrazyCastleTrainerTest {
+
+    @Test
+    public void classifiesDmgOnlyTrainerAsNonCgb() throws IOException {
+        Rom rom = new Rom(trainerRom());
+
+        assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
+        assertEquals(GameboyType.DMG, new Gameboy.GameboyConfiguration(rom).getGameboyType());
+    }
+
+    @Test
+    public void doesNotReclassifyOtherUniversalMbc5Carts() throws IOException {
+        byte[] data = trainerRom();
+        data[0x00e0] = 0;
+        Rom rom = new Rom(data);
+
+        assertEquals(Rom.GameboyColorFlag.UNIVERSAL, rom.getGameboyColorFlag());
+        assertEquals(GameboyType.CGB, new Gameboy.GameboyConfiguration(rom).getGameboyType());
+    }
+
+    private static byte[] trainerRom() {
+        byte[] data = new byte[0x100000];
+        byte[] title = "BUGS CC3 CRACK".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x19;
+        data[0x0148] = 0x05;
+        int[] entryStub = {0xf5, 0x3e, 0x03, 0xea, 0x00, 0x21, 0xf1, 0xc3, 0x00, 0x68};
+        for (int i = 0; i < entryStub.length; i++) {
+            data[0x00e0 + i] = (byte) entryStub[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #136.

The trainer advertises CGB compatibility but only initializes the DMG palette registers and depends on DMG startup HRAM. Coffee therefore ran it in native CGB mode and rendered an all-white screen.

Recognize the trainer by its title, mapper, size, CGB flag, and entry stub, then classify only that exact layout as non-CGB. Other universal MBC5 carts remain unchanged.

Validation:
- focused positive and negative classification tests
- full core unit suite
- exact issue ROM shows the trainer at frame 30
- Start leaves the trainer and reaches the Kemco game