### PR TITLE
Fix late interrupt priority arbitration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,511 match hardware; 163 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,519 match hardware; 155 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -136,7 +136,7 @@ GB matches them, while unresolved Gambatte outputs are pinned against regression
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 163 unresolved cases are likewise pinned to their complete
+output. Gambatte's 155 unresolved cases are likewise pinned to their complete
 hexadecimal output, so any change fails CI; a hardware-correct improvement removes
 the corresponding baseline entry.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -457,6 +457,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
                 break;
 
             case IRQ_JUMP:
+                applyLateInterruptPriority();
                 if (requestedIrq != null) {
                     registers.setPC(requestedIrq.getHandler());
                 } else {
@@ -465,6 +466,30 @@ public class Cpu implements Serializable, Originator<Cpu> {
                 requestedIrq = null;
                 state = State.OPCODE;
                 break;
+        }
+    }
+
+    /**
+     * The interrupt priority gate remains live through the final vector cycle. If a
+     * higher-priority source arrives after the stack pushes selected and acknowledged
+     * a lower source, vector to the new source and leave the old one pending.
+     */
+    private void applyLateInterruptPriority() {
+        if (requestedIrq == null) {
+            return;
+        }
+        for (InterruptManager.InterruptType irq : InterruptManager.InterruptType.VALUES) {
+            if (irq.ordinal() >= requestedIrq.ordinal()) {
+                return;
+            }
+            int mask = 1 << irq.ordinal();
+            if ((interruptEnabled & mask) != 0
+                    && interruptManager.isInterruptFlagSet(irq)) {
+                interruptManager.requestInterrupt(requestedIrq);
+                interruptManager.clearInterrupt(irq);
+                requestedIrq = irq;
+                return;
+            }
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.cpu;
 
+import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
@@ -163,6 +164,44 @@ public class CpuPpuInterruptTimingTest {
     }
 
     @Test
+    public void lateHigherPriorityInterruptRedirectsTheFinalVectorCycle() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            Harness h = new Harness(gbc);
+            h.memory.setByte(PROGRAM, 0x00);
+            h.enable(LCDC, Timer);
+            h.interrupts.enableInterrupts(false);
+            h.interrupts.requestInterrupt(Timer);
+            h.advanceToIrqJump();
+
+            h.interrupts.requestInterrupt(LCDC);
+            h.tickMachineCycle();
+
+            assertEquals(LCDC.getHandler(), h.cpu.getRegisters().getPC());
+            assertFalse(h.interrupts.isInterruptFlagSet(LCDC));
+            assertTrue(h.interrupts.isInterruptFlagSet(Timer));
+        }
+    }
+
+    @Test
+    public void lateLowerPriorityInterruptCannotRedirectTheFinalVectorCycle() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            Harness h = new Harness(gbc);
+            h.memory.setByte(PROGRAM, 0x00);
+            h.enable(LCDC, Timer);
+            h.interrupts.enableInterrupts(false);
+            h.interrupts.requestInterrupt(LCDC);
+            h.advanceToIrqJump();
+
+            h.interrupts.requestInterrupt(Timer);
+            h.tickMachineCycle();
+
+            assertEquals(LCDC.getHandler(), h.cpu.getRegisters().getPC());
+            assertFalse(h.interrupts.isInterruptFlagSet(LCDC));
+            assertTrue(h.interrupts.isInterruptFlagSet(Timer));
+        }
+    }
+
+    @Test
     public void interruptInHaltEntryWindowRephasesTheHaltBug() {
         for (boolean gbc : new boolean[] {false, true}) {
             Harness h = new Harness(gbc);
@@ -265,8 +304,31 @@ public class CpuPpuInterruptTimingTest {
         private Harness(boolean gbc) {
             interrupts = new InterruptManager(gbc);
             speedMode = new SpeedMode(gbc);
-            cpu = new Cpu(memory, interrupts, null, speedMode, new Display(gbc));
+            AddressSpace bus = new AddressSpace() {
+                @Override
+                public boolean accepts(int address) {
+                    return true;
+                }
+
+                @Override
+                public void setByte(int address, int value) {
+                    if (interrupts.accepts(address)) {
+                        interrupts.setByte(address, value);
+                    } else {
+                        memory.setByte(address, value);
+                    }
+                }
+
+                @Override
+                public int getByte(int address) {
+                    return interrupts.accepts(address)
+                            ? interrupts.getByte(address)
+                            : memory.getByte(address);
+                }
+            };
+            cpu = new Cpu(bus, interrupts, null, speedMode, new Display(gbc));
             cpu.getRegisters().setPC(PROGRAM);
+            cpu.getRegisters().setSP(0xfffe);
             memory.setByte(PROGRAM, 0x76);
             interrupts.setByte(0xff0f, 0);
         }
@@ -291,6 +353,13 @@ public class CpuPpuInterruptTimingTest {
 
         private void tickMachineCycle() {
             tickCpuTicks(4 / speedMode.getSpeedMode());
+        }
+
+        private void advanceToIrqJump() {
+            for (int i = 0; i < 6 && cpu.getState() != Cpu.State.IRQ_JUMP; i++) {
+                tickMachineCycle();
+            }
+            assertEquals(Cpu.State.IRQ_JUMP, cpu.getState());
         }
 
         private void tickCpuTicks(int ticks) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 163;
+    private static final int CURRENT_BASELINE_COUNT = 155;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 163 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 155 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -47,14 +47,6 @@ hwtests/irq_precedence/late_m0irq_retrigger_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_ds_1_cgb04c_outE2.gbc [CGB]	E0
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [CGB]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx2_1_dmg08_cgb04c_out4.gbc [CGB]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx2_1_dmg08_cgb04c_out4.gbc [DMG]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx2_halt_1_dmg08_cgb04c_out4.gbc [CGB]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx2_halt_1_dmg08_cgb04c_out4.gbc [DMG]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx3_1_dmg08_cgb04c_out4.gbc [CGB]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx3_1_dmg08_cgb04c_out4.gbc [DMG]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx3_halt_1_dmg08_cgb04c_out4.gbc [CGB]	2
-hwtests/irq_precedence/late_m0irq_vs_tima_scx3_halt_1_dmg08_cgb04c_out4.gbc [DMG]	2
 hwtests/lcd_offset/offset1_lyc8fint_m1stat_ds_1_cgb04c_outC0.gbc [CGB]	C4
 hwtests/lcd_offset/offset1_lyc98int_ly_count_ds_2_cgb04c_out9A.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx2_2_cgb04c_out90.gbc [CGB]	00


### PR DESCRIPTION
## Summary
- keep interrupt priority arbitration live through the final vector cycle
- redirect a provisional lower-priority interrupt when a newly requested higher-priority source wins, while leaving the displaced source pending
- add focused DMG and CGB timing coverage in both priority directions
- move eight Gambatte IRQ-precedence cases to their hardware result, raising matches to 4,519 of 4,674 and reducing the pinned baseline to 155

## Verification
- mvn -q -f core/pom.xml -Dtest=CpuPpuInterruptTimingTest test
- mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw
- mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb
- mvn -q test -f core/pom.xml
- mvn -q test