### PR TITLE
Fix Bo Jackson scoreboard rendering

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
@@ -139,6 +139,12 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
     // window mid-window-fetch suppresses the glitch for the rest of the line
     private boolean insertionGlitchDisabled;
 
+    // The DMG's disabled-window insertion glitch is gated by the PPU's latched WY
+    // comparison, not by LY merely having passed WY. A game may leave arbitrary WY/WX
+    // values behind while never enabling the window (Bo Jackson does); those values must
+    // not create pixels on their own.
+    private boolean windowYTriggered;
+
     public Fetcher(
             PixelFifo fifo,
             AddressSpace videoRam0,
@@ -181,6 +187,10 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
 
     public void disableInsertionGlitch() {
         insertionGlitchDisabled = true;
+    }
+
+    public void setWindowYTriggered(boolean windowYTriggered) {
+        this.windowYTriggered = windowYTriggered;
     }
 
     /**
@@ -267,8 +277,8 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
                 if (fifo.getLength() == 0) {
                     if (!gbc
                             && !insertionGlitchDisabled
-                            && !lcdc.isWindowDisplay()
-                            && r.get(GpuRegister.LY) >= r.get(GpuRegister.WY)) {
+                            && windowYTriggered
+                            && !lcdc.isWindowDisplay()) {
                         int logicalPosition = (position + 7) & 0xff;
                         if (logicalPosition > 167) {
                             logicalPosition = 0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -209,6 +209,8 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         // in all modes (the last pixels of a line leave the delay line during HBlank)
         r.tickConflicts();
         lcdc.tickConflicts();
+        pixelTransferPhase.checkWindowY();
+        pixelMachine.checkWindowY();
         pixelMachine.outputTick();
         pixelMachine.machineTick();
 
@@ -465,6 +467,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         }
         r.put(LY, 0);
         pixelTransferPhase.resetWindowLineCounter();
+        pixelMachine.resetWindowLineCounter();
         this.line = 0;
         this.ticksInLine = 0;
         this.firstLine = false;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -60,6 +60,11 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
 
     private int windowLineCounter = -1;
 
+    // Latched when the window is enabled while LY equals WY. It remains set for the
+    // frame even if LCDC.5 is later cleared; hardware uses this latch both for window
+    // activation and for the disabled-window insertion glitch.
+    private boolean windowYTriggered;
+
     // a WX comparator match holds the activation pending for one tick: the comparator
     // on hardware sees register writes one machine cycle before our CPU commits them,
     // so a WX write landing within the skew means the window never triggered. The
@@ -265,6 +270,20 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
     public void resetWindowLineCounter() {
         // pre-incremented at window activation: the first activated line renders row 0
         windowLineCounter = -1;
+        windowYTriggered = false;
+        fetcher.setWindowYTriggered(false);
+    }
+
+    /** Samples the DMG/CGB WY comparator. Called every PPU tick, including mode 2. */
+    public void checkWindowY() {
+        if (!windowYTriggered && lcdc.isWindowDisplay() && r.get(LY) == r.get(WY)) {
+            windowYTriggered = true;
+            fetcher.setWindowYTriggered(true);
+        }
+    }
+
+    boolean isWindowYTriggered() {
+        return windowYTriggered;
     }
 
     @Override
@@ -397,7 +416,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         // desync branch below). Only for regular WX>=7 positions so the discard-phase
         // WX=0..6 activation is untouched.
         if (!gbc && !window && !lcdc.isWindowDisplay() && !windowActivatedThisLine
-                && r.get(LY) >= r.get(WY)) {
+                && windowYTriggered) {
             int wxNow = r.get(WX);
             if (wxNow >= 7 && wxNow < 166 && !r.isWxJustChanged()
                     && wxNow == ((position + 7) & 0xff)) {
@@ -412,7 +431,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         if (!window
                 && lcdc.isWindowDisplay()
                 && (gbc || lcdc.isBgAndWindowDisplay())
-                && r.get(LY) >= r.get(WY)) {
+                && windowYTriggered) {
             int wx = r.get(WX);
             boolean activate;
             if (wx == 0) {
@@ -641,7 +660,8 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
                 windowPendingPos,
                 windowActivatedThisLine,
                 insertBgPixel,
-                machineStall);
+                machineStall,
+                windowYTriggered);
     }
 
     @Override
@@ -686,6 +706,8 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         this.windowActivatedThisLine = mem.windowActivatedThisLine;
         this.insertBgPixel = mem.insertBgPixel;
         this.machineStall = mem.machineStall;
+        this.windowYTriggered = mem.windowYTriggered;
+        fetcher.setWindowYTriggered(windowYTriggered);
     }
 
     private record PixelTransferMemento(
@@ -710,7 +732,8 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
             int windowPendingPos,
             boolean windowActivatedThisLine,
             boolean insertBgPixel,
-            int machineStall)
+            int machineStall,
+            boolean windowYTriggered)
             implements Memento<PixelTransfer> {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherWindowInsertionTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherWindowInsertionTest.java
@@ -1,0 +1,92 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.memory.Ram;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FetcherWindowInsertionTest {
+
+    @Test
+    public void disabledWindowDoesNotInsertPixelWithoutWyTrigger() {
+        RecordingFifo fifo = runFetch(false);
+
+        assertEquals(0, fifo.singlePixelPushes);
+        assertEquals(1, fifo.tilePushes);
+    }
+
+    @Test
+    public void disabledWindowInsertsPixelAfterWyTrigger() {
+        RecordingFifo fifo = runFetch(true);
+
+        assertEquals(1, fifo.singlePixelPushes);
+        assertEquals(0, fifo.tilePushes);
+    }
+
+    private static RecordingFifo runFetch(boolean windowYTriggered) {
+        RecordingFifo fifo = new RecordingFifo();
+        GpuRegisterValues registers = new GpuRegisterValues();
+        registers.put(GpuRegister.LY, 128);
+        registers.put(GpuRegister.WY, 128);
+        registers.put(GpuRegister.WX, 151);
+
+        Lcdc lcdc = new Lcdc(); // $91: LCD and BG on, window off (Bo Jackson scoreboard)
+        Fetcher fetcher = new Fetcher(
+                fifo,
+                new Ram(0x8000, 0x2000),
+                null,
+                new Ram(0xfe00, 0xa0),
+                lcdc,
+                registers,
+                false);
+        fetcher.startLine();
+        fetcher.setWindowYTriggered(windowYTriggered);
+
+        while (fifo.singlePixelPushes == 0 && fifo.tilePushes == 0) {
+            fetcher.advance(144, false, -1, false);
+        }
+        return fifo;
+    }
+
+    private static class RecordingFifo implements PixelFifo {
+
+        private int singlePixelPushes;
+        private int tilePushes;
+
+        @Override
+        public int getLength() {
+            return 0;
+        }
+
+        @Override
+        public void enqueuePixel(int pixel) {
+            singlePixelPushes++;
+        }
+
+        @Override
+        public void enqueue8Pixels(int[] pixels, TileAttributes tileAttributes) {
+            tilePushes++;
+        }
+
+        @Override
+        public void putPixelToScreen() {
+        }
+
+        @Override
+        public void dropPixel() {
+        }
+
+        @Override
+        public void setOverlay(
+                int[] pixelLine, int offset, TileAttributes flags, int oamIndex) {
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public void clearBg() {
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
@@ -1,0 +1,80 @@
+package eu.rekawek.coffeegb.core.gpu.phase;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.gpu.ColorPalette;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.gpu.GpuRegister;
+import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
+import eu.rekawek.coffeegb.core.gpu.Lcdc;
+import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.Ram;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PixelTransferWindowTriggerTest {
+
+    @Test
+    public void triggerRequiresEnabledWindowAtMatchingLineAndSurvivesDisable() {
+        Harness h = new Harness();
+        h.registers.put(GpuRegister.LY, 128);
+        h.registers.put(GpuRegister.WY, 128);
+
+        h.transfer.checkWindowY();
+        assertFalse(h.transfer.isWindowYTriggered());
+
+        h.lcdc.set(0xb1); // enable window while LY == WY
+        h.transfer.checkWindowY();
+        assertTrue(h.transfer.isWindowYTriggered());
+
+        h.lcdc.set(0x91);
+        h.transfer.checkWindowY();
+        assertTrue(h.transfer.isWindowYTriggered());
+    }
+
+    @Test
+    public void triggerResetsWithFrameAndRoundTripsThroughMemento() {
+        Harness h = new Harness();
+        h.registers.put(GpuRegister.LY, 42);
+        h.registers.put(GpuRegister.WY, 42);
+        h.lcdc.set(0xb1);
+        h.transfer.checkWindowY();
+        Memento<PixelTransfer> triggered = h.transfer.saveToMemento();
+
+        h.transfer.resetWindowLineCounter();
+        assertFalse(h.transfer.isWindowYTriggered());
+
+        h.transfer.restoreFromMemento(triggered);
+        assertTrue(h.transfer.isWindowYTriggered());
+    }
+
+    private static class Harness {
+
+        private final GpuRegisterValues registers = new GpuRegisterValues();
+        private final Lcdc lcdc = new Lcdc();
+        private final PixelTransfer transfer;
+
+        private Harness() {
+            SpritePosition[] sprites = new SpritePosition[10];
+            for (int i = 0; i < sprites.length; i++) {
+                sprites[i] = new SpritePosition();
+            }
+            transfer = new PixelTransfer(
+                    new Display(false),
+                    new Ram(0x8000, 0x2000),
+                    null,
+                    new Ram(0xfe00, 0xa0),
+                    lcdc,
+                    registers,
+                    false,
+                    new ColorPalette(0xff68),
+                    new ColorPalette(0xff6a),
+                    sprites,
+                    null,
+                    new SpeedMode(false),
+                    0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #120

Coffee GB applied the DMG disabled-window insertion glitch whenever LY had merely passed WY. Hardware gates that glitch on the latched WY comparison: the window must have been enabled while LY equaled WY. Bo Jackson leaves WY/WX values behind with LCDC.5 disabled, so the old condition inserted a blank pixel on scoreboard lines 128-141 and shifted their right edge.

This adds the missing frame-scoped WY latch, uses it for window activation/catch-up/insertion, resets it on frame wrap and LCD disable, and persists it in save states.

Validation:
- exact Bo Jackson scoreboard: 0 pixel mismatches against the live background tile map
- Mealybug Tearoom: 24/24 image tests pass
- full Maven reactor: 127 tests pass
- unit coverage for armed/unarmed insertion plus latch acquire, retain, reset, and memento restore

Hardware references:
- https://github.com/gbdev/pandocs/issues/376
- https://github.com/LIJI32/SameBoy/issues/278