### PR TITLE
Restore the CGB post-boot object palette state

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPalette.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPalette.java
@@ -8,6 +8,19 @@ import java.io.Serializable;
 
 public class ColorPalette implements AddressSpace, Serializable, Originator<ColorPalette> {
 
+    // Object palette RAM observed immediately after the CGB boot ROM. Some early
+    // homebrew, including Vila Caldan, relies on these values for its sprites.
+    private static final int[] CGB_OBJECT_PALETTE_BOOT_VALUES = {
+            0x0000, 0xabf2, 0xc261, 0xbad9,
+            0x6e88, 0x63dd, 0x2728, 0x9ffb,
+            0x4235, 0xd4d6, 0x4850, 0x5e57,
+            0x3e23, 0xca3d, 0x2171, 0xc037,
+            0xb3c6, 0xf9fb, 0x0008, 0x298d,
+            0x20a3, 0x87db, 0x0562, 0xd45d,
+            0x080e, 0xaffe, 0x0220, 0xffd7,
+            0x6a07, 0xec55, 0x4083, 0x770b
+    };
+
     private final int indexAddr;
 
     private final int dataAddr;
@@ -98,11 +111,9 @@ public class ColorPalette implements AddressSpace, Serializable, Originator<Colo
         return b.toString();
     }
 
-    public void fillWithFF() {
-        for (int i = 0; i < 8; i++) {
-            for (int j = 0; j < 4; j++) {
-                palettes[i][j] = 0x7fff;
-            }
+    void initializeCgbBootValues() {
+        for (int i = 0; i < CGB_OBJECT_PALETTE_BOOT_VALUES.length; i++) {
+            palettes[i / 4][i % 4] = CGB_OBJECT_PALETTE_BOOT_VALUES[i];
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -89,7 +89,9 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
 
         this.bgPalette = new ColorPalette(0xff68);
         this.oamPalette = new ColorPalette(0xff6a);
-        oamPalette.fillWithFF();
+        if (gbc) {
+            oamPalette.initializeCgbBootValues();
+        }
 
         this.oamSearchPhase = new OamSearch(oamRam, lcdc, r);
         this.pixelTransferPhase = new PixelTransfer(new Display(gbc), videoRam0, videoRam1, oamRam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), null, speedMode, 0);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPaletteTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPaletteTest.java
@@ -28,6 +28,16 @@ public class ColorPaletteTest {
         assertArrayEquals(new int[]{0xee44, 0xff55, 0x0000, 0x0000}, p.getPalette(1));
     }
 
+    @Test
+    public void initializesCgbObjectPaletteFromPostBootDump() {
+        ColorPalette p = new ColorPalette(0xff6a);
+
+        p.initializeCgbBootValues();
+
+        assertArrayEquals(new int[]{0x0000, 0xabf2, 0xc261, 0xbad9}, p.getPalette(0));
+        assertArrayEquals(new int[]{0x6a07, 0xec55, 0x4083, 0x770b}, p.getPalette(7));
+    }
+
     private static void assertArrayEquals(int[] expected, int[] actual) {
         assertEquals(expected.length, actual.length);
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
Fixes #184.

Vila Caldan only writes object-palette color 0 and relies on the remaining post-boot CGB palette RAM values for its animated characters. Coffee GB initialized every object color to white, so the intended green/tan sprite colors were lost.

This seeds object palette RAM from the hardware-derived CGB post-boot dump and adds regression coverage for the first and last palettes. The Vila Caldan frame now uses the same raw palette values and visible character colors as Gambatte.

Verification:
- Full project test suite (169 tests)
- SameSuite (71 tests)
- Gambatte hardware suite (9 tests)
- Vila Caldan frame replay and palette comparison against Gambatte