### PR TITLE
Handle Sachen option-probe open bus

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -41,7 +41,8 @@ public final class CartridgeProperties {
         MBC1_MULTICART,
         MBC1_FULL_BANK_REGISTER,
         MBC1_ALWAYS_ENABLED_RAM,
-        MBC2_EXTENDED_BANKING
+        MBC2_EXTENDED_BANKING,
+        SACHEN_OPEN_BUS_BANKS
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -81,6 +82,8 @@ public final class CartridgeProperties {
                     Mapper.SACHEN_MMC1, Feature.SCRAMBLED_SACHEN_HEADER),
             profile("raw Sachen MMC2", CartridgeProperties::isRawSachenMmc2,
                     Mapper.SACHEN_MMC2, Feature.SCRAMBLED_SACHEN_HEADER),
+            features("Rocman X Gold option probe", CartridgeProperties::isRocmanXGold,
+                    Feature.SACHEN_OPEN_BUS_BANKS),
             mapper("linear-header Sachen MMC2", CartridgeProperties::isLinearSachenMmc2,
                     Mapper.SACHEN_MMC2_LINEAR),
             mapper("cooked Sachen MMC", CartridgeProperties::isCookedSachen,
@@ -280,6 +283,10 @@ public final class CartridgeProperties {
                 && info.byteAt(0x106) == 0xc0
                 && info.byteAt(0x107) == 0x00
                 && hasLogoAt(info.data, 0x184);
+    }
+
+    private static boolean isRocmanXGold(RomInfo info) {
+        return info.crc32() == 0x7e1351cf;
     }
 
     private static boolean isCookedSachen(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java
@@ -4,6 +4,8 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 
+import static eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties.Feature.SACHEN_OPEN_BUS_BANKS;
+
 /**
  * The Sachen MMC1/MMC2 multicart mapper ("4B-xxx" 4-in-1 collections and the Rocket Games
  * two-in-one carts, issues #73/#75), modelled after mGBA's reverse-engineered
@@ -58,6 +60,8 @@ public class SachenMmc implements MemoryController {
 
     private final boolean scrambledHeader;
 
+    private final boolean openBusForOutOfRangeBanks;
+
     // while true, reads of the 0x0104-0x0133 logo window return the Nintendo logo instead of
     // the linear ROM data. Cooked dumps have no logo stored (the raw carts serve it through
     // the scrambling/lockout); this reproduces that so the authentic boot ROM's logo check
@@ -80,11 +84,19 @@ public class SachenMmc implements MemoryController {
 
     /** Raw cart, optionally using the alternate straight-through header wiring. */
     public SachenMmc(Rom rom, boolean mmc2, boolean scrambledHeader) {
+        this(rom, mmc2, scrambledHeader,
+                rom.getCartridgeProperties().has(SACHEN_OPEN_BUS_BANKS));
+    }
+
+    /** Raw cart with an explicit out-of-range bank behavior (for focused mapper tests). */
+    public SachenMmc(Rom rom, boolean mmc2, boolean scrambledHeader,
+                     boolean openBusForOutOfRangeBanks) {
         this.rom = rom.getRom();
         this.romBanks = Math.max(2, this.rom.length / 0x4000);
         this.mmc2 = mmc2;
         this.cooked = false;
         this.scrambledHeader = scrambledHeader;
+        this.openBusForOutOfRangeBanks = openBusForOutOfRangeBanks;
         // the MMC1 has no DMG/CGB detection phase; it starts in the counting state
         this.lockState = mmc2 ? LOCKED_DMG : LOCKED_CGB;
     }
@@ -96,6 +108,7 @@ public class SachenMmc implements MemoryController {
         this.mmc2 = true;
         this.cooked = true;
         this.scrambledHeader = false;
+        this.openBusForOutOfRangeBanks = false;
         this.lockState = UNLOCKED;
         this.base = initialBase;
         this.serveBootLogo = true;
@@ -171,12 +184,22 @@ public class SachenMmc implements MemoryController {
             // the cooked dumps hold the menu at its physical bank; the raw carts map
             // the masked base like mGBA does
             int bank0 = cooked ? base : (base & mask);
-            return rom[(bank0 % romBanks) * 0x4000 + address];
+            return readBank(bank0, address);
         } else if (address < 0x8000) {
-            int effective = ((unmaskedBank & ~mask) | (base & mask)) % romBanks;
-            return rom[effective * 0x4000 + (address - 0x4000)];
+            int effective = (unmaskedBank & ~mask) | (base & mask);
+            return readBank(effective, address - 0x4000);
         }
         return 0xff;
+    }
+
+    private int readBank(int bank, int address) {
+        if (bank < 0 || bank >= romBanks) {
+            if (openBusForOutOfRangeBanks) {
+                return 0xff;
+            }
+            bank = Math.floorMod(bank, romBanks);
+        }
+        return rom[bank * 0x4000 + address];
     }
 
     private int lockAndUnscramble(int address) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RawSachenTest.java
@@ -68,6 +68,23 @@ public class RawSachenTest {
         assertEquals(128, new Rom(rawMmc2Rom(0x200000)).getRomBanks());
     }
 
+    @Test
+    public void outOfRangeBanksReadAsOpenBusRatherThanMirroring() throws IOException {
+        byte[] data = rawMmc2Rom(0x80000); // 32 physical banks
+        data[0x0200] = 0x42;
+        SachenMmc mapper = new SachenMmc(new Rom(data), true, true, true);
+        assertEquals(0x42, mapper.getByte(0x0200));
+
+        // The Rocman X Gold startup probes banks 0x20 and 0x40 to detect the MMC2
+        // board's solder options. These addresses are beyond its 32-bank ROM and must
+        // see the pulled-up bus; wrapping them to bank zero makes the probe loop forever.
+        mapper.setByte(0x2000, 0xff); // enable base/mask register writes
+        mapper.setByte(0x0000, 0x20);
+        mapper.setByte(0x4000, 0x20);
+        assertEquals(0xff, mapper.getByte(0x0200));
+        assertEquals(0xff, mapper.getByte(0x4200));
+    }
+
     private static byte[] rawMmc2Rom() {
         return rawMmc2Rom(0x200000);
     }


### PR DESCRIPTION
Fixes #236.

This is stacked on #239 because the supplied MMC2 ROM also needs that boot-transition correction. After boot, Rocman X Gold deliberately probes physical banks 0x20 and 0x40 to identify the board solder-option layout. The 512 KiB dump has only banks 0x00-0x1f, but the mapper wrapped absent banks modulo the image size; all probes therefore resembled bank zero and the startup routine repeated forever.

This adds a compatibility flag for the supplied board and returns pulled-up/open-bus data for its absent physical banks while preserving the intentional mirroring behavior of other Sachen boards.

Verification:
- `/opt/maven/bin/mvn -q -pl core test`
- Supplied ROM reaches the Rocman X title screen
- Pressed Start and verified the game proceeds into its opening/gameplay scene
- Added a focused regression test for the absent-bank probe

Hardware context: https://blog.tauwasser.eu/one-week-later/