### PR TITLE
Fix Altered Space character glitches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,11 @@ change one without re-running the full battery.**
   CPU acceptance (normal dispatch and HALT wake) is synchronized at the boundary;
   readable coincidence and its IF edge update at tl=0 but the level contribution
   settles at tl=4; STAT int is one level line, IF on rising edge only (this yields
-  stat_irq_blocking for free); DMG STAT-write glitch = all enables act 1 for a moment,
-  except that HBlank masks the transient OAM source at the HBlank-to-OAM boundary.
+  stat_irq_blocking for free); the mode-1 source follows the internal VBlank state
+  through line 153 even while the readable mode bits briefly expose mode 0, so it
+  remains continuous with line 0's mode-2 pulse; DMG STAT-write glitch = all enables
+  act 1 for a moment, except that HBlank masks the transient OAM source at the
+  HBlank-to-OAM boundary.
 - firstLine (LCD enable): no OAM scan and mode reads 0 until tl=79, but the early
   mode-2 interrupt condition still appears at the shortened line's end;
   OAM/VRAM open until then; end-of-line events at 451 instead of 452.
@@ -255,9 +258,10 @@ rising edge) — see `StatRegister`.
   SameBoy's `GB_apu_set_sample_callback` output.
 - **State diffing**: when a game diverges, diff WRAM/HRAM against SameBoy at the same
   game-frame — the culprit variable pops out (few diffs).
-- Games found relying on subtle behaviors: Altered Space (single LYC=0 STAT int per
-  frame across the 153->0 transition), mezase/GB-Video (timer phase-locked to the line
-  grid -> needs FAST_FORWARD boot), Super Snakey (PCT_TRN before CHR_TRN -> border
+- Games found relying on subtle behaviors: Altered Space (the mode-1 STAT source stays
+  asserted through line 153's readable mode-0 blip, blocking a line-0 mode-2 edge;
+  otherwise its 8-byte sprite update spills into mode 3), mezase/GB-Video (timer
+  phase-locked to the line grid -> needs FAST_FORWARD boot), Super Snakey (PCT_TRN before CHR_TRN -> border
   re-render), ZAS (30 Hz flicker -> LCD ghosting display option), Kirby (MBC7 EEPROM
   dirty flag + 256-byte save).
 - Mappers now implemented: MBC1(+M), MBC2, MBC3(+RTC), MBC5, MBC6(+flash), MBC7(+EEPROM,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -375,6 +375,15 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     }
 
     /**
+     * The mode-1 STAT source follows the PPU's internal VBlank state. On DMG the readable
+     * STAT mode briefly becomes 0 at the end of line 153, but the interrupt source remains
+     * asserted until the line-0 mode-2 source takes over.
+     */
+    public boolean isMode1IntWindow() {
+        return lcdEnabled && mode == Mode.VBlank;
+    }
+
+    /**
      * OAM is locked from 4 ticks before the end of the preceding line until the end of the
      * pixel transfer. On the first line after enabling the LCD, it is locked when the pixel
      * transfer starts.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -155,7 +155,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         boolean line = (enable & 0b01000000) != 0 && intCoincidence;
         if (gpu.isLcdEnabled()) {
             line |= (enable & 0b00001000) != 0 && gpu.isMode0IntWindow();
-            line |= (enable & 0b00010000) != 0 && gpu.getVisibleStatMode() == 1;
+            line |= (enable & 0b00010000) != 0 && gpu.isMode1IntWindow();
             line |= (enable & 0b00100000) != 0 && gpu.isMode2IntWindow();
         }
         return line;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -36,6 +36,18 @@ public class StatRegisterTest {
         assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
     }
 
+    @Test
+    public void vblankSourceMasksLineZeroOamSource() {
+        Fixture fixture = new Fixture();
+        fixture.advanceTo(144, 8);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x30);
+        fixture.clearInterrupts();
+
+        fixture.advanceTo(0, 4);
+
+        assertEquals(0, fixture.lcdInterruptFlag());
+    }
+
     private static class Fixture {
 
         private final InterruptManager interrupts = new InterruptManager(false);
@@ -70,6 +82,12 @@ public class StatRegisterTest {
             while (gpu.getLine() != targetLine || gpu.getTicksInLine() != 0) {
                 tick();
             }
+        }
+
+        private void advanceTo(int line, int ticksInLine) {
+            do {
+                tick();
+            } while (gpu.getLine() != line || gpu.getTicksInLine() != ticksInLine);
         }
 
         private void tick() {

--- a/doc/derived/ppu-stat-model.md
+++ b/doc/derived/ppu-stat-model.md
@@ -62,7 +62,7 @@ blocking" (`stat_irq_blocking`) with no special cases:
 ```
 line = (LYC enabled  AND settled coincidence)
     OR (mode0 enabled AND tl >= hblankIntFrom, lines 0-143)
-    OR (mode1 enabled AND visible mode == 1)
+    OR (mode1 enabled AND internal VBlank state)
     OR (mode2 enabled AND previous tl >= 452 or tl < 4, lines 0-144)
 ```
 
@@ -79,6 +79,10 @@ line = (LYC enabled  AND settled coincidence)
 - The **mode-0 term** rises 3 T after the visible mode 0, i.e. at `E+4`
   (`hblank_ly_scx_timing-GS`, `intr_2_0_timing`); the pixel pipeline is T-exact, so no
   quantization is applied.
+- The **mode-1 term** follows the internal VBlank state through the end of line 153. On
+  DMG the readable mode bits briefly expose mode 0 there, but the interrupt source stays
+  high until the line-0 mode-2 pulse takes over. Keeping those sources continuous is
+  required for STAT blocking across the frame boundary (Altered Space).
 - VBLANK IF (bit 0) is requested at `tl=0` of line 144.
 - **DMG STAT write glitch**: during a STAT write all four enable bits act as 1 for a moment
   ("all interrupts are enabled before data settles" — `ff41_stat` annotation), which can


### PR DESCRIPTION
Fixes #162.

## Root cause

On DMG, the readable STAT mode briefly exposes mode 0 at the end of line 153, but the mode-1 interrupt source follows the internal VBlank state until line 0. CoffeeGB incorrectly derived the mode-1 interrupt source from the readable mode bits, allowing the shared STAT line to fall and rise again for line 0 mode 2.

Altered Space enables mode 0, 1, and 2 STAT sources together. The extra line-0 edge ran its eight-byte sprite-copy handler as mode 3 began: the first byte landed while VRAM was open and the remaining seven writes were rejected, corrupting four rows in the player and animated room object.

## Fix

- derive the mode-1 STAT source from the internal VBlank state
- keep it asserted through line 153 so line-0 mode 2 is blocked by the shared level line
- add a regression test for VBlank-to-line-0 STAT blocking
- document the hardware distinction and Altered Space dependency

## Verification

- `/opt/maven/bin/mvn -pl core test -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-mealybug -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg -q`
- deterministic Altered Space replay with walking in all four directions: 27 sampled frames from 2200 through 3500 match mGBA pixel-for-pixel after palette normalization; matched checkpoints also agree with SameBoy and Gambatte
- ROM SHA-1: `ca586c59b2473a8bec2f0f37504cb74e3a1e4d11`