### PR TITLE
Model SGB output filtering for Bomber Man Collection

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -1,8 +1,10 @@
 package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.GameboyType;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.sound.Sound;
+import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.SoundProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +61,8 @@ public class AudioSystemSound implements Runnable {
     private volatile boolean isStopped;
     private volatile boolean enabled;
 
+    private volatile GameboyType gameboyType = GameboyType.DMG;
+
     private final BlockingQueue<byte[]> queue = new ArrayBlockingQueue<>(3);
 
     private double resamplePos;
@@ -71,10 +75,21 @@ public class AudioSystemSound implements Runnable {
 
     private final DcBlocker dcBlockerR = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
 
+    private final SgbOutputLowPass lowPassL = new SgbOutputLowPass(SAMPLE_RATE);
+
+    private final SgbOutputLowPass lowPassR = new SgbOutputLowPass(SAMPLE_RATE);
+
     public AudioSystemSound(SoundProperties properties, EventBus eventBus, String callerId) {
         enabled = properties.getSoundEnabled();
         eventBus.register(this::play, Sound.SoundSampleEvent.class, callerId);
+        eventBus.register(this::onGameboyType, Controller.GameboyTypeEvent.class, callerId);
         eventBus.register(e -> this.enabled = e.enabled(), Sound.SoundEnabledEvent.class);
+    }
+
+    private void onGameboyType(Controller.GameboyTypeEvent event) {
+        gameboyType = event.getGameboyType();
+        lowPassL.reset();
+        lowPassR.reset();
     }
 
     @Override
@@ -133,6 +148,7 @@ public class AudioSystemSound implements Runnable {
     private void play(Sound.SoundSampleEvent event) {
         int[] source = event.buffer();
         int ticks = source.length / 2;
+        GameboyType outputModel = gameboyType;
 
         byte[] out = new byte[MAX_FRAME_SAMPLES * 4];
         int j = 0;
@@ -149,8 +165,8 @@ public class AudioSystemSound implements Runnable {
                 int total = prevCnt + cnt;
                 double rawL = (double) (prevSumL + sumL) / total;
                 double rawR = (double) (prevSumR + sumR) / total;
-                double filteredL = dcBlockerL.filter(rawL);
-                double filteredR = dcBlockerR.filter(rawR);
+                double filteredL = lowPassL.filter(dcBlockerL.filter(rawL), outputModel);
+                double filteredR = lowPassR.filter(dcBlockerR.filter(rawR), outputModel);
                 int left = enabled ? (int) (filteredL * VOLUME_SCALE) : 0;
                 int right = enabled ? (int) (filteredR * VOLUME_SCALE) : 0;
                 out[j++] = (byte) left;

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SgbOutputLowPass.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SgbOutputLowPass.java
@@ -1,0 +1,39 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.GameboyType;
+
+/**
+ * Models the RC low-pass on each audio output of the SGB-R-10 board. The SGB CPU's L/R outputs
+ * pass through a 910 ohm resistor and have a 0.1 uF capacitor to ground before reaching the
+ * SNES cartridge contacts. Handheld models do not use this output stage and pass through
+ * unchanged.
+ *
+ * <p>Schematic: https://gbdev.gg8.se/wiki/images/4/41/Super-gameboy.gif
+ */
+final class SgbOutputLowPass {
+
+    static final double RESISTANCE_OHMS = 910.0;
+
+    static final double CAPACITANCE_FARADS = 0.1e-6;
+
+    private final double pole;
+
+    private double previousOutput;
+
+    SgbOutputLowPass(double sampleRate) {
+        double timeConstant = RESISTANCE_OHMS * CAPACITANCE_FARADS;
+        pole = Math.exp(-1.0 / (sampleRate * timeConstant));
+    }
+
+    double filter(double input, GameboyType gameboyType) {
+        if (gameboyType != GameboyType.SGB) {
+            return input;
+        }
+        previousOutput = input + pole * (previousOutput - input);
+        return previousOutput;
+    }
+
+    void reset() {
+        previousOutput = 0;
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SgbOutputLowPassTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SgbOutputLowPassTest.java
@@ -1,0 +1,76 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.GameboyType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SgbOutputLowPassTest {
+
+    private static final int SAMPLE_RATE = 44_100;
+
+    @Test
+    public void leavesHandheldOutputUnchanged() {
+        SgbOutputLowPass filter = new SgbOutputLowPass(SAMPLE_RATE);
+        double[] inputs = {-480.0, -1.25, 0.0, 42.5, 480.0};
+
+        filter.filter(480.0, GameboyType.SGB);
+        for (GameboyType type : new GameboyType[]{GameboyType.DMG, GameboyType.CGB}) {
+            for (double input : inputs) {
+                assertEquals(input, filter.filter(input, type), 0.0);
+            }
+        }
+    }
+
+    @Test
+    public void sgbStepReachesOneBoardTimeConstant() {
+        SgbOutputLowPass filter = new SgbOutputLowPass(SAMPLE_RATE);
+        double timeConstant =
+                SgbOutputLowPass.RESISTANCE_OHMS * SgbOutputLowPass.CAPACITANCE_FARADS;
+        int timeConstantSamples = (int) Math.round(SAMPLE_RATE * timeConstant);
+
+        double output = 0;
+        for (int i = 0; i < timeConstantSamples; i++) {
+            output = filter.filter(1.0, GameboyType.SGB);
+        }
+
+        assertEquals(1.0 - Math.exp(-1.0), output, 0.002);
+    }
+
+    @Test
+    public void sgbIsThreeDbDownAtBoardCutoff() {
+        SgbOutputLowPass filter = new SgbOutputLowPass(SAMPLE_RATE);
+        double timeConstant =
+                SgbOutputLowPass.RESISTANCE_OHMS * SgbOutputLowPass.CAPACITANCE_FARADS;
+        double cutoff = 1.0 / (2.0 * Math.PI * timeConstant);
+        int warmup = SAMPLE_RATE / 10;
+        double inputEnergy = 0;
+        double outputEnergy = 0;
+
+        for (int i = 0; i < SAMPLE_RATE; i++) {
+            double input = Math.sin(2.0 * Math.PI * cutoff * i / SAMPLE_RATE);
+            double output = filter.filter(input, GameboyType.SGB);
+            if (i >= warmup) {
+                inputEnergy += input * input;
+                outputEnergy += output * output;
+            }
+        }
+
+        assertEquals(1.0 / Math.sqrt(2.0), Math.sqrt(outputEnergy / inputEnergy), 0.02);
+    }
+
+    @Test
+    public void resetDischargesTheFilter() {
+        SgbOutputLowPass filter = new SgbOutputLowPass(SAMPLE_RATE);
+        for (int i = 0; i < 100; i++) {
+            filter.filter(1.0, GameboyType.SGB);
+        }
+
+        filter.reset();
+
+        double timeConstant =
+                SgbOutputLowPass.RESISTANCE_OHMS * SgbOutputLowPass.CAPACITANCE_FARADS;
+        double expectedFirstSample = 1.0 - Math.exp(-1.0 / (SAMPLE_RATE * timeConstant));
+        assertEquals(expectedFirstSample, filter.filter(1.0, GameboyType.SGB), 1e-12);
+    }
+}


### PR DESCRIPTION
**AI-generated pull request**

## Summary

- model the SGB-R-10 board's per-channel 910 ohm / 0.1 uF RC output stage
- apply its approximately 1.75 kHz low-pass only in Super Game Boy mode
- leave DMG and CGB output unchanged and reset filter state when the model changes
- cover pass-through, time-domain, cutoff-frequency, and reset behavior

## Rationale

The supplied Bomber Man Collection state isolates the reported background sound to the noise channel. The prior 28 Hz high-pass adjustment cannot attenuate that content. The physical Super Game Boy board has an additional analog low-pass stage between the Game Boy audio outputs and the SNES cartridge contacts, which Coffee GB did not model.

This is deliberately model-specific: handheld output is bit-for-bit unchanged.

## Verification

- `/opt/maven/bin/mvn -pl swing -am test`
- 154 tests passed (135 core, 13 controller, 6 swing)
- focused filter-response tests: 4 passed

Addresses #122. Please keep the issue open until the supplied save state is checked manually by the reporter; an audio-only change does not have a meaningful fixed-state screenshot.
