### PR TITLE
Fix Sachen 8-in-1 subgame mapping

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -126,7 +126,7 @@ public class SachenMmc implements MemoryController {
                 }
                 break;
             case 1:
-                if ((address & 0x40) != 0) {
+                if (cooked && (address & 0x40) != 0) {
                     // 0x2000-0x3FFF with A6 set is the multicart outer/game-select register.
                     // The 2-in-1 carts (issues #73/#75) point the 0x0000-0x3FFF window at the
                     // chosen 256 KB game (base bank = game * 16) and force that offset into the
@@ -190,7 +190,13 @@ public class SachenMmc implements MemoryController {
                 address |= 0x80;
             }
         }
-        if (scrambledHeader && (address & 0xff00) == 0x0100) {
+        // The alternate MMC2 dump keeps the menu's power-on header linear, but the
+        // embedded games retain the ordinary Sachen-scrambled header pages. Once the
+        // menu maps a non-zero base, expose those pages through the same permutation as
+        // the other raw boards. Flea War enters through its 0x0100 reset header.
+        boolean mappedGameHeader = !cooked && !scrambledHeader
+                && (base & mask) % romBanks != 0;
+        if ((scrambledHeader || mappedGameHeader) && (address & 0xff00) == 0x0100) {
             address = unscramble(address);
         }
         return address;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/LinearSachenMmcTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/LinearSachenMmcTest.java
@@ -18,7 +18,11 @@ public class LinearSachenMmcTest {
             0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
 
     private static byte[] linearSachenRom() {
-        byte[] rom = new byte[0x10000];
+        return linearSachenRom(0x10000);
+    }
+
+    private static byte[] linearSachenRom(int size) {
+        byte[] rom = new byte[size];
         rom[0x100] = 0x00;
         rom[0x101] = (byte) 0xc3;
         rom[0x102] = 0x50;
@@ -73,5 +77,67 @@ public class LinearSachenMmcTest {
         assertEquals(0x11, cart.getByte(0x6000));
         cart.setByte(0x2000, 0x03);
         assertEquals(0x33, cart.getByte(0x6000));
+    }
+
+    @Test
+    public void rawLinearCartTreatsA6HighWritesAsNormalBankWrites() throws IOException {
+        byte[] rom = linearSachenRom(0x80000);
+        for (int bank = 0; bank < 32; bank++) {
+            rom[bank * 0x4000 + 0x200] = (byte) bank;
+        }
+        Cartridge cart = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+
+        // This is the menu's launch sequence for Flea War: select banks 20/21.
+        cart.setByte(0x2000, 0xff);
+        cart.setByte(0x0000, 0x14);
+        cart.setByte(0x4000, 0x14);
+        cart.setByte(0x2000, 0x00);
+        assertEquals(0x14, cart.getByte(0x0200));
+        assertEquals(0x15, cart.getByte(0x4200));
+
+        // Flea War clears memory through the cartridge window. On a raw MMC2, A6 is
+        // not an outer-select signal: these remain ordinary bank-register writes.
+        cart.setByte(0x3fff, 0x04);
+        assertEquals(0x14, cart.getByte(0x0200));
+        assertEquals(0x14, cart.getByte(0x4200));
+        cart.setByte(0x3ffe, 0x01);
+        assertEquals(0x15, cart.getByte(0x4200));
+    }
+
+    @Test
+    public void keepsWrappedMenuHeaderLinearAndUnscramblesMappedGameHeader() throws IOException {
+        byte[] rom = linearSachenRom(0x80000);
+        rom[0x0140] = 0x3c;
+        rom[0x14 * 0x4000 + 0x0101] = 0x69;
+        rom[0x14 * 0x4000 + unscramble(0x0100)] = 0x5a;
+        rom[0x14 * 0x4000 + unscramble(0x0101)] = (byte) 0xa5;
+        Cartridge cart = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+
+        // The menu probes base 0x20 on this 32-bank image. It wraps to physical bank 0,
+        // whose alternate-wiring power-on header remains linear.
+        cart.setByte(0x2000, 0xff);
+        cart.setByte(0x0000, 0x20);
+        cart.setByte(0x4000, 0x20);
+        cart.setByte(0x2000, 0x00);
+        assertEquals(0x00, cart.getByte(0x0100));
+        assertEquals(0xc3, cart.getByte(0x0101));
+
+        // Embedded games keep the normal Sachen header permutation. Flea War maps
+        // physical bank 20 and enters through this 0x0100 reset header.
+        cart.setByte(0x2000, 0xff);
+        cart.setByte(0x0000, 0x14);
+        cart.setByte(0x4000, 0x14);
+        cart.setByte(0x2000, 0x00);
+        assertEquals(0x5a, cart.getByte(0x0100));
+        assertEquals(0xa5, cart.getByte(0x0101));
+    }
+
+    private static int unscramble(int address) {
+        int result = address & 0xffac;
+        result |= (address & 0x40) >> 6;
+        result |= (address & 0x10) >> 3;
+        result |= (address & 0x02) << 3;
+        result |= (address & 0x01) << 6;
+        return result;
     }
 }


### PR DESCRIPTION
## Summary

- decode A6-high writes as ordinary bank writes on raw MMC2 carts while retaining the cooked-dump outer-select compatibility path
- keep the alternate dump menu header linear when its fixed bank wraps to bank 0, and apply the Sachen address permutation to mapped subgame headers
- add regressions for the Flea War write sweep, the menu wrap probe, and embedded header decoding

## Verification

- targeted Sachen mapper tests: 16/16 passed
- full core unit suite: 205/205 passed
- headless replay: all eight menu entries reach their correct titles; Sky Ace, Explosive, and Flea War reach gameplay

Fixes #187