### PR TITLE
Add infrared communication to linked sessions

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
+import eu.rekawek.coffeegb.core.ir.InfraredEndpoint
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memento.Originator
@@ -13,6 +14,7 @@ class Session(
     val eventBus: EventBus,
     private val console: Console?,
     serialEndpoint: SerialEndpoint = SerialEndpoint.NULL_ENDPOINT,
+    infraredEndpoint: InfraredEndpoint = InfraredEndpoint.NULL_ENDPOINT,
 ) : AutoCloseable, Originator<Session> {
 
   internal val gameboy: Gameboy = config.build()
@@ -21,7 +23,7 @@ class Session(
     private set
 
   init {
-    gameboy.init(eventBus, serialEndpoint, console)
+    gameboy.init(eventBus, serialEndpoint, infraredEndpoint, console)
   }
 
   /** Hot-swaps the link-port device (e.g. connecting the printer) without a reset. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -29,6 +29,7 @@ import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.gpu.Display
+import eu.rekawek.coffeegb.core.ir.Peer2PeerInfraredEndpoint
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
@@ -74,6 +75,10 @@ class LinkedController(
 
   private val peerSerialEndpoint = Peer2PeerSerialEndpoint()
 
+  private val mainInfraredEndpoint = Peer2PeerInfraredEndpoint()
+
+  private val peerInfraredEndpoint = Peer2PeerInfraredEndpoint()
+
   private var frame = 0L
 
   private var currentInput: Input? = null
@@ -90,6 +95,7 @@ class LinkedController(
 
   init {
     peerSerialEndpoint.init(mainSerialEndpoint)
+    peerInfraredEndpoint.init(mainInfraredEndpoint)
 
     eventQueue.register<LoadedMainConfigEvent> { e ->
       mainSession?.close()
@@ -246,6 +252,7 @@ class LinkedController(
             mainEventBus,
             console,
             mainSerialEndpoint,
+            mainInfraredEndpoint,
         )
     if (snapshot != null) {
       mainSession?.gameboy?.restoreFromMemento(snapshot.deserializeToGameboyMemento())
@@ -281,6 +288,7 @@ class LinkedController(
             peerEventBus,
             null,
             peerSerialEndpoint,
+            peerInfraredEndpoint,
         )
     if (state != null) {
       peerSession.gameboy.restoreFromMemento(state)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -9,6 +9,7 @@ import eu.rekawek.coffeegb.core.Gameboy.TICKS_PER_FRAME
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.ir.Peer2PeerInfraredEndpoint
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.Joypad
 import eu.rekawek.coffeegb.core.memento.Memento
@@ -73,6 +74,9 @@ class StateHistory() {
     val mainLink = Peer2PeerSerialEndpoint()
     val peerLink = Peer2PeerSerialEndpoint()
     mainLink.init(peerLink)
+    val mainIrLink = Peer2PeerInfraredEndpoint()
+    val peerIrLink = Peer2PeerInfraredEndpoint()
+    mainIrLink.init(peerIrLink)
 
     val mainEventBus = EventBusImpl(null, null, false)
     val peerEventBus = EventBusImpl(null, null, false)
@@ -87,11 +91,23 @@ class StateHistory() {
     // boot sequence, which FAST_FORWARD would otherwise emulate on every rebase
     val mainSession =
         mainConfig?.let {
-          Session(if (baseState.mainMemento != null) it.forRestore() else it, mainEventBus, null, mainLink)
+          Session(
+              if (baseState.mainMemento != null) it.forRestore() else it,
+              mainEventBus,
+              null,
+              mainLink,
+              mainIrLink,
+          )
         }
     val peerSession =
         peerConfig?.let {
-          Session(if (baseState.peerMemento != null) it.forRestore() else it, peerEventBus, null, peerLink)
+          Session(
+              if (baseState.peerMemento != null) it.forRestore() else it,
+              peerEventBus,
+              null,
+              peerLink,
+              peerIrLink,
+          )
         }
     if (mainSession != null && baseState.mainMemento != null) {
       mainSession.restoreFromMemento(baseState.mainMemento)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -8,6 +8,8 @@ import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.genie.Genie;
 import eu.rekawek.coffeegb.core.gpu.*;
+import eu.rekawek.coffeegb.core.ir.InfraredEndpoint;
+import eu.rekawek.coffeegb.core.ir.InfraredPort;
 import eu.rekawek.coffeegb.core.joypad.Joypad;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
@@ -74,7 +76,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     private final SerialPort serialPort;
 
-    private final eu.rekawek.coffeegb.core.ir.InfraredPort infraredPort;
+    private final InfraredPort infraredPort;
 
     private final Joypad joypad;
 
@@ -145,7 +147,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         sound = new Sound(timer, speedMode, gbc);
         joypad = new Joypad(interruptManager, sgbBus, sgb);
         serialPort = new SerialPort(interruptManager, timer, gbc, speedMode);
-        infraredPort = new eu.rekawek.coffeegb.core.ir.InfraredPort(gbc, speedMode);
+        infraredPort = new InfraredPort(gbc, speedMode);
 
         if (configuration.batteryData != null) {
             cartridge = new Cartridge(configuration.rom, new MemoryBattery(configuration.batteryData),
@@ -287,6 +289,11 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     }
 
     public void init(EventBus eventBus, SerialEndpoint serialEndpoint, Console console) {
+        init(eventBus, serialEndpoint, InfraredEndpoint.NULL_ENDPOINT, console);
+    }
+
+    public void init(EventBus eventBus, SerialEndpoint serialEndpoint,
+                     InfraredEndpoint infraredEndpoint, Console console) {
         this.console = console;
         if (console != null) {
             console.setGameboy(this);
@@ -296,7 +303,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         display.init(eventBus);
         sound.init(eventBus);
         serialPort.init(serialEndpoint);
-        infraredPort.init(eventBus);
+        infraredPort.init(eventBus, infraredEndpoint);
         background.init(eventBus);
         sgbDisplay.init(eventBus);
         gameGenie.init(eventBus);
@@ -534,6 +541,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public void close() {
+        infraredPort.close();
         cartridge.flushBattery();
         if (slotCartridge != null) {
             slotCartridge.flushBattery();
@@ -547,7 +555,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<InterruptManager> interruptManagerMemento, Memento<Timer> timerMemento,
                                   Memento<Dma> dmaMemento, Memento<Hdma> hdmaMemento, Memento<Display> displayMemento,
                                   Memento<Sound> soundMemento, Memento<SerialPort> serialPortMemento,
-                                  Memento<eu.rekawek.coffeegb.core.ir.InfraredPort> infraredPortMemento,
+                                  Memento<InfraredPort> infraredPortMemento,
                                   Memento<Joypad> joypadMemento, Memento<SpeedMode> speedModeMemento,
                                   Memento<SuperGameboy> superGameboyMemento, Memento<Background> backgroundMemento,
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredEndpoint.java
@@ -1,0 +1,24 @@
+package eu.rekawek.coffeegb.core.ir;
+
+/**
+ * A device connected to the CGB infrared port.
+ *
+ * <p>The port reports its own LED state to the endpoint and samples light received from it.
+ */
+public interface InfraredEndpoint {
+
+    void setLightOn(boolean lightOn);
+
+    boolean isLightOn();
+
+    InfraredEndpoint NULL_ENDPOINT = new InfraredEndpoint() {
+        @Override
+        public void setLightOn(boolean lightOn) {
+        }
+
+        @Override
+        public boolean isLightOn() {
+            return false;
+        }
+    };
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -16,8 +16,8 @@ import java.io.Serializable;
  * read-enable bits 6-7 are set; otherwise bit 1 reads 1. The register does not exist in
  * DMG-compatibility mode (reads 0xFF), matching the other CGB-only registers.
  *
- * <p>Received light comes from a pluggable external device; the only one emulated so far
- * is the {@link FullChanger} (Zok Zok Heroes).
+ * <p>Received light comes from a pluggable external device. Supported sources are another
+ * linked Game Boy and the {@link FullChanger} (Zok Zok Heroes).
  */
 public class InfraredPort implements AddressSpace, Serializable, Originator<InfraredPort> {
 
@@ -26,6 +26,8 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
     private final SpeedMode speedMode;
 
     private final FullChanger fullChanger = new FullChanger();
+
+    private transient InfraredEndpoint endpoint = InfraredEndpoint.NULL_ENDPOINT;
 
     // the written bits of RP: bit 0 (own LED) and bits 6-7 (read enable)
     private int rp;
@@ -36,7 +38,19 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
     }
 
     public void init(EventBus eventBus) {
+        init(eventBus, InfraredEndpoint.NULL_ENDPOINT);
+    }
+
+    public void init(EventBus eventBus, InfraredEndpoint endpoint) {
+        this.endpoint.setLightOn(false);
+        this.endpoint = endpoint;
+        endpoint.setLightOn((rp & 0x01) != 0);
         eventBus.register(e -> fullChanger.transform(e.characterId()), FullChanger.TransformEvent.class);
+    }
+
+    public void close() {
+        endpoint.setLightOn(false);
+        endpoint = InfraredEndpoint.NULL_ENDPOINT;
     }
 
     public void tick() {
@@ -53,6 +67,7 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
     @Override
     public void setByte(int address, int value) {
         rp = value & 0xc1;
+        endpoint.setLightOn((rp & 0x01) != 0);
     }
 
     @Override
@@ -64,7 +79,7 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
         // loop observes the first pulse from its beginning
         fullChanger.onRpRead();
         int result = rp | 0x3c | 0x02;
-        if ((rp & 0xc0) == 0xc0 && fullChanger.isLightOn()) {
+        if ((rp & 0xc0) == 0xc0 && (fullChanger.isLightOn() || endpoint.isLightOn())) {
             result &= ~0x02;
         }
         return result;
@@ -81,6 +96,7 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
             throw new IllegalArgumentException("Invalid memento type");
         }
         this.rp = mem.rp;
+        endpoint.setLightOn((rp & 0x01) != 0);
         fullChanger.restoreFromMemento(mem.fullChangerMemento);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/Peer2PeerInfraredEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/Peer2PeerInfraredEndpoint.java
@@ -1,0 +1,25 @@
+package eu.rekawek.coffeegb.core.ir;
+
+/** Couples the infrared LEDs and sensors of two locally emulated Game Boys. */
+public class Peer2PeerInfraredEndpoint implements InfraredEndpoint {
+
+    private volatile Peer2PeerInfraredEndpoint peer;
+
+    private volatile boolean lightOn;
+
+    public void init(Peer2PeerInfraredEndpoint peer) {
+        this.peer = peer;
+        peer.peer = this;
+    }
+
+    @Override
+    public void setLightOn(boolean lightOn) {
+        this.lightOn = lightOn;
+    }
+
+    @Override
+    public boolean isLightOn() {
+        Peer2PeerInfraredEndpoint peer = this.peer;
+        return peer != null && peer.lightOn;
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/Peer2PeerInfraredEndpointTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/Peer2PeerInfraredEndpointTest.java
@@ -1,0 +1,76 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Peer2PeerInfraredEndpointTest {
+
+    private final InfraredPort firstPort = new InfraredPort(true, new SpeedMode(true));
+
+    private final InfraredPort secondPort = new InfraredPort(true, new SpeedMode(true));
+
+    @Before
+    public void setUp() {
+        Peer2PeerInfraredEndpoint firstEndpoint = new Peer2PeerInfraredEndpoint();
+        Peer2PeerInfraredEndpoint secondEndpoint = new Peer2PeerInfraredEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(new EventBusImpl(), firstEndpoint);
+        secondPort.init(new EventBusImpl(), secondEndpoint);
+    }
+
+    @Test
+    public void lightFromPeerReachesEnabledSensor() {
+        firstPort.setByte(0xff56, 0x01);
+        secondPort.setByte(0xff56, 0xc0);
+
+        assertEquals(0, secondPort.getByte(0xff56) & 0x02);
+
+        firstPort.setByte(0xff56, 0x00);
+        assertEquals(0x02, secondPort.getByte(0xff56) & 0x02);
+    }
+
+    @Test
+    public void peerLightIsIgnoredWhileSensorIsDisabled() {
+        firstPort.setByte(0xff56, 0x01);
+        secondPort.setByte(0xff56, 0x00);
+
+        assertEquals(0x02, secondPort.getByte(0xff56) & 0x02);
+    }
+
+    @Test
+    public void communicationWorksInBothDirections() {
+        firstPort.setByte(0xff56, 0xc0);
+        secondPort.setByte(0xff56, 0x01);
+
+        assertEquals(0, firstPort.getByte(0xff56) & 0x02);
+    }
+
+    @Test
+    public void restoringPortStateRestoresEmittedLight() {
+        firstPort.setByte(0xff56, 0x01);
+        Memento<InfraredPort> lightOn = firstPort.saveToMemento();
+        firstPort.setByte(0xff56, 0x00);
+        secondPort.setByte(0xff56, 0xc0);
+        assertEquals(0x02, secondPort.getByte(0xff56) & 0x02);
+
+        firstPort.restoreFromMemento(lightOn);
+
+        assertEquals(0, secondPort.getByte(0xff56) & 0x02);
+    }
+
+    @Test
+    public void closingPortTurnsOffEmittedLight() {
+        firstPort.setByte(0xff56, 0x01);
+        secondPort.setByte(0xff56, 0xc0);
+        assertEquals(0, secondPort.getByte(0xff56) & 0x02);
+
+        firstPort.close();
+
+        assertEquals(0x02, secondPort.getByte(0xff56) & 0x02);
+    }
+}


### PR DESCRIPTION
## Summary

- add an infrared endpoint abstraction and a peer-to-peer implementation
- couple the two locally emulated Game Boys in live TCP-linked sessions
- recreate the same IR coupling during rollback replay
- turn off emitted light when a session closes

The TCP protocol itself is unchanged: netplay already exchanges ROM/input/state and simulates the remote Game Boy locally, so IR can follow the existing serial-link architecture.

The RP register remains the source of truth for emitted-light state. It is already part of the Game Boy memento, and restoring it re-drives the endpoint, so save states and rollback do not need another serialized field.

## Verification

- `/opt/maven/bin/mvn -pl core test` (215 tests)
- `/opt/maven/bin/mvn -pl controller -am -Dtest=LinkedControllerTest -Dsurefire.failIfNoSpecifiedTests=false test` (4 tests)
- attached Infra-Read demo after 20 frames: no light produces solid RGB555 `0x001f`; received peer light produces solid `0x03e0` (all 23,040 pixels change)

Fixes #238