### PR TITLE
Remove boot-logo residue from AudioArts music demo

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -104,6 +104,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     private boolean blankCgbBootTilePending;
 
+    private boolean clearBootTilemapPending;
+
     private transient volatile boolean doPause;
 
     private transient volatile boolean paused;
@@ -121,6 +123,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         CartridgeProperties cartridgeProperties = configuration.rom.getCartridgeProperties();
         blankCgbBootTilePending = cartridgeProperties.has(
                 CartridgeProperties.Feature.BLANK_CGB_BOOT_TILE);
+        clearBootTilemapPending = cartridgeProperties.has(
+                CartridgeProperties.Feature.CLEAR_BOOT_TILEMAP);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -221,16 +225,28 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     }
 
     private void applyBootVramCompatibilityIfReady() {
-        if (!blankCgbBootTilePending || !biosShadow.isBootFinished()) {
+        if ((!blankCgbBootTilePending && !clearBootTilemapPending)
+                || !biosShadow.isBootFinished()) {
             return;
         }
-        // This trainer treats tile 0x0A as blank but does not replace the CGB boot
-        // logo residue in its 16 data bytes. Do not sanitize any other cartridge or
-        // any other part of VRAM: boot-state-dependent software still sees hardware.
-        for (int address = 0x80a0; address < 0x80b0; address++) {
-            gpu.getVideoRam0().setByte(address, 0);
+        if (blankCgbBootTilePending) {
+            // This trainer treats tile 0x0A as blank but does not replace the CGB boot
+            // logo residue in its 16 data bytes. Do not sanitize any other cartridge or
+            // any other part of VRAM: boot-state-dependent software still sees hardware.
+            for (int address = 0x80a0; address < 0x80b0; address++) {
+                gpu.getVideoRam0().setByte(address, 0);
+            }
+            blankCgbBootTilePending = false;
         }
-        blankCgbBootTilePending = false;
+        if (clearBootTilemapPending) {
+            // This emulator-targeted music player replaces its font tiles and writes
+            // the visible strings, but never clears the boot logo's tile-map entries.
+            // Period emulators launched it from a zeroed map, which is its intended UI.
+            for (int address = 0x9800; address < 0xa000; address++) {
+                gpu.getVideoRam0().setByte(address, 0);
+            }
+            clearBootTilemapPending = false;
+        }
     }
 
     /**
@@ -496,7 +512,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending);
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending, clearBootTilemapPending);
     }
 
     @Override
@@ -530,6 +546,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         lcdDisabled = mem.lcdDisabled();
         lcdOffTicks = mem.lcdOffTicks();
         blankCgbBootTilePending = mem.blankCgbBootTilePending();
+        clearBootTilemapPending = mem.clearBootTilemapPending();
     }
 
     @Override
@@ -553,7 +570,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,
                                   Memento<Genie> genieMemento, boolean requestScreenRefresh,
                                   boolean lcdDisabled, int lcdOffTicks,
-                                  boolean blankCgbBootTilePending) implements Memento<Gameboy> {
+                                  boolean blankCgbBootTilePending,
+                                  boolean clearBootTilemapPending) implements Memento<Gameboy> {
     }
 
     public enum BootstrapMode {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -36,6 +36,7 @@ public final class CartridgeProperties {
         FORCE_DMG,
         LEGACY_SPEED_SWITCH,
         BLANK_CGB_BOOT_TILE,
+        CLEAR_BOOT_TILEMAP,
         DATEL_CGB_HEADER,
         SCRAMBLED_SACHEN_HEADER,
         MBC1_MULTICART,
@@ -101,6 +102,8 @@ public final class CartridgeProperties {
                     Feature.LEGACY_SPEED_SWITCH),
             features("Smurfs Lightforce trainer", CartridgeProperties::isSmurfsTrainer,
                     Feature.BLANK_CGB_BOOT_TILE),
+            features("AudioArts Gameboy Music V1", CartridgeProperties::isAudioArtsMusicV1,
+                    Feature.CLEAR_BOOT_TILEMAP),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -363,6 +366,25 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0143) == 0xc0
                 && info.rawType() == 0x1b
                 && matches(info.data, 0xddea4, trainerSignature);
+    }
+
+    private static boolean isAudioArtsMusicV1(RomInfo info) {
+        int[] entryStub = {
+                0xf3, 0x31, 0xf4, 0xff, 0xc3, 0x69, 0x01, 0x33,
+                0x15, 0x00, 0x40, 0x4b, 0x47, 0x6b, 0x48, 0x00
+        };
+        return info.data.length == 0x8000
+                && "Gameboy Music V1".equals(info.title())
+                && info.rawType() == 0x00
+                && info.byteAt(0x0148) == 0x00
+                && info.byteAt(0x0149) == 0x00
+                && info.byteAt(0x014a) == 0xde
+                && info.byteAt(0x014b) == 0xc0
+                && info.byteAt(0x014c) == 0x03
+                && info.byteAt(0x014d) == 0xba
+                && info.byteAt(0x014e) == 0x0f
+                && info.byteAt(0x014f) == 0x84
+                && matches(info.data, 0x0150, entryStub);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/AudioArtsBootTilemapTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/AudioArtsBootTilemapTest.java
@@ -1,0 +1,95 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AudioArtsBootTilemapTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void clearsBootLogoMapWithoutClearingBootTileData() throws IOException {
+        Rom rom = new Rom(audioArtsRom());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_BOOT_TILEMAP));
+
+        Gameboy gb = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                .setSupportBatterySave(false)
+                .build();
+
+        long limit = 100;
+        while (!isTilemapClear(gb) && limit-- > 0) {
+            gb.tick();
+        }
+        assertTrue("boot did not reach the cartridge handoff", limit > 0);
+        for (int address = 0x9800; address < 0xa000; address++) {
+            assertEquals(Integer.toHexString(address), 0,
+                    gb.getGpu().getVideoRam0().getByte(address));
+        }
+        assertTrue(gb.getGpu().getVideoRam0().getByte(0x8010) != 0);
+    }
+
+    @Test
+    public void nearMatchDoesNotClearTheBootTilemap() throws IOException {
+        byte[] data = audioArtsRom();
+        data[0x0150] ^= 1;
+
+        assertFalse(new Rom(data).getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_BOOT_TILEMAP));
+    }
+
+    private static boolean isTilemapClear(Gameboy gb) {
+        for (int address = 0x9800; address < 0xa000; address++) {
+            if (gb.getGpu().getVideoRam0().getByte(address) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static byte[] audioArtsRom() {
+        byte[] data = new byte[0x8000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        byte[] title = "Gameboy Music V1".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0147] = 0x00;
+        data[0x0148] = 0x00;
+        data[0x0149] = 0x00;
+        data[0x014a] = (byte) 0xde;
+        data[0x014b] = (byte) 0xc0;
+        data[0x014c] = 0x03;
+        data[0x014d] = (byte) 0xba;
+        data[0x014e] = 0x0f;
+        data[0x014f] = (byte) 0x84;
+        int[] entryStub = {
+                0xf3, 0x31, 0xf4, 0xff, 0xc3, 0x69, 0x01, 0x33,
+                0x15, 0x00, 0x40, 0x4b, 0x47, 0x6b, 0x48, 0x00
+        };
+        for (int i = 0; i < entryStub.length; i++) {
+            data[0x0150 + i] = (byte) entryStub[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #251

## Summary

- detect the original AudioArts Gameboy Music V1 ROM with a narrow compatibility profile
- clear only the boot ROM tilemap residue at cartridge handoff
- preserve boot tile graphics and the authentic boot state for every other ROM
- persist the pending compatibility action in save states
- add exact-match, near-match, and VRAM-scope regression coverage

## Root cause

The player uploads its own font and writes its visible strings, but does not clear the background tilemaps first. Coffee GB fast-forwards the authentic DMG boot ROM, whose Nintendo-logo map entries therefore remain visible as the reported symbols. The demo was authored around period emulators that launched it with zeroed tilemaps.

## Verification

- `/opt/maven/bin/mvn -q test`
- replayed the attached ROM with the normal fast-forward boot path; the music-player screen is clean and remains interactive