### PR TITLE
Fix GBMicrotest STAT tail regressions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,6 +53,12 @@ jobs:
             profiles: test-dmgacid2,test-cgbacid2
           - name: Mealybug Tearoom
             profiles: test-mealybug
+          - name: GBMicrotest
+            profiles: test-gbmicrotest
+          - name: gbc-hw-tests
+            profiles: test-gbc-hw
+          - name: Misc.-GB-Tests
+            profiles: test-misc-gb
 
     steps:
     - uses: actions/checkout@v4

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -353,13 +353,17 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         if (firstLine && ticksInLine < 79) {
             return 0;
         }
-        // A fractional-scroll or window fetch can leave the readable mode-3 tail
-        // asserted through the mode-0 interrupt edge even though the internal
-        // phase has already released the VRAM/OAM locks (Misc.-GB-Tests' NOP-
-        // shifted sprite timing variants). Keep this separate from `mode`: the
-        // lock handoff and HBlank interrupt retain their calibrated timings.
+        // A scanline containing enabled objects, combined with fractional scroll or the
+        // window, can leave the readable mode-3 tail asserted through the mode-0
+        // interrupt edge even after the internal phase released the VRAM/OAM locks
+        // (Misc.-GB-Tests' NOP-shifted sprite timing variants). Keep this separate from
+        // `mode`: the lock handoff and HBlank interrupt retain their calibrated timings.
+        // Vertically inactive objects and sprite-disabled lines do not produce this tail
+        // (GBMicrotest), while selected objects beyond the right edge still do.
         if (mode == Mode.HBlank
                 && ticksInLine <= hblankIntFrom
+                && lcdc.isObjDisplayEffective()
+                && pixelTransferPhase.hasObjectsOnLine()
                 && ((r.get(SCX) & 7) != 0 || lcdc.isWindowDisplay())) {
             return Mode.PixelTransfer.ordinal();
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -259,6 +259,10 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         return objStep >= 0 || objWaiting;
     }
 
+    public boolean hasObjectsOnLine() {
+        return spriteCount > 0;
+    }
+
     public boolean isWindowBeingFetched() {
         return windowBeingFetched;
     }


### PR DESCRIPTION
## Summary

- limit the extended readable STAT mode-3 tail to scanlines that actually selected enabled objects
- keep the previously calibrated Misc.-GB-Tests behavior for active and off-screen-right objects
- avoid reporting the tail for sprite-disabled lines or vertically inactive objects, matching GBMicrotest hardware results

This is a follow-up to #224 and the issue #223 test-suite integration.

## Verification

- core unit suite: 203/203 passed
- GBMicrotest: 513/513 passed
- gbc-hw-tests: 221/221 passed
- Misc.-GB-Tests: 17/17 passed