### PR TITLE
Keep ROM loading recoverable after failures

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -13,6 +13,8 @@ import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
 import eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class BasicController(
     parentEventBus: EventBus,
@@ -58,17 +60,7 @@ class BasicController(
 
   init {
     eventQueue.register<AddPatches> { patches.addAll(it.patches) }
-    eventQueue.register<Controller.LoadRomEvent> {
-      stop()
-      patches.clear()
-      rewindManager.clear()
-      val config = Controller.createGameboyConfig(properties, Rom(it.rom))
-      session = createSession(config)
-      if (it.memento != null) {
-        session?.gameboy?.restoreFromMemento(it.memento)
-      }
-      start()
-    }
+    eventQueue.register<Controller.LoadRomEvent> { loadRom(properties, it) }
     eventQueue.register<Controller.RestoreSnapshotEvent> { e -> loadSnapshot(e.slot) }
     eventQueue.register<Controller.SaveSnapshotEvent> { e -> saveSnapshot(e.slot) }
     eventQueue.register<Controller.PauseEmulationEvent> { isPaused = true }
@@ -132,7 +124,44 @@ class BasicController(
 
   private fun createSession(config: Gameboy.GameboyConfiguration): Session {
     val sessionBus = eventBus.fork("main")
-    return Session(config, sessionBus, console, createLinkDevice(sessionBus))
+    try {
+      return Session(config, sessionBus, console, createLinkDevice(sessionBus))
+    } catch (e: Exception) {
+      try {
+        sessionBus.close()
+      } catch (cleanupException: Exception) {
+        e.addSuppressed(cleanupException)
+      }
+      throw e
+    }
+  }
+
+  private fun loadRom(properties: EmulatorProperties, event: Controller.LoadRomEvent) {
+    var nextSession: Session? = null
+    try {
+      // Validate the ROM before closing the running game. A bad file selected in the picker
+      // should not interrupt the current session, and must never kill the controller thread.
+      val config = Controller.createGameboyConfig(properties, Rom(event.rom))
+
+      stop()
+      patches.clear()
+      rewindManager.clear()
+
+      nextSession = createSession(config)
+      event.memento?.let { nextSession.gameboy.restoreFromMemento(it) }
+      session = nextSession
+      nextSession = null
+      start()
+    } catch (e: Exception) {
+      try {
+        nextSession?.close()
+      } catch (cleanupException: Exception) {
+        e.addSuppressed(cleanupException)
+      }
+      LOG.error("Can't load ROM ${event.rom}", e)
+      val message = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
+      eventBus.post(Controller.LoadRomFailedEvent(event.rom, message))
+    }
   }
 
   private fun createLinkDevice(sessionBus: EventBus): SerialEndpoint =
@@ -214,5 +243,9 @@ class BasicController(
     eventBus.close()
 
     return state
+  }
+
+  private companion object {
+    val LOG: Logger = LoggerFactory.getLogger(BasicController::class.java)
   }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -22,6 +22,8 @@ interface Controller : AutoCloseable {
 
   data class LoadRomEvent(val rom: File, val memento: Memento<Gameboy>? = null) : Event
 
+  data class LoadRomFailedEvent(val rom: File, val message: String) : Event
+
   class PauseEmulationEvent : Event
 
   class ResumeEmulationEvent : Event

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.Controller.EmulationStartedEvent
+import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
+import eu.rekawek.coffeegb.controller.Controller.LoadRomFailedEvent
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.Test
+
+class BasicControllerTest {
+
+  @Test
+  fun failedLoadDoesNotPreventLoadingAnotherRom() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val failures = LinkedBlockingQueue<LoadRomFailedEvent>()
+    eventBus.register<EmulationStartedEvent> { started.add(it) }
+    eventBus.register<LoadRomFailedEvent> { failures.add(it) }
+    val controller = BasicController(eventBus, EmulatorProperties(), null)
+    val invalidRom = Files.createTempFile("coffee-gb-invalid-rom", ".gbc").toFile()
+    invalidRom.writeText("not a Game Boy ROM")
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(ROM))
+      assertEquals("CPU_INSTRS", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+
+      eventBus.post(LoadRomEvent(invalidRom))
+      val failure = failures.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      assertNotNull(failure, "the failed load should be reported")
+      assertEquals(invalidRom, failure.rom)
+
+      eventBus.post(LoadRomEvent(ROM))
+      assertEquals(
+          "CPU_INSTRS",
+          started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName,
+          "the controller thread should keep processing load requests",
+      )
+    } finally {
+      controller.close()
+      eventBus.close()
+      invalidRom.delete()
+    }
+  }
+
+  private companion object {
+    val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
+
+    const val TIMEOUT_SECONDS = 10L
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.Controller.EmulationStartedEvent
 import eu.rekawek.coffeegb.controller.Controller.EmulationStoppedEvent
 import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
+import eu.rekawek.coffeegb.controller.Controller.LoadRomFailedEvent
 import eu.rekawek.coffeegb.controller.Controller.PauseEmulationEvent
 import eu.rekawek.coffeegb.controller.Controller.ResetEmulationEvent
 import eu.rekawek.coffeegb.controller.Controller.ResumeEmulationEvent
@@ -111,6 +112,17 @@ class SwingMenu(
       currentRomFileName = pendingRomFileName ?: currentRomFileName
       pendingRomFileName = null
       currentRomTitle = it.romName
+    }
+    eventBus.register<LoadRomFailedEvent> {
+      pendingRomFileName = null
+      SwingUtilities.invokeLater {
+        JOptionPane.showMessageDialog(
+            window,
+            "Can't open ${it.rom.name}: ${it.message}",
+            "Error",
+            JOptionPane.ERROR_MESSAGE,
+        )
+      }
     }
     eventBus.register<EmulationStoppedEvent> {
       currentRomFileName = null


### PR DESCRIPTION
Addresses #161.

## What changed

- validate a selected ROM before closing the running session
- catch load/session initialization failures on the controller thread so later load requests are still processed
- clean up partially created session event buses
- show asynchronous load errors in the Swing UI
- add a regression covering valid load → failed load → valid load

## Verification

- `/opt/maven/bin/mvn -pl controller,swing -am test -q`
- `/opt/maven/bin/mvn -pl controller -am -Dtest=BasicControllerTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- direct reproduction: before the fix, an invalid load killed the controller thread and the following valid load timed out; after the fix, the following load emits `EmulationStartedEvent`
- repeated switching among two CGB games and one DMG game from `/mnt/nas/emu/roms`

The exact intermittent valid-ROM sequence from the report was not reproduced, so the issue should remain open until the change is verified manually.