### PR TITLE
Support SL multi-game cartridges

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -304,6 +304,9 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         eventBus.register(
                 e -> requestWarmReset(((eu.rekawek.coffeegb.core.memory.cart.type.Datel.LaunchEvent) e).nonCgbGame),
                 eu.rekawek.coffeegb.core.memory.cart.type.Datel.LaunchEvent.class);
+        eventBus.register(
+                e -> requestWarmReset(((eu.rekawek.coffeegb.core.memory.cart.type.SlMulticart.ResetEvent) e).nonCgbGame()),
+                eu.rekawek.coffeegb.core.memory.cart.type.SlMulticart.ResetEvent.class);
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -45,6 +45,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case BUNG_EMS -> new BungEms(rom, battery);
             case HIDDEN_MMM01 -> new Mmm01(rom, battery, false);
             case MANI_32K_MULTICART -> new Mani32kMulticart(rom);
+            case SL_MULTICART -> new SlMulticart(rom, battery);
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
@@ -136,6 +137,9 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
                     ? rom.getRamSize() : 0x2000 * rom.getRamBanks();
             if (rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.BUNG_EMS) {
                 ramSize = 0x8000;
+            }
+            if (rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.SL_MULTICART) {
+                ramSize = 0x20000;
             }
             if (ramSize == 0 && rom.getType().isRam()) {
                 ramSize = 0x2000;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -19,6 +19,7 @@ public final class CartridgeProperties {
         BUNG_EMS,
         HIDDEN_MMM01,
         MANI_32K_MULTICART,
+        SL_MULTICART,
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
@@ -71,6 +72,8 @@ public final class CartridgeProperties {
                     Mapper.HIDDEN_MMM01),
             mapper("Mani 32 KiB multicart", CartridgeProperties::isMani32kMulticart,
                     Mapper.MANI_32K_MULTICART),
+            mapper("SL multicart", CartridgeProperties::isSlMulticart,
+                    Mapper.SL_MULTICART),
             mapper("Duz multicart", CartridgeProperties::isDuzMulticart,
                     Mapper.DUZ_MULTICART),
             mapper("Blue Hippo G.B.O.S. multicart", CartridgeProperties::isBhgosMulticart,
@@ -245,6 +248,18 @@ public final class CartridgeProperties {
             }
         }
         return false;
+    }
+
+    private static boolean isSlMulticart(RomInfo info) {
+        int[] title = {
+                'P', 'O', 'K', 'E', 'M', 'O', 'N', '_',
+                'G', 'L', 'D', 'A', 'A', 'U', 'J'
+        };
+        return info.data.length == 0x400000
+                && matches(info.data, 0x0134, title)
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x10
+                && info.byteAt(0x0148) == 0x06;
     }
 
     private static boolean isBhgosMulticart(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
@@ -1,0 +1,210 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+
+import java.util.Arrays;
+
+/**
+ * The SL multi-game cartridge controller used by large Chinese MBC1/MBC5 collections.
+ * The menu starts in configuration mode, where writes to 0x5000 and 0x7000 select a
+ * command and its argument. It assigns a ROM base and mask and an independent SRAM
+ * partition to the selected game, then pulses the console reset line. Those assignments
+ * survive the reset and the selected game sees an ordinary MBC1- or MBC5-like interface.
+ */
+public class SlMulticart implements MemoryController {
+
+    public record ResetEvent(boolean nonCgbGame) implements Event {
+    }
+
+    private final int[] rom;
+
+    private final int romBanks;
+
+    private final int[] ram = new int[0x20000];
+
+    private final Battery battery;
+
+    private int configCommand = 0x100;
+
+    private int baseRomBank;
+
+    private int selectedRomBank = 1;
+
+    private int romBankMask = 1;
+
+    private int zeroRemap;
+
+    private boolean configurationMode = true;
+
+    private boolean mbc5Mode;
+
+    private boolean ramAllowed;
+
+    private boolean ramEnabled;
+
+    private int baseRamBank;
+
+    private int selectedRamBank;
+
+    private int ramBankMask;
+
+    private transient EventBus eventBus = EventBus.NULL_EVENT_BUS;
+
+    public SlMulticart(Rom rom, Battery battery) {
+        this.rom = rom.getRom();
+        this.romBanks = Math.max(2, this.rom.length / 0x4000);
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (address < 0x2000) {
+            ramEnabled = ramAllowed && (value & 0x0f) == 0x0a;
+        } else if (address < 0x3000) {
+            selectedRomBank = value;
+        } else if (address < 0x4000) {
+            if (!mbc5Mode) {
+                selectedRomBank = value;
+            }
+        } else if (address < 0x5000) {
+            selectedRamBank = value & 0x0f;
+        } else if (address < 0x6000) {
+            if (configurationMode) {
+                configCommand = value;
+            } else {
+                selectedRamBank = value & 0x0f;
+            }
+        } else if (address >= 0x7000 && address < 0x8000 && configurationMode) {
+            executeConfiguration(value);
+        } else if (address >= 0xa000 && address < 0xc000 && ramEnabled) {
+            ram[ramAddress(address)] = value;
+        }
+    }
+
+    private void executeConfiguration(int value) {
+        switch (configCommand) {
+            case 0x55 -> configureMapping(value);
+            case 0xaa -> baseRomBank = (baseRomBank & ~0x01fe) | (value << 1);
+            case 0xbb -> {
+                ramAllowed = (value & 0x20) != 0;
+                baseRamBank = value & 0x0f;
+                ramBankMask = (value & 0x10) != 0 ? 0 : 3;
+                if (!ramAllowed) {
+                    ramEnabled = false;
+                }
+            }
+            default -> {
+                // Vast Fame menus write a stray 0x07 after setting the base bank.
+            }
+        }
+        configCommand = 0x100;
+    }
+
+    private void configureMapping(int value) {
+        baseRomBank = (baseRomBank & ~0x0200) | (((value >>> 3) & 1) << 9);
+        romBankMask = (2 << ((~value) & 7)) - 1;
+        int mode = (value >>> 5) & 3;
+        mbc5Mode = mode == 0;
+        zeroRemap = mode == 3 ? 1 : 0;
+        configurationMode = false;
+        if ((value & 0x80) != 0) {
+            selectedRomBank = 1;
+            ramEnabled = false;
+            int cgbFlag = rom[romAddress(lowRomBank(), 0x0143)];
+            eventBus.post(new ResetEvent((cgbFlag & 0x80) == 0));
+        }
+    }
+
+    private int lowRomBank() {
+        return baseRomBank & ~romBankMask;
+    }
+
+    private int highRomBank() {
+        int bank = selectedRomBank & romBankMask;
+        return (baseRomBank & ~romBankMask) | (bank != 0 ? bank : zeroRemap & romBankMask);
+    }
+
+    private int ramBank() {
+        return (baseRamBank & ~ramBankMask) | (selectedRamBank & ramBankMask);
+    }
+
+    private int romAddress(int bank, int offset) {
+        return Math.floorMod(bank, romBanks) * 0x4000 + offset;
+    }
+
+    private int ramAddress(int address) {
+        return (ramBank() & 0x0f) * 0x2000 + address - 0xa000;
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address < 0x4000) {
+            return rom[romAddress(lowRomBank(), address)];
+        } else if (address < 0x8000) {
+            return rom[romAddress(highRomBank(), address - 0x4000)];
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ramEnabled ? ram[ramAddress(address)] : 0xff;
+        }
+        return 0xff;
+    }
+
+    @Override
+    public void flushRam() {
+        battery.saveRam(ram);
+        battery.flush();
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento() {
+        return new SlMulticartMemento(ram.clone(), configCommand, baseRomBank,
+                selectedRomBank, romBankMask, zeroRemap, configurationMode, mbc5Mode,
+                ramAllowed, ramEnabled, baseRamBank, selectedRamBank, ramBankMask);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<MemoryController> memento) {
+        if (!(memento instanceof SlMulticartMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        configCommand = mem.configCommand;
+        baseRomBank = mem.baseRomBank;
+        selectedRomBank = mem.selectedRomBank;
+        romBankMask = mem.romBankMask;
+        zeroRemap = mem.zeroRemap;
+        configurationMode = mem.configurationMode;
+        mbc5Mode = mem.mbc5Mode;
+        ramAllowed = mem.ramAllowed;
+        ramEnabled = mem.ramEnabled;
+        baseRamBank = mem.baseRamBank;
+        selectedRamBank = mem.selectedRamBank;
+        ramBankMask = mem.ramBankMask;
+    }
+
+    private record SlMulticartMemento(int[] ram, int configCommand, int baseRomBank,
+                                      int selectedRomBank, int romBankMask, int zeroRemap,
+                                      boolean configurationMode, boolean mbc5Mode,
+                                      boolean ramAllowed, boolean ramEnabled, int baseRamBank,
+                                      int selectedRamBank, int ramBankMask)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticartTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticartTest.java
@@ -1,0 +1,137 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SlMulticartTest {
+
+    private static final int BANKS = 256;
+
+    private static byte[] slRom() {
+        byte[] rom = new byte[BANKS * 0x4000];
+        byte[] title = "POKEMON_GLDAAUJ".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, rom, 0x0134, title.length);
+        rom[0x0143] = (byte) 0x80;
+        rom[0x0147] = 0x10;
+        rom[0x0148] = 0x06;
+        rom[0x0149] = 0x03;
+        for (int bank = 0; bank < BANKS; bank++) {
+            rom[bank * 0x4000 + 0x0200] = (byte) bank;
+        }
+        return rom;
+    }
+
+    private static Cartridge cartridge() throws IOException {
+        return new Cartridge(new Rom(slRom()), Battery.NULL_BATTERY);
+    }
+
+    @Test
+    public void detectsTheSl36In1BeforeTheBroadDuzHeuristic() throws IOException {
+        byte[] rom = slRom();
+        // An embedded game header is what caused the old Duz false positive.
+        int[] logo = {
+                0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+                0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+                0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+                0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+                0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+                0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+        };
+        for (int i = 0; i < logo.length; i++) {
+            rom[2 * 0x4000 + 0x0104 + i] = (byte) logo[i];
+        }
+
+        assertEquals(CartridgeProperties.Mapper.SL_MULTICART,
+                new Rom(rom).getCartridgeProperties().getMapper());
+    }
+
+    @Test
+    public void configurationRelocatesBothRomWindowsAndUsesMbc1ZeroRemap()
+            throws IOException {
+        Cartridge cart = cartridge();
+        assertEquals(0, cart.getByte(0x0200));
+        assertEquals(1, cart.getByte(0x4200));
+
+        // Base bank 64, eight-bank window, MBC1 mode.
+        cart.setByte(0x5000, 0xaa);
+        cart.setByte(0x7000, 0x20);
+        cart.setByte(0x5000, 0x55);
+        cart.setByte(0x7000, 0x65);
+        assertEquals(64, cart.getByte(0x0200));
+        assertEquals(65, cart.getByte(0x4200));
+
+        cart.setByte(0x2000, 3);
+        assertEquals(67, cart.getByte(0x4200));
+        cart.setByte(0x2000, 0);
+        assertEquals(65, cart.getByte(0x4200));
+        // In MBC1 mode the complete 0x2000-0x3fff range selects the bank.
+        cart.setByte(0x3000, 4);
+        assertEquals(68, cart.getByte(0x4200));
+    }
+
+    @Test
+    public void mbc5ModeIgnoresTheCoarseBankRange() throws IOException {
+        Cartridge cart = cartridge();
+        cart.setByte(0x5000, 0x55);
+        cart.setByte(0x7000, 0x05); // eight-bank window, MBC5 mode
+        cart.setByte(0x2000, 2);
+        cart.setByte(0x3000, 7);
+        assertEquals(2, cart.getByte(0x4200));
+    }
+
+    @Test
+    public void ramConfigurationAllocatesAnIndependentPartition() throws IOException {
+        Cartridge cart = cartridge();
+        cart.setByte(0x5000, 0xbb);
+        cart.setByte(0x7000, 0x25); // RAM allowed, base bank 5, four-bank mask
+        cart.setByte(0x5000, 0x55);
+        cart.setByte(0x7000, 0x65);
+        cart.setByte(0x0000, 0x0a);
+
+        cart.setByte(0x4000, 2); // (5 & ~3) | 2 = bank 6
+        cart.setByte(0xa123, 0x42);
+        cart.setByte(0x4000, 1);
+        assertEquals(0xff, cart.getByte(0xa123));
+        cart.setByte(0x4000, 2);
+        assertEquals(0x42, cart.getByte(0xa123));
+    }
+
+    @Test
+    public void launchResetsBankAndRequestsTheSelectedConsoleMode() throws IOException {
+        byte[] rom = slRom();
+        // The selected game's header is monochrome.
+        rom[64 * 0x4000 + 0x0143] = 0x00;
+        Cartridge cart = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        AtomicReference<SlMulticart.ResetEvent> reset = new AtomicReference<>();
+        cart.init(bus);
+        bus.register(reset::set, SlMulticart.ResetEvent.class);
+
+        cart.setByte(0x5000, 0xaa);
+        cart.setByte(0x7000, 0x20);
+        cart.setByte(0x2000, 7);
+        cart.setByte(0x5000, 0x55);
+        cart.setByte(0x7000, 0xe5); // MBC1 mode, eight-bank window, reset
+
+        assertNotNull(reset.get());
+        assertTrue(reset.get().nonCgbGame());
+        assertEquals(64, cart.getByte(0x0200));
+        assertEquals(65, cart.getByte(0x4200));
+
+        // Configuration registers are no longer exposed after launch.
+        cart.setByte(0x5000, 0xaa);
+        cart.setByte(0x7000, 0x00);
+        assertEquals(64, cart.getByte(0x0200));
+    }
+}


### PR DESCRIPTION
Fixes #233.

The supplied 36-in-1 is an SL multicart, but its MBC3-shaped header and embedded game logos made the broad compatibility heuristic select the Duz mapper. This adds the SL controller described by MAME: configuration commands, masked/base-relative MBC1 and MBC5 ROM banking, partitioned 128 KiB SRAM, and the cartridge-triggered console reset used when launching a selected game.

Verification:
- `/opt/maven/bin/mvn -q -pl core test`
- Supplied ROM reaches the 36-game menu instead of booting Pokémon directly
- Selected Burger Fighter and verified it proceeds into gameplay after the cartridge reset
- Added focused mapper/detection/reset/RAM regression tests

Hardware reference: https://github.com/mamedev/mame/blob/master/src/devices/bus/gameboy/slmulti.cpp