### PR TITLE
Fix Xin Shuma Baobei Huang mapper detection

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -58,6 +58,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case DATEL -> new Datel(rom, battery);
             case WISDOM_TREE -> new WisdomTree(rom);
             case MBC1 -> new Mbc1(rom, battery);
+            case MBC5 -> new Mbc5(rom, battery);
             case STANDARD -> createStandardMemoryController(rom, battery, rtcTimeSource);
         };
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -31,7 +31,8 @@ public final class CartridgeProperties {
         SACHEN_COOKED,
         DATEL,
         WISDOM_TREE,
-        MBC1
+        MBC1,
+        MBC5
     }
 
     public enum Feature {
@@ -110,6 +111,8 @@ public final class CartridgeProperties {
                     Feature.DATEL_CGB_HEADER),
             mapper("Wisdom Tree 32 KiB banking", CartridgeProperties::isWisdomTree,
                     Mapper.WISDOM_TREE),
+            mapper("Xin Shuma Baobei Huang MBC5 wiring",
+                    CartridgeProperties::isXinShumaBaobeiHuang, Mapper.MBC5),
             mapper("oversized ROM-only image", CartridgeProperties::isOversizedRomOnly,
                     Mapper.MBC1),
             features("Crazy Castle 3 trainer", CartridgeProperties::isCrazyCastleTrainer,
@@ -377,6 +380,27 @@ public final class CartridgeProperties {
         return info.data.length >= 0x20000
                 && isPlainRomType(info.rawType())
                 && info.hasValidLogo();
+    }
+
+    private static boolean isXinShumaBaobeiHuang(RomInfo info) {
+        // This 16 Mbit Chinese Pokemon Yellow bootleg advertises a tiny MBC1 cart, but
+        // its software uses an MBC5-style ROM register and treats 4000-5FFF solely as
+        // the RAM-bank register. Standard MBC1 handling therefore replaces ROM-bank
+        // bits whenever the game selects save RAM and immediately jumps into garbage.
+        return info.data.length == 0x200000
+                && "POKEMON YELLOW".equals(info.title())
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0144) == 0x30
+                && info.byteAt(0x0145) == 0x31
+                && info.byteAt(0x0146) == 0x03
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x01
+                && info.byteAt(0x0149) == 0x01
+                && info.byteAt(0x014a) == 0x00
+                && info.byteAt(0x014b) == 0x33
+                && info.byteAt(0x014c) == 0x00
+                && info.byteAt(0x014e) == 0x33
+                && info.byteAt(0x014f) == 0xcd;
     }
 
     private static boolean isOversizedRomOnly(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/XinShumaBaobeiHuangTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/XinShumaBaobeiHuangTest.java
@@ -1,0 +1,56 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XinShumaBaobeiHuangTest {
+
+    @Test
+    public void usesMbc5WiringDespiteTheMbc1Header() throws IOException {
+        Rom rom = new Rom(xinShumaRom());
+
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY).getMemoryController()
+                instanceof Mbc5);
+    }
+
+    @Test
+    public void ramBankWritesDoNotReplaceTheSelectedRomBank() throws IOException {
+        MemoryController mapper = new Cartridge(
+                new Rom(xinShumaRom()), Battery.NULL_BATTERY).getMemoryController();
+
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(0x21, mapper.getByte(0x4123));
+
+        mapper.setByte(0x4000, 0x02);
+        assertEquals(0x21, mapper.getByte(0x4123));
+    }
+
+    private static byte[] xinShumaRom() {
+        byte[] data = new byte[0x200000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000 + 0x0123] = (byte) bank;
+        }
+        byte[] title = "POKEMON YELLOW".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0144] = 0x30;
+        data[0x0145] = 0x31;
+        data[0x0146] = 0x03;
+        data[0x0147] = 0x01; // misleading MBC1 header
+        data[0x0148] = 0x01;
+        data[0x0149] = 0x01;
+        data[0x014a] = 0x00;
+        data[0x014b] = 0x33;
+        data[0x014c] = 0x00;
+        data[0x014d] = 0x38;
+        data[0x014e] = 0x33;
+        data[0x014f] = (byte) 0xcd;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #258

## Symptom and reproduction

The attached `Xin Shuma Baobei Huang (China) (Pirate)` image (SHA-256 `9899532aeb0b7dc50daf8561ad6cf5ac2f53de213cffd600d459f2b9dcad88ce`) stayed on a blank DMG screen. A deterministic 600-frame headless run reproduced it.

## Root cause

The 16 Mbit bootleg advertises MBC1 in its header but uses MBC5 register semantics. It selects ROM bank `0x21`, then writes `2` to `4000-5FFF` as a RAM-bank selection. Coffee GB treated that second write as MBC1 upper ROM bits, changed the active ROM bank from `0x21` to `0x41`, and executed unrelated data.

## Fix

Add a narrow compatibility signature for this exact header/size combination and route it through the existing MBC5 implementation. The normal MBC1 heuristic and other cartridges are unchanged.

## Regression coverage

- new synthetic regression verifies the cartridge selects MBC5 despite its MBC1 header
- new bank-level regression verifies a RAM-bank write preserves ROM bank `0x21` (failed before the fix with `0x41`)
- `/opt/maven/bin/mvn -pl core -Dtest=XinShumaBaobeiHuangTest test -q`
- `/opt/maven/bin/mvn -pl core test -q`
- exact attached ROM replayed for 600 frames; the menu and opening dialogue render correctly

A stable after-fix frame was captured locally from the exact attachment; no ROM or save data is included in this PR.