### PR TITLE
Fix NBA Jam 99 options-screen artifact

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
@@ -21,28 +21,31 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
 
     public static final int GET_TILE_T1 = 0;
 
-    // the horizontal part of the map offset: the position is frozen at the fetch
-    // start, but SCX is read two dots later - the DMG commits SCX writes two cycles
-    // into the write, earlier than other registers (SameBoy
-    // GB_CONFLICT_SCX_DMG_AND_CGB_DOUBLE; m3_scx_high_5_bits)
+    // The horizontal part of the map offset. CGB latches SCX with the fetch position at
+    // GET_TILE_T1. DMG reads SCX two dots later because its register write commits early
+    // (SameBoy GB_CONFLICT_SCX_DMG_AND_CGB_DOUBLE; m3_scx_high_5_bits).
     private int tileMapX;
 
     private int xBasePosition;
 
     private boolean xBaseObjectFetch;
 
-    private void sampleXBase(int position, boolean duringObjectFetch) {
+    private void sampleXBase(int position, boolean window, boolean duringObjectFetch) {
         xBasePosition = position;
         xBaseObjectFetch = duringObjectFetch;
+        if (gbc) {
+            sampleX(window);
+        }
     }
 
     private void sampleX(boolean window) {
+        int scx = r.getForFetcher(GpuRegister.SCX);
         if (window) {
             tileMapX = windowTileX;
         } else if (xBasePosition + 16 < 8) {
-            tileMapX = r.get(GpuRegister.SCX) >> 3;
+            tileMapX = scx >> 3;
         } else {
-            tileMapX = ((r.get(GpuRegister.SCX) + xBasePosition + 8 - ((gbc && !xBaseObjectFetch) ? 1 : 0)) / 8) & 0x1f;
+            tileMapX = ((scx + xBasePosition + 8 - ((gbc && !xBaseObjectFetch) ? 1 : 0)) / 8) & 0x1f;
         }
     }
 
@@ -221,7 +224,7 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
             case GET_TILE_T1:
                 // the pipeline position for the horizontal map coordinate is frozen
                 // at the fetch start ...
-                sampleXBase(position, duringObjectFetch);
+                sampleXBase(position, window, duringObjectFetch);
                 state++;
                 break;
 
@@ -234,9 +237,11 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
                 break;
 
             case GET_TILE_DATA_LOW_T2: {
-                // ... SCX itself and the vertical coordinate (SCY) resolve with the
-                // map read here (m3_scx_high_5_bits, m3_scy_change)
-                sampleX(window);
+                // ... on DMG, SCX resolves here; the vertical coordinate (SCY) resolves
+                // here on both families (m3_scx_high_5_bits, m3_scy_change)
+                if (!gbc) {
+                    sampleX(window);
+                }
                 sampleY(window, windowY);
                 // the map read (and the map-select LCDC bit with it) resolves here,
                 // two T-cycles after the offset was sampled (m3_lcdc_bg_map_change,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -77,6 +77,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.lcdc = new Lcdc();
         this.gbc = gbc;
         this.r.setGbc(gbc);
+        this.r.setSpeedMode(speedMode);
         this.lcdc.setGbc(gbc);
         this.videoRam0 = new Ram(0x8000, 0x2000);
         if (gbc) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuRegisterValues.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuRegisterValues.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -36,8 +37,21 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
 
     private boolean gbc;
 
+    private SpeedMode speedMode;
+
+    // On CGB in normal speed, a tile-index fetch colliding with an SCX write reads the
+    // old value. The CPU write is processed before the PPU in our tick, so retain that
+    // old value for the PPU side of the same tick (SameBoy GB_CONFLICT_READ_OLD).
+    private int scxOldValue = -1;
+
+    private int pendingScxOldValue = -1;
+
     public void setGbc(boolean gbc) {
         this.gbc = gbc;
+    }
+
+    public void setSpeedMode(SpeedMode speedMode) {
+        this.speedMode = speedMode;
     }
 
     public GpuRegisterValues() {
@@ -54,6 +68,14 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
         return values[reg.ordinal()];
     }
 
+    /** Register value seen by the tile fetcher during the current PPU tick. */
+    public int getForFetcher(GpuRegister reg) {
+        if (reg == GpuRegister.SCX && scxOldValue >= 0) {
+            return scxOldValue;
+        }
+        return values[reg.ordinal()];
+    }
+
     /** Register value as seen by the LCD output stage (with the DMG write-conflict mix). */
     public int getEffective(GpuRegister reg) {
         int mix = mixValues[reg.ordinal()];
@@ -62,6 +84,8 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
 
     /** Called once per GPU tick: a mix value lives for the single tick after the write. */
     void tickConflicts() {
+        scxOldValue = pendingScxOldValue;
+        pendingScxOldValue = -1;
         for (GpuRegister reg : PALETTE_REGISTERS) {
             mixValues[reg.ordinal()] = pendingMixValues[reg.ordinal()];
             pendingMixValues[reg.ordinal()] = -1;
@@ -102,6 +126,10 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
             if (reg == GpuRegister.WX) {
                 wxJustChangedTicks = WX_CHANGE_TICKS;
             }
+            if (gbc && reg == GpuRegister.SCX
+                    && (speedMode == null || speedMode.getSpeedMode() == 1)) {
+                pendingScxOldValue = values[reg.ordinal()];
+            }
             values[reg.ordinal()] = value;
         }
     }
@@ -127,7 +155,8 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
 
     @Override
     public Memento<GpuRegisterValues> saveToMemento() {
-        return new GpuRegisterValuesMemento(values.clone(), mixValues.clone(), pendingMixValues.clone(), wxJustChangedTicks);
+        return new GpuRegisterValuesMemento(values.clone(), mixValues.clone(), pendingMixValues.clone(),
+                wxJustChangedTicks, scxOldValue, pendingScxOldValue);
     }
 
     @Override
@@ -147,10 +176,13 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
             java.util.Arrays.fill(this.pendingMixValues, -1);
         }
         this.wxJustChangedTicks = mem.wxJustChangedTicks;
+        this.scxOldValue = mem.scxOldValue;
+        this.pendingScxOldValue = mem.pendingScxOldValue;
     }
 
     private record GpuRegisterValuesMemento(int[] values, int[] mixValues, int[] pendingMixValues,
-                                            int wxJustChangedTicks)
+                                            int wxJustChangedTicks, int scxOldValue,
+                                            int pendingScxOldValue)
             implements Memento<GpuRegisterValues> {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherScrollSamplingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherScrollSamplingTest.java
@@ -1,0 +1,112 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.memory.Ram;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class FetcherScrollSamplingTest {
+
+    @Test
+    public void cgbLatchesScxAtTileFetchStart() {
+        Fixture f = new Fixture();
+
+        f.fetcher.advance(144, false, -1, false); // GET_TILE_T1
+        f.registers.put(GpuRegister.SCX, 64);
+        f.finishFetch();
+
+        assertArrayEquals(new int[]{1, 1, 1, 1, 1, 1, 1, 1}, f.fifo.pixels);
+    }
+
+    @Test
+    public void cgbTileFetchCollidingWithScxWriteSeesOldValue() {
+        Fixture f = new Fixture();
+
+        f.registers.setByte(GpuRegister.SCX.getAddress(), 64);
+        f.registers.tickConflicts();
+        f.finishFetch();
+
+        assertArrayEquals(new int[]{1, 1, 1, 1, 1, 1, 1, 1}, f.fifo.pixels);
+    }
+
+    @Test
+    public void cgbSeesScxWrittenBeforeTileFetchStart() {
+        Fixture f = new Fixture();
+
+        f.registers.put(GpuRegister.SCX, 64);
+        f.finishFetch();
+
+        assertArrayEquals(new int[]{2, 2, 2, 2, 2, 2, 2, 2}, f.fifo.pixels);
+    }
+
+    private static class Fixture {
+
+        private final RecordingFifo fifo = new RecordingFifo();
+        private final GpuRegisterValues registers = new GpuRegisterValues();
+        private final Fetcher fetcher;
+
+        private Fixture() {
+            Ram vram0 = new Ram(0x8000, 0x2000);
+            Ram vram1 = new Ram(0x8000, 0x2000);
+            registers.put(GpuRegister.LY, 0);
+            registers.put(GpuRegister.SCY, 0);
+            registers.put(GpuRegister.SCX, 0);
+            registers.setGbc(true);
+
+            // At position 144 the CGB fetches map column 18 with SCX=0 and column 26
+            // with SCX=64. Give the two columns solid, distinguishable tile rows.
+            vram0.setByte(0x9800 + 18, 1);
+            vram0.setByte(0x9800 + 26, 2);
+            vram0.setByte(0x8000 + 1 * 16, 0xff);
+            vram0.setByte(0x8000 + 1 * 16 + 1, 0x00);
+            vram0.setByte(0x8000 + 2 * 16, 0x00);
+            vram0.setByte(0x8000 + 2 * 16 + 1, 0xff);
+
+            fetcher = new Fetcher(
+                    fifo, vram0, vram1, new Ram(0xfe00, 0xa0),
+                    new Lcdc(), registers, true);
+            fetcher.startLine();
+        }
+
+        private void finishFetch() {
+            while (fifo.pixels == null) {
+                fetcher.advance(144, false, -1, false);
+            }
+        }
+    }
+
+    private static class RecordingFifo implements PixelFifo {
+
+        private int[] pixels;
+
+        @Override
+        public int getLength() {
+            return 0;
+        }
+
+        @Override
+        public void enqueue8Pixels(int[] pixels, TileAttributes tileAttributes) {
+            this.pixels = pixels.clone();
+        }
+
+        @Override
+        public void putPixelToScreen() {
+        }
+
+        @Override
+        public void dropPixel() {
+        }
+
+        @Override
+        public void setOverlay(int[] pixelLine, int offset, TileAttributes flags, int oamIndex) {
+        }
+
+        @Override
+        public void clear() {
+        }
+
+        @Override
+        public void clearBg() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- latch SCX at the beginning of CGB tile-index fetches
- emulate the CGB normal-speed same-dot FF43 collision, where the fetcher sees the old SCX value
- preserve the distinct DMG and CGB double-speed timing path
- add focused fetcher regressions for pre-fetch, mid-fetch, and colliding SCX writes

## Verification
- reproduced the intermittent white segment at x=152..159, y=39 in NBA Jam 99
- replayed the same 36-frame transition after the fix with zero white-line occurrences
- matched fresh SameBoy CGB-E and AGB-A captures of the affected frame
- `/opt/maven/bin/mvn test -q`
- core Mealybug, SameSuite, Mooneye, DMG/CGB Acid2, and Blargg profiles

ROM SHA-1: `f34d0ac01f14c7c2671b6097c2ef891e70826d72`

Fixes #177