### PR TITLE
Fix double-speed disabled-window STAT timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,503 match hardware; 171 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,507 match hardware; 167 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 171 unresolved cases are likewise pinned to their complete
+output. Gambatte's 167 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -864,6 +864,16 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             return Mode.PixelTransfer.ordinal();
         }
         if (gbc && speedMode.getSpeedMode() == 2
+                && mode == Mode.HBlank
+                && ticksInLine < hblankIntFrom
+                && ticksInLine + 2 >= hblankIntFrom
+                && pixelMachine.hasActivatedWindowOnLine()
+                && !pixelMachine.isWindowActive()) {
+            // A disabled window still owns the dynamic prediction, but double-speed
+            // CPU reads release its mode-3 latch two dots before the mode-0 edge.
+            return Mode.HBlank.ordinal();
+        }
+        if (gbc && speedMode.getSpeedMode() == 2
                 && ((mode == Mode.PixelTransfer && pixelTransferDone)
                 || (mode == Mode.HBlank && ticksInLine < hblankIntFrom))) {
             return Mode.PixelTransfer.ordinal();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
@@ -255,6 +255,28 @@ public class GpuDisplayEnableTimingTest {
     }
 
     @Test
+    public void doubleSpeedDisabledWindowExposesModeZeroDuringModeZeroLookahead() {
+        Fixture fixture = new Fixture(2);
+        fixture.gpu.onSpeedSwitch();
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff4a, 0);
+        fixture.gpu.setByte(0xff4b, 15);
+        fixture.gpu.setByte(0xff40, 0xb1);
+        fixture.advanceTo(1, 130);
+
+        fixture.gpu.setByte(0xff40, 0x91);
+        int modeImmediatelyBeforeModeZero = -1;
+        while (!fixture.gpu.isMode0IntWindow()) {
+            if (fixture.gpu.getMode() == Mode.HBlank) {
+                modeImmediatelyBeforeModeZero = fixture.gpu.getVisibleStatMode();
+            }
+            fixture.tick();
+        }
+
+        assertEquals(Mode.HBlank.ordinal(), modeImmediatelyBeforeModeZero);
+    }
+
+    @Test
     public void doubleSpeedMode2DispatchExtendsObjectFreeStatTailThroughHblankPlusThree() {
         Fixture fixture = new Fixture(2);
         fixture.advanceTo(1, 0);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 171;
+    private static final int CURRENT_BASELINE_COUNT = 167;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 171 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 167 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -156,10 +156,6 @@ hwtests/vramw_m3end/vramw_m3end_scx3_2_dmg08_cgb04c_out7.gbc [CGB]	0
 hwtests/vramw_m3end/vramw_m3end_scx3_4_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/arg/late_wy_1toFF_lcdoffset1_1_cgb04c_out0.gbc [CGB]	3
 hwtests/window/arg/late_wy_FFto2_ly2_scx5_3_dmg08_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_disable_early_scx00_wx0f_ds_1_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_disable_early_scx00_wx10_ds_1_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_disable_early_scx00_wx11_ds_1_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_disable_early_scx00_wx12_ds_1_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_disable_early_scx03_wx12_2_dmg08_out0_cgb04c_out3.gbc [DMG]	3
 hwtests/window/late_disable_late_scx03_wx12_1_dmg08_cgb04c_out0.gbc [DMG]	3
 hwtests/window/late_disable_scx2_0_dmg08_cgb04c_out0.gbc [DMG]	3


### PR DESCRIPTION
## Summary
- release the CGB double-speed readable mode-3 latch two dots before the predicted mode-0 edge after a window is disabled
- add a focused regression test for the disabled-window lookahead
- remove four hardware-correct Gambatte baselines (4,507/4,674 now match hardware)

## Validation
- `mvn -q test`
- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw` (4,674 tests)
- `mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb`
- `mvn -q -pl core -Dtest=GpuDisplayEnableTimingTest test`
- full hardware-oracle differential: 4 fixes, 0 regressions