### PR TITLE
Fix Cardcaptor Sakura library transition corruption

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -194,8 +194,13 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         entryTicks = entryDelay + extraEntryDelay;
         machineActive = true;
         position = -16;
+        // Comparator state is local to the scanline. A CGB WX=166 match is normally
+        // settled at the end of tick(); this reset is the defensive boundary that keeps
+        // any cancelled/serialized pending match from jumping the next line to X=159.
+        windowPendingTicks = 0;
         windowActivatedThisLine = false;
         windowCatchUpPos = -1;
+        insertBgPixel = false;
         machineStall = 0;
         fifo.startLine();
         window = false;
@@ -284,6 +289,14 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
 
     boolean isWindowYTriggered() {
         return windowYTriggered;
+    }
+
+    boolean isWindowActivationPending() {
+        return windowPendingTicks > 0;
+    }
+
+    int getWindowLineCounter() {
+        return windowLineCounter;
     }
 
     @Override
@@ -534,7 +547,16 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
             wdwRefreshPops = 0;
             System.arraycopy(fetcher.getWindowRefreshZip(), 0, wdwRefreshZip, 0, 8);
         }
-        return position != 160;
+        boolean active = position != 160;
+        if (!active && gbc && windowPendingTicks > 0 && windowPendingWx == 166) {
+            // WX=166 matches only after the final visible CGB pixel. Hardware performs
+            // the activation in HBlank: it advances the window's internal Y counter but
+            // draws no window pixel. Committing the ordinary delayed activation on the
+            // next scanline would instead skip that line to X=159 (Cardcaptor Sakura).
+            windowLineCounter++;
+            windowPendingTicks = 0;
+        }
+        return active;
     }
 
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
@@ -11,6 +11,7 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -50,6 +51,29 @@ public class PixelTransferWindowTriggerTest {
         assertTrue(h.transfer.isWindowYTriggered());
     }
 
+    @Test
+    public void cgbWx166MatchAdvancesCounterWithoutCarryingIntoNextScanline() {
+        Harness h = new Harness(true);
+        h.registers.put(GpuRegister.LY, 0);
+        h.registers.put(GpuRegister.WY, 0);
+        h.registers.put(GpuRegister.WX, 166);
+        h.lcdc.set(0xb1);
+        h.transfer.checkWindowY();
+
+        h.transfer.start();
+        int guard = 1000;
+        while (h.transfer.tick() && guard-- > 0) {
+            // Run the line through the final visible-pixel comparator match.
+        }
+        assertFalse("the end-of-line match should settle in HBlank", h.transfer.isWindowActivationPending());
+        assertEquals("WX=166 advances the internal window Y counter",
+                0, h.transfer.getWindowLineCounter());
+
+        h.registers.put(GpuRegister.LY, 1);
+        h.transfer.start();
+        assertFalse("a pending activation is scanline-local", h.transfer.isWindowActivationPending());
+    }
+
     private static class Harness {
 
         private final GpuRegisterValues registers = new GpuRegisterValues();
@@ -57,23 +81,29 @@ public class PixelTransferWindowTriggerTest {
         private final PixelTransfer transfer;
 
         private Harness() {
+            this(false);
+        }
+
+        private Harness(boolean gbc) {
+            registers.setGbc(gbc);
+            lcdc.setGbc(gbc);
             SpritePosition[] sprites = new SpritePosition[10];
             for (int i = 0; i < sprites.length; i++) {
                 sprites[i] = new SpritePosition();
             }
             transfer = new PixelTransfer(
-                    new Display(false),
+                    new Display(gbc),
                     new Ram(0x8000, 0x2000),
-                    null,
+                    gbc ? new Ram(0x8000, 0x2000) : null,
                     new Ram(0xfe00, 0xa0),
                     lcdc,
                     registers,
-                    false,
+                    gbc,
                     new ColorPalette(0xff68),
                     new ColorPalette(0xff6a),
                     sprites,
                     null,
-                    new SpeedMode(false),
+                    new SpeedMode(gbc),
                     0);
         }
     }


### PR DESCRIPTION
## Summary

- settle the CGB `WX=166` comparator match at the end of its scanline
- advance the hidden window's internal Y counter without drawing a visible pixel
- clear scanline-local pending window state before the next line
- add a focused regression test for the HBlank-only activation

## Root cause

Cardcaptor Sakura uses `WX=166` to hide the window while building a scanline-timed collapse transition. On CGB hardware the final-pixel match takes effect in HBlank: it advances the window row counter but does not emit a window pixel. Coffee GB left its delayed activation pending, then committed it on the next scanline. That jumped the pixel machine directly to X=159, so alternating hidden-window lines emitted only one pixel and shifted the linear framebuffer into diagonal bands.

The fixed output was checked through the reported new-game/date-entry path with the Rev B ROM (SHA-1 `a53e7f8d95375aea144e870977b0966cc1fd4b94`) and now follows the same clean collapse sequence as SameBoy and Gambatte.

## Verification

- `/opt/maven/bin/mvn -pl core test`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2`
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg`
- `/opt/maven/bin/mvn -pl core test -Ptest-mealybug`
- scripted ROM reproduction through frames 470-520

Fixes #167
