### PR TITLE
Fix Helitac V0.01 stray sprites

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -104,6 +104,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     private boolean blankCgbBootTilePending;
 
+    private boolean clearCgbBootOamShadowPending;
+
     private transient volatile boolean doPause;
 
     private transient volatile boolean paused;
@@ -121,6 +123,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         CartridgeProperties cartridgeProperties = configuration.rom.getCartridgeProperties();
         blankCgbBootTilePending = cartridgeProperties.has(
                 CartridgeProperties.Feature.BLANK_CGB_BOOT_TILE);
+        clearCgbBootOamShadowPending = cartridgeProperties.has(
+                CartridgeProperties.Feature.CLEAR_CGB_BOOT_OAM_SHADOW);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -217,20 +221,31 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             applyPostBootState(configuration.rom.getGameboyColorFlag() == Rom.GameboyColorFlag.NON_CGB
                     && !cartridgeProperties.has(CartridgeProperties.Feature.DATEL_CGB_HEADER));
         }
-        applyBootVramCompatibilityIfReady();
+        applyBootCompatibilityIfReady();
     }
 
-    private void applyBootVramCompatibilityIfReady() {
-        if (!blankCgbBootTilePending || !biosShadow.isBootFinished()) {
+    private void applyBootCompatibilityIfReady() {
+        if (!biosShadow.isBootFinished()) {
             return;
         }
-        // This trainer treats tile 0x0A as blank but does not replace the CGB boot
-        // logo residue in its 16 data bytes. Do not sanitize any other cartridge or
-        // any other part of VRAM: boot-state-dependent software still sees hardware.
-        for (int address = 0x80a0; address < 0x80b0; address++) {
-            gpu.getVideoRam0().setByte(address, 0);
+        if (blankCgbBootTilePending) {
+            // This trainer treats tile 0x0A as blank but does not replace the CGB boot
+            // logo residue in its 16 data bytes. Do not sanitize any other cartridge or
+            // any other part of VRAM: boot-state-dependent software still sees hardware.
+            for (int address = 0x80a0; address < 0x80b0; address++) {
+                gpu.getVideoRam0().setByte(address, 0);
+            }
+            blankCgbBootTilePending = false;
         }
-        blankCgbBootTilePending = false;
+        if (clearCgbBootOamShadowPending) {
+            // This early demo uses C000-C09F as its OAM shadow without initializing the
+            // unused entries. The authentic CGB boot leaves cartridge scratch data there,
+            // while boot-skipping emulators leave zeroes; clear only that shadow once.
+            for (int address = 0xc000; address < 0xc0a0; address++) {
+                mmu.setByte(address, 0);
+            }
+            clearCgbBootOamShadowPending = false;
+        }
     }
 
     /**
@@ -353,7 +368,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         boolean result = false;
 
         Mode newMode = tickSubsystems();
-        applyBootVramCompatibilityIfReady();
+        applyBootCompatibilityIfReady();
         if (newMode != null) {
             hdma.onGpuUpdate(newMode);
         }
@@ -496,7 +511,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending);
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending, clearCgbBootOamShadowPending);
     }
 
     @Override
@@ -530,6 +545,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         lcdDisabled = mem.lcdDisabled();
         lcdOffTicks = mem.lcdOffTicks();
         blankCgbBootTilePending = mem.blankCgbBootTilePending();
+        clearCgbBootOamShadowPending = mem.clearCgbBootOamShadowPending();
     }
 
     @Override
@@ -553,7 +569,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,
                                   Memento<Genie> genieMemento, boolean requestScreenRefresh,
                                   boolean lcdDisabled, int lcdOffTicks,
-                                  boolean blankCgbBootTilePending) implements Memento<Gameboy> {
+                                  boolean blankCgbBootTilePending,
+                                  boolean clearCgbBootOamShadowPending) implements Memento<Gameboy> {
     }
 
     public enum BootstrapMode {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -41,7 +41,8 @@ public final class CartridgeProperties {
         MBC1_MULTICART,
         MBC1_FULL_BANK_REGISTER,
         MBC1_ALWAYS_ENABLED_RAM,
-        MBC2_EXTENDED_BANKING
+        MBC2_EXTENDED_BANKING,
+        CLEAR_CGB_BOOT_OAM_SHADOW
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -101,6 +102,8 @@ public final class CartridgeProperties {
                     Feature.LEGACY_SPEED_SWITCH),
             features("Smurfs Lightforce trainer", CartridgeProperties::isSmurfsTrainer,
                     Feature.BLANK_CGB_BOOT_TILE),
+            features("Helitac V0.01 boot WRAM", CartridgeProperties::isHelitacV001,
+                    Feature.CLEAR_CGB_BOOT_OAM_SHADOW),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -363,6 +366,17 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0143) == 0xc0
                 && info.rawType() == 0x1b
                 && matches(info.data, 0xddea4, trainerSignature);
+    }
+
+    private static boolean isHelitacV001(RomInfo info) {
+        return info.data.length == 0x100000
+                && "Helitac".equals(info.title())
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x1c
+                && info.byteAt(0x0148) == 0x05
+                && info.byteAt(0x0149) == 0x00
+                && info.byteAt(0x014e) == 0x5e
+                && info.byteAt(0x014f) == 0xb8;
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/HelitacBootWramTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/HelitacBootWramTest.java
@@ -1,0 +1,81 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HelitacBootWramTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void clearsTheUninitializedOamShadowAfterCgbBoot() throws IOException {
+        Rom rom = new Rom(helitacV001());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_CGB_BOOT_OAM_SHADOW));
+
+        Gameboy gb = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                .setSupportBatterySave(false)
+                .build();
+
+        long limit = 40_000_000;
+        while (!isOamShadowClear(gb) && limit-- > 0) {
+            gb.tick();
+        }
+        assertTrue("boot did not reach the cartridge handoff", limit > 0);
+        for (int address = 0xc000; address < 0xc0a0; address++) {
+            assertEquals(Integer.toHexString(address), 0, gb.getAddressSpace().getByte(address));
+        }
+    }
+
+    private static boolean isOamShadowClear(Gameboy gb) {
+        for (int address = 0xc000; address < 0xc0a0; address++) {
+            if (gb.getAddressSpace().getByte(address) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Test
+    public void doesNotMatchAnotherHelitacBuild() throws IOException {
+        byte[] data = helitacV001();
+        data[0x014f] ^= 1;
+
+        assertFalse(new Rom(data).getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_CGB_BOOT_OAM_SHADOW));
+    }
+
+    private static byte[] helitacV001() {
+        byte[] data = new byte[0x100000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        byte[] title = "Helitac".getBytes();
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x1c;
+        data[0x0148] = 0x05;
+        data[0x014e] = 0x5e;
+        data[0x014f] = (byte) 0xb8;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #246.

Helitac V0.01 uses C000-C09F as its OAM shadow without initializing unused entries. The authentic CGB boot leaves scratch data in that range, so the demo DMA-copies stray sprites; boot-skipping emulators start it at zero.

This adds an exact-ROM compatibility profile that clears only those 160 shadow bytes once at the cartridge handoff. Other WRAM and every other ROM retain the normal boot state.

Verification:
- full Maven test suite
- replayed the supplied ROM through the scrolling demo
- inspected frames through 600; the fixed output contains only the intended helicopter sprites and no stationary squares