### PR TITLE
Fix CGB WX=166 terminal timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,408 match hardware; 266 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,417 match hardware; 257 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 266 unresolved cases are likewise pinned to their complete
+output. Gambatte's 257 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -454,7 +454,21 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                         mode = Mode.HBlank;
                     } else {
                         int oldPosition = pixelTransferPhase.getPosition();
+                        boolean terminalWindowAlreadyStarted =
+                                pixelTransferPhase.hasCgbTerminalWindowStarted();
                         boolean active = phase.tick();
+                        if (!terminalWindowAlreadyStarted
+                                && pixelTransferPhase.hasCgbTerminalWindowStarted()
+                                && pixelTransferPhase.hasSpriteAtTerminalPredictionEdge()
+                                && mode0IntFrom != Integer.MAX_VALUE) {
+                            // The X=166 M0 event is independent of the later X=167
+                            // STAT/bus prediction. When both comparators collide, its
+                            // CPU-visible event crosses two dots after Coffee's early
+                            // right-edge prediction has been captured. That prediction
+                            // always crosses X=158->159 one tick before this terminal
+                            // X=159->160 commit, so mode0IntFrom is already finite.
+                            mode0IntFrom += 2;
+                        }
                         if (mode0IntFrom == Integer.MAX_VALUE
                                 && pixelTransferPhase.hasSpriteAtMode0PredictionEdge()
                                 && oldPosition <= 158
@@ -825,22 +839,25 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                 || (mode == Mode.HBlank && ticksInLine < hblankIntFrom))) {
             return Mode.PixelTransfer.ordinal();
         }
-        // The CGB's readable mode-3 latch is tied to the LCD output delay rather than
-        // directly to the timing skeleton. At normal speed, a line containing objects
-        // retains mode 3 through output position 159 and releases it with the final
-        // pixel latch. At double speed the CPU read latch retains mode 3 for the two
-        // dots after the skeleton completes, including BG-only lines where object
-        // display is disabled.
-        int terminalWindowReadTail = speedMode.getSpeedMode() == 2 ? 4 : 0;
+        // Gambatte's terminal prediction targets PPU X=167 rather than the physical
+        // end of mode 3. WX=166 contributes the remaining StartWindowDraw states; an
+        // object exactly at X=167 then restarts the tile phase and contributes ten more
+        // predicted dots. Double speed has its own CPU sampling phase.
+        int terminalWindowReadTail = speedMode.getSpeedMode() == 2
+                ? 5
+                : pixelTransferPhase.hasSpriteAtTerminalPredictionEdge() ? 12 : 2;
         if (gbc && (mode == Mode.PixelTransfer
                 || (mode == Mode.HBlank
                 && ticksInLine <= hblankIntFrom + terminalWindowReadTail))
-                && pixelTransferPhase.getPosition() >= 160
-                && pixelTransferPhase.isCgbWindowStartActive()) {
+                && ((mode == Mode.PixelTransfer
+                && pixelTransferPhase.willStartCgbTerminalWindow())
+                || pixelTransferPhase.hasCgbTerminalWindowStarted()
+                || (pixelTransferPhase.getPosition() >= 160
+                && pixelTransferPhase.isCgbWindowStartActive()))) {
             // WX=166 starts the CGB window machine after the last visible pixel. Its
             // physical transfer tail ends first; the CPU-readable mode-3 latch remains
-            // through the HBlank edge at normal speed and four dots beyond it at
-            // double speed, without delaying the mode-0 interrupt edge.
+            // through the independently predicted X=167 edge. The mode-0 interrupt
+            // continues to use its separate X=166 event above.
             return Mode.PixelTransfer.ordinal();
         }
         if (gbc && speedMode.getSpeedMode() == 1
@@ -1103,12 +1120,18 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                 // output stage. An OAM DMA that owned the scan leaves the read bus
                 // released at the internal edge instead. Otherwise normal-speed
                 // release is quantized by fine SCX and double speed follows the
-                // internal hand-off.
-                int handoffTick = !write && oamSearchPhase.wasDmaBlockedThisLine()
+                // internal hand-off. Terminal StartWindowDraw retains ownership for
+                // four additional dots without extending physical mode 3.
+                boolean dmaReadHandoff = !write && oamSearchPhase.wasDmaBlockedThisLine();
+                int handoffTick = dmaReadHandoff
                         ? hblankIntFrom
                         : speedMode.getSpeedMode() == 1 && !firstLine
                                 ? 254 + ((r.get(SCX) & 0x04) != 0 ? 4 : 0)
                                 : hblankIntFrom + 4;
+                if (!write && !dmaReadHandoff
+                        && pixelTransferPhase.hasCgbTerminalWindowStarted()) {
+                    handoffTick += 4;
+                }
                 if (ticksInLine < handoffTick) {
                     return false;
                 }
@@ -1231,6 +1254,12 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                 handoffTick = 254 + ((r.get(SCX) & 0x04) != 0 ? 4 : 0);
             } else {
                 handoffTick = hblankIntFrom + 4;
+            }
+            if (!pixelTransferPhase.hasObjectsOnLine()
+                    && pixelTransferPhase.hasCgbTerminalWindowStarted()) {
+                // Terminal StartWindowDraw keeps the idle CGB read arbiter occupied
+                // after the physical transfer has already entered HBlank.
+                handoffTick += 4;
             }
             return ticksInLine >= handoffTick;
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -137,6 +137,11 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
     // the fetcher changes back to the background source.
     private int cgbWindowStartTicks;
 
