### PR TITLE
Centralize cartridge profiles and fix Makon 23-in-1

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -6,7 +6,7 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.memento.Memento
-import eu.rekawek.coffeegb.core.memory.cart.Cartridge
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import java.io.File
 
@@ -81,11 +81,13 @@ interface Controller : AutoCloseable {
 
   companion object {
     fun createGameboyConfig(
-        properties: EmulatorProperties,
-        rom: Rom,
+      properties: EmulatorProperties,
+      rom: Rom,
     ): Gameboy.GameboyConfiguration {
       val config = Gameboy.GameboyConfiguration(rom)
-      if (Cartridge.isDatel(rom)) {
+      val isDatel =
+          rom.cartridgeProperties.has(CartridgeProperties.Feature.DATEL_CGB_HEADER)
+      if (isDatel) {
         properties.getProperty(EmulatorProperties.Key.DatelSlotRom, null)?.let { path ->
           val file = File(path)
           if (file.isFile) {
@@ -97,7 +99,7 @@ interface Controller : AutoCloseable {
       config.setGameboyType(gameboyType)
       if (rom.gameboyColorFlag == Rom.GameboyColorFlag.NON_CGB &&
           gameboyType == GameboyType.CGB &&
-          !Cartridge.isDatel(rom)) {
+          !isDatel) {
         // (Datel carts ship a deliberately bad logo; the visible boot ROM would hang on
         // it forever - FAST_FORWARD times out and falls back to the post-boot presets)
         config.setBootstrapMode(Gameboy.BootstrapMode.NORMAL)
@@ -121,7 +123,7 @@ interface Controller : AutoCloseable {
               rom.gameboyColorFlag == Rom.GameboyColorFlag.UNIVERSAL ||
               // the Action Replay dumps carry a garbage CGB flag; the real cart's ASIC
               // presents a colour header to the console
-              Cartridge.isDatel(rom)
+              rom.cartridgeProperties.has(CartridgeProperties.Feature.DATEL_CGB_HEADER)
       ) {
         if (properties.cgbGamesType == GameboyType.SGB && !rom.isSuperGameboyFlag) {
           return GameboyType.CGB

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -13,6 +13,7 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.*;
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
@@ -117,9 +118,12 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         this.gbc = configuration.gameboyType == GameboyType.CGB;
         boolean gbc = this.gbc;
         boolean sgb = configuration.gameboyType == GameboyType.SGB;
-        blankCgbBootTilePending = configuration.rom.requiresBlankCgbBootTile();
+        CartridgeProperties cartridgeProperties = configuration.rom.getCartridgeProperties();
+        blankCgbBootTilePending = cartridgeProperties.has(
+                CartridgeProperties.Feature.BLANK_CGB_BOOT_TILE);
 
-        boolean legacySpeedSwitchRequired = configuration.rom.isLegacySpeedSwitchRequired();
+        boolean legacySpeedSwitchRequired = cartridgeProperties.has(
+                CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
         speedMode = new SpeedMode(gbc, legacySpeedSwitchRequired);
         interruptManager = new InterruptManager(gbc);
         timer = new Timer(interruptManager, speedMode);
@@ -211,7 +215,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             // the Datel Action Replay's ASIC presents a valid CGB header to the console,
             // so the machine boots native-colour despite the dump's garbage flag byte
             applyPostBootState(configuration.rom.getGameboyColorFlag() == Rom.GameboyColorFlag.NON_CGB
-                    && !Cartridge.isDatel(configuration.rom));
+                    && !cartridgeProperties.has(CartridgeProperties.Feature.DATEL_CGB_HEADER));
         }
         applyBootVramCompatibilityIfReady();
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -13,7 +13,6 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.zip.CRC32;
 
 public class Cartridge implements AddressSpace, Serializable, Originator<Cartridge> {
 
@@ -26,8 +25,6 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
                 new SystemTimeSource());
     }
 
-    private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B, 0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
-
     public Cartridge(Rom rom, Battery battery) {
         this(rom, battery, new SystemTimeSource());
     }
@@ -39,67 +36,56 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
 
     public Cartridge(Rom rom, Battery battery, TimeSource rtcTimeSource) {
         this.battery = battery;
+        this.addressSpace = createMemoryController(rom, battery, rtcTimeSource);
+    }
 
+    private static MemoryController createMemoryController(Rom rom, Battery battery,
+                                                           TimeSource rtcTimeSource) {
+        return switch (rom.getCartridgeProperties().getMapper()) {
+            case BUNG_EMS -> new BungEms(rom, battery);
+            case HIDDEN_MMM01 -> new Mmm01(rom, battery, false);
+            case MANI_32K_MULTICART -> new Mani32kMulticart(rom);
+            case DUZ_MULTICART -> new DuzMulticart(rom, battery);
+            case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
+            case SACHEN_MMC1 -> new SachenMmc(rom, false, true);
+            case SACHEN_MMC2 -> new SachenMmc(rom, true, true);
+            case SACHEN_MMC2_LINEAR -> new SachenMmc(rom, true, false);
+            case SACHEN_COOKED -> new SachenMmc(rom, 0);
+            case DATEL -> new Datel(rom, battery);
+            case WISDOM_TREE -> new WisdomTree(rom);
+            case MBC1 -> new Mbc1(rom, battery);
+            case STANDARD -> createStandardMemoryController(rom, battery, rtcTimeSource);
+        };
+    }
+
+    private static MemoryController createStandardMemoryController(Rom rom, Battery battery,
+                                                                   TimeSource rtcTimeSource) {
         var type = rom.getType();
-        int sachenType = sachenType(rom);
-        if (isBungEms(rom)) {
-            addressSpace = new BungEms(rom, battery);
-        } else if (type.isMmm01()) {
-            // the dump has the menu program first; the mapper wants it last
-            addressSpace = new Mmm01(rom, battery, true);
-        } else if (isHiddenMmm01(rom)) {
-            addressSpace = new Mmm01(rom, battery, false);
-        } else if (isMani32kMulticart(rom)) {
-            addressSpace = new Mani32kMulticart(rom);
-        } else if (isDuzMulticart(rom)) {
-            addressSpace = new DuzMulticart(rom, battery);
-        } else if (isBhgosMulticart(rom)) {
-            addressSpace = new BhgosMulticart(rom, battery);
-        } else if (sachenType >= 0) {
-            // Type 3 is the alternate MMC2 wiring: its header page is linear, but it
-            // otherwise uses the same lockout and banking logic as a raw MMC2 cart.
-            addressSpace = new SachenMmc(rom, sachenType != 1, sachenType != 3);
-        } else if (isCookedSachen(rom)) {
-            // post-unlock ("cooked") Sachen dumps: no lockout, boot at base 0 like the
-            // power-on cart (issues #73/#75)
-            addressSpace = new SachenMmc(rom, 0);
+        if (type.isMmm01()) {
+            // The dump has the menu program first; the mapper wants it last.
+            return new Mmm01(rom, battery, true);
         } else if (type.isHuc1()) {
-            addressSpace = new Huc1(rom, battery);
+            return new Huc1(rom, battery);
         } else if (type.isHuc3()) {
-            addressSpace = new Huc3(rom, battery);
+            return new Huc3(rom, battery);
         } else if (type.isTama5()) {
-            addressSpace = new Tama5(rom, battery);
+            return new Tama5(rom, battery);
         } else if (type.isMbc1()) {
-            addressSpace = new Mbc1(rom, battery);
+            return new Mbc1(rom, battery);
         } else if (type.isMbc2()) {
-            addressSpace = new Mbc2(rom, battery);
+            return new Mbc2(rom, battery);
         } else if (type.isMbc3()) {
-            addressSpace = new Mbc3(rom, battery, rtcTimeSource);
+            return new Mbc3(rom, battery, rtcTimeSource);
         } else if (type.isMbc5()) {
-            addressSpace = new Mbc5(rom, battery);
+            return new Mbc5(rom, battery);
         } else if (type.isMbc6()) {
-            addressSpace = new Mbc6(rom, battery);
+            return new Mbc6(rom, battery);
         } else if (type.isMbc7()) {
-            addressSpace = new Mbc7(rom, battery);
+            return new Mbc7(rom, battery);
         } else if (type.isPocketCamera()) {
-            addressSpace = new PocketCamera(rom, battery);
-        } else if (rom.getRom().length > 0x8000 && !hasValidLogo(rom)) {
-            // Datel Action Replay / GameShark carts: "ROM only" type with a deliberately
-            // bad Nintendo logo (the ASIC swaps it after the boot check on hardware) and
-            // banking registers at 0x7FE0/0x7FE1 (issue #66)
-            addressSpace = new Datel(rom, battery);
-        } else if (rom.getRom().length >= 0x20000) {
-            // "ROM only" carts of 128 KB and more are Wisdom Tree style unlicensed
-            // mappers with a single switchable 32 KB window (issue #61)
-            addressSpace = new WisdomTree(rom);
-        } else if (rom.getRom().length > 0x8000) {
-            // a "ROM only" header on a cart bigger than the 32 KB a no-MBC cart can address
-            // is wrong (common in homebrew, e.g. Dimensionless Sample, #76): bank it as MBC1
-            // like BGB does. MBC1's power-on mapping is identical to a plain 32 KB ROM, so
-            // this never breaks a genuinely 32 KB-addressable dump.
-            addressSpace = new Mbc1(rom, battery);
+            return new PocketCamera(rom, battery);
         } else {
-            addressSpace = new BasicRom(rom, battery);
+            return new BasicRom(rom, battery);
         }
     }
 
@@ -126,22 +112,6 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         addressSpace.flushRam();
     }
 
-    /**
-     * MMM01 multicarts are often dumped with a plain MBC header in the first game's bank
-     * while the menu program (with the real header) sits in the last 32 KB. Detect them by
-     * the duplicated logo and the menu header's type (like SameBoy does).
-     */
-    /**
-     * The Duz multicart (Pokemon Red-Blue 2-in-1 and similar) is an MBC3-typed cart whose
-     * individual games each carry their own Nintendo logo at a 16 KB boundary past bank 0.
-     * A normal single-game cart has exactly one logo.
-     */
-    /**
-     * The Mani "TETRIS SET" style multicart (issue #74): a menu in the first 32 KB block
-     * followed by plain 32 KB games, each with a valid logo and a plain-ROM (0x00) type
-     * byte in its own header. The Duz multicarts also duplicate logos at 32 KB blocks,
-     * but their sub-games are banked (non-zero type bytes).
-     */
     /** The Sachen MMC2 needs to observe reads on the upper half of the bus (see Mmu). */
     public SachenMmc getSachenMmc() {
         return addressSpace instanceof SachenMmc s ? s : null;
@@ -157,214 +127,13 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         return addressSpace;
     }
 
-    /**
-     * Whether this ROM is a Datel Action Replay / GameShark cart (deliberately bad logo on
-     * an oversized "ROM only" image). These carts run on the Game Boy Color - the ASIC
-     * presents a valid CGB header to the console - so the type mapping treats them as
-     * colour carts despite the garbage CGB flag byte in the dump.
-     */
-    public static boolean isDatel(Rom rom) {
-        return rom.getRom().length > 0x8000 && !hasValidLogo(rom)
-                && rom.getType() == CartridgeType.ROM;
-    }
-
-    private static boolean isMani32kMulticart(Rom rom) {
-        int[] data = rom.getRom();
-        // MBC1-typed carts with per-game logos are MBC1M multicarts (handled by Mbc1);
-        // the Mani TETRIS SET declares a bogus MBC3-family type
-        if (rom.getType() == CartridgeType.ROM || rom.getType().isMbc1() || data.length < 0x10000) {
-            return false;
-        }
-        int subGames = 0;
-        for (int block = 1; block * 0x8000 + 0x150 <= data.length; block++) {
-            int base = block * 0x8000;
-            boolean logo = true;
-            for (int i = 0; i < NINTENDO_LOGO.length; i++) {
-                if (data[base + 0x104 + i] != NINTENDO_LOGO[i]) {
-                    logo = false;
-                    break;
-                }
-            }
-            if (!logo) {
-                // trailing blocks may be pad filler; games are contiguous from block 1
-                break;
-            }
-            if (data[base + 0x147] != 0x00) {
-                return false;
-            }
-            subGames++;
-        }
-        return subGames >= 2;
-    }
-
-    private static boolean isDuzMulticart(Rom rom) {
-        int[] data = rom.getRom();
-        if (!rom.getType().isMbc3() || data.length < 0x10000) {
-            return false;
-        }
-        for (int bank = 2; bank * 0x4000 + 0x134 < data.length; bank += 2) {
-            boolean logo = true;
-            for (int i = 0; i < NINTENDO_LOGO.length; i++) {
-                if (data[bank * 0x4000 + 0x104 + i] != NINTENDO_LOGO[i]) {
-                    logo = false;
-                    break;
-                }
-            }
-            if (logo) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Blue Hippo's Game Boy Operating System multicarts keep the menu's MBC5 header but
-     * add a register that relocates the complete 32 KiB cartridge window to a selected
-     * embedded game. A standalone 32 KiB copy of the menu needs no special mapping.
-     */
-    private static boolean isBhgosMulticart(Rom rom) {
-        return "MultiCart".equals(rom.getTitle())
-                && rom.getType().isMbc5()
-                && rom.getRom().length > 0x8000;
-    }
-
-    /** Bung/EMS flashcarts use an MBC5-like bank register plus a configurable OR mask. */
-    private static boolean isBungEms(Rom rom) {
-        int[] data = rom.getRom();
-        if (data.length < 0x150) {
-            return false;
-        }
-
-        int rawType = data[0x0147];
-        // Pocket Voice uses the proposed 0xBE marker for unrelated voice hardware.
-        if (rawType == 0xbe && rom.getTitle().startsWith("Pocket Voice")) {
-            return false;
-        }
-
-        CRC32 crc = new CRC32();
-        for (int value : data) {
-            crc.update(value);
-        }
-        switch ((int) crc.getValue()) {
-            case 0x2ed509d9: // Green Beret
-            case 0xf004440c: // Cube Raider
-            case 0xfdc1483a: // Bugs Bunny - Crazy Castle 3 trainer
-            case 0x96c29163: // MainBlow: Bung's 32 KiB SRAM despite its MBC5+8 KiB header
-                return true;
-        }
-
-        return hasNullTerminatedTitle(data, "EMSMENU")
-                || hasNullTerminatedTitle(data, "GB16M")
-                || rawType == 0xbe
-                || (rawType == 0x1b && data[0x014a] == 0xe1);
-    }
-
-    private static boolean hasNullTerminatedTitle(int[] data, String title) {
-        for (int i = 0; i < title.length(); i++) {
-            if (data[0x0134 + i] != title.charAt(i)) {
-                return false;
-            }
-        }
-        return data[0x0134 + title.length()] == 0;
-    }
-
-    /**
-     * Detects the Sachen MMC1/MMC2 multicarts (issues #73/#75) by their scrambled header:
-     * the 0x0100-0x01FF page is wired with A0/A6 and A1/A4 swapped, so the logo bytes sit
-     * at the scrambled offsets (0xED at 0x144, 0x66 at 0x114); the MMC2 stores the logo
-     * served during boot in the 0x0180-0x01FF half of the page (mGBA's detection).
-     * Returns 1 for MMC1, 2 for the address-scrambled MMC2, 3 for the alternate
-     * linear-header MMC2 wiring, and -1 for regular carts.
-     */
-    /**
-     * The fixed, cart-independent header the Sachen mapper descrambles for the boot ROM. The
-     * raw carts store it scrambled in the 0x0100-0x01FF page (and serve it through the
-     * lockout); "cooked" (post-unlock) dumps store it linearised at 0x0104, in place of the
-     * Nintendo logo. It is identical across every Sachen title, so it is a reliable marker.
-     */
-    private static final int[] SACHEN_COOKED_HEADER = {0x11, 0x23, 0xf1, 0x1e, 0x01, 0x22, 0xf0,
-            0x00, 0x08, 0x99, 0x78, 0x00, 0x08, 0x11, 0x9a, 0x48};
-
-    /**
-     * Post-unlock ("cooked") dumps of the Sachen carts (issues #73/#75). They carry no valid
-     * Nintendo logo (the boot ROM's logo check is bypassed for them, as on a flashcart) and
-     * hold the Sachen descrambled boot header at 0x0104. They power on at base bank 0 - the
-     * menu/game code and their per-game bank switching all run from there; the earlier
-     * detection booted them at the logo bank, which left the menu mapped to the wrong bank.
-     */
-    private static boolean isCookedSachen(Rom rom) {
-        int[] data = rom.getRom();
-        if (data.length < 0x8000 || hasValidLogo(rom)) {
-            return false;
-        }
-        for (int i = 0; i < SACHEN_COOKED_HEADER.length; i++) {
-            if (data[0x104 + i] != SACHEN_COOKED_HEADER[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static int sachenType(Rom rom) {
-        int[] data = rom.getRom();
-        if (data.length < 0x10000) {
-            return -1;
-        }
-        if (data[0x104] == 0xce && data[0x144] == 0xed && data[0x114] == 0x66) {
-            return 1;
-        }
-        if (data[0x184] == 0xce && data[0x1c4] == 0xed && data[0x194] == 0x66) {
-            return 2;
-        }
-        // Some MMC2 boards wire the four lower ROM address lines straight through.
-        // Their raw dumps contain Sachen's replacement logo linearly at 0x0104 and
-        // the Nintendo logo selected by RA7 linearly at 0x0184 (issue #187).
-        if (data[0x104] == 0x7c && data[0x105] == 0xe7
-                && data[0x106] == 0xc0 && data[0x107] == 0x00
-                && hasLogoAt(data, 0x184)) {
-            return 3;
-        }
-        return -1;
-    }
-
-    private static boolean hasLogoAt(int[] data, int offset) {
-        if (offset + NINTENDO_LOGO.length > data.length) {
-            return false;
-        }
-        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
-            if (data[offset + i] != NINTENDO_LOGO[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean hasValidLogo(Rom rom) {
-        return hasLogoAt(rom.getRom(), 0x104);
-    }
-
-    private static boolean isHiddenMmm01(Rom rom) {
-        int[] data = rom.getRom();
-        int menuBase = data.length - 0x8000;
-        if (menuBase <= 0) {
-            return false;
-        }
-        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
-            if (data[0x104 + i] != data[menuBase + 0x104 + i]) {
-                return false;
-            }
-        }
-        int menuType = data[menuBase + 0x147];
-        return menuType == 0x0b || menuType == 0x0c || menuType == 0x0d || menuType == 0x11;
-    }
-
     private static Battery createBattery(Rom rom) {
         if (rom.getType().isBattery()) {
             // Existing MBC implementations expose RAM in 8 KiB banks. Plain ROM+RAM
             // is the exception: its 2 KiB header size is mirrored across A000-BFFF.
             int ramSize = rom.getType() == CartridgeType.ROM_RAM_BATTERY
                     ? rom.getRamSize() : 0x2000 * rom.getRamBanks();
-            if (isBungEms(rom)) {
+            if (rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.BUNG_EMS) {
                 ramSize = 0x8000;
             }
             if (ramSize == 0 && rom.getType().isRam()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -47,6 +47,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case MANI_32K_MULTICART -> new Mani32kMulticart(rom);
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
+            case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);
             case SACHEN_MMC2 -> new SachenMmc(rom, true, true);
             case SACHEN_MMC2_LINEAR -> new SachenMmc(rom, true, false);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -1,0 +1,519 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.CRC32;
+
+/**
+ * Compatibility properties for cartridges whose hardware or software does not match the
+ * standard header. All ROM-specific signatures and non-standard mapper detection live here;
+ * the emulator components only consume the resulting mapper and feature flags.
+ */
+public final class CartridgeProperties {
+
+    public enum Mapper {
+        STANDARD,
+        BUNG_EMS,
+        HIDDEN_MMM01,
+        MANI_32K_MULTICART,
+        DUZ_MULTICART,
+        BHGOS_MULTICART,
+        SACHEN_MMC1,
+        SACHEN_MMC2,
+        SACHEN_MMC2_LINEAR,
+        SACHEN_COOKED,
+        DATEL,
+        WISDOM_TREE,
+        MBC1
+    }
+
+    public enum Feature {
+        POCKET_VOICE,
+        FORCE_DMG,
+        LEGACY_SPEED_SWITCH,
+        BLANK_CGB_BOOT_TILE,
+        DATEL_CGB_HEADER,
+        SCRAMBLED_SACHEN_HEADER,
+        MBC1_MULTICART,
+        MBC1_FULL_BANK_REGISTER,
+        MBC1_ALWAYS_ENABLED_RAM,
+        MBC2_EXTENDED_BANKING
+    }
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    private static final int[] SACHEN_COOKED_HEADER = {
+            0x11, 0x23, 0xf1, 0x1e, 0x01, 0x22, 0xf0, 0x00,
+            0x08, 0x99, 0x78, 0x00, 0x08, 0x11, 0x9a, 0x48
+    };
+
+    /**
+     * Ordered so a more specific mapper wins before a broad fallback. Feature-only profiles
+     * may still match the same ROM and add their flags.
+     */
+    private static final List<Profile> PROFILES = List.of(
+            features("Pocket Voice V2.0", CartridgeProperties::isPocketVoice,
+                    Feature.POCKET_VOICE),
+            mapper("Bung/EMS flash cartridge", CartridgeProperties::isBungEms,
+                    Mapper.BUNG_EMS),
+            mapper("hidden MMM01 multicart", CartridgeProperties::isHiddenMmm01,
+                    Mapper.HIDDEN_MMM01),
+            mapper("Mani 32 KiB multicart", CartridgeProperties::isMani32kMulticart,
+                    Mapper.MANI_32K_MULTICART),
+            mapper("Duz multicart", CartridgeProperties::isDuzMulticart,
+                    Mapper.DUZ_MULTICART),
+            mapper("Blue Hippo G.B.O.S. multicart", CartridgeProperties::isBhgosMulticart,
+                    Mapper.BHGOS_MULTICART),
+            profile("raw Sachen MMC1", CartridgeProperties::isRawSachenMmc1,
+                    Mapper.SACHEN_MMC1, Feature.SCRAMBLED_SACHEN_HEADER),
+            profile("raw Sachen MMC2", CartridgeProperties::isRawSachenMmc2,
+                    Mapper.SACHEN_MMC2, Feature.SCRAMBLED_SACHEN_HEADER),
+            mapper("linear-header Sachen MMC2", CartridgeProperties::isLinearSachenMmc2,
+                    Mapper.SACHEN_MMC2_LINEAR),
+            mapper("cooked Sachen MMC", CartridgeProperties::isCookedSachen,
+                    Mapper.SACHEN_COOKED),
+            mapper("Datel Action Replay/GameShark", CartridgeProperties::isDatel,
+                    Mapper.DATEL),
+            features("Datel colour header", CartridgeProperties::hasDatelCgbHeader,
+                    Feature.DATEL_CGB_HEADER),
+            mapper("Wisdom Tree 32 KiB banking", CartridgeProperties::isWisdomTree,
+                    Mapper.WISDOM_TREE),
+            mapper("oversized ROM-only image", CartridgeProperties::isOversizedRomOnly,
+                    Mapper.MBC1),
+            features("Crazy Castle 3 trainer", CartridgeProperties::isCrazyCastleTrainer,
+                    Feature.FORCE_DMG),
+            features("DarkFader Threads demo", CartridgeProperties::isDarkFaderThreadsDemo,
+                    Feature.FORCE_DMG),
+            features("Namco Gallery Vol. 2 trainer", CartridgeProperties::isNamcoGallery2Trainer,
+                    Feature.LEGACY_SPEED_SWITCH),
+            features("Smurfs Lightforce trainer", CartridgeProperties::isSmurfsTrainer,
+                    Feature.BLANK_CGB_BOOT_TILE),
+            features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
+                    Feature.MBC1_MULTICART),
+            features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
+                    Feature.MBC1_FULL_BANK_REGISTER),
+            features("Work Master flash cartridge", CartridgeProperties::isWorkMaster,
+                    Feature.MBC1_ALWAYS_ENABLED_RAM),
+            features("Gokuu Hishouden Chinese translation", CartridgeProperties::isGokuuTranslation,
+                    Feature.MBC2_EXTENDED_BANKING)
+    );
+
+    private final Mapper mapper;
+
+    private final Set<Feature> features;
+
+    private final List<String> profiles;
+
+    private CartridgeProperties(Mapper mapper, Set<Feature> features, List<String> profiles) {
+        this.mapper = mapper;
+        this.features = Collections.unmodifiableSet(features);
+        this.profiles = Collections.unmodifiableList(profiles);
+    }
+
+    public static CartridgeProperties detect(int[] rom) {
+        RomInfo info = new RomInfo(rom);
+        Mapper mapper = Mapper.STANDARD;
+        EnumSet<Feature> features = EnumSet.noneOf(Feature.class);
+        List<String> profiles = new ArrayList<>();
+        for (Profile profile : PROFILES) {
+            if (!profile.matcher.matches(info)) {
+                continue;
+            }
+            profiles.add(profile.name);
+            features.addAll(profile.features);
+            if (mapper == Mapper.STANDARD && profile.mapper != Mapper.STANDARD) {
+                mapper = profile.mapper;
+            }
+        }
+        return new CartridgeProperties(mapper, features, profiles);
+    }
+
+    public Mapper getMapper() {
+        return mapper;
+    }
+
+    public boolean has(Feature feature) {
+        return features.contains(feature);
+    }
+
+    public List<String> getProfiles() {
+        return profiles;
+    }
+
+    int[] getHeader(int[] rom) {
+        if (!has(Feature.SCRAMBLED_SACHEN_HEADER)) {
+            return rom;
+        }
+        int[] header = new int[0x150];
+        for (int address = 0x100; address < header.length; address++) {
+            header[address] = rom[unscrambleSachenAddress(address)];
+        }
+        return header;
+    }
+
+    private static Profile mapper(String name, Matcher matcher, Mapper mapper) {
+        return profile(name, matcher, mapper);
+    }
+
+    private static Profile features(String name, Matcher matcher, Feature... features) {
+        return profile(name, matcher, Mapper.STANDARD, features);
+    }
+
+    private static Profile profile(String name, Matcher matcher, Mapper mapper,
+                                   Feature... features) {
+        EnumSet<Feature> featureSet = EnumSet.noneOf(Feature.class);
+        Collections.addAll(featureSet, features);
+        return new Profile(name, matcher, mapper, featureSet);
+    }
+
+    private static boolean isPocketVoice(RomInfo info) {
+        return info.rawType() == 0xbe && info.title().startsWith("Pocket Voice");
+    }
+
+    private static boolean isBungEms(RomInfo info) {
+        if (isPocketVoice(info)) {
+            return false;
+        }
+        int crc = info.crc32();
+        return crc == 0x2ed509d9 // Green Beret
+                || crc == 0xf004440c // Cube Raider
+                || crc == 0xfdc1483a // Bugs Bunny - Crazy Castle 3 trainer
+                || crc == 0x96c29163 // MainBlow
+                || info.hasNullTerminatedTitle("EMSMENU")
+                || info.hasNullTerminatedTitle("GB16M")
+                || info.rawType() == 0xbe
+                || (info.rawType() == 0x1b && info.byteAt(0x014a) == 0xe1);
+    }
+
+    private static boolean isHiddenMmm01(RomInfo info) {
+        int[] data = info.data;
+        if (info.rawType() >= 0x0b && info.rawType() <= 0x0d) {
+            return false;
+        }
+        int menuBase = data.length - 0x8000;
+        if (menuBase <= 0) {
+            return false;
+        }
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            if (data[0x104 + i] != data[menuBase + 0x104 + i]) {
+                return false;
+            }
+        }
+        int menuType = data[menuBase + 0x147];
+        return menuType == 0x0b || menuType == 0x0c || menuType == 0x0d || menuType == 0x11;
+    }
+
+    private static boolean isMani32kMulticart(RomInfo info) {
+        int type = info.rawType();
+        if (isPlainRomType(type) || isMbc1Type(type) || info.data.length < 0x10000) {
+            return false;
+        }
+        int subGames = 0;
+        for (int block = 1; block * 0x8000 + 0x150 <= info.data.length; block++) {
+            int base = block * 0x8000;
+            if (!hasLogoAt(info.data, base + 0x104)) {
+                break;
+            }
+            if (info.data[base + 0x147] != 0x00) {
+                return false;
+            }
+            subGames++;
+        }
+        return subGames >= 2;
+    }
+
+    private static boolean isDuzMulticart(RomInfo info) {
+        if (!isMbc3Type(info.rawType()) || info.data.length < 0x10000) {
+            return false;
+        }
+        for (int bank = 2; bank * 0x4000 + 0x134 < info.data.length; bank += 2) {
+            if (hasLogoAt(info.data, bank * 0x4000 + 0x104)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBhgosMulticart(RomInfo info) {
+        return "MultiCart".equals(info.title())
+                && isMbc5Type(info.rawType())
+                && info.data.length > 0x8000;
+    }
+
+    private static boolean isRawSachenMmc1(RomInfo info) {
+        return info.data.length >= 0x10000
+                && info.byteAt(0x104) == 0xce
+                && info.byteAt(0x144) == 0xed
+                && info.byteAt(0x114) == 0x66;
+    }
+
+    private static boolean isRawSachenMmc2(RomInfo info) {
+        return info.data.length >= 0x10000
+                && info.byteAt(0x184) == 0xce
+                && info.byteAt(0x1c4) == 0xed
+                && info.byteAt(0x194) == 0x66;
+    }
+
+    private static boolean isLinearSachenMmc2(RomInfo info) {
+        return info.data.length >= 0x10000
+                && info.byteAt(0x104) == 0x7c
+                && info.byteAt(0x105) == 0xe7
+                && info.byteAt(0x106) == 0xc0
+                && info.byteAt(0x107) == 0x00
+                && hasLogoAt(info.data, 0x184);
+    }
+
+    private static boolean isCookedSachen(RomInfo info) {
+        if (info.data.length < 0x8000 || info.hasValidLogo()) {
+            return false;
+        }
+        return matches(info.data, 0x104, SACHEN_COOKED_HEADER);
+    }
+
+    private static boolean isDatel(RomInfo info) {
+        return info.data.length > 0x8000
+                && isPlainRomType(info.rawType())
+                && !info.hasValidLogo()
+                && !isSachen(info);
+    }
+
+    private static boolean hasDatelCgbHeader(RomInfo info) {
+        return info.data.length > 0x8000
+                && info.rawType() == 0x00
+                && !info.hasValidLogo()
+                && !isSachen(info);
+    }
+
+    private static boolean isSachen(RomInfo info) {
+        return isRawSachenMmc1(info)
+                || isRawSachenMmc2(info)
+                || isLinearSachenMmc2(info)
+                || isCookedSachen(info);
+    }
+
+    private static boolean isWisdomTree(RomInfo info) {
+        return info.data.length >= 0x20000
+                && isPlainRomType(info.rawType())
+                && info.hasValidLogo();
+    }
+
+    private static boolean isOversizedRomOnly(RomInfo info) {
+        return info.data.length > 0x8000
+                && info.data.length < 0x20000
+                && isPlainRomType(info.rawType())
+                && info.hasValidLogo();
+    }
+
+    private static boolean isCrazyCastleTrainer(RomInfo info) {
+        int[] entryStub = {0xf5, 0x3e, 0x03, 0xea, 0x00, 0x21, 0xf1, 0xc3, 0x00, 0x68};
+        return info.data.length == 0x100000
+                && "BUGS CC3 CRACK".equals(info.title())
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x19
+                && matches(info.data, 0x00e0, entryStub);
+    }
+
+    private static boolean isDarkFaderThreadsDemo(RomInfo info) {
+        return info.data.length == 0x10000
+                && "OS".equals(info.title())
+                && info.byteAt(0x0100) == 0x00 && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x91 && info.byteAt(0x0103) == 0x09
+                && info.byteAt(0x0143) == 0x80 && info.rawType() == 0x01
+                && info.byteAt(0x0149) == 0x00 && info.byteAt(0x014c) == 0x01
+                && info.byteAt(0x014e) == 0x7b && info.byteAt(0x014f) == 0x1e;
+    }
+
+    private static boolean isNamcoGallery2Trainer(RomInfo info) {
+        int[] speedSwitchStub = {
+                0x3e, 0x01, 0xe0, 0x4d, 0x10, 0x00, 0x00, 0x00,
+                0xcd, 0x0d, 0x71, 0xfa, 0xf0, 0xdf, 0xc3, 0x50, 0x01
+        };
+        return info.data.length == 0x80000
+                && "GALLERY2 +4".equals(info.title())
+                && info.byteAt(0x0143) == 0x00
+                && info.rawType() == 0x01
+                && matches(info.data, 0x3f0fc, speedSwitchStub);
+    }
+
+    private static boolean isSmurfsTrainer(RomInfo info) {
+        int[] trainerSignature = {
+                0x7d, 0xea, 0xa1, 0xc0, 0xe6, 0x03, 0x6f, 0x01,
+                0xe0, 0x01, 0xcb, 0x25, 0xcb, 0x25, 0x09, 0xe9
+        };
+        return info.data.length == 0x100000
+                && info.byteAt(0x0143) == 0xc0
+                && info.rawType() == 0x1b
+                && matches(info.data, 0xddea4, trainerSignature);
+    }
+
+    private static boolean isMbc1Multicart(RomInfo info) {
+        if (!isMbc1Type(info.rawType()) || info.romBanks() != 64) {
+            return false;
+        }
+        int logoCount = 0;
+        for (int bank = 0; bank * 0x4000 < info.data.length; bank++) {
+            if (hasLogoAt(info.data, bank * 0x4000 + 0x104)) {
+                logoCount++;
+            }
+        }
+        return logoCount > 1;
+    }
+
+    private static boolean isHongKongPokemonRed(RomInfo info) {
+        return info.romBanks() == 64
+                && "POCKETMON BE".equals(info.title())
+                && info.byteAt(0x014e) == 0x9c
+                && info.byteAt(0x014f) == 0x8c;
+    }
+
+    private static boolean isWorkMaster(RomInfo info) {
+        return info.data.length == 0x80000 && "WORK MASTER 1.00".equals(info.title());
+    }
+
+    private static boolean isGokuuTranslation(RomInfo info) {
+        int[] entryStub = {0x00, 0xc3, 0xf0, 0x3f};
+        int[] bankStub = {0xf5, 0x3e, 0x0c, 0xea, 0x00, 0x20, 0xf1, 0xc3, 0x00, 0x70};
+        return info.data.length == 0x80000
+                && "GB DBZ GOKOU".equals(info.title())
+                && info.rawType() == 0x06
+                && info.byteAt(0x0148) == 0x04
+                && matches(info.data, 0x0100, entryStub)
+                && matches(info.data, 0x3ff0, bankStub);
+    }
+
+    private static boolean isPlainRomType(int type) {
+        return type == 0x00 || type == 0x08 || type == 0x09;
+    }
+
+    private static boolean isMbc1Type(int type) {
+        return type >= 0x01 && type <= 0x03;
+    }
+
+    private static boolean isMbc3Type(int type) {
+        return type >= 0x0f && type <= 0x13;
+    }
+
+    private static boolean isMbc5Type(int type) {
+        return type >= 0x19 && type <= 0x1e;
+    }
+
+    private static boolean hasLogoAt(int[] data, int offset) {
+        return matches(data, offset, NINTENDO_LOGO);
+    }
+
+    private static boolean matches(int[] data, int offset, int[] expected) {
+        if (offset < 0 || offset + expected.length > data.length) {
+            return false;
+        }
+        for (int i = 0; i < expected.length; i++) {
+            if (data[offset + i] != expected[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int unscrambleSachenAddress(int address) {
+        int unscrambled = address & 0xffac;
+        unscrambled |= (address & 0x40) >> 6;
+        unscrambled |= (address & 0x10) >> 3;
+        unscrambled |= (address & 0x02) << 3;
+        unscrambled |= (address & 0x01) << 6;
+        return unscrambled;
+    }
+
+    private interface Matcher {
+        boolean matches(RomInfo info);
+    }
+
+    private record Profile(String name, Matcher matcher, Mapper mapper, Set<Feature> features) {
+    }
+
+    private static final class RomInfo {
+
+        private final int[] data;
+
+        private Integer crc32;
+
+        private RomInfo(int[] data) {
+            this.data = data;
+        }
+
+        private int byteAt(int address) {
+            return address >= 0 && address < data.length ? data[address] : -1;
+        }
+
+        private int rawType() {
+            return byteAt(0x0147);
+        }
+
+        private String title() {
+            StringBuilder title = new StringBuilder();
+            for (int address = 0x0134; address <= 0x0143 && address < data.length; address++) {
+                int value = data[address];
+                if (value == 0) {
+                    break;
+                }
+                title.append((char) value);
+            }
+            return title.toString();
+        }
+
+        private boolean hasNullTerminatedTitle(String title) {
+            if (0x0134 + title.length() >= data.length) {
+                return false;
+            }
+            for (int i = 0; i < title.length(); i++) {
+                if (data[0x0134 + i] != title.charAt(i)) {
+                    return false;
+                }
+            }
+            return data[0x0134 + title.length()] == 0;
+        }
+
+        private boolean hasValidLogo() {
+            return hasLogoAt(data, 0x104);
+        }
+
+        private int romBanks() {
+            int declaredBanks = switch (byteAt(0x0148)) {
+                case 0 -> 2;
+                case 1 -> 4;
+                case 2 -> 8;
+                case 3 -> 16;
+                case 4 -> 32;
+                case 5 -> 64;
+                case 6 -> 128;
+                case 7 -> 256;
+                case 8 -> 512;
+                case 0x52 -> 72;
+                case 0x53 -> 80;
+                case 0x54 -> 96;
+                default -> 2;
+            };
+            int physicalBanks = Math.max(2, (data.length + 0x3fff) / 0x4000);
+            return Math.max(declaredBanks, physicalBanks);
+        }
+
+        private int crc32() {
+            if (crc32 == null) {
+                CRC32 value = new CRC32();
+                for (int b : data) {
+                    value.update(b);
+                }
+                crc32 = (int) value.getValue();
+            }
+            return crc32;
+        }
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -21,6 +21,7 @@ public final class CartridgeProperties {
         MANI_32K_MULTICART,
         DUZ_MULTICART,
         BHGOS_MULTICART,
+        MAKON_NT_OLD_2,
         SACHEN_MMC1,
         SACHEN_MMC2,
         SACHEN_MMC2_LINEAR,
@@ -74,6 +75,8 @@ public final class CartridgeProperties {
                     Mapper.DUZ_MULTICART),
             mapper("Blue Hippo G.B.O.S. multicart", CartridgeProperties::isBhgosMulticart,
                     Mapper.BHGOS_MULTICART),
+            mapper("Makon/NT old type 2 multicart", CartridgeProperties::isMakonNtOld2,
+                    Mapper.MAKON_NT_OLD_2),
             profile("raw Sachen MMC1", CartridgeProperties::isRawSachenMmc1,
                     Mapper.SACHEN_MMC1, Feature.SCRAMBLED_SACHEN_HEADER),
             profile("raw Sachen MMC2", CartridgeProperties::isRawSachenMmc2,
@@ -248,6 +251,12 @@ public final class CartridgeProperties {
         return "MultiCart".equals(info.title())
                 && isMbc5Type(info.rawType())
                 && info.data.length > 0x8000;
+    }
+
+    private static boolean isMakonNtOld2(RomInfo info) {
+        return info.data.length > 0x80000
+                && "POKEBOM USA".equals(info.title())
+                && info.byteAt(0x0102) == 0xe0;
     }
 
     private static boolean isRawSachenMmc1(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -33,9 +33,9 @@ public class Rom {
 
     private final GameboyColorFlag gameboyColorFlag;
 
-    private final boolean legacySpeedSwitchRequired;
-
     private final boolean superGameboyFlag;
+
+    private final CartridgeProperties cartridgeProperties;
 
     public Rom(File romFile) throws IOException {
         this(loadFile(romFile), romFile);
@@ -51,19 +51,19 @@ public class Rom {
             rom[i] = romByteArray[i] & 0xFF;
         }
 
-        // Raw Sachen MMC1/MMC2 dumps have A0/A6 and A1/A4 swapped throughout the
-        // 0x0100-0x01ff page. Parse their logical header rather than the scrambled bytes
-        // in the file; in particular, 31B-001's CGB flag is physically stored elsewhere.
-        // The mapper still receives the untouched raw image so it can reproduce the bus.
-        boolean rawSachen = isRawSachen(rom);
-        int[] header = rawSachen ? unscrambleSachenHeader(rom) : rom;
+        cartridgeProperties = CartridgeProperties.detect(rom);
+        int[] header = cartridgeProperties.getHeader(rom);
+        if (!cartridgeProperties.getProfiles().isEmpty()) {
+            LOG.info("Cartridge compatibility profiles: {}", cartridgeProperties.getProfiles());
+        }
 
         // Correct an invalid header checksum (0x14D) so the authentic boot ROM does not lock
         // up. The real DMG/CGB boot ROM verifies the checksum over 0x134-0x14C and hangs on
         // the logo screen if it is wrong; some homebrew/PD dumps ship a bad one (e.g.
         // Dimensionless Sample, #76 - it renders past a SKIP boot but hangs the boot ROM).
         // BGB, SameBoy and real flashcarts silently fix it; only touches already-invalid ROMs.
-        if (!rawSachen && rom.length > 0x014D) {
+        if (!cartridgeProperties.has(CartridgeProperties.Feature.SCRAMBLED_SACHEN_HEADER)
+                && rom.length > 0x014D) {
             int headerChecksum = 0;
             for (int a = 0x0134; a <= 0x014C; a++) {
                 headerChecksum = (headerChecksum - rom[a] - 1) & 0xFF;
@@ -83,7 +83,7 @@ public class Rom {
             // Unknown/custom mapper byte. Some are known unlicensed carts we handle
             // deliberately as MBC5; the rest fall back to MBC5 banking rather than
             // refusing to load (issues #58, #71).
-            if (isPocketVoice(header, title)) {
+            if (cartridgeProperties.has(CartridgeProperties.Feature.POCKET_VOICE)) {
                 // The Pocket Voice V2.0 voice recorder (type 0xBE) is MBC5-compatible for
                 // everything the Game Boy can observe: it banks 32x16 KB normally and its
                 // full UI (record screen, built-in sample library) is reachable. The voice
@@ -103,32 +103,13 @@ public class Rom {
         cartridgeType = type;
         LOG.debug("Cartridge {}, type: {}", title, cartridgeType);
         GameboyColorFlag colorFlag = GameboyColorFlag.getFlag(header[0x0143]);
-        boolean legacySpeedSwitchRequired = false;
-        if (isDmgOnlyCrazyCastleTrainer(rom, title)) {
-            // This trainer advertises CGB compatibility but only initializes the DMG
-            // BGP/OBP registers. Native CGB startup therefore renders its menu entirely
-            // white and also leaves HRAM in a state the trainer does not expect.
-            LOG.info("DMG-only Crazy Castle 3 trainer detected; ignoring its CGB flag");
+        if (cartridgeProperties.has(CartridgeProperties.Feature.FORCE_DMG)) {
             colorFlag = GameboyColorFlag.NON_CGB;
-        } else if (isDarkFaderThreadsDemo(rom, title)) {
-            // This early homebrew marks itself CGB-compatible but never initializes CGB
-            // palette RAM; the CGB boot ROM leaves every color white, so native CGB mode
-            // displays a blank screen. Its scheduler only uses hardware shared with DMG,
-            // where BGP supplies the intended monochrome palette.
-            LOG.info("DMG-only DarkFader Threads Demo detected; ignoring its CGB flag");
-            colorFlag = GameboyColorFlag.NON_CGB;
-        } else if (isNamcoGallery2Trainer(rom, title)) {
-            // This old emulator-oriented trainer keeps the original DMG header, but its
-            // launch stub writes KEY1 and executes STOP before handing off to the game.
-            // Accept that speed switch as a narrowly scoped extension while retaining
-            // DMG rendering; treating the whole image as native CGB corrupts its colours.
-            LOG.info("Namco Gallery Vol.2 trainer detected; enabling its CGB speed-switch extension");
-            legacySpeedSwitchRequired = true;
         }
         gameboyColorFlag = colorFlag;
-        this.legacySpeedSwitchRequired = legacySpeedSwitchRequired;
         superGameboyFlag = header[0x0146] == 0x03;
-        romBanks = rawSachen ? Math.max(2, (rom.length + 0x3fff) / 0x4000)
+        romBanks = cartridgeProperties.has(CartridgeProperties.Feature.SCRAMBLED_SACHEN_HEADER)
+                ? Math.max(2, (rom.length + 0x3fff) / 0x4000)
                 : getRomBanks(header[0x0148], rom.length);
         int ramSize = getRamSize(header[0x0149]);
         if (ramSize == 0 && cartridgeType.isRam()) {
@@ -173,108 +154,12 @@ public class Rom {
         return gameboyColorFlag;
     }
 
-    public boolean isLegacySpeedSwitchRequired() {
-        return legacySpeedSwitchRequired;
-    }
-
     public boolean isSuperGameboyFlag() {
         return superGameboyFlag;
     }
 
-    /**
-     * The Lightforce +1 trainer for The Adventures of the Smurfs uses tile 0x0A as
-     * its blank background without uploading that tile. The CGB boot ROM leaves logo
-     * pixels there, while the skip-boot environment the trainer was authored for starts
-     * it at zero. Match the injected trainer code rather than the filename so renamed
-     * copies receive the same compatibility handling.
-     */
-    public boolean requiresBlankCgbBootTile() {
-        int[] trainerSignature = {
-                0x7d, 0xea, 0xa1, 0xc0, 0xe6, 0x03, 0x6f, 0x01,
-                0xe0, 0x01, 0xcb, 0x25, 0xcb, 0x25, 0x09, 0xe9
-        };
-        int signatureOffset = 0xddea4;
-        if (rom.length != 0x100000 || rom[0x0143] != 0xc0 || rom[0x0147] != 0x1b) {
-            return false;
-        }
-        for (int i = 0; i < trainerSignature.length; i++) {
-            if (rom[signatureOffset + i] != trainerSignature[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // The Pocket Voice V2.0 voice recorder uses cartridge-type byte 0xBE and stamps its name
-    // in the header title ("Pocket Voice2.0"); match both so an unrelated cart that happens to
-    // reuse 0xBE is not mislabelled.
-    private static boolean isPocketVoice(int[] rom, String title) {
-        return rom[0x0147] == 0xBE && title.startsWith("Pocket Voice");
-    }
-
-    private static boolean isDmgOnlyCrazyCastleTrainer(int[] rom, String title) {
-        int[] entryStub = {0xf5, 0x3e, 0x03, 0xea, 0x00, 0x21, 0xf1, 0xc3, 0x00, 0x68};
-        if (rom.length != 0x100000 || !"BUGS CC3 CRACK".equals(title)
-                || rom[0x0143] != 0x80 || rom[0x0147] != 0x19) {
-            return false;
-        }
-        for (int i = 0; i < entryStub.length; i++) {
-            if (rom[0x00e0 + i] != entryStub[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isDarkFaderThreadsDemo(int[] rom, String title) {
-        return rom.length == 0x10000
-                && "OS".equals(title)
-                && rom[0x0100] == 0x00 && rom[0x0101] == 0xc3
-                && rom[0x0102] == 0x91 && rom[0x0103] == 0x09
-                && rom[0x0143] == 0x80 && rom[0x0147] == 0x01
-                && rom[0x0149] == 0x00 && rom[0x014c] == 0x01
-                && rom[0x014e] == 0x7b && rom[0x014f] == 0x1e;
-    }
-
-    private static boolean isRawSachen(int[] data) {
-        if (data.length < 0x200) {
-            return false;
-        }
-        boolean mmc1 = data[0x104] == 0xce && data[0x144] == 0xed && data[0x114] == 0x66;
-        boolean mmc2 = data[0x184] == 0xce && data[0x1c4] == 0xed && data[0x194] == 0x66;
-        return mmc1 || mmc2;
-    }
-
-    private static int[] unscrambleSachenHeader(int[] data) {
-        int[] header = new int[0x150];
-        for (int address = 0x100; address < header.length; address++) {
-            header[address] = data[unscrambleSachenAddress(address)];
-        }
-        return header;
-    }
-
-    private static int unscrambleSachenAddress(int address) {
-        int unscrambled = address & 0xffac;
-        unscrambled |= (address & 0x40) >> 6;
-        unscrambled |= (address & 0x10) >> 3;
-        unscrambled |= (address & 0x02) << 3;
-        unscrambled |= (address & 0x01) << 6;
-        return unscrambled;
-    }
-
-    private static boolean isNamcoGallery2Trainer(int[] rom, String title) {
-        int[] speedSwitchStub = {0x3e, 0x01, 0xe0, 0x4d, 0x10, 0x00, 0x00, 0x00,
-                0xcd, 0x0d, 0x71, 0xfa, 0xf0, 0xdf, 0xc3, 0x50, 0x01};
-        if (rom.length != 0x80000 || !"GALLERY2 +4".equals(title)
-                || rom[0x0143] != 0x00 || rom[0x0147] != 0x01) {
-            return false;
-        }
-        for (int i = 0; i < speedSwitchStub.length; i++) {
-            if (rom[0x3f0fc + i] != speedSwitchStub[i]) {
-                return false;
-            }
-        }
-        return true;
+    public CartridgeProperties getCartridgeProperties() {
+        return cartridgeProperties;
     }
 
     private static String getTitle(int[] rom) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
@@ -1,0 +1,197 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+import java.util.Arrays;
+
+/**
+ * Makon/N&amp;T's old type 2 mapper, used by the Pocket Bomberman-based 23-in-1
+ * multicart. Registers 0x5001 and 0x5002 select an embedded game's base and size;
+ * the game's subsequent bank writes are relative to that base. Register 0x5003
+ * enables the alternate ROM-bank bit wiring used by some of the embedded games.
+ */
+public class MakonNtOld2 implements MemoryController {
+
+    private final int[] rom;
+
+    private final int romBanks;
+
+    private final int[] ram = new int[0x2000];
+
+    private final Battery battery;
+
+    private int selectedRomBank = 1;
+
+    private int mappedRomBank = 1;
+
+    private int baseRomBank;
+
+    private int gameRomBankMask;
+
+    private boolean weirdMode;
+
+    private boolean rumbleEnabled;
+
+    private boolean motorOn;
+
+    private boolean ramUpdated;
+
+    private transient EventBus eventBus;
+
+    public MakonNtOld2(Rom rom, Battery battery) {
+        this.rom = rom.getRom();
+        this.romBanks = Math.max(2, (this.rom.length + 0x3fff) / 0x4000);
+        this.gameRomBankMask = Integer.highestOneBit(this.romBanks) - 1;
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (address >= 0x2000 && address < 0x4000) {
+            selectRomBank(value);
+        } else if (address == 0x5001) {
+            setRumbleEnabled((value & 0x80) != 0);
+            updateMotor(value);
+
+            int newBaseRomBank = (value & 0x3f) * 2;
+            if (newBaseRomBank > 0) {
+                baseRomBank = newBaseRomBank;
+                mappedRomBank = 1;
+            }
+        } else if (address == 0x5002) {
+            gameRomBankMask = switch (value & 0x0f) {
+                case 0x08 -> 0x0f; // 256 KiB
+                case 0x0c -> 0x07; // 128 KiB
+                case 0x0e -> 0x03; // 64 KiB
+                case 0x0f -> 0x01; // 32 KiB
+                default -> 0x1f;   // 512 KiB
+            };
+            updateMotor(value);
+        } else if (address == 0x5003) {
+            updateMotor(value);
+            weirdMode = (value & 0x10) != 0;
+            selectRomBank(selectedRomBank);
+        } else if (address >= 0x4000 && address < 0x6000) {
+            updateMotor(value);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            ram[address - 0xa000] = value;
+            ramUpdated = true;
+        }
+    }
+
+    private void selectRomBank(int bank) {
+        if (bank == 0) {
+            bank = 1;
+        }
+        if (weirdMode) {
+            bank = reorderBankBits(bank);
+        }
+        selectedRomBank = bank;
+        mappedRomBank = bank & gameRomBankMask;
+    }
+
+    private static int reorderBankBits(int bank) {
+        return (bank & 0xf8)
+                | ((bank & 0x01) << 2)
+                | ((bank & 0x04) >> 1)
+                | ((bank & 0x02) >> 1);
+    }
+
+    private void setRumbleEnabled(boolean enabled) {
+        rumbleEnabled = enabled;
+        if (!enabled) {
+            setMotorOn(false);
+        }
+    }
+
+    private void updateMotor(int value) {
+        if (rumbleEnabled) {
+            setMotorOn((value & (weirdMode ? 0x08 : 0x02)) != 0);
+        }
+    }
+
+    private void setMotorOn(boolean on) {
+        if (on == motorOn) {
+            return;
+        }
+        motorOn = on;
+        if (eventBus != null) {
+            eventBus.post(new Mbc5.RumbleEvent(on));
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x4000) {
+            return getRomByte(baseRomBank, address);
+        } else if (address >= 0x4000 && address < 0x8000) {
+            return getRomByte(baseRomBank + mappedRomBank, address - 0x4000);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ram[address - 0xa000];
+        }
+        throw new IllegalArgumentException(Integer.toHexString(address));
+    }
+
+    private int getRomByte(int bank, int address) {
+        int offset = Math.floorMod(bank, romBanks) * 0x4000 + address;
+        return offset < rom.length ? rom[offset] : 0xff;
+    }
+
+    @Override
+    public void flushRam() {
+        if (ramUpdated) {
+            battery.saveRam(ram);
+            battery.flush();
+        }
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new MakonNtOld2Memento(battery.saveToMemento(), ram.clone(), selectedRomBank,
+                mappedRomBank, baseRomBank, gameRomBankMask, weirdMode, rumbleEnabled,
+                motorOn, ramUpdated);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof MakonNtOld2Memento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        battery.restoreFromMemento(mem.batteryMemento);
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        selectedRomBank = mem.selectedRomBank;
+        mappedRomBank = mem.mappedRomBank;
+        baseRomBank = mem.baseRomBank;
+        gameRomBankMask = mem.gameRomBankMask;
+        weirdMode = mem.weirdMode;
+        rumbleEnabled = mem.rumbleEnabled;
+        motorOn = mem.motorOn;
+        ramUpdated = mem.ramUpdated;
+    }
+
+    private record MakonNtOld2Memento(Memento<Battery> batteryMemento, int[] ram,
+                                       int selectedRomBank, int mappedRomBank,
+                                       int baseRomBank, int gameRomBankMask,
+                                       boolean weirdMode, boolean rumbleEnabled,
+                                       boolean motorOn, boolean ramUpdated)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -12,8 +13,6 @@ import java.util.Arrays;
 public class Mbc1 implements MemoryController {
 
     private static final Logger LOG = LoggerFactory.getLogger(Mbc1.class);
-
-    private static final int[] NINTENDO_LOGO = {0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B, 0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D, 0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99, 0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E};
 
     private final int romBanks;
 
@@ -63,14 +62,13 @@ public class Mbc1 implements MemoryController {
 
     public Mbc1(Rom rom, Battery battery) {
         this.cartridge = rom.getRom();
-        this.multicart = rom.getRomBanks() == 64 && isMulticart(this.cartridge);
-        this.hongKongPokemonRed = rom.getRomBanks() == 64
-                && "POCKETMON BE".equals(rom.getTitle())
-                && this.cartridge[0x014e] == 0x9c
-                && this.cartridge[0x014f] == 0x8c;
+        CartridgeProperties properties = rom.getCartridgeProperties();
+        this.multicart = properties.has(CartridgeProperties.Feature.MBC1_MULTICART);
+        this.hongKongPokemonRed = properties.has(
+                CartridgeProperties.Feature.MBC1_FULL_BANK_REGISTER);
         this.wideBank = hongKongPokemonRed;
-        this.workMasterFlashCart = "WORK MASTER 1.00".equals(rom.getTitle())
-                && this.cartridge.length == 0x80000;
+        this.workMasterFlashCart = properties.has(
+                CartridgeProperties.Feature.MBC1_ALWAYS_ENABLED_RAM);
         this.ramBanks = rom.getRamBanks();
         this.romBanks = rom.getRomBanks();
         this.ram = new int[0x2000 * this.ramBanks];
@@ -231,23 +229,6 @@ public class Mbc1 implements MemoryController {
         } else {
             return (selectedRamBank % ramBanks) * 0x2000 + (address - 0xa000);
         }
-    }
-
-    private static boolean isMulticart(int[] rom) {
-        int logoCount = 0;
-        for (int i = 0; i < rom.length; i += 0x4000) {
-            boolean logoMatches = true;
-            for (int j = 0; j < NINTENDO_LOGO.length; j++) {
-                if (rom[i + 0x104 + j] != NINTENDO_LOGO[j]) {
-                    logoMatches = false;
-                    break;
-                }
-            }
-            if (logoMatches) {
-                logoCount++;
-            }
-        }
-        return logoCount > 1;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -35,7 +36,8 @@ public class Mbc2 implements MemoryController {
     public Mbc2(Rom rom, Battery battery) {
         this.romBanks = rom.getRomBanks();
         this.cartridge = rom.getRom();
-        this.legacyExtendedBanking = isGokuuHishoudenChineseTranslation(rom);
+        this.legacyExtendedBanking = rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.MBC2_EXTENDED_BANKING);
         this.ram = new int[0x0200];
         Arrays.fill(ram, 0xff);
         this.battery = battery;
@@ -110,29 +112,6 @@ public class Mbc2 implements MemoryController {
 
     private int getRamAddress(int address) {
         return (address - 0xa000) % ram.length;
-    }
-
-    private static boolean isGokuuHishoudenChineseTranslation(Rom rom) {
-        int[] data = rom.getRom();
-        int[] entryAndBankStub = {
-                0x00, 0xc3, 0xf0, 0x3f,
-                0xf5, 0x3e, 0x0c, 0xea, 0x00, 0x20, 0xf1, 0xc3, 0x00, 0x70
-        };
-        if (data.length != 0x80000 || !"GB DBZ GOKOU".equals(rom.getTitle())
-                || data[0x0147] != 0x06 || data[0x0148] != 0x04) {
-            return false;
-        }
-        for (int i = 0; i < 4; i++) {
-            if (data[0x0100 + i] != entryAndBankStub[i]) {
-                return false;
-            }
-        }
-        for (int i = 4; i < entryAndBankStub.length; i++) {
-            if (data[0x3ff0 + i - 4] != entryAndBankStub[i]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/CgbTrainerBootVramTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/CgbTrainerBootVramTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core;
 
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -28,7 +29,8 @@ public class CgbTrainerBootVramTest {
     @Test
     public void clearsOnlyTheUninitializedBlankTileAfterCgbBoot() throws IOException {
         Rom rom = new Rom(trainerRom());
-        assertTrue(rom.requiresBlankCgbBootTile());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.BLANK_CGB_BOOT_TILE));
 
         Gameboy gb = new Gameboy.GameboyConfiguration(rom)
                 .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
@@ -53,7 +55,8 @@ public class CgbTrainerBootVramTest {
         byte[] data = trainerRom();
         data[0xddea4] ^= 1;
 
-        assertFalse(new Rom(data).requiresBlankCgbBootTile());
+        assertFalse(new Rom(data).getCartridgeProperties().has(
+                CartridgeProperties.Feature.BLANK_CGB_BOOT_TILE));
     }
 
     private static boolean isBlankTile(Gameboy gb) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DatelTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/DatelTest.java
@@ -66,7 +66,8 @@ public class DatelTest {
     @Test
     public void detectedAsDatel() throws IOException {
         assertNotNull(build().getDatel());
-        assertEquals(true, Cartridge.isDatel(new Rom(datelRom())));
+        assertEquals(CartridgeProperties.Mapper.DATEL,
+                new Rom(datelRom()).getCartridgeProperties().getMapper());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/NamcoGallery2TrainerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/NamcoGallery2TrainerTest.java
@@ -18,7 +18,8 @@ public class NamcoGallery2TrainerTest {
         Rom rom = new Rom(trainerRom());
 
         assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
-        assertTrue(rom.isLegacySpeedSwitchRequired());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.LEGACY_SPEED_SWITCH));
         assertEquals(GameboyType.DMG, new Gameboy.GameboyConfiguration(rom).getGameboyType());
     }
 
@@ -29,7 +30,8 @@ public class NamcoGallery2TrainerTest {
         Rom rom = new Rom(data);
 
         assertEquals(Rom.GameboyColorFlag.NON_CGB, rom.getGameboyColorFlag());
-        assertFalse(rom.isLegacySpeedSwitchRequired());
+        assertFalse(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.LEGACY_SPEED_SWITCH));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -1,0 +1,132 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MakonNtOld2Test {
+
+    @Test
+    public void detectsIssue229RomAndRelocatesEmbeddedGames() throws IOException {
+        Rom rom = new Rom(multicartRom(0xe0));
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+        MemoryController mapper = cartridge.getMemoryController();
+
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_OLD_2,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(mapper instanceof MakonNtOld2);
+
+        // Before the menu chooses a game, all 2 MiB are bankable.
+        mapper.setByte(0x2000, 65);
+        assertEquals(65, mapper.getByte(0x4000));
+
+        // Select the 512 KiB game beginning at byte 0x100000 (ROM bank 64).
+        mapper.setByte(0x5001, 0x20);
+        mapper.setByte(0x5002, 0x00);
+        assertEquals(64, mapper.getByte(0x0000));
+        assertEquals(65, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 3);
+        assertEquals(67, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void masksBanksToTheSelectedGameSizeAndSupportsAlternateWiring()
+            throws IOException {
+        MemoryController mapper = new MakonNtOld2(
+                new Rom(multicartRom(0xe0)), Battery.NULL_BATTERY);
+
+        // A 128 KiB game begins at ROM bank 96. Bank 9 wraps to bank 1 within it.
+        mapper.setByte(0x5001, 0x30);
+        mapper.setByte(0x5002, 0x0c);
+        mapper.setByte(0x2000, 9);
+        assertEquals(96, mapper.getByte(0x0000));
+        assertEquals(97, mapper.getByte(0x4000));
+
+        // Alternate wiring maps low bank bits 001 -> 100, 010 -> 001, 100 -> 010.
+        mapper.setByte(0x2000, 1);
+        mapper.setByte(0x5003, 0x10);
+        assertEquals(100, mapper.getByte(0x4000));
+        mapper.setByte(0x2000, 2);
+        assertEquals(97, mapper.getByte(0x4000));
+        mapper.setByte(0x2000, 4);
+        assertEquals(98, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void mementoRestoresMappingAndVolatileRam() throws IOException {
+        MemoryController mapper = new MakonNtOld2(
+                new Rom(multicartRom(0xe0)), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x5001, 0x30);
+        mapper.setByte(0x5002, 0x0c);
+        mapper.setByte(0x2000, 3);
+        mapper.setByte(0xa123, 0x5a);
+        Memento<MemoryController> memento = mapper.saveToMemento();
+
+        mapper.setByte(0x5001, 0x20);
+        mapper.setByte(0x2000, 7);
+        mapper.setByte(0xa123, 0x33);
+        mapper.restoreFromMemento(memento);
+
+        assertEquals(96, mapper.getByte(0x0000));
+        assertEquals(99, mapper.getByte(0x4000));
+        assertEquals(0x5a, mapper.getByte(0xa123));
+    }
+
+    @Test
+    public void controlsRumbleUsingTheMapperMode() throws IOException {
+        List<Boolean> motorLog = new ArrayList<>();
+        MakonNtOld2 mapper = new MakonNtOld2(
+                new Rom(multicartRom(0xe0)), Battery.NULL_BATTERY);
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        bus.register(event -> motorLog.add(event.on()), Mbc5.RumbleEvent.class);
+        mapper.init(bus);
+
+        mapper.setByte(0x5001, 0x80); // enable rumble; old mode uses bit 1
+        mapper.setByte(0x4000, 0x02);
+        mapper.setByte(0x4000, 0x00);
+        mapper.setByte(0x5003, 0x10); // alternate mode uses bit 3
+        mapper.setByte(0x4000, 0x08);
+        mapper.setByte(0x5001, 0x00); // disabling rumble also stops the motor
+
+        assertEquals(List.of(true, false, true, false), motorLog);
+    }
+
+    @Test
+    public void doesNotRouteTheRelated25In1ThroughTheType2Mapper() throws IOException {
+        Rom rom = new Rom(multicartRom(0xc0));
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof Mbc5);
+    }
+
+    private static byte[] multicartRom(int entryByte) {
+        byte[] data = new byte[128 * 0x4000];
+        for (int bank = 0; bank < 128; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        byte[] title = "POKEBOM USA".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x134, title.length);
+        data[0x0102] = (byte) entryByte;
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x19; // MBC5 in the menu's standard header
+        data[0x0148] = 0x06; // 2 MiB
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary

- centralize all non-standard cartridge signatures in CartridgeProperties, with mapper selection and feature flags consumed by the emulator
- remove ROM-specific detection helpers from Rom, Cartridge, Mbc1, and Mbc2
- add the Makon/N&T old type 2 mapper used by the reported 23 in 1 ROM, including embedded-game base/size selection, alternate bank wiring, RAM, rumble, and save-state support
- add regression coverage for routing, banking, mapper modes, RAM, rumble, and mementos

The changes are split into the requested two commits: the compatibility-profile refactor first, then the issue fix.

## Verification

- /opt/apache-maven-3.8.6/bin/mvn test (237 tests across core, controller, and Swing)
- reproduced the original failure with the ROM attached to #229
- verified the exact attachment now launches Super Mario 3 and Bomber Man 6 from the multicart menu

Closes #229