### PR TITLE
Add CodeBreaker rumble support

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -35,6 +35,7 @@ import eu.rekawek.coffeegb.core.joypad.Joypad
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge
 import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay
 import eu.rekawek.coffeegb.core.sound.Sound
@@ -237,6 +238,7 @@ class LinkedController(
             Display.GbcFrameReadyEvent::class,
             SgbDisplay.SgbFrameReadyEvent::class,
             Sound.SoundSampleEvent::class,
+            RumbleEvent::class,
             Joypad.JoypadPressEvent::class,
         ),
     )

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -18,6 +18,7 @@ import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
+import eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import eu.rekawek.coffeegb.core.serial.SerialPort;
 import eu.rekawek.coffeegb.core.sgb.Background;
@@ -75,6 +76,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     private final SerialPort serialPort;
 
     private final eu.rekawek.coffeegb.core.ir.InfraredPort infraredPort;
+
+    private final CodeBreakerRumble codeBreakerRumble;
 
     private final Joypad joypad;
 
@@ -146,6 +149,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         joypad = new Joypad(interruptManager, sgbBus, sgb);
         serialPort = new SerialPort(interruptManager, timer, gbc, speedMode);
         infraredPort = new eu.rekawek.coffeegb.core.ir.InfraredPort(gbc, speedMode);
+        codeBreakerRumble = new CodeBreakerRumble();
+        mmu.setCodeBreakerRumble(codeBreakerRumble);
 
         if (configuration.batteryData != null) {
             cartridge = new Cartridge(configuration.rom, new MemoryBattery(configuration.batteryData),
@@ -297,6 +302,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         sound.init(eventBus);
         serialPort.init(serialEndpoint);
         infraredPort.init(eventBus);
+        codeBreakerRumble.init(eventBus);
         background.init(eventBus);
         sgbDisplay.init(eventBus);
         gameGenie.init(eventBus);
@@ -496,7 +502,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending);
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), codeBreakerRumble.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, blankCgbBootTilePending);
     }
 
     @Override
@@ -519,6 +525,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         sound.restoreFromMemento(mem.soundMemento());
         serialPort.restoreFromMemento(mem.serialPortMemento());
         infraredPort.restoreFromMemento(mem.infraredPortMemento());
+        codeBreakerRumble.restoreFromMemento(mem.codeBreakerRumbleMemento());
         joypad.restoreFromMemento(mem.joypadMemento());
         speedMode.restoreFromMemento(mem.speedModeMemento());
         superGameboy.restoreFromMemento(mem.superGameboyMemento());