+    // Captures the terminal CGB comparator event independently of the mutable WX,
+    // WY, and LCDC registers. The event's physical, bus, and STAT tails outlive the
+    // live window-enable condition that predicted it.
+    private boolean cgbTerminalWindowStartedThisLine;
+
     // a WX re-match while the window is already active and its fetch has settled
     // inserts one synthetic blank pixel at the FIFO's read end (SameBoy's
     // insert_bg_pixel; mealybug m3_wx_5_change rows where WX=LY re-matches)
@@ -277,6 +282,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         windowActivatedThisLine = false;
         previousWindowDisplay = isWindowDisplay();
         cgbWindowStartTicks = 0;
+        cgbTerminalWindowStartedThisLine = false;
         fifo.discardClearedBg();
         windowCatchUpPos = -1;
         insertBgPixel = false;
@@ -364,6 +370,16 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         return false;
     }
 
+    /** Whether an object is selected at the X=167 readable-STAT prediction boundary. */
+    public boolean hasSpriteAtTerminalPredictionEdge() {
+        for (int i = 0; i < spriteCount; i++) {
+            if (sprites[spriteOrder[i]].getX() == 167) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean isWindowBeingFetched() {
         return windowBeingFetched;
     }
@@ -380,6 +396,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
     public void resetWindowLineCounter() {
         // pre-incremented at window activation: the first activated line renders row 0
         windowLineCounter = -1;
+        cgbTerminalWindowStartedThisLine = false;
         setWindowYTriggered(false);
     }
 
@@ -555,6 +572,18 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         return cgbWindowStartTicks > 0;
     }
 
+    /** Whether the live CGB comparator is about to run terminal StartWindowDraw. */
+    public boolean willStartCgbTerminalWindow() {
+        return gbc && position == 159 && !windowActivatedThisLine && !window
+                && getWindowX() == 166 && isWindowDisplay()
+                && !isNormalSpeedWindowEnableEdge() && isWindowYMatch();
+    }
+
+    /** Whether terminal StartWindowDraw has actually been captured on this scanline. */
+    public boolean hasCgbTerminalWindowStarted() {
+        return cgbTerminalWindowStartedThisLine;
+    }
+
     public boolean isWindowActive() {
         return window;
     }
@@ -572,8 +601,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
     public boolean tick() {
         boolean windowDisplayRising = gbc
                 && isWindowDisplay() && !previousWindowDisplay;
-        boolean windowEnabledOnThisTick = windowDisplayRising
-                && speedMode.getSpeedMode() == 1;
+        boolean windowEnabledOnThisTick = isNormalSpeedWindowEnableEdge();
         previousWindowDisplay = isWindowDisplay();
         int currentScx = r.get(SCX);
         int fineScxAdvance = (currentScx & 7) - (previousScx & 7);
@@ -894,10 +922,16 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
             // occupy the physical transfer; the final two belong to the independently
             // readable STAT latch in HBlank.
             cgbWindowStartTicks = 6;
+            cgbTerminalWindowStartedThisLine = true;
             machineStall = 4;
             return true;
         }
         return active;
+    }
+
+    private boolean isNormalSpeedWindowEnableEdge() {
+        return gbc && isWindowDisplay() && !previousWindowDisplay
+                && speedMode.getSpeedMode() == 1;
     }
 
 
