### PR TITLE
Make save-state restoration self-contained

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -459,7 +459,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled);
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks);
     }
 
     @Override
@@ -491,6 +491,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         gameGenie.restoreFromMemento(mem.genieMemento());
         requestedScreenRefresh = mem.requestScreenRefresh();
         lcdDisabled = mem.lcdDisabled();
+        lcdOffTicks = mem.lcdOffTicks();
     }
 
     @Override
@@ -513,7 +514,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<SuperGameboy> superGameboyMemento, Memento<Background> backgroundMemento,
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,
                                   Memento<Genie> genieMemento, boolean requestScreenRefresh,
-                                  boolean lcdDisabled) implements Memento<Gameboy> {
+                                  boolean lcdDisabled, int lcdOffTicks) implements Memento<Gameboy> {
     }
 
     public enum BootstrapMode {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -19,7 +19,8 @@ public class Display implements Serializable, Originator<Display> {
     private final int[] buffer = new int[DISPLAY_WIDTH * DISPLAY_HEIGHT];
 
     // the last complete frame that was shown, re-emitted for the one-frame repeat after a
-    // CGB LCD-on (see repeatFrame); a display-only cache, not part of the machine state
+    // CGB LCD-on. It is panel/output state rather than PPU state, but must be in the memento
+    // so restoring during the enable delay does not repeat a frame from the abandoned timeline.
     private final transient int[] lastFrame = new int[DISPLAY_WIDTH * DISPLAY_HEIGHT];
 
     private final boolean gbc;
@@ -117,7 +118,7 @@ public class Display implements Serializable, Originator<Display> {
 
     @Override
     public Memento<Display> saveToMemento() {
-        return new DisplayMemento(buffer.clone(), i, enabled);
+        return new DisplayMemento(buffer.clone(), i, enabled, lastFrame.clone(), firstFrameAfterLcdEnable);
     }
 
     @Override
@@ -131,6 +132,17 @@ public class Display implements Serializable, Originator<Display> {
         System.arraycopy(mem.buffer, 0, this.buffer, 0, this.buffer.length);
         this.i = mem.i;
         this.enabled = mem.enabled;
+        if (mem.lastFrame == null) {
+            // Older snapshots predate the LCD-on frame cache. The current buffer is the
+            // closest available complete picture and avoids leaking the live pre-restore frame.
+            System.arraycopy(mem.buffer, 0, this.lastFrame, 0, this.lastFrame.length);
+        } else {
+            if (this.lastFrame.length != mem.lastFrame.length) {
+                throw new IllegalArgumentException("Memento last frame length doesn't match");
+            }
+            System.arraycopy(mem.lastFrame, 0, this.lastFrame, 0, this.lastFrame.length);
+        }
+        this.firstFrameAfterLcdEnable = mem.firstFrameAfterLcdEnable;
     }
 
     public record GbcFrameReadyEvent(int[] pixels) implements Event {
@@ -206,6 +218,7 @@ public class Display implements Serializable, Originator<Display> {
         }
     }
 
-    private record DisplayMemento(int[] buffer, int i, boolean enabled) implements Memento<Display> {
+    private record DisplayMemento(int[] buffer, int i, boolean enabled, int[] lastFrame,
+                                  boolean firstFrameAfterLcdEnable) implements Memento<Display> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
@@ -80,7 +80,8 @@ public class Background implements Originator<Background> {
 
     @Override
     public Memento<Background> saveToMemento() {
-        return new BackgroundMemento(tiles.clone());
+        return new BackgroundMemento(tiles.clone(),
+                lastPicture == null ? null : lastPicture.saveToMemento());
     }
 
     @Override
@@ -92,9 +93,20 @@ public class Background implements Originator<Background> {
             throw new IllegalArgumentException("Memento array length doesn't match");
         }
         System.arraycopy(mem.tiles, 0, this.tiles, 0, this.tiles.length);
+        if (mem.lastPictureMemento == null) {
+            this.lastPicture = null;
+        } else {
+            var restored = Commands.TransferCommand.restoreFromMemento(mem.lastPictureMemento);
+            if (!(restored instanceof Commands.PctTrnCmd picture)) {
+                throw new IllegalArgumentException("Memento does not contain a picture transfer command");
+            }
+            this.lastPicture = picture;
+        }
     }
 
-    private record BackgroundMemento(int[] tiles) implements Memento<Background> {
+    private record BackgroundMemento(int[] tiles,
+                                     Memento<Commands.TransferCommand> lastPictureMemento)
+            implements Memento<Background> {
     }
 
     public record SgbBackgroundReadyEvent(int[] buffer, int[] mask) implements Event {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
@@ -77,9 +77,9 @@ public class Commands {
             if (!(memento instanceof TransferCommandMemento mem)) {
                 throw new IllegalArgumentException("Invalid memento type");
             }
-            var command = Commands.toCommand(mem.packet);
+            var command = Commands.toCommand(mem.packet.clone());
             if (command instanceof TransferCommand transferCommand) {
-                transferCommand.setDataTransfer(mem.dataTransfer);
+                transferCommand.setDataTransfer(mem.dataTransfer == null ? null : mem.dataTransfer.clone());
                 return transferCommand;
             } else {
                 throw new IllegalArgumentException("Memento does not contain a transfer command");
@@ -91,7 +91,7 @@ public class Commands {
         }
 
         public Memento<TransferCommand> saveToMemento() {
-            return new TransferCommandMemento(packet, dataTransfer);
+            return new TransferCommandMemento(packet.clone(), dataTransfer == null ? null : dataTransfer.clone());
         }
 
         private record TransferCommandMemento(int[] packet, int[] dataTransfer) implements Memento<TransferCommand> {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -210,7 +210,8 @@ public class SgbDisplay implements Originator<SgbDisplay> {
 
     @Override
     public Memento<SgbDisplay> saveToMemento() {
-        return new SgbDisplayMemento(sgbBuffer.clone(), sgbMask.clone(), palettes.clone(), systemPalettes.clone(), paletteMap.clone(), attributeFiles.clone(), screenMask, atfNumber);
+        return new SgbDisplayMemento(sgbBuffer.clone(), sgbMask.clone(), clone2(palettes),
+                clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask, atfNumber);
     }
 
     @Override
@@ -238,15 +239,15 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         }
         System.arraycopy(mem.sgbBuffer, 0, this.sgbBuffer, 0, this.sgbBuffer.length);
         System.arraycopy(mem.sgbMask, 0, this.sgbMask, 0, this.sgbMask.length);
-        arraycopy2(mem.palettes, this.palettes);
-        arraycopy2(mem.systemPalettes, this.systemPalettes);
+        replaceRows(mem.palettes, this.palettes, 4);
+        replaceRows(mem.systemPalettes, this.systemPalettes, 4);
         System.arraycopy(mem.paletteMap, 0, this.paletteMap, 0, this.paletteMap.length);
-        arraycopy2(mem.attributeFiles, this.attributeFiles);
+        replaceRows(mem.attributeFiles, this.attributeFiles, DMG_TILES_WIDTH * DMG_TILES_HEIGHT);
         this.screenMask = mem.screenMask;
         this.atfNumber = mem.atfNumber;
     }
 
-    private static void arraycopy2(int[][] src, int[][] dst) {
+    private static void replaceRows(int[][] src, int[][] dst, int expectedRowLength) {
         if (src.length != dst.length) {
             throw new IllegalArgumentException("Array length doesn't match");
         }
@@ -255,11 +256,21 @@ public class SgbDisplay implements Originator<SgbDisplay> {
                 dst[i] = null;
                 continue;
             }
-            if (src[i].length != dst[i].length) {
+            if (src[i].length != expectedRowLength) {
                 throw new IllegalArgumentException("Array length doesn't match at i=" + i);
             }
-            System.arraycopy(src[i], 0, dst[i], 0, src[i].length);
+            // PAL_SET makes active palette rows aliases of system palette rows. Replace
+            // each row so restore cannot write through aliases left by the abandoned timeline.
+            dst[i] = src[i].clone();
         }
+    }
+
+    private static int[][] clone2(int[][] src) {
+        int[][] clone = new int[src.length][];
+        for (int i = 0; i < src.length; i++) {
+            clone[i] = src[i] == null ? null : src[i].clone();
+        }
+        return clone;
     }
 
     private record SgbDisplayMemento(int[] sgbBuffer, int[] sgbMask, int[][] palettes, int[][] systemPalettes,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
@@ -84,7 +84,9 @@ public class SuperGameboy implements Originator<SuperGameboy> {
 
     @Override
     public Memento<SuperGameboy> saveToMemento() {
-        return new SuperGameboyMemento(multipacket, multipacketIndex, multipacketLength, transferCountdown, waitingTransferCommand == null ? null : waitingTransferCommand.saveToMemento());
+        int[][] multipacketCopy = Arrays.stream(multipacket).map(int[]::clone).toArray(int[][]::new);
+        return new SuperGameboyMemento(multipacketCopy, multipacketIndex, multipacketLength, transferCountdown,
+                waitingTransferCommand == null ? null : waitingTransferCommand.saveToMemento());
     }
 
     @Override
@@ -101,9 +103,9 @@ public class SuperGameboy implements Originator<SuperGameboy> {
             System.arraycopy(mem.multipacket[i], 0, this.multipacket[i], 0, 16);
         }
         this.transferCountdown = mem.transferCountdown;
-        if (mem.waitingTransferCommandMemento != null) {
-            this.waitingTransferCommand = TransferCommand.restoreFromMemento(mem.waitingTransferCommandMemento);
-        }
+        this.waitingTransferCommand = mem.waitingTransferCommandMemento == null
+                ? null
+                : TransferCommand.restoreFromMemento(mem.waitingTransferCommandMemento);
     }
 
     private record SuperGameboyMemento(int[][] multipacket, int multipacketIndex,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
@@ -1,0 +1,36 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameboyMementoTest {
+
+    @Test
+    public void restoresElapsedLcdOffTicks() throws IOException {
+        byte[] romBytes = new byte[0x8000];
+        romBytes[0x147] = 0;
+        try (Gameboy gameboy = new Gameboy(new Rom(romBytes))) {
+            gameboy.getGpu().setByte(0xff40, 0);
+            int elapsedBeforeSave = 123;
+            for (int i = 0; i < elapsedBeforeSave; i++) {
+                gameboy.tick();
+            }
+            var memento = gameboy.saveToMemento();
+
+            for (int i = 0; i < 456; i++) {
+                gameboy.tick();
+            }
+            gameboy.restoreFromMemento(memento);
+
+            int ticksUntilBlank = 0;
+            do {
+                ticksUntilBlank++;
+            } while (!gameboy.tick());
+            assertEquals(Gameboy.TICKS_PER_FRAME - elapsedBeforeSave, ticksUntilBlank);
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
@@ -57,6 +57,32 @@ public class DisplayTest {
         assertArrayEquals(expected, frame.get());
     }
 
+    @Test
+    public void mementoRestoresPendingLcdEnableFrameAndCachedPicture() {
+        Display display = new Display(true);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.pixels().clone()), Display.GbcFrameReadyEvent.class);
+        display.init(eventBus);
+
+        int[] expected = new int[PIXELS];
+        java.util.Arrays.fill(expected, 0x1234);
+        fillCgb(display, 0x1234);
+        display.frameIsReady();
+        display.disableLcd();
+        display.enableLcd();
+        var memento = display.saveToMemento();
+
+        // Destroy both pieces of display state before restoring: blankFrame clears the
+        // cached picture and cancels the pending first-frame repeat.
+        display.blankFrame();
+        display.restoreFromMemento(memento);
+        fillCgb(display, 0x4321);
+        display.frameIsReady();
+
+        assertArrayEquals(expected, frame.get());
+    }
+
     private static void fillDmg(Display display, int color) {
         for (int i = 0; i < PIXELS; i++) {
             display.putDmgPixel(color);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbMementoTest.java
@@ -1,0 +1,153 @@
+package eu.rekawek.coffeegb.core.sgb;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SgbMementoTest {
+
+    @Test
+    public void backgroundRestoreClearsPictureThatIsAbsentFromMemento() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        Background background = new Background(sgbBus);
+        AtomicInteger renderedPictures = new AtomicInteger();
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        eventBus.register(event -> renderedPictures.incrementAndGet(), Background.SgbBackgroundReadyEvent.class);
+        background.init(eventBus);
+        var emptyMemento = background.saveToMemento();
+
+        Commands.PctTrnCmd picture = (Commands.PctTrnCmd) command(0x14);
+        picture.setDataTransfer(new int[0x1000]);
+        sgbBus.post(picture);
+        assertEquals(1, renderedPictures.get());
+
+        background.restoreFromMemento(emptyMemento);
+        renderedPictures.set(0);
+        Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
+        characters.setDataTransfer(new int[0x1000]);
+        sgbBus.post(characters);
+
+        assertEquals(0, renderedPictures.get());
+    }
+
+    @Test
+    public void backgroundMementoRestoresItsOwnPictureData() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        Background background = new Background(sgbBus);
+        AtomicReference<int[]> rendered = new AtomicReference<>();
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        eventBus.register(event -> rendered.set(event.buffer().clone()),
+                Background.SgbBackgroundReadyEvent.class);
+        background.init(eventBus);
+
+        Commands.PctTrnCmd picture = (Commands.PctTrnCmd) command(0x14);
+        int[] pictureData = new int[0x1000];
+        pictureData[0x780] = 0x34;
+        pictureData[0x781] = 0x12;
+        picture.setDataTransfer(pictureData);
+        sgbBus.post(picture);
+        var memento = background.saveToMemento();
+
+        pictureData[0x780] = 0x78;
+        pictureData[0x781] = 0x56;
+        background.restoreFromMemento(memento);
+        rendered.set(null);
+        Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
+        characters.setDataTransfer(new int[0x1000]);
+        sgbBus.post(characters);
+
+        assertEquals(0x1234, rendered.get()[0]);
+    }
+
+    @Test
+    public void displayMementoDeepCopiesAttributeFiles() throws IOException {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, false);
+        display.init(eventBus);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.buffer().clone()), SgbDisplay.SgbFrameReadyEvent.class);
+
+        int[] attrSetPacket = new int[16];
+        attrSetPacket[0] = (0x16 << 3) | 1;
+        sgbBus.post(Commands.toCommand(attrSetPacket));
+        var memento = display.saveToMemento();
+
+        Commands.AttrTrnCmd attributes = (Commands.AttrTrnCmd) command(0x15);
+        int[] attributeData = new int[0x1000];
+        Arrays.fill(attributeData, 0xff);
+        attributes.setDataTransfer(attributeData);
+        sgbBus.post(attributes);
+        display.restoreFromMemento(memento);
+
+        int[] dmgPixels = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        Arrays.fill(dmgPixels, 1);
+        eventBus.post(new Display.DmgFrameReadyEvent(dmgPixels));
+        assertNotEquals(0, frame.get()[0]);
+    }
+
+    @Test
+    public void displayRestoreBreaksAbandonedPaletteAliases() throws IOException {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, false);
+        display.init(eventBus);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.buffer().clone()), SgbDisplay.SgbFrameReadyEvent.class);
+
+        Commands.PalTrnCmd palettes = (Commands.PalTrnCmd) command(0x0b);
+        int[] paletteData = new int[0x1000];
+        paletteData[0] = 0x11;
+        paletteData[1] = 0x01;
+        paletteData[8] = 0x22;
+        paletteData[9] = 0x02;
+        palettes.setDataTransfer(paletteData);
+        sgbBus.post(palettes);
+        sgbBus.post(paletteSet(0));
+        var memento = display.saveToMemento();
+
+        // All active rows now alias system palette 1. Restoring by copying into these
+        // rows would leave the active palette and/or the saved system table corrupted.
+        sgbBus.post(paletteSet(1));
+        display.restoreFromMemento(memento);
+
+        int[] dmgPixels = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        eventBus.post(new Display.DmgFrameReadyEvent(dmgPixels));
+        assertEquals(Display.GbcFrameReadyEvent.translateGbcRgb(0x0111), frame.get()[0]);
+
+        sgbBus.post(paletteSet(1));
+        eventBus.post(new Display.DmgFrameReadyEvent(dmgPixels));
+        assertEquals(Display.GbcFrameReadyEvent.translateGbcRgb(0x0222), frame.get()[0]);
+    }
+
+    private static Commands.AbstractCommand command(int code) {
+        int[] packet = new int[16];
+        packet[0] = (code << 3) | 1;
+        return Commands.toCommand(packet);
+    }
+
+    private static Commands.PalSetCmd paletteSet(int paletteId) {
+        int[] packet = new int[16];
+        packet[0] = (0x0a << 3) | 1;
+        packet[1] = paletteId;
+        packet[3] = paletteId;
+        packet[5] = paletteId;
+        packet[7] = paletteId;
+        return (Commands.PalSetCmd) Commands.toCommand(packet);
+    }
+
+    private static Rom testRom() throws IOException {
+        byte[] bytes = new byte[0x8000];
+        bytes[0x147] = 0;
+        return new Rom(bytes);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SuperGameboyTest.java
@@ -54,6 +54,74 @@ public class SuperGameboyTest {
         assertEquals(3, transfer.get().dataTransfer[0]);
     }
 
+    @Test
+    public void restoreClearsTransferThatIsAbsentFromMemento() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        SuperGameboy superGameboy = new SuperGameboy(sgbBus);
+        AtomicReference<Commands.PctTrnCmd> transfer = new AtomicReference<>();
+        sgbBus.register(transfer::set, Commands.PctTrnCmd.class);
+        var idleMemento = superGameboy.saveToMemento();
+
+        int[] packet = new int[16];
+        packet[0] = (0x14 << 3) | 1;
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(packet));
+        superGameboy.restoreFromMemento(idleMemento);
+
+        postFrame(sgbBus, 1);
+        postFrame(sgbBus, 2);
+        postFrame(sgbBus, 3);
+        assertNull(transfer.get());
+    }
+
+    @Test
+    public void mementoOwnsPartialMultipacketData() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        SuperGameboy superGameboy = new SuperGameboy(sgbBus);
+        AtomicReference<Commands.Pal01Cmd> command = new AtomicReference<>();
+        sgbBus.register(command::set, Commands.Pal01Cmd.class);
+
+        int[] firstPacket = new int[16];
+        firstPacket[0] = 2; // two-packet PAL01
+        firstPacket[1] = 0x34;
+        firstPacket[2] = 0x12;
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(firstPacket));
+        var partialMemento = superGameboy.saveToMemento();
+
+        // Finish that command, then overwrite row zero of the live multipacket buffer.
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(new int[16]));
+        int[] overwrite = new int[16];
+        overwrite[0] = 1;
+        overwrite[1] = 0x78;
+        overwrite[2] = 0x56;
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(overwrite));
+
+        superGameboy.restoreFromMemento(partialMemento);
+        command.set(null);
+        sgbBus.post(new SuperGameboy.PacketReceivedEvent(new int[16]));
+
+        assertEquals(0x1234, command.get().getPalette0()[0]);
+    }
+
+    @Test
+    public void transferCommandMementoOwnsPacketAndFrameData() {
+        int[] packet = new int[16];
+        packet[0] = (0x13 << 3) | 1;
+        packet[1] = 1;
+        int[] frame = new int[0x1000];
+        frame[0] = 7;
+        Commands.ChrTrnCmd command = (Commands.ChrTrnCmd) Commands.toCommand(packet);
+        command.setDataTransfer(frame);
+        var memento = command.saveToMemento();
+
+        packet[1] = 0;
+        frame[0] = 9;
+        Commands.ChrTrnCmd restored =
+                (Commands.ChrTrnCmd) Commands.TransferCommand.restoreFromMemento(memento);
+
+        assertEquals(0x80, restored.getTileOffset());
+        assertEquals(7, restored.dataTransfer[0]);
+    }
+
     private static void postFrame(EventBusImpl sgbBus, int value) {
         int[] frame = new int[0x1000];
         Arrays.fill(frame, value);


### PR DESCRIPTION
**AI-generated pull request:**

## Summary
- persist the LCD-off counter, cached/pending display frame, and SGB background picture in mementos
- always clear or restore nullable pending SGB transfers instead of retaining live-session state
- deep-copy partial packets, transfer buffers, palettes, and attribute files on save and restore
- add regressions for omitted state, mutable-array ownership, and PAL_SET alias corruption

## Root cause
The snapshot restored most machine state but omitted recent display/SGB fields and shallow-copied several mutable arrays. Loading an older snapshot could therefore combine it with state from the abandoned live timeline, including a pending screen mask/transfer or stale frame cache, producing the invisible screen reported in #154.

The new record components are appended and nullable fallbacks preserve compatibility with older serialized snapshots.

## Verification
- exact #154 attachment created at `046ee08` deserialized successfully and produced 30/30 visible frames after restore; the final frame contained 57,088 non-black pixels
- `/opt/maven/bin/mvn -pl core test` (148 tests)
- Mooneye + DMG/CGB Acid2 suites (132 tests)
- combined and individual Blargg suites (54 tests)
- two independent correctness reviews, including palette-alias regression coverage

Fixes #154