### PR TITLE
Fix Bomberman Collection SGB graphics

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -33,6 +33,7 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
     private int currentPlayer;
 
     private boolean transferInProgress;
+    private boolean transferWaitForHigh;
     private int currentByte;
     private final int[] currentPacket = new int[16];
     private int currentByteIndex;
@@ -42,6 +43,11 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         this.interruptManager = interruptManager;
         this.isSgb = isSgb;
         this.sgbBus = sgbBus;
+        // JOYP powers on with both selector lines low. On an SGB, that level has already
+        // reset the ICD2 receiver, so the first transition to idle-high may release the
+        // start pulse without software having to create another falling edge first.
+        transferInProgress = isSgb;
+        transferWaitForHigh = isSgb;
         sgbBus.register(event -> {
             players = event.getMultiplayerControl();
             if (players == 2) {
@@ -99,31 +105,11 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
     @Override
     public void setByte(int address, int value) {
         if (isSgb) {
-            boolean bit4 = BitUtils.getBit(value, 4);
-            boolean bit5 = BitUtils.getBit(value, 5);
-
-            if (!bit4 && !bit5) {
-                transferInProgress = true;
-                currentByte = 0;
-                currentByteIndex = 0;
-                currentPacketIndex = 0;
-                Arrays.fill(currentPacket, 0);
-            } else if (transferInProgress && (!bit4 || !bit5)) {
-                if (!bit5) {
-                    currentByte |= (1 << currentByteIndex);
-                }
-                currentByteIndex++;
-                if (currentByteIndex == 8) {
-                    if (currentPacketIndex < 16) {
-                        currentPacket[currentPacketIndex++] = currentByte;
-                        if (currentPacketIndex == 16) {
-                            transferInProgress = false;
-                            sgbBus.post(new SuperGameboy.PacketReceivedEvent(currentPacket.clone()));
-                        }
-                    }
-                    currentByteIndex = 0;
-                    currentByte = 0;
-                }
+            int input = value & 0x30;
+            // The ICD2 receiver reacts to line transitions. Rewriting the level that is
+            // already on JOYP must neither add a bit nor abort an in-flight packet.
+            if (input != p1) {
+                receiveSgbPacketPulse(input);
             }
         }
         if (players > 0 && players != 2 && !BitUtils.getBit(p1, 5) && BitUtils.getBit(value, 5)) {
@@ -134,6 +120,62 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
             LOG.atDebug().log("Player changed to {}", currentPlayer);
         }
         p1 = value & 0b00110000;
+    }
+
+    private void receiveSgbPacketPulse(int input) {
+        if (input == 0x00) {
+            // Both lines low reset the receiver and start a fresh 16-byte packet.
+            transferInProgress = true;
+            transferWaitForHigh = true;
+            currentByte = 0;
+            currentByteIndex = 0;
+            currentPacketIndex = 0;
+            Arrays.fill(currentPacket, 0);
+            return;
+        }
+        if (!transferInProgress) {
+            return;
+        }
+        if (transferWaitForHigh) {
+            if (input == 0x30) {
+                transferWaitForHigh = false;
+            } else {
+                abortSgbPacket();
+            }
+            return;
+        }
+        if (input == 0x30) {
+            // Licensed software commonly leaves both lines high much longer than the
+            // receiver requires. Additional writes during that idle period are harmless.
+            return;
+        }
+
+        if (currentPacketIndex == currentPacket.length) {
+            // A packet is complete only after its mandatory 129th, zero-valued stop bit.
+            if (input == 0x20) {
+                sgbBus.post(new SuperGameboy.PacketReceivedEvent(currentPacket.clone()));
+            }
+            abortSgbPacket();
+            return;
+        }
+
+        // P14 low ($20) transmits zero; P15 low ($10) transmits one, least-significant
+        // bit first. No next pulse is accepted until both lines return high.
+        if (input == 0x10) {
+            currentByte |= 1 << currentByteIndex;
+        }
+        currentByteIndex++;
+        if (currentByteIndex == 8) {
+            currentPacket[currentPacketIndex++] = currentByte;
+            currentByteIndex = 0;
+            currentByte = 0;
+        }
+        transferWaitForHigh = true;
+    }
+
+    private void abortSgbPacket() {
+        transferInProgress = false;
+        transferWaitForHigh = false;
     }
 
     @Override
@@ -165,7 +207,9 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         // button held in a rewound-past frame would be re-applied and, with no matching
         // release event ever arriving, stick when forward emulation resumes (issue: rewind
         // replays past button presses).
-        return new JoypadMemento(p1, tick, players, currentPlayer, transferInProgress, currentByte, currentPacket, currentByteIndex, currentPacketIndex);
+        return new JoypadMemento(p1, tick, players, currentPlayer, transferInProgress,
+                transferWaitForHigh, currentByte, currentPacket.clone(), currentByteIndex,
+                currentPacketIndex);
     }
 
     @Override
@@ -178,6 +222,7 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         this.players = mem.players;
         this.currentPlayer = mem.currentPlayer;
         this.transferInProgress = mem.transferInProgress;
+        this.transferWaitForHigh = mem.transferWaitForHigh;
         this.currentByte = mem.currentByte;
         if (mem.currentPacket.length != this.currentPacket.length) {
             throw new IllegalArgumentException("Invalid memento length");
@@ -188,7 +233,10 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
 
     }
 
-    private record JoypadMemento(int p1, long tick, int players, int currentPlayer, boolean transferInProgress, int currentByte, int[] currentPacket, int currentByteIndex, int currentPacketIndex) implements Memento<Joypad> {
+    private record JoypadMemento(int p1, long tick, int players, int currentPlayer,
+                                boolean transferInProgress, boolean transferWaitForHigh,
+                                int currentByte, int[] currentPacket, int currentByteIndex,
+                                int currentPacketIndex) implements Memento<Joypad> {
     }
 
     public record JoypadPressEvent(Button button, long tick) implements Event {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadSgbPacketTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadSgbPacketTest.java
@@ -1,0 +1,224 @@
+package eu.rekawek.coffeegb.core.joypad;
+
+import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.sgb.Commands;
+import eu.rekawek.coffeegb.core.sgb.SuperGameboy;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class JoypadSgbPacketTest {
+
+    private EventBusImpl sgbBus;
+    private Joypad joypad;
+    private List<int[]> receivedPackets;
+
+    @Before
+    public void setUp() {
+        sgbBus = new EventBusImpl(null, null, false);
+        joypad = new Joypad(new InterruptManager(false), sgbBus, true);
+        receivedPackets = new ArrayList<>();
+        sgbBus.register(event -> receivedPackets.add(event.packet()),
+                SuperGameboy.PacketReceivedEvent.class);
+    }
+
+    @Test
+    public void completePacketIsPostedOnlyAfterZeroStopBit() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 128, false);
+
+        assertTrue(receivedPackets.isEmpty());
+        writeSelector(0x20); // required zero stop bit
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void firstPacketCanUsePowerOnLowAsStartPulse() {
+        int[] packet = patternedPacket();
+        writeSelector(0x00); // JOYP already powers on at this level
+        writeSelector(0x30);
+        writeDataBits(packet, 0, 128, false);
+        writeSelector(0x20);
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void oneStopBitRejectsPacket() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 128, false);
+        writeSelector(0x10); // invalid one stop bit
+
+        assertTrue(receivedPackets.isEmpty());
+    }
+
+    @Test
+    public void dataPulseImmediatelyAfterResetRejectsPacket() {
+        writeSelector(0x30);
+        writeSelector(0x00);
+        writeSelector(0x10); // the start pulse was never released to idle-high
+
+        writeDataBits(patternedPacket(), 1, 128, false);
+        writeSelector(0x20);
+
+        assertTrue(receivedPackets.isEmpty());
+    }
+
+    @Test
+    public void alternatingControllerPollingCannotBecomeAaPacket() {
+        writeSelector(0x30);
+        writeSelector(0x00);
+        for (int i = 0; i < 256; i++) {
+            // Ordinary polling can alternate the two selector lines, but without the
+            // idle-high spaces this is not an SGB transmission.
+            writeSelector((i & 1) == 0 ? 0x20 : 0x10);
+        }
+
+        assertTrue(receivedPackets.isEmpty());
+    }
+
+    @Test
+    public void repeatedJoypLevelsDoNotDuplicateBits() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 128, true);
+        writeSelector(0x20);
+        writeSelector(0x20);
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void midPacketMementoRestoresReceiverPhaseAndData() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 37, false);
+        Memento<Joypad> memento = joypad.saveToMemento();
+
+        // Mutate every receiver field, including the packet array retained by the
+        // snapshot, before restoring the partial transfer.
+        startPacket();
+        writeDataBits(new int[16], 0, 19, false);
+        joypad.restoreFromMemento(memento);
+
+        writeDataBits(packet, 37, 128, false);
+        writeSelector(0x20);
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void mementoRestoresPendingIdleHighPhase() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 37, false);
+        writeSelector(selectorForBit(packet, 37));
+        Memento<Joypad> memento = joypad.saveToMemento();
+
+        startPacket();
+        joypad.restoreFromMemento(memento);
+        writeSelector(0x30);
+        writeDataBits(packet, 38, 128, false);
+        writeSelector(0x20);
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void mementoRestoresPacketAwaitingStopBit() {
+        int[] packet = patternedPacket();
+        startPacket();
+        writeDataBits(packet, 0, 128, false);
+        Memento<Joypad> memento = joypad.saveToMemento();
+
+        startPacket();
+        joypad.restoreFromMemento(memento);
+        writeSelector(0x20);
+
+        assertEquals(1, receivedPackets.size());
+        assertArrayEquals(packet, receivedPackets.get(0));
+    }
+
+    @Test
+    public void malformedPollingCannotPoisonFollowingSgbCommand() {
+        new SuperGameboy(sgbBus);
+        AtomicReference<Commands.Pal01Cmd> command = new AtomicReference<>();
+        sgbBus.register(command::set, Commands.Pal01Cmd.class);
+
+        writeSelector(0x30);
+        writeSelector(0x00);
+        for (int i = 0; i < 128; i++) {
+            writeSelector((i & 1) == 0 ? 0x20 : 0x10);
+        }
+
+        int[] packet = new int[16];
+        packet[0] = 1; // PAL01, one packet
+        packet[1] = 0x34;
+        packet[2] = 0x12;
+        sendPacket(packet);
+
+        assertNotNull(command.get());
+        assertEquals(0x1234, command.get().getPalette0()[0]);
+    }
+
+    private void sendPacket(int[] packet) {
+        startPacket();
+        writeDataBits(packet, 0, 128, false);
+        writeSelector(0x20);
+    }
+
+    private void startPacket() {
+        writeSelector(0x30);
+        writeSelector(0x00);
+        writeSelector(0x30);
+    }
+
+    private void writeDataBits(int[] packet, int from, int to, boolean repeatLevels) {
+        for (int bitIndex = from; bitIndex < to; bitIndex++) {
+            int selector = selectorForBit(packet, bitIndex);
+            writeSelector(selector);
+            if (repeatLevels) {
+                writeSelector(selector);
+            }
+            writeSelector(0x30);
+            if (repeatLevels) {
+                writeSelector(0x30);
+            }
+        }
+    }
+
+    private static int selectorForBit(int[] packet, int bitIndex) {
+        int bit = (packet[bitIndex / 8] >> (bitIndex & 7)) & 1;
+        return bit == 0 ? 0x20 : 0x10;
+    }
+
+    private void writeSelector(int selector) {
+        joypad.setByte(0xff00, selector);
+    }
+
+    private static int[] patternedPacket() {
+        int[] packet = new int[16];
+        for (int i = 0; i < packet.length; i++) {
+            packet[i] = (i * 37 + 0x51) & 0xff;
+        }
+        return packet;
+    }
+}