@@ -1063,6 +1097,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
                 windowActivatedThisLine,
                 previousWindowDisplay,
                 cgbWindowStartTicks,
+                cgbTerminalWindowStartedThisLine,
                 insertBgPixel,
                 machineStall,
                 windowYTriggered,
@@ -1133,6 +1168,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         this.windowActivatedThisLine = mem.windowActivatedThisLine;
         this.previousWindowDisplay = mem.previousWindowDisplay;
         this.cgbWindowStartTicks = mem.cgbWindowStartTicks;
+        this.cgbTerminalWindowStartedThisLine = mem.cgbTerminalWindowStartedThisLine;
         this.insertBgPixel = mem.insertBgPixel;
         this.machineStall = mem.machineStall;
         this.windowYTriggered = mem.windowYTriggered;
@@ -1193,6 +1229,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
             boolean windowActivatedThisLine,
             boolean previousWindowDisplay,
             int cgbWindowStartTicks,
+            boolean cgbTerminalWindowStartedThisLine,
             boolean insertBgPixel,
             int machineStall,
             boolean windowYTriggered,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
+import eu.rekawek.coffeegb.core.memento.Memento;
 import org.junit.Test;
 
 import static eu.rekawek.coffeegb.core.events.EventBus.NULL_EVENT_BUS;
@@ -93,7 +94,7 @@ public class GpuDisplayEnableTimingTest {
     }
 
     @Test
