### PR TITLE
Fix raw Sachen 4-in-1 + 8-in-1 multicarts

### DIFF
--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
@@ -44,8 +44,18 @@ public class RawSachenTest {
         }
     }
 
+    @Test
+    public void derivesBankCountFromRawDumpSize() throws IOException {
+        assertEquals(32, new Rom(rawMmc2Rom(0x80000)).getRomBanks());
+        assertEquals(128, new Rom(rawMmc2Rom(0x200000)).getRomBanks());
+    }
+
     private static byte[] rawMmc2Rom() {
-        byte[] data = new byte[0x200000];
+        return rawMmc2Rom(0x200000);
+    }
+
+    private static byte[] rawMmc2Rom(int size) {
+        byte[] data = new byte[size];
         // The low half contains the pirate logo; the CGB-selected A7-high copy contains
         // the Nintendo logo. Header fields are identical in both halves.
         for (int i = 0; i < NINTENDO_LOGO.length; i++) {


### PR DESCRIPTION
## Summary
- recognize raw Sachen MMC2 dumps before parsing the electrically permuted header
- derive Color mode and ROM size from the logical header and dump length while preserving the raw cartridge image
- model the CGB logo-spoof transition on the pre-header WRAM bus write used by the original board
- cover the 512 KiB size used by the four reported 8B-001 through 8B-004 sets

This shares the underlying raw-board correction with #203; this issue-specific branch adds coverage for the smaller family.

## Verification
- all four attached ROMs reach their correct full-color 8-in-1 menus
- selecting the first entry launches Zip Ball, Virus Attack, Arctic Zone, and Ant Soldier respectively
- `/opt/maven/bin/mvn -pl core test` (155 tests)
- Mooneye + dmg-acid2 + cgb-acid2 profiles
- Blargg individual + aggregate profiles

Fixes #170