### PR TITLE
Emulate CGB highlight clipping during white transitions

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
@@ -15,7 +15,7 @@ class DisplayProperties(private val properties: EmulatorProperties) {
 
   val colorCorrection
     get() =
-        properties.getProperty(EmulatorProperties.Key.DisplayColorCorrection, "false").toBoolean()
+        properties.getProperty(EmulatorProperties.Key.DisplayColorCorrection, "true").toBoolean()
 
   val rotation
     get() = properties.getProperty(EmulatorProperties.Key.DisplayRotation, "0").toInt()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/DisplayPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/DisplayPropertiesTest.kt
@@ -20,4 +20,20 @@ class DisplayPropertiesTest {
 
     assertFalse(properties.display.blending)
   }
+
+  @Test
+  fun `CGB color correction is enabled for fresh profiles`() {
+    val properties = EmulatorProperties()
+    properties.properties.remove(EmulatorProperties.Key.DisplayColorCorrection.propertyName)
+
+    assertTrue(properties.display.colorCorrection)
+  }
+
+  @Test
+  fun `explicit CGB color correction preference is preserved`() {
+    val properties = EmulatorProperties()
+    properties.properties[EmulatorProperties.Key.DisplayColorCorrection.propertyName] = "false"
+
+    assertFalse(properties.display.colorCorrection)
+  }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -329,7 +329,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
         boolean stopFrameBlanked = cpu.consumeStopFrameBlankRequest();
         if (stopFrameBlanked) {
-            display.blankFrame();
+            display.blankFrameForStop();
             result = true;
         }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -111,7 +111,9 @@ public class Display implements Serializable, Originator<Display> {
     public void blankFrame() {
         // a deliberate blank overrides any pending enable-frame skip
         firstFrameAfterLcdEnable = false;
-        Arrays.fill(buffer, 0);
+        // Color 0 is black in CGB RGB555, unlike DMG shade 0. An inactive LCD is
+        // white, so use the CGB white value instead of clearing both modes to zero.
+        Arrays.fill(buffer, gbc ? 0x7fff : 0);
         i = 0;
         frameIsReady();
     }
@@ -159,9 +161,23 @@ public class Display implements Serializable, Originator<Display> {
             if (lut == null) {
                 lut = new int[0x8000];
                 for (int color = 0; color < 0x8000; color++) {
-                    int r = CURVE[color & 0x1f];
-                    int g = CURVE[(color >> 5) & 0x1f];
-                    int b = CURVE[(color >> 10) & 0x1f];
+                    int r5 = color & 0x1f;
+                    int g5 = (color >> 5) & 0x1f;
+                    int b5 = (color >> 10) & 0x1f;
+
+                    // The original reflective LCD loses chroma at the very top of its
+                    // range. KiGB derived this clipping point while testing the complete
+                    // GoodGBX set on hardware: RGB555 colors whose component sum reaches
+                    // 86 are one indistinguishable highlight. NBA Jam '99 relies on that
+                    // response to hide a screen rebuild behind two colors at sums 86 and
+                    // 90; raw-RGB displays expose the rebuild as transition garbage.
+                    if (r5 + g5 + b5 >= 86) {
+                        r5 = g5 = b5 = 31;
+                    }
+
+                    int r = CURVE[r5];
+                    int g = CURVE[g5];
+                    int b = CURVE[b5];
                     if (g != b) {
                         g = (int) Math.round(Math.pow(
                                 (Math.pow(g / 255.0, 2.2) * 3 + Math.pow(b / 255.0, 2.2)) / 4, 1 / 2.2) * 255);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -109,11 +109,21 @@ public class Display implements Serializable, Originator<Display> {
 
     /** Emits a blank frame while the LCD stays off (a sustained off blanks the screen). */
     public void blankFrame() {
+        emitSolidFrame(gbc ? 0x7fff : 0);
+    }
+
+    /**
+     * Emits the panel state produced by STOP while LCDC remains enabled. CGB drives black
+     * pixels in that state; DMG shade 0 remains the normal blank output.
+     */
+    public void blankFrameForStop() {
+        emitSolidFrame(0);
+    }
+
+    private void emitSolidFrame(int color) {
         // a deliberate blank overrides any pending enable-frame skip
         firstFrameAfterLcdEnable = false;
-        // Color 0 is black in CGB RGB555, unlike DMG shade 0. An inactive LCD is
-        // white, so use the CGB white value instead of clearing both modes to zero.
-        Arrays.fill(buffer, gbc ? 0x7fff : 0);
+        Arrays.fill(buffer, color);
         i = 0;
         frameIsReady();
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
@@ -76,6 +76,19 @@ public class DisplayTest {
     }
 
     @Test
+    public void cgbUsesBlackWhenStopHaltsAnEnabledLcd() {
+        Display display = new Display(true);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.pixels().clone()), Display.GbcFrameReadyEvent.class);
+        display.init(eventBus);
+
+        display.blankFrameForStop();
+
+        assertArrayEquals(new int[PIXELS], frame.get());
+    }
+
+    @Test
     public void cgbCorrectionClipsHardwareHighlights() {
         int[] rgb = new int[3];
         // NBA Jam '99's two transition colors: RGB555 (28, 27, 31), sum 86,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class DisplayTest {
 
@@ -55,6 +57,35 @@ public class DisplayTest {
         display.frameIsReady();
 
         assertArrayEquals(expected, frame.get());
+    }
+
+    @Test
+    public void cgbUsesWhiteWhileLcdIsOff() {
+        Display display = new Display(true);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.pixels().clone()), Display.GbcFrameReadyEvent.class);
+        display.init(eventBus);
+
+        display.disableLcd();
+        display.blankFrame();
+
+        int[] expected = new int[PIXELS];
+        java.util.Arrays.fill(expected, 0x7fff);
+        assertArrayEquals(expected, frame.get());
+    }
+
+    @Test
+    public void cgbCorrectionClipsHardwareHighlights() {
+        int[] rgb = new int[3];
+        // NBA Jam '99's two transition colors: RGB555 (28, 27, 31), sum 86,
+        // and (28, 31, 31), sum 90. Both are white on the physical LCD.
+        new Display.GbcFrameReadyEvent(new int[]{0x7f7c, 0x7ffc, 0x6f3c})
+                .toRgb(rgb, true);
+
+        assertEquals(rgb[0], rgb[1]);
+        // A highlight below the clipping threshold retains its chroma.
+        assertNotEquals(rgb[1], rgb[2]);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- render sustained CGB LCD-off output as RGB555 white instead of black
- reproduce the original LCD highlight clipping used to hide near-white transition work
- enable CGB LCD color correction by default for fresh profiles while preserving explicit raw-RGB preferences
- add regression coverage for the NBA Jam transition colors, LCD-off output, and display defaults

## Hardware/reference investigation

The ROM intentionally fades its palettes up, disables the LCD, rebuilds the Options screen, and fades back down. Its two intermediate RGB555 colors have component sums 86 and 90. Raw RGB preserves their chroma and exposes the rebuild. Hardware-tested KiGB clips highlights starting at sum 86, producing a uniform blank screen; its v1.54 changelog specifically lists the NBA Jam 99 transition-garbage fix: https://www.allegro.cc/depot/KiGB/

A deterministic replay now produces one-color white frames from frame 1425 through 1550, followed by the completed Options screen fading in. This matches the physical-GBA result reported on the issue and does not use a game-specific check.

## Tests

- `/opt/maven/bin/mvn -pl core,controller -am test -q`
- `/opt/maven/bin/mvn -pl swing -am test -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2 -q`
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg -q`
- deterministic NBA Jam replay with ROM SHA-1 `f34d0ac01f14c7c2671b6097c2ef891e70826d72`

Fixes #176