### PR TITLE
Fix late HDMA opcode arbitration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,522 match hardware; 152 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,526 match hardware; 148 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 152 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 148 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -553,38 +553,48 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 // rephase arbitration onto the CPU half-cycle. Let the opcode at
                 // that boundary finish before granting the pending DMA burst.
                 cpu.tick();
-                if (!cpu.hasInFlightInstructionForHdma()) {
+                if (!cpu.isCpuRequestSlotInProgressForHdma()) {
                     hdma.onSpeedSwitchWakeCpuInstructionFinished();
                 }
-            } else if (hdma.yieldsToInterruptEntry()
-                    && cpu.advancesInterruptEntryForHdma()) {
+            } else if (hdma.isInterruptEntryRequestOwner()
+                    && cpu.canAdvanceInterruptEntryForHdma()) {
                 // Once interrupt acceptance has won the arbitration slot, its stack
                 // pushes finish before HDMA takes the bus. If the request won during
                 // the retiring instruction, first advance its pending acceptance at
                 // the following opcode boundary. This ordering is visible when the
                 // DMA source is the top of that same stack.
                 cpu.tick();
-            } else if (hdma.yieldsToFetchedCpuInstruction(
-                    cpu.hasFetchedInstructionForHdma())) {
-                // A fetched instruction owns the CPU/HDMA arbitration slot until its
-                // next opcode boundary. Its final double-speed HBlank read also keeps
-                // the VRAM slot that was granted with the instruction.
-                gpu.setCpuRetiringInstructionForHdma(true);
-                try {
-                    cpu.tick();
-                } finally {
-                    gpu.setCpuRetiringInstructionForHdma(false);
-                }
-                if (!cpu.hasFetchedInstructionForHdma()) {
-                    hdma.onFetchedCpuInstructionFinished();
-                }
             } else {
-                // VRAM is not connected as a CGB VRAM-DMA source. Its first invalid
-                // read slots expose the instruction bus left at the CPU's next PC.
-                hdma.setCpuBusValue(cpu.getBusValueForHdma());
-                cpu.prefetchOpcodeForHdma();
-                if (hdma.tick() && hdma.yieldsCpuAfterBlock()) {
-                    cpu.releaseHdmaPrefetchedOpcode();
+                if (hdma.isCpuRequestUnresolved()) {
+                    boolean cpuClaimedSlot = cpu.claimCpuRequestSlotForHdma();
+                    hdma.resolveCpuRequest(cpuClaimedSlot,
+                            cpu.hasPendingInterruptForHdmaArbitration());
+                }
+                if (hdma.isCpuInstructionRequestOwner()) {
+                    // A CPU-fetched instruction owns the request slot until its next
+                    // opcode boundary. Its final double-speed HBlank read also keeps
+                    // the VRAM slot that was granted with the instruction.
+                    gpu.setCpuRetiringInstructionForHdma(true);
+                    try {
+                        cpu.tick();
+                    } finally {
+                        gpu.setCpuRetiringInstructionForHdma(false);
+                    }
+                    if (cpu.isInterruptEntryBusSequenceActiveForHdma()) {
+                        hdma.onInterruptEntryAcceptedByCpu();
+                    } else if (!cpu.isCpuRequestSlotInProgressForHdma()) {
+                        hdma.onCpuRequestSlotRetired();
+                    }
+                } else {
+                    // VRAM is not connected as a CGB VRAM-DMA source. Its first invalid
+                    // read slots expose the instruction bus left at the CPU's next PC.
+                    // A late arbitration fetch is already latched, so both operations
+                    // below reuse that sample without another opcode-bus read.
+                    hdma.setCpuBusValue(cpu.getBusValueForHdma());
+                    cpu.prefetchOpcodeForHdma();
+                    if (hdma.tick() && hdma.yieldsCpuAfterBlock()) {
+                        cpu.releaseHdmaPrefetchedOpcode();
+                    }
                 }
             }
         } else {
@@ -621,8 +631,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         // The HBlank request crosses from the PPU to the CPU arbiter while the CPU is
         // still allowed to finish the current machine cycle.
         hdma.advanceHblankRequest(cpu.hasInFlightWriteCycleForHdma(),
-                cpu.hasInFlightInstructionForHdma(),
-                cpu.winsInterruptEntryArbitrationForHdma());
+                cpu.isCpuRequestSlotInProgressForHdma(),
+                cpu.isInterruptClaimedAtHdmaSample());
         Mode mode = gpu.tick();
         statRegister.tick();
         cpu.onPeripheralsTicked();
