### PR TITLE
Make SGB border transfers atomic and fade them

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
@@ -2,16 +2,25 @@ package eu.rekawek.coffeegb.core.sgb;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
 public class Background implements Originator<Background> {
 
+    // SGB2 measurement used by SameBoy: wait 41 frames, fade the old border
+    // out for 32, swap at black, then fade the new border in for 32.
+    private static final int BORDER_ANIMATION_FRAMES = 105;
+
+    private static final int BORDER_SWAP_FRAME = 32;
+
     private final int[] tiles = new int[0x2000];
 
     private EventBus eventBus;
 
-    private Commands.PctTrnCmd lastPicture;
+    private Commands.PctTrnCmd pendingPicture;
+
+    private int borderAnimation;
 
     public Background(EventBus sgbBus) {
         sgbBus.register(this::onPictureTransfer, Commands.PctTrnCmd.class);
@@ -20,22 +29,45 @@ public class Background implements Originator<Background> {
 
     public void init(EventBus eventBus) {
         this.eventBus = eventBus;
+        eventBus.register(e -> onFrame(), Display.DmgFrameReadyEvent.class);
     }
 
     private void onCharTransfer(Commands.ChrTrnCmd e) {
         // the tile type bit does not affect where the data is stored
         System.arraycopy(e.dataTransfer, 0, tiles, e.getTileOffset() * 32, 0x1000);
-        // the SNES side renders continuously: a border picture sent before its tile
-        // data becomes visible once the tiles arrive (Super Snakey sends PCT_TRN
-        // before CHR_TRN)
-        if (lastPicture != null) {
-            render(lastPicture);
-        }
     }
 
     private void onPictureTransfer(Commands.PctTrnCmd picture) {
-        lastPicture = picture;
-        render(picture);
+        pendingPicture = picture;
+        borderAnimation = BORDER_ANIMATION_FRAMES;
+        if (eventBus != null) {
+            eventBus.post(new SgbBackgroundFadeEvent(0));
+        }
+    }
+
+    private void onFrame() {
+        if (borderAnimation == 0) {
+            return;
+        }
+        borderAnimation--;
+        int fade;
+        if (borderAnimation >= 64) {
+            fade = 0;
+        } else if (borderAnimation > BORDER_SWAP_FRAME) {
+            fade = 64 - borderAnimation;
+        } else {
+            fade = borderAnimation;
+        }
+        if (borderAnimation == BORDER_SWAP_FRAME && pendingPicture != null) {
+            // CHR_TRN updates the pending tile data in either valid ordering:
+            // Galaga/Galaxian sends CHR then PCT, while Super Snakey sends PCT
+            // then CHR. Commit the complete pending border only at the black
+            // midpoint so neither ordering exposes half-updated graphics.
+            render(pendingPicture);
+        }
+        if (eventBus != null) {
+            eventBus.post(new SgbBackgroundFadeEvent(fade));
+        }
     }
 
     private void render(Commands.PctTrnCmd picture) {
@@ -81,7 +113,7 @@ public class Background implements Originator<Background> {
     @Override
     public Memento<Background> saveToMemento() {
         return new BackgroundMemento(tiles.clone(),
-                lastPicture == null ? null : lastPicture.saveToMemento());
+                pendingPicture == null ? null : pendingPicture.saveToMemento(), borderAnimation);
     }
 
     @Override
@@ -93,22 +125,27 @@ public class Background implements Originator<Background> {
             throw new IllegalArgumentException("Memento array length doesn't match");
         }
         System.arraycopy(mem.tiles, 0, this.tiles, 0, this.tiles.length);
-        if (mem.lastPictureMemento == null) {
-            this.lastPicture = null;
+        if (mem.pendingPictureMemento == null) {
+            this.pendingPicture = null;
         } else {
-            var restored = Commands.TransferCommand.restoreFromMemento(mem.lastPictureMemento);
+            var restored = Commands.TransferCommand.restoreFromMemento(mem.pendingPictureMemento);
             if (!(restored instanceof Commands.PctTrnCmd picture)) {
                 throw new IllegalArgumentException("Memento does not contain a picture transfer command");
             }
-            this.lastPicture = picture;
+            this.pendingPicture = picture;
         }
+        this.borderAnimation = mem.borderAnimation;
     }
 
     private record BackgroundMemento(int[] tiles,
-                                     Memento<Commands.TransferCommand> lastPictureMemento)
+                                     Memento<Commands.TransferCommand> pendingPictureMemento,
+                                     int borderAnimation)
             implements Memento<Background> {
     }
 
     public record SgbBackgroundReadyEvent(int[] buffer, int[] mask) implements Event {
+    }
+
+    public record SgbBackgroundFadeEvent(int amount) implements Event {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -50,6 +50,8 @@ public class SgbDisplay implements Originator<SgbDisplay> {
 
     private int atfNumber = -1;
 
+    private int borderFade;
+
     public SgbDisplay(Rom rom, EventBus sgbBus, boolean sgb, boolean sgbBorder) {
         this.sgbBorder = sgbBorder;
         this.sgb = sgb;
@@ -62,6 +64,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         if (sgb) {
             this.eventBus = eventBus;
             eventBus.register(this::onSgbBackground, Background.SgbBackgroundReadyEvent.class);
+            eventBus.register(e -> borderFade = e.amount(), Background.SgbBackgroundFadeEvent.class);
             eventBus.register(this::onDmgFrame, DmgFrameReadyEvent.class);
             eventBus.register(e -> this.sgbBorder = e.borderEnabled, SetSgbBorder.class);
 
@@ -196,7 +199,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
                 if (mask == 0) {
                     result[i] = translateGbcRgb(dmgPixel);
                 } else {
-                    result[i] = translateGbcRgb(sgbPixel);
+                    result[i] = translateGbcRgb(fadeBorderColor(sgbPixel, borderFade));
                 }
             }
         }
@@ -208,10 +211,18 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         System.arraycopy(sgbBackgroundReadyEvent.mask(), 0, sgbMask, 0, sgbMask.length);
     }
 
+    private static int fadeBorderColor(int color, int fade) {
+        int red = Math.max(0, (color & 0x1f) - fade);
+        int green = Math.max(0, ((color >> 5) & 0x1f) - fade);
+        int blue = Math.max(0, ((color >> 10) & 0x1f) - fade);
+        return red | (green << 5) | (blue << 10);
+    }
+
     @Override
     public Memento<SgbDisplay> saveToMemento() {
         return new SgbDisplayMemento(sgbBuffer.clone(), sgbMask.clone(), clone2(palettes),
-                clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask, atfNumber);
+                clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask, atfNumber,
+                borderFade);
     }
 
     @Override
@@ -245,6 +256,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         replaceRows(mem.attributeFiles, this.attributeFiles, DMG_TILES_WIDTH * DMG_TILES_HEIGHT);
         this.screenMask = mem.screenMask;
         this.atfNumber = mem.atfNumber;
+        this.borderFade = mem.borderFade;
     }
 
     private static void replaceRows(int[][] src, int[][] dst, int expectedRowLength) {
@@ -275,7 +287,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
 
     private record SgbDisplayMemento(int[] sgbBuffer, int[] sgbMask, int[][] palettes, int[][] systemPalettes,
                                      int[] paletteMap, int[][] attributeFiles, GameboyScreenMask screenMask,
-                                     int atfNumber) implements Memento<SgbDisplay> {
+                                     int atfNumber, int borderFade) implements Memento<SgbDisplay> {
     }
 
     public record SgbFrameReadyEvent(int[] buffer, boolean includeBorder) implements Event {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbMementoTest.java
@@ -28,6 +28,7 @@ public class SgbMementoTest {
         Commands.PctTrnCmd picture = (Commands.PctTrnCmd) command(0x14);
         picture.setDataTransfer(new int[0x1000]);
         sgbBus.post(picture);
+        advanceFrames(eventBus, 73);
         assertEquals(1, renderedPictures.get());
 
         background.restoreFromMemento(emptyMemento);
@@ -35,6 +36,7 @@ public class SgbMementoTest {
         Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
         characters.setDataTransfer(new int[0x1000]);
         sgbBus.post(characters);
+        advanceFrames(eventBus, 105);
 
         assertEquals(0, renderedPictures.get());
     }
@@ -64,8 +66,58 @@ public class SgbMementoTest {
         Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
         characters.setDataTransfer(new int[0x1000]);
         sgbBus.post(characters);
+        advanceFrames(eventBus, 73);
 
         assertEquals(0x1234, rendered.get()[0]);
+    }
+
+    @Test
+    public void borderCharactersRemainPendingUntilThePictureTransition() {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        Background background = new Background(sgbBus);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicInteger renderedPictures = new AtomicInteger();
+        eventBus.register(event -> renderedPictures.incrementAndGet(),
+                Background.SgbBackgroundReadyEvent.class);
+        background.init(eventBus);
+
+        Commands.ChrTrnCmd characters = (Commands.ChrTrnCmd) command(0x13);
+        characters.setDataTransfer(new int[0x1000]);
+        sgbBus.post(characters);
+        advanceFrames(eventBus, 100);
+        assertEquals(0, renderedPictures.get());
+
+        Commands.PctTrnCmd picture = (Commands.PctTrnCmd) command(0x14);
+        picture.setDataTransfer(new int[0x1000]);
+        sgbBus.post(picture);
+        advanceFrames(eventBus, 72);
+        assertEquals(0, renderedPictures.get());
+        advanceFrames(eventBus, 1);
+        assertEquals(1, renderedPictures.get());
+    }
+
+    @Test
+    public void displayAppliesAndRestoresBorderFade() throws IOException {
+        EventBusImpl sgbBus = new EventBusImpl(null, null, false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, true);
+        display.init(eventBus);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.buffer().clone()), SgbDisplay.SgbFrameReadyEvent.class);
+
+        int[] border = new int[SuperGameboy.SGB_DISPLAY_WIDTH * SuperGameboy.SGB_DISPLAY_HEIGHT];
+        int[] mask = new int[border.length];
+        Arrays.fill(border, 0x7fff);
+        Arrays.fill(mask, 1);
+        eventBus.post(new Background.SgbBackgroundReadyEvent(border, mask));
+        eventBus.post(new Background.SgbBackgroundFadeEvent(1));
+        var memento = display.saveToMemento();
+
+        eventBus.post(new Background.SgbBackgroundFadeEvent(31));
+        display.restoreFromMemento(memento);
+        eventBus.post(new Display.DmgFrameReadyEvent(new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT]));
+
+        assertEquals(Display.GbcFrameReadyEvent.translateGbcRgb(0x7bde), frame.get()[0]);
     }
 
     @Test
@@ -133,6 +185,13 @@ public class SgbMementoTest {
         int[] packet = new int[16];
         packet[0] = (code << 3) | 1;
         return Commands.toCommand(packet);
+    }
+
+    private static void advanceFrames(EventBusImpl eventBus, int count) {
+        int[] pixels = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        for (int i = 0; i < count; i++) {
+            eventBus.post(new Display.DmgFrameReadyEvent(pixels));
+        }
     }
 
     private static Commands.PalSetCmd paletteSet(int paletteId) {


### PR DESCRIPTION
Fixes #173.

Coffee GB rendered each incoming `CHR_TRN` immediately through the previously active `PCT_TRN` map. Galaga & Galaxian sends both new character halves before the new picture map, so the mixed generations produced the reported garbage border.

This implements the original SGB border transition model instead of special-casing the game: character and picture transfers update a pending border, the active border remains intact, it fades to black, pending data is committed atomically, and the new border fades in. The 105-frame sequence and 32-frame black midpoint follow the SGB2-measured timing documented in [SameBoy’s SGB core](https://github.com/LIJI32/SameBoy/blob/213a12ce93d66b105a113debd9396306066a7cfc/Core/sgb.c#L649-L663). Both valid command orderings are supported, including Super Snakey’s `PCT_TRN`-before-`CHR_TRN` sequence. Transition and fade state are included in save states.

Validation:
- reproduced the exact reported transient with ROM SHA-1 `739671d6cf151fa5527d68f78345197d278cdf19`
- scripted Galaxian selection now retains the valid Galaga border until the fade and matches the measured SameBoy transition sequence
- Super Snakey still receives its complete border with the reverse transfer order
- 151 unit tests pass
- Mooneye + DMG/CGB Acid2 profiles pass
- Blargg combined and individual profiles pass