### PR TITLE
Boot Sachen 31-in-1 Color multicarts

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -38,8 +38,8 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
 
     private AddressSpace[] addressToSpace;
 
-    // the Sachen MMC2 cart watches the external bus for reads at 0xC000 and above to tell
-    // a CGB boot from a DMG one; null for every other cartridge (see SachenMmc)
+    // the Sachen MMC2 cart watches pre-header WRAM writes to tell a CGB boot from a DMG
+    // one; null for every other cartridge (see SachenMmc)
     private transient eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc busListener;
 
     public void setBusListener(eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc listener) {
@@ -106,15 +106,15 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
     public void setByte(int address, int value) {
         checkByteArgument("value", value);
         checkWordArgument("address", address);
+        if (busListener != null && address >= 0xc000 && address < 0xe000) {
+            busListener.onHighBusWrite();
+        }
         getSpace(address).setByte(address, value);
     }
 
     @Override
     public int getByte(int address) {
         checkWordArgument("address", address);
-        if (busListener != null && address >= 0xc000) {
-            busListener.onHighBusRead();
-        }
         return getSpace(address).getByte(address);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -49,12 +49,19 @@ public class Rom {
             rom[i] = romByteArray[i] & 0xFF;
         }
 
+        // Raw Sachen MMC1/MMC2 dumps have A0/A6 and A1/A4 swapped throughout the
+        // 0x0100-0x01ff page. Parse their logical header rather than the scrambled bytes
+        // in the file; in particular, 31B-001's CGB flag is physically stored elsewhere.
+        // The mapper still receives the untouched raw image so it can reproduce the bus.
+        boolean rawSachen = isRawSachen(rom);
+        int[] header = rawSachen ? unscrambleSachenHeader(rom) : rom;
+
         // Correct an invalid header checksum (0x14D) so the authentic boot ROM does not lock
         // up. The real DMG/CGB boot ROM verifies the checksum over 0x134-0x14C and hangs on
         // the logo screen if it is wrong; some homebrew/PD dumps ship a bad one (e.g.
         // Dimensionless Sample, #76 - it renders past a SKIP boot but hangs the boot ROM).
         // BGB, SameBoy and real flashcarts silently fix it; only touches already-invalid ROMs.
-        if (rom.length > 0x014D) {
+        if (!rawSachen && rom.length > 0x014D) {
             int headerChecksum = 0;
             for (int a = 0x0134; a <= 0x014C; a++) {
                 headerChecksum = (headerChecksum - rom[a] - 1) & 0xFF;
@@ -66,15 +73,15 @@ public class Rom {
             }
         }
 
-        title = getTitle(rom);
+        title = getTitle(header);
         CartridgeType type;
         try {
-            type = CartridgeType.getById(rom[0x0147]);
+            type = CartridgeType.getById(header[0x0147]);
         } catch (IllegalArgumentException e) {
             // Unknown/custom mapper byte. Some are known unlicensed carts we handle
             // deliberately as MBC5; the rest fall back to MBC5 banking rather than
             // refusing to load (issues #58, #71).
-            if (isPocketVoice(rom, title)) {
+            if (isPocketVoice(header, title)) {
                 // The Pocket Voice V2.0 voice recorder (type 0xBE) is MBC5-compatible for
                 // everything the Game Boy can observe: it banks 32x16 KB normally and its
                 // full UI (record screen, built-in sample library) is reachable. The voice
@@ -87,13 +94,13 @@ public class Rom {
                 LOG.info("Pocket Voice cartridge detected; handling as MBC5 (external voice chip not emulated)");
             } else {
                 LOG.warn("Unsupported cartridge type {}, falling back to MBC5",
-                        Integer.toHexString(rom[0x0147]));
+                        Integer.toHexString(header[0x0147]));
             }
             type = CartridgeType.getById(0x19);
         }
         cartridgeType = type;
         LOG.debug("Cartridge {}, type: {}", title, cartridgeType);
-        GameboyColorFlag colorFlag = GameboyColorFlag.getFlag(rom[0x0143]);
+        GameboyColorFlag colorFlag = GameboyColorFlag.getFlag(header[0x0143]);
         if (isDmgOnlyCrazyCastleTrainer(rom, title)) {
             // This trainer advertises CGB compatibility but only initializes the DMG
             // BGP/OBP registers. Native CGB startup therefore renders its menu entirely
@@ -102,9 +109,10 @@ public class Rom {
             colorFlag = GameboyColorFlag.NON_CGB;
         }
         gameboyColorFlag = colorFlag;
-        superGameboyFlag = rom[0x0146] == 0x03;
-        romBanks = getRomBanks(rom[0x0148], rom.length);
-        int ramSize = getRamSize(rom[0x0149]);
+        superGameboyFlag = header[0x0146] == 0x03;
+        romBanks = rawSachen ? Math.max(2, (rom.length + 0x3fff) / 0x4000)
+                : getRomBanks(header[0x0148], rom.length);
+        int ramSize = getRamSize(header[0x0149]);
         if (ramSize == 0 && cartridgeType.isRam()) {
             LOG.warn("RAM bank is defined to 0. Overriding to 1.");
             ramSize = 0x2000;
@@ -170,6 +178,32 @@ public class Rom {
             }
         }
         return true;
+    }
+
+    private static boolean isRawSachen(int[] data) {
+        if (data.length < 0x200) {
+            return false;
+        }
+        boolean mmc1 = data[0x104] == 0xce && data[0x144] == 0xed && data[0x114] == 0x66;
+        boolean mmc2 = data[0x184] == 0xce && data[0x1c4] == 0xed && data[0x194] == 0x66;
+        return mmc1 || mmc2;
+    }
+
+    private static int[] unscrambleSachenHeader(int[] data) {
+        int[] header = new int[0x150];
+        for (int address = 0x100; address < header.length; address++) {
+            header[address] = data[unscrambleSachenAddress(address)];
+        }
+        return header;
+    }
+
+    private static int unscrambleSachenAddress(int address) {
+        int unscrambled = address & 0xffac;
+        unscrambled |= (address & 0x40) >> 6;
+        unscrambled |= (address & 0x10) >> 3;
+        unscrambled |= (address & 0x02) << 3;
+        unscrambled |= (address & 0x01) << 6;
+        return unscrambled;
     }
 
     private static String getTitle(int[] rom) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -25,9 +25,9 @@ import eu.rekawek.coffeegb.core.memory.cart.Rom;
  * reads of that page are counted and (in the CGB-locked state) redirected to 0x0180-0x01FF,
  * where the carts store the logo the boot ROM must see; the 0x31st read advances the lock
  * state. The MMC2 additionally starts in a DMG-locked state and moves to the CGB-locked
- * state on the first bus read at or above 0xC000 (the CGB boot ROM touches WRAM before
- * reading the logo, the DMG one does not - that is how the cart tells the consoles apart
- * and serves the right logo to each).
+ * state on the CGB boot ROM's first WRAM write (the DMG boot ROM does not perform one
+ * before reading the header - that is how the cart tells the consoles apart and serves
+ * the right logo to each).
  */
 public class SachenMmc implements MemoryController {
 
@@ -95,8 +95,8 @@ public class SachenMmc implements MemoryController {
         return address >= 0x0000 && address < 0x8000;
     }
 
-    /** Notified by the MMU of reads at 0xC000 and above (visible on the cartridge bus). */
-    public void onHighBusRead() {
+    /** Notified by the MMU of the WRAM write the CGB boot ROM performs before reading the header. */
+    public void onHighBusWrite() {
         if (mmc2 && lockState == LOCKED_DMG) {
             lockState = LOCKED_CGB;
             transition = 0;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
@@ -1,0 +1,78 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.Mmu;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RawSachenTest {
+
+    private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89,
+            0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63,
+            0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
+
+    @Test
+    public void parsesLogicalHeaderWithoutModifyingRawImage() throws IOException {
+        byte[] data = rawMmc2Rom();
+        int physicalChecksum = data[unscramble(0x14d)] & 0xff;
+
+        Rom rom = new Rom(data);
+
+        assertEquals(Rom.GameboyColorFlag.UNIVERSAL, rom.getGameboyColorFlag());
+        assertEquals(128, rom.getRomBanks());
+        assertEquals(physicalChecksum, rom.getRom()[unscramble(0x14d)]);
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY).getSachenMmc() instanceof SachenMmc);
+    }
+
+    @Test
+    public void cgbWramWriteEnablesNintendoLogoCopy() throws IOException {
+        SachenMmc mapper = new SachenMmc(new Rom(rawMmc2Rom()), true);
+        Mmu mmu = new Mmu(true);
+        mmu.setBusListener(mapper);
+        mmu.indexSpaces();
+
+        mmu.setByte(0xc000, 0x42);
+
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            assertEquals("logo byte " + i, NINTENDO_LOGO[i], mapper.getByte(0x0104 + i));
+        }
+    }
+
+    private static byte[] rawMmc2Rom() {
+        byte[] data = new byte[0x200000];
+        // The low half contains the pirate logo; the CGB-selected A7-high copy contains
+        // the Nintendo logo. Header fields are identical in both halves.
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[unscramble(0x0104 + i)] = (byte) (NINTENDO_LOGO[i] ^ 0xff);
+            data[unscramble(0x0184 + i)] = (byte) NINTENDO_LOGO[i];
+        }
+        for (int address = 0x0134; address <= 0x0142; address++) {
+            data[unscramble(address)] = 0x20;
+            data[unscramble(address | 0x80)] = 0x20;
+        }
+        data[unscramble(0x0143)] = (byte) 0x80;
+        data[unscramble(0x01c3)] = (byte) 0x80;
+        int checksum = 0;
+        for (int address = 0x0134; address <= 0x014c; address++) {
+            checksum = (checksum - (data[unscramble(address)] & 0xff) - 1) & 0xff;
+        }
+        data[unscramble(0x014d)] = (byte) checksum;
+        data[unscramble(0x01cd)] = (byte) checksum;
+        return data;
+    }
+
+    private static int unscramble(int address) {
+        int result = address & 0xffac;
+        result |= (address & 0x40) >> 6;
+        result |= (address & 0x10) >> 3;
+        result |= (address & 0x02) << 3;
+        result |= (address & 0x01) << 6;
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes #171

31B-001 is a raw Sachen MMC2 dump whose entire header page has swapped address lines. Coffee GB parsed the physical bytes as an ordinary header, selected DMG mode from a scrambled CGB flag, and also watched high-address reads for the mapper's DMG/CGB logo phase. The CGB boot ROM actually distinguishes itself with a WRAM write before reading the cartridge header.

Parse raw Sachen metadata through the board's A0/A6 and A1/A4 address permutation while preserving the raw image for mapper reads, derive the bank count from the dump size, and transition the MMC2 logo state on the pre-header CGB WRAM write. This follows the current MAME Sachen MMC2 model rather than retaining the older read-based approximation.

Verification:
- The exact attachment boots through the Sachen and Super 31 in 1 screens.
- The game list is usable and launching entry 1 reaches Thunder Blast Man gameplay.
- Added synthetic raw-MMC2 tests for logical header parsing, image preservation, mapper detection, and the CGB logo copy.
- 154 core unit tests pass.
- Mooneye plus DMG/CGB Acid2 profiles pass.
- Combined and individual Blargg profiles pass.