@@ -534,6 +541,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public void close() {
+        codeBreakerRumble.close();
         cartridge.flushBattery();
         if (slotCartridge != null) {
             slotCartridge.flushBattery();
@@ -548,6 +556,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                                   Memento<Dma> dmaMemento, Memento<Hdma> hdmaMemento, Memento<Display> displayMemento,
                                   Memento<Sound> soundMemento, Memento<SerialPort> serialPortMemento,
                                   Memento<eu.rekawek.coffeegb.core.ir.InfraredPort> infraredPortMemento,
+                                  Memento<CodeBreakerRumble> codeBreakerRumbleMemento,
                                   Memento<Joypad> joypadMemento, Memento<SpeedMode> speedModeMemento,
                                   Memento<SuperGameboy> superGameboyMemento, Memento<Background> backgroundMemento,
                                   Memento<VRamTransfer> vRamTransferMemento, Memento<SgbDisplay> sgbDisplayMemento,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.memory;
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
+import eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +43,16 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
     // one; null for every other cartridge (see SachenMmc)
     private transient eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc busListener;
 
+    // the CodeBreaker pass-through cartridge watches the console bus for writes to the
+    // last byte of HRAM, using bit 7 as its built-in motor line
+    private transient CodeBreakerRumble codeBreakerRumble;
+
     public void setBusListener(eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc listener) {
         this.busListener = listener;
+    }
+
+    public void setCodeBreakerRumble(CodeBreakerRumble codeBreakerRumble) {
+        this.codeBreakerRumble = codeBreakerRumble;
     }
 
     public Mmu(boolean gbc) {
@@ -110,6 +119,9 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
             busListener.onHighBusWrite();
         }
         getSpace(address).setByte(address, value);
+        if (codeBreakerRumble != null && address == 0xfffe) {
+            codeBreakerRumble.onHramWrite(value);
+        }
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 
 import java.util.Arrays;
 
@@ -134,7 +135,7 @@ public class MakonNtOld2 implements MemoryController {
         }
         motorOn = on;
         if (eventBus != null) {
-            eventBus.post(new Mbc5.RumbleEvent(on));
+            eventBus.post(new RumbleEvent(on));
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -1,19 +1,15 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
-import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 
 import java.util.Arrays;
 
 public class Mbc5 implements MemoryController {
-
-    /** The rumble carts' motor turning on or off (issue #93). */
-    public record RumbleEvent(boolean on) implements Event {
-    }
 
     private final int romBanks;
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumble.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumble.java
@@ -1,0 +1,61 @@
+package eu.rekawek.coffeegb.core.rumble;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memento.Originator;
+
+import java.io.Serializable;
+
+/**
+ * The vibration motor built into the Game Boy CodeBreaker pass-through accessory.
+ *
+ * <p>CodeBreaker-aware games drive the motor with bit 7 of writes to HRAM address
+ * 0xFFFE. The other seven bits may carry a duration counter and remain ordinary HRAM.
+ */
+public class CodeBreakerRumble implements Serializable, Originator<CodeBreakerRumble> {
+
+    private transient EventBus eventBus = EventBus.NULL_EVENT_BUS;
+
+    private boolean motorOn;
+
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus;
+        if (motorOn) {
+            eventBus.post(new RumbleEvent(true));
+        }
+    }
+
+    public void onHramWrite(int value) {
+        setMotorOn((value & 0x80) != 0);
+    }
+
+    public void close() {
+        setMotorOn(false);
+        eventBus = EventBus.NULL_EVENT_BUS;
+    }
+
+    private void setMotorOn(boolean on) {
+        if (on == motorOn) {
+            return;
+        }
+        motorOn = on;
+        eventBus.post(new RumbleEvent(on));
+    }
+
+    @Override
+    public Memento<CodeBreakerRumble> saveToMemento() {
+        return new CodeBreakerRumbleMemento(motorOn);
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<CodeBreakerRumble> memento) {
+        if (!(memento instanceof CodeBreakerRumbleMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        setMotorOn(mem.motorOn);
+    }
+
+    private record CodeBreakerRumbleMemento(boolean motorOn)
+            implements Memento<CodeBreakerRumble> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/rumble/RumbleEvent.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/rumble/RumbleEvent.java
@@ -1,0 +1,7 @@
+package eu.rekawek.coffeegb.core.rumble;
+
+import eu.rekawek.coffeegb.core.events.Event;
+
+/** A cartridge or pass-through accessory turning its vibration motor on or off. */
+public record RumbleEvent(boolean on) implements Event {
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -7,6 +7,7 @@ import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -93,7 +94,7 @@ public class MakonNtOld2Test {
         MakonNtOld2 mapper = new MakonNtOld2(
                 new Rom(multicartRom(0xe0)), Battery.NULL_BATTERY);
         EventBusImpl bus = new EventBusImpl(null, null, false);
-        bus.register(event -> motorLog.add(event.on()), Mbc5.RumbleEvent.class);
+        bus.register(event -> motorLog.add(event.on()), RumbleEvent.class);
         mapper.init(bus);
 
         mapper.setByte(0x5001, 0x80); // enable rumble; old mode uses bit 1

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5RumbleTest.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.memory.cart.type;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class Mbc5RumbleTest {
     private static Mbc5 build(int type, List<Boolean> motorLog) throws IOException {
         Mbc5 mbc = new Mbc5(new Rom(rom(type)), Battery.NULL_BATTERY);
         EventBusImpl bus = new EventBusImpl(null, null, false);
-        bus.register(e -> motorLog.add(e.on()), Mbc5.RumbleEvent.class);
+        bus.register(e -> motorLog.add(e.on()), RumbleEvent.class);
         mbc.init(bus);
         return mbc;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumbleTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumbleTest.java
@@ -1,0 +1,67 @@
+package eu.rekawek.coffeegb.core.rumble;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.Mmu;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CodeBreakerRumbleTest {
+
+    private final List<Boolean> motorLog = new ArrayList<>();
+
+    private final CodeBreakerRumble rumble = new CodeBreakerRumble();
+
+    private final Mmu mmu = new Mmu(true);
+
+    @Before
+    public void setUp() {
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        eventBus.register(event -> motorLog.add(event.on()), RumbleEvent.class);
+        rumble.init(eventBus);
+        mmu.setCodeBreakerRumble(rumble);
+        mmu.indexSpaces();
+    }
+
+    @Test
+    public void bit7OfFffeControlsMotorAndValueRemainsInHram() {
+        mmu.setByte(0xfffe, 0x86);
+        mmu.setByte(0xfffe, 0x85);
+        mmu.setByte(0xfffe, 0x06);
+
+        assertEquals(0x06, mmu.getByte(0xfffe));
+        assertEquals(List.of(true, false), motorLog);
+    }
+
+    @Test
+    public void otherHramWritesDoNotControlMotor() {
+        mmu.setByte(0xfffd, 0x80);
+
+        assertEquals(List.of(), motorLog);
+    }
+
+    @Test
+    public void mementoRestoresMotorState() {
+        mmu.setByte(0xfffe, 0x80);
+        Memento<CodeBreakerRumble> motorOn = rumble.saveToMemento();
+        mmu.setByte(0xfffe, 0x00);
+
+        rumble.restoreFromMemento(motorOn);
+
+        assertEquals(List.of(true, false, true), motorLog);
+    }
+
+    @Test
+    public void closingAccessoryStopsMotor() {
+        mmu.setByte(0xfffe, 0x80);
+
+        rumble.close();
+
+        assertEquals(List.of(true, false), motorLog);
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.GameboyType;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import eu.rekawek.coffeegb.controller.properties.DisplayProperties;
 
@@ -58,8 +59,8 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private GameboyType gameboyType;
 
-    // the rumble carts' motor (issue #93): while it runs, the picture is jiggled by a
-    // pixel each frame - a dependency-free stand-in for a vibrating console
+    // while a rumble motor runs, jiggle the picture by a pixel each frame as a
+    // dependency-free stand-in for a vibrating console
     private volatile boolean rumbling;
 
     private int rumblePhase;
@@ -82,7 +83,7 @@ public class SwingDisplay extends JPanel implements Runnable {
         eventBus.register(e -> setBlending(e.blending), SetBlendingEvent.class);
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
-        eventBus.register(e -> this.rumbling = e.on(), eu.rekawek.coffeegb.core.memory.cart.type.Mbc5.RumbleEvent.class, callerId);
+        eventBus.register(e -> this.rumbling = e.on(), RumbleEvent.class, callerId);
         eventBus.register(e -> showNotification("State saved (slot " + e.getSlot() + ")"),
                 Controller.SnapshotSavedEvent.class, callerId);
         eventBus.register(e -> showNotification("State loaded (slot " + e.getSlot() + ")"),

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
@@ -6,7 +6,7 @@ import eu.rekawek.coffeegb.core.joypad.Button;
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent;
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent;
 import eu.rekawek.coffeegb.core.memory.cart.type.AccelerometerEvent;
-import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import io.github.libsdl4j.api.gamecontroller.SDL_GameController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +35,8 @@ import static io.github.libsdl4j.api.joystick.SdlJoystick.SDL_NumJoysticks;
  * controls MBC7 cartridge tilt for Kirby's Tilt 'n' Tumble. Hotplug is handled by
  * rescanning while no controller is open.
  *
- * <p>The MBC5 rumble carts' motor (issue #93) is forwarded to the controller's force
- * feedback when it has any.
+ * <p>Rumble requests from cartridges and pass-through accessories are forwarded to the
+ * controller's force feedback when it has any.
  *
  * <p>libsdl4j bundles the SDL2 native only for Linux and Windows. On macOS SDL2 must be
  * installed separately ({@code brew install sdl2}); this looks it up in Homebrew's lib
@@ -73,7 +73,7 @@ public class SwingGamepad implements Runnable {
 
     public SwingGamepad(EventBus eventBus) {
         this.eventBus = eventBus;
-        eventBus.register(e -> rumbleRequested = e.on(), Mbc5.RumbleEvent.class);
+        eventBus.register(e -> rumbleRequested = e.on(), RumbleEvent.class);
     }
 
     public void stop() {


### PR DESCRIPTION
## Summary

- emulate the CodeBreaker pass-through rumble motor from bit 7 of writes to `FFFE`, while preserving the complete HRAM value
- share rumble events across MBC5, Makon, and CodeBreaker sources and forward them through linked sessions to the existing controller/display outputs
- preserve CodeBreaker motor state in save states and stop the motor when the emulator closes

## Verification

- `/opt/maven/bin/mvn test` (214 core, 18 controller, and 9 Swing tests)
- ran the supplied `In-Game Rumble Demo (PD) [C].gbc`; its encoded vibration sequence produced alternating rumble on/off events

Fixes #240