### PR TITLE
Fix Gambatte timing mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,569 match hardware; 105 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,566 match hardware; 108 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 105 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 108 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 | [Mooneye Test Suite](https://github.com/Gekkio/mooneye-test-suite) | 130 | 130 / 130 selected cases pass |
 | [RTC3Test](https://github.com/aaaaaa123456789/rtc3test) | 3 | 3 / 3 menus pass |
 | [SameSuite](https://github.com/LIJI32/SameSuite) | 71 | 71 / 71 later-revision cases pass |
-| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,542 match hardware; 132 current outputs are pinned exactly |
+| [Gambatte HWTests](https://github.com/pokemon-speedrunning/gambatte-core/tree/master/test) | 4,674 | 4,569 match hardware; 105 current outputs are pinned exactly |
 | [BullyGB](https://github.com/Ashiepaws/BullyGB) | 2 | 2 / 2 DMG and CGB cases pass |
 | [MBC30Test](https://github.com/ZoomTen/mbc30test) | 1 | 1 / 1 ROM banking and SRAM case passes |
 | [Daid / GB Emulator Shootout](https://github.com/gbdev/GBEmulatorShootout/tree/main/testroms/daid) | 9 | 8 / 8 images have no out-of-tolerance pixels; ROM+RAM passes |
@@ -139,7 +139,7 @@ GB matches them, while unresolved outputs are pinned against regressions.
 
 Every ROM with a machine-readable result must produce its documented pass value,
 match its selected raw hardware capture, or match an exact documented current
-output. Gambatte's 132 unresolved cases are pinned to their complete hexadecimal
+output. Gambatte's 105 unresolved cases are pinned to their complete hexadecimal
 output. CGB-ACID-HELL, Strikethrough, and CasualPokePlayer are compared pixel for
 pixel with their upstream references. Any change fails CI; a hardware-correct
 Gambatte improvement removes the corresponding baseline entry.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -493,6 +493,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
     }
 
     private Mode tickSubsystems() {
+        statRegister.captureCpuStatReadPhase();
+        statRegister.publishFrameLyc0Mode2HandoffBeforeCpu();
         boolean speedSwitching = cpu.isSpeedSwitching();
         boolean speedSwitchTail = speedSwitchTailTicks > 0;
         dma.setCpuInterruptStackWrite(cpu.getState() == Cpu.State.IRQ_PUSH_1
@@ -574,8 +576,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 }
                 if (hdma.isCpuInstructionRequestOwner()) {
                     // A CPU-fetched instruction owns the request slot until its next
-                    // opcode boundary. Its final double-speed HBlank read also keeps
-                    // the VRAM slot that was granted with the instruction.
+                    // opcode boundary. Its final HBlank read also keeps the VRAM slot
+                    // that was granted with the instruction.
                     gpu.setCpuRetiringInstructionForHdma(true);
                     try {
                         cpu.tick();
@@ -600,11 +602,21 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 }
             }
         } else {
-            cpu.tick();
+            // A retiring instruction can issue its final VRAM read on the CPU half
+            // of the edge immediately before an HBlank request reaches arbitration.
+            boolean retiringIntoHdmaRequest = cpu.isInstructionRetiringForHdma()
+                    && hdma.isHblankRequestArrivingAfterCpuTick();
+            gpu.setCpuRetiringInstructionForHdma(retiringIntoHdmaRequest);
+            try {
+                cpu.tick();
+            } finally {
+                gpu.setCpuRetiringInstructionForHdma(false);
+            }
         }
         if (!speedSwitching && cpu.isSpeedSwitching()) {
             sound.onSpeedSwitch();
             gpu.onSpeedSwitch();
+            dma.onSpeedSwitch();
             if (hdma.onSpeedSwitch()) {
                 cpu.replaySpeedSwitchPaddingByte();
             }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -413,10 +413,14 @@ public class Cpu implements Serializable, Originator<Cpu> {
         if (haltEntrySampleTicks <= 0) {
             return;
         }
-        if (state == State.HALTED && interruptManager.isInterruptRequested()) {
+        boolean ime = interruptManager.isIme();
+        boolean asynchronousRequest = ime
+                ? interruptManager.isInterruptRequestedWhileHaltWakeBlocked()
+                : interruptManager.isInterruptRequested();
+        if (state == State.HALTED && asynchronousRequest) {
             haltEntrySampleTicks = 0;
             state = State.OPCODE;
-            if (interruptManager.isIme()) {
+            if (ime) {
                 // The enabled request is accepted, but the asynchronous edge makes
                 // interrupt entry push HALT's address so RETI executes it again.
                 registers.setPC((registers.getPC() - 1) & 0xffff);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -354,8 +354,7 @@ public class Cpu implements Serializable, Originator<Cpu> {
                             return;
                         } else {
                             state = State.HALTED;
-                            haltEntrySampleTicks = interruptManager.isIme()
-                                    ? 0 : speedMode.isGbc() ? 2 : 4;
+                            haltEntrySampleTicks = speedMode.isGbc() ? 2 : 4;
                             return;
                         }
                     }
@@ -414,16 +413,21 @@ public class Cpu implements Serializable, Originator<Cpu> {
         if (haltEntrySampleTicks <= 0) {
             return;
         }
-        if (state == State.HALTED && !interruptManager.isIme()
-                && interruptManager.isInterruptRequested()) {
+        if (state == State.HALTED && interruptManager.isInterruptRequested()) {
             haltEntrySampleTicks = 0;
             state = State.OPCODE;
-            haltBugMode = true;
-            // The request reached HALT after the ordinary CPU sample. Rephase the
-            // resumed bus clock onto that asynchronous edge.
-            clockCycle++;
-            if (timer != null) {
-                timer.onHaltBug();
+            if (interruptManager.isIme()) {
+                // The enabled request is accepted, but the asynchronous edge makes
+                // interrupt entry push HALT's address so RETI executes it again.
+                registers.setPC((registers.getPC() - 1) & 0xffff);
+            } else {
+                haltBugMode = true;
+                // The disabled request resumes opcode fetch on the asynchronous
+                // edge, producing the ordinary halt-bug bus rephase.
+                clockCycle++;
+                if (timer != null) {
+                    timer.onHaltBug();
+                }
             }
         } else {
             haltEntrySampleTicks--;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
@@ -262,6 +262,11 @@ public class InterruptManager implements AddressSpace, Serializable, Originator<
                 & ~haltBlockedInterrupts & 0x1f) != 0;
     }
 
+    public boolean isInterruptRequestedWhileHaltWakeBlocked() {
+        return (interruptFlag & interruptEnabled & ~cpuBlockedInterrupts
+                & haltBlockedInterrupts & 0x1f) != 0;
+    }
+
     public boolean isUnphasedPpuInterruptRequested() {
         return (interruptFlag & interruptEnabled & ~cpuBlockedInterrupts
                 & ~cpuPhasedPpuInterrupts & PPU_INTERRUPT_MASK) != 0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1100,13 +1100,14 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         // A scanline containing enabled objects, combined with fractional scroll or the
         // window, can leave the readable mode-3 tail asserted after the internal phase
         // releases the VRAM/OAM locks (Misc.-GB-Tests' NOP-shifted sprite variants).
-        // The window path retains the latch through the mode-0 edge; fractional SCX
-        // without a window releases it two dots before that edge. Keep this separate
-        // from `mode`: the lock handoff and HBlank interrupt retain their calibrated
-        // timings. Vertically inactive objects and sprite-disabled lines do not produce
-        // this tail (GBMicrotest), while selected objects beyond the right edge still do.
+        // The window and high fine-SCX phases retain the latch through the mode-0
+        // edge; fine SCX 1..4 without a window release it two dots earlier. Keep this
+        // separate from `mode`: the lock handoff and HBlank interrupt retain their
+        // calibrated timings. Vertically inactive objects and sprite-disabled lines do
+        // not produce this tail (GBMicrotest), while selected objects beyond the right
+        // edge still do.
         if (!gbc && mode == Mode.HBlank
-                && (lcdc.isWindowDisplay()
+                && (lcdc.isWindowDisplay() || (r.get(SCX) & 7) >= 5
                 ? ticksInLine <= hblankIntFrom
                 : ticksInLine < hblankIntFrom - 2)
                 && lcdc.isObjDisplayEffective()

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -76,6 +76,10 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     // phase survives frame rollover until the LCD is disabled again.
     private boolean lcdEnableClockPhase;
 
+    // The first frame after LCD enable has a distinct native-CGB LY read phase at
+    // line 153 dot zero. Later frames retain 153 there on the ordinary CPU bus.
+    private boolean firstFrameAfterLcdEnable;
+
     private Mode mode;
 
     private GpuPhase phase;
@@ -463,6 +467,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             line++;
             if (line == 154) {
                 line = 0;
+                firstFrameAfterLcdEnable = false;
                 if (!earlyWindowFrameEdge) {
                     pixelTransferPhase.resetWindowLineCounter();
                     pixelMachine.resetWindowLineCounter();
@@ -817,7 +822,8 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         int visibleLy = getVisibleLy();
         if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
                 && lcdEnableClockPhase && !lyReadLatchRephasedBySpeedSwitch
-                && line == 153 && ticksInLine < 4) {
+                && line == 153 && ticksInLine < 4
+                && (ticksInLine != 0 || firstFrameAfterLcdEnable)) {
             // Restarting the LCD leaves the normal-speed CPU read phase just past
             // line 153's transient LY latch. The PPU comparator and an ordinary
             // power-on grid continue to retain 153 for all four dots.
@@ -1199,10 +1205,6 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
      * or {@code -1} when that callback uses the ordinary readable STAT latch.
      */
     int getCpuReadStatModeOverride() {
-        int mode2Handoff = getCpuMode2HandoffStatOverride();
-        if (mode2Handoff >= 0) {
-            return mode2Handoff;
-        }
         if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
                 && firstLine && mode == Mode.HBlank
                 && !pixelTransferPhase.hasObjectsOnLine()
@@ -1368,7 +1370,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             // dot 453 double speed (the `> releaseTick` CGB rule below maps to 452).
             return speedMode.getSpeedMode() == 2 ? 452 : getEarlyLineEdgeTick();
         }
-        if (lcdEnableClockPhase && gbc && !speedMode.isDmgCompat()
+        if (line == 0 && lcdEnableClockPhase && gbc && !speedMode.isDmgCompat()
                 && speedMode.getSpeedMode() == 1
                 && !statModeLatchRephasedBySpeedSwitch) {
             // On the LCD-restart grid, stored dot 452 is already the comparator's
@@ -1524,6 +1526,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.line = 0;
         this.ticksInLine = 0;
         this.firstLine = false;
+        this.firstFrameAfterLcdEnable = false;
         this.pixelTransferDone = false;
         this.hblankIntFrom = Integer.MAX_VALUE;
         this.mode0IntFrom = Integer.MAX_VALUE;
@@ -1552,6 +1555,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.ticksInLine = -1;
         this.firstLine = true;
         this.lcdEnableClockPhase = true;
+        this.firstFrameAfterLcdEnable = true;
         this.lyReadLatchRephasedBySpeedSwitch = false;
         this.pixelTransferDone = false;
         this.hblankIntFrom = Integer.MAX_VALUE;
@@ -1619,7 +1623,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         Memento<Ram> videoRam0Memento = videoRam0 instanceof Ram ? videoRam0.saveToMemento() : null;
         Memento<Ram> videoRam1Memento = videoRam1 instanceof Ram ? videoRam1.saveToMemento() : null;
 
-        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, lyReadLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
+        return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, firstFrameAfterLcdEnable, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, lyReadLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, earlyScxStatTailThisLine, wyWrittenThisLine, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
     }
 
     @Override
@@ -1653,6 +1657,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         this.ticksInLine = mem.ticksInLine;
         this.firstLine = mem.firstLine;
         this.lcdEnableClockPhase = mem.lcdEnableClockPhase;
+        this.firstFrameAfterLcdEnable = mem.firstFrameAfterLcdEnable;
         this.pixelTransferDone = mem.pixelTransferDone;
         this.hblankIntFrom = mem.hblankIntFrom;
         this.mode0IntFrom = mem.mode0IntFrom;
@@ -1693,7 +1698,8 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                               Memento<PixelTransfer> pixelMachineMemento,
                               Memento<GpuRegisterValues> rMemento, boolean lcdEnabled, int displayEnabledDelay,
                               int line, int ticksInLine, boolean firstLine,
-                              boolean lcdEnableClockPhase, boolean pixelTransferDone,
+                              boolean lcdEnableClockPhase, boolean firstFrameAfterLcdEnable,
+                              boolean pixelTransferDone,
                               int hblankIntFrom, int mode0IntFrom,
                               boolean statModeLatchRephasedBySpeedSwitch,
                               boolean speedSwitchCompletedThisLine,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -815,6 +815,14 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
      */
     private int getCpuVisibleLy() {
         int visibleLy = getVisibleLy();
+        if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
+                && lcdEnableClockPhase && !lyReadLatchRephasedBySpeedSwitch
+                && line == 153 && ticksInLine < 4) {
+            // Restarting the LCD leaves the normal-speed CPU read phase just past
+            // line 153's transient LY latch. The PPU comparator and an ordinary
+            // power-on grid continue to retain 153 for all four dots.
+            return 0;
+        }
         if (!gbc || speedMode.isDmgCompat() || !lyReadLatchRephasedBySpeedSwitch) {
             return visibleLy;
         }
@@ -1090,14 +1098,17 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             return Mode.PixelTransfer.ordinal();
         }
         // A scanline containing enabled objects, combined with fractional scroll or the
-        // window, can leave the readable mode-3 tail asserted through the mode-0
-        // interrupt edge even after the internal phase released the VRAM/OAM locks
-        // (Misc.-GB-Tests' NOP-shifted sprite timing variants). Keep this separate from
-        // `mode`: the lock handoff and HBlank interrupt retain their calibrated timings.
-        // Vertically inactive objects and sprite-disabled lines do not produce this tail
-        // (GBMicrotest), while selected objects beyond the right edge still do.
+        // window, can leave the readable mode-3 tail asserted after the internal phase
+        // releases the VRAM/OAM locks (Misc.-GB-Tests' NOP-shifted sprite variants).
+        // The window path retains the latch through the mode-0 edge; fractional SCX
+        // without a window releases it two dots before that edge. Keep this separate
+        // from `mode`: the lock handoff and HBlank interrupt retain their calibrated
+        // timings. Vertically inactive objects and sprite-disabled lines do not produce
+        // this tail (GBMicrotest), while selected objects beyond the right edge still do.
         if (!gbc && mode == Mode.HBlank
-                && ticksInLine <= hblankIntFrom
+                && (lcdc.isWindowDisplay()
+                ? ticksInLine <= hblankIntFrom
+                : ticksInLine < hblankIntFrom - 2)
                 && lcdc.isObjDisplayEffective()
                 && pixelTransferPhase.hasObjectsOnLine()
                 && ((r.get(SCX) & 7) != 0 || lcdc.isWindowDisplay())) {
@@ -1109,6 +1120,15 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     /** Returns the normal-speed STAT mode sampled at the end of a rephased CPU read. */
     int getCpuVisibleStatMode() {
         int visibleMode = getVisibleStatMode();
+        if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
+                && mode == Mode.HBlank && dma.ownsOamForPpu()
+                && pixelTransferPhase.hasObjectsOnLine()
+                && ticksInLine == hblankIntFrom) {
+            // An object-owned OAM-DMA scan can put the CPU read exactly on the
+            // predicted mode-0 edge. That bus phase still sees the retiring mode-3
+            // latch even though the internal timing skeleton has entered HBlank.
+            return Mode.PixelTransfer.ordinal();
+        }
         if (!gbc || speedMode.isDmgCompat() || !statModeLatchRephasedBySpeedSwitch
                 || speedSwitchCompletedThisLine || speedMode.getSpeedMode() != 1
                 || scxWrittenThisLine
@@ -1127,6 +1147,15 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         return visibleMode;
     }
 
+    boolean isUnrephasedLineZeroStatTail() {
+        return gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
+                && lcdEnableClockPhase && !statModeLatchRephasedBySpeedSwitch
+                && !firstLine && line == 0 && mode == Mode.HBlank
+                && !pixelTransferPhase.hasObjectsOnLine()
+                && !pixelTransferPhase.hasActivatedWindowOnLine()
+                && ticksInLine <= hblankIntFrom + 4;
+    }
+
     /**
      * Returns the mode sampled by the CGB CPU bus before this dot's PPU clocks have
      * settled, or {@code -1} when the ordinary readable STAT latch is visible.
@@ -1138,9 +1167,9 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
      * transition for its current bus phase.</p>
      */
     int getCpuStatModeOverride() {
-        if (gbc && speedMode.getSpeedMode() == 1
-                && !firstLine && mode == Mode.OamSearch && ticksInLine == 78) {
-            return Mode.OamSearch.ordinal();
+        int mode2Handoff = getCpuMode2HandoffStatOverride();
+        if (mode2Handoff >= 0) {
+            return mode2Handoff;
         }
         if (gbc && speedMode.getSpeedMode() == 2
                 && statModeLatchRephasedBySpeedSwitch
@@ -1148,6 +1177,38 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                 && pixelMachine.hasActivatedWindowOnLine()
                 && pixelMachine.getPosition() < 160) {
             return Mode.PixelTransfer.ordinal();
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the old side of native CGB's normal-speed mode-2-to-mode-3 CPU mux
+     * at stored dot 78, or {@code -1} outside that single hand-off phase.
+     */
+    int getCpuMode2HandoffStatOverride() {
+        if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
+                && !firstLine && mode == Mode.OamSearch && ticksInLine == 78) {
+            return Mode.OamSearch.ordinal();
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the mode captured immediately before this tick's CPU memory callback,
+     * or {@code -1} when that callback uses the ordinary readable STAT latch.
+     */
+    int getCpuReadStatModeOverride() {
+        int mode2Handoff = getCpuMode2HandoffStatOverride();
+        if (mode2Handoff >= 0) {
+            return mode2Handoff;
+        }
+        if (gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1
+                && firstLine && mode == Mode.HBlank
+                && !pixelTransferPhase.hasObjectsOnLine()
+                && ticksInLine + 1 >= hblankIntFrom) {
+            // On the LCD-enable line, an object-free normal-speed CPU read samples
+            // the mode-0 side of the mux one dot before the ordinary STAT latch.
+            return Mode.HBlank.ordinal();
         }
         return -1;
     }
@@ -1306,6 +1367,14 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
             // dot 453 double speed (the `> releaseTick` CGB rule below maps to 452).
             return speedMode.getSpeedMode() == 2 ? 452 : getEarlyLineEdgeTick();
         }
+        if (lcdEnableClockPhase && gbc && !speedMode.isDmgCompat()
+                && speedMode.getSpeedMode() == 1
+                && !statModeLatchRephasedBySpeedSwitch) {
+            // On the LCD-restart grid, stored dot 452 is already the comparator's
+            // non-readable tail slot. A speed switch replaces this phase with its
+            // separately modelled CPU-facing mux.
+            return 451;
+        }
         if (!gbc) {
             return getEarlyLineEdgeTick();
         }
@@ -1340,8 +1409,7 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         if (!lcdEnabled) {
             return true;
         }
-        if (!write && cpuRetiringInstructionForHdma && gbc
-                && speedMode.getSpeedMode() == 2 && mode == Mode.HBlank) {
+        if (!write && cpuRetiringInstructionForHdma && gbc && mode == Mode.HBlank) {
             return true;
         }
         if (firstLine && gbc && ticksInLine < 84) {
@@ -1354,11 +1422,11 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
                 return false;
             }
             int position = pixelTransferPhase.getPosition();
-            // The final VRAM fetch slot is returned to the CPU before the internal
-            // mode transition. Fine SCX moves that slot by the corresponding number
-            // of output dots.
-            if (speedMode.getSpeedMode() == 1
-                    && position >= 158 - (r.get(SCX) & 0x07)
+            // The final normal-speed CPU slot is released once the fetcher has
+            // committed X=159. Reads use the request retained by the immediately
+            // preceding write; fine SCX changes when X=159 is reached, not the
+            // comparator itself (vramw_m3end).
+            if (speedMode.getSpeedMode() == 1 && position >= 159
                     && (write || followsCpuVramWrite())) {
                 return true;
             }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -430,6 +430,23 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         }
     }
 
+    /** Captures the PPU mux phase before this tick's CPU memory callback. */
+    public void captureCpuStatReadPhase() {
+        cpuStatModeOverride = gpu.getCpuReadStatModeOverride();
+    }
+
+    /** Publishes line 1's LYC=0-blocked normal-speed mode-2 handoff before CPU I/O. */
+    public void publishFrameLyc0Mode2HandoffBeforeCpu() {
+        if (pendingCgbMode2Interrupt && !isDoubleSpeed()
+                && isDeferredCgbMode2Phase()
+                && gpu.getLine() == 1
+                && (enableBits & 0x60) == 0x60
+                && modeIrqLycLatch == 0
+                && gpu.getTicksInLine() == 450) {
+            publishPendingCgbMode2Event();
+        }
+    }
+
     public void onLcdDisabled() {
         cpuStatModeOverride = -1;
         pendingCgbMode1Interrupt = false;
@@ -1314,6 +1331,12 @@ public class StatRegister implements AddressSpace, Originator<StatRegister> {
         int visibleMode = cpuStatModeOverride >= 0
                 ? cpuStatModeOverride
                 : gpu.getCpuVisibleStatMode();
+        if (enableBits == 0 && gpu.isUnrephasedLineZeroStatTail()) {
+            // With no STAT source selected, the LCD-restart clock phase exposes
+            // line zero's mode-3 latch for the five-dot mode-0 hand-off. Selecting
+            // any interrupt source moves the CPU read onto the ordinary MSTAT path.
+            visibleMode = Mode.PixelTransfer.ordinal();
+        }
         // A speed switch rephases the native CGB's CPU-facing STAT mux. Its last
         // bus slot of an active scanline (and of line 153) already exposes the next
         // line's mode 2. The LYC source shares this tail mux and keeps the current

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -137,19 +137,33 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
                     currentByte++;
                 }
                 if (transferClocks >= 648) {
-                    transferInProgress = false;
-                    restarted = false;
-                    ppuOamOwnedThroughRestart = false;
-                    ticks = 0;
-                    transferClocks = 0;
-                    currentByte = 0;
-                    pendingInterruptWriteByte = -1;
+                    finishTransfer();
                     break;
                 }
             }
         }
         updatePpuOamOwnership();
         vramDmaBusAddress = -1;
+    }
+
+    private void finishTransfer() {
+        transferInProgress = false;
+        restarted = false;
+        ppuOamOwnedThroughRestart = false;
+        ticks = 0;
+        transferClocks = 0;
+        currentByte = 0;
+        pendingInterruptWriteByte = -1;
+    }
+
+    /**
+     * A speed switch disconnects an OAM-DMA transfer whose final copy edge has
+     * completed, without waiting for the ordinary four-clock release tail.
+     */
+    public void onSpeedSwitch() {
+        if (transferInProgress && currentByte >= 0xa0) {
+            finishTransfer();
+        }
     }
 
     public void setVramDmaBusSample(Hdma.SourceBusSample sample) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -13,7 +13,7 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
 
     private static final int DMG_SOURCE_BUS_RELEASE_CLOCKS = 636;
 
-    private final AddressSpace addressSpace;
+    private final DmaAddressSpace addressSpace;
 
     private final AddressSpace oam;
 
@@ -264,6 +264,13 @@ public class Dma implements AddressSpace, Serializable, Originator<Dma> {
             return ((from + byteIndex) >> 8) & 0x9f;
         }
         int oamAddress = getActiveOamAddress();
+        if (speedMode.isGbc() && from >= 0xe000) {
+            // The invalid high source leaves the OAM copy-data pins open, but its
+            // partially decoded cartridge-bus request still reads the A000-BF9F
+            // SRAM alias. CPU accesses contending on that bus see the SRAM byte,
+            // independently of the FF byte written into OAM.
+            return addressSpace.getCpuBusByte(from + oamAddress - 0xfe00);
+        }
         int value = oam.getByte(oamAddress);
         if (speedMode.isGbc() && getSourceType() == SourceType.VRAM) {
             // A CGB read collision on the VRAM bus returns the byte currently driven

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaAddressSpace.java
@@ -32,6 +32,10 @@ public class DmaAddressSpace implements AddressSpace, Serializable {
             // purposes, but the OAM-DMA copy data pins themselves remain open.
             return 0xff;
         }
+        return getCpuBusByte(address);
+    }
+
+    int getCpuBusByte(int address) {
         return addressSpace.getByte(mapAddress(address, gbc));
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaAddressSpace.java
@@ -27,6 +27,11 @@ public class DmaAddressSpace implements AddressSpace, Serializable {
 
     @Override
     public int getByte(int address) {
+        if (gbc && address >= 0xe000) {
+            // Native CGB decodes these pages onto the cartridge bus for conflict
+            // purposes, but the OAM-DMA copy data pins themselves remain open.
+            return 0xff;
+        }
         return addressSpace.getByte(mapAddress(address, gbc));
     }
 
@@ -35,8 +40,9 @@ public class DmaAddressSpace implements AddressSpace, Serializable {
             return address;
         }
         // The DMG copy engine follows the normal echo mapping for the high
-        // source range. CGB instead decodes those source pages onto cartridge
-        // RAM, including while running in monochrome compatibility mode.
+        // source range. CGB instead classifies those source pages as cartridge
+        // RAM for bus-conflict purposes, including in compatibility mode; its
+        // copy-data decoder handles this invalid range separately in getByte().
         return gbc ? address & 0xbfff : address - 0x2000;
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -567,6 +567,15 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
         return cpuRequestArbitration == CpuRequestArbitration.CPU;
     }
 
+    /**
+     * Whether the HBlank request will reach the CPU arbiter after this tick's CPU
+     * callback. A retiring instruction still owns its read phase on that edge.
+     */
+    public boolean isHblankRequestArrivingAfterCpuTick() {
+        return transferInProgress && hblankTransfer && !cpuHalted
+                && hblankRequestTicks == 1;
+    }
+
     public void onCpuRequestSlotRetired() {
         if (cpuRequestArbitration == CpuRequestArbitration.CPU) {
             setCpuRequestArbitration(CpuRequestArbitration.DMA);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -227,7 +227,7 @@ public class CpuPpuInterruptTimingTest {
     }
 
     @Test
-    public void imeEnabledInterruptInHaltEntryWindowPushesTheHaltAddress() {
+    public void imeEnabledHaltBlockedInterruptInEntryWindowPushesTheHaltAddress() {
         for (boolean gbc : new boolean[] {false, true}) {
             Harness h = new Harness(gbc);
             h.enable(LCDC);
@@ -235,7 +235,7 @@ public class CpuPpuInterruptTimingTest {
             h.enterHalt();
 
             h.cpu.tick();
-            h.interrupts.requestInterrupt(LCDC);
+            h.interrupts.requestInterruptBeforeHaltWake(LCDC);
             h.cpu.onPeripheralsTicked();
 
             assertEquals(Cpu.State.OPCODE, h.cpu.getState());
@@ -248,6 +248,25 @@ public class CpuPpuInterruptTimingTest {
             h.advanceToIrqJump();
             assertEquals(0x01, h.memory.getByte(0xfffd));
             assertEquals(0x00, h.memory.getByte(0xfffc));
+        }
+    }
+
+    @Test
+    public void imeEnabledOrdinaryInterruptInEntryWindowPushesTheFollowingAddress() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            Harness h = new Harness(gbc);
+            h.enable(LCDC);
+            h.interrupts.enableInterrupts(false);
+            h.enterHalt();
+
+            h.cpu.tick();
+            h.interrupts.requestInterrupt(LCDC);
+            h.cpu.onPeripheralsTicked();
+
+            assertEquals(Cpu.State.HALTED, h.cpu.getState());
+            h.advanceToIrqJump();
+            assertEquals(0x01, h.memory.getByte(0xfffd));
+            assertEquals(0x01, h.memory.getByte(0xfffc));
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -227,6 +227,31 @@ public class CpuPpuInterruptTimingTest {
     }
 
     @Test
+    public void imeEnabledInterruptInHaltEntryWindowPushesTheHaltAddress() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            Harness h = new Harness(gbc);
+            h.enable(LCDC);
+            h.interrupts.enableInterrupts(false);
+            h.enterHalt();
+
+            h.cpu.tick();
+            h.interrupts.requestInterrupt(LCDC);
+            h.cpu.onPeripheralsTicked();
+
+            assertEquals(Cpu.State.OPCODE, h.cpu.getState());
+            assertEquals(PROGRAM, h.cpu.getRegisters().getPC());
+            h.tickCpuTicks(2);
+            assertEquals(Cpu.State.OPCODE, h.cpu.getState());
+            h.cpu.tick();
+            assertEquals(gbc ? Cpu.State.IRQ_PUSH_1 : Cpu.State.IRQ_WAIT_2,
+                    h.cpu.getState());
+            h.advanceToIrqJump();
+            assertEquals(0x01, h.memory.getByte(0xfffd));
+            assertEquals(0x00, h.memory.getByte(0xfffc));
+        }
+    }
+
+    @Test
     public void hdmaDoesNotPrefetchPastAnEnabledPendingInterrupt() {
         Harness h = new Harness(true);
         h.memory.setByte(PROGRAM, 0x00);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
@@ -114,7 +114,7 @@ public class GpuDisplayEnableTimingTest {
     }
 
     @Test
-    public void dmgFineScxSpriteLatchReleasesTwoDotsBeforeModeZeroEdge() {
+    public void dmgLowerFineScxSpriteLatchReleasesTwoDotsBeforeModeZeroEdge() {
         Fixture fixture = new Fixture(1, false, false);
         fixture.gpu.setByte(0xff40, 0x00);
         fixture.gpu.setByte(0xff43, 4);
@@ -136,6 +136,29 @@ public class GpuDisplayEnableTimingTest {
         assertEquals(Mode.PixelTransfer.ordinal(), threeDotsBefore);
         assertEquals(Mode.HBlank.ordinal(), twoDotsBefore);
         assertEquals(Mode.HBlank.ordinal(), oneDotBefore);
+    }
+
+    @Test
+    public void dmgHighFineScxSpriteLatchPersistsThroughModeZeroEdge() {
+        for (int fineScx = 5; fineScx <= 7; fineScx++) {
+            Fixture fixture = new Fixture(1, false, false);
+            fixture.gpu.setByte(0xff40, 0x00);
+            fixture.gpu.setByte(0xff43, fineScx);
+            fixture.oam.setByte(0xfe00, 16);
+            fixture.oam.setByte(0xfe01, 9);
+            fixture.gpu.setByte(0xff40, 0x93);
+            fixture.advanceTo(1, 0);
+
+            while (!fixture.gpu.isMode0IntWindow()) {
+                fixture.tick();
+            }
+
+            assertEquals("SCX=" + fineScx,
+                    Mode.PixelTransfer.ordinal(), fixture.gpu.getVisibleStatMode());
+            fixture.tick();
+            assertEquals("SCX=" + fineScx,
+                    Mode.HBlank.ordinal(), fixture.gpu.getVisibleStatMode());
+        }
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuDisplayEnableTimingTest.java
@@ -73,6 +73,26 @@ public class GpuDisplayEnableTimingTest {
     }
 
     @Test
+    public void normalSpeedCpuReadSamplesFirstLineModeZeroOneDotEarly() {
+        Fixture fixture = new Fixture(1);
+        fixture.gpu.setByte(0xff43, 1);
+        fixture.gpu.setByte(0xff40, 0x11);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(88);
+        fixture.gpu.setByte(0xff43, 7);
+        fixture.advanceTo(251);
+
+        assertEquals(Mode.HBlank, fixture.gpu.getMode());
+        assertFalse(fixture.gpu.hasObjectsOnLine());
+        assertFalse(fixture.gpu.isMode0IntWindow());
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.gpu.getVisibleStatMode());
+
+        fixture.stat.captureCpuStatReadPhase();
+        assertEquals(Mode.HBlank.ordinal(),
+                fixture.stat.getByte(StatRegister.ADDRESS) & 0x03);
+    }
+
+    @Test
     public void firstLineSpriteCandidateHoldsCgbReadableModeThroughPhysicalHandoff() {
         Fixture fixture = new Fixture(1);
         fixture.gpu.setByte(0xff40, 0x00);
@@ -91,6 +111,31 @@ public class GpuDisplayEnableTimingTest {
             fixture.tick();
         }
         assertEquals(Mode.HBlank.ordinal(), fixture.gpu.getVisibleStatMode());
+    }
+
+    @Test
+    public void dmgFineScxSpriteLatchReleasesTwoDotsBeforeModeZeroEdge() {
+        Fixture fixture = new Fixture(1, false, false);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff43, 4);
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 9);
+        fixture.gpu.setByte(0xff40, 0x93);
+        fixture.advanceTo(1, 0);
+
+        int threeDotsBefore = -1;
+        int twoDotsBefore = -1;
+        int oneDotBefore = -1;
+        while (!fixture.gpu.isMode0IntWindow()) {
+            threeDotsBefore = twoDotsBefore;
+            twoDotsBefore = oneDotBefore;
+            oneDotBefore = fixture.gpu.getVisibleStatMode();
+            fixture.tick();
+        }
+
+        assertEquals(Mode.PixelTransfer.ordinal(), threeDotsBefore);
+        assertEquals(Mode.HBlank.ordinal(), twoDotsBefore);
+        assertEquals(Mode.HBlank.ordinal(), oneDotBefore);
     }
 
     @Test
@@ -436,7 +481,11 @@ public class GpuDisplayEnableTimingTest {
         }
 
         private Fixture(int speed, boolean dmgCompat) {
-            SpeedMode speedMode = new SpeedMode(true) {
+            this(speed, dmgCompat, true);
+        }
+
+        private Fixture(int speed, boolean dmgCompat, boolean gbc) {
+            SpeedMode speedMode = new SpeedMode(gbc) {
                 @Override
                 public int getSpeedMode() {
                     return speed;
@@ -445,12 +494,12 @@ public class GpuDisplayEnableTimingTest {
             speedMode.setDmgCompat(dmgCompat);
             dma = new Dma(new Ram(0, 0x10000), oam, speedMode);
             gpu = new Gpu(
-                    new Display(true),
+                    new Display(gbc),
                     dma,
                     oam,
                     new VRamTransfer(NULL_EVENT_BUS),
                     stat,
-                    true,
+                    gbc,
                     speedMode);
             stat.init(gpu);
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuVramAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuVramAccessTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 public class GpuVramAccessTest {
 
     @Test
-    public void normalSpeedFinalReadSlotRequiresTheImmediatelyPrecedingWriteRequest() {
+    public void normalSpeedFinalMode3SlotsRemainBlocked() {
         Fixture standaloneRead = new Fixture(1);
         standaloneRead.gpu.setByte(0x8000, 0x42);
         standaloneRead.advanceTo(1, 246);
@@ -24,7 +24,33 @@ public class GpuVramAccessTest {
         writeThenRead.advanceTo(1, 238);
         writeThenRead.gpu.setByte(0x8000, 0x99);
         writeThenRead.advanceTo(1, 246);
-        assertEquals(0x42, writeThenRead.gpu.getByte(0x8000));
+        assertEquals(0xff, writeThenRead.gpu.getByte(0x8000));
+
+        Fixture finalWrite = new Fixture(1);
+        finalWrite.gpu.setByte(0x8000, 0x42);
+        finalWrite.advanceTo(1, 246);
+        finalWrite.gpu.setByte(0x8000, 0x99);
+        finalWrite.advanceTo(1, 254);
+        assertEquals(0x42, finalWrite.gpu.getByte(0x8000));
+    }
+
+    @Test
+    public void fineScxMovesTheFinalSlotWithoutMovingItsXComparator() {
+        Fixture finalRead = new Fixture(1);
+        finalRead.gpu.setByte(0x8000, 0x42);
+        finalRead.gpu.setByte(GpuRegister.SCX.getAddress(), 3);
+        finalRead.advanceTo(1, 242);
+        finalRead.gpu.setByte(0x8000, 0x99);
+        finalRead.advanceTo(1, 250);
+        assertEquals(0x42, finalRead.gpu.getByte(0x8000));
+
+        Fixture finalWrite = new Fixture(1);
+        finalWrite.gpu.setByte(0x8000, 0x42);
+        finalWrite.gpu.setByte(GpuRegister.SCX.getAddress(), 3);
+        finalWrite.advanceTo(1, 250);
+        finalWrite.gpu.setByte(0x8000, 0x99);
+        finalWrite.advanceTo(1, 258);
+        assertEquals(0x99, finalWrite.gpu.getByte(0x8000));
     }
 
     @Test
@@ -43,17 +69,19 @@ public class GpuVramAccessTest {
     }
 
     @Test
-    public void retiringHdmaCpuInstructionKeepsItsDoubleSpeedHblankReadSlot() {
-        Fixture fixture = new Fixture(2);
-        fixture.gpu.setByte(0x8000, 0x42);
-        fixture.advanceTo(1, 248);
-        assertEquals(0xff, fixture.gpu.getByte(0x8000));
+    public void retiringHdmaCpuInstructionKeepsItsHblankReadSlotAtBothSpeeds() {
+        for (int[] timing : new int[][] {{1, 250}, {2, 248}}) {
+            Fixture fixture = new Fixture(timing[0]);
+            fixture.gpu.setByte(0x8000, 0x42);
+            fixture.advanceTo(1, timing[1]);
+            assertEquals(0xff, fixture.gpu.getByte(0x8000));
 
-        fixture.gpu.setCpuRetiringInstructionForHdma(true);
-        assertEquals(0x42, fixture.gpu.getByte(0x8000));
+            fixture.gpu.setCpuRetiringInstructionForHdma(true);
+            assertEquals(0x42, fixture.gpu.getByte(0x8000));
 
-        fixture.gpu.setCpuRetiringInstructionForHdma(false);
-        assertEquals(0xff, fixture.gpu.getByte(0x8000));
+            fixture.gpu.setCpuRetiringInstructionForHdma(false);
+            assertEquals(0xff, fixture.gpu.getByte(0x8000));
+        }
     }
 
     @Test
@@ -79,15 +107,17 @@ public class GpuVramAccessTest {
     public void pendingWriteRequestIsPreservedByMemento() {
         Fixture fixture = new Fixture(1);
         fixture.gpu.setByte(0x8000, 0x42);
-        fixture.advanceTo(1, 238);
+        fixture.gpu.setByte(GpuRegister.SCX.getAddress(), 3);
+        fixture.advanceTo(1, 242);
         fixture.gpu.setByte(0x8000, 0x99);
         Memento<Gpu> memento = fixture.gpu.saveToMemento();
 
-        fixture.advanceTo(1, 246);
+        fixture.advanceTo(1, 250);
         assertEquals(0x42, fixture.gpu.getByte(0x8000));
+        fixture.advanceTo(2, 0);
 
         fixture.gpu.restoreFromMemento(memento);
-        fixture.advanceTo(1, 246);
+        fixture.advanceTo(1, 250);
         assertEquals(0x42, fixture.gpu.getByte(0x8000));
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -101,6 +101,17 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void cgbLcdRestartCpuPhaseSkipsTheTransientLine153Latch() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(153, 0);
+
+        assertEquals(153, fixture.gpu.getVisibleLy());
+        assertEquals(0, fixture.readLy());
+    }
+
+    @Test
     public void rephasedNormalSpeedCgbCpuReadSeesLyRippleAtLineTail() {
         Fixture fixture = new Fixture(true);
         fixture.gpu.onSpeedSwitch();
@@ -325,10 +336,35 @@ public class StatRegisterTest {
         fixture.advanceTo(1, 78);
 
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
-        fixture.stat.preCpuTick();
+        fixture.stat.captureCpuStatReadPhase();
         assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
         fixture.tick();
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void cgbOamDmaObjectLineCpuReadRetainsMode3AtTheMode0Edge() {
+        Fixture fixture = new Fixture(true);
+        for (int i = 0; i < 9; i++) {
+            fixture.oam.setByte(0xfe00 + i * 4, 16);
+            fixture.oam.setByte(0xfe01 + i * 4, 160);
+        }
+        fixture.advanceTo(1, 0);
+        while (fixture.gpu.getMode() != Mode.HBlank
+                || !fixture.gpu.isMode0IntWindow()) {
+            fixture.tick();
+        }
+
+        assertEquals(Mode.HBlank.ordinal(), fixture.gpu.getVisibleStatMode());
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+        fixture.dma.setByte(0xff46, 0x12);
+        for (int i = 0; i < 8; i++) {
+            fixture.dma.tick();
+        }
+        assertTrue(fixture.dma.ownsOamForPpu());
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
     }
 
     @Test
@@ -356,6 +392,35 @@ public class StatRegisterTest {
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
         fixture.tick();
         assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void lcdRestartedCgbLineZeroRetainsBootPhaseMode3TailUntilRephased() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(0xff40, 0x11);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(1, 0);
+        fixture.advanceTo(0, 254);
+
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        fixture.tick();
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+
+        Fixture interruptSourceSelected = new Fixture(true);
+        interruptSourceSelected.gpu.setByte(0xff40, 0x11);
+        interruptSourceSelected.gpu.setByte(0xff40, 0x91);
+        interruptSourceSelected.stat.setByte(StatRegister.ADDRESS, 0x20);
+        interruptSourceSelected.advanceTo(1, 0);
+        interruptSourceSelected.advanceTo(0, 254);
+        assertEquals(Mode.HBlank.ordinal(), interruptSourceSelected.readStatMode());
+
+        Fixture rephased = new Fixture(true);
+        rephased.gpu.setByte(0xff40, 0x11);
+        rephased.gpu.setByte(0xff40, 0x91);
+        rephased.gpu.onSpeedSwitch();
+        rephased.advanceTo(1, 0);
+        rephased.advanceTo(0, 254);
+        assertEquals(Mode.HBlank.ordinal(), rephased.readStatMode());
     }
 
     @Test
@@ -411,6 +476,27 @@ public class StatRegisterTest {
         assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
         fixture.stat.preCpuTick();
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        fixture.stat.captureCpuStatReadPhase();
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void cgbDoubleSpeedObjectTailDoesNotUseACpuModeOverride() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 16);
+        fixture.gpu.setByte(GpuRegister.SCX.getAddress(), 0);
+        fixture.gpu.onSpeedSwitch();
+        fixture.advanceTo(1, 260);
+
+        assertTrue(fixture.gpu.hasObjectsOnLine());
+        assertEquals(Mode.HBlank, fixture.gpu.getMode());
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        assertEquals(-1, fixture.gpu.getCpuReadStatModeOverride());
+
+        fixture.tick();
+        assertEquals(-1, fixture.gpu.getCpuReadStatModeOverride());
+        assertEquals(Mode.HBlank.ordinal(), fixture.readStatMode());
     }
 
     @Test
@@ -532,6 +618,21 @@ public class StatRegisterTest {
         assertEquals(0x04, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
         fixture.tick();
         assertEquals(451, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
+    }
+
+    @Test
+    public void cgbLcdRestartGridReleasesLaterCoincidenceAtStoredDot452() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 0);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(1, 0);
+        fixture.advanceTo(0, 451);
+
+        assertEquals(0x04, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
+        fixture.tick();
+        assertEquals(452, fixture.gpu.getTicksInLine());
         assertEquals(0, fixture.stat.getByte(StatRegister.ADDRESS) & 0x04);
     }
 
@@ -874,6 +975,28 @@ public class StatRegisterTest {
         assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
         assertFalse(fixture.interrupts.isInterruptRequested());
         assertFalse(fixture.interrupts.isInterruptRequestedForHalt());
+    }
+
+    @Test
+    public void firstPostFrameLyc0M2HandoffPublishesBeforeCpuIo() {
+        Fixture fixture = pendingFrameLyc0M2Event(0x60, 0, 1);
+
+        fixture.stat.publishFrameLyc0Mode2HandoffBeforeCpu();
+
+        assertEquals(1 << LCDC.ordinal(), fixture.lcdInterruptFlag());
+        assertFalse(fixture.interrupts.isInterruptRequested());
+        assertFalse(fixture.interrupts.isInterruptRequestedForHalt());
+    }
+
+    @Test
+    public void ordinaryM2HandoffsDoNotPublishEarlyBeforeCpuIo() {
+        Fixture m2Only = pendingFrameLyc0M2Event(0x20, 0, 1);
+        m2Only.stat.publishFrameLyc0Mode2HandoffBeforeCpu();
+        assertEquals(0, m2Only.lcdInterruptFlag());
+
+        Fixture ordinaryLine = pendingFrameLyc0M2Event(0x60, 4, 5);
+        ordinaryLine.stat.publishFrameLyc0Mode2HandoffBeforeCpu();
+        assertEquals(0, ordinaryLine.lcdInterruptFlag());
     }
 
     @Test
@@ -1238,6 +1361,21 @@ public class StatRegisterTest {
         return fixture;
     }
 
+    private static Fixture pendingFrameLyc0M2Event(int stat, int lyc, int line) {
+        Fixture fixture = new Fixture(true);
+        fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), lyc);
+        fixture.stat.setByte(StatRegister.ADDRESS, stat);
+        fixture.advanceTo(line, 447);
+        fixture.clearInterrupts();
+        fixture.tick();
+        fixture.tick();
+        fixture.tick();
+        assertEquals(450, fixture.gpu.getTicksInLine());
+        assertEquals(0, fixture.lcdInterruptFlag());
+        return fixture;
+    }
+
     private static Fixture publishedDoubleSpeedCgbM2Event() {
         Fixture fixture = new Fixture(true, true);
         fixture.interrupts.setByte(0xffff, 1 << LCDC.ordinal());
@@ -1305,6 +1443,8 @@ public class StatRegisterTest {
 
         private final Ram oam = new Ram(0xfe00, 0xa0);
 
+        private final Dma dma;
+
         private final Gpu gpu;
 
         private Fixture() {
@@ -1324,9 +1464,10 @@ public class StatRegisterTest {
                     return 2;
                 }
             } : new SpeedMode(gbc);
+            dma = new Dma(new Ram(0, 0x10000), oam, speedMode);
             gpu = new Gpu(
                     new Display(gbc),
-                    new Dma(new Ram(0, 0x10000), oam, speedMode),
+                    dma,
                     oam,
                     new VRamTransfer(NULL_EVENT_BUS),
                     stat,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -112,6 +112,22 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void cgbLcdRestartLyDotZeroExceptionExpiresAfterTheFirstFrame() {
+        Fixture fixture = new Fixture(true);
+        fixture.gpu.setByte(0xff40, 0x00);
+        fixture.gpu.setByte(0xff40, 0x91);
+        fixture.advanceTo(153, 0);
+        assertEquals(0, fixture.readLy());
+
+        fixture.advanceTo(0, 0);
+        fixture.advanceTo(153, 0);
+        assertEquals(153, fixture.readLy());
+
+        fixture.advanceTo(153, 2);
+        assertEquals(0, fixture.readLy());
+    }
+
+    @Test
     public void rephasedNormalSpeedCgbCpuReadSeesLyRippleAtLineTail() {
         Fixture fixture = new Fixture(true);
         fixture.gpu.onSpeedSwitch();
@@ -331,13 +347,13 @@ public class StatRegisterTest {
     }
 
     @Test
-    public void cgbCpuBusStillSamplesOamModeAtDot78() {
+    public void cgbCpuBusUsesSettledPixelTransferModeAtDot78() {
         Fixture fixture = new Fixture(true);
         fixture.advanceTo(1, 78);
 
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
         fixture.stat.captureCpuStatReadPhase();
-        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
         fixture.tick();
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 132;
+    private static final int CURRENT_BASELINE_COUNT = 105;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -37,7 +37,7 @@ public class GambatteHwRomTest {
     private static final String CURRENT_BASELINE =
             "/roms/gambatte/current-baseline.tsv";
 
-    private static final int CURRENT_BASELINE_COUNT = 105;
+    private static final int CURRENT_BASELINE_COUNT = 108;
 
     private static final int ARCHIVE_ROM_COUNT = 3_524;
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
@@ -61,6 +61,16 @@ public class DmaCpuAddressSpaceTest {
     }
 
     @Test
+    public void cgbHighSourceSeparatesOpenCopyDataFromAliasedCartridgeBusData() {
+        for (int sourceHigh : new int[]{0xe0, 0xff}) {
+            Fixture fixture = new Fixture(true, sourceHigh);
+
+            assertEquals(0xff, fixture.oam.getByte(0xfe00));
+            assertEquals(0x42, fixture.cpu.getByte(0x0100));
+        }
+    }
+
+    @Test
     public void cgbCanUseTheCartridgeBusDuringWramDma() {
         Fixture fixture = new Fixture(true, 0xc0);
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
@@ -219,6 +219,29 @@ public class DmaTest {
     }
 
     @Test
+    public void speedSwitchReleasesOnlyAnOamDmaWhoseFinalByteWasCopied() {
+        Fixture pendingFinalByte = new Fixture(true);
+        pendingFinalByte.start();
+        pendingFinalByte.tick(640);
+        pendingFinalByte.dma.onSpeedSwitch();
+        pendingFinalByte.dma.tick(true, false);
+
+        assertTrue(pendingFinalByte.dma.isTransferInProgress());
+        assertEquals(0xee, pendingFinalByte.oam.getByte(0xfe9f));
+
+        Fixture copiedFinalByte = new Fixture(true);
+        copiedFinalByte.start();
+        copiedFinalByte.tick(644);
+        copiedFinalByte.dma.onSpeedSwitch();
+
+        assertFalse(copiedFinalByte.dma.isTransferInProgress());
+        assertEquals(0xdf, copiedFinalByte.oam.getByte(0xfe9f));
+        copiedFinalByte.dma.tick(true, false);
+        assertTrue(copiedFinalByte.dma.ownedOamForPpuBeforeTick());
+        assertFalse(copiedFinalByte.dma.ownsOamForPpu());
+    }
+
+    @Test
     public void dmaRegisterPowersUpAsZeroOnCgb() {
         assertEquals(0x00, createDma(true).getByte(0xff46));
     }
@@ -241,14 +264,14 @@ public class DmaTest {
     }
 
     @Test
-    public void cgbHighSourceCopyAliasesCartridgeRam() {
+    public void cgbHighSourceCopyReturnsOpenBusData() {
         Ram memory = new Ram(0, 0x10000);
         memory.setByte(0xa000, 0x42);
 
         DmaAddressSpace dmaMemory = new DmaAddressSpace(memory, true);
 
-        assertEquals(0x42, dmaMemory.getByte(0xe000));
-        assertEquals(0x00, dmaMemory.getByte(0xff9f));
+        assertEquals(0xff, dmaMemory.getByte(0xe000));
+        assertEquals(0xff, dmaMemory.getByte(0xff9f));
     }
 
     private static Dma createDma(boolean gbc) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -159,6 +159,21 @@ public class HdmaTest {
     }
 
     @Test
+    public void reportsTheCpuEdgeImmediatelyBeforeHblankArbitration() {
+        Fixture fixture = new Fixture();
+        fixture.hdma.onLcdSwitch(true);
+        fixture.startTransfer(0x80);
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+
+        fixture.advanceHblankRequest(1);
+        assertFalse(fixture.hdma.isHblankRequestArrivingAfterCpuTick());
+        fixture.advanceHblankRequest(1);
+        assertTrue(fixture.hdma.isHblankRequestArrivingAfterCpuTick());
+        fixture.advanceHblankRequest(1);
+        assertFalse(fixture.hdma.isHblankRequestArrivingAfterCpuTick());
+    }
+
+    @Test
     public void interruptPendingWhenCpuClaimsDoesNotSupersedeDma() {
         Fixture fixture = synchronizedHblankRequest(1);
         var unresolvedRequest = fixture.hdma.saveToMemento();

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 105 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 108 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/SOURCE.md
+++ b/core/src/test/resources/roms/gambatte/SOURCE.md
@@ -20,7 +20,7 @@ dumper entries do not encode a hexadecimal tile verdict and remain in the
 complete archive. Optional deterministic batches partition the sorted manifest;
 the default profile still selects every verdict.
 
-`current-baseline.tsv` pins the exact hexadecimal output for the 132 cases that
+`current-baseline.tsv` pins the exact hexadecimal output for the 105 cases that
 do not yet match the hardware verdict encoded in the ROM filename. Green cases
 continue to assert hardware directly. Any output change fails the profile; when
 an emulation fix reaches the hardware result, remove that case from the baseline.

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -1,10 +1,6 @@
 # Exact Coffee GB outputs for cases that do not yet match the hardware verdict.
 # Format: archive path [model]<TAB>current hexadecimal output
 # Remove an entry when the emulator is fixed to produce the filename's canonical result.
-hwtests/display_startstate/stat_1_cgb04c_out87.gbc [CGB]	84
-hwtests/display_startstate/stat_scx2_1_cgb04c_out87.gbc [CGB]	84
-hwtests/display_startstate/stat_scx3_1_cgb04c_out87.gbc [CGB]	84
-hwtests/display_startstate/stat_scx5_1_cgb04c_out87.gbc [CGB]	84
 hwtests/dma/gdma_cycles_2xshort_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/dma/gdma_cycles_2xshort_scx5_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/dma/gdma_cycles_long_scx3_2_cgb04c_out0.gbc [CGB]	3
@@ -18,23 +14,14 @@ hwtests/dma/hdma_late_m3speedchange_ly_scx1_3_cgb04c_out92.gbc [CGB]	93
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx1_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m0speedchange_late_m3wakeup_scx2_2_cgb04c_out00.gbc [CGB]	FF
 hwtests/dma/hdma_m3speedchange_late_m0wakeup_1_cgb04c_outFF.gbc [CGB]	00
-hwtests/dma/hdma_start_ly0_1_cgb04c_out0.gbc [CGB]	7
 hwtests/dma/hdma_transition_ei_halt_late_unhalt_ldaaimm_hdma_scx1_1_cgb04c_out00.gbc [CGB]	01
-hwtests/enable_display/frame1_ly_count_2_dmg08_cgb04c_out9A.gbc [CGB]	00
-hwtests/enable_display/frame1_m2stat_count_1_dmg08_cgb04c_out91.gbc [CGB]	01
-hwtests/enable_display/ly0_late_scx7_m3stat_scx1_2_dmg08_cgb04c_out84.gbc [CGB]	87
 hwtests/halt/ifandie_ei_halt_m2int_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/halt/late_m0int_halt_m0stat_scx2_3a_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/halt/late_m0int_halt_m0stat_scx2_3a_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/halt/late_m0int_halt_m0stat_scx3_2b_dmg08_cgb04c_out2.gbc [DMG]	0
-hwtests/halt/late_m0int_halt_m0stat_scx3_3a_dmg08_cgb04c_out0.gbc [DMG]	2
-hwtests/halt/late_m0int_halt_m0stat_scx3_3b_dmg08_out0_cgb04c_out2.gbc [DMG]	2
 hwtests/halt/late_m0irq_halt_m0stat_scx2_4a_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/halt/late_m0irq_halt_m0stat_scx2_4b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_2b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_3b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_4a_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/halt/lycirq_m2stat_1_dmg08_cgb04c_out2.gbc [CGB]	3
 hwtests/halt/m1int_ly_2_dmg08_out90_cgb04c_out91.gbc [CGB]	90
 hwtests/halt/noime_ifandie_m2int_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/halt/noime_m2irq_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
@@ -47,14 +34,11 @@ hwtests/lcd_offset/offset1_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset1_lyc99int_m3stat_count_ds_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset2_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m2irq_count_2_cgb04c_out91.gbc [CGB]	00
-hwtests/ly0/lycint152_ly153_3_dmg08_cgb04c_out00.gbc [CGB]	99
 hwtests/ly0/lycint152_lyc153flag_3_dmg08_cgb04c_outC1.gbc [CGB]	C5
-hwtests/ly0/lycint152_m2stat_1_dmg08_cgb04c_outC2.gbc [CGB]	C3
 hwtests/lyc0int_m0irq/lyc0int_m0irq_ds_2_cgb04c_out2.gbc [CGB]	0
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_ds_2_cgb04c_out0.gbc [CGB]	2
-hwtests/lycm2int/lyc0m2int_m2irq_2_dmg08_cgb04c_out2.gbc [CGB]	0
 hwtests/m0int_m0stat/m0int_m0stat_ds_2_cgb04c_out2.gbc [CGB]	0
 hwtests/m0int_m0stat/m0int_m0stat_scx3_2_dmg08_cgb04c_out2.gbc [CGB]	0
 hwtests/m0int_m0stat/m0int_m0stat_scx5_ds_2_cgb04c_out2.gbc [CGB]	0
@@ -93,7 +77,6 @@ hwtests/m2int_m2irq/m2int_m2irq_ds_1_cgb04c_out1.gbc [CGB]	3
 hwtests/m2int_m2irq/m2int_m2irq_ifw_ds_1_cgb04c_out2.gbc [CGB]	0
 hwtests/m2int_m2irq/m2int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/m2int_m2irq/m2int_m2irq_late_retrigger_ds_1_cgb04c_out2.gbc [CGB]	0
-hwtests/m2int_m2stat/m2int_m2stat_1_dmg08_cgb04c_out2.gbc [CGB]	3
 hwtests/m2int_m2stat/m2int_m2stat_ds_1_cgb04c_out2.gbc [CGB]	3
 hwtests/m2int_m2stat/m2int_scx4_m2stat_ds_1_cgb04c_out2.gbc [CGB]	3
 hwtests/miscmstatirq/lycflag_statwirq_2_dmg08_out2.gb [DMG]	0
@@ -104,24 +87,14 @@ hwtests/miscmstatirq/m2statwirq_trigger_00_df_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/miscmstatirq/m2statwirq_trigger_00_ff_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/miscmstatirq/m2statwirq_trigger_20_df_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/miscmstatirq/m2statwirq_trigger_20_ff_dmg08_cgb04c_out0.gbc [CGB]	2
-hwtests/oamdma/late_sp39x_4_cgb04c_out3.gbc [CGB]	0
-hwtests/oamdma/oamdma_late_speedchange_stat_2_cgb04c_out3.gbc [CGB]	0
-hwtests/oamdma/oamdma_srcE000_readFE00_dmg08_out2_cgb04c_out0.gbc [CGB]	2
 hwtests/scx_during_m3/scx_m3_extend_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/sprites/10spritesPrLine_10xposA6_m0irq_2_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/sprites/10spritesPrLine_10xposA7_m0irq_2_dmg08_cgb04c_out2.gbc [DMG]	0
-hwtests/sprites/1spritesPrLine_scx1_offset7_m3stat_2_dmg08_cgb04c_out0.gbc [DMG]	3
-hwtests/sprites/1spritesPrLine_xpos01_scx4_m3stat_2_dmg08_cgb04c_out0.gbc [DMG]	3
-hwtests/sprites/1spritesPrLine_xpos09_scx4_m3stat_2_dmg08_cgb04c_out0.gbc [DMG]	3
 hwtests/sprites/space/10spritesPrLine_late_scx4_ds_1_cgb04c_out0.gbc [CGB]	3
 hwtests/sprites/space/10spritesPrLine_wx0_m3stat_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/sprites/space/10spritesPrLine_wx1_m3stat_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/sprites/space/10spritesPrLine_wx2_m3stat_ds_2_cgb04c_out0.gbc [CGB]	3
 hwtests/sprites/space/9pos8_wx08_scx5_m3stat_ds_2_cgb04c_out0.gbc [CGB]	3
-hwtests/vramw_m3end/vramw_m3end_2_dmg08_cgb04c_out7.gbc [CGB]	0
-hwtests/vramw_m3end/vramw_m3end_4_dmg08_cgb04c_out0.gbc [CGB]	1
-hwtests/vramw_m3end/vramw_m3end_scx3_2_dmg08_cgb04c_out7.gbc [CGB]	0
-hwtests/vramw_m3end/vramw_m3end_scx3_4_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/arg/late_wy_FFto2_ly2_scx5_3_dmg08_cgb04c_out0.gbc [CGB]	3
 hwtests/window/late_disable_early_scx03_wx12_2_dmg08_out0_cgb04c_out3.gbc [DMG]	3
 hwtests/window/late_disable_late_scx03_wx12_1_dmg08_cgb04c_out0.gbc [DMG]	3

--- a/core/src/test/resources/roms/gambatte/current-baseline.tsv
+++ b/core/src/test/resources/roms/gambatte/current-baseline.tsv
@@ -22,6 +22,7 @@ hwtests/halt/late_m0irq_halt_m0stat_scx2_4b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_2b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_3b_dmg08_cgb04c_out2.gbc [DMG]	0
 hwtests/halt/late_m0irq_halt_m0stat_scx3_4a_dmg08_cgb04c_out0.gbc [CGB]	2
+hwtests/halt/lycirq_m2stat_1_dmg08_cgb04c_out2.gbc [CGB]	3
 hwtests/halt/m1int_ly_2_dmg08_out90_cgb04c_out91.gbc [CGB]	90
 hwtests/halt/noime_ifandie_m2int_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/halt/noime_m2irq_m0stat_1_dmg08_cgb04c_out0.gbc [CGB]	2
@@ -35,6 +36,7 @@ hwtests/lcd_offset/offset1_lyc99int_m3stat_count_ds_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset2_lyc99int_m2irq_count_2_cgb04c_out90.gbc [CGB]	00
 hwtests/lcd_offset/offset3_lyc99int_m2irq_count_2_cgb04c_out91.gbc [CGB]	00
 hwtests/ly0/lycint152_lyc153flag_3_dmg08_cgb04c_outC1.gbc [CGB]	C5
+hwtests/ly0/lycint152_m2stat_1_dmg08_cgb04c_outC2.gbc [CGB]	C3
 hwtests/lyc0int_m0irq/lyc0int_m0irq_ds_2_cgb04c_out2.gbc [CGB]	0
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [CGB]	2
 hwtests/lyc153int_m2irq/lyc153int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	2
@@ -77,6 +79,7 @@ hwtests/m2int_m2irq/m2int_m2irq_ds_1_cgb04c_out1.gbc [CGB]	3
 hwtests/m2int_m2irq/m2int_m2irq_ifw_ds_1_cgb04c_out2.gbc [CGB]	0
 hwtests/m2int_m2irq/m2int_m2irq_late_retrigger_2_dmg08_cgb04c_out0.gbc [DMG]	2
 hwtests/m2int_m2irq/m2int_m2irq_late_retrigger_ds_1_cgb04c_out2.gbc [CGB]	0
+hwtests/m2int_m2stat/m2int_m2stat_1_dmg08_cgb04c_out2.gbc [CGB]	3
 hwtests/m2int_m2stat/m2int_m2stat_ds_1_cgb04c_out2.gbc [CGB]	3
 hwtests/m2int_m2stat/m2int_scx4_m2stat_ds_1_cgb04c_out2.gbc [CGB]	3
 hwtests/miscmstatirq/lycflag_statwirq_2_dmg08_out2.gb [DMG]	0


### PR DESCRIPTION
## Summary
- model CPU-visible PPU and STAT phase boundaries more precisely across LCD startup, mode transitions, and HALT interrupt entry
- correct VRAM, HDMA, OAM-DMA, and speed-switch arbitration edge cases
- keep CGB DMA copy data separate from the aliased cartridge bus and constrain first-frame LY/coincidence exceptions
- add focused timing regressions and reduce the pinned Gambatte baseline from 132 cases to 108 (24 hardware-correct improvements)

## Testing
- Gambatte HWTests: 4,674/4,674 pass
- gbc-hw-tests: 221/221 pass
- core unit tests: 582/582 pass
- Misc.-GB-Tests: 17/17 pass
- baseline ordering/count checks and git diff --check pass