-    public void terminalCgbWindowStartSeparatesReadableModeFromMode0Interrupt() {
+    public void terminalCgbWindowStartKeepsTwoReadableDotsBeyondMode0Interrupt() {
         Fixture fixture = new Fixture(1);
         fixture.gpu.setByte(0xff4a, 0);
         fixture.gpu.setByte(0xff4b, 166);
@@ -112,13 +113,15 @@ public class GpuDisplayEnableTimingTest {
             readableTailDots++;
         }
         assertEquals(2, readableTailDots);
-        assertEquals(Mode.PixelTransfer.ordinal(), fixture.gpu.getVisibleStatMode());
-        fixture.tick();
+        for (int tailDot = 0; tailDot < 3; tailDot++) {
+            assertEquals(Mode.PixelTransfer.ordinal(), fixture.gpu.getVisibleStatMode());
+            fixture.tick();
+        }
         assertEquals(Mode.HBlank.ordinal(), fixture.gpu.getVisibleStatMode());
     }
 
     @Test
-    public void terminalCgbWindowStartKeepsFourExtraDoubleSpeedDots() {
+    public void terminalCgbWindowStartKeepsFiveDotsBeyondDoubleSpeedMode0Edge() {
         Fixture fixture = new Fixture(2);
         fixture.gpu.onSpeedSwitch();
         fixture.gpu.setByte(0xff4a, 0);
@@ -134,8 +137,98 @@ public class GpuDisplayEnableTimingTest {
             fixture.tick();
             readableTailDots++;
         }
-        assertEquals(5, readableTailDots);
+        assertEquals(6, readableTailDots);
         assertEquals(Mode.HBlank.ordinal(), fixture.gpu.getVisibleStatMode());
+    }
+
+    @Test
+    public void terminalWindowAndX167ObjectRephaseMode0EventByTwoDots() {
+        int ordinaryEdge = mode0EdgeWithX167Object(false);
+        int terminalEdge = mode0EdgeWithX167Object(true);
+
+        assertEquals("the terminal comparator collision crosses the CPU event latch two dots later",
+                ordinaryEdge + 2, terminalEdge);
+    }
+
+    @Test
+    public void terminalWindowMode0PredictionSurvivesMemento() {
+        Fixture fixture = fixtureWithX167Object(true);
+        Memento<Gpu> immediatelyBeforeEdge = null;
+
+        while (!fixture.gpu.isMode0IntWindow()) {
+            immediatelyBeforeEdge = fixture.gpu.saveToMemento();
+            fixture.tick();
+        }
+        int edge = fixture.gpu.getTicksInLine();
+
+        fixture.gpu.restoreFromMemento(immediatelyBeforeEdge);
+        assertFalse(fixture.gpu.isMode0IntWindow());
+        fixture.tick();
+        assertTrue(fixture.gpu.isMode0IntWindow());
+        assertEquals(edge, fixture.gpu.getTicksInLine());
+    }
+
+    @Test
+    public void terminalWindowUsesTheLongStatPredictionOnlyForX167Object() {
+        int x166Tail = terminalReadableTailWithObjectAt(166);
+        int x167Tail = terminalReadableTailWithObjectAt(167);
+        int x168Tail = terminalReadableTailWithObjectAt(168);
+
+        assertEquals("resetting the tile predictor at WX=166 adds ten X=167 cycles",
+                x166Tail + 10, x167Tail);
+        assertEquals("the long prediction is scoped to X=167 exactly",
+                x166Tail, x168Tail);
+    }
+
+    @Test
+    public void lateWx166WriteCannotResurrectAMissedTerminalComparator() {
+        int ordinaryTail = readableTailAfterMissedTerminalComparator(false);
+        int lateWriteTail = readableTailAfterMissedTerminalComparator(true);
+
+        assertEquals("HBlank uses the captured event rather than live WX",
+                ordinaryTail, lateWriteTail);
+    }
+
+    @Test
+    public void terminalWindowKeepsOamAndVramLockedThroughTheirHandoff() {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0x8000, 0x55);
+        fixture.gpu.setByte(0xff4a, 0);
+        fixture.gpu.setByte(0xff4b, 166);
+        fixture.gpu.setByte(0xff40, 0xb1);
+        fixture.advanceTo(1, 0);
+
+        while (fixture.gpu.getMode() != Mode.HBlank) {
+            fixture.tick();
+        }
+
+        int readLockedDots = 0;
+        int writeLockedDots = 0;
+        while (!fixture.gpu.isOamAvailableForCpu(false) && readLockedDots < 20) {
+            assertEquals("VRAM and OAM retain the same terminal prediction",
+                    0xff, fixture.gpu.getByte(0x8000));
+            if (!fixture.gpu.isOamAvailableForCpu(true)) {
+                writeLockedDots++;
+            }
+            fixture.tick();
+            readLockedDots++;
+        }
+        assertEquals(6, readLockedDots);
+        assertEquals("WX=166 does not extend the independently timed write latch",
+                2, writeLockedDots);
+        assertTrue(fixture.gpu.isOamAvailableForCpu(false));
+        assertTrue(fixture.gpu.isOamAvailableForCpu(true));
+        assertEquals(0x55, fixture.gpu.getByte(0x8000));
+    }
+
+    @Test
+    public void terminalWindowPreservesDmaOwnedOamReadHandoff() {
+        int ordinaryHandoff = dmaOwnedOamReadLockedDots(false);
+        int terminalHandoff = dmaOwnedOamReadLockedDots(true);
+
+        assertEquals("WX=166 must not delay the OAM-DMA read release",
+                ordinaryHandoff, terminalHandoff);
     }
 
     @Test
@@ -174,11 +267,101 @@ public class GpuDisplayEnableTimingTest {
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.gpu.getVisibleStatMode());
     }
 
