### PR TITLE
Model rephased CGB LCD bus reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,529 match hardware; 145 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,542 match hardware; 132 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 145 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 132 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,526 match hardware; 148 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,529 match hardware; 145 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 148 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 145 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -511,6 +511,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             speedSwitchTailTicks--;
             if (speedSwitchTailTicks == 0) {
                 hdma.onSpeedSwitchComplete();
+                gpu.onSpeedSwitchComplete();
             }
         } else if (speedSwitching) {
             // A CGB speed switch pauses instruction execution and VRAM DMA while
@@ -535,6 +536,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 }
                 if (speedSwitchTailTicks <= 0) {
                     hdma.onSpeedSwitchComplete();
+                    gpu.onSpeedSwitchComplete();
                 }
             }
         } else if (hdma.isTransferInProgress()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
@@ -59,6 +59,11 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
     // asserted, but that one bus read sees VBlank low.
     private boolean maskVBlankOnNextRead;
 
+    // A rephased normal-speed CGB CPU can begin its final line-143 IF read before
+    // the captured mode-1 request reaches the bus. Keep the stored request intact;
+    // only that CPU slot sees LCDC low.
+    private boolean maskLcdcUntilNextPeripheralTick;
+
     // The CPU acknowledges an interrupt near the middle of its final dispatch
     // machine cycle. Serial events in the remaining part of that cycle are
     // evaluated before the acknowledge clears IF.
@@ -205,6 +210,9 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
         cpuPhasedPpuInterrupts &= ~(1 << type.ordinal());
         cpuPhasedMode2Interrupts &= ~(1 << type.ordinal());
         cpuFirstLineMode2Interrupts &= ~(1 << type.ordinal());
+        if (type == InterruptType.LCDC) {
+            maskLcdcUntilNextPeripheralTick = false;
+        }
     }
 
     public boolean consumeSerialInterruptAcknowledge() {
@@ -281,6 +289,14 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
         maskVBlankOnNextRead = true;
     }
 
