### PR TITLE
Clarify emulator comparison policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,12 @@ rising edge) — see `StatRegister`.
   observed result, and current reproduction state.
 - If an issue cannot be reproduced or fixed, the issue comment must explicitly
   state that the issue will be verified manually.
+- Comparing behavior with SameBoy, Gearboy, and other emulators is useful for
+  diagnosis, but their behavior is not a compatibility ceiling. If the same bug
+  exists in other emulators, investigate hardware documentation, test ROMs, and
+  original solutions instead of treating the issue as unfixable. The goal is to
+  make Coffee GB the most compatible emulator, not merely keep it on par with
+  other implementations.
 - When possible, attach a screenshot showing the fixed state to the issue or
   pull request, especially for graphics, UI, and game-behavior regressions.
 - Every comment posted to a GitHub issue by an agent must be clearly identified


### PR DESCRIPTION
## Summary
- document that SameBoy, Gearboy, and other emulators are diagnostic references, not compatibility ceilings
- require continued investigation of hardware documentation, test ROMs, and original solutions when peer emulators share a bug
- state the goal of making Coffee GB the most compatible emulator rather than merely matching peers