### PR TITLE
Fix frame-boundary mode-2 interrupt timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,485 match hardware; 189 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,502 match hardware; 172 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 189 unresolved cases are likewise pinned to their complete
+output. Gambatte's 172 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1076,8 +1076,8 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
 
     /**
      * The mode-2 STAT source is a short pulse during the final machine cycle of the
-     * preceding line. At the frame boundary there is no visible preceding line, so the
-     * pulse is exposed during the first four ticks of line 0 instead.
+     * preceding line. At the frame boundary native CGB exposes it in line 153's tail;
+     * DMG and compatibility mode expose it during the first four ticks of line 0.
      */
     public boolean isMode2IntWindow() {
         if (!lcdEnabled) {
@@ -1085,9 +1085,9 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         }
         return (line < 144 && ticksInLine >= getEarlyLineEdgeTick())
                 || (gbc && !speedMode.isDmgCompat()
-                && speedMode.getSpeedMode() == 2
                 && line == 153 && ticksInLine >= 454)
-                || (!firstLine && line == 0 && ticksInLine < 4);
+                || ((!gbc || speedMode.isDmgCompat())
+                && !firstLine && line == 0 && ticksInLine < 4);
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -150,6 +150,10 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
 
     private boolean pendingCgbMode2Interrupt;
 
+    // Normal-speed CGB captures the new-frame mode-2 event in line 153's tail,
+    // then publishes it at the phase-adjusted frame rollover.
+    private boolean pendingCgbFrameMode2Interrupt;
+
     // A double-speed FF41 write can still withdraw the just-published mode-2
     // request while it remains behind the CPU synchronizer.
     private boolean retractableCgbMode2Interrupt;
@@ -198,6 +202,22 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         boolean suppressNaturalModeEdge = updateModeIrqEvents();
         if (pendingCgbMode2Interrupt && gpu.getTicksInLine() == 452) {
             publishPendingCgbMode2Event();
+        }
+        boolean publishCgbFrameMode2 = pendingCgbFrameMode2Interrupt && !isDoubleSpeed()
+                && ((getNormalSpeedClockPhase() == 0
+                && gpu.getLine() == 153 && gpu.getTicksInLine() == 455)
+                || (getNormalSpeedClockPhase() == 1
+                && gpu.getLine() == 0 && gpu.getTicksInLine() == 0));
+        if (publishCgbFrameMode2) {
+            // The normal-speed frame mode-2 event captures FF41/FF45 at dot 454.
+            // A speed-switch clock rephase moves publication across the rollover.
+            if (getNormalSpeedClockPhase() == 1) {
+                interruptManager.requestInterruptBeforeCpuAcceptanceUnphased(
+                        InterruptType.LCDC);
+            } else {
+                interruptManager.requestMode2InterruptBeforeCpuAcceptance(false);
+            }
+            pendingCgbFrameMode2Interrupt = false;
         }
         if (retractableCgbMode2Interrupt && gpu.getTicksInLine() > 454) {
             retractableCgbMode2Interrupt = false;
@@ -391,6 +411,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         pendingCgbMode1Interrupt = false;
         pendingCgbMode0Interrupt = false;
         pendingCgbMode2Interrupt = false;
+        pendingCgbFrameMode2Interrupt = false;
         retractableCgbMode2Interrupt = false;
         scxChangedSinceMode0Event = false;
     }
@@ -413,6 +434,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         pendingCgbMode1Interrupt = false;
         pendingCgbMode0Interrupt = false;
         pendingCgbMode2Interrupt = false;
+        pendingCgbFrameMode2Interrupt = false;
         retractableCgbMode2Interrupt = false;
         interruptManager.releaseCpuAcceptance(InterruptType.LCDC);
     }
