### PR TITLE
Fix Crazy Climber prototype startup

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -178,9 +178,9 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         if (configuration.bootstrapMode != BootstrapMode.SKIP) {
             // at power-on the LCD is off; the boot ROM enables it, anchoring the PPU
             // line grid to that write; the CGB divider phase accounts for the boot
-            // ROM's accurately paced HDMA, and revision 0 adds another 512 T
+            // ROM's accurately paced HDMA setup, and revision 0 adds another 512 T
             // (boot_div-cgbABCDE, boot_div-cgb0)
-            timer.presetDiv(gbc ? (configuration.cgb0Revision ? 518 : 0xfffa) : 4);
+            timer.presetDiv(gbc ? (configuration.cgb0Revision ? 536 : 12) : 4);
             gpu.setByte(0xff40, 0x00);
         }
         boolean bootTimedOut = false;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -19,6 +19,9 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
 
     private static final int HDMA5 = 0xff55;
 
+    // The CGB spends two dots setting up a VRAM DMA burst before copying data.
+    private static final int STARTUP_TICKS = 2;
+
     private final AddressSpace addressSpace;
 
     private Mode gpuMode;
@@ -58,7 +61,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         }
         src = (src + 0x10) & 0xffff;
         dst = (dst + 0x10) & 0xffff;
-        tick = 0;
+        tick = hblankTransfer ? -STARTUP_TICKS : 0;
         if (length-- == 0) {
             transferInProgress = false;
             length = 0x7f;
@@ -120,7 +123,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         hblankTransfer = (reg & (1 << 7)) != 0;
         length = reg & 0x7f;
         transferInProgress = true;
-        tick = 0;
+        tick = -STARTUP_TICKS;
         if (hblankTransfer && !lcdEnabled) {
             // With the LCD off, starting HDMA copies one block immediately. There are
             // no subsequent HBlanks, so the transfer then remains paused.

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -1,0 +1,87 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.gpu.Mode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HdmaTest {
+
+    @Test
+    public void generalPurposeDmaIncludesStartupTicks() {
+        Fixture fixture = new Fixture();
+        fixture.startTransfer(0x00);
+
+        fixture.tick(33);
+        assertEquals(0, fixture.memory.getByte(0x8000));
+
+        fixture.tick(1);
+        assertEquals(0xa0, fixture.memory.getByte(0x8000));
+        assertEquals(0xaf, fixture.memory.getByte(0x800f));
+        assertEquals(0xff, fixture.hdma.getByte(0xff55));
+    }
+
+    @Test
+    public void generalPurposeDmaPaysStartupCostOnlyOnce() {
+        Fixture fixture = new Fixture();
+        fixture.startTransfer(0x01);
+
+        fixture.tick(34);
+        assertEquals(0xa0, fixture.memory.getByte(0x8000));
+        assertEquals(0, fixture.memory.getByte(0x8010));
+
+        fixture.tick(31);
+        assertEquals(0, fixture.memory.getByte(0x8010));
+
+        fixture.tick(1);
+        assertEquals(0xb0, fixture.memory.getByte(0x8010));
+        assertEquals(0xbf, fixture.memory.getByte(0x801f));
+    }
+
+    @Test
+    public void hblankDmaIncludesStartupTicksForEveryBurst() {
+        Fixture fixture = new Fixture();
+        fixture.hdma.onLcdSwitch(true);
+        fixture.startTransfer(0x81);
+
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        fixture.tick(34);
+        assertEquals(0xa0, fixture.memory.getByte(0x8000));
+        assertEquals(0, fixture.memory.getByte(0x8010));
+
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        fixture.tick(33);
+        assertEquals(0, fixture.memory.getByte(0x8010));
+
+        fixture.tick(1);
+        assertEquals(0xb0, fixture.memory.getByte(0x8010));
+        assertEquals(0xbf, fixture.memory.getByte(0x801f));
+    }
+
+    private static class Fixture {
+
+        private final Ram memory = new Ram(0, 0x10000);
+
+        private final Hdma hdma = new Hdma(memory);
+
+        private Fixture() {
+            for (int i = 0; i < 0x20; i++) {
+                memory.setByte(0x1200 + i, 0xa0 + i);
+            }
+            hdma.setByte(0xff51, 0x12);
+            hdma.setByte(0xff52, 0x00);
+            hdma.setByte(0xff53, 0x00);
+            hdma.setByte(0xff54, 0x00);
+        }
+
+        private void startTransfer(int control) {
+            hdma.setByte(0xff55, control);
+        }
+
+        private void tick(int count) {
+            for (int i = 0; i < count; i++) {
+                hdma.tick();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #168

## Cause

Crazy Climber runs a 0x400-byte general-purpose CGB VRAM DMA in its VBlank handler. Coffee GB omitted the DMA burst setup time, making that handler two dots too short. The game then hit the same CPU/PPU phase every frame and its LY wait loop was always interrupted before it could disable the LCD and load the title graphics.

## Fix

- Model the CGB's two-dot setup before a general-purpose VRAM DMA and before every independently resumed HBlank burst.
- Recalibrate the CGB boot divider phase for the now-complete boot-ROM HDMA timing.
- Add focused tests for one-block and multi-block general DMA timing and per-burst HBlank DMA timing.

## Verification

- Reproduced with the issue attachment (SHA-1 `68979eb91a968998c2fb58396971265be5b312ca`).
- The ROM now reaches the Crazy Climber title screen, accepts Start, and enters gameplay.
- `/opt/maven/bin/mvn -pl core test` (155 tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-samesuite` (71 tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` (130 Mooneye + both Acid2)
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` (all aggregate and individual suites)