### PR TITLE
Support BBD unlicensed mapper

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -48,6 +48,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
+            case BBD -> new Bbd(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);
             case SACHEN_MMC2 -> new SachenMmc(rom, true, true);
             case SACHEN_MMC2_LINEAR -> new SachenMmc(rom, true, false);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -22,6 +22,7 @@ public final class CartridgeProperties {
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
+        BBD,
         SACHEN_MMC1,
         SACHEN_MMC2,
         SACHEN_MMC2_LINEAR,
@@ -77,6 +78,8 @@ public final class CartridgeProperties {
                     Mapper.BHGOS_MULTICART),
             mapper("Makon/NT old type 2 multicart", CartridgeProperties::isMakonNtOld2,
                     Mapper.MAKON_NT_OLD_2),
+            mapper("BBD unlicensed mapper", CartridgeProperties::isBbd,
+                    Mapper.BBD),
             profile("raw Sachen MMC1", CartridgeProperties::isRawSachenMmc1,
                     Mapper.SACHEN_MMC1, Feature.SCRAMBLED_SACHEN_HEADER),
             profile("raw Sachen MMC2", CartridgeProperties::isRawSachenMmc2,
@@ -257,6 +260,12 @@ public final class CartridgeProperties {
         return info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;
+    }
+
+    private static boolean isBbd(RomInfo info) {
+        int secondaryLogo = info.crc32(0x0184, 0x30);
+        return (secondaryLogo == 0xc7d8c1df || secondaryLogo == 0x6d1ea662)
+                && info.byteAt(0x7fff) != 0x01;
     }
 
     private static boolean isRawSachenMmc1(RomInfo info) {
@@ -516,13 +525,20 @@ public final class CartridgeProperties {
 
         private int crc32() {
             if (crc32 == null) {
-                CRC32 value = new CRC32();
-                for (int b : data) {
-                    value.update(b);
-                }
-                crc32 = (int) value.getValue();
+                crc32 = crc32(0, data.length);
             }
             return crc32;
+        }
+
+        private int crc32(int offset, int length) {
+            if (offset < 0 || length < 0 || offset + length > data.length) {
+                return -1;
+            }
+            CRC32 value = new CRC32();
+            for (int i = offset; i < offset + length; i++) {
+                value.update(data[i]);
+            }
+            return (int) value.getValue();
         }
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
@@ -1,0 +1,112 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+/**
+ * The unlicensed BBD mapper used by Garou/Fatal Fury bootlegs. It is MBC5-compatible,
+ * with additional registers that permute ROM-bank bits and data bits in the switchable
+ * window. The game programs both permutations before reading its protected code.
+ */
+public class Bbd implements MemoryController {
+
+    private static final int[] IDENTITY = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    private static final int[][] DATA_REORDERING = {
+            IDENTITY,
+            IDENTITY,
+            IDENTITY,
+            IDENTITY,
+            {0, 5, 1, 3, 4, 2, 6, 7},
+            {0, 4, 2, 3, 1, 5, 6, 7},
+            IDENTITY,
+            {0, 1, 5, 3, 4, 2, 6, 7}
+    };
+
+    private static final int[][] BANK_REORDERING = {
+            IDENTITY,
+            IDENTITY,
+            IDENTITY,
+            {3, 4, 2, 0, 1, 5, 6, 7},
+            IDENTITY,
+            {1, 2, 3, 4, 0, 5, 6, 7},
+            IDENTITY,
+            IDENTITY
+    };
+
+    private final Mbc5 delegate;
+
+    private int dataSwapMode;
+
+    private int bankSwapMode;
+
+    public Bbd(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        switch (address & 0xf0ff) {
+            case 0x2000 -> value = reorderBits(value, BANK_REORDERING[bankSwapMode]);
+            case 0x2001 -> dataSwapMode = value & 0x07;
+            case 0x2080 -> bankSwapMode = value & 0x07;
+            default -> {
+            }
+        }
+        delegate.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        int value = delegate.getByte(address);
+        if (address >= 0x4000 && address < 0x8000) {
+            return reorderBits(value, DATA_REORDERING[dataSwapMode]);
+        }
+        return value;
+    }
+
+    private static int reorderBits(int value, int[] reorder) {
+        int result = 0;
+        for (int newBit = 0; newBit < 8; newBit++) {
+            result |= ((value >> reorder[newBit]) & 1) << newBit;
+        }
+        return result;
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new BbdMemento(delegate.saveToMemento(), dataSwapMode, bankSwapMode);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof BbdMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        delegate.restoreFromMemento(mem.delegateMemento);
+        dataSwapMode = mem.dataSwapMode;
+        bankSwapMode = mem.bankSwapMode;
+    }
+
+    private record BbdMemento(Memento<MemoryController> delegateMemento, int dataSwapMode,
+                              int bankSwapMode) implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BbdTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/BbdTest.java
@@ -1,0 +1,74 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BbdTest {
+
+    private static final int[] GAROU_SECONDARY_LOGO = {
+            0xf8, 0x8e, 0x54, 0x44, 0x88, 0x88, 0xd9, 0x99,
+            0xe0, 0x0c, 0xf8, 0x8f, 0x08, 0x80, 0xf8, 0x8e,
+            0x55, 0x55, 0xe1, 0x1e, 0x46, 0x65, 0x13, 0x35,
+            0x88, 0x80, 0x44, 0x40, 0x55, 0x20, 0x11, 0x10,
+            0x00, 0xe0, 0xa9, 0x80, 0x00, 0x80, 0x88, 0x80,
+            0x55, 0x50, 0x42, 0x10, 0x54, 0x40, 0x59, 0x90
+    };
+
+    @Test
+    public void detectsGarouSecondaryLogo() throws IOException {
+        Rom rom = new Rom(bbdRom());
+
+        assertEquals(CartridgeProperties.Mapper.BBD,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY).getMemoryController() instanceof Bbd);
+    }
+
+    @Test
+    public void reordersBankAndDataBits() throws IOException {
+        byte[] data = bbdRom();
+        data[4 * 0x4000 + 0x0123] = 0x04;
+        data[8 * 0x4000 + 0x0123] = 0x58;
+        Bbd mapper = new Bbd(new Rom(data), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2001, 0x04); // data mode 4; MBC5 also selects bank 4
+        assertEquals(0x20, mapper.getByte(0x4123));
+
+        mapper.setByte(0x2001, 0x00); // data mode 0
+        mapper.setByte(0x2080, 0x03); // bank mode 3
+        mapper.setByte(0x2000, 0x01); // bit 0 is routed to bank bit 3
+        assertEquals(0x58, mapper.getByte(0x4123));
+    }
+
+    @Test
+    public void mementoRestoresProtectionModes() throws IOException {
+        byte[] data = bbdRom();
+        data[4 * 0x4000 + 0x0123] = 0x04;
+        Bbd mapper = new Bbd(new Rom(data), Battery.NULL_BATTERY);
+        mapper.setByte(0x2001, 0x04);
+        Memento<MemoryController> memento = mapper.saveToMemento();
+
+        mapper.setByte(0x2001, 0x00);
+        mapper.restoreFromMemento(memento);
+        assertEquals(0x20, mapper.getByte(0x4123));
+    }
+
+    private static byte[] bbdRom() {
+        byte[] rom = new byte[0x100000];
+        rom[0x0147] = 0x19; // MBC5-compatible base mapper
+        rom[0x0148] = 0x05;
+        for (int i = 0; i < GAROU_SECONDARY_LOGO.length; i++) {
+            rom[0x0184 + i] = (byte) GAROU_SECONDARY_LOGO[i];
+        }
+        return rom;
+    }
+}


### PR DESCRIPTION
Fixes #231.

Detect the Garou/Fatal Fury BBD board from its secondary-logo signature and emulate its MBC5-derived bank-bit and data-bit permutation registers. Mapper state is included in save states.

Verification:
- `mvn -q -pl core test`
- Reproduced the supplied ROM through its character intro sequence (frame 600).