### PR TITLE
Support Bung EMS mapper for Cube Raider

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -13,6 +13,7 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.zip.CRC32;
 
 public class Cartridge implements AddressSpace, Serializable, Originator<Cartridge> {
 
@@ -40,7 +41,9 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         this.battery = battery;
 
         var type = rom.getType();
-        if (type.isMmm01()) {
+        if (isBungEms(rom)) {
+            addressSpace = new BungEms(rom, battery);
+        } else if (type.isMmm01()) {
             // the dump has the menu program first; the mapper wants it last
             addressSpace = new Mmm01(rom, battery, true);
         } else if (isHiddenMmm01(rom)) {
@@ -222,6 +225,45 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
                 && rom.getRom().length > 0x8000;
     }
 
+    /** Bung/EMS flashcarts use an MBC5-like bank register plus a configurable OR mask. */
+    private static boolean isBungEms(Rom rom) {
+        int[] data = rom.getRom();
+        if (data.length < 0x150) {
+            return false;
+        }
+
+        int rawType = data[0x0147];
+        // Pocket Voice uses the proposed 0xBE marker for unrelated voice hardware.
+        if (rawType == 0xbe && rom.getTitle().startsWith("Pocket Voice")) {
+            return false;
+        }
+
+        CRC32 crc = new CRC32();
+        for (int value : data) {
+            crc.update(value);
+        }
+        switch ((int) crc.getValue()) {
+            case 0x2ed509d9: // Green Beret
+            case 0xf004440c: // Cube Raider
+            case 0xfdc1483a: // Bugs Bunny - Crazy Castle 3 trainer
+                return true;
+        }
+
+        return hasNullTerminatedTitle(data, "EMSMENU")
+                || hasNullTerminatedTitle(data, "GB16M")
+                || rawType == 0xbe
+                || (rawType == 0x1b && data[0x014a] == 0xe1);
+    }
+
+    private static boolean hasNullTerminatedTitle(int[] data, String title) {
+        for (int i = 0; i < title.length(); i++) {
+            if (data[0x0134 + i] != title.charAt(i)) {
+                return false;
+            }
+        }
+        return data[0x0134 + title.length()] == 0;
+    }
+
     /**
      * Detects the Sachen MMC1/MMC2 multicarts (issues #73/#75) by their scrambled header:
      * the 0x0100-0x01FF page is wired with A0/A6 and A1/A4 swapped, so the logo bytes sit
@@ -303,6 +345,9 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             // is the exception: its 2 KiB header size is mirrored across A000-BFFF.
             int ramSize = rom.getType() == CartridgeType.ROM_RAM_BATTERY
                     ? rom.getRamSize() : 0x2000 * rom.getRamBanks();
+            if (isBungEms(rom)) {
+                ramSize = 0x8000;
+            }
             if (ramSize == 0 && rom.getType().isRam()) {
                 ramSize = 0x2000;
             }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
@@ -1,0 +1,148 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+import java.util.Arrays;
+
+/**
+ * Bung/EMS flashcart mapper. The selected ROM bank is ORed with a configurable
+ * base mask, allowing a menu to expose one embedded game as a complete cartridge.
+ */
+public class BungEms implements MemoryController {
+
+    private static final int RAM_BANKS = 4;
+
+    private final int[] cartridge;
+
+    private final int romBanks;
+
+    private final int[] ram = new int[RAM_BANKS * 0x2000];
+
+    private final Battery battery;
+
+    private int romBankLow = 1;
+
+    private int romBankHigh;
+
+    private int romBankMask;
+
+    private int romBankLatch = 1;
+
+    private int selectedRamBank;
+
+    private boolean configureMode;
+
+    private boolean ramEnabled = true;
+
+    private boolean ramUpdated;
+
+    public BungEms(Rom rom, Battery battery) {
+        cartridge = rom.getRom();
+        romBanks = Math.max(1, (cartridge.length + 0x3fff) / 0x4000);
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (address >= 0x0000 && address < 0x2000) {
+            if (value == 0xa5) {
+                configureMode = true;
+            } else if (value == 0x98) {
+                configureMode = false;
+            } else {
+                ramEnabled = (value & 0x0f) == 0x0a;
+            }
+        } else if (address >= 0x2000 && address < 0x3000) {
+            romBankLow = value;
+            romBankLatch = value;
+        } else if (address >= 0x3000 && address < 0x4000) {
+            romBankHigh = value & 1;
+        } else if (address >= 0x4000 && address < 0x6000) {
+            selectedRamBank = value & (RAM_BANKS - 1);
+        } else if (address >= 0x7000 && address < 0x8000 && configureMode) {
+            romBankMask = romBankLatch;
+        } else if (address >= 0xa000 && address < 0xc000 && ramEnabled) {
+            ram[getRamAddress(address)] = value;
+            ramUpdated = true;
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x4000) {
+            return getRomByte(normalizeRomBank(romBankMask), address);
+        } else if (address >= 0x4000 && address < 0x8000) {
+            int selected = romBankLow | (romBankHigh << 8) | romBankMask;
+            return getRomByte(normalizeRomBank(selected), address - 0x4000);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ramEnabled ? ram[getRamAddress(address)] : 0xff;
+        } else {
+            throw new IllegalArgumentException(Integer.toHexString(address));
+        }
+    }
+
+    @Override
+    public void flushRam() {
+        if (ramUpdated) {
+            battery.saveRam(ram);
+            battery.flush();
+        }
+    }
+
+    private int normalizeRomBank(int bank) {
+        return bank % romBanks;
+    }
+
+    private int getRomByte(int bank, int address) {
+        int offset = bank * 0x4000 + address;
+        return offset < cartridge.length ? cartridge[offset] : 0xff;
+    }
+
+    private int getRamAddress(int address) {
+        return selectedRamBank * 0x2000 + address - 0xa000;
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new BungEmsMemento(battery.saveToMemento(), ram.clone(), romBankLow, romBankHigh,
+                romBankMask, romBankLatch, selectedRamBank, configureMode, ramEnabled, ramUpdated);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof BungEmsMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        if (ram.length != mem.ram.length) {
+            throw new IllegalArgumentException("Memento ram length doesn't match");
+        }
+        battery.restoreFromMemento(mem.batteryMemento);
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        romBankLow = mem.romBankLow;
+        romBankHigh = mem.romBankHigh;
+        romBankMask = mem.romBankMask;
+        romBankLatch = mem.romBankLatch;
+        selectedRamBank = mem.selectedRamBank;
+        configureMode = mem.configureMode;
+        ramEnabled = mem.ramEnabled;
+        ramUpdated = mem.ramUpdated;
+    }
+
+    private record BungEmsMemento(Memento<Battery> batteryMemento, int[] ram,
+                                  int romBankLow, int romBankHigh, int romBankMask,
+                                  int romBankLatch, int selectedRamBank, boolean configureMode,
+                                  boolean ramEnabled, boolean ramUpdated)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEmsTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEmsTest.java
@@ -1,0 +1,184 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BungEmsTest {
+
+    @Test
+    public void selectsRomBanksAndAppliesTheGameMask() throws IOException {
+        MemoryController mapper = new BungEms(new Rom(bankMarkedRom("EMSMENU", 0x1b, 0x00)),
+                Battery.NULL_BATTERY);
+
+        assertEquals(0, mapper.getByte(0x0000));
+        assertEquals(1, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 3);
+        assertEquals(3, mapper.getByte(0x4000));
+        mapper.setByte(0x6000, 0xff);
+        mapper.setByte(0x7000, 0xff);
+        assertEquals(0, mapper.getByte(0x0000));
+        assertEquals(3, mapper.getByte(0x4000));
+
+        // Unlike MBC1, selecting bank zero is allowed.
+        mapper.setByte(0x2000, 0);
+        assertEquals(0, mapper.getByte(0x4000));
+
+        // The menu latches the embedded game's base bank in configuration mode. The
+        // mask relocates both ROM windows; later game bank writes remain relative to it.
+        mapper.setByte(0x1000, 0xa5);
+        mapper.setByte(0x2000, 8);
+        mapper.setByte(0x7000, 0);
+        mapper.setByte(0x1000, 0x98);
+        mapper.setByte(0x2000, 1);
+
+        assertEquals(8, mapper.getByte(0x0000));
+        assertEquals(9, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void selectsTheNinthRomBankBit() throws IOException {
+        MemoryController mapper = new BungEms(
+                new Rom(bankMarkedRom("EMSMENU", 0x1b, 0x00, 512)),
+                Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2000, 1);
+        mapper.setByte(0x3000, 1);
+
+        assertEquals(1, mapper.getByte(0x4000));
+        assertEquals(1, mapper.getByte(0x4001));
+    }
+
+    @Test
+    public void exposesFourRamBanksAndHonoursTheEnableRegister() throws IOException {
+        MemoryController mapper = new BungEms(new Rom(bankMarkedRom("EMSMENU", 0x1b, 0x00)),
+                Battery.NULL_BATTERY);
+
+        // Bung/EMS SRAM is enabled at power-on.
+        mapper.setByte(0x4000, 3);
+        mapper.setByte(0xa123, 0x5a);
+        assertEquals(0x5a, mapper.getByte(0xa123));
+
+        mapper.setByte(0x4000, 0);
+        assertEquals(0xff, mapper.getByte(0xa123));
+
+        mapper.setByte(0x0000, 0x00);
+        mapper.setByte(0xa123, 0x33);
+        assertEquals(0xff, mapper.getByte(0xa123));
+
+        mapper.setByte(0x0000, 0x0a);
+        assertEquals(0xff, mapper.getByte(0xa123));
+        mapper.setByte(0xa123, 0x33);
+        assertEquals(0x33, mapper.getByte(0xa123));
+    }
+
+    @Test
+    public void mementoRoundTripRestoresMappingAndRam() throws IOException {
+        MemoryController mapper = new BungEms(
+                new Rom(bankMarkedRom("EMSMENU", 0x1b, 0x00, 512)),
+                Battery.NULL_BATTERY);
+
+        mapper.setByte(0x1000, 0xa5);
+        mapper.setByte(0x2000, 0x80);
+        mapper.setByte(0x7000, 0);
+        mapper.setByte(0x3000, 1);
+        mapper.setByte(0x2000, 5); // pending mask latch
+        mapper.setByte(0x4000, 2);
+        mapper.setByte(0xa000, 0x66);
+        mapper.setByte(0x0000, 0x00); // save with RAM disabled and config mode active
+        Memento<MemoryController> memento = mapper.saveToMemento();
+
+        mapper.setByte(0x1000, 0x98);
+        mapper.setByte(0x0000, 0x0a);
+        mapper.setByte(0x3000, 0);
+        mapper.setByte(0x2000, 3);
+        mapper.setByte(0x4000, 0);
+        mapper.setByte(0xa000, 0x33);
+        mapper.restoreFromMemento(memento);
+
+        assertEquals(0x80, mapper.getByte(0x0000));
+        assertEquals(0x85, mapper.getByte(0x4000));
+        assertEquals(1, mapper.getByte(0x4001));
+        assertEquals(0xff, mapper.getByte(0xa000));
+
+        mapper.setByte(0x0000, 0x0a);
+        assertEquals(0x66, mapper.getByte(0xa000));
+        mapper.setByte(0x7000, 0); // restored config mode commits the restored pending latch
+        assertEquals(5, mapper.getByte(0x0000));
+        assertEquals(5, mapper.getByte(0x4000));
+        assertEquals(1, mapper.getByte(0x4001));
+    }
+
+    @Test
+    public void allocatesA32KiBBatteryForDocumentedHeaders() throws IOException {
+        byte[] data = bankMarkedRom("EMSMENU", 0x1b, 0x00);
+        data[0x149] = 0; // the flashcart header may omit its physical SRAM size
+        File romFile = Files.createTempFile("bung-ems", ".gb").toFile();
+        File saveFile = Cartridge.getSaveName(romFile);
+        try {
+            Files.write(romFile.toPath(), data);
+            Cartridge cartridge = new Cartridge(new Rom(romFile), true);
+            cartridge.setByte(0xa000, 0x5a);
+            cartridge.flushBattery();
+
+            assertEquals(0x8000, saveFile.length());
+        } finally {
+            Files.deleteIfExists(saveFile.toPath());
+            Files.deleteIfExists(romFile.toPath());
+        }
+    }
+
+    @Test
+    public void detectsDocumentedBungEmsHeaders() throws IOException {
+        assertBungEms(bankMarkedRom("EMSMENU", 0x1b, 0x00));
+        assertBungEms(bankMarkedRom("GB16M", 0x1b, 0x00));
+        assertBungEms(bankMarkedRom("CART", 0xbe, 0x00));
+        assertBungEms(bankMarkedRom("CART", 0x1b, 0xe1));
+    }
+
+    @Test
+    public void doesNotTreatPocketVoiceAsBungEms() throws IOException {
+        Cartridge cartridge = new Cartridge(
+                new Rom(bankMarkedRom("Pocket Voice2.0", 0xbe, 0x00)),
+                Battery.NULL_BATTERY);
+
+        assertTrue(cartridge.getMemoryController() instanceof Mbc5);
+    }
+
+    private static void assertBungEms(byte[] data) throws IOException {
+        Cartridge cartridge = new Cartridge(new Rom(data), Battery.NULL_BATTERY);
+        assertTrue(cartridge.getMemoryController() instanceof BungEms);
+    }
+
+    private static byte[] bankMarkedRom(String title, int type, int region) {
+        return bankMarkedRom(title, type, region, 16);
+    }
+
+    private static byte[] bankMarkedRom(String title, int type, int region, int banks) {
+        byte[] data = new byte[banks * 0x4000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+            data[bank * 0x4000 + 1] = (byte) (bank >> 8);
+        }
+        byte[] titleBytes = title.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(titleBytes, 0, data, 0x134, titleBytes.length);
+        data[0x134 + titleBytes.length] = 0;
+        data[0x147] = (byte) type;
+        data[0x148] = 0x03;
+        data[0x149] = 0x03;
+        data[0x14a] = (byte) region;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #137.

Cube Raider is a Bung/EMS flashcart dump whose MBC2 header does not describe its banking hardware. Add mapper detection from documented headers, type markers, and known dump CRCs; implement its MBC5-like low/high bank registers, configuration latch and OR mask, four SRAM banks, battery sizing, and memento state.

The Pocket Voice custom type 0xBE remains on MBC5.

Validation:
- `mvn -q clean test`
- exact issue ROM reaches the Bung splash and Cube Raider intro after Start
- exact Green Beret Bung dump remains bootable
- synthetic tests cover detection, bank zero and the ninth bit, mask protocol, SRAM and battery behavior, and save states