### PR TITLE
Show on-screen save-state notifications

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -187,12 +187,19 @@ class BasicController(
   }
 
   private fun saveSnapshot(slot: Int) {
-    session?.gameboy?.let { snapshotManager?.saveSnapshot(slot, it) }
+    val currentSession = session ?: return
+    val manager = snapshotManager ?: return
+    manager.saveSnapshot(slot, currentSession.gameboy)
+    currentSession.eventBus.post(Controller.SnapshotSavedEvent(slot))
   }
 
   private fun loadSnapshot(slot: Int) {
-    session?.gameboy?.let { snapshotManager?.loadSnapshot(slot, it) }
-    rewindManager.clear()
+    val currentSession = session ?: return
+    val manager = snapshotManager ?: return
+    if (manager.loadSnapshot(slot, currentSession.gameboy)) {
+      rewindManager.clear()
+      currentSession.eventBus.post(Controller.SnapshotRestoredEvent(slot))
+    }
   }
 
   override fun snapshotAvailable(slot: Int): Boolean {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -34,6 +34,12 @@ interface Controller : AutoCloseable {
 
   data class RestoreSnapshotEvent(val slot: Int) : Event
 
+  /** Emitted after a snapshot has been written successfully. */
+  data class SnapshotSavedEvent(val slot: Int) : Event
+
+  /** Emitted after a snapshot has been restored successfully. */
+  data class SnapshotRestoredEvent(val slot: Int) : Event
+
   data class SessionPauseSupportEvent(val enabled: Boolean) : Event
 
   data class SessionSnapshotSupportEvent(val snapshotSupport: SnapshotSupport?) : Event

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/SnapshotManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/SnapshotManager.kt
@@ -16,14 +16,15 @@ class SnapshotManager(private val rom: File) {
     gameboy.saveToMemento().serialize().let { snapshotFile.writeBytes(it) }
   }
 
-  fun loadSnapshot(slot: Int, gameboy: Gameboy) {
+  fun loadSnapshot(slot: Int, gameboy: Gameboy): Boolean {
     val snapshotFile = getSnapshotFile(slot)
     if (!snapshotFile.exists()) {
-      return
+      return false
     }
 
     val memento = snapshotFile.readBytes().deserializeToGameboyMemento()
     gameboy.restoreFromMemento(memento)
+    return true
   }
 
   private fun getSnapshotFile(slot: Int): File {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -8,6 +8,7 @@ import eu.rekawek.coffeegb.controller.Controller.PauseEmulationEvent
 import eu.rekawek.coffeegb.controller.Controller.ResetEmulationEvent
 import eu.rekawek.coffeegb.controller.Controller.ResumeEmulationEvent
 import eu.rekawek.coffeegb.controller.Controller.SaveSnapshotEvent
+import eu.rekawek.coffeegb.controller.Controller.SnapshotSavedEvent
 import eu.rekawek.coffeegb.controller.Controller.SessionSnapshotSupportEvent
 import eu.rekawek.coffeegb.controller.Controller.StopEmulationEvent
 import eu.rekawek.coffeegb.controller.SnapshotSupport
@@ -192,7 +193,11 @@ class SwingMenu(
     gameMenu.add(saveSnapshot)
     saveSnapshot.addActionListener {
       eventBus.post(SaveSnapshotEvent(stateSlot))
-      loadSnapshot.isEnabled = snapshotSupport?.snapshotAvailable(stateSlot) == true
+    }
+    eventBus.register<SnapshotSavedEvent> {
+      if (it.slot == stateSlot) {
+        loadSnapshot.isEnabled = true
+      }
     }
     eventBus.register<EmulationStartedEvent> { saveSnapshot.isEnabled = snapshotSupport != null }
     eventBus.register<EmulationStoppedEvent> { saveSnapshot.isEnabled = false }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -12,6 +12,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
+import java.util.concurrent.TimeUnit;
 
 import static eu.rekawek.coffeegb.core.gpu.Display.DISPLAY_HEIGHT;
 import static eu.rekawek.coffeegb.core.gpu.Display.DISPLAY_WIDTH;
@@ -19,6 +20,8 @@ import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_HEIGHT;
 import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_WIDTH;
 
 public class SwingDisplay extends JPanel implements Runnable {
+
+    private static final int NOTIFICATION_DURATION_MS = 1500;
 
     private final EventBus eventBus;
 
@@ -59,6 +62,10 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private int rumblePhase;
 
+    private volatile String notificationText;
+
+    private volatile long notificationExpiresAt;
+
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
         this.eventBus = eventBus;
@@ -74,6 +81,10 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
         eventBus.register(e -> this.rumbling = e.on(), eu.rekawek.coffeegb.core.memory.cart.type.Mbc5.RumbleEvent.class, callerId);
+        eventBus.register(e -> showNotification("State saved (slot " + e.slot() + ")"),
+                Controller.SnapshotSavedEvent.class, callerId);
+        eventBus.register(e -> showNotification("State loaded (slot " + e.slot() + ")"),
+                Controller.SnapshotRestoredEvent.class, callerId);
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());
         setBlending(properties.getBlending());
@@ -201,7 +212,43 @@ public class SwingDisplay extends JPanel implements Runnable {
         synchronized (rasterLock) {
             g2d.drawImage(localImg, 0, 0, w, h, null);
         }
+        paintNotification(g2d, w, h, localScale);
         g2d.dispose();
+    }
+
+    private void showNotification(String text) {
+        notificationText = text;
+        notificationExpiresAt = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(NOTIFICATION_DURATION_MS);
+        SwingUtilities.invokeLater(() -> {
+            repaint();
+            Timer timer = new Timer(NOTIFICATION_DURATION_MS, e -> repaint());
+            timer.setRepeats(false);
+            timer.start();
+        });
+    }
+
+    private void paintNotification(Graphics2D g, int width, int height, int localScale) {
+        String text = notificationText;
+        if (text == null || System.nanoTime() >= notificationExpiresAt) {
+            return;
+        }
+
+        int fontSize = Math.max(12, 7 * localScale);
+        g.setFont(new Font(Font.SANS_SERIF, Font.BOLD, fontSize));
+        FontMetrics metrics = g.getFontMetrics();
+        int paddingX = Math.max(6, 4 * localScale);
+        int paddingY = Math.max(4, 2 * localScale);
+        int boxWidth = metrics.stringWidth(text) + 2 * paddingX;
+        int boxHeight = metrics.getHeight() + 2 * paddingY;
+        int x = (width - boxWidth) / 2;
+        int y = height - boxHeight - Math.max(4, 4 * localScale);
+        int arc = Math.max(6, 4 * localScale);
+
+        g.setColor(new Color(0, 0, 0, 190));
+        g.fillRoundRect(x, y, boxWidth, boxHeight, arc, arc);
+        g.setColor(Color.WHITE);
+        g.drawString(text, x + paddingX, y + paddingY + metrics.getAscent());
     }
 
     private int getDisplayWidth() {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -81,9 +81,9 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
         eventBus.register(e -> this.rumbling = e.on(), eu.rekawek.coffeegb.core.memory.cart.type.Mbc5.RumbleEvent.class, callerId);
-        eventBus.register(e -> showNotification("State saved (slot " + e.slot() + ")"),
+        eventBus.register(e -> showNotification("State saved (slot " + e.getSlot() + ")"),
                 Controller.SnapshotSavedEvent.class, callerId);
-        eventBus.register(e -> showNotification("State loaded (slot " + e.slot() + ")"),
+        eventBus.register(e -> showNotification("State loaded (slot " + e.getSlot() + ")"),
                 Controller.SnapshotRestoredEvent.class, callerId);
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -1,7 +1,9 @@
 package eu.rekawek.coffeegb.swing.io;
 
+import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import org.junit.Test;
 
 import java.awt.Graphics;
@@ -15,6 +17,43 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class SwingDisplayTest {
+
+    @Test
+    public void snapshotCompletionEventsShowAnOnScreenNotification() throws Exception {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        EventBus session = root.fork("test");
+        SwingDisplay display = new SwingDisplay(
+                new EmulatorProperties().getDisplay(), root, "test");
+        Field textField = SwingDisplay.class.getDeclaredField("notificationText");
+        textField.setAccessible(true);
+
+        session.post(new Controller.SnapshotSavedEvent(3));
+        assertEquals("State saved (slot 3)", textField.get(display));
+
+        display.setSize(display.getPreferredSize());
+        BufferedImage target = new BufferedImage(
+                display.getWidth(), display.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics graphics = target.getGraphics();
+        try {
+            display.paintComponent(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        boolean hasVisibleText = false;
+        for (int y = 0; y < target.getHeight() && !hasVisibleText; y++) {
+            for (int x = 0; x < target.getWidth(); x++) {
+                if ((target.getRGB(x, y) & 0xffffff) != 0) {
+                    hasVisibleText = true;
+                    break;
+                }
+            }
+        }
+        assertTrue("notification was not painted over the game image", hasVisibleText);
+
+        session.post(new Controller.SnapshotRestoredEvent(7));
+        assertEquals("State loaded (slot 7)", textField.get(display));
+        root.close();
+    }
 
     @Test
     public void paintingDoesNotAcquireTheComponentMonitor() throws Exception {


### PR DESCRIPTION
## Summary

- show a 1.5-second on-screen confirmation after F5 saves a state
- show the selected slot in both save and F7 load confirmations
- emit the notification only after the controller successfully writes or restores the snapshot
- enable the current slot's Load state action from the save-completion event
- keep notification expiry working while emulation is paused

The overlay is drawn over the scaled/rotated game image with a translucent background and works for DMG, CGB, and SGB display sizes.

## Verification

- `/opt/maven/bin/mvn -pl swing -am test`
- added an event-routing/rendering test for both save and load messages

Fixes #166