+    private static int mode0EdgeWithX167Object(boolean terminalWindow) {
+        Fixture fixture = fixtureWithX167Object(terminalWindow);
+
+        while (!fixture.gpu.isMode0IntWindow()) {
+            fixture.tick();
+        }
+        return fixture.gpu.getTicksInLine();
+    }
+
+    private static Fixture fixtureWithX167Object(boolean terminalWindow) {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 167);
+        if (terminalWindow) {
+            fixture.gpu.setByte(0xff4a, 0);
+            fixture.gpu.setByte(0xff4b, 166);
+        }
+        fixture.gpu.setByte(0xff40, terminalWindow ? 0xb3 : 0x93);
+        fixture.advanceTo(1, 0);
+        return fixture;
+    }
+
+    private static int terminalReadableTailWithObjectAt(int x) {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, x);
+        fixture.gpu.setByte(0xff4a, 0);
+        fixture.gpu.setByte(0xff4b, 166);
+        fixture.gpu.setByte(0xff40, 0xb3);
+        fixture.advanceTo(1, 0);
+
+        while (fixture.gpu.getMode() != Mode.HBlank) {
+            fixture.tick();
+        }
+        int readableDots = 0;
+        while (fixture.gpu.getVisibleStatMode() == Mode.PixelTransfer.ordinal()
+                && readableDots < 30) {
+            fixture.tick();
+            readableDots++;
+        }
+        return readableDots;
+    }
+
+    private static int readableTailAfterMissedTerminalComparator(boolean writeWxInHblank) {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff4a, 0);
+        fixture.gpu.setByte(0xff4b, 167);
+        fixture.gpu.setByte(0xff40, 0xb1);
+        fixture.advanceTo(1, 0);
+
+        while (fixture.gpu.getMode() != Mode.HBlank) {
+            fixture.tick();
+        }
+        if (writeWxInHblank) {
+            fixture.gpu.setByte(0xff4b, 166);
+        }
+        int readableDots = 0;
+        while (fixture.gpu.getVisibleStatMode() == Mode.PixelTransfer.ordinal()
+                && readableDots < 20) {
+            fixture.tick();
+            readableDots++;
+        }
+        return readableDots;
+    }
+
+    private static int dmaOwnedOamReadLockedDots(boolean terminalWindow) {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff4a, 0);
+        fixture.gpu.setByte(0xff4b, terminalWindow ? 166 : 167);
+        fixture.gpu.setByte(0xff40, 0xb1);
+        fixture.dma.setByte(0xff46, 0x00);
+        fixture.advanceTo(1, 0);
+
+        while (fixture.gpu.getMode() != Mode.HBlank) {
+            fixture.tick();
+        }
+        int lockedDots = 0;
+        while (!fixture.gpu.isOamAvailableForCpu(false) && lockedDots < 20) {
+            fixture.tick();
+            lockedDots++;
+        }
+        return lockedDots;
+    }
+
     private static class Fixture {
 
         private final Ram oam = new Ram(0xfe00, 0xa0);
 
         private final StatRegister stat = new StatRegister(new InterruptManager(true));
+
+        private final Dma dma;
 
         private final Gpu gpu;
 
@@ -189,9 +372,10 @@ public class GpuDisplayEnableTimingTest {
                     return speed;
                 }
             };
