### PR TITLE
Use the CGB power-on value for FF46

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
@@ -79,6 +79,10 @@ public class SpeedMode implements AddressSpace, Serializable, Originator<SpeedMo
         return currentSpeed ? 2 : 1;
     }
 
+    public boolean isGbc() {
+        return gbc;
+    }
+
     @Override
     public Memento<SpeedMode> saveToMemento() {
         return new SpeedModeMomento(currentSpeed, prepareSpeedSwitch, dmgCompat);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -23,12 +23,15 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     private int ticks;
 
-    private int regValue = 0xff;
+    private int regValue;
 
     public Dma(AddressSpace addressSpace, AddressSpace oam, SpeedMode speedMode) {
         this.addressSpace = new DmaAddressSpace(addressSpace);
         this.speedMode = speedMode;
         this.oam = oam;
+        // FF46 most commonly powers up as 00 on CGB and FF on DMG.
+        // Doc Cosmos reads FF46 to choose the phase of its title-screen scroller.
+        regValue = speedMode.isGbc() ? 0x00 : 0xff;
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
@@ -1,0 +1,23 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DmaTest {
+
+    @Test
+    public void dmaRegisterPowersUpAsZeroOnCgb() {
+        assertEquals(0x00, createDma(true).getByte(0xff46));
+    }
+
+    @Test
+    public void dmaRegisterPowersUpAsFfOnDmg() {
+        assertEquals(0xff, createDma(false).getByte(0xff46));
+    }
+
+    private static Dma createDma(boolean gbc) {
+        return new Dma(new Ram(0, 0x10000), new Ram(0xfe00, 0xa0), new SpeedMode(gbc));
+    }
+}


### PR DESCRIPTION
Fixes #185.

Doc Cosmos reads FF46 during startup and uses it to choose when its title-screen crawl rotates the background tile row. Coffee GB initialized FF46 to `FF` for both hardware families, which selects the DMG phase and causes an 8-pixel jump before and after every SCX wrap.

This initializes FF46 to the common hardware power-on values (`00` on CGB, `FF` on DMG) and adds regression coverage for both models. Frame-by-frame replay shows the crawl moving one pixel per frame across the wrap instead of jumping.

Verification:
- Full project test suite (170 tests)
- Mooneye suite (130 tests)
- SameSuite (71 tests)
- Gambatte hardware suite (9 tests)
- Mealybug suite (24 tests)
- Doc Cosmos title crawl replay across repeated SCX/tile-map wraps