### PR TITLE
Model rephased CGB STAT tail reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,519 match hardware; 155 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,522 match hardware; 152 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 155 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 152 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -1308,6 +1308,17 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         int visibleMode = cpuStatModeOverride >= 0
                 ? cpuStatModeOverride
                 : gpu.getVisibleStatMode();
+        // A speed switch rephases the native CGB's CPU-facing STAT mux. Its last
+        // bus slot of an active scanline (and of line 153) already exposes the next
+        // line's mode 2. The LYC source shares this tail mux and keeps the current
+        // mode visible in that rephased slot when selected.
+        if (gpu.isGbc() && !gpu.isDmgCompatMode()
+                && gpu.isLcdEnabled() && gpu.isStatModeLatchRephasedBySpeedSwitch()
+                && (gpu.getLine() < 143 || gpu.getLine() == 153)
+                && gpu.getTicksInLine() >= (isDoubleSpeed() ? 453 : 450)
+                && (enableBits & 0x40) == 0) {
+            visibleMode = Mode.OamSearch.ordinal();
+        }
         if (gpu.isGbc() && !isDoubleSpeed() && gpu.isLcdEnabled()
                 && gpu.getLine() < 143 && gpu.getTicksInLine() == 454
                 && !gpu.hasObjectsOnLine() && (enableBits & 0x40) != 0

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -149,6 +149,59 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void rephasedNormalSpeedCgbStatProjectsMode2InFinalCpuBusSlot() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 449);
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void rephasedDoubleSpeedCgbStatProjectsMode2InFinalCpuBusSlot() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 452);
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void rephasedNormalSpeedCgbStatProjectsMode2AtFrameTail() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(153, 449);
+
+        assertEquals(Mode.VBlank.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void rephasedCgbDmgCompatibilityKeepsOrdinaryTailMux() {
+        Fixture fixture = new Fixture(true);
+        fixture.speedMode.setDmgCompat(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 450);
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void rephasedCgbLycSourceKeepsCurrentModeInTailMux() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x40);
+        fixture.advanceTo(1, 450);
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
     public void cgbLycStatReadRetainsHblankThroughDot454OnObjectFreeLine() {
         Fixture fixture = new Fixture(true);
         fixture.stat.setByte(StatRegister.ADDRESS, 0x40);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 155;
+    private static final int CURRENT_BASELINE_COUNT = 152;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 155 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 152 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -52,8 +52,6 @@ hwtests/lcd_offset/offset1_lyc98int_ly_count_ds_2_cgb04c_out9A.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx2_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx3_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset1_lyc99int_m2stat_count_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset1_lyc99int_m2stat_count_ds_2_cgb04c_out90.gbc [CGB]	01
 hwtests/lcd_offset/offset1_lyc99int_m3stat_count_ds_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset2_lyc8fint_m1irq_1_cgb04c_outE0.gbc [CGB]	E2
 hwtests/lcd_offset/offset2_lyc8fint_m1stat_1_cgb04c_outC4.gbc [CGB]	C1
@@ -64,7 +62,6 @@ hwtests/lcd_offset/offset3_lyc98int_ly_count_2_cgb04c_out9A.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx0_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx1_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m2irq_count_2_cgb04c_out91.gbc [CGB]	00
-hwtests/lcd_offset/offset3_lyc99int_m2stat_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m3stat_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/ly0/lycint152_ly153_3_dmg08_cgb04c_out00.gbc [CGB]	99
 hwtests/ly0/lycint152_lyc153flag_3_dmg08_cgb04c_outC1.gbc [CGB]	C5


### PR DESCRIPTION
## Summary
- model the CPU-facing native CGB STAT mux after a speed switch, projecting the next mode-2 state in the final bus slot
- preserve the ordinary mux for CGB DMG-compatibility mode, the line-143 VBlank transition, and a selected LYC source
- add focused normal-speed, double-speed, frame-tail, compatibility-mode, and LYC-source coverage
- move three lcd_offset cases to their hardware result, raising Gambatte matches to 4,522 of 4,674 and reducing the pinned baseline to 152

## Verification
- mvn -q -f core/pom.xml -Dtest=StatRegisterTest test
- mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw
- mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb
- mvn -q test -f core/pom.xml
- mvn -q test