### PR TITLE
Fix final Mealybug window insertion pixel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,10 +260,7 @@ rising edge) — see `StatRegister`.
 ## Mealybug Tearoom status (mid-mode-3 register writes, DMG)
 
 `mvn -pl core test -Ptest-mealybug` — 24 DMG tests compared strictly with the
-hardware references, with only the single documented pixel exception below.
-**Status (machine-retiming branch, 2026-07-10): 23/24 pixel-perfect, 1 diff
-pixel total** (m3_lcdc_win_en_change_multiple_wx row 39 — an LCD-PPU desync
-boundary case SameBoy documents as present on "most but not all" DMG units).
+hardware references. **Status: 24/24 pixel-perfect.**
 
 **The architecture** — dual machine + the +3 write skew:
 - The GPU runs TWO PixelTransfer instances: an unshifted skeleton driving
@@ -290,9 +287,11 @@ boundary case SameBoy documents as present on "most but not all" DMG units).
   moving any calibrated read dot.
 - Other landed semantics: live SCY everywhere (no line-start latch); the WX=0
   activation stall only with SCX&7!=0; the insertion-glitch blank still pops
-  the object FIFO; the line's first pixel resolves its LCDC mux one dot later
-  than its palettes (two-phase resolution); a pending window activation
-  cancels if LCDC.5 went off during the pending tick.
+  the object FIFO; a background-source insertion comparator sees a live
+  LCDC.5 disable while an in-flight window fetch retains the delayed view; the
+  line's first pixel resolves its LCDC mux one dot later than its palettes
+  (two-phase resolution); a pending window activation cancels if LCDC.5 went
+  off during the pending tick.
 - CGB legs (compat palettes, WRITE_CPU WX class, *2 variants) unchanged — see
   the memory notes; the CGB board is separate territory.
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
@@ -231,6 +231,13 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
                 ? windowDisplayView != 0 : lcdc.isWindowDisplay();
     }
 
+    private boolean isWindowDisabledForInsertion(boolean fetchingWindow) {
+        // The shifted pixel machine normally uses its delayed LCDC.5 view. Once it has
+        // already selected the background source, the insertion comparator sees a live
+        // disable edge; an in-flight window fetch retains the delayed view.
+        return !isWindowDisplay() || (!fetchingWindow && !lcdc.isWindowDisplay());
+    }
+
     /**
      * Advances the fetcher by one T-cycle. The tile map, the scroll registers and the tile
      * data area are read live at the respective fetch states (like on hardware), so
@@ -340,7 +347,7 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
                     if (!gbc
                             && !insertionGlitchDisabled
                             && windowYTriggered
-                            && !isWindowDisplay()) {
+                            && isWindowDisabledForInsertion(window)) {
                         int logicalPosition = (position + 7) & 0xff;
                         if (logicalPosition > 167) {
                             logicalPosition = 0;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherWindowInsertionTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/FetcherWindowInsertionTest.java
@@ -23,7 +23,30 @@ public class FetcherWindowInsertionTest {
         assertEquals(0, fifo.tilePushes);
     }
 
+    @Test
+    public void backgroundInsertionComparatorSeesLiveWindowDisable() {
+        RecordingFifo fifo = runFetch(true, false, true);
+
+        assertEquals(1, fifo.singlePixelPushes);
+        assertEquals(0, fifo.tilePushes);
+    }
+
+    @Test
+    public void activeWindowFetchKeepsDelayedWindowEnable() {
+        RecordingFifo fifo = runFetch(true, true, true);
+
+        assertEquals(0, fifo.singlePixelPushes);
+        assertEquals(1, fifo.tilePushes);
+    }
+
     private static RecordingFifo runFetch(boolean windowYTriggered) {
+        return runFetch(windowYTriggered, false, false);
+    }
+
+    private static RecordingFifo runFetch(
+            boolean windowYTriggered,
+            boolean fetchingWindow,
+            boolean delayedWindowEnabled) {
         RecordingFifo fifo = new RecordingFifo();
         GpuRegisterValues registers = new GpuRegisterValues();
         registers.put(GpuRegister.LY, 128);
@@ -41,9 +64,10 @@ public class FetcherWindowInsertionTest {
                 false);
         fetcher.startLine();
         fetcher.setWindowYTriggered(windowYTriggered);
+        fetcher.setWindowRegisterView(151, delayedWindowEnabled);
 
         while (fifo.singlePixelPushes == 0 && fifo.tilePushes == 0) {
-            fetcher.advance(144, false, -1, false);
+            fetcher.advance(144, fetchingWindow, -1, false);
         }
         return fifo;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/mealybug/MealybugRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/mealybug/MealybugRomTest.java
@@ -24,24 +24,11 @@ import static org.junit.Assert.fail;
  * against photos of a real DMG-CPU B (DMG-blob where no CPU B photo exists). The tests run
  * with the FAST_FORWARD boot because they reuse the boot ROM's VRAM leftovers (the (r) logo
  * tile) as sprite data.
- *
- * <p>Every reference is pixel-exact except for the one explicitly documented hardware-photo
- * discrepancy in {@code m3_lcdc_win_en_change_multiple_wx.gb}.
  */
 @RunWith(ParallelParameterized.class)
 public class MealybugRomTest {
 
     private static final int TEST_COUNT = 24;
-
-    private static final String PIXEL_EXCEPTION_ROM = "m3_lcdc_win_en_change_multiple_wx.gb";
-
-    private static final int PIXEL_EXCEPTION_X = 32;
-
-    private static final int PIXEL_EXCEPTION_Y = 39;
-
-    private static final int PIXEL_EXCEPTION_EXPECTED = 0xffffff;
-
-    private static final int PIXEL_EXCEPTION_ACTUAL = 0xaaaaaa;
 
     private final File rom;
 
@@ -85,14 +72,8 @@ public class MealybugRomTest {
             if (actual[i] != expected[i]) {
                 int x = i % Display.DISPLAY_WIDTH;
                 int y = i / Display.DISPLAY_WIDTH;
-                boolean allowedPixel = rom.getName().equals(PIXEL_EXCEPTION_ROM)
-                        && x == PIXEL_EXCEPTION_X && y == PIXEL_EXCEPTION_Y;
-                if (!allowedPixel) {
-                    fail(String.format("%s differs at (%d,%d): expected #%06x, actual #%06x",
-                            rom.getName(), x, y, expected[i], actual[i]));
-                }
-                assertEquals("exception expected color", PIXEL_EXCEPTION_EXPECTED, expected[i]);
-                assertEquals("exception actual color", PIXEL_EXCEPTION_ACTUAL, actual[i]);
+                fail(String.format("%s differs at (%d,%d): expected #%06x, actual #%06x",
+                        rom.getName(), x, y, expected[i], actual[i]));
             }
         }
     }


### PR DESCRIPTION
## Summary

- make the DMG background insertion comparator observe the live LCDC.5 disable edge while preserving the delayed view for an in-flight window fetch
- remove the stale one-pixel Mealybug waiver and compare all 24 reference images strictly
- add focused coverage for both sides of the window timing-domain split

## Reproduction

Before this change, `m3_lcdc_win_en_change_multiple_wx.gb` differed at `(32,39)`: expected `#ffffff`, actual `#aaaaaa`. The integration suite passed only because that pixel was explicitly allowlisted.

## Verification

- `mvn -pl core -Ptest-mealybug test` — 24/24 pixel-perfect
- `mvn -pl core test` — 584/584
- `mvn -pl core -Ptest-dmgacid2 test` — pixel-perfect
- Gambatte HWTests — all 4,674 guarded outputs verified
- `git diff --check`
