### PR TITLE
Fix Darkman sprite line during OAM DMA

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.gpu.phase.*;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.Dma;
+import eu.rekawek.coffeegb.core.memory.DmaOamAddressSpace;
 import eu.rekawek.coffeegb.core.memory.Ram;
 
 import java.io.Serializable;
@@ -86,14 +87,15 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         }
         this.oamRam = oamRam;
         this.dma = dma;
+        AddressSpace ppuOam = new DmaOamAddressSpace(oamRam, dma);
 
         this.bgPalette = new ColorPalette(0xff68);
         this.oamPalette = new ColorPalette(0xff6a);
         oamPalette.fillWithFF();
 
-        this.oamSearchPhase = new OamSearch(oamRam, lcdc, r);
-        this.pixelTransferPhase = new PixelTransfer(new Display(gbc), videoRam0, videoRam1, oamRam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), null, speedMode, 0);
-        this.pixelMachine = new PixelTransfer(display, videoRam0, videoRam1, oamRam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), vRamTransfer, speedMode, 4);
+        this.oamSearchPhase = new OamSearch(oamRam, dma, lcdc, r);
+        this.pixelTransferPhase = new PixelTransfer(new Display(gbc), videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), null, speedMode, 0);
+        this.pixelMachine = new PixelTransfer(display, videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), vRamTransfer, speedMode, 4);
 
         this.mode = Mode.OamSearch;
         this.phase = oamSearchPhase.start();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
 import eu.rekawek.coffeegb.core.gpu.Lcdc;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
+import eu.rekawek.coffeegb.core.memory.Dma;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -77,6 +78,8 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
 
     private final AddressSpace oemRam;
 
+    private final Dma dma;
+
     private final GpuRegisterValues registers;
 
     private final SpritePosition[] sprites;
@@ -91,10 +94,13 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
 
     private int spriteX;
 
+    private boolean spriteDmaBlocked;
+
     private int i;
 
