### PR TITLE
Fix Dragon Ball Z Chinese translation startup

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
@@ -17,6 +17,15 @@ public class Mbc2 implements MemoryController {
 
     private final int romBanks;
 
+    /**
+     * The Chinese Gokuu Hishouden translation was assembled for older emulators that
+     * decoded the whole 2000-3FFF range as a five-bit ROM-bank register. Its launcher
+     * consequently writes bank 0x0c to 0x2000 instead of an address with A8 set, and
+     * the translated game later selects banks 0x10-0x1f in its expanded 512 KiB image.
+     * It cannot run on an accurately decoded four-bit MBC2 without both quirks.
+     */
+    private final boolean legacyExtendedBanking;
+
     private int selectedRomBank = 1;
 
     private boolean ramWriteEnabled;
@@ -26,6 +35,7 @@ public class Mbc2 implements MemoryController {
     public Mbc2(Rom rom, Battery battery) {
         this.romBanks = rom.getRomBanks();
         this.cartridge = rom.getRom();
+        this.legacyExtendedBanking = isGokuuHishoudenChineseTranslation(rom);
         this.ram = new int[0x0200];
         Arrays.fill(ram, 0xff);
         this.battery = battery;
@@ -40,10 +50,10 @@ public class Mbc2 implements MemoryController {
     @Override
     public void setByte(int address, int value) {
         if (address >= 0x0000 && address < 0x4000) {
-            if ((address & 0x0100) == 0) {
+            if ((address & 0x0100) == 0 && !(legacyExtendedBanking && address >= 0x2000)) {
                 ramWriteEnabled = (value & 0b1111) == 0b1010;
             } else {
-                selectedRomBank = value & 0b00001111;
+                selectedRomBank = value & (legacyExtendedBanking ? 0b00011111 : 0b00001111);
                 if (selectedRomBank == 0) {
                     selectedRomBank = 1;
                 }
@@ -100,6 +110,29 @@ public class Mbc2 implements MemoryController {
 
     private int getRamAddress(int address) {
         return (address - 0xa000) % ram.length;
+    }
+
+    private static boolean isGokuuHishoudenChineseTranslation(Rom rom) {
+        int[] data = rom.getRom();
+        int[] entryAndBankStub = {
+                0x00, 0xc3, 0xf0, 0x3f,
+                0xf5, 0x3e, 0x0c, 0xea, 0x00, 0x20, 0xf1, 0xc3, 0x00, 0x70
+        };
+        if (data.length != 0x80000 || !"GB DBZ GOKOU".equals(rom.getTitle())
+                || data[0x0147] != 0x06 || data[0x0148] != 0x04) {
+            return false;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (data[0x0100 + i] != entryAndBankStub[i]) {
+                return false;
+            }
+        }
+        for (int i = 4; i < entryAndBankStub.length; i++) {
+            if (data[0x3ff0 + i - 4] != entryAndBankStub[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2Test.java
@@ -1,0 +1,62 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class Mbc2Test {
+
+    @Test
+    public void regularMbc2RequiresAddressBit8ForRomBankWrites() throws IOException {
+        byte[] data = rom();
+        data[4 * 0x4000] = 0x24;
+        data[12 * 0x4000] = 0x12;
+        Mbc2 mbc = new Mbc2(new Rom(data), Battery.NULL_BATTERY);
+
+        mbc.setByte(0x2000, 12);
+
+        assertEquals(0, mbc.getByte(0x4000));
+        mbc.setByte(0x2100, 12);
+        assertEquals(0x12, mbc.getByte(0x4000));
+        mbc.setByte(0x2100, 20);
+        assertEquals(0x24, mbc.getByte(0x4000));
+    }
+
+    @Test
+    public void gokuuHishoudenTranslationUsesLegacyExtendedBanking() throws IOException {
+        byte[] data = rom();
+        byte[] title = "GB DBZ GOKOU".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        int[] entry = {0x00, 0xc3, 0xf0, 0x3f};
+        int[] bankStub = {0xf5, 0x3e, 0x0c, 0xea, 0x00, 0x20, 0xf1, 0xc3, 0x00, 0x70};
+        copy(entry, data, 0x0100);
+        copy(bankStub, data, 0x3ff0);
+        data[12 * 0x4000] = 0x34;
+        data[20 * 0x4000] = 0x56;
+        Mbc2 mbc = new Mbc2(new Rom(data), Battery.NULL_BATTERY);
+
+        mbc.setByte(0x2000, 12);
+
+        assertEquals(0x34, mbc.getByte(0x4000));
+        mbc.setByte(0x2000, 20);
+        assertEquals(0x56, mbc.getByte(0x4000));
+    }
+
+    private static byte[] rom() {
+        byte[] data = new byte[0x80000];
+        data[0x0147] = 0x06;
+        data[0x0148] = 0x04;
+        return data;
+    }
+
+    private static void copy(int[] source, byte[] target, int offset) {
+        for (int i = 0; i < source.length; i++) {
+            target[offset + i] = (byte) source[i];
+        }
+    }
+}


### PR DESCRIPTION
Fixes #172

The translation expands this MBC2 game to 512 KiB but was built for legacy emulator banking: it writes the ROM bank at 0x2000 (where real MBC2 sees RAM control) and uses five-bit bank values up to 0x1f. Coffee GB therefore stayed on bank 1 during the injected launcher, and masking later banks to four bits caused a second crash.

Detect the translation by its title, header, entry point, and injected bank-switch stub, then enable its legacy address decode and five-bit bank register without changing accurate behavior for ordinary MBC2 cartridges.

Verification:
- The attached ROM now advances through the WOOD splash to the Chinese title screen and main menu.
- Added mapper regressions for normal MBC2 address/four-bit decoding and the translation-specific extended behavior.
- 151 core unit tests pass.
- Mooneye plus DMG/CGB Acid2 profiles pass.
- Combined and individual Blargg profiles pass.