### PR TITLE
Fix FreeArt Intro V2 blank screen

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -41,6 +41,7 @@ public final class CartridgeProperties {
         MBC1_MULTICART,
         MBC1_FULL_BANK_REGISTER,
         MBC1_ALWAYS_ENABLED_RAM,
+        MBC1_RAM_ENABLED_AT_POWER_ON,
         MBC2_EXTENDED_BANKING
     }
 
@@ -101,6 +102,8 @@ public final class CartridgeProperties {
                     Feature.LEGACY_SPEED_SWITCH),
             features("Smurfs Lightforce trainer", CartridgeProperties::isSmurfsTrainer,
                     Feature.BLANK_CGB_BOOT_TILE),
+            features("FreeArt Intro V2", CartridgeProperties::isFreeArtIntroV2,
+                    Feature.MBC1_RAM_ENABLED_AT_POWER_ON),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -363,6 +366,23 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0143) == 0xc0
                 && info.rawType() == 0x1b
                 && matches(info.data, 0xddea4, trainerSignature);
+    }
+
+    private static boolean isFreeArtIntroV2(RomInfo info) {
+        int[] entryStub = {
+                0xf3, 0x31, 0xff, 0xff, 0x97, 0xe0, 0x40, 0xe0,
+                0x42, 0xe0, 0x43, 0x3c, 0xe0, 0x4d, 0xe0, 0xff,
+                0x10, 0x00, 0xcd, 0x78, 0x16
+        };
+        return info.data.length == 0x8000
+                && info.title().startsWith("FreeArt Intro 2")
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x02
+                && info.byteAt(0x0148) == 0x00
+                && info.byteAt(0x0149) == 0x03
+                && info.byteAt(0x014e) == 0xc1
+                && info.byteAt(0x014f) == 0x1d
+                && matches(info.data, 0x0150, entryStub);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -79,7 +79,11 @@ public class Mbc1 implements MemoryController {
         // power-on and never gates it off. Work Master writes ordinary flash commands
         // through 0000-1FFF; treating those as MBC1 RAM-disable commands makes later
         // file reads return FF and sends the image viewer into unmapped work RAM.
-        ramWriteEnabled = workMasterFlashCart;
+        // FreeArt Intro V2 writes a lookup table to external RAM before its first MBC1
+        // enable command. Period emulators exposed the RAM at startup, and the demo was
+        // authored around that behaviour; after boot it uses the normal enable register.
+        ramWriteEnabled = workMasterFlashCart || properties.has(
+                CartridgeProperties.Feature.MBC1_RAM_ENABLED_AT_POWER_ON);
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/FreeArtIntroV2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/FreeArtIntroV2Test.java
@@ -1,0 +1,62 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.Mbc1;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FreeArtIntroV2Test {
+
+    @Test
+    public void originalIntroCanWriteMbc1RamBeforeItsFirstEnableCommand() throws IOException {
+        Rom rom = new Rom(freeArtIntroRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.MBC1_RAM_ENABLED_AT_POWER_ON));
+
+        Mbc1 mapper = new Mbc1(rom, Battery.NULL_BATTERY);
+        mapper.setByte(0xa000, 0x5a);
+        assertEquals(0x5a, mapper.getByte(0xa000));
+    }
+
+    @Test
+    public void ordinaryMbc1RamStillStartsFilledWithFf() throws IOException {
+        byte[] data = freeArtIntroRom();
+        data[0x0150] = 0x00;
+        Rom rom = new Rom(data);
+
+        assertFalse(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.MBC1_RAM_ENABLED_AT_POWER_ON));
+
+        Mbc1 mapper = new Mbc1(rom, Battery.NULL_BATTERY);
+        mapper.setByte(0xa000, 0x5a);
+        assertEquals(0xff, mapper.getByte(0xa000));
+    }
+
+    private static byte[] freeArtIntroRom() {
+        byte[] data = new byte[0x8000];
+        byte[] title = "FreeArt Intro 2".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x02;
+        data[0x0148] = 0x00;
+        data[0x0149] = 0x03;
+        data[0x014e] = (byte) 0xc1;
+        data[0x014f] = 0x1d;
+        int[] entryStub = {
+                0xf3, 0x31, 0xff, 0xff, 0x97, 0xe0, 0x40, 0xe0,
+                0x42, 0xe0, 0x43, 0x3c, 0xe0, 0x4d, 0xe0, 0xff,
+                0x10, 0x00, 0xcd, 0x78, 0x16
+        };
+        for (int i = 0; i < entryStub.length; i++) {
+            data[0x0150 + i] = (byte) entryStub[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #248

## Summary

- detect the original 32 KiB FreeArt Intro V2 release with a narrow compatibility profile
- expose its MBC1 RAM at power-on so the pre-enable lookup-table upload is retained
- keep normal MBC1 RAM gating after the demo writes its enable register
- add regression tests for both the exact profile and ordinary MBC1 carts

## Root cause

The intro writes a lookup table into external RAM before issuing its first MBC1 RAM-enable command. Period emulators exposed that RAM on startup, which the demo relies on. Coffee GB correctly dropped those writes under standard MBC1 behavior, leaving the demo with invalid lookup data and a blank display.

## Verification

- `/opt/maven/bin/mvn -q test`
- replayed the attached original ROM through the opening logo and later credits sequence without modifying the ROM or RAM externally