+            dma = new Dma(new Ram(0, 0x10000), oam, speedMode);
             gpu = new Gpu(
                     new Display(true),
-                    new Dma(new Ram(0, 0x10000), oam, speedMode),
+                    dma,
                     oam,
                     new VRamTransfer(NULL_EVENT_BUS),
                     stat,
@@ -209,7 +393,11 @@ public class GpuDisplayEnableTimingTest {
         }
 
         private void advanceTo(int dot) {
-            while (gpu.getLine() != 0 || gpu.getTicksInLine() != dot) {
+            advanceTo(0, dot);
+        }
+
+        private void advanceTo(int line, int dot) {
+            while (gpu.getLine() != line || gpu.getTicksInLine() != dot) {
                 gpu.tick();
                 stat.tick();
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowTriggerTest.java
@@ -136,6 +136,14 @@ public class PixelTransferWindowTriggerTest {
                 0, h.transfer.getWindowLineCounter());
         assertTrue("the final two startup states belong to the readable HBlank latch",
                 h.transfer.isCgbWindowStartActive());
+        assertTrue("the terminal comparator event remains captured through HBlank",
+                h.transfer.hasCgbTerminalWindowStarted());
+        Memento<PixelTransfer> terminalStart = h.transfer.saveToMemento();
+
+        h.registers.put(GpuRegister.WX, 167);
+        h.lcdc.set(0x91);
+        assertTrue("later register changes cannot withdraw the captured terminal event",
+                h.transfer.hasCgbTerminalWindowStarted());
 
         Harness noTerminalMatch = new Harness(true);
         noTerminalMatch.registers.put(GpuRegister.LY, 0);
@@ -154,6 +162,15 @@ public class PixelTransferWindowTriggerTest {
         h.registers.put(GpuRegister.LY, 1);
         h.transfer.start();
         assertFalse("a pending activation is scanline-local", h.transfer.isWindowActivationPending());
+        assertFalse("the captured terminal event is scanline-local",
+                h.transfer.hasCgbTerminalWindowStarted());
+
+        h.transfer.restoreFromMemento(terminalStart);
+        assertTrue("the captured terminal event must survive save-state restoration",
+                h.transfer.hasCgbTerminalWindowStarted());
+        h.transfer.resetWindowLineCounter();
+        assertFalse("LCD/frame reset clears the captured terminal event",
+                h.transfer.hasCgbTerminalWindowStarted());
     }
 
     @Test
@@ -237,6 +254,31 @@ public class PixelTransferWindowTriggerTest {
         h.transfer.tick();
         assertFalse("the inhibited edge must survive save-state restoration",
                 h.transfer.hasActivatedWindowOnLine());
+    }
+
+    @Test
+    public void normalCgbWindowEnableEdgeDoesNotPredictTerminalStart() {
+        Harness h = new Harness(true);
+        h.registers.put(GpuRegister.LY, 0);
+        h.registers.put(GpuRegister.WY, 0);
+        h.registers.put(GpuRegister.WX, 166);
+        h.lcdc.set(0x91);
+        h.transfer.checkWindowY();
+        h.transfer.start();
+
+        int remainingTicks = 1000;
+        while (h.transfer.getPosition() < 159 && remainingTicks-- > 0) {
+            h.transfer.tick();
+        }
+        assertTrue("the output machine must reach the terminal comparator",
+                remainingTicks > 0);
+
+        h.lcdc.set(0xb1);
+        assertFalse("the lookahead must see the same inhibited enable edge as tick()",
+                h.transfer.willStartCgbTerminalWindow());
+        assertFalse("the rising edge must finish the line without a terminal start",
+                h.transfer.tick());
+        assertFalse(h.transfer.hasCgbTerminalWindowStarted());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 266;
+    private static final int CURRENT_BASELINE_COUNT = 257;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 266 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 257 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -257,13 +257,4 @@ hwtests/window/late_wx_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wx_wx03_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wx_wx0f_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wy_lcdoffset1_1_cgb04c_out0.gbc [CGB]	3
-hwtests/window/m2int_wxA6_oambusyread_2_dmg08_out5_cgb04c_out0.gbc [CGB]	5
-hwtests/window/m2int_wxA6_scx2_m3stat_3_dmg08_out0_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_scx3_m3stat_1_dmg08_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_scx3_m3stat_3_dmg08_out0_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_scx5_m3stat_ds_1_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_spxA7_m0irq_1_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/window/m2int_wxA6_spxA7_m0irq_2_dmg08_cgb04c_out2.gbc [DMG]	0
-hwtests/window/m2int_wxA6_spxA7_m3stat_2_dmg08_out0_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_spxA7_m3stat_4_dmg08_out0_cgb04c_out3.gbc [CGB]	0
-hwtests/window/m2int_wxA6_vrambusyread_2_dmg08_out5_cgb04c_out0.gbc [CGB]	5


### PR DESCRIPTION
Summary:
- model the CGB WX=166 terminal StartWindowDraw event across physical, readable STAT, mode-0 IRQ, and idle bus timing
- latch the accepted event so later register writes, LCD reset, and save-state restore follow hardware timing
- add focused comparator, X=167, DMA handoff, bus, and memento regressions
- remove nine now-hardware-correct Gambatte baselines (257 remain)

Tests:
- /opt/maven/bin/mvn clean test -f core/pom.xml -Ptest-gambatte-hw (4,674 passed)
- /opt/maven/bin/mvn -q -f core/pom.xml test (495 passed)
- /opt/maven/bin/mvn -B package --file pom.xml (reactor passed before final edge-only regression additions; core and compatibility suites rerun afterward)