@@ -635,6 +645,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     public Cpu getCpu() {
         return cpu;
+    }
+
+    Hdma getHdma() {
+        return hdma;
     }
 
     boolean isSpeedSwitchTailActive() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -70,6 +70,10 @@ public class Cpu implements Serializable, Originator<Cpu> {
 
     private boolean hdmaOpcodePrefetched;
 
+    private int hdmaArbitrationOpcode;
+
+    private boolean hdmaArbitrationOpcodeValid;
+
     private int haltPrefetchedOpcode;
 
     private boolean haltOpcodePrefetchValid;
@@ -163,6 +167,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
         if (state == State.OPCODE || state == State.STOPPED) {
             if (interruptManager.isIme() && interruptManager.isInterruptRequested()) {
                 haltOpcodePrefetchValid = false;
+                hdmaArbitrationOpcodeValid = false;
                 if (state == State.STOPPED) {
                     display.enableLcd();
                 }
@@ -217,8 +222,10 @@ public class Cpu implements Serializable, Originator<Cpu> {
                 case OPCODE:
                     boolean useHdmaHaltPrefetch = haltOpcodePrefetchValid;
                     boolean useSpeedSwitchPadding = speedSwitchPaddingReplayValid;
+                    boolean useHdmaArbitrationOpcode = hdmaArbitrationOpcodeValid;
                     haltOpcodePrefetchValid = false;
                     speedSwitchPaddingReplayValid = false;
+                    hdmaArbitrationOpcodeValid = false;
                     if (useHdmaHaltPrefetch) {
                         // A request acknowledged by HALT owns the bus before the held
                         // opcode may run, just like the ordinary DMA prefetch below.
@@ -229,6 +236,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
                             ? haltPrefetchedOpcode
                             : useSpeedSwitchPadding
                             ? speedSwitchPaddingOpcode
+                            : useHdmaArbitrationOpcode
+                            ? hdmaArbitrationOpcode
                             : addressSpace.getByte(pc);
                     accessedMemory = true;
                     if (opcode1 == 0xcb) {
@@ -533,6 +542,9 @@ public class Cpu implements Serializable, Originator<Cpu> {
         if (state == State.EXT_OPCODE || state == State.OPERAND || state == State.RUNNING) {
             return opcode1;
         }
+        if (hdmaArbitrationOpcodeValid) {
+            return hdmaArbitrationOpcode;
+        }
         return addressSpace.getByte(registers.getPC());
     }
 
@@ -547,8 +559,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
             return;
         }
         int pc = registers.getPC();
-        if (gpu != null && pc >= 0x8000 && pc < 0xa000
-                && gpu.getMode() == Mode.OamSearch && gpu.getTicksInLine() >= 79) {
+        if (isHdmaOpcodeFetchBlockedByPpu(pc)) {
             // At the closing mode-2 arbitration slot, the PPU has already claimed
             // VRAM for mode 3. A simultaneously started VRAM DMA wins before the
             // CPU can perform its speculative opcode fetch.
@@ -556,10 +567,14 @@ public class Cpu implements Serializable, Originator<Cpu> {
         }
 
         boolean useSpeedSwitchPadding = speedSwitchPaddingReplayValid;
+        boolean useHdmaArbitrationOpcode = hdmaArbitrationOpcodeValid;
         speedSwitchPaddingReplayValid = false;
+        hdmaArbitrationOpcodeValid = false;
         clearState();
         opcode1 = useSpeedSwitchPadding
                 ? speedSwitchPaddingOpcode
+                : useHdmaArbitrationOpcode
+                ? hdmaArbitrationOpcode
                 : addressSpace.getByte(pc);
         if (opcode1 == 0xcb || opcode1 == 0x10) {
             state = State.EXT_OPCODE;
@@ -578,6 +593,11 @@ public class Cpu implements Serializable, Originator<Cpu> {
             haltBugMode = false;
         }
         hdmaOpcodePrefetched = true;
+    }
+
+    private boolean isHdmaOpcodeFetchBlockedByPpu(int pc) {
+        return gpu != null && pc >= 0x8000 && pc < 0xa000
+                && gpu.getMode() == Mode.OamSearch && gpu.getTicksInLine() >= 79;
     }
 
     /** Preserve HALT's sampled next opcode when HALT acknowledges an HDMA request. */
@@ -600,23 +620,59 @@ public class Cpu implements Serializable, Originator<Cpu> {
     }
 
     /**
-     * Once an instruction's opcode fetch has won bus arbitration, the instruction is
-     * allowed to finish when an HBlank-DMA request arrives. An instruction that has not
-     * started yet remains at the opcode boundary until the burst completes.
+     * Whether the CPU side of an HDMA request slot is still in progress. Besides an
+     * already decoded instruction, the latter half of an opcode cycle owns the slot
+     * until the arbiter performs its one authoritative opcode fetch.
      */
-    public boolean hasInFlightInstructionForHdma() {
-        return hasFetchedInstructionForHdma()
+    public boolean isCpuRequestSlotInProgressForHdma() {
+        return isInstructionRetiringForHdma()
                 || (!hdmaOpcodePrefetched && state == State.OPCODE && clockCycle >= 2);
     }
 
-    /** Whether HDMA arrived after the current instruction's opcode was fetched. */
-    public boolean hasFetchedInstructionForHdma() {
+    /** Whether an ordinary CPU-fetched instruction is currently retiring. */
+    public boolean isInstructionRetiringForHdma() {
         return !hdmaOpcodePrefetched
                 && (state == State.EXT_OPCODE || state == State.OPERAND
                 || state == State.RUNNING);
     }
 
-    public boolean isInterruptEntryInFlightForHdma() {
+    /**
+     * Resolves the CPU side of a newly synchronized HDMA request. If the request
+     * reaches the latter half of an opcode cycle, this method samples that byte once
+     * without advancing PC or decoding it. The ordinary opcode boundary or DMA
+     * prefetch later consumes the same latch. HALT yields the slot; every other opcode
+     * keeps it. Interrupt ownership sampled before this point is resolved separately.
+     */
+    public boolean claimCpuRequestSlotForHdma() {
+        if (isInstructionRetiringForHdma()) {
+            return true;
+        }
+        if (hdmaOpcodePrefetched || state != State.OPCODE || clockCycle < 2) {
+            return false;
+        }
+        if (haltOpcodePrefetchValid) {
+            return haltPrefetchedOpcode != 0x76;
+        }
+        if (speedSwitchPaddingReplayValid) {
+            return speedSwitchPaddingOpcode != 0x76;
+        }
+        if (!hdmaArbitrationOpcodeValid) {
+            int pc = registers.getPC();
+            if (isHdmaOpcodeFetchBlockedByPpu(pc)) {
+                return false;
+            }
+            hdmaArbitrationOpcode = addressSpace.getByte(pc);
+            hdmaArbitrationOpcodeValid = true;
+        }
+        return hdmaArbitrationOpcode != 0x76;
+    }
+
+    /** Whether IE and IF already asserted a request when the HDMA slot was resolved. */
+    public boolean hasPendingInterruptForHdmaArbitration() {
+        return interruptManager.isInterruptRequested();
+    }
+
+    public boolean isInterruptEntryBusSequenceActiveForHdma() {
         return state == State.IRQ_WAIT_1 || state == State.IRQ_WAIT_2
                 || state == State.IRQ_PUSH_1 || state == State.IRQ_PUSH_2;
     }
@@ -627,16 +683,16 @@ public class Cpu implements Serializable, Originator<Cpu> {
      * has already been sampled even though the dispatch state is entered only when
      * that machine cycle completes.
      */
-    public boolean winsInterruptEntryArbitrationForHdma() {
-        return isInterruptEntryInFlightForHdma()
+    public boolean isInterruptClaimedAtHdmaSample() {
+        return isInterruptEntryBusSequenceActiveForHdma()
                 || ((state == State.OPCODE || state == State.RUNNING) && clockCycle == 2
                 && interruptManager.isIme() && interruptManager.isInterruptRequested());
     }
 
-    /** Continue the CPU side of a previously won interrupt/HDMA arbitration slot. */
-    public boolean advancesInterruptEntryForHdma() {
-        return isInterruptEntryInFlightForHdma()
-                || (state == State.OPCODE
+    /** Continue the CPU side of a previously sampled interrupt entry. */
+    public boolean canAdvanceInterruptEntryForHdma() {
+        return isInterruptEntryBusSequenceActiveForHdma()
+                || ((state == State.OPCODE || state == State.RUNNING)
                 && interruptManager.isIme() && interruptManager.isInterruptRequested());
     }
 
@@ -679,7 +735,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
         return new CpuMemento(registers.saveToMemento(), opcode1, opcode2, operand, operandIndex, opIndex,
                 state, opContext, interruptFlag, interruptEnabled, requestedIrq, clockCycle, haltBugMode,
                 haltEntrySampleTicks,
-                hdmaOpcodePrefetched, haltPrefetchedOpcode, haltOpcodePrefetchValid,
+                hdmaOpcodePrefetched, hdmaArbitrationOpcode, hdmaArbitrationOpcodeValid,
+                haltPrefetchedOpcode, haltOpcodePrefetchValid,
                 speedSwitchPaddingOpcode, speedSwitchPaddingReplayValid,
                 speedSwitchTicks, phasedPpuInputHigh, fastPhasedPpuDispatch);
     }
@@ -705,6 +762,8 @@ public class Cpu implements Serializable, Originator<Cpu> {
         this.haltBugMode = mem.haltBugMode;
         this.haltEntrySampleTicks = mem.haltEntrySampleTicks;
         this.hdmaOpcodePrefetched = mem.hdmaOpcodePrefetched;
+        this.hdmaArbitrationOpcode = mem.hdmaArbitrationOpcode;
+        this.hdmaArbitrationOpcodeValid = mem.hdmaArbitrationOpcodeValid;
         this.haltPrefetchedOpcode = mem.haltPrefetchedOpcode;
         this.haltOpcodePrefetchValid = mem.haltOpcodePrefetchValid;
         this.speedSwitchPaddingOpcode = mem.speedSwitchPaddingOpcode;
@@ -723,6 +782,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
                               int interruptEnabled, InterruptManager.InterruptType requestedIrq, int clockCycle,
                               boolean haltBugMode, int haltEntrySampleTicks,
                               boolean hdmaOpcodePrefetched,
+                              int hdmaArbitrationOpcode, boolean hdmaArbitrationOpcodeValid,
                               int haltPrefetchedOpcode, boolean haltOpcodePrefetchValid,
                               int speedSwitchPaddingOpcode, boolean speedSwitchPaddingReplayValid,
                               int speedSwitchTicks, boolean phasedPpuInputHigh,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -125,6 +125,8 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
 
     private CpuRequestArbitration cpuRequestArbitration = CpuRequestArbitration.NONE;
 
+    private boolean cpuRequestAllowsLateInterrupt;
+
     private boolean haltOpcodeRequestLatched;
 
     // A source-bus sample is consumed by OAM DMA later in the same scheduler tick.
@@ -138,6 +140,13 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
     public Hdma(AddressSpace addressSpace, SpeedMode speedMode) {
         this.addressSpace = addressSpace;
         this.speedMode = speedMode;
+    }
+
+    private void setCpuRequestArbitration(CpuRequestArbitration arbitration) {
+        cpuRequestArbitration = arbitration;
+        if (arbitration != CpuRequestArbitration.CPU) {
+            cpuRequestAllowsLateInterrupt = false;
+        }
     }
 
     @Override
@@ -181,7 +190,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         // rather than wrapping the raw counter (dma_dst_wrap_1/2).
         if (stopAfterCurrentBlock || dst == 0 || length-- == 0) {
             transferInProgress = false;
-            cpuRequestArbitration = CpuRequestArbitration.NONE;
+            setCpuRequestArbitration(CpuRequestArbitration.NONE);
             length = preserveLengthAfterCurrentBlock ? length : 0x7f;
             stopAfterCurrentBlock = false;
             preserveLengthAfterCurrentBlock = false;
@@ -197,9 +206,9 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             // block is not postponed by an entire line.
             boolean overlappingRequest = nextHblankRequestTicks == 0;
             hblankRequestTicks = overlappingRequest && nextHblankRequestAge == 0 ? 0 : -1;
-            cpuRequestArbitration = hblankRequestTicks == 0
+            setCpuRequestArbitration(hblankRequestTicks == 0
                     ? CpuRequestArbitration.UNRESOLVED
-                    : CpuRequestArbitration.NONE;
+                    : CpuRequestArbitration.NONE);
             hblankRequestAge = 0;
             nextHblankRequestTicks = -1;
             nextHblankRequestAge = 0;
@@ -305,14 +314,14 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             hblankRequestTicks = wakeRequestArbitration == WakeRequestArbitration.REVERSE_PENDING
                     ? Math.max(1, 251 - gpuTicksInLine)
                     : 3;
-            cpuRequestArbitration = CpuRequestArbitration.NONE;
+            setCpuRequestArbitration(CpuRequestArbitration.NONE);
             hblankRequestAge = 0;
             requestOverlappedCpuWrite = false;
             interruptEntryWonArbitration = false;
         } else if (newGpuMode != Mode.HBlank && hblankTransfer
                 && hblankRequestTicks > 0) {
             hblankRequestTicks = -1;
-            cpuRequestArbitration = CpuRequestArbitration.NONE;
+            setCpuRequestArbitration(CpuRequestArbitration.NONE);
             hblankRequestAge = 0;
             interruptEntryWonArbitration = false;
         }
@@ -349,7 +358,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             if (--hblankRequestTicks == 0) {
                 requestOverlappedCpuWrite = cpuWriteCycleInFlight;
                 interruptEntryWonArbitration = cpuInterruptEntryInFlight;
-                cpuRequestArbitration = CpuRequestArbitration.UNRESOLVED;
+                setCpuRequestArbitration(CpuRequestArbitration.UNRESOLVED);
                 hblankRequestAge = 0;
                 if (wakeRequestArbitration == WakeRequestArbitration.REVERSE_PENDING) {
                     // The CPU/HDMA arbiter resumes on the opposite half-cycle after
@@ -362,7 +371,9 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             }
         } else if (!cpuHalted && hblankRequestTicks == 0) {
             int ticksSinceHblankStart = gpuTicksInLine - hblankStartTicksInLine;
-            if (hblankRequestAge == 0 && cpuInterruptEntryInFlight
+            if (hblankRequestAge == 0
+                    && cpuRequestArbitration == CpuRequestArbitration.UNRESOLVED
+                    && cpuInterruptEntryInFlight
                     && gpuMode == Mode.HBlank
                     && ticksSinceHblankStart >= 0 && ticksSinceHblankStart <= 2) {
                 // HALT restores an unsynchronized request directly on wake. If the
@@ -410,7 +421,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                     && !requestWasAlreadyActive;
             if (hblankTransfer) {
                 hblankRequestTicks = -1;
-                cpuRequestArbitration = CpuRequestArbitration.NONE;
+                setCpuRequestArbitration(CpuRequestArbitration.NONE);
                 hblankRequestAge = 0;
                 nextHblankRequestTicks = -1;
                 nextHblankRequestAge = 0;
@@ -421,7 +432,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                 && (haltHdmaState == HaltHdmaState.REQUESTED
                 || (haltHdmaState == HaltHdmaState.LOW && isCurrentHblankWakeRequestable()))) {
             hblankRequestTicks = 0;
-            cpuRequestArbitration = CpuRequestArbitration.UNRESOLVED;
+            setCpuRequestArbitration(CpuRequestArbitration.UNRESOLVED);
             hblankRequestAge = 0;
             nextHblankRequestTicks = -1;
             nextHblankRequestAge = 0;
@@ -443,7 +454,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             // paused until the display is enabled again.
             gpuMode = Mode.HBlank;
             hblankRequestTicks = 0;
-            cpuRequestArbitration = CpuRequestArbitration.UNRESOLVED;
+            setCpuRequestArbitration(CpuRequestArbitration.UNRESOLVED);
             hblankRequestAge = 0;
             nextHblankRequestTicks = -1;
             nextHblankRequestAge = 0;
@@ -475,7 +486,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
             // STOP won before the synchronized request was stable. Lose this
             // scanline's grant but leave the programmed HBlank transfer armed.
             hblankRequestTicks = -1;
-            cpuRequestArbitration = CpuRequestArbitration.NONE;
+            setCpuRequestArbitration(CpuRequestArbitration.NONE);
             hblankRequestAge = 0;
             requestOverlappedCpuWrite = false;
             interruptEntryWonArbitration = false;
@@ -496,9 +507,9 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                 // first resumed CPU edge. A wake near the end of HBlank still has
                 // to cross the ordinary three-tick hand-off.
                 hblankRequestTicks = gpuTicksInLine <= 446 ? 0 : 3;
-                cpuRequestArbitration = hblankRequestTicks == 0
+                setCpuRequestArbitration(hblankRequestTicks == 0
                         ? CpuRequestArbitration.UNRESOLVED
-                        : CpuRequestArbitration.NONE;
+                        : CpuRequestArbitration.NONE);
                 hblankRequestAge = 0;
                 requestOverlappedCpuWrite = false;
                 interruptEntryWonArbitration = false;
@@ -528,33 +539,54 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         return wakeRequestArbitration == WakeRequestArbitration.YIELD_CPU;
     }
 
-    public boolean yieldsToInterruptEntry() {
+    public boolean isInterruptEntryRequestOwner() {
         return interruptEntryWonArbitration;
     }
 
-    /** Resolves a newly active request once, then retains the winner until retirement. */
-    public boolean yieldsToFetchedCpuInstruction(boolean fetchedInstruction) {
-        if (cpuRequestArbitration == CpuRequestArbitration.UNRESOLVED) {
-            boolean frameStartDmaPhase = hblankTransfer && lcdEnabled && gpuLine == 0;
-            cpuRequestArbitration = fetchedInstruction
-                    && wakeRequestArbitration != WakeRequestArbitration.PREEMPT_CPU
-                    && !frameStartDmaPhase
-                    ? CpuRequestArbitration.CPU
-                    : CpuRequestArbitration.DMA;
+    public boolean isCpuRequestUnresolved() {
+        return cpuRequestArbitration == CpuRequestArbitration.UNRESOLVED;
+    }
+
+    /** Resolves a newly active request once; the selected owner is retained. */
+    public void resolveCpuRequest(boolean cpuClaimedSlot,
+                                  boolean interruptPendingAtResolution) {
+        if (cpuRequestArbitration != CpuRequestArbitration.UNRESOLVED) {
+            return;
         }
+        boolean frameStartDmaPhase = hblankTransfer && lcdEnabled && gpuLine == 0;
+        setCpuRequestArbitration(cpuClaimedSlot
+                && wakeRequestArbitration != WakeRequestArbitration.PREEMPT_CPU
+                && !frameStartDmaPhase
+                ? CpuRequestArbitration.CPU
+                : CpuRequestArbitration.DMA);
+        cpuRequestAllowsLateInterrupt = cpuRequestArbitration == CpuRequestArbitration.CPU
+                && !interruptPendingAtResolution;
+    }
+
+    public boolean isCpuInstructionRequestOwner() {
         return cpuRequestArbitration == CpuRequestArbitration.CPU;
     }
 
-    public void onFetchedCpuInstructionFinished() {
+    public void onCpuRequestSlotRetired() {
         if (cpuRequestArbitration == CpuRequestArbitration.CPU) {
-            cpuRequestArbitration = CpuRequestArbitration.DMA;
+            setCpuRequestArbitration(CpuRequestArbitration.DMA);
         }
+    }
+
+    /** Retire the CPU slot, preserving only an interrupt that arrived after its grant. */
+    public void onInterruptEntryAcceptedByCpu() {
+        if (cpuRequestArbitration != CpuRequestArbitration.CPU) {
+            return;
+        }
+        boolean promoteInterruptEntry = cpuRequestAllowsLateInterrupt;
+        setCpuRequestArbitration(CpuRequestArbitration.DMA);
+        interruptEntryWonArbitration = promoteInterruptEntry;
     }
 
     /** A request already asserted while STOP holds the CPU owns the wake boundary. */
     public void onStoppedCpuRequest() {
         if (cpuRequestArbitration == CpuRequestArbitration.UNRESOLVED) {
-            cpuRequestArbitration = CpuRequestArbitration.DMA;
+            setCpuRequestArbitration(CpuRequestArbitration.DMA);
         }
     }
 
@@ -600,9 +632,9 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         nextHblankRequestAge = 0;
         tick = -startupTicks();
         hblankRequestTicks = hblankTransfer && (!isCurrentHblankRequestable()) ? -1 : 0;
-        cpuRequestArbitration = hblankRequestTicks == 0
+        setCpuRequestArbitration(hblankRequestTicks == 0
                 ? CpuRequestArbitration.UNRESOLVED
-                : CpuRequestArbitration.NONE;
+                : CpuRequestArbitration.NONE);
         hblankRequestAge = 0;
         if (hblankTransfer && !lcdEnabled) {
             // With the LCD off, starting HDMA copies one block immediately. There are
@@ -640,7 +672,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         } else {
             transferInProgress = false;
             hblankRequestTicks = -1;
-            cpuRequestArbitration = CpuRequestArbitration.NONE;
+            setCpuRequestArbitration(CpuRequestArbitration.NONE);
             hblankRequestAge = 0;
             nextHblankRequestTicks = -1;
             nextHblankRequestAge = 0;
@@ -662,6 +694,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                 gpuLine, gpuTicksInLine, hblankStartTicksInLine, cpuHalted, haltHdmaState,
                 haltEnteredThisTick, requestOverlappedCpuWrite,
                 interruptEntryWonArbitration, cpuRequestArbitration,
+                cpuRequestAllowsLateInterrupt,
                 haltOpcodeRequestLatched);
     }
 
@@ -707,6 +740,8 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         } else {
             this.cpuRequestArbitration = CpuRequestArbitration.NONE;
         }
+        this.cpuRequestAllowsLateInterrupt = cpuRequestArbitration == CpuRequestArbitration.CPU
+                && mem.cpuRequestAllowsLateInterrupt;
         this.haltOpcodeRequestLatched = mem.haltOpcodeRequestLatched;
     }
 
@@ -729,6 +764,7 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
                               boolean requestOverlappedCpuWrite,
                               boolean interruptEntryWonArbitration,
                               CpuRequestArbitration cpuRequestArbitration,
+                              boolean cpuRequestAllowsLateInterrupt,
                               boolean haltOpcodeRequestLatched) implements Memento<Hdma> {
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyHdmaArbitrationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyHdmaArbitrationTest.java
@@ -1,0 +1,188 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.cpu.Cpu;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GameboyHdmaArbitrationTest {
+
+    private static final int PROGRAM = 0xc000;
+
+    @Test
+    public void lateNonHaltOpcodeRetiresBeforeHdma() throws IOException {
+        try (Fixture fixture = new Fixture(0x04, 0x00)) { // INC B; NOP
+            fixture.advanceCpuTicks(2);
+            fixture.startHdma(0xc100);
+
+            fixture.gameboy.tick();
+            assertEquals(PROGRAM, fixture.cpu().getRegisters().getPC());
+            assertEquals(Cpu.State.OPCODE, fixture.cpu().getState());
+            assertEquals(0, fixture.cpu().getRegisters().getB());
+
+            fixture.gameboy.tick();
+            assertEquals(1, fixture.cpu().getRegisters().getB());
+            assertEquals(Cpu.State.OPCODE, fixture.cpu().getState());
+            assertEquals(0, fixture.read(0xff55) & 0x80);
+        }
+    }
+
+    @Test
+    public void lateHaltOpcodeIsHeldUntilHdmaFinishes() throws IOException {
+        try (Fixture fixture = new Fixture(0x76, 0x00)) { // HALT; NOP
+            fixture.advanceCpuTicks(2);
+            fixture.startHdma(0xc100);
+
+            fixture.gameboy.tick();
+            assertEquals(PROGRAM + 1, fixture.cpu().getRegisters().getPC());
+            assertEquals(Cpu.State.OPERAND, fixture.cpu().getState());
+
+            fixture.finishHdma();
+            for (int i = 0; i < 4 && fixture.cpu().getState() != Cpu.State.HALTED; i++) {
+                fixture.gameboy.tick();
+            }
+            assertEquals(Cpu.State.HALTED, fixture.cpu().getState());
+        }
+    }
+
+    @Test
+    public void interruptAcceptedFromALateOpcodeSlotPushesBeforeHdma() throws IOException {
+        try (Fixture fixture = new Fixture(0xfb, 0x04, 0x00)) { // EI; INC B; NOP
+            fixture.cpu().getRegisters().setSP(0xdffe);
+            fixture.advanceCpuTicks(10);
+            assertEquals(PROGRAM + 2, fixture.cpu().getRegisters().getPC());
+            fixture.startHdma(0xdff0);
+
+            // The non-HALT opcode first claims the late fetch slot. An interrupt
+            // arriving in the remaining half-cycle must retain that CPU ownership.
+            fixture.gameboy.tick();
+            fixture.write(0xffff, 0x01);
+            fixture.write(0xff0f, 0x01);
+
+            fixture.gameboy.tick();
+            assertEquals(Cpu.State.IRQ_WAIT_2, fixture.cpu().getState());
+
+            for (int i = 0; i < 16 && fixture.cpu().getState() != Cpu.State.IRQ_JUMP; i++) {
+                fixture.gameboy.tick();
+            }
+            assertEquals(Cpu.State.IRQ_JUMP, fixture.cpu().getState());
+            assertEquals(0xdffc, fixture.cpu().getRegisters().getSP());
+            assertEquals((PROGRAM + 2) & 0xff, fixture.read(0xdffc));
+            assertEquals(PROGRAM >> 8, fixture.read(0xdffd));
+
+            fixture.finishHdma();
+            assertEquals((PROGRAM + 2) & 0xff, fixture.readVram(0x800c));
+            assertEquals(PROGRAM >> 8, fixture.readVram(0x800d));
+        }
+    }
+
+    @Test
+    public void lateStopKeepsItsPaddingAcrossTheHdmaSpeedSwitchBurst() throws IOException {
+        try (Fixture fixture = new Fixture(0x10, 0x3c, 0x00)) { // STOP $3c; NOP
+            fixture.cpu().getRegisters().setA(0);
+            fixture.advanceCpuTicks(2);
+            fixture.write(0xff4d, 0x01);
+            fixture.startHdma(0xc100);
+
+            for (int i = 0; i < 12 && !fixture.cpu().isSpeedSwitching(); i++) {
+                fixture.gameboy.tick();
+            }
+            assertTrue(fixture.cpu().isSpeedSwitching());
+            assertEquals(2, fixture.gameboy.getSpeedMode().getSpeedMode());
+            assertEquals(PROGRAM + 2, fixture.cpu().getRegisters().getPC());
+
+            for (int i = 0; i < 70_000
+                    && (fixture.cpu().isSpeedSwitching()
+                    || fixture.gameboy.isSpeedSwitchTailActive()); i++) {
+                fixture.gameboy.tick();
+            }
+            assertFalse(fixture.cpu().isSpeedSwitching());
+            assertFalse(fixture.gameboy.isSpeedSwitchTailActive());
+            fixture.finishHdma();
+            for (int i = 0; i < 4 && fixture.cpu().getRegisters().getA() == 0; i++) {
+                fixture.gameboy.tick();
+            }
+
+            assertEquals(1, fixture.cpu().getRegisters().getA());
+            assertEquals(PROGRAM + 2, fixture.cpu().getRegisters().getPC());
+            assertEquals(0x80, fixture.read(0xff55));
+        }
+    }
+
+    private static final class Fixture implements AutoCloseable {
+
+        private final Gameboy gameboy;
+
+        private Fixture(int... program) throws IOException {
+            byte[] rom = new byte[0x8000];
+            rom[0x143] = (byte) 0x80;
+            rom[0x147] = 0;
+            gameboy = new Gameboy.GameboyConfiguration(new Rom(rom))
+                    .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                    .setGameboyType(GameboyType.CGB)
+                    .setSupportBatterySave(false)
+                    .build();
+            gameboy.getGpu().setByte(0xff40, 0);
+            gameboy.tick();
+            advanceCpuTicks(3);
+            assertEquals(Cpu.State.OPCODE, cpu().getState());
+            cpu().getRegisters().setPC(PROGRAM);
+            write(0xff0f, 0);
+            write(0xffff, 0);
+            for (int i = 0; i < program.length; i++) {
+                write(PROGRAM + i, program[i]);
+            }
+            for (int i = 0; i < 0x10; i++) {
+                write(0xc100 + i, 0xa0 + i);
+            }
+        }
+
+        private Cpu cpu() {
+            return gameboy.getCpu();
+        }
+
+        private void advanceCpuTicks(int ticks) {
+            for (int i = 0; i < ticks; i++) {
+                cpu().tick();
+            }
+        }
+
+        private void startHdma(int source) {
+            write(0xff51, source >> 8);
+            write(0xff52, source & 0xf0);
+            write(0xff53, 0);
+            write(0xff54, 0);
+            write(0xff55, 0x80);
+            assertTrue(gameboy.getHdma().isTransferInProgress());
+        }
+
+        private void finishHdma() {
+            for (int i = 0; i < 48 && gameboy.getHdma().isTransferInProgress(); i++) {
+                gameboy.tick();
+            }
+            assertFalse(gameboy.getHdma().isTransferInProgress());
+        }
+
+        private void write(int address, int value) {
+            gameboy.getAddressSpace().setByte(address, value);
+        }
+
+        private int read(int address) {
+            return gameboy.getAddressSpace().getByte(address);
+        }
+
+        private int readVram(int address) {
+            return gameboy.getGpu().getVideoRam().getByte(address);
+        }
+
+        @Override
+        public void close() throws IOException {
+            gameboy.close();
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -247,18 +247,63 @@ public class CpuPpuInterruptTimingTest {
         h.memory.setByte(PROGRAM + 1, 0x42);
 
         h.tickCpuTicks(2);
-        assertTrue(h.cpu.hasInFlightInstructionForHdma());
-        assertFalse(h.cpu.hasFetchedInstructionForHdma());
+        assertTrue(h.cpu.isCpuRequestSlotInProgressForHdma());
+        assertFalse(h.cpu.isInstructionRetiringForHdma());
 
         h.tickCpuTicks(2);
         assertEquals(Cpu.State.OPERAND, h.cpu.getState());
-        assertTrue(h.cpu.hasFetchedInstructionForHdma());
+        assertTrue(h.cpu.isInstructionRetiringForHdma());
 
         Harness prefetched = new Harness(true);
         prefetched.memory.setByte(PROGRAM, 0x06);
         prefetched.cpu.prefetchOpcodeForHdma();
         assertEquals(Cpu.State.OPERAND, prefetched.cpu.getState());
-        assertFalse(prefetched.cpu.hasFetchedInstructionForHdma());
+        assertFalse(prefetched.cpu.isInstructionRetiringForHdma());
+    }
+
+    @Test
+    public void hdmaArbitrationFetchIsTheOnlyOpcodeBusRead() {
+        for (int opcode : new int[] {0x04, 0x76}) { // INC B; HALT
+            Harness h = new Harness(true);
+            h.memory.setByte(PROGRAM, opcode);
+            h.tickCpuTicks(2);
+
+            assertEquals(opcode != 0x76, h.cpu.claimCpuRequestSlotForHdma());
+            assertEquals(Cpu.State.OPCODE, h.cpu.getState());
+            assertEquals(PROGRAM, h.cpu.getRegisters().getPC());
+            assertEquals(opcode, h.cpu.getBusValueForHdma());
+            h.cpu.prefetchOpcodeForHdma();
+
+            assertEquals(1, h.programReads);
+        }
+    }
+
+    @Test
+    public void hdmaArbitrationOpcodeLatchSurvivesMementoRestore() {
+        Harness h = new Harness(true);
+        h.memory.setByte(PROGRAM, 0xcb);
+        h.memory.setByte(PROGRAM + 1, 0x00); // RLC B
+        h.cpu.getRegisters().setB(0x80);
+        h.tickCpuTicks(2);
+
+        assertTrue(h.cpu.claimCpuRequestSlotForHdma());
+        var latched = h.cpu.saveToMemento();
+        h.cpu.tick();
+        h.cpu.restoreFromMemento(latched);
+
+        assertEquals(Cpu.State.OPCODE, h.cpu.getState());
+        assertEquals(PROGRAM, h.cpu.getRegisters().getPC());
+        assertEquals(0xcb, h.cpu.getBusValueForHdma());
+        assertEquals(1, h.programReads);
+
+        h.tickCpuTicks(2);
+        assertEquals(Cpu.State.EXT_OPCODE, h.cpu.getState());
+        assertEquals(PROGRAM + 1, h.cpu.getRegisters().getPC());
+        assertEquals(1, h.programReads);
+        h.tickMachineCycle();
+
+        assertEquals(1, h.cpu.getRegisters().getB());
+        assertEquals(PROGRAM + 2, h.cpu.getRegisters().getPC());
     }
 
     @Test
@@ -301,6 +346,8 @@ public class CpuPpuInterruptTimingTest {
 
         private final Cpu cpu;
 
+        private int programReads;
+
         private Harness(boolean gbc) {
             interrupts = new InterruptManager(gbc);
             speedMode = new SpeedMode(gbc);
@@ -321,6 +368,9 @@ public class CpuPpuInterruptTimingTest {
 
                 @Override
                 public int getByte(int address) {
+                    if (address == PROGRAM) {
+                        programReads++;
+                    }
                     return interrupts.accepts(address)
                             ? interrupts.getByte(address)
                             : memory.getByte(address);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 152;
+    private static final int CURRENT_BASELINE_COUNT = 148;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -134,29 +134,54 @@ public class HdmaTest {
         fixture.hdma.advanceHblankRequest(false, false, false);
         fixture.hdma.advanceHblankRequest(false, false, true);
 
-        assertTrue(fixture.hdma.yieldsToInterruptEntry());
+        assertTrue(fixture.hdma.isInterruptEntryRequestOwner());
     }
 
     @Test
     public void fetchedInstructionOwnsARequestUntilItRetires() {
         Fixture fixture = synchronizedHblankRequest(1);
 
-        assertTrue(fixture.hdma.yieldsToFetchedCpuInstruction(true));
+        fixture.hdma.resolveCpuRequest(true, false);
+        assertTrue(fixture.hdma.isCpuInstructionRequestOwner());
         var cpuOwnedRequest = fixture.hdma.saveToMemento();
-        assertTrue(fixture.hdma.yieldsToFetchedCpuInstruction(false));
+        fixture.hdma.resolveCpuRequest(false, false);
+        assertTrue(fixture.hdma.isCpuInstructionRequestOwner());
 
-        fixture.hdma.onFetchedCpuInstructionFinished();
-        assertFalse(fixture.hdma.yieldsToFetchedCpuInstruction(true));
+        fixture.hdma.onCpuRequestSlotRetired();
+        fixture.hdma.resolveCpuRequest(true, false);
+        assertFalse(fixture.hdma.isCpuInstructionRequestOwner());
 
         fixture.hdma.restoreFromMemento(cpuOwnedRequest);
-        assertTrue(fixture.hdma.yieldsToFetchedCpuInstruction(false));
+        fixture.hdma.resolveCpuRequest(false, false);
+        assertTrue(fixture.hdma.isCpuInstructionRequestOwner());
+        fixture.hdma.onInterruptEntryAcceptedByCpu();
+        assertTrue(fixture.hdma.isInterruptEntryRequestOwner());
+    }
+
+    @Test
+    public void interruptPendingWhenCpuClaimsDoesNotSupersedeDma() {
+        Fixture fixture = synchronizedHblankRequest(1);
+        var unresolvedRequest = fixture.hdma.saveToMemento();
+
+        fixture.hdma.resolveCpuRequest(true, true);
+        assertTrue(fixture.hdma.isCpuInstructionRequestOwner());
+        var preexistingInterrupt = fixture.hdma.saveToMemento();
+
+        fixture.hdma.restoreFromMemento(unresolvedRequest);
+        fixture.hdma.resolveCpuRequest(true, false);
+        fixture.hdma.restoreFromMemento(preexistingInterrupt);
+        fixture.hdma.onInterruptEntryAcceptedByCpu();
+
+        assertFalse(fixture.hdma.isCpuInstructionRequestOwner());
+        assertFalse(fixture.hdma.isInterruptEntryRequestOwner());
     }
 
     @Test
     public void frameStartHblankRequestPreemptsAFetchedInstruction() {
         Fixture fixture = synchronizedHblankRequest(0);
 
-        assertFalse(fixture.hdma.yieldsToFetchedCpuInstruction(true));
+        fixture.hdma.resolveCpuRequest(true, false);
+        assertFalse(fixture.hdma.isCpuInstructionRequestOwner());
     }
 
     @Test
@@ -164,7 +189,8 @@ public class HdmaTest {
         Fixture fixture = new Fixture();
         fixture.startTransfer(0x00);
 
-        assertTrue(fixture.hdma.yieldsToFetchedCpuInstruction(true));
+        fixture.hdma.resolveCpuRequest(true, false);
+        assertTrue(fixture.hdma.isCpuInstructionRequestOwner());
     }
 
     @Test
@@ -173,7 +199,8 @@ public class HdmaTest {
 
         fixture.hdma.onStoppedCpuRequest();
 
-        assertFalse(fixture.hdma.yieldsToFetchedCpuInstruction(true));
+        fixture.hdma.resolveCpuRequest(true, false);
+        assertFalse(fixture.hdma.isCpuInstructionRequestOwner());
     }
 
     private Fixture synchronizedHblankRequest(int line) {
@@ -202,11 +229,11 @@ public class HdmaTest {
         var memento = fixture.hdma.saveToMemento();
 
         fixture.hdma.advanceHblankRequest(false, false, true);
-        assertTrue(fixture.hdma.yieldsToInterruptEntry());
+        assertTrue(fixture.hdma.isInterruptEntryRequestOwner());
 
         fixture.hdma.restoreFromMemento(memento);
         fixture.hdma.advanceHblankRequest(false, false, true);
-        assertTrue(fixture.hdma.yieldsToInterruptEntry());
+        assertTrue(fixture.hdma.isInterruptEntryRequestOwner());
     }
 
     @Test

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 152 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 148 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -13,15 +13,12 @@ hwtests/dma/hdma_cycles_scx5_ds_1_cgb04c_out3.gbc [CGB]	0
 hwtests/dma/hdma_late_enable_lcdoffset3_2_cgb04c_out0.gbc [CGB]	1
 hwtests/dma/hdma_late_m3halt_m2unhalt_ly_scx1_3_cgb04c_out02.gbc [CGB]	03
 hwtests/dma/hdma_late_m3halt_m2unhalt_ly_scx2_3_cgb04c_out02.gbc [CGB]	03
-hwtests/dma/hdma_late_m3speedchange_hdma5_scx2_2_cgb04c_out80.gbc [CGB]	FF
 hwtests/dma/hdma_late_m3speedchange_ly_scx1_1_cgb04c_out92.gbc [CGB]	93
 hwtests/dma/hdma_late_m3speedchange_ly_scx1_3_cgb04c_out92.gbc [CGB]	93
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx1_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx2_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m3speedchange_late_m0wakeup_1_cgb04c_outFF.gbc [CGB]	00
 hwtests/dma/hdma_start_ly0_1_cgb04c_out0.gbc [CGB]	7
-hwtests/dma/hdma_start_scx2_1_cgb04c_out0.gbc [CGB]	1
-hwtests/dma/hdma_start_scx3_1_cgb04c_out0.gbc [CGB]	1
 hwtests/dma/hdma_transition_ei_halt_late_unhalt_ldaaimm_hdma_scx1_1_cgb04c_out00.gbc [CGB]	01
 hwtests/enable_display/frame1_ly_count_2_dmg08_cgb04c_out9A.gbc [CGB]	00
 hwtests/enable_display/frame1_m2stat_count_1_dmg08_cgb04c_out91.gbc [CGB]	01
@@ -41,7 +38,6 @@ hwtests/halt/lycirq_m2stat_1_dmg08_cgb04c_out2.gbc [CGB]	3
 hwtests/halt/m1int_ly_2_dmg08_out90_cgb04c_out91.gbc [CGB]	90
 hwtests/halt/noime_ifandie_m2int_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/halt/noime_m2irq_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/irq_precedence/hdma_vs_m0_scx2_cgb04c_out0183.gbc [CGB]	1234
 hwtests/irq_precedence/late_m0irq_retrigger_2_dmg08_cgb04c_outE0.gbc [CGB]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_ds_1_cgb04c_outE2.gbc [CGB]	E0


### PR DESCRIPTION
## Summary
- latch a late HDMA opcode fetch once without advancing or decoding the CPU pipeline early
- retain CPU, DMA, and newly-arrived interrupt ownership across the complete arbitration slot
- cover HALT, STOP, CB-prefixed opcodes, VRAM mode-2 ownership, and save-state restoration
- remove four now-hardware-correct Gambatte pins (4,526/4,674 matches; 148 remain)

## Validation
- mvn -q -f core/pom.xml -Dtest=GameboyHdmaArbitrationTest,CpuPpuInterruptTimingTest,HdmaTest test
- mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw
- mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb
- mvn -q test -f core/pom.xml
- mvn -q test