### PR TITLE
Keep unused SGB border tiles transparent

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
@@ -50,6 +50,14 @@ public class Background implements Originator<Background> {
 
             Commands.PctTrnCmd.BgMapEntry e = picture.getBgMapEntry(charX + charY * 32);
 
+            // CHR_TRN only supplies tiles 0x00-0xff. Some games (Pocket Kanjirou,
+            // issue #174) fill the Game Boy window with 0x2ff entries so that the
+            // SNES background leaves it unobstructed. Do not wrap those entries to
+            // transferred tile 0xff.
+            if (e.isUnusedTile()) {
+                continue;
+            }
+
             int charPixelX = x % 8;
             int charPixelY = y % 8;
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
@@ -642,6 +642,10 @@ public class Commands {
                 return value & 0b0000000011111111;
             }
 
+            public boolean isUnusedTile() {
+                return (value & 0b0000001100000000) != 0;
+            }
+
             public int getPaletteNumber() {
                 return (value >> 10) & 0b00000111;
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/BackgroundTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/BackgroundTest.java
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.core.sgb;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+
+public class BackgroundTest {
+
+    @Test
+    public void characterNumbersAboveTransferredRangeRemainUnused() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        Background background = new Background(sgbBus);
+        background.init(eventBus);
+        AtomicReference<Background.SgbBackgroundReadyEvent> rendered = new AtomicReference<>();
+        eventBus.register(rendered::set, Background.SgbBackgroundReadyEvent.class);
+
+        Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
+        characters.packet[1] = 1; // transfer tiles 0x80-0xff
+        int[] characterData = new int[0x1000];
+        Arrays.fill(characterData, 0x7f * 32, 0x80 * 32, 0xff);
+        characters.setDataTransfer(characterData);
+        sgbBus.post(characters);
+
+        Commands.PctTrnCmd picture = (Commands.PctTrnCmd) command(0x14);
+        int[] pictureData = new int[0x1000];
+        int firstGameboyTile = 6 + 5 * 32;
+        setMapEntry(pictureData, firstGameboyTile, 0x02ff);
+        setMapEntry(pictureData, firstGameboyTile + 1, 0x10ff);
+        pictureData[0x081e] = 0x34;
+        pictureData[0x081f] = 0x12;
+        picture.setDataTransfer(pictureData);
+        sgbBus.post(picture);
+
+        int firstGameboyPixel = 48 + 40 * SuperGameboy.SGB_DISPLAY_WIDTH;
+        assertEquals(0, rendered.get().mask()[firstGameboyPixel]);
+        assertEquals(0, rendered.get().buffer()[firstGameboyPixel]);
+
+        int nextTilePixel = firstGameboyPixel + 8;
+        assertEquals(15, rendered.get().mask()[nextTilePixel]);
+        assertEquals(0x1234, rendered.get().buffer()[nextTilePixel]);
+    }
+
+    private static Commands.AbstractCommand command(int code) {
+        int[] packet = new int[16];
+        packet[0] = (code << 3) | 1;
+        return Commands.toCommand(packet);
+    }
+
+    private static void setMapEntry(int[] pictureData, int index, int value) {
+        pictureData[2 * index] = value & 0xff;
+        pictureData[2 * index + 1] = value >> 8;
+    }
+}


### PR DESCRIPTION
Fixes #174

## Root cause

Pocket Kanjirou fills the 20×18 Game Boy window in its transferred SGB border map with character value `0x02ff`. `CHR_TRN` only supplies characters `0x00`–`0xff`, but Coffee GB discarded character bits 8–9 and rendered transferred tile `0xff` instead. Its nonzero pixels then covered the live Game Boy frame with a dark rectangle.

The SGB border map format reserves ten character-number bits while transferred border characters are limited to `0x00`–`0xff`: https://gbdev.io/pandocs/SGB_Command_Border.html

## Fix

- recognize border-map entries with character bits 8–9 set as unused
- leave those pixels unobstructed instead of wrapping them to tile `0xff`
- add a regression test for the ROM's exact `0x02ff` sentinel
- verify that a valid `0x00ff` tile still renders normally

## Verification

- affected ROM SHA-1: `ef150c97cb4e9a46f90d826b1aad208cbaa4410f`
- 1,200-frame SGB capture reaches the full-color Pocket Kanjirou title screen inside its border
- core unit tests: 150 passed
- Mooneye: 130 passed
- DMG/CGB Acid2: 2 passed
- Blargg combined + individual: 54 passed