@@ -478,6 +500,17 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
     private boolean computeIntLine(int enable) {
         boolean line = (enable & 0b01000000) != 0 && intCoincidence;
         if (gpu.isLcdEnabled()) {
+            boolean holdCgbFrameLycToMode2Handoff = gpu.isGbc()
+                    && !gpu.isDmgCompatMode()
+                    && gpu.getLine() == 153
+                    && intCoincidence
+                    && lycIrqValueSource == 0
+                    && (lastModeIrqStatWriteOld & 0x40) != 0
+                    && (enable & 0x60) == 0x20
+                    && lastModeIrqStatWriteLineTick >= 0
+                    && gpu.getTicksInLine() >= lastModeIrqStatWriteLineTick
+                    && cpuCyclesSince(lastModeIrqStatWriteClock) <= 4;
+            line |= holdCgbFrameLycToMode2Handoff;
             boolean suppressTailCgbMode0Enable = gpu.isGbc()
                     && gpu.getLine() < 144
                     && (lastModeIrqStatWriteOld & 0x08) == 0
@@ -502,7 +535,13 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
                     && (enable & 0x10) != 0;
             line |= !suppressLateCgbMode1Enable
                     && (enable & 0b00010000) != 0 && isMode1IrqLineActive();
-            line |= !suppressLateCgbModeEnable
+            boolean suppressLateDmgLine0Mode2Enable = !gpu.isGbc()
+                    && gpu.getLine() == 0 && gpu.getTicksInLine() < 4
+                    && lastModeIrqStatWriteLineTick >= 0
+                    && lastModeIrqStatWriteLineTick < 4
+                    && lycIrqClock - lastModeIrqStatWriteClock <= 4
+                    && (lastModeIrqStatWriteOld & 0x20) == 0;
+            line |= !suppressLateCgbModeEnable && !suppressLateDmgLine0Mode2Enable
                     && (enable & 0b00100000) != 0 && gpu.isMode2IntWindow();
         }
         return line;
@@ -662,6 +701,22 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
                         && precedingLy == modeIrqLycLatch;
                 if (blockedByM1 || blockedByLyc) {
                     suppressNaturalModeEdge = true;
+                } else if (gpu.isGbc() && !gpu.isDmgCompatMode()
+                        && !isDoubleSpeed() && gpu.getLine() == 153
+                        && gpu.getTicksInLine() == 454) {
+                    boolean capturedRequest =
+                            !interruptManager.isInterruptFlagSet(InterruptType.LCDC);
+                    boolean capturedLyc153Source = (modeIrqStatLatch & 0x40) != 0
+                            && modeIrqLycLatch == 153;
+                    if (capturedRequest && capturedLyc153Source) {
+                        // The outgoing LYC=153 source gives the frame event its
+                        // dot-454 IF phase. A following IF clear must be able to
+                        // consume it before rollover.
+                        interruptManager.requestMode2InterruptBeforeCpuAcceptance(false);
+                    } else {
+                        pendingCgbFrameMode2Interrupt = capturedRequest && !intLine;
+                    }
+                    suppressNaturalModeEdge = true;
                 }
                 refreshModeIrqLatches(true);
             }