### PR DESCRIPTION
## Root cause

The SGB receiver accepted every alternating `$10`/`$20` JOYP selector write after `$00` as packet data. Bomberman Collection performs ordinary controller polling with that pattern, so Coffee GB synthesized an `AA AA ...` packet and treated it as a multi-packet `ATTR_TRN`. The following real packet was then consumed as its continuation, corrupting the border tile map over the Game Boy image.

## Fix

- Decode only selector transitions with the required idle-high gaps.
- Require the documented zero stop bit before publishing a 16-byte packet.
- Arm the receiver for the power-on JOYP-low state, including skip-bootstrap startup.
- Persist the complete receiver phase and an independent packet buffer in mementos.
- Add 10 focused tests for valid framing, malformed polling, power-on, stop bits, repeated levels, subsequent commands, and save-state phases.

## Verification

- Bomberman Collection exact-ROM path: complete border and unobstructed Game Boy image in both `NORMAL` and `SKIP` bootstrap modes.
- 42 decoded packets and zero synthetic all-`AA` packets through the selected-game menu path.
- `JoypadSgbPacketTest`: 10/10 passed.
- Full Maven reactor: 122 core tests and 13 controller tests passed.

## Protocol references

- Pan Docs packet framing: https://gbdev.io/pandocs/SGB_Command_Packet.html
- mGBA pinned receiver implementation: https://github.com/mgba-emu/mgba/blob/5157ce208a5965e8a47bf5b48b5aae5198c22a5e/src/gb/io.c#L114-L152
- Mesen2 pinned receiver implementation: https://github.com/SourMesen/Mesen2/blob/b9fa69ddc6d0a331fb103fdb5eef6904305703c2/Core/SNES/Coprocessors/SGB/SuperGameboy.cpp#L139-L203