### PR TITLE
Expose repository skills to Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
Make all workflows maintained under `.claude/skills` discoverable by Codex through its supported repository path.

The `.agents/skills` symlink keeps `.claude/skills` as the single source of truth and automatically exposes future skills added there as well.