### PR TITLE
Support Sintax unlicensed mapper

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -48,6 +48,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
+            case SINTAX -> new Sintax(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);
             case SACHEN_MMC2 -> new SachenMmc(rom, true, true);
             case SACHEN_MMC2_LINEAR -> new SachenMmc(rom, true, false);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -22,6 +22,7 @@ public final class CartridgeProperties {
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
+        SINTAX,
         SACHEN_MMC1,
         SACHEN_MMC2,
         SACHEN_MMC2_LINEAR,
@@ -77,6 +78,8 @@ public final class CartridgeProperties {
                     Mapper.BHGOS_MULTICART),
             mapper("Makon/NT old type 2 multicart", CartridgeProperties::isMakonNtOld2,
                     Mapper.MAKON_NT_OLD_2),
+            mapper("Sintax unlicensed mapper", CartridgeProperties::isSintax,
+                    Mapper.SINTAX),
             profile("raw Sachen MMC1", CartridgeProperties::isRawSachenMmc1,
                     Mapper.SACHEN_MMC1, Feature.SCRAMBLED_SACHEN_HEADER),
             profile("raw Sachen MMC2", CartridgeProperties::isRawSachenMmc2,
@@ -257,6 +260,12 @@ public final class CartridgeProperties {
         return info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;
+    }
+
+    private static boolean isSintax(RomInfo info) {
+        int secondaryLogo = info.crc32(0x0184, 0x30);
+        return (secondaryLogo == 0x6c1dcf2d || secondaryLogo == 0x99e3449d)
+                && info.byteAt(0x7fff) != 0x01;
     }
 
     private static boolean isRawSachenMmc1(RomInfo info) {
@@ -516,13 +525,20 @@ public final class CartridgeProperties {
 
         private int crc32() {
             if (crc32 == null) {
-                CRC32 value = new CRC32();
-                for (int b : data) {
-                    value.update(b);
-                }
-                crc32 = (int) value.getValue();
+                crc32 = crc32(0, data.length);
             }
             return crc32;
+        }
+
+        private int crc32(int offset, int length) {
+            if (offset < 0 || length < 0 || offset + length > data.length) {
+                return -1;
+            }
+            CRC32 value = new CRC32();
+            for (int i = offset; i < offset + length; i++) {
+                value.update(data[i]);
+            }
+            return (int) value.getValue();
         }
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
@@ -1,0 +1,132 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+/**
+ * The Sintax unlicensed mapper used by Crash II Advance and other bootlegs. Its base is
+ * MBC5, with a programmable ROM-bank bit permutation and four XOR values selected by
+ * the low two bits of the unpermuted bank number.
+ */
+public class Sintax implements MemoryController {
+
+    private static final int[] IDENTITY = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    private static final int[][] BANK_REORDERING = {
+            {2, 1, 4, 3, 6, 5, 0, 7},
+            {3, 2, 5, 4, 7, 6, 1, 0},
+            IDENTITY,
+            IDENTITY,
+            IDENTITY,
+            {4, 5, 2, 3, 0, 1, 6, 7},
+            IDENTITY,
+            {6, 7, 4, 5, 1, 3, 0, 2},
+            IDENTITY,
+            {7, 6, 1, 0, 3, 2, 5, 4},
+            IDENTITY,
+            {5, 4, 7, 6, 1, 0, 3, 2},
+            IDENTITY,
+            {2, 3, 4, 5, 6, 7, 0, 1},
+            IDENTITY,
+            IDENTITY
+    };
+
+    private final Mbc5 delegate;
+
+    private final int[] xorValues = new int[4];
+
+    private int mode;
+
+    private int bankNo;
+
+    private int romBankXor;
+
+    public Sintax(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if ((address & 0xf0f0) == 0x5010) {
+            mode = value & 0x0f;
+            selectBank();
+            return;
+        }
+        if (address >= 0x2000 && address < 0x3000) {
+            bankNo = value;
+            selectBank();
+            return;
+        }
+        if (address >= 0x7000 && address < 0x8000) {
+            int xorIndex = (address & 0x00f0) >> 4;
+            if (xorIndex >= 2 && xorIndex <= 5) {
+                xorValues[xorIndex - 2] = value;
+                romBankXor = xorValues[bankNo & 0x03];
+            }
+        }
+        delegate.setByte(address, value);
+    }
+
+    private void selectBank() {
+        delegate.setByte(0x2000, reorderBits(bankNo, BANK_REORDERING[mode]));
+        romBankXor = xorValues[bankNo & 0x03];
+    }
+
+    @Override
+    public int getByte(int address) {
+        int value = delegate.getByte(address);
+        return address >= 0x4000 && address < 0x8000 ? value ^ romBankXor : value;
+    }
+
+    private static int reorderBits(int value, int[] reorder) {
+        int result = 0;
+        for (int newBit = 0; newBit < 8; newBit++) {
+            result |= ((value >> reorder[newBit]) & 1) << newBit;
+        }
+        return result;
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new SintaxMemento(delegate.saveToMemento(), xorValues.clone(), mode, bankNo,
+                romBankXor);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof SintaxMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        if (mem.xorValues.length != xorValues.length) {
+            throw new IllegalArgumentException("Memento XOR values length doesn't match");
+        }
+        delegate.restoreFromMemento(mem.delegateMemento);
+        System.arraycopy(mem.xorValues, 0, xorValues, 0, xorValues.length);
+        mode = mem.mode;
+        bankNo = mem.bankNo;
+        romBankXor = mem.romBankXor;
+    }
+
+    private record SintaxMemento(Memento<MemoryController> delegateMemento, int[] xorValues,
+                                 int mode, int bankNo, int romBankXor)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SintaxTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SintaxTest.java
@@ -1,0 +1,74 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SintaxTest {
+
+    private static final int[] CRASH_II_SECONDARY_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0x99, 0x89, 0x93, 0x73, 0x22, 0x0d, 0x44, 0x0b,
+            0xcc, 0xc3, 0xcd, 0xc3, 0x3f, 0x3c, 0x20, 0x2f,
+            0x57, 0x78, 0x22, 0x87, 0x66, 0xe1, 0xdd, 0x1e
+    };
+
+    @Test
+    public void detectsCrashIiSecondaryLogo() throws IOException {
+        Rom rom = new Rom(sintaxRom());
+
+        assertEquals(CartridgeProperties.Mapper.SINTAX,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY).getMemoryController() instanceof Sintax);
+    }
+
+    @Test
+    public void appliesBankPermutationAndPerBankXor() throws IOException {
+        byte[] data = sintaxRom();
+        data[64 * 0x4000 + 0x0123] = 0x55;
+        Sintax mapper = new Sintax(new Rom(data), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x7030, 0x22); // XOR value selected by unpermuted bank 1
+        mapper.setByte(0x5010, 0x00); // mode 0
+        mapper.setByte(0x2000, 0x01); // bank bit 0 is routed to bit 6
+
+        assertEquals(0x77, mapper.getByte(0x4123));
+    }
+
+    @Test
+    public void mementoRestoresProtectionState() throws IOException {
+        byte[] data = sintaxRom();
+        data[64 * 0x4000 + 0x0123] = 0x55;
+        Sintax mapper = new Sintax(new Rom(data), Battery.NULL_BATTERY);
+        mapper.setByte(0x7030, 0x22);
+        mapper.setByte(0x5010, 0x00);
+        mapper.setByte(0x2000, 0x01);
+        Memento<MemoryController> memento = mapper.saveToMemento();
+
+        mapper.setByte(0x7030, 0x00);
+        mapper.setByte(0x2000, 0x02);
+        mapper.restoreFromMemento(memento);
+        assertEquals(0x77, mapper.getByte(0x4123));
+    }
+
+    private static byte[] sintaxRom() {
+        byte[] rom = new byte[0x200000];
+        rom[0x0147] = 0x19; // MBC5-compatible base mapper
+        rom[0x0148] = 0x06;
+        for (int i = 0; i < CRASH_II_SECONDARY_LOGO.length; i++) {
+            rom[0x0184 + i] = (byte) CRASH_II_SECONDARY_LOGO[i];
+        }
+        return rom;
+    }
+}


### PR DESCRIPTION
Fixes #232.

Detect the Crash II Advance Sintax board from its secondary-logo signature and emulate its MBC5-derived bank-bit permutation plus four programmable XOR values. Mapper state is included in save states.

Verification:
- `mvn -q -pl core test`
- Reproduced the supplied ROM through its animated story sequence (frame 1400).