### PR TITLE
Parallelize integration test profiles and CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -29,29 +28,39 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - name: Mooneye acceptance tests
-      run: mvn -B -pl core test -Ptest-mooneye
-    - name: Blargg tests (aggregate)
-      run: mvn -B -pl core test -Ptest-blargg
-    - name: Blargg tests (individual)
-      run: mvn -B -pl core test -Ptest-blargg-individual
-    - name: Daid tests (baseline-guarded)
-      run: mvn -B -pl core test -Ptest-daid
-    - name: BullyGB tests
-      run: mvn -B -pl core test -Ptest-bullygb
-    - name: MBC30 tests
-      run: mvn -B -pl core test -Ptest-mbc30
-    - name: RTC3 tests
-      run: mvn -B -pl core test -Ptest-rtc3
-    - name: SameSuite tests
-      run: mvn -B -pl core test -Ptest-samesuite
-    - name: dmg-acid2
-      run: mvn -B -pl core test -Ptest-dmgacid2
-    - name: cgbacid2
-      run: mvn -B -pl core test -Ptest-cgbacid2
-    - name: Mealybug Tearoom (baseline-guarded)
-      run: mvn -B -pl core test -Ptest-mealybug
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+
+  integration-tests:
+    name: Integration tests (${{ matrix.name }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Mooneye
+            profiles: test-mooneye
+          - name: Blargg aggregate
+            profiles: test-blargg
+          - name: Blargg individual
+            profiles: test-blargg-individual
+          - name: Compatibility ROMs
+            profiles: test-daid,test-bullygb,test-mbc30,test-rtc3,test-samesuite
+          - name: Acid2
+            profiles: test-dmgacid2,test-cgbacid2
+          - name: Mealybug Tearoom
+            profiles: test-mealybug
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run integration tests
+      run: mvn -B -pl core test -P"${{ matrix.profiles }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,14 @@ them before touching Gpu/StatRegister/Cpu/Sound.**
 - Use `/opt/maven/bin/mvn` in scripts (PATH lacks mvn in non-interactive shells).
 - Run java/mvn from the repo root; use **absolute paths in classpaths** (relative
   classpath entries misbehaved under zsh in this environment).
+- Integration profiles can be combined with commas. Their test methods run on two
+  threads by default; override with `-Dintegration.test.threadCount=N`. BullyGB is
+  kept serial because its two methods have tight 10-second timeouts.
 - Full battery (each ~1-2 min):
   ```
   mvn -pl core test                            # unit
-  mvn -pl core test -Ptest-mooneye             # all mooneye suites
-  mvn -pl core test -Ptest-dmgacid2
-  mvn -pl core test -Ptest-blargg-individual
-  mvn -pl core test -Ptest-blargg              # aggregate roms
+  mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2
+  mvn -pl core test -Ptest-blargg-individual,test-blargg
   ```
 - Fast iteration mains in `core/src/test/.../integration/support/`:
   - `MooneyeMain <roms...>` — prints PASS/FAIL + register dump + test output

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The [Blargg's test ROMs](http://gbdev.gg8.se/wiki/articles/Test_ROMs) are used f
     mvn clean test -f core/pom.xml -Ptest-blargg
     mvn clean test -f core/pom.xml -Ptest-blargg-individual # for running "single" tests providing more diagnostic info
 
-They are also part of the [Travis-based CI](https://travis-ci.org/trekawek/coffee-gb).
+They are also part of the GitHub Actions build.
 
 The tests output (normally displayed on the Gameboy screen) is redirected to the stdout:
 
@@ -69,6 +69,18 @@ Coffee GB passes all the tests:
 * interrupt_time
 * mem_timing-2
 * oam_bug-2
+
+## Running multiple integration test suites
+
+Integration test profiles can be combined in one Maven invocation by separating
+their names with commas:
+
+    mvn clean test -f core/pom.xml -Ptest-mooneye,test-dmgacid2,test-cgbacid2
+
+Each selected profile has its own test execution, so no profile overrides another.
+Integration test methods use two threads by default. Override that number when
+needed with `-Dintegration.test.threadCount=4`, or set it to `1` to run serially.
+The timeout-sensitive BullyGB profile always runs its two methods serially.
 
 ## Mooneye tests
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,212 +13,375 @@
     <name>core</name>
 
     <profiles>
-
         <profile>
             <id>test-blargg</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/blargg/BlarggRomTest.java</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-blargg</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/blargg/BlarggRomTest.java</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-blargg-individual</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/blargg/individual/*.java</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-blargg-individual</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/blargg/individual/*.java</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-mooneye</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/mooneye/**/*.java</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mooneye</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/mooneye/**/*.java</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-rtc3</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/rtc3/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-rtc3</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/rtc3/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-samesuite</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/samesuite/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-samesuite</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/samesuite/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-bullygb</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/bullygb/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-bullygb</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/bullygb/*</include>
+                                    </includes>
+                                    <!-- Both methods have tight 10-second deadlines and contend
+                                         heavily when they run at the same time. -->
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-mbc30</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/mbc30/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mbc30</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/mbc30/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-daid</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/daid/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-daid</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/daid/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-dmgacid2</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/dmgacid2/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-dmgacid2</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/dmgacid2/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-cgbacid2</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/cgbacid2/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-cgbacid2</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/cgbacid2/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>test-mealybug</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>x</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/integration/mealybug/*</include>
-                            </includes>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test-mealybug</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/mealybug/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>2.4.0</kotlin.version>
+        <skip.unit.tests>false</skip.unit.tests>
+        <integration.test.threadCount>2</integration.test.threadCount>
     </properties>
     <build>
         <pluginManagement>
@@ -101,6 +103,14 @@
                         <exclude>**/integration/**</exclude>
                     </excludes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <skipTests>${skip.unit.tests}</skipTests>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- make integration-test Maven profiles composable in one invocation
- run profile test methods with bounded Surefire parallelism, keeping timeout-sensitive BullyGB serial
- fan integration suites out across a GitHub Actions matrix
- document multi-profile and thread-count usage

## Validation

- 135 unit tests pass
- all 296 integration tests pass
- combined profile groups pass
- Maven XML and workflow YAML validate