### PR TITLE
Avoid ghosting LCD-off transition frames

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -75,7 +75,7 @@ public class Display implements Serializable, Originator<Display> {
                 // The DMG drives a blank frame instead of exposing the incomplete render.
                 Arrays.fill(buffer, 0);
                 System.arraycopy(buffer, 0, lastFrame, 0, buffer.length);
-                eventBus.post(new DmgFrameReadyEvent(buffer));
+                eventBus.post(new DmgFrameReadyEvent(buffer, true));
             }
             return;
         }
@@ -125,7 +125,10 @@ public class Display implements Serializable, Originator<Display> {
         firstFrameAfterLcdEnable = false;
         Arrays.fill(buffer, color);
         i = 0;
-        frameIsReady();
+        System.arraycopy(buffer, 0, lastFrame, 0, buffer.length);
+        eventBus.post(gbc
+                ? new GbcFrameReadyEvent(buffer)
+                : new DmgFrameReadyEvent(buffer, true));
     }
 
     @Override
@@ -227,7 +230,15 @@ public class Display implements Serializable, Originator<Display> {
         }
     }
 
-    public record DmgFrameReadyEvent(int[] pixels) implements Event {
+    /**
+     * {@code lcdBlank} distinguishes panel blanking from a game-rendered shade-0 frame.
+     * Frontends use it to avoid carrying a short-lived transition scanout into the blank.
+     */
+    public record DmgFrameReadyEvent(int[] pixels, boolean lcdBlank) implements Event {
+
+        public DmgFrameReadyEvent(int[] pixels) {
+            this(pixels, false);
+        }
 
         public static final int[] COLORS = new int[]{0xe6f8da, 0x99c886, 0x437969, 0x051f2a};
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/DisplayTest.java
@@ -7,7 +7,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DisplayTest {
 
@@ -17,8 +19,9 @@ public class DisplayTest {
     public void dmgBlanksFirstFrameAfterLcdEnable() {
         Display display = new Display(false);
         EventBusImpl eventBus = new EventBusImpl(null, null, false);
-        AtomicReference<int[]> frame = new AtomicReference<>();
-        eventBus.register(event -> frame.set(event.pixels().clone()), Display.DmgFrameReadyEvent.class);
+        AtomicReference<Display.DmgFrameReadyEvent> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(new Display.DmgFrameReadyEvent(
+                event.pixels().clone(), event.lcdBlank())), Display.DmgFrameReadyEvent.class);
         display.init(eventBus);
 
         fillDmg(display, 3);
@@ -29,13 +32,30 @@ public class DisplayTest {
         fillDmg(display, 2);
         display.frameIsReady();
 
-        assertArrayEquals(new int[PIXELS], frame.get());
+        assertArrayEquals(new int[PIXELS], frame.get().pixels());
+        assertTrue(frame.get().lcdBlank());
 
         int[] expected = new int[PIXELS];
         java.util.Arrays.fill(expected, 1);
         fillDmg(display, 1);
         display.frameIsReady();
-        assertArrayEquals(expected, frame.get());
+        assertArrayEquals(expected, frame.get().pixels());
+        assertFalse(frame.get().lcdBlank());
+    }
+
+    @Test
+    public void dmgMarksLcdOffBlankForPresentation() {
+        Display display = new Display(false);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        AtomicReference<Display.DmgFrameReadyEvent> frame = new AtomicReference<>();
+        eventBus.register(frame::set, Display.DmgFrameReadyEvent.class);
+        display.init(eventBus);
+
+        display.disableLcd();
+        display.blankFrame();
+
+        assertArrayEquals(new int[PIXELS], frame.get().pixels());
+        assertTrue(frame.get().lcdBlank());
     }
 
     @Test

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -42,6 +42,8 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private boolean frameIsWaiting;
 
+    private boolean resetBlendForWaitingFrame;
+
     private int scale;
 
     private boolean grayscale;
@@ -99,7 +101,7 @@ public class SwingDisplay extends JPanel implements Runnable {
     private synchronized void onGbcFrame(Display.GbcFrameReadyEvent e) {
         e.toRgb(waitingFrame, colorCorrection);
         setBorder(false);
-        frameQueued();
+        frameQueued(false);
     }
 
     private synchronized void onDmgFrame(Display.DmgFrameReadyEvent e) {
@@ -108,13 +110,13 @@ public class SwingDisplay extends JPanel implements Runnable {
         }
         e.toRgb(waitingFrame, grayscale);
         setBorder(false);
-        frameQueued();
+        frameQueued(e.lcdBlank());
     }
 
     private synchronized void onSgbFrame(SgbDisplay.SgbFrameReadyEvent e) {
         e.toRgb(waitingFrame, grayscale);
         setBorder(e.includeBorder());
-        frameQueued();
+        frameQueued(false);
     }
 
     /**
@@ -122,7 +124,8 @@ public class SwingDisplay extends JPanel implements Runnable {
      * frame yet. In particular, LCD-off can replace a just-finished partial scanout before
      * Swing paints it instead of leaving that stale transition visible for a host frame.
      */
-    private void frameQueued() {
+    private void frameQueued(boolean resetBlend) {
+        resetBlendForWaitingFrame = resetBlend;
         if (!frameIsWaiting) {
             frameIsWaiting = true;
             notify();
@@ -272,6 +275,11 @@ public class SwingDisplay extends JPanel implements Runnable {
             synchronized (this) {
                 if (frameIsWaiting) {
                     if (blending) {
+                        if (resetBlendForWaitingFrame) {
+                            // LCD-off is a new panel state, not another rendered frame to
+                            // average. Retaining a partial scanout here creates ghost sprites.
+                            previousFrame = null;
+                        }
                         blendWithPreviousFrame();
                     }
                     synchronized (rasterLock) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -78,6 +78,46 @@ public class SwingDisplayTest {
     }
 
     @Test
+    public void lcdBlankDoesNotBlendWithTransitionFrame() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = new SwingDisplay(
+                new EmulatorProperties().getDisplay(), eventBus, "test");
+        eventBus.post(new SwingDisplay.SetBlendingEvent(true));
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+
+        int size = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
+        int[] scene = new int[size];
+        java.util.Arrays.fill(scene, 3);
+        int[] transition = new int[size];
+        transition[0] = 3;
+        int[] blank = new int[size];
+        int[] expectedBlank = new int[size];
+        new Display.DmgFrameReadyEvent(blank).toRgb(
+                expectedBlank, new EmulatorProperties().getDisplay().getGrayscale());
+
+        Field previousFrameField = SwingDisplay.class.getDeclaredField("previousFrame");
+        previousFrameField.setAccessible(true);
+        Field imagePixelsField = SwingDisplay.class.getDeclaredField("imgPixels");
+        imagePixelsField.setAccessible(true);
+        try {
+            eventBus.post(new Display.DmgFrameReadyEvent(scene));
+            awaitArray(previousFrameField, display, dmgRgb(scene));
+
+            eventBus.post(new Display.DmgFrameReadyEvent(transition));
+            awaitArray(previousFrameField, display, dmgRgb(transition));
+
+            eventBus.post(new Display.DmgFrameReadyEvent(blank, true));
+            awaitArray(previousFrameField, display, expectedBlank);
+            assertArrayEquals(expectedBlank, (int[]) imagePixelsField.get(display));
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
+
+    @Test
     public void paintingDoesNotAcquireTheComponentMonitor() throws Exception {
         int modifiers = SwingDisplay.class
                 .getDeclaredMethod("paintComponent", Graphics.class)
@@ -165,6 +205,27 @@ public class SwingDisplayTest {
         Thread thread = new Thread(runnable);
         thread.setDaemon(true);
         return thread;
+    }
+
+    private static int[] dmgRgb(int[] pixels) {
+        int[] rgb = new int[pixels.length];
+        new Display.DmgFrameReadyEvent(pixels).toRgb(
+                rgb, new EmulatorProperties().getDisplay().getGrayscale());
+        return rgb;
+    }
+
+    private static void awaitArray(Field field, Object target, int[] expected) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (System.nanoTime() < deadline) {
+            synchronized (target) {
+                int[] actual = (int[]) field.get(target);
+                if (actual != null && java.util.Arrays.equals(expected, actual)) {
+                    return;
+                }
+            }
+            Thread.yield();
+        }
+        fail("display thread did not upload the expected frame");
     }
 
     private static void paint(SwingDisplay display, Graphics graphics, CountDownLatch painted,


### PR DESCRIPTION
Fixes #126.

## What changed

- distinguish DMG frames produced by actual LCD blanking from game-rendered shade-0 frames
- reset Swing's LCD-ghosting history when that panel blank is presented
- keep normal frame blending unchanged for games which intentionally alternate rendered frames
- cover both LCD-blank event metadata and the stable-frame / transient-scanout / blank presentation sequence

## Root cause

The existing first-frame-after-LCD-enable handling matches SameBoy, and the reported transition's core LCD timing was correct. The remaining artifact was produced in the Swing frontend with the default LCD ghosting option enabled:

1. a short-lived transition scanout was blended with the previous scene
2. LCD-off then emitted a blank frame
3. that blank was blended with the transition scanout, manufacturing the isolated sprite fragment visible in the recording

An LCD-off blank is a new panel state rather than another rendered frame, so it now starts a fresh blend history.

## Verification

- `/opt/maven/bin/mvn -pl core test -q`
- `/opt/maven/bin/mvn -pl swing -am test -q`
- compared the LCD-enable sequence against SameBoy; both suppress the first DMG frame after re-enable
