### PR TITLE
Fix Namco Gallery Vol.2 trainer launch

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -110,7 +110,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         boolean gbc = this.gbc;
         boolean sgb = configuration.gameboyType == GameboyType.SGB;
 
-        speedMode = new SpeedMode(gbc);
+        boolean legacySpeedSwitchRequired = configuration.rom.isLegacySpeedSwitchRequired();
+        speedMode = new SpeedMode(gbc, legacySpeedSwitchRequired);
         interruptManager = new InterruptManager(gbc);
         timer = new Timer(interruptManager, speedMode);
         mmu = new Mmu(gbc);
@@ -163,8 +164,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         mmu.addAddressSpace(dma);
         mmu.addAddressSpace(sound);
 
-        if (gbc) {
+        if (gbc || legacySpeedSwitchRequired) {
             mmu.addAddressSpace(speedMode);
+        }
+        if (gbc) {
             mmu.addAddressSpace(hdma);
             mmu.addAddressSpace(infraredPort);
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
@@ -11,6 +11,8 @@ public class SpeedMode implements AddressSpace, Serializable, Originator<SpeedMo
 
     private final boolean gbc;
 
+    private final boolean allowLegacySpeedSwitch;
+
     private boolean currentSpeed;
 
     private boolean prepareSpeedSwitch;
@@ -22,7 +24,12 @@ public class SpeedMode implements AddressSpace, Serializable, Originator<SpeedMo
     private BiosShadow biosShadow;
 
     public SpeedMode(boolean gbc) {
+        this(gbc, false);
+    }
+
+    public SpeedMode(boolean gbc, boolean allowLegacySpeedSwitch) {
         this.gbc = gbc;
+        this.allowLegacySpeedSwitch = allowLegacySpeedSwitch;
     }
 
     public void setBiosShadow(BiosShadow biosShadow) {
@@ -48,7 +55,7 @@ public class SpeedMode implements AddressSpace, Serializable, Originator<SpeedMo
             if (biosShadow == null || !biosShadow.isBootFinished()) {
                 dmgCompat = (value & 0x0c) != 0;
             }
-        } else if (!dmgCompat) {
+        } else if (isSpeedSwitchAccessible()) {
             prepareSpeedSwitch = (value & 0x01) != 0;
         }
     }
@@ -58,11 +65,15 @@ public class SpeedMode implements AddressSpace, Serializable, Originator<SpeedMo
         if (address == 0xff4c) {
             return 0xff;
         }
-        if (gbc && !dmgCompat) {
+        if (isSpeedSwitchAccessible()) {
             return (currentSpeed ? (1 << 7) : 0) | (prepareSpeedSwitch ? (1 << 0) : 0) | 0b01111110;
         } else {
             return 0xff;
         }
+    }
+
+    private boolean isSpeedSwitchAccessible() {
+        return allowLegacySpeedSwitch || (gbc && !dmgCompat);
     }
 
     boolean onStop() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -33,6 +33,8 @@ public class Rom {
 
     private final GameboyColorFlag gameboyColorFlag;
 
+    private final boolean legacySpeedSwitchRequired;
+
     private final boolean superGameboyFlag;
 
     public Rom(File romFile) throws IOException {
@@ -94,14 +96,23 @@ public class Rom {
         cartridgeType = type;
         LOG.debug("Cartridge {}, type: {}", title, cartridgeType);
         GameboyColorFlag colorFlag = GameboyColorFlag.getFlag(rom[0x0143]);
+        boolean legacySpeedSwitchRequired = false;
         if (isDmgOnlyCrazyCastleTrainer(rom, title)) {
             // This trainer advertises CGB compatibility but only initializes the DMG
             // BGP/OBP registers. Native CGB startup therefore renders its menu entirely
             // white and also leaves HRAM in a state the trainer does not expect.
             LOG.info("DMG-only Crazy Castle 3 trainer detected; ignoring its CGB flag");
             colorFlag = GameboyColorFlag.NON_CGB;
+        } else if (isNamcoGallery2Trainer(rom, title)) {
+            // This old emulator-oriented trainer keeps the original DMG header, but its
+            // launch stub writes KEY1 and executes STOP before handing off to the game.
+            // Accept that speed switch as a narrowly scoped extension while retaining
+            // DMG rendering; treating the whole image as native CGB corrupts its colours.
+            LOG.info("Namco Gallery Vol.2 trainer detected; enabling its CGB speed-switch extension");
+            legacySpeedSwitchRequired = true;
         }
         gameboyColorFlag = colorFlag;
+        this.legacySpeedSwitchRequired = legacySpeedSwitchRequired;
         superGameboyFlag = rom[0x0146] == 0x03;
         romBanks = getRomBanks(rom[0x0148], rom.length);
         int ramSize = getRamSize(rom[0x0149]);
@@ -147,6 +158,10 @@ public class Rom {
         return gameboyColorFlag;
     }
 
+    public boolean isLegacySpeedSwitchRequired() {
+        return legacySpeedSwitchRequired;
+    }
+
     public boolean isSuperGameboyFlag() {
         return superGameboyFlag;
     }
@@ -166,6 +181,21 @@ public class Rom {
         }
         for (int i = 0; i < entryStub.length; i++) {
             if (rom[0x00e0 + i] != entryStub[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isNamcoGallery2Trainer(int[] rom, String title) {
+        int[] speedSwitchStub = {0x3e, 0x01, 0xe0, 0x4d, 0x10, 0x00, 0x00, 0x00,
+                0xcd, 0x0d, 0x71, 0xfa, 0xf0, 0xdf, 0xc3, 0x50, 0x01};
+        if (rom.length != 0x80000 || !"GALLERY2 +4".equals(title)
+                || rom[0x0143] != 0x00 || rom[0x0147] != 0x01) {
+            return false;
+        }
+        for (int i = 0; i < speedSwitchStub.length; i++) {
+            if (rom[0x3f0fc + i] != speedSwitchStub[i]) {
                 return false;
             }
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/SpeedModeTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/SpeedModeTest.java
@@ -1,0 +1,22 @@
+package eu.rekawek.coffeegb.core.cpu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SpeedModeTest {
+
+    @Test
+    public void canEnableKnownDmgCompatibilitySpeedSwitchExtension() {
+        SpeedMode speedMode = new SpeedMode(false, true);
+        speedMode.setDmgCompat(true);
+
+        speedMode.setByte(0xff4d, 0x01);
+
+        assertEquals(0x7f, speedMode.getByte(0xff4d));
+        assertTrue(speedMode.onStop());
+        assertEquals(2, speedMode.getSpeedMode());
+        assertEquals(0xfe, speedMode.getByte(0xff4d));
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/NamcoGallery2TrainerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/NamcoGallery2TrainerTest.java
@@ -1,0 +1,59 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.GameboyType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NamcoGallery2TrainerTest {
+
+    @Test
+    public void enablesKey1ExtensionWithoutChangingItsDmgRenderingMode() throws IOException {
+        Rom rom = new Rom(trainerRom());
+
+        assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
+        assertTrue(rom.isLegacySpeedSwitchRequired());
+        assertEquals(GameboyType.DMG, new Gameboy.GameboyConfiguration(rom).getGameboyType());
+    }
+
+    @Test
+    public void doesNotReclassifyAnotherDmgMbc1Cartridge() throws IOException {
+        byte[] data = trainerRom();
+        data[0x3f0fc] = 0;
+        Rom rom = new Rom(data);
+
+        assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
+        assertFalse(rom.isLegacySpeedSwitchRequired());
+    }
+
+    @Test
+    public void mapsKey1ForTheTrainerOnItsDefaultDmgConsole() throws IOException {
+        Rom rom = new Rom(trainerRom());
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(rom).build();
+
+        assertEquals(0x7e, gameboy.getAddressSpace().getByte(0xff4d));
+        gameboy.getAddressSpace().setByte(0xff4d, 0x01);
+        assertEquals(0x7f, gameboy.getAddressSpace().getByte(0xff4d));
+    }
+
+    private static byte[] trainerRom() {
+        byte[] data = new byte[0x80000];
+        byte[] title = "GALLERY2 +4".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x04;
+        int[] speedSwitchStub = {0x3e, 0x01, 0xe0, 0x4d, 0x10, 0x00, 0x00, 0x00,
+                0xcd, 0x0d, 0x71, 0xfa, 0xf0, 0xdf, 0xc3, 0x50, 0x01};
+        for (int i = 0; i < speedSwitchStub.length; i++) {
+            data[0x3f0fc + i] = (byte) speedSwitchStub[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #175.

The trainer keeps a DMG-only cartridge header but its launch stub writes `KEY1` and executes `STOP`, expecting a double-speed switch. On a real DMG-compatible register map that write disappears, so the CPU remains stopped and the display stays blank.

This recognizes the exact `GALLERY2 +4` trainer signature and exposes the legacy KEY1 speed-switch extension only for that image. It deliberately retains DMG rendering; classifying the entire ROM as native CGB makes the original game render with incorrect colors.

Validation:
- scripted START exits the trainer and reaches the Namco Gallery Vol.2 title screen
- 153 unit tests pass
- Mooneye + DMG/CGB Acid2 profiles pass
- Blargg combined and individual profiles pass