### PR TITLE
Fix CGB speed-switch tail timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,502 match hardware; 172 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,503 match hardware; 171 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 172 unresolved cases are likewise pinned to their complete
+output. Gambatte's 171 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -53,8 +53,13 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     static final int SPEED_SWITCH_TAIL_TICKS = 2;
 
     // Observed CGB timing uses the longer path on the other normal-speed
-    // CPU/PPU half-phase and when the HBlank VRAM-DMA mode latch is retained.
+    // CPU/PPU half-phase.
     static final int LONG_SPEED_SWITCH_TAIL_TICKS = 8;
+
+    // A retained HBlank VRAM-DMA mode latch takes an intermediate path on the
+    // short clock-mux half-phase. The ordinary long half-phase still wins when
+    // both conditions coincide.
+    static final int HBLANK_SPEED_SWITCH_TAIL_TICKS = 7;
 
     // The native CGB boot ROM hands control to the cartridge before its final
     // peripheral-clock handoff has propagated. The CPU is already at $0100 while
@@ -520,10 +525,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                         && !speedSwitchClockPhaseShifted
                         && gpu.isLcdEnabled()
                         && (gpu.getTicksInLine() & 3) == 0;
-                speedSwitchTailTicks = (hdma.holdsHblankSpeedSwitchTail()
-                        || longClockMuxPhase
-                        ? LONG_SPEED_SWITCH_TAIL_TICKS
-                        : SPEED_SWITCH_TAIL_TICKS)
+                speedSwitchTailTicks = baseSpeedSwitchTailTicks(longClockMuxPhase,
+                        hdma.holdsHblankSpeedSwitchTail())
                         + (speedMode.getSpeedMode() == 2 && speedSwitchClockPhaseShifted ? 1 : 0)
                         + (hdma.hasPendingHblankTransfer()
                         ? PENDING_HBLANK_SPEED_SWITCH_ALIGNMENT_TICKS : 0);
@@ -635,6 +638,15 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     boolean isSpeedSwitchTailActive() {
         return speedSwitchTailTicks > 0;
+    }
+
+    static int baseSpeedSwitchTailTicks(boolean longClockMuxPhase,
+                                        boolean hblankSpeedSwitchTail) {
+        return longClockMuxPhase
+                ? LONG_SPEED_SWITCH_TAIL_TICKS
+                : hblankSpeedSwitchTail
+                ? HBLANK_SPEED_SWITCH_TAIL_TICKS
+                : SPEED_SWITCH_TAIL_TICKS;
     }
 
     public SpeedMode getSpeedMode() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyMementoTest.java
@@ -95,10 +95,8 @@ public class GameboyMementoTest {
             }
             gameboy.restoreFromMemento(memento);
 
-            for (int i = 0; i < Gameboy.LONG_SPEED_SWITCH_TAIL_TICKS; i++) {
-                assertTrue(gameboy.isSpeedSwitchTailActive());
-                gameboy.tick();
-            }
+            assertEquals(Gameboy.LONG_SPEED_SWITCH_TAIL_TICKS,
+                    drainSpeedSwitchTail(gameboy));
             assertFalse(gameboy.isSpeedSwitchTailActive());
             assertEquals(pcAtTailStart, gameboy.getCpu().getRegisters().getPC());
             assertEquals(0, gameboy.getAddressSpace().getByte(0xff05));
@@ -127,6 +125,14 @@ public class GameboyMementoTest {
             assertEquals(Gameboy.SPEED_SWITCH_TAIL_TICKS,
                     drainSpeedSwitchTail(gameboy));
         }
+    }
+
+    @Test
+    public void retainedHblankLatchUsesIntermediateTailOnlyOnShortPhase() {
+        assertEquals(2, Gameboy.baseSpeedSwitchTailTicks(false, false));
+        assertEquals(7, Gameboy.baseSpeedSwitchTailTicks(false, true));
+        assertEquals(8, Gameboy.baseSpeedSwitchTailTicks(true, false));
+        assertEquals(8, Gameboy.baseSpeedSwitchTailTicks(true, true));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 172;
+    private static final int CURRENT_BASELINE_COUNT = 171;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 172 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 171 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -16,7 +16,6 @@ hwtests/dma/hdma_late_m3halt_m2unhalt_ly_scx2_3_cgb04c_out02.gbc [CGB]	03
 hwtests/dma/hdma_late_m3speedchange_hdma5_scx2_2_cgb04c_out80.gbc [CGB]	FF
 hwtests/dma/hdma_late_m3speedchange_ly_scx1_1_cgb04c_out92.gbc [CGB]	93
 hwtests/dma/hdma_late_m3speedchange_ly_scx1_3_cgb04c_out92.gbc [CGB]	93
-hwtests/dma/hdma_late_m3speedchange_ly_scx1_5_cgb04c_out92.gbc [CGB]	93
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx1_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx2_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m3speedchange_late_m0wakeup_1_cgb04c_outFF.gbc [CGB]	00


### PR DESCRIPTION
## Summary

- model the retained HBlank-DMA speed-switch tail as seven master ticks on the short clock-mux half-phase
- preserve the ordinary two-tick tail and give the eight-tick long half-phase precedence when both states coincide
- cover the 2/7/8 tail decision table and promote one Gambatte DMA case to its hardware verdict

## Validation

- `mvn -q -pl core -Dtest=GameboyMementoTest test`
- `mvn -q -pl core test -Ptest-daid`
- `mvn -q -pl core test -Ptest-gbc-hw`
- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw`
- `mvn test -q`