### PR TITLE
Fix Konami GB Collection LCD-off screen flash

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -37,6 +37,12 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     // 60 frames per second
     public static final int TICKS_PER_FRAME = Gameboy.TICKS_PER_SEC / 60;
 
+    // Keep very short LCD-off VRAM rewrites on the previous panel image, but do not
+    // hold a partial scanout until the next emulated refresh. Four scanlines are longer
+    // than known sub-frame rewrites (A Bug's Life uses about 1100 ticks) while still
+    // allowing a sustained LCD-off to replace a transition fragment before host paint.
+    static final int LCD_OFF_BLANK_DELAY = 4 * 456;
+
     private final Cartridge cartridge;
 
     private final Cartridge slotCartridge;
@@ -339,12 +345,18 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 hdma.onLcdSwitch(false);
                 lcdOffTicks = 0;
             }
-            // a game that only blanks the LCD for a fraction of a frame (a common way to
-            // squeeze a big VRAM rewrite in, e.g. the A Bug's Life intro) must not flash a
-            // blank frame - the display keeps the last picture. Only a sustained LCD-off
-            // blanks the screen, at the normal refresh cadence.
-            if (++lcdOffTicks >= TICKS_PER_FRAME) {
-                lcdOffTicks = 0;
+            // A very short LCD-off (a common way to squeeze in a VRAM rewrite, e.g. the
+            // A Bug's Life intro) keeps the last panel image. Once the off period outlives
+            // that settling window, publish the blank state immediately. Otherwise a
+            // partial scanout immediately before LCD-off is held for a complete host frame
+            // (Konami GB Collection Vol. 1, issue #127). Subsequent blank refreshes retain
+            // the normal cadence.
+            lcdOffTicks++;
+            if (lcdOffTicks == LCD_OFF_BLANK_DELAY
+                    || lcdOffTicks >= LCD_OFF_BLANK_DELAY + TICKS_PER_FRAME) {
+                if (lcdOffTicks >= LCD_OFF_BLANK_DELAY + TICKS_PER_FRAME) {
+                    lcdOffTicks = LCD_OFF_BLANK_DELAY;
+                }
                 display.blankFrame();
                 result = true;
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GameboyMementoTest {
 
@@ -30,7 +32,41 @@ public class GameboyMementoTest {
             do {
                 ticksUntilBlank++;
             } while (!gameboy.tick());
-            assertEquals(Gameboy.TICKS_PER_FRAME - elapsedBeforeSave, ticksUntilBlank);
+            assertEquals(Gameboy.LCD_OFF_BLANK_DELAY - elapsedBeforeSave, ticksUntilBlank);
+        }
+    }
+
+    @Test
+    public void briefLcdOffDoesNotPublishBlankFrame() throws IOException {
+        byte[] romBytes = new byte[0x8000];
+        romBytes[0x147] = 0;
+        try (Gameboy gameboy = new Gameboy(new Rom(romBytes))) {
+            gameboy.getGpu().setByte(0xff40, 0);
+            for (int i = 1; i < Gameboy.LCD_OFF_BLANK_DELAY; i++) {
+                assertFalse(gameboy.tick());
+            }
+
+            gameboy.getGpu().setByte(0xff40, 0x91);
+            assertFalse(gameboy.tick());
+        }
+    }
+
+    @Test
+    public void sustainedLcdOffKeepsNormalCadenceAfterEarlyBlank() throws IOException {
+        byte[] romBytes = new byte[0x8000];
+        romBytes[0x147] = 0;
+        try (Gameboy gameboy = new Gameboy(new Rom(romBytes))) {
+            gameboy.getGpu().setByte(0xff40, 0);
+            for (int i = 1; i < Gameboy.LCD_OFF_BLANK_DELAY; i++) {
+                assertFalse(gameboy.tick());
+            }
+            assertTrue(gameboy.tick());
+
+            int ticksUntilNextBlank = 0;
+            do {
+                ticksUntilNextBlank++;
+            } while (!gameboy.tick());
+            assertEquals(Gameboy.TICKS_PER_FRAME, ticksUntilNextBlank);
         }
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -86,33 +86,36 @@ public class SwingDisplay extends JPanel implements Runnable {
     }
 
     private synchronized void onGbcFrame(Display.GbcFrameReadyEvent e) {
-        if (frameIsWaiting) {
-            return;
-        }
-        frameIsWaiting = true;
         e.toRgb(waitingFrame, colorCorrection);
         setBorder(false);
-        notify();
+        frameQueued();
     }
 
     private synchronized void onDmgFrame(Display.DmgFrameReadyEvent e) {
-        if (frameIsWaiting || gameboyType == GameboyType.SGB) {
+        if (gameboyType == GameboyType.SGB) {
             return;
         }
-        frameIsWaiting = true;
         e.toRgb(waitingFrame, grayscale);
         setBorder(false);
-        notify();
+        frameQueued();
     }
 
     private synchronized void onSgbFrame(SgbDisplay.SgbFrameReadyEvent e) {
-        if (frameIsWaiting) {
-            return;
-        }
-        frameIsWaiting = true;
         e.toRgb(waitingFrame, grayscale);
         setBorder(e.includeBorder());
-        notify();
+        frameQueued();
+    }
+
+    /**
+     * Keep the newest panel state while the display thread has not uploaded the pending
+     * frame yet. In particular, LCD-off can replace a just-finished partial scanout before
+     * Swing paints it instead of leaving that stale transition visible for a host frame.
+     */
+    private void frameQueued() {
+        if (!frameIsWaiting) {
+            frameIsWaiting = true;
+            notify();
+        }
     }
 
     private void setBorder(boolean isSgbBorder) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -2,6 +2,8 @@ package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
 import org.junit.Test;
 
 import java.awt.Graphics;
@@ -15,6 +17,27 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class SwingDisplayTest {
+
+    @Test
+    public void newestFrameReplacesPendingTransitionFrame() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = new SwingDisplay(
+                new EmulatorProperties().getDisplay(), eventBus, "test");
+        int[] transition = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        java.util.Arrays.fill(transition, 3);
+        int[] blank = new int[transition.length];
+
+        eventBus.post(new Display.DmgFrameReadyEvent(transition));
+        eventBus.post(new Display.DmgFrameReadyEvent(blank));
+
+        Field waitingFrameField = SwingDisplay.class.getDeclaredField("waitingFrame");
+        waitingFrameField.setAccessible(true);
+        int[] waitingFrame = (int[]) waitingFrameField.get(display);
+        int[] expected = new int[waitingFrame.length];
+        new Display.DmgFrameReadyEvent(blank).toRgb(
+                expected, new EmulatorProperties().getDisplay().getGrayscale());
+        assertArrayEquals(expected, waitingFrame);
+    }
 
     @Test
     public void paintingDoesNotAcquireTheComponentMonitor() throws Exception {


### PR DESCRIPTION
## Summary
- publish a sustained LCD-off blank after a four-scanline panel-settling window instead of holding a partial scanout for a full refresh
- make Swing retain the newest pending panel state so LCD-off blanking replaces a transition fragment before paint
- preserve brief LCD-off VRAM updates such as the 1,124-tick swaps used by A Bug's Life
- add regression coverage for brief/sustained LCD-off timing, save-state restoration, normal blank cadence, and pending-frame replacement

Fixes #127.

## Reproduction and diagnosis
Using ROM SHA-256 `7c4edefe1c662016e9b398c29164ac6c8bec013c9ce20dc860f39c49f58b9add`, I selected the default game from the collection menu. The ROM enables a full-screen blank window, then disables the window at LY=135, exposing the old menu's bottom eight rows. It disables the LCD shortly afterward. Baseline host frame 804 therefore held the girl's boots for an entire refresh.

SameBoy and Gearboy both expose the same logical partial scanout. That comparison helped locate the shared framebuffer presentation problem, but was not treated as a compatibility ceiling: the patch keeps the dot-level PPU result and models the subsequent panel state so the transient is replaced in the same host refresh. In the patched host-cadence capture, frames 802-815 are uniformly blank; baseline frame 804 contains the reported boots.

## Regression checks
- A Bug's Life LCD-off durations: 153 swaps at 1,124 ticks remain below the 1,824-tick grace window
- `git diff --check`
- `/opt/maven/bin/mvn test` (174 tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` (130 mooneye + both acid2 suites)
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` (8 aggregate + 46 individual ROM tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-mealybug` (24/24)