-    public OamSearch(AddressSpace oemRam, Lcdc lcdc, GpuRegisterValues registers) {
+    public OamSearch(AddressSpace oemRam, Dma dma, Lcdc lcdc, GpuRegisterValues registers) {
         this.oemRam = oemRam;
+        this.dma = dma;
         this.registers = registers;
         this.lcdc = lcdc;
         this.sprites = new SpritePosition[10];
@@ -108,6 +114,7 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
         state = State.READING_Y;
         spriteY = 0;
         spriteX = 0;
+        spriteDmaBlocked = false;
         i = 0;
         for (SpritePosition sprite : sprites) {
             sprite.disable();
@@ -121,12 +128,15 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
         switch (state) {
             case READING_Y:
                 spriteY = oemRam.getByte(spriteAddress);
+                spriteDmaBlocked = dma.isTransferInProgress();
                 state = State.READING_X;
                 break;
 
             case READING_X:
                 spriteX = oemRam.getByte(spriteAddress + 1);
-                if (spritePosIndex < sprites.length
+                spriteDmaBlocked |= dma.isTransferInProgress();
+                if (!spriteDmaBlocked
+                        && spritePosIndex < sprites.length
                         && between(
                         spriteY, registers.get(GpuRegister.LY) + 16, spriteY + lcdc.getSpriteHeight())) {
                     sprites[spritePosIndex++].enable(spriteX, spriteY, spriteAddress);
@@ -150,7 +160,8 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
     public Memento<OamSearch> saveToMemento() {
         Memento<?>[] spriteMementos =
                 Arrays.stream(sprites).map(SpritePosition::saveToMemento).toArray(Memento[]::new);
-        return new OamSearchMemento(spriteMementos, spritePosIndex, state, spriteY, spriteX, i);
+        return new OamSearchMemento(
+                spriteMementos, spritePosIndex, state, spriteY, spriteX, spriteDmaBlocked, i);
     }
 
     @Override
@@ -168,11 +179,13 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
         this.state = mem.state;
         this.spriteY = mem.spriteY;
         this.spriteX = mem.spriteX;
+        this.spriteDmaBlocked = mem.spriteDmaBlocked;
         this.i = mem.i;
     }
 
     private record OamSearchMemento(
-            Memento<?>[] sprites, int spritePosIndex, State state, int spriteY, int spriteX, int i)
+            Memento<?>[] sprites, int spritePosIndex, State state, int spriteY, int spriteX,
+            boolean spriteDmaBlocked, int i)
             implements Memento<OamSearch> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -23,6 +23,10 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     private int ticks;
 
+    // Index of the next OAM byte written by the transfer. The PPU sees the DMA's
+    // current two-byte OAM bus row while the copy is running, not an atomic snapshot.
+    private int currentByte;
+
     private int regValue = 0xff;
 
     public Dma(AddressSpace addressSpace, AddressSpace oam, SpeedMode speedMode) {
@@ -38,13 +42,17 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     public void tick() {
         if (transferInProgress) {
-            if (++ticks >= 648 / speedMode.getSpeedMode()) {
+            ticks++;
+            int dmaTicks = ticks * speedMode.getSpeedMode();
+            if (dmaTicks >= 8 && dmaTicks <= 644 && dmaTicks % 4 == 0) {
+                oam.setByte(0xfe00 + currentByte, addressSpace.getByte(from + currentByte));
+                currentByte++;
+            }
+            if (dmaTicks >= 648) {
                 transferInProgress = false;
                 restarted = false;
                 ticks = 0;
-                for (int i = 0; i < 0xa0; i++) {
-                    oam.setByte(0xfe00 + i, addressSpace.getByte(from + i));
-                }
+                currentByte = 0;
             }
         }
     }
@@ -54,6 +62,7 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
         from = value * 0x100;
         restarted = isOamBlocked();
         ticks = 0;
+        currentByte = 0;
         transferInProgress = true;
         regValue = value;
     }
@@ -65,6 +74,10 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     public boolean isOamBlocked() {
         return restarted || (transferInProgress && ticks >= 5);
+    }
+
+    public boolean isTransferInProgress() {
+        return transferInProgress;
     }
 
     public boolean isCpuAccessBlocked(int address, boolean gbc) {
@@ -81,6 +94,15 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
         return addressSpace.getByte(from + byteIndex);
     }
 
+    /** Reads OAM as seen by the PPU while an OAM DMA owns its bus. */
+    public int getOamByteForPpu(int address) {
+        if (transferInProgress && currentByte > 0 && currentByte < 0xa0) {
+            int busAddress = (currentByte & ~1) | (address & 1);
+            return oam.getByte(0xfe00 + busAddress);
+        }
+        return oam.getByte(address);
+    }
+
     private static int getBus(int address, boolean gbc) {
         if (address < 0x8000 || (address >= 0xa000 && address < 0xc000)) {
             return 0; // cartridge
@@ -95,7 +117,7 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     @Override
     public Memento<Dma> saveToMemento() {
-        return new DmaMemento(transferInProgress, restarted, from, ticks, regValue);
+        return new DmaMemento(transferInProgress, restarted, from, ticks, currentByte, regValue);
     }
 
     @Override
@@ -107,10 +129,11 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
         this.restarted = mem.restarted;
         this.from = mem.from;
         this.ticks = mem.ticks;
+        this.currentByte = mem.currentByte;
         this.regValue = mem.regValue;
     }
 
     public record DmaMemento(boolean transferInProgress, boolean restarted, int from, int ticks,
-                             int regValue) implements Memento<Dma> {
+                             int currentByte, int regValue) implements Memento<Dma> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaOamAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaOamAddressSpace.java
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+
+import java.io.Serializable;
+
+/** OAM view used by the PPU, including the row driven by an active OAM DMA. */
+public class DmaOamAddressSpace implements AddressSpace, Serializable {
+
+    private final AddressSpace oam;
+
+    private final Dma dma;
+
+    public DmaOamAddressSpace(AddressSpace oam, Dma dma) {
+        this.oam = oam;
+        this.dma = dma;
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return oam.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        oam.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        return dma.getOamByteForPpu(address);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
@@ -1,0 +1,75 @@
+package eu.rekawek.coffeegb.core.gpu.phase;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.gpu.GpuRegister;
+import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
+import eu.rekawek.coffeegb.core.gpu.Lcdc;
+import eu.rekawek.coffeegb.core.memory.Dma;
+import eu.rekawek.coffeegb.core.memory.Ram;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OamSearchTest {
+
+    @Test
+    public void findsVisibleSpriteWithoutDma() {
+        Fixture fixture = new Fixture();
+
+        fixture.runSearch();
+
+        assertTrue(fixture.search.getSprites()[0].isEnabled());
+    }
+
+    @Test
+    public void hidesSpriteWhenDmaOverlapsOamScan() {
+        Fixture fixture = new Fixture();
+        fixture.dma.setByte(0xff46, 0x12);
+
+        fixture.runSearch();
+
+        assertFalse(fixture.search.getSprites()[0].isEnabled());
+    }
+
+    @Test
+    public void hidesSpriteWhenDmaEndsBetweenItsYAndXReads() {
+        Fixture fixture = new Fixture();
+        fixture.dma.setByte(0xff46, 0x12);
+        fixture.search.start();
+
+        fixture.search.tick();
+        for (int i = 0; i < 648; i++) {
+            fixture.dma.tick();
+        }
+        fixture.search.tick();
+
+        assertFalse(fixture.search.getSprites()[0].isEnabled());
+    }
+
+    private static class Fixture {
+
+        private final Ram memory = new Ram(0, 0x10000);
+
+        private final Ram oam = new Ram(0xfe00, 0xa0);
+
+        private final Dma dma = new Dma(memory, oam, new SpeedMode(false));
+
+        private final GpuRegisterValues registers = new GpuRegisterValues();
+
+        private final OamSearch search = new OamSearch(oam, dma, new Lcdc(), registers);
+
+        private Fixture() {
+            registers.put(GpuRegister.LY, 0);
+            oam.setByte(0xfe00, 16);
+            oam.setByte(0xfe01, 8);
+        }
+
+        private void runSearch() {
+            search.start();
+            while (search.tick()) {
+                // Complete the 80-dot OAM scan.
+            }
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
@@ -1,0 +1,75 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DmaTest {
+
+    @Test
+    public void copiesOamProgressively() {
+        Fixture fixture = new Fixture();
+        fixture.start();
+
+        fixture.tick(7);
+        assertEquals(0xee, fixture.oam.getByte(0xfe00));
+
+        fixture.tick(1);
+        assertEquals(0x40, fixture.oam.getByte(0xfe00));
+        assertEquals(0xee, fixture.oam.getByte(0xfe01));
+
+        fixture.tick(4);
+        assertEquals(0x41, fixture.oam.getByte(0xfe01));
+        assertEquals(0xee, fixture.oam.getByte(0xfe02));
+
+        fixture.tick(632);
+        assertEquals(0xdf, fixture.oam.getByte(0xfe9f));
+        assertTrue(fixture.dma.isTransferInProgress());
+
+        fixture.tick(4);
+        assertFalse(fixture.dma.isTransferInProgress());
+    }
+
+    @Test
+    public void ppuReadsTheOamWordCurrentlyDrivenByDma() {
+        Fixture fixture = new Fixture();
+        fixture.start();
+
+        fixture.tick(8);
+        assertEquals(0x40, fixture.dma.getOamByteForPpu(0xfe04));
+        assertEquals(0xee, fixture.dma.getOamByteForPpu(0xfe05));
+
+        fixture.tick(4);
+        assertEquals(0xee, fixture.dma.getOamByteForPpu(0xfe00));
+        assertEquals(0xee, fixture.dma.getOamByteForPpu(0xfe01));
+    }
+
+    private static class Fixture {
+
+        private final Ram memory = new Ram(0, 0x10000);
+
+        private final Ram oam = new Ram(0xfe00, 0xa0);
+
+        private final Dma dma = new Dma(memory, oam, new SpeedMode(false));
+
+        private Fixture() {
+            for (int i = 0; i < 0xa0; i++) {
+                memory.setByte(0x1200 + i, 0x40 + i);
+                oam.setByte(0xfe00 + i, 0xee);
+            }
+        }
+
+        private void start() {
+            dma.setByte(0xff46, 0x12);
+        }
+
+        private void tick(int count) {
+            for (int i = 0; i < count; i++) {
+                dma.tick();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #169.

## What changed
- copy OAM DMA bytes progressively instead of applying the entire transfer atomically
- hide sprites whose mode-2 OAM scan overlaps an active DMA transfer
- expose the DMA-driven 16-bit OAM word to mode-3 sprite fetches
- preserve the new DMA and OAM-search state in save-state mementos
- add focused DMA timing and OAM-search regression tests

This follows the documented hardware behavior for OAM DMA/PPU conflicts: https://gbdev.io/pandocs/OAM_DMA_Transfer.html

## Verification
- reproduced the flashing line with `Darkman (USA, Europe).gb` (SHA-1 `f168733ddf4f083559e52198a503e4f295fabf0d`)
- compared 276 consecutive fixed intro frames against SameBoy; all matched, including the 12 frames that previously contained the stray row
- `/opt/maven/bin/mvn -pl core test` (157 tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` (130 Mooneye tests and both Acid2 ROMs)
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` (aggregate and 46 individual Blargg tests)