@@ -746,6 +801,12 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
 
     private void publishPendingCgbMode2Event() {
         commitPendingModeIrqRegisters();
+        if (!isDoubleSpeed()
+                && pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                && cpuCyclesSince(pendingModeIrqStatClock) == 2) {
+            modeIrqStatLatch = pendingModeIrqStat;
+            pendingModeIrqStatClock = NO_LYC_IRQ_EVENT;
+        }
         if (!isDoubleSpeed()
                 && pendingModeIrqLycClock != NO_LYC_IRQ_EVENT
                 && cpuCyclesSince(pendingModeIrqLycClock) == 6) {
@@ -1151,6 +1212,19 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
 
     @Override
     public void setByte(int address, int value) {
+        int newEnableBits = value & 0b01111000;
+        boolean capturedDmgLycToMode2Handoff = !gpu.isGbc()
+                && gpu.isLcdEnabled()
+                && (enableBits & 0x40) != 0
+                && (newEnableBits & 0x68) == 0x20
+                && lycIrqValueSource == gpu.getLine()
+                && gpu.isMode2IntWindow()
+                && cpuCyclesToNextLy() <= 4;
+        if (capturedDmgLycToMode2Handoff) {
+            // The outgoing LYC source is still high at the final mode-2 capture.
+            // Preserve that shared level so the FF41 handoff cannot create an edge.
+            intLine = true;
+        }
         if (!gpu.isGbc()) {
             if ((value & 0b01111000) == 0
                     && gpu.isLcdEnabled()
@@ -1167,6 +1241,12 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
             // DMG STAT write glitch: all interrupt sources are enabled for a moment
             // before the written data settles
             int glitchEnable = 0b01111000;
+            if (gpu.getLine() == 0 && gpu.getTicksInLine() < 4
+                    && (enableBits & 0x20) == 0 && (newEnableBits & 0x20) != 0) {
+                // The line-zero mode-2 event has already sampled FF41. Its transient
+                // all-enabled write phase cannot arm that event retroactively.
+                glitchEnable &= ~0x20;
+            }
             if (gpu.isLcdEnabled()
                     && gpu.getTicksInLine() == 0
                     && (enableBits & 0b00101000) == 0b00001000) {
@@ -1178,12 +1258,18 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
             }
             updateIntLine(computeIntLine(glitchEnable));
         }
-        int newEnableBits = value & 0b01111000;
         if (isDoubleSpeed() && retractableCgbMode2Interrupt
                 && gpu.getTicksInLine() <= 454
                 && (newEnableBits & 0x20) == 0) {
             interruptManager.cancelMode2InterruptBeforeCpuAcceptance();
             retractableCgbMode2Interrupt = false;
+        }
+        if (pendingCgbFrameMode2Interrupt && gpu.isGbc() && !gpu.isDmgCompatMode()
+                && !isDoubleSpeed() && gpu.getLine() == 153
+                && gpu.getTicksInLine() <= 454 && (newEnableBits & 0x20) == 0) {
+            // A write in the capture dot can still withdraw the frame mode-2
+            // occurrence before it is published at rollover.
+            pendingCgbFrameMode2Interrupt = false;
         }
         if (canReschedulePendingCgbMode2Event()) {
             pendingCgbMode2Interrupt = (newEnableBits & 0x28) == 0x20;
@@ -1260,7 +1346,8 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
                 mode0EventArmed, previousMode0Window,
                 previousMode1Window, previousMode2Window,
                 pendingCgbMode0Interrupt, pendingCgbMode2Interrupt,
-                retractableCgbMode2Interrupt, scxChangedSinceMode0Event);
+                pendingCgbFrameMode2Interrupt, retractableCgbMode2Interrupt,
+                scxChangedSinceMode0Event);
     }
 
     @Override
@@ -1311,6 +1398,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         this.previousMode2Window = mem.previousMode2Window;
         this.pendingCgbMode0Interrupt = mem.pendingCgbMode0Interrupt;
         this.pendingCgbMode2Interrupt = mem.pendingCgbMode2Interrupt;
+        this.pendingCgbFrameMode2Interrupt = mem.pendingCgbFrameMode2Interrupt;
         this.retractableCgbMode2Interrupt = mem.retractableCgbMode2Interrupt;
         this.scxChangedSinceMode0Event = mem.scxChangedSinceMode0Event;
     }
@@ -1348,6 +1436,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
                                        boolean previousMode2Window,
                                        boolean pendingCgbMode0Interrupt,
                                        boolean pendingCgbMode2Interrupt,
+                                       boolean pendingCgbFrameMode2Interrupt,
                                        boolean retractableCgbMode2Interrupt,
                                        boolean scxChangedSinceMode0Event) implements Memento<StatRegister> {
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -720,6 +720,121 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void normalSpeedCgbFrameMode2CapturesAtDot454AndPublishesAtDot455() {
+        Fixture fixture = new Fixture(true);
+        fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        fixture.advanceTo(153, 453);
+        fixture.clearInterrupts();
+
+        fixture.tick();
+        assertEquals(454, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.lcdInterruptFlag());
+
+        fixture.tick();
+        assertEquals(455, fixture.gpu.getTicksInLine());
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+        assertFalse(fixture.interrupts.isInterruptRequested());
+    }
+
+    @Test
+    public void rephasedNormalSpeedCgbFrameMode2PublishesAfterRollover() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        fixture.advanceTo(153, 453);
+        fixture.clearInterrupts();
+
+        fixture.tick();
+        fixture.tick();
+        assertEquals(455, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.lcdInterruptFlag());
+
+        fixture.tick();
+        assertEquals(0, fixture.gpu.getLine());
+        assertEquals(0, fixture.gpu.getTicksInLine());
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+        assertTrue(fixture.interrupts.isInterruptRequested());
+        assertTrue(fixture.interrupts.isUnphasedPpuInterruptRequested());
+    }
+
+    @Test
+    public void normalSpeedCgbLyc153FrameMode2PublishesAtDot454() {
+        Fixture fixture = new Fixture(true);
+        fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 153);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x60);
+        fixture.advanceTo(153, 453);
+        fixture.clearInterrupts();
+
+        fixture.tick();
+
+        assertEquals(454, fixture.gpu.getTicksInLine());
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+        assertFalse(fixture.interrupts.isInterruptRequested());
+    }
+
+    @Test
+    public void normalSpeedCgbFrameMode2DoesNotRetriggerAfterCapturedHighIf() {
+        Fixture fixture = new Fixture(true);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        fixture.advanceTo(153, 453);
+        fixture.interrupts.setByte(0xff0f, 1 << LCDC.ordinal());
+
+        fixture.tick();
+        fixture.clearInterrupts();
+        fixture.tick();
+
+        assertEquals(455, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.lcdInterruptFlag());
+    }
+
+    @Test
+    public void normalSpeedCgbFrameMode2DisableCancelsCapturedEvent() {
+        Fixture fixture = new Fixture(true);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        fixture.advanceTo(153, 453);
+        fixture.clearInterrupts();
+        fixture.tick();
+
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x00);
+        fixture.tick();
+
+        assertEquals(455, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.lcdInterruptFlag());
+    }
+
+    @Test
+    public void pendingNormalSpeedCgbFrameMode2SurvivesMementoRoundTrip() {
+        Fixture fixture = new Fixture(true);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        fixture.advanceTo(153, 453);
+        fixture.clearInterrupts();
+        fixture.tick();
+        var gpuMemento = fixture.gpu.saveToMemento();
+        var statMemento = fixture.stat.saveToMemento();
+        var interruptMemento = fixture.interrupts.saveToMemento();
+
+        fixture.tick();
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+
+        fixture.gpu.restoreFromMemento(gpuMemento);
+        fixture.stat.restoreFromMemento(statMemento);
+        fixture.interrupts.restoreFromMemento(interruptMemento);
+        fixture.tick();
+
+        assertEquals(455, fixture.gpu.getTicksInLine());
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+    }
+
+    @Test
+    public void normalSpeedCgbMode2CapturesStatWriteAtTwoClockBoundary() {
+        assertEquals(1 << LCDC.ordinal(), cgbMode2StatCaptureFlagAt(448));
+        assertEquals(0, cgbMode2StatCaptureFlagAt(449));
+    }
+
+    @Test
     public void doubleSpeedCgbMode2DisableRetractsRequestThroughDot454() {
         Fixture fixture = publishedDoubleSpeedCgbM2Event();
 
@@ -921,6 +1036,27 @@ public class StatRegisterTest {
         assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
         assertFalse(fixture.interrupts.isInterruptRequested());
         return fixture;
+    }
+
+    private static int cgbMode2StatCaptureFlagAt(int writeTick) {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 1);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x60);
+        fixture.advanceTo(1, 447);
+        fixture.clearInterrupts();
+        fixture.tick();
+        if (writeTick == 449) {
+            fixture.stat.preCpuTick();
+            fixture.tick();
+        }
+
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x20);
+        while (fixture.gpu.getTicksInLine() < 450) {
+            fixture.stat.preCpuTick();
+            fixture.tick();
+        }
+        fixture.stat.preCpuTick();
+        return fixture.lcdInterruptFlag();
     }
 
     private static Fixture activeCgbMode0(boolean doubleSpeed) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 189;
