### PR TITLE
Fix Helitac audio after starting game

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -187,7 +187,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         mmu.indexSpaces();
         mmu.setBusListener(cartridge.getSachenMmc());
 
-        cpu = new Cpu(new DmaCpuAddressSpace(getAddressSpace(), dma, gbc),
+        cpu = new Cpu(new DmaCpuAddressSpace(getAddressSpace(), dma, gbc,
+                cartridgeProperties.has(CartridgeProperties.Feature.DMA_BLOCKED_READS_RETURN_FF)),
                 interruptManager, gpu, speedMode, display);
 
         interruptManager.disableInterrupts(false);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
@@ -13,10 +13,18 @@ public class DmaCpuAddressSpace implements AddressSpace, Serializable {
 
     private final boolean gbc;
 
+    private final boolean blockedReadsReturnFF;
+
     public DmaCpuAddressSpace(AddressSpace addressSpace, Dma dma, boolean gbc) {
+        this(addressSpace, dma, gbc, false);
+    }
+
+    public DmaCpuAddressSpace(AddressSpace addressSpace, Dma dma, boolean gbc,
+                              boolean blockedReadsReturnFF) {
         this.addressSpace = addressSpace;
         this.dma = dma;
         this.gbc = gbc;
+        this.blockedReadsReturnFF = blockedReadsReturnFF;
     }
 
     @Override
@@ -34,7 +42,7 @@ public class DmaCpuAddressSpace implements AddressSpace, Serializable {
     @Override
     public int getByte(int address) {
         if (dma.isCpuAccessBlocked(address, gbc)) {
-            return dma.getCpuBusValue();
+            return blockedReadsReturnFF ? 0xff : dma.getCpuBusValue();
         }
         return addressSpace.getByte(address);
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -41,7 +41,8 @@ public final class CartridgeProperties {
         MBC1_MULTICART,
         MBC1_FULL_BANK_REGISTER,
         MBC1_ALWAYS_ENABLED_RAM,
-        MBC2_EXTENDED_BANKING
+        MBC2_EXTENDED_BANKING,
+        DMA_BLOCKED_READS_RETURN_FF
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -101,6 +102,8 @@ public final class CartridgeProperties {
                     Feature.LEGACY_SPEED_SWITCH),
             features("Smurfs Lightforce trainer", CartridgeProperties::isSmurfsTrainer,
                     Feature.BLANK_CGB_BOOT_TILE),
+            features("Helitac demo DMA compatibility", CartridgeProperties::isHelitacDemo,
+                    Feature.DMA_BLOCKED_READS_RETURN_FF),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -363,6 +366,17 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0143) == 0xc0
                 && info.rawType() == 0x1b
                 && matches(info.data, 0xddea4, trainerSignature);
+    }
+
+    private static boolean isHelitacDemo(RomInfo info) {
+        return info.data.length == 0x100000
+                && "Helitac".equals(info.title())
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x1c
+                && info.byteAt(0x0148) == 0x05
+                && info.byteAt(0x0149) == 0x00
+                && info.byteAt(0x014e) == 0x35
+                && info.byteAt(0x014f) == 0xbc;
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
@@ -39,6 +39,14 @@ public class DmaCpuAddressSpaceTest {
         assertEquals(0x42, fixture.cpu.getByte(0xc001));
     }
 
+    @Test
+    public void compatibilityModeReturnsFFForBlockedReads() {
+        Fixture fixture = new Fixture(true, 0xc0, true);
+
+        assertEquals(0xff, fixture.cpu.getByte(0xc001));
+        assertEquals(0x11, fixture.cpu.getByte(0x0100));
+    }
+
     private static class Fixture {
 
         private final TestAddressSpace memory = new TestAddressSpace();
@@ -46,6 +54,10 @@ public class DmaCpuAddressSpaceTest {
         private final DmaCpuAddressSpace cpu;
 
         private Fixture(boolean gbc, int sourceHigh) {
+            this(gbc, sourceHigh, false);
+        }
+
+        private Fixture(boolean gbc, int sourceHigh, boolean blockedReadsReturnFF) {
             memory.setByte(0x0100, 0x11);
             memory.setByte(0x8000, 0x55);
             memory.setByte(0xc001, 0x22);
@@ -53,7 +65,7 @@ public class DmaCpuAddressSpaceTest {
             memory.setByte(sourceHigh << 8, 0x42);
 
             Dma dma = new Dma(memory, new Ram(0xfe00, 0xa0), new SpeedMode(gbc));
-            cpu = new DmaCpuAddressSpace(memory, dma, gbc);
+            cpu = new DmaCpuAddressSpace(memory, dma, gbc, blockedReadsReturnFF);
             dma.setByte(0xff46, sourceHigh);
             for (int i = 0; i < 5; i++) {
                 dma.tick();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/HelitacCompatibilityTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/HelitacCompatibilityTest.java
@@ -1,0 +1,40 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HelitacCompatibilityTest {
+
+    @Test
+    public void detectsTheHelitacDemoAudioCompatibility() throws IOException {
+        Rom rom = new Rom(helitacDemo());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.DMA_BLOCKED_READS_RETURN_FF));
+    }
+
+    @Test
+    public void doesNotMatchAnotherHelitacBuild() throws IOException {
+        byte[] data = helitacDemo();
+        data[0x014f] ^= 1;
+
+        assertFalse(new Rom(data).getCartridgeProperties().has(
+                CartridgeProperties.Feature.DMA_BLOCKED_READS_RETURN_FF));
+    }
+
+    private static byte[] helitacDemo() {
+        byte[] data = new byte[0x100000];
+        byte[] title = "Helitac".getBytes();
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x1c;
+        data[0x0148] = 0x05;
+        data[0x014e] = 0x35;
+        data[0x014f] = (byte) 0xbc;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #245.

Helitac reads WRAM while an OAM DMA owns that bus. Its audio path expects blocked reads to return `FF`; exposing the DMA source byte eventually treats the cartridge startup stub as CH3 waveform data and produces a sustained buzz.

This adds an exact-ROM compatibility profile that returns `FF` only for blocked reads in this demo, preserving the hardware-oriented default for every other ROM.

Verification:
- full Maven test suite
- replayed the attached ROM through the title speech and into a new game
- confirmed the CH3 wave table remains zero after playback and the sustained output is gone