### PR TITLE
Support the Hong Kong Pokemon Red pirate mapper

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -27,6 +27,13 @@ public class Mbc1 implements MemoryController {
 
     private final boolean multicart;
 
+    // This unlicensed translation has an MBC1 header but a different board: 0x2000 is
+    // a complete 6-bit ROM-bank register and 0x4000 does not contribute ROM bank bits.
+    // Its patched far-call stubs select bank 0x21 directly, while surviving original
+    // code still writes 2 to 0x4000; treating that as MBC1 bit 6 maps data as code and
+    // freezes on an illegal opcode at 0x4004 (issue #179).
+    private final boolean hongKongPokemonRed;
+
     private int selectedRamBank;
 
     private int selectedRomBank = 1;
@@ -53,6 +60,11 @@ public class Mbc1 implements MemoryController {
     public Mbc1(Rom rom, Battery battery) {
         this.cartridge = rom.getRom();
         this.multicart = rom.getRomBanks() == 64 && isMulticart(this.cartridge);
+        this.hongKongPokemonRed = rom.getRomBanks() == 64
+                && "POCKETMON BE".equals(rom.getTitle())
+                && this.cartridge[0x014e] == 0x9c
+                && this.cartridge[0x014f] == 0x8c;
+        this.wideBank = hongKongPokemonRed;
         this.ramBanks = rom.getRamBanks();
         this.romBanks = rom.getRomBanks();
         this.ram = new int[0x2000 * this.ramBanks];
@@ -87,17 +99,23 @@ public class Mbc1 implements MemoryController {
             }
             cachedRomBankFor0x0000 = cachedRomBankFor0x4000 = -1;
         } else if (address >= 0x4000 && address < 0x6000 && memoryModel == 0) {
-            LOG.trace("High 2 bits of ROM bank: {}", ((value & 0b11) << 5));
-            upperRegisterUsed = true;
-            wideBank = false;
-            int bank = selectedRomBank & 0b00011111;
-            bank = bank | ((value & 0b11) << 5);
-            selectRomBank(bank);
+            if (hongKongPokemonRed) {
+                LOG.trace("Ignoring upper ROM bank write on Hong Kong Pokemon Red");
+            } else {
+                LOG.trace("High 2 bits of ROM bank: {}", ((value & 0b11) << 5));
+                upperRegisterUsed = true;
+                wideBank = false;
+                int bank = selectedRomBank & 0b00011111;
+                bank = bank | ((value & 0b11) << 5);
+                selectRomBank(bank);
+            }
             cachedRomBankFor0x0000 = cachedRomBankFor0x4000 = -1;
         } else if (address >= 0x4000 && address < 0x6000 && memoryModel == 1) {
             LOG.trace("RAM bank: {}", (value & 0b11));
-            upperRegisterUsed = true;
-            wideBank = false;
+            if (!hongKongPokemonRed) {
+                upperRegisterUsed = true;
+                wideBank = false;
+            }
             selectedRamBank = value & 0b11;
             cachedRomBankFor0x0000 = cachedRomBankFor0x4000 = -1;
         } else if (address >= 0x6000 && address < 0x8000) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1Test.java
@@ -1,0 +1,65 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class Mbc1Test {
+
+    @Test
+    public void hongKongPokemonRedKeepsItsWideRomBankAfterUpperRegisterWrites()
+            throws IOException {
+        Mbc1 mapper = mapper(pokemonRedRom());
+
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(0x21, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 0x10);
+        mapper.setByte(0x4000, 2);
+        assertEquals(0x10, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(0x21, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void upperRegisterStillDisablesWideBankDetectionForRegularMbc1Roms()
+            throws IOException {
+        Mbc1 mapper = mapper(bankMarkedRom());
+
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(0x21, mapper.getByte(0x4000));
+
+        mapper.setByte(0x4000, 2);
+        assertEquals(1, mapper.getByte(0x4000));
+    }
+
+    private static Mbc1 mapper(byte[] data) throws IOException {
+        return new Mbc1(new Rom(data), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] pokemonRedRom() {
+        byte[] data = bankMarkedRom();
+        byte[] title = "POCKETMON BE".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x134, title.length);
+        data[0x14e] = (byte) 0x9c;
+        data[0x14f] = (byte) 0x8c;
+        return data;
+    }
+
+    private static byte[] bankMarkedRom() {
+        byte[] data = new byte[64 * 0x4000];
+        for (int bank = 0; bank < 64; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        data[0x147] = 0x03; // MBC1 + RAM + battery
+        data[0x148] = 0x05; // 1 MiB / 64 ROM banks
+        data[0x149] = 0x03; // 32 KiB / four RAM banks
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #179

## Root cause

This unlicensed translation identifies itself as an MBC1 cartridge, but its patched far-call stubs write the complete ROM bank number to `0x2000`. Later, surviving original code writes `2` to `0x4000`; treating that as ordinary MBC1 upper ROM bits maps data into the executable window and freezes at an illegal opcode.

## Fix

- recognize this ROM by its 64-bank header title and global checksum
- retain wide ROM-bank selection for this board
- ignore `0x4000` for ROM banking while preserving RAM-bank selection
- keep ordinary MBC1 behavior unchanged
- add regression tests for both the pirate mapper and a regular MBC1 cartridge

## Verification

- affected ROM SHA-1: `66dc27a6998031e78042fcd24fcc053d78aabd2d`
- ROM ran for 2,100+ frames and reached its animated title screen
- `/opt/maven/bin/mvn -pl core test`: 151 passed
- Mooneye + DMG/CGB Acid2: 132 passed
- Blargg combined + individual: 54 passed
- full reactor package: success