+    private static final int CURRENT_BASELINE_COUNT = 172;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 189 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 172 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -83,8 +83,6 @@ hwtests/ly0/lycint152_ly153_3_dmg08_cgb04c_out00.gbc [CGB]	99
 hwtests/ly0/lycint152_lyc153flag_3_dmg08_cgb04c_outC1.gbc [CGB]	C5
 hwtests/ly0/lycint152_m2stat_1_dmg08_cgb04c_outC2.gbc [CGB]	C3
 hwtests/lyc0int_m0irq/lyc0int_m0irq_ds_2_cgb04c_out2.gbc [CGB]	0
-hwtests/lyc153int_m2irq/lyc153int_m2irq_2_dmg08_cgb04c_out2.gbc [CGB]	0
-hwtests/lyc153int_m2irq/lyc153int_m2irq_ifw_2_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_ds_2_cgb04c_out0.gbc [CGB]	2
@@ -95,8 +93,6 @@ hwtests/m0int_m0stat/m0int_m0stat_scx5_ds_2_cgb04c_out2.gbc [CGB]	0
 hwtests/m0int_m3stat/m0int_m3stat_2_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/m0int_m3stat/m0int_m3stat_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/m1/lyc143_late_m0enable_lycdisable_2_dmg08_cgb04c_out1.gbc [DMG]	3
