### PR TITLE
Support alternate Sachen MMC2 wiring

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -41,6 +41,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         this.battery = battery;
 
         var type = rom.getType();
+        int sachenType = sachenType(rom);
         if (isBungEms(rom)) {
             addressSpace = new BungEms(rom, battery);
         } else if (type.isMmm01()) {
@@ -54,8 +55,10 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             addressSpace = new DuzMulticart(rom, battery);
         } else if (isBhgosMulticart(rom)) {
             addressSpace = new BhgosMulticart(rom, battery);
-        } else if (sachenType(rom) >= 0) {
-            addressSpace = new SachenMmc(rom, sachenType(rom) == 2);
+        } else if (sachenType >= 0) {
+            // Type 3 is the alternate MMC2 wiring: its header page is linear, but it
+            // otherwise uses the same lockout and banking logic as a raw MMC2 cart.
+            addressSpace = new SachenMmc(rom, sachenType != 1, sachenType != 3);
         } else if (isCookedSachen(rom)) {
             // post-unlock ("cooked") Sachen dumps: no lockout, boot at base 0 like the
             // power-on cart (issues #73/#75)
@@ -270,7 +273,8 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
      * the 0x0100-0x01FF page is wired with A0/A6 and A1/A4 swapped, so the logo bytes sit
      * at the scrambled offsets (0xED at 0x144, 0x66 at 0x114); the MMC2 stores the logo
      * served during boot in the 0x0180-0x01FF half of the page (mGBA's detection).
-     * Returns 1 for MMC1, 2 for MMC2, -1 for regular carts.
+     * Returns 1 for MMC1, 2 for the address-scrambled MMC2, 3 for the alternate
+     * linear-header MMC2 wiring, and -1 for regular carts.
      */
     /**
      * The fixed, cart-independent header the Sachen mapper descrambles for the boot ROM. The
@@ -312,17 +316,31 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         if (data[0x184] == 0xce && data[0x1c4] == 0xed && data[0x194] == 0x66) {
             return 2;
         }
+        // Some MMC2 boards wire the four lower ROM address lines straight through.
+        // Their raw dumps contain Sachen's replacement logo linearly at 0x0104 and
+        // the Nintendo logo selected by RA7 linearly at 0x0184 (issue #187).
+        if (data[0x104] == 0x7c && data[0x105] == 0xe7
+                && data[0x106] == 0xc0 && data[0x107] == 0x00
+                && hasLogoAt(data, 0x184)) {
+            return 3;
+        }
         return -1;
     }
 
-    private static boolean hasValidLogo(Rom rom) {
-        int[] data = rom.getRom();
+    private static boolean hasLogoAt(int[] data, int offset) {
+        if (offset + NINTENDO_LOGO.length > data.length) {
+            return false;
+        }
         for (int i = 0; i < NINTENDO_LOGO.length; i++) {
-            if (data[0x104 + i] != NINTENDO_LOGO[i]) {
+            if (data[offset + i] != NINTENDO_LOGO[i]) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static boolean hasValidLogo(Rom rom) {
+        return hasLogoAt(rom.getRom(), 0x104);
     }
 
     private static boolean isHiddenMmm01(Rom rom) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -51,8 +51,12 @@ public class SachenMmc implements MemoryController {
 
     private int transition;
 
-    // false for post-unlock ("cooked") dumps stored with a linear 0x0100-0x01FF page
-    private final boolean scrambled;
+    // Raw carts use the lockout state machine; cooked dumps have already been captured
+    // after it unlocked. This is separate from header scrambling because some MMC2
+    // boards use straight-through address wiring (issue #187).
+    private final boolean cooked;
+
+    private final boolean scrambledHeader;
 
     // while true, reads of the 0x0104-0x0133 logo window return the Nintendo logo instead of
     // the linear ROM data. Cooked dumps have no logo stored (the raw carts serve it through
@@ -71,10 +75,16 @@ public class SachenMmc implements MemoryController {
             0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
 
     public SachenMmc(Rom rom, boolean mmc2) {
+        this(rom, mmc2, true);
+    }
+
+    /** Raw cart, optionally using the alternate straight-through header wiring. */
+    public SachenMmc(Rom rom, boolean mmc2, boolean scrambledHeader) {
         this.rom = rom.getRom();
         this.romBanks = Math.max(2, this.rom.length / 0x4000);
         this.mmc2 = mmc2;
-        this.scrambled = true;
+        this.cooked = false;
+        this.scrambledHeader = scrambledHeader;
         // the MMC1 has no DMG/CGB detection phase; it starts in the counting state
         this.lockState = mmc2 ? LOCKED_DMG : LOCKED_CGB;
     }
@@ -84,7 +94,8 @@ public class SachenMmc implements MemoryController {
         this.rom = rom.getRom();
         this.romBanks = Math.max(2, this.rom.length / 0x4000);
         this.mmc2 = true;
-        this.scrambled = false;
+        this.cooked = true;
+        this.scrambledHeader = false;
         this.lockState = UNLOCKED;
         this.base = initialBase;
         this.serveBootLogo = true;
@@ -153,13 +164,13 @@ public class SachenMmc implements MemoryController {
         if (serveBootLogo && address >= 0x0104 && address < 0x0134) {
             return NINTENDO_LOGO[address - 0x0104];
         }
-        if (scrambled) {
+        if (!cooked) {
             address = lockAndUnscramble(address);
         }
         if (address < 0x4000) {
             // the cooked dumps hold the menu at its physical bank; the raw carts map
             // the masked base like mGBA does
-            int bank0 = scrambled ? (base & mask) : base;
+            int bank0 = cooked ? base : (base & mask);
             return rom[(bank0 % romBanks) * 0x4000 + address];
         } else if (address < 0x8000) {
             int effective = ((unmaskedBank & ~mask) | (base & mask)) % romBanks;
@@ -179,7 +190,7 @@ public class SachenMmc implements MemoryController {
                 address |= 0x80;
             }
         }
-        if ((address & 0xff00) == 0x0100) {
+        if (scrambledHeader && (address & 0xff00) == 0x0100) {
             address = unscramble(address);
         }
         return address;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/LinearSachenMmcTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/LinearSachenMmcTest.java
@@ -1,0 +1,77 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Alternate straight-through Sachen MMC2 header wiring used by issue #187. */
+public class LinearSachenMmcTest {
+
+    private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89,
+            0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63,
+            0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
+
+    private static byte[] linearSachenRom() {
+        byte[] rom = new byte[0x10000];
+        rom[0x100] = 0x00;
+        rom[0x101] = (byte) 0xc3;
+        rom[0x102] = 0x50;
+        rom[0x103] = 0x01;
+
+        // Sachen's replacement logo is stored linearly in the ordinary header window.
+        rom[0x104] = 0x7c;
+        rom[0x105] = (byte) 0xe7;
+        rom[0x106] = (byte) 0xc0;
+        rom[0x107] = 0x00;
+        // In CGB-locked mode RA7 selects the genuine logo in the upper half of the page.
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            rom[0x184 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        return rom;
+    }
+
+    private static Cartridge build() throws IOException {
+        return new Cartridge(new Rom(linearSachenRom()), Battery.NULL_BATTERY);
+    }
+
+    @Test
+    public void detectedAsSachenMmc() throws IOException {
+        assertTrue(build().getSachenMmc() instanceof SachenMmc);
+    }
+
+    @Test
+    public void cgbLockoutServesLinearNintendoLogoThenLinearGameHeader() throws IOException {
+        Cartridge cart = build();
+        SachenMmc mapper = cart.getSachenMmc();
+
+        // The CGB boot ROM's WRAM access moves MMC2 directly to CGB-locked mode.
+        mapper.onHighBusRead();
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            assertEquals(NINTENDO_LOGO[i], cart.getByte(0x104 + i));
+        }
+
+        // The following header-page transition unlocks the mapper. The game entry point
+        // remains linear; in particular, A0 is not swapped with A6 on this board.
+        assertEquals(0x00, cart.getByte(0x100));
+        assertEquals(0xc3, cart.getByte(0x101));
+    }
+
+    @Test
+    public void usesSachenBankRegister() throws IOException {
+        Cartridge cart = build();
+        byte[] rom = linearSachenRom();
+        rom[0x6000] = 0x11; // bank 1
+        rom[0xe000] = 0x33; // bank 3
+        cart = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+
+        assertEquals(0x11, cart.getByte(0x6000));
+        cart.setByte(0x2000, 0x03);
+        assertEquals(0x33, cart.getByte(0x6000));
+    }
+}


### PR DESCRIPTION
Fixes #187.

The attached 8-in-1 dump uses the MMC2 lockout and bank registers, but unlike the already-supported boards it wires the lower header address lines straight through. Detect this format from its linear Sachen logo at `0x0104` and Nintendo logo at `0x0184`, and keep raw-lockout state separate from address scrambling.

Verification:
- `/opt/maven/bin/mvn -pl core test` (142 tests)
- Headless boot reaches the 8-in-1 selection menu
- Selecting the first entry launches Ant Soldier and advances through its credits