### PR TITLE
Enable LCD frame blending by default

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
@@ -11,7 +11,7 @@ class DisplayProperties(private val properties: EmulatorProperties) {
     get() = properties.getProperty(EmulatorProperties.Key.ShowSgbBorder, "false").toBoolean()
 
   val blending
-    get() = properties.getProperty(EmulatorProperties.Key.DisplayBlending, "false").toBoolean()
+    get() = properties.getProperty(EmulatorProperties.Key.DisplayBlending, "true").toBoolean()
 
   val colorCorrection
     get() =


### PR DESCRIPTION
Fixes #147

F-1 Race emits complementary alternating frames during races and relies on the original DMG LCD persistence to fuse them. Coffee GB already implements the required previous-frame blend, but fresh configurations left it disabled, exposing a flashing band.

This enables frame blending by default while preserving an explicitly saved user preference to disable it. It also improves other titles that rely on LCD persistence, such as ZAS.

Verification:
- Reproduced the race using `F-1 Race (World) (Rev A).gb`
- Verified consecutive raw frames are complementary
- Verified the existing blend reconstructs the stable full race image
- `/opt/apache-maven-3.8.6/bin/mvn -pl controller -am test` (135 core tests plus controller tests, pass)