-hwtests/m1/lyc143_late_m2enable_lycdisable_1_dmg08_cgb04c_out3.gbc [CGB]	1
-hwtests/m1/lyc143_late_m2enable_lycdisable_2_dmg08_cgb04c_out1.gbc [DMG]	3
 hwtests/m1/lycint143_m1irq_ifw_ds_2_cgb04c_out0.gbc [CGB]	1
 hwtests/m1/lycint143_m1irq_late_retrigger_2_dmg08_cgb04c_out1.gbc [DMG]	3
 hwtests/m1/lycint143_m1irq_late_retrigger_ds_1_cgb04c_out3.gbc [CGB]	1
@@ -110,19 +106,6 @@ hwtests/m1/m1irq_enable_after_lyc144_2_dmg08_out1_cgb04c_out3.gbc [DMG]	3
 hwtests/m1/m1irq_late_enable_3_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/m1/m1irq_m2enable_lyc_2_dmg08_out1_cgb04c_out3.gbc [DMG]	3
 hwtests/m1/m2m1irq_ifw_ds_3_cgb04c_out0.gbc [CGB]	1
-hwtests/m2enable/late_enable_after_lycint_disable_1_dmg08_cgb04c_out2.gbc [CGB]	0
-hwtests/m2enable/late_enable_ly0_2_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/late_enable_ly0_2_dmg08_cgb04c_out0.gbc [DMG]	2
-hwtests/m2enable/late_enable_ly0_ds_2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/late_enable_ly0_ds_lcdoffset1_2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/late_enable_ly0_lcdoffset2_2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/late_enable_m1disable_ly0_3_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/late_enable_m1disable_ly0_3_dmg08_cgb04c_out0.gbc [DMG]	2
-hwtests/m2enable/late_enable_m1disable_ly0_ds_2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/lyc0_late_m2enable_lycdisable_2_dmg08_out2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/lyc0_late_m2enable_lycdisable_ds_2_cgb04c_out0.gbc [CGB]	2
-hwtests/m2enable/lyc1_late_m2enable_lycdisable_1_dmg08_out0_cgb04c_out2.gbc [DMG]	2
-hwtests/m2enable/lyc1_m2irq_late_lycdisable_1_dmg08_cgb04c_out2.gbc [CGB]	0
 hwtests/m2int_m0irq/m2int_m0irq_1_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/m2int_m0irq/m2int_m0irq_ds_1_cgb04c_out1.gbc [CGB]	3
 hwtests/m2int_m0irq/m2int_m0irq_scx2_ei_2_dmg08_cgb04c_out2.gbc [CGB]	0


### PR DESCRIPTION
## Summary

- move the native-CGB new-frame mode-2 capture to the line 153 tail and publish it according to the normal-speed clock phase
- preserve CGB and DMG shared STAT-source handoffs around the capture boundary
- cover capture, cancellation, IF-high suppression, memento restore, write-latch timing, and rephased rollover behavior

## Results

- fixes all 13 remaining `m2enable` failures plus 2 `m1` and 2 `lyc153int_m2irq` cases
- raises hardware matches from 4,485 to 4,502 of 4,674
- reduces the exact unresolved-output baseline from 189 to 172
- exact differential: 17 resolved, 0 new failures, 0 changed unresolved outputs

## Testing

- `mvn -q -pl core -Dtest=StatRegisterTest test`
- direct full Gambatte corpus: 4,502 / 4,674 hardware matches
- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw`
- `mvn test -q`