### PR TITLE
Keep Work Master flash cart RAM mapped

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -34,6 +34,10 @@ public class Mbc1 implements MemoryController {
     // freezes on an illegal opcode at 0x4004 (issue #179).
     private final boolean hongKongPokemonRed;
 
+    // Work Master targets A.D.Inform's 4 Mbit flash cartridge. Unlike Nintendo's
+    // MBC1, that board keeps its SRAM mapped regardless of writes to 0000-1FFF.
+    private final boolean workMasterFlashCart;
+
     private int selectedRamBank;
 
     private int selectedRomBank = 1;
@@ -65,19 +69,19 @@ public class Mbc1 implements MemoryController {
                 && this.cartridge[0x014e] == 0x9c
                 && this.cartridge[0x014f] == 0x8c;
         this.wideBank = hongKongPokemonRed;
+        this.workMasterFlashCart = "WORK MASTER 1.00".equals(rom.getTitle())
+                && this.cartridge.length == 0x80000;
         this.ramBanks = rom.getRamBanks();
         this.romBanks = rom.getRomBanks();
         this.ram = new int[0x2000 * this.ramBanks];
         Arrays.fill(ram, 0xff);
         this.battery = battery;
         battery.loadRam(ram);
-        // Work Master was made for A.D.Inform's 4 Mbit flash cartridge rather than a
-        // Nintendo MBC1 board. Its header says MBC1+RAM, but its startup writes the
-        // workspace at A000 without issuing the usual 0000=0A RAM-enable command. The
-        // original flash cartridge exposes that RAM at power-on; without this initial
-        // state the OS reads back FF and immediately runs its WM CLOSE path.
-        ramWriteEnabled = "WORK MASTER 1.00".equals(rom.getTitle())
-                && cartridge.length == 0x80000;
+        // The header says MBC1+RAM, but the original flash cartridge exposes SRAM at
+        // power-on and never gates it off. Work Master writes ordinary flash commands
+        // through 0000-1FFF; treating those as MBC1 RAM-disable commands makes later
+        // file reads return FF and sends the image viewer into unmapped work RAM.
+        ramWriteEnabled = workMasterFlashCart;
     }
 
     @Override
@@ -88,7 +92,7 @@ public class Mbc1 implements MemoryController {
     @Override
     public void setByte(int address, int value) {
         if (address >= 0x0000 && address < 0x2000) {
-            ramWriteEnabled = (value & 0b1111) == 0b1010;
+            ramWriteEnabled = workMasterFlashCart || (value & 0b1111) == 0b1010;
             LOG.trace("RAM write: {}", ramWriteEnabled);
         } else if (address >= 0x2000 && address < 0x4000) {
             if (!wideBank && !multicart && !upperRegisterUsed && memoryModel == 0

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1Test.java
@@ -30,12 +30,12 @@ public class Mbc1Test {
     }
 
     @Test
-    public void workMasterCanStillDisableAndEnableRam() throws IOException {
+    public void workMasterFlashCommandsDoNotUnmapRam() throws IOException {
         Mbc1 mapper = mapper(mbc1Rom("WORK MASTER 1.00", 0x80000));
         mapper.setByte(0xa123, 0x5a);
 
         mapper.setByte(0x0000, 0x00);
-        assertEquals(0xff, mapper.getByte(0xa123));
+        assertEquals(0x5a, mapper.getByte(0xa123));
         mapper.setByte(0x0000, 0x0a);
         assertEquals(0x5a, mapper.getByte(0xa123));
     }


### PR DESCRIPTION
Closes #183.

Work Master 1.00 targets A.D.Inform's 4 Mbit flash cartridge, whose SRAM remains mapped while flash commands are written through `0000-1FFF`. Coffee GB's existing compatibility path enabled SRAM at startup but still interpreted a later flash command as an MBC1 RAM-disable write.

That made the `50DOL.PIC` file read return `FF`; the resulting unterminated copy overwrote Work Master's RAM interrupt handler and crashed to a blank screen. This change keeps SRAM mapped for this exact title/ROM-size signature while retaining normal MBC1 RAM gating for other cartridges.

Verification:

- Added a mapper regression test for the later `0000=00` command.
- Replayed Start -> Demo -> `50DOL.PIC`; the banknote image now renders and remains responsive.
- `/opt/maven/bin/mvn -pl core test -q`
