### PR TITLE
Fix asynchronous HALT-entry timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,507 match hardware; 167 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,511 match hardware; 163 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 167 unresolved cases are likewise pinned to their complete
+output. Gambatte's 163 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -625,6 +625,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 cpu.winsInterruptEntryArbitrationForHdma());
         Mode mode = gpu.tick();
         statRegister.tick();
+        cpu.onPeripheralsTicked();
         return mode;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -66,6 +66,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
 
     private boolean haltBugMode;
 
+    private int haltEntrySampleTicks;
+
     private boolean hdmaOpcodePrefetched;
 
     private int haltPrefetchedOpcode;
@@ -136,6 +138,9 @@ public class Cpu implements Serializable, Originator<Cpu> {
         if (state == State.LOCKED) {
             return;
         }
+
+        // HALT's asynchronous entry window closes at the next CPU boundary.
+        haltEntrySampleTicks = 0;
 
         boolean wokeFromHalt = false;
         if (state == State.HALTED && interruptManager.isInterruptRequestedForHalt()) {
@@ -340,6 +345,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
                             return;
                         } else {
                             state = State.HALTED;
+                            haltEntrySampleTicks = interruptManager.isIme()
+                                    ? 0 : speedMode.isGbc() ? 2 : 4;
                             return;
                         }
                     }
@@ -391,6 +398,27 @@ public class Cpu implements Serializable, Originator<Cpu> {
 
     private boolean isJoypadLineLow() {
         return (addressSpace.getByte(0xff00) & 0x0f) != 0x0f;
+    }
+
+    /** Completes HALT's entry sample after this tick's peripheral edges settle. */
+    public void onPeripheralsTicked() {
+        if (haltEntrySampleTicks <= 0) {
+            return;
+        }
+        if (state == State.HALTED && !interruptManager.isIme()
+                && interruptManager.isInterruptRequested()) {
+            haltEntrySampleTicks = 0;
+            state = State.OPCODE;
+            haltBugMode = true;
+            // The request reached HALT after the ordinary CPU sample. Rephase the
+            // resumed bus clock onto that asynchronous edge.
+            clockCycle++;
+            if (timer != null) {
+                timer.onHaltBug();
+            }
+        } else {
+            haltEntrySampleTicks--;
+        }
     }
 
     private void handleInterrupt() {
@@ -625,6 +653,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
         operand[1] = this.operand[1];
         return new CpuMemento(registers.saveToMemento(), opcode1, opcode2, operand, operandIndex, opIndex,
                 state, opContext, interruptFlag, interruptEnabled, requestedIrq, clockCycle, haltBugMode,
+                haltEntrySampleTicks,
                 hdmaOpcodePrefetched, haltPrefetchedOpcode, haltOpcodePrefetchValid,
                 speedSwitchPaddingOpcode, speedSwitchPaddingReplayValid,
                 speedSwitchTicks, phasedPpuInputHigh, fastPhasedPpuDispatch);
@@ -649,6 +678,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
         this.requestedIrq = mem.requestedIrq;
         this.clockCycle = mem.clockCycle;
         this.haltBugMode = mem.haltBugMode;
+        this.haltEntrySampleTicks = mem.haltEntrySampleTicks;
         this.hdmaOpcodePrefetched = mem.hdmaOpcodePrefetched;
         this.haltPrefetchedOpcode = mem.haltPrefetchedOpcode;
         this.haltOpcodePrefetchValid = mem.haltOpcodePrefetchValid;
@@ -666,7 +696,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
     private record CpuMemento(Memento<Registers> registersMemento, int opcode1, int opcode2, int[] operand,
                               int operandIndex, int opIndex, State state, int opContext, int interruptFlag,
                               int interruptEnabled, InterruptManager.InterruptType requestedIrq, int clockCycle,
-                              boolean haltBugMode, boolean hdmaOpcodePrefetched,
+                              boolean haltBugMode, int haltEntrySampleTicks,
+                              boolean hdmaOpcodePrefetched,
                               int haltPrefetchedOpcode, boolean haltOpcodePrefetchValid,
                               int speedSwitchPaddingOpcode, boolean speedSwitchPaddingReplayValid,
                               int speedSwitchTicks, boolean phasedPpuInputHigh,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -163,6 +163,31 @@ public class CpuPpuInterruptTimingTest {
     }
 
     @Test
+    public void interruptInHaltEntryWindowRephasesTheHaltBug() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            Harness h = new Harness(gbc);
+            h.memory.setByte(PROGRAM + 1, 0x3d); // DEC A
+            h.cpu.getRegisters().setA(8);
+            h.enable(LCDC);
+            h.enterHalt();
+            var entryWindow = h.cpu.saveToMemento();
+            h.tickMachineCycle();
+            h.cpu.restoreFromMemento(entryWindow);
+
+            h.cpu.tick();
+            h.interrupts.requestInterrupt(LCDC);
+            h.cpu.onPeripheralsTicked();
+
+            assertEquals(Cpu.State.OPCODE, h.cpu.getState());
+            h.tickCpuTicks(2);
+            assertEquals(7, h.cpu.getRegisters().getA());
+            h.tickCpuTicks(4);
+            assertEquals(6, h.cpu.getRegisters().getA());
+            assertEquals(PROGRAM + 2, h.cpu.getRegisters().getPC());
+        }
+    }
+
+    @Test
     public void hdmaDoesNotPrefetchPastAnEnabledPendingInterrupt() {
         Harness h = new Harness(true);
         h.memory.setByte(PROGRAM, 0x00);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 167;
+    private static final int CURRENT_BASELINE_COUNT = 163;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 167 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 163 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -32,10 +32,6 @@ hwtests/halt/late_m0int_halt_m0stat_scx2_3a_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/halt/late_m0int_halt_m0stat_scx3_2b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0int_halt_m0stat_scx3_3a_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/halt/late_m0int_halt_m0stat_scx3_3b_dmg08_out0_cgb04c_out2.gbc [DMG]	2
-hwtests/halt/late_m0irq_halt_dec_scx2_2_dmg08_cgb04c_out6.gbc [CGB]	7
-hwtests/halt/late_m0irq_halt_dec_scx2_2_dmg08_cgb04c_out6.gbc [DMG]	7
-hwtests/halt/late_m0irq_halt_dec_scx3_2_dmg08_cgb04c_out6.gbc [CGB]	7
-hwtests/halt/late_m0irq_halt_dec_scx3_2_dmg08_cgb04c_out6.gbc [DMG]	7
 hwtests/halt/late_m0irq_halt_m0stat_scx2_4a_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/halt/late_m0irq_halt_m0stat_scx2_4b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_2b_dmg08_cgb04c_out2.gbc [DMG]	0


### PR DESCRIPTION
## Summary
- model the asynchronous HALT-entry interrupt sample after peripheral edges settle
- apply halt-bug PC suppression and rephase the resumed CPU bus clock by one T
- preserve the entry window in save states and add focused DMG/CGB coverage
- remove four hardware-correct Gambatte baselines (4,511/4,674 now match hardware)

## Validation
- `mvn -q test`
- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw` (4,674 tests)
- `mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb` (744 tests)
- `mvn -q -pl core -Dtest=CpuPpuInterruptTimingTest test`
- full hardware-oracle differential: 4 fixes, 0 regressions