### PR TITLE
Add Gambatte hardware test archive

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
           - name: Blargg individual
             profiles: test-blargg-individual
           - name: Compatibility ROMs
-            profiles: test-daid,test-bullygb,test-mbc30,test-rtc3,test-samesuite
+            profiles: test-daid,test-bullygb,test-mbc30,test-rtc3,test-samesuite,test-gambatte-hw
           - name: Acid2
             profiles: test-dmgacid2,test-cgbacid2
           - name: Mealybug Tearoom

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ and SGB tests use their automated register result protocol:
 ROMs for older CGB revisions are included as resources but excluded from this
 profile because Coffee GB's generic CGB mode targets the later revision behavior.
 
+## Gambatte emulator HWTests
+
+The [Gambatte emulator HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test)
+archive includes the complete upstream ROM set and sources. A representative
+automated set covers startup state, TIMA, OAM, DMA, palettes, sprites, and
+window timing:
+
+    mvn clean test -f core/pom.xml -Ptest-gambatte-hw
+
 ## BullyGB
 
 The [BullyGB](https://github.com/Ashiepaws/BullyGB) framework is run in both

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -184,6 +184,40 @@
             </build>
         </profile>
         <profile>
+            <id>test-gambatte-hw</id>
+            <properties>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>integration-test-gambatte-hw</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes combine.self="override">
+                                        <exclude>x</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>**/integration/gambatte/*</include>
+                                    </includes>
+                                    <parallel>methods</parallel>
+                                    <threadCount>${integration.test.threadCount}</threadCount>
+                                    <perCoreThreadCount>false</perCoreThreadCount>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>test-bullygb</id>
             <properties>
                 <skip.unit.tests>true</skip.unit.tests>

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -1,0 +1,103 @@
+package eu.rekawek.coffeegb.core.integration.gambatte;
+
+import eu.rekawek.coffeegb.core.GameboyType;
+import eu.rekawek.coffeegb.core.integration.support.GambatteHwTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class GambatteHwRomTest {
+
+    private static final String ARCHIVE = "/roms/gambatte/gambatte-hwtests.zip";
+
+    private static final List<TestCase> TEST_CASES = List.of(
+            dmg("hwtests/display_startstate/ly_dmg08_out00_cgb04c_out90.gbc", "00"),
+            cgb("hwtests/cgbpal_m3/cgbpal_m3start_2_cgb04c_out0.gbc", "0"),
+            cgb("hwtests/tima/tc00_start_1_cgb04c_outF0.gbc", "F0"),
+            cgb("hwtests/dma/hdma_ei_m3halt_m0unhalt_ly_1_cgb04c_out02.gbc", "02"),
+            dmg("hwtests/oam_access/postread_2_dmg08_cgb04c_out0.gbc", "0"),
+            cgb("hwtests/oam_access/postread_2_dmg08_cgb04c_out0.gbc", "0"),
+            dmg("hwtests/sprites/10spritesPrLine_1xpos0_m3stat_1_dmg08_cgb04c_out3.gbc", "3"),
+            cgb("hwtests/sprites/10spritesPrLine_1xpos0_m3stat_1_dmg08_cgb04c_out3.gbc", "3"),
+            dmg("hwtests/window/m2int_wxA6_m3stat_2_dmg08_out0_cgb04c_out3.gbc", "0")
+    );
+
+    private final String name;
+
+    private final byte[] rom;
+
+    private final GameboyType gameboyType;
+
+    private final String expected;
+
+    public GambatteHwRomTest(String name, byte[] rom, GameboyType gameboyType, String expected) {
+        this.name = name;
+        this.rom = rom;
+        this.gameboyType = gameboyType;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters(name = "{0} [{2}]")
+    public static Collection<Object[]> data() throws IOException {
+        Set<String> names = TEST_CASES.stream().map(TestCase::rom).collect(java.util.stream.Collectors.toSet());
+        Map<String, byte[]> roms = readRoms(names);
+        List<Object[]> parameters = new ArrayList<>();
+        for (TestCase test : TEST_CASES) {
+            byte[] rom = roms.get(test.rom());
+            if (rom == null) {
+                throw new IOException("Missing Gambatte HWTest ROM: " + test.rom());
+            }
+            parameters.add(new Object[]{test.rom(), rom, test.gameboyType(), test.expected()});
+        }
+        return parameters;
+    }
+
+    @Test(timeout = 10000)
+    public void test() throws IOException {
+        String actual = new GambatteHwTestRunner(rom, gameboyType).runTest(expected.length());
+        assertEquals(name, expected, actual);
+    }
+
+    private static Map<String, byte[]> readRoms(Set<String> names) throws IOException {
+        InputStream input = GambatteHwRomTest.class.getResourceAsStream(ARCHIVE);
+        if (input == null) {
+            throw new IOException("Missing Gambatte HWTest archive: " + ARCHIVE);
+        }
+        Map<String, byte[]> roms = new LinkedHashMap<>();
+        try (input; ZipInputStream zip = new ZipInputStream(input)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (names.contains(entry.getName())) {
+                    roms.put(entry.getName(), zip.readAllBytes());
+                }
+                zip.closeEntry();
+            }
+        }
+        return roms;
+    }
+
+    private static TestCase dmg(String rom, String expected) {
+        return new TestCase(rom, GameboyType.DMG, expected);
+    }
+
+    private static TestCase cgb(String rom, String expected) {
+        return new TestCase(rom, GameboyType.CGB, expected);
+    }
+
+    private record TestCase(String rom, GameboyType gameboyType, String expected) {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/GambatteHwTestRunner.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/GambatteHwTestRunner.java
@@ -1,0 +1,47 @@
+package eu.rekawek.coffeegb.core.integration.support;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.GameboyType;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+
+import java.io.IOException;
+
+import static eu.rekawek.coffeegb.core.integration.support.RomTestUtils.isByteSequenceAtPc;
+
+/** Runs Gambatte HWTests that print their result as hexadecimal tiles at 0x9800. */
+public final class GambatteHwTestRunner {
+
+    private static final long MAX_TICKS = 5_000_000L;
+
+    private final Gameboy gameboy;
+
+    public GambatteHwTestRunner(byte[] rom, GameboyType gameboyType) throws IOException {
+        Gameboy.GameboyConfiguration configuration = new Gameboy.GameboyConfiguration(new Rom(rom))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setGameboyType(gameboyType)
+                .setSupportBatterySave(false);
+        gameboy = configuration.build();
+        gameboy.init(new EventBusImpl(), SerialEndpoint.NULL_ENDPOINT, null);
+    }
+
+    public String runTest(int outputDigits) {
+        long ticks = 0;
+        // Every hexadecimal-result ROM ends in `jr lprint_limbo` (JR -2) after it has
+        // copied the digit tiles and enabled the LCD.
+        while (!isByteSequenceAtPc(gameboy, 0x18, 0xfe)) {
+            if (++ticks > MAX_TICKS) {
+                throw new AssertionError("Gambatte HWTest did not reach its result loop");
+            }
+            gameboy.tick();
+        }
+
+        StringBuilder output = new StringBuilder(outputDigits);
+        for (int i = 0; i < outputDigits; i++) {
+            int digit = gameboy.getAddressSpace().getByte(0x9800 + i) & 0x0f;
+            output.append(Character.toUpperCase(Character.forDigit(digit, 16)));
+        }
+        return output.toString();
+    }
+}

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -1,0 +1,16 @@
+# Gambatte emulator HWTests
+
+`gambatte-hwtests.zip` contains 3,524 ROMs built from the
+[`pokemon-speedrunning/gambatte-core`](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test)
+hardware tests at commit `5a41a68c25402421fb1983ddadc9faf2418ddb0f`.
+
+The archive also includes the upstream reference PNGs, assembly sources,
+`qdgbas.py` assembler, and GPL-2.0 `COPYING` file. Keeping the complete suite in
+one compressed test resource avoids adding thousands of loose files to Git.
+
+The issue attachment was used to identify the requested suite. The ROMs in this
+archive were rebuilt from the linked source so their expected DMG/CGB results
+remain encoded in their canonical upstream filenames and the build is
+reproducible.
+
+SHA-256: `5492d5a2d79296fedd732fc3dfc8e3de702946cea7cd7e4977f9470b00815900`


### PR DESCRIPTION
## Summary
- add all 3,524 Gambatte HWTest ROMs as one 4.4 MB compressed test resource
- include canonical expected-result filenames, reference images, assembly sources, assembler, and GPL license for reproducibility
- add a result-tile test runner and a representative 9-case DMG/CGB Maven profile
- run the new profile in the compatibility-ROM CI matrix

## Test plan
- `/tmp/apache-maven-3.9.11/bin/mvn -B -pl core test -Ptest-gambatte-hw -Dintegration.test.threadCount=1` (9 tests pass)
- archive integrity checked with `unzip -t`

Closes #144