+    public void maskLcdcUntilNextPeripheralTick() {
+        maskLcdcUntilNextPeripheralTick = true;
+    }
+
+    public void finishLcdcReadMaskWindow() {
+        maskLcdcUntilNextPeripheralTick = false;
+    }
+
     @Override
     public boolean accepts(int address) {
         return address == 0xff0f || address == 0xffff;
@@ -297,6 +313,7 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
                 cpuPhasedMode2Interrupts = 0;
                 cpuFirstLineMode2Interrupts = 0;
                 maskVBlankOnNextRead = false;
+                maskLcdcUntilNextPeripheralTick = false;
                 break;
 
             case 0xffff:
@@ -309,11 +326,16 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
     public int getByte(int address) {
         switch (address) {
             case 0xff0f:
+                int value = interruptFlag;
                 if (maskVBlankOnNextRead) {
                     maskVBlankOnNextRead = false;
-                    return interruptFlag & ~(1 << InterruptType.VBlank.ordinal());
+                    value &= ~(1 << InterruptType.VBlank.ordinal());
                 }
-                return interruptFlag;
+                if (maskLcdcUntilNextPeripheralTick) {
+                    maskLcdcUntilNextPeripheralTick = false;
+                    value &= ~(1 << InterruptType.LCDC.ordinal());
+                }
+                return value;
 
             case 0xffff:
                 return interruptEnabled;
@@ -328,7 +350,8 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
         return new InterruptManagerMemento(ime, interruptFlag, interruptEnabled, pendingEnableInterrupts,
                 haltBlockedInterrupts, cpuBlockedInterrupts, cpuPhasedPpuInterrupts,
                 cpuPhasedMode2Interrupts, cpuFirstLineMode2Interrupts,
-                maskVBlankOnNextRead, serialInterruptAcknowledge,
+                maskVBlankOnNextRead, maskLcdcUntilNextPeripheralTick,
+                serialInterruptAcknowledge,
                 timerInterruptAcknowledge, lcdcInterruptAcknowledge);
     }
 
@@ -347,6 +370,7 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
         this.cpuPhasedMode2Interrupts = mem.cpuPhasedMode2Interrupts;
         this.cpuFirstLineMode2Interrupts = mem.cpuFirstLineMode2Interrupts;
         this.maskVBlankOnNextRead = mem.maskVBlankOnNextRead;
+        this.maskLcdcUntilNextPeripheralTick = mem.maskLcdcUntilNextPeripheralTick;
         this.serialInterruptAcknowledge = mem.serialInterruptAcknowledge;
         this.timerInterruptAcknowledge = mem.timerInterruptAcknowledge;
         this.lcdcInterruptAcknowledge = mem.lcdcInterruptAcknowledge;
@@ -360,6 +384,7 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
                                            int cpuPhasedMode2Interrupts,
                                            int cpuFirstLineMode2Interrupts,
                                            boolean maskVBlankOnNextRead,
+                                           boolean maskLcdcUntilNextPeripheralTick,
                                            boolean serialInterruptAcknowledge,
                                            boolean timerInterruptAcknowledge,
                                            boolean lcdcInterruptAcknowledge) implements Memento<InterruptManager> {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -95,6 +95,10 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     // STAT mode latch. Until that happens, the boot-time latch has its five-dot tail.
     private boolean statModeLatchRephasedBySpeedSwitch;
 
+    // The clock mux retains its old STAT read phase for the remainder of the scanline
+    // on which a speed-switch tail completes.
+    private boolean speedSwitchCompletedThisLine;
+
     // A line-scoped SCX write makes a no-window line follow the dynamic shifted
     // pipeline instead of the steady-line fixed STAT release.
     private boolean scxWrittenThisLine;
@@ -447,6 +451,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             pixelTransferDone = false;
             hblankIntFrom = Integer.MAX_VALUE;
             mode0IntFrom = Integer.MAX_VALUE;
+            speedSwitchCompletedThisLine = false;
             scxWrittenThisLine = false;
             doubleSpeedMode2DispatchStatTailThisLine = false;
             earlyScxStatTailThisLine = false;
@@ -547,6 +552,11 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     /** Rephases the CGB CPU-readable STAT latch when the CPU clock mux changes. */
     public void onSpeedSwitch() {
         statModeLatchRephasedBySpeedSwitch = true;
+    }
+
+    /** Retains the old CPU-readable STAT phase until the current scanline ends. */
+    public void onSpeedSwitchComplete() {
+        speedSwitchCompletedThisLine = true;
     }
 
     /** Captures the CPU/PPU phase selected when a double-speed mode-2 IRQ is accepted. */
@@ -1068,6 +1078,27 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         return mode.ordinal();
     }
 
+    /** Returns the normal-speed STAT mode sampled at the end of a rephased CPU read. */
+    int getCpuVisibleStatMode() {
+        int visibleMode = getVisibleStatMode();
+        if (!gbc || speedMode.isDmgCompat() || !statModeLatchRephasedBySpeedSwitch
+                || speedSwitchCompletedThisLine || speedMode.getSpeedMode() != 1
+                || scxWrittenThisLine
+                || firstLine || line >= 144) {
+            return visibleMode;
+        }
+        if (mode == Mode.OamSearch && ticksInLine >= 74) {
+            return Mode.PixelTransfer.ordinal();
+        }
+        int readAhead = 4 - (ticksInLine & 3);
+        if ((mode == Mode.PixelTransfer || mode == Mode.HBlank)
+                && pixelTransferPhase.getPosition() + readAhead
+                >= 160 + (r.get(SCX) & 7)) {
+            return Mode.HBlank.ordinal();
+        }
+        return visibleMode;
+    }
+
     /**
      * Returns the mode sampled by the CGB CPU bus before this dot's PPU clocks have
      * settled, or {@code -1} when the ordinary readable STAT latch is visible.
@@ -1399,6 +1430,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.pixelTransferDone = false;
         this.hblankIntFrom = Integer.MAX_VALUE;
         this.mode0IntFrom = Integer.MAX_VALUE;
+        this.speedSwitchCompletedThisLine = false;
         this.scxWrittenThisLine = false;
         this.doubleSpeedMode2DispatchStatTailThisLine = false;
         this.earlyScxStatTailThisLine = false;
@@ -1426,6 +1458,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.pixelTransferDone = false;
         this.hblankIntFrom = Integer.MAX_VALUE;
         this.mode0IntFrom = Integer.MAX_VALUE;
+        this.speedSwitchCompletedThisLine = false;
         this.scxWrittenThisLine = false;
         this.doubleSpeedMode2DispatchStatTailThisLine = false;
         this.earlyScxStatTailThisLine = false;
@@ -1488,7 +1521,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         Memento<Ram> videoRam0Memento = videoRam0 instanceof Ram ? videoRam0.saveToMemento() : null;
         Memento<Ram> videoRam1Memento = videoRam1 instanceof Ram ? videoRam1.saveToMemento() : null;
 
-        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
+        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
     }
 
     @Override
@@ -1526,6 +1559,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.hblankIntFrom = mem.hblankIntFrom;
         this.mode0IntFrom = mem.mode0IntFrom;
         this.statModeLatchRephasedBySpeedSwitch = mem.statModeLatchRephasedBySpeedSwitch;
+        this.speedSwitchCompletedThisLine = mem.speedSwitchCompletedThisLine;
         this.scxWrittenThisLine = mem.scxWrittenThisLine;
         this.doubleSpeedMode2DispatchStatTailThisLine =
                 mem.doubleSpeedMode2DispatchStatTailThisLine;
@@ -1563,6 +1597,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                               boolean lcdEnableClockPhase, boolean pixelTransferDone,
                               int hblankIntFrom, int mode0IntFrom,
                               boolean statModeLatchRephasedBySpeedSwitch,
+                              boolean speedSwitchCompletedThisLine,
                               boolean scxWrittenThisLine,
                               boolean doubleSpeedMode2DispatchStatTailThisLine,
                               boolean earlyScxStatTailThisLine,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -99,6 +99,10 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     // on which a speed-switch tail completes.
     private boolean speedSwitchCompletedThisLine;
 
+    // The CPU-facing LY bus is rephased by the clock mux too, but restarting the
+    // LCD realigns this latch with the new line grid while the STAT phase persists.
+    private boolean lyReadLatchRephasedBySpeedSwitch;
+
     // A line-scoped SCX write makes a no-window line follow the dynamic shifted
     // pipeline instead of the steady-line fixed STAT release.
     private boolean scxWrittenThisLine;
@@ -335,7 +339,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             }
         }
         if (address == LY.getAddress()) {
-            return getVisibleLy();
+            return getCpuVisibleLy();
         }
         if (!gbc && oamRam.accepts(address)) {
             int accessedRow = getDirectOamReadRow();
@@ -549,9 +553,10 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         }
     }
 
-    /** Rephases the CGB CPU-readable STAT latch when the CPU clock mux changes. */
+    /** Rephases the CGB CPU-readable PPU latches when the CPU clock mux changes. */
     public void onSpeedSwitch() {
         statModeLatchRephasedBySpeedSwitch = true;
+        lyReadLatchRephasedBySpeedSwitch = lcdEnabled;
     }
 
     /** Retains the old CPU-readable STAT phase until the current scanline ends. */
@@ -800,6 +805,29 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             return line + 1;
         }
         return line;
+    }
+
+    /**
+     * LY as sampled by a native-CGB CPU bus read after the clock mux has been
+     * rephased. The PPU's registered LY value and its LYC comparator keep using
+     * {@link #getVisibleLy()}; only the CPU bus can observe the ripple-counter
+     * hand-off between consecutive LY values.
+     */
+    private int getCpuVisibleLy() {
+        int visibleLy = getVisibleLy();
+        if (!gbc || speedMode.isDmgCompat() || !lyReadLatchRephasedBySpeedSwitch) {
+            return visibleLy;
+        }
+        if (line == 153) {
+            int resetTransitionTick = speedMode.getSpeedMode() == 2 ? 1 : 2;
+            if (ticksInLine == resetTransitionTick) {
+                return 0;
+            }
+        } else if ((speedMode.getSpeedMode() == 1 && ticksInLine == 455)
+                || (speedMode.getSpeedMode() == 2 && ticksInLine == 451)) {
+            return line & (line + 1);
+        }
+        return visibleLy;
     }
 
     /**
@@ -1455,6 +1483,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.ticksInLine = -1;
         this.firstLine = true;
         this.lcdEnableClockPhase = true;
+        this.lyReadLatchRephasedBySpeedSwitch = false;
         this.pixelTransferDone = false;
         this.hblankIntFrom = Integer.MAX_VALUE;
         this.mode0IntFrom = Integer.MAX_VALUE;
@@ -1521,7 +1550,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         Memento<Ram> videoRam0Memento = videoRam0 instanceof Ram ? videoRam0.saveToMemento() : null;
         Memento<Ram> videoRam1Memento = videoRam1 instanceof Ram ? videoRam1.saveToMemento() : null;
 
-        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
+        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, lyReadLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
     }
 
     @Override
@@ -1560,6 +1589,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.mode0IntFrom = mem.mode0IntFrom;
         this.statModeLatchRephasedBySpeedSwitch = mem.statModeLatchRephasedBySpeedSwitch;
         this.speedSwitchCompletedThisLine = mem.speedSwitchCompletedThisLine;
+        this.lyReadLatchRephasedBySpeedSwitch = mem.lyReadLatchRephasedBySpeedSwitch;
         this.scxWrittenThisLine = mem.scxWrittenThisLine;
         this.doubleSpeedMode2DispatchStatTailThisLine =
                 mem.doubleSpeedMode2DispatchStatTailThisLine;
@@ -1598,6 +1628,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                               int hblankIntFrom, int mode0IntFrom,
                               boolean statModeLatchRephasedBySpeedSwitch,
                               boolean speedSwitchCompletedThisLine,
+                              boolean lyReadLatchRephasedBySpeedSwitch,
                               boolean scxWrittenThisLine,
                               boolean doubleSpeedMode2DispatchStatTailThisLine,
                               boolean earlyScxStatTailThisLine,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -1307,7 +1307,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
     public int getByte(int address) {
         int visibleMode = cpuStatModeOverride >= 0
                 ? cpuStatModeOverride
-                : gpu.getVisibleStatMode();
+                : gpu.getCpuVisibleStatMode();
         // A speed switch rephases the native CGB's CPU-facing STAT mux. Its last
         // bus slot of an active scanline (and of line 153) already exposes the next
         // line's mode 2. The LYC source shares this tail mux and keeps the current

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -1332,7 +1332,16 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
             // use their independently captured mode-2 path.
             visibleMode = Mode.HBlank.ordinal();
         }
-        return 0b10000000 | enableBits | (coincidence ? 0b100 : 0) | visibleMode;
+        boolean visibleCoincidence = coincidence;
+        if (gpu.isGbc() && !gpu.isDmgCompatMode() && isDoubleSpeed()
+                && gpu.isStatModeLatchRephasedBySpeedSwitch()
+                && gpu.getLine() == 143 && gpu.getTicksInLine() == 453) {
+            // On the rephased double-speed CPU bus, the final line-143 read slot
+            // samples the comparison release ahead of the direct readable latch.
+            // The following CPU slot lands after the ordinary release at dot 454.
+            visibleCoincidence = false;
+        }
+        return 0b10000000 | enableBits | (visibleCoincidence ? 0b100 : 0) | visibleMode;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -188,6 +188,7 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
     }
 
     public void tick() {
+        interruptManager.finishLcdcReadMaskWindow();
         lycIrqClock++;
         cpuStatModeOverride = -1;
         if (interruptManager.consumeLcdcInterruptAcknowledge()) {
@@ -752,7 +753,12 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         }
         if (gpu.isGbc() && !isDoubleSpeed() && gpu.getLine() == 143
                 && gpu.getTicksInLine() == 455 && pendingCgbMode1Interrupt) {
+            boolean newlyAsserted =
+                    !interruptManager.isInterruptFlagSet(InterruptType.LCDC);
             interruptManager.requestInterrupt(InterruptType.LCDC);
+            if (newlyAsserted && gpu.isStatModeLatchRephasedBySpeedSwitch()) {
+                interruptManager.maskLcdcUntilNextPeripheralTick();
+            }
             pendingCgbMode1Interrupt = false;
         }
         if (mode0Event && mode0EventArmed) {
@@ -1320,7 +1326,8 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
             visibleMode = Mode.OamSearch.ordinal();
         }
         if (gpu.isGbc() && !isDoubleSpeed() && gpu.isLcdEnabled()
-                && gpu.getLine() < 143 && gpu.getTicksInLine() == 454
+                && (gpu.getLine() < 143 && gpu.getTicksInLine() == 454
+                || gpu.getLine() == 143 && gpu.getTicksInLine() >= 454)
                 && !gpu.hasObjectsOnLine() && (enableBits & 0x40) != 0
                 && (lycIrqValueSource != registeredLy
                 || lycIrqClock - lastLycIrqRegisterChangeClock
@@ -1341,7 +1348,14 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
             // The following CPU slot lands after the ordinary release at dot 454.
             visibleCoincidence = false;
         }
-        return 0b10000000 | enableBits | (visibleCoincidence ? 0b100 : 0) | visibleMode;
+        if (gpu.isGbc() && !gpu.isDmgCompatMode() && !isDoubleSpeed()
+                && gpu.isStatModeLatchRephasedBySpeedSwitch()
+                && gpu.getLine() == 143 && gpu.getTicksInLine() == 455
+                && registeredLy == lycIrqValueSource) {
+            visibleCoincidence = true;
+        }
+        return 0b10000000 | enableBits
+                | (visibleCoincidence ? 0b100 : 0) | visibleMode;
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/InterruptManagerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/InterruptManagerTest.java
@@ -195,6 +195,21 @@ public class InterruptManagerTest {
     }
 
     @Test
+    public void lcdcBusMaskExpiresAtTheNextPeripheralTick() {
+        InterruptManager interrupts = new InterruptManager(true);
+        interrupts.setByte(0xff0f, 1 << LCDC.ordinal());
+        interrupts.maskLcdcUntilNextPeripheralTick();
+        var memento = interrupts.saveToMemento();
+
+        assertEquals(0xe0, interrupts.getByte(0xff0f));
+        assertTrue(interrupts.isInterruptFlagSet(LCDC));
+
+        interrupts.restoreFromMemento(memento);
+        interrupts.finishLcdcReadMaskWindow();
+        assertEquals(0xe2, interrupts.getByte(0xff0f));
+    }
+
+    @Test
     public void eiEnablesImeAfterTheFollowingInstruction() {
         InterruptManager interrupts = new InterruptManager(true);
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -486,6 +486,25 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void rephasedDoubleSpeedCgbReleasesCoincidenceInFinalVblankBusSlot() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 143);
+        fixture.advanceTo(143, 452);
+
+        assertEquals(0x04, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
+        fixture.tick();
+        assertEquals(0, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
+        fixture.tick();
+        assertEquals(0, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
+
+        Fixture unrephased = new Fixture(true, true);
+        unrephased.gpu.setByte(GpuRegister.LYC.getAddress(), 143);
+        unrephased.advanceTo(143, 453);
+        assertEquals(0x04, unrephased.stat.getByte(StatRegister.ADDRESS) & 0x04);
+    }
+
+    @Test
     public void cgbDoubleSpeedTailLycEdgeIsReadableBeforeCpuAcceptance() {
         Fixture fixture = new Fixture(true, true);
         fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -101,6 +101,57 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void rephasedNormalSpeedCgbCpuReadSeesLyRippleAtLineTail() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(5, 455);
+
+        assertEquals(6, fixture.gpu.getVisibleLy());
+        assertEquals(4, fixture.readLy());
+    }
+
+    @Test
+    public void rephasedDoubleSpeedCgbCpuReadSeesLyRippleBeforeLineTail() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(5, 451);
+
+        assertEquals(5, fixture.gpu.getVisibleLy());
+        assertEquals(4, fixture.readLy());
+    }
+
+    @Test
+    public void cgbLcdRestartRealignsCpuVisibleLyLatch() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.gpu.setByte(0xff40, 0x11);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(5, 451);
+
+        assertEquals(5, fixture.gpu.getVisibleLy());
+        assertEquals(5, fixture.readLy());
+    }
+
+    @Test
+    public void rephasedCgbCpuReadSeesLyResetRippleWithoutMovingComparatorLatch() {
+        Fixture normalSpeed = new Fixture(true);
+        normalSpeed.gpu.onSpeedSwitch();
+        normalSpeed.advanceTo(153, 2);
+
+        assertEquals(153, normalSpeed.gpu.getVisibleLy());
+        assertEquals(0, normalSpeed.readLy());
+        normalSpeed.tick();
+        assertEquals(153, normalSpeed.readLy());
+
+        Fixture doubleSpeed = new Fixture(true, true);
+        doubleSpeed.gpu.onSpeedSwitch();
+        doubleSpeed.advanceTo(153, 1);
+
+        assertEquals(153, doubleSpeed.gpu.getVisibleLy());
+        assertEquals(0, doubleSpeed.readLy());
+    }
+
+    @Test
     public void cgbDoubleSpeedTailLycEdgeDuringVblankIsReleasedAtLineStart() {
         Fixture fixture = new Fixture(true, true);
         fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -461,6 +461,18 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void rephasedCpuReadSeesMode3AtDot74Boundary() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 73);
+
+        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(74, fixture.gpu.getTicksInLine());
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
     public void speedSwitchCompletionRetainsOldStatPhaseUntilNextLine() {
         Fixture fixture = new Fixture(true);
         fixture.gpu.setByte(GpuRegister.SCX.getAddress(), 2);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -202,6 +202,38 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void rephasedCgbLycTailReadsOutgoingStateAtVblankBoundary() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 143);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x40);
+        fixture.advanceTo(143, 454);
+
+        assertEquals(0xc0, fixture.stat.getByte(StatRegister.ADDRESS));
+        fixture.tick();
+        assertEquals(0xc4, fixture.stat.getByte(StatRegister.ADDRESS));
+        fixture.tick();
+        assertEquals(0xc1, fixture.stat.getByte(StatRegister.ADDRESS));
+    }
+
+    @Test
+    public void rephasedCgbMode1RequestIsHiddenInFinalLine143IfBusSlot() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x10);
+        fixture.advanceTo(143, 447);
+        fixture.clearInterrupts();
+        fixture.advanceTo(143, 454);
+
+        fixture.tick();
+
+        assertTrue(fixture.interrupts.isInterruptFlagSet(LCDC));
+        assertEquals(0, fixture.lcdInterruptFlag());
+        fixture.tick();
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+    }
+
+    @Test
     public void cgbLycStatReadRetainsHblankThroughDot454OnObjectFreeLine() {
         Fixture fixture = new Fixture(true);
         fixture.stat.setByte(StatRegister.ADDRESS, 0x40);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -352,10 +352,55 @@ public class StatRegisterTest {
     }
 
     @Test
-    public void rephasedBackgroundLineDoesNotUseBootPhaseFixedMode3Release() {
+    public void rephasedBackgroundCpuReadSettlesAtEndOfMachineCycle() {
         Fixture fixture = new Fixture(true);
         fixture.gpu.setByte(GpuRegister.SCX.getAddress(), 2);
         fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 244);
+
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        fixture.advanceTo(1, 248);
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+
+        Fixture phaseThree = new Fixture(true);
+        phaseThree.gpu.setByte(GpuRegister.SCX.getAddress(), 1);
+        phaseThree.gpu.onSpeedSwitch();
+        phaseThree.advanceTo(1, 247);
+
+        assertEquals(Mode.PixelTransfer.ordinal(), phaseThree.readStatMode());
+
+        Fixture phaseTwo = new Fixture(true);
+        phaseTwo.gpu.onSpeedSwitch();
+        phaseTwo.advanceTo(1, 246);
+
+        assertEquals(Mode.HBlank.ordinal(), phaseTwo.readStatMode());
+    }
+
+    @Test
+    public void speedSwitchCompletionRetainsOldStatPhaseUntilNextLine() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(GpuRegister.SCX.getAddress(), 2);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 248);
+        fixture.gpu.onSpeedSwitchComplete();
+        var completionLine = fixture.gpu.saveToMemento();
+
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+
+        fixture.advanceTo(2, 248);
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+
+        fixture.gpu.restoreFromMemento(completionLine);
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void sameLineScxWriteRetainsDynamicStatPhase() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 200);
+        fixture.gpu.setByteFromCpu(GpuRegister.SCX.getAddress(), 2);
         fixture.advanceTo(1, 248);
 
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 148;
+    private static final int CURRENT_BASELINE_COUNT = 145;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 145;
+    private static final int CURRENT_BASELINE_COUNT = 132;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 145 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 132 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 148 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 145 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -43,19 +43,10 @@ hwtests/irq_precedence/late_m0irq_retrigger_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_ds_1_cgb04c_outE2.gbc [CGB]	E0
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [CGB]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
-hwtests/lcd_offset/offset1_lyc8fint_m1stat_ds_1_cgb04c_outC0.gbc [CGB]	C4
-hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx2_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx3_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m3stat_count_ds_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset2_lyc8fint_m1irq_1_cgb04c_outE0.gbc [CGB]	E2
-hwtests/lcd_offset/offset2_lyc8fint_m1stat_1_cgb04c_outC4.gbc [CGB]	C1
 hwtests/lcd_offset/offset2_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset3_lyc8fint_m1stat_1_cgb04c_outC0.gbc [CGB]	C1
-hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx0_2_cgb04c_out90.gbc [CGB]	00
-hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx1_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m2irq_count_2_cgb04c_out91.gbc [CGB]	00
-hwtests/lcd_offset/offset3_lyc99int_m3stat_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/ly0/lycint152_ly153_3_dmg08_cgb04c_out00.gbc [CGB]	99
 hwtests/ly0/lycint152_lyc153flag_3_dmg08_cgb04c_outC1.gbc [CGB]	C5
 hwtests/ly0/lycint152_m2stat_1_dmg08_cgb04c_outC2.gbc [CGB]	C3
@@ -73,7 +64,6 @@ hwtests/m1/lyc143_late_m0enable_lycdisable_2_dmg08_cgb04c_out1.gbc [DMG]	3
 hwtests/m1/lycint143_m1irq_ifw_ds_2_cgb04c_out0.gbc [CGB]	1
 hwtests/m1/lycint143_m1irq_late_retrigger_2_dmg08_cgb04c_out1.gbc [DMG]	3
 hwtests/m1/lycint143_m1irq_late_retrigger_ds_1_cgb04c_out3.gbc [CGB]	1
-hwtests/m1/lycint_m1stat_1_dmg08_cgb04c_out0.gbc [CGB]	1
 hwtests/m1/lycint_vblankirq_late_retrigger_2_dmg08_cgb04c_out0.gbc [CGB]	1
 hwtests/m1/lycint_vblankirq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	1
 hwtests/m1/lycint_vblankirq_late_retrigger_ds_2_cgb04c_out0.gbc [CGB]	1
@@ -132,7 +122,6 @@ hwtests/vramw_m3end/vramw_m3end_2_dmg08_cgb04c_out7.gbc [CGB]	0
 hwtests/vramw_m3end/vramw_m3end_4_dmg08_cgb04c_out0.gbc [CGB]	1
 hwtests/vramw_m3end/vramw_m3end_scx3_2_dmg08_cgb04c_out7.gbc [CGB]	0
 hwtests/vramw_m3end/vramw_m3end_scx3_4_dmg08_cgb04c_out0.gbc [CGB]	3
-hwtests/window/arg/late_wy_1toFF_lcdoffset1_1_cgb04c_out0.gbc [CGB]	3
 hwtests/window/arg/late_wy_FFto2_ly2_scx5_3_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_disable_early_scx03_wx12_2_dmg08_out0_cgb04c_out3.gbc [DMG]	3
 hwtests/window/late_disable_late_scx03_wx12_1_dmg08_cgb04c_out0.gbc [DMG]	3
@@ -140,9 +129,7 @@ hwtests/window/late_disable_scx2_0_dmg08_cgb04c_out0.gbc [DMG]	3
 hwtests/window/late_disable_spx10_wx0f_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_disable_spx10_wx0f_1_dmg08_cgb04c_out0.gbc [DMG]	3
 hwtests/window/late_enable_afterVblank_ds_lcdoffset1_2_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_enable_afterVblank_lcdoffset1_2_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wx_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wx_wx03_1_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_wx_wx0f_1_dmg08_cgb04c_out0.gbc [CGB]	3
-hwtests/window/late_wy_lcdoffset1_1_cgb04c_out0.gbc [CGB]	3
 hwtests/window/m2int_wxA6_spxA7_m0irq_2_dmg08_cgb04c_out2.gbc [DMG]	0

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -44,17 +44,14 @@ hwtests/irq_precedence/late_m0irq_retrigger_ds_1_cgb04c_outE2.gbc [CGB]	E0
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [CGB]	E2
 hwtests/irq_precedence/late_m0irq_retrigger_scx1_2_dmg08_cgb04c_outE0.gbc [DMG]	E2
 hwtests/lcd_offset/offset1_lyc8fint_m1stat_ds_1_cgb04c_outC0.gbc [CGB]	C4
-hwtests/lcd_offset/offset1_lyc98int_ly_count_ds_2_cgb04c_out9A.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx2_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m0stat_count_scx3_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m3stat_count_ds_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset2_lyc8fint_m1irq_1_cgb04c_outE0.gbc [CGB]	E2
 hwtests/lcd_offset/offset2_lyc8fint_m1stat_1_cgb04c_outC4.gbc [CGB]	C1
-hwtests/lcd_offset/offset2_lyc98int_ly_count_2_cgb04c_out9A.gbc [CGB]	01
 hwtests/lcd_offset/offset2_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc8fint_m1stat_1_cgb04c_outC0.gbc [CGB]	C1
-hwtests/lcd_offset/offset3_lyc98int_ly_count_2_cgb04c_out9A.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx0_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m0stat_count_scx1_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m2irq_count_2_cgb04c_out91.gbc [CGB]	00


### PR DESCRIPTION
## Summary

- model normal-speed CGB CPU-visible STAT read completion, including the speed-switch completion-line and same-line SCX phases
- model rephased frame-tail STAT/IF reads and double-speed coincidence release
- model the CPU-visible LY ripple while keeping the PPU and LYC view registered
- add focused phase, regression, and memento tests
- remove 16 outputs that now match Gambatte hardware verdicts

## Result

- fixes 12 of the 16 `lcd_offset` failures; the four remaining cases require a separate CPU IF pulse-window model
- improves Gambatte hardware matches from 4,526 to 4,542
- reduces the pinned baseline from 148 to 132

## Validation

- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw` (4,674/4,674)
- `mvn -q -pl core test -Ptest-mealybug,test-gbmicrotest,test-gbc-hw,test-misc-gb`
- `mvn -q test -f core/pom.xml`
- `mvn -q test`
- `git diff --check origin/master..HEAD`