### PR TITLE
Render DarkFader 16 Threads Demo

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -100,6 +100,13 @@ public class Rom {
             // white and also leaves HRAM in a state the trainer does not expect.
             LOG.info("DMG-only Crazy Castle 3 trainer detected; ignoring its CGB flag");
             colorFlag = GameboyColorFlag.NON_CGB;
+        } else if (isDarkFaderThreadsDemo(rom, title)) {
+            // This early homebrew marks itself CGB-compatible but never initializes CGB
+            // palette RAM; the CGB boot ROM leaves every color white, so native CGB mode
+            // displays a blank screen. Its scheduler only uses hardware shared with DMG,
+            // where BGP supplies the intended monochrome palette.
+            LOG.info("DMG-only DarkFader Threads Demo detected; ignoring its CGB flag");
+            colorFlag = GameboyColorFlag.NON_CGB;
         }
         gameboyColorFlag = colorFlag;
         superGameboyFlag = rom[0x0146] == 0x03;
@@ -170,6 +177,16 @@ public class Rom {
             }
         }
         return true;
+    }
+
+    private static boolean isDarkFaderThreadsDemo(int[] rom, String title) {
+        return rom.length == 0x10000
+                && "OS".equals(title)
+                && rom[0x0100] == 0x00 && rom[0x0101] == 0xc3
+                && rom[0x0102] == 0x91 && rom[0x0103] == 0x09
+                && rom[0x0143] == 0x80 && rom[0x0147] == 0x01
+                && rom[0x0149] == 0x00 && rom[0x014c] == 0x01
+                && rom[0x014e] == 0x7b && rom[0x014f] == 0x1e;
     }
 
     private static String getTitle(int[] rom) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DarkFaderThreadsDemoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DarkFaderThreadsDemoTest.java
@@ -1,0 +1,47 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.GameboyType;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class DarkFaderThreadsDemoTest {
+
+    @Test
+    public void classifiesPaletteLessDemoAsDmgOnly() throws IOException {
+        Rom rom = new Rom(threadsDemoRom());
+
+        assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
+        assertEquals(GameboyType.DMG, new Gameboy.GameboyConfiguration(rom).getGameboyType());
+    }
+
+    @Test
+    public void doesNotReclassifyAnotherUniversalMbc1Rom() throws IOException {
+        byte[] data = threadsDemoRom();
+        data[0x0102] = 0;
+        Rom rom = new Rom(data);
+
+        assertEquals(Rom.GameboyColorFlag.UNIVERSAL, rom.getGameboyColorFlag());
+        assertEquals(GameboyType.CGB, new Gameboy.GameboyConfiguration(rom).getGameboyType());
+    }
+
+    private static byte[] threadsDemoRom() {
+        byte[] data = new byte[0x10000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = (byte) 0x91;
+        data[0x0103] = 0x09;
+        data[0x0134] = 'O';
+        data[0x0135] = 'S';
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x01;
+        data[0x0149] = 0x00;
+        data[0x014c] = 0x01;
+        data[0x014e] = 0x7b;
+        data[0x014f] = 0x1e;
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary
- identify the exact malformed DarkFader Threads Demo header
- launch this DMG-compatible demo in DMG mode instead of honoring its incorrect CGB-compatible flag
- keep the correction fingerprint-specific and cover both the match and a near-miss ROM

## Root cause
The demo advertises CGB compatibility (`0x80`) but never initializes CGB background palette RAM. The CGB boot ROM initializes every background color to white, so the demo updates its tile map correctly while remaining invisible. Its scheduler and rendering use DMG-compatible hardware; in DMG mode, `BGP` supplies the intended monochrome palette and the sixteen changing glyphs render immediately.

SameBoy and mGBA currently reproduce the same blank screen. Rather than accepting that shared behavior, this change follows the documented boot-ROM palette state and corrects only this known malformed public-domain ROM header. Pan Docs: https://gbdev.io/pandocs/Palettes.html

## Reproduction
ROM: 16 Threads Demo by DarkFader (PD) [C].gbc
SHA-1: `4f607382d17ee43aabaf0100936863dd2dbea983`

Before this change the display stays white although tile-map bytes change. After this change the default configuration selects DMG mode and shows the changing sixteen-glyph row from the issue reference.

## Verification
- `/opt/maven/bin/mvn -pl core test -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2 -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg -q`
- frame captures in forced CGB, forced DMG, and corrected automatic mode
- current SameBoy and mGBA comparison captures

Fixes #164