### PR TITLE
Fix Pocket Camera debug tester mapper detection

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -58,6 +58,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
             case DATEL -> new Datel(rom, battery);
             case WISDOM_TREE -> new WisdomTree(rom);
             case MBC1 -> new Mbc1(rom, battery);
+            case POCKET_CAMERA -> new PocketCamera(rom, battery);
             case STANDARD -> createStandardMemoryController(rom, battery, rtcTimeSource);
         };
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -31,7 +31,8 @@ public final class CartridgeProperties {
         SACHEN_COOKED,
         DATEL,
         WISDOM_TREE,
-        MBC1
+        MBC1,
+        POCKET_CAMERA
     }
 
     public enum Feature {
@@ -76,6 +77,8 @@ public final class CartridgeProperties {
     private static final List<Profile> PROFILES = List.of(
             features("Pocket Voice V2.0", CartridgeProperties::isPocketVoice,
                     Feature.POCKET_VOICE),
+            mapper("Pocket Camera debug tester", CartridgeProperties::isPocketCameraDebugTester,
+                    Mapper.POCKET_CAMERA),
             mapper("Bung/EMS flash cartridge", CartridgeProperties::isBungEms,
                     Mapper.BUNG_EMS),
             mapper("hidden MMM01 multicart", CartridgeProperties::isHiddenMmm01,
@@ -216,6 +219,35 @@ public final class CartridgeProperties {
 
     private static boolean isPocketVoice(RomInfo info) {
         return info.rawType() == 0xbe && info.title().startsWith("Pocket Voice");
+    }
+
+    private static boolean isPocketCameraDebugTester(RomInfo info) {
+        int[] entryStub = {
+                0xf3, 0xaf, 0xe0, 0x42, 0xe0, 0x43, 0xe0, 0xa0,
+                0xe0, 0x41, 0xe0, 0x01, 0xe0, 0x02, 0xe0, 0x4a,
+                0xe0, 0x4b, 0xe0, 0x06, 0x31, 0xff, 0xdf, 0xaf,
+                0x21, 0x00, 0x80, 0x01, 0x00, 0x20, 0x22, 0x0d
+        };
+        return info.data.length == 0x100000
+                && info.title().isEmpty()
+                && info.hasValidLogo()
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0144) == 0x30
+                && info.byteAt(0x0145) == 0x31
+                && info.byteAt(0x0146) == 0x03
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x03
+                && info.byteAt(0x0149) == 0x00
+                && info.byteAt(0x014a) == 0x00
+                && info.byteAt(0x014b) == 0x33
+                && info.byteAt(0x014c) == 0x00
+                && info.byteAt(0x014d) == 0x4c
+                && info.byteAt(0x014e) == 0x00
+                && info.byteAt(0x014f) == 0x00
+                && matches(info.data, 0x0150, entryStub);
     }
 
     private static boolean isBungEms(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCameraDebugTesterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCameraDebugTesterTest.java
@@ -1,0 +1,92 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PocketCameraDebugTesterTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    private static final int[] ENTRY_STUB = {
+            0xf3, 0xaf, 0xe0, 0x42, 0xe0, 0x43, 0xe0, 0xa0,
+            0xe0, 0x41, 0xe0, 0x01, 0xe0, 0x02, 0xe0, 0x4a,
+            0xe0, 0x4b, 0xe0, 0x06, 0x31, 0xff, 0xdf, 0xaf,
+            0x21, 0x00, 0x80, 0x01, 0x00, 0x20, 0x22, 0x0d
+    };
+
+    @Test
+    public void routesDebugTesterWithMbc1HeaderThroughPocketCameraHardware()
+            throws IOException {
+        Rom rom = new Rom(debugTesterRom());
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+        MemoryController mapper = cartridge.getMemoryController();
+
+        assertEquals(CartridgeProperties.Mapper.POCKET_CAMERA,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(mapper instanceof PocketCamera);
+
+        // The Movie test starts a capture and polls camera register 0 until its busy bit
+        // clears. MBC1 returns open bus here, leaving the test stuck on 0xff forever.
+        mapper.setByte(0x4000, 0x10);
+        mapper.setByte(0xa000, 0x01);
+        assertEquals(0, mapper.getByte(0xa000) & 0x01);
+    }
+
+    @Test
+    public void doesNotReclassifyAnUnrelatedUntitledMbc1Rom() throws IOException {
+        byte[] data = debugTesterRom();
+        data[0x0150] = 0x00;
+
+        Rom rom = new Rom(data);
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof Mbc1);
+    }
+
+    private static byte[] debugTesterRom() {
+        byte[] data = new byte[0x100000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        copy(data, 0x0104, NINTENDO_LOGO);
+        data[0x0144] = 0x30;
+        data[0x0145] = 0x31;
+        data[0x0146] = 0x03;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x03;
+        data[0x0149] = 0x00;
+        data[0x014a] = 0x00;
+        data[0x014b] = 0x33;
+        data[0x014c] = 0x00;
+        data[0x014d] = 0x4c;
+        data[0x014e] = 0x00;
+        data[0x014f] = 0x00;
+        copy(data, 0x0150, ENTRY_STUB);
+        return data;
+    }
+
+    private static void copy(byte[] target, int offset, int[] source) {
+        for (int i = 0; i < source.length; i++) {
+            target[offset + i] = (byte) source[i];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect the Pocket Camera Debug Game Tester v10.24 despite its misleading MBC1 header
- route that exact cartridge profile through the existing Pocket Camera hardware implementation
- add a ROM-free regression fixture plus a near-match guard

## Root cause
The 1 MiB debug tester declares cartridge type `0x01` (MBC1), but it was built to test Game Boy Camera hardware. Its Movie path writes the camera shoot bit at `A000` and polls bit 0 until the camera is no longer busy. Under MBC1, that address reads open bus as `0xFF`, so the loop never exits. Gallery likewise reads nonexistent MBC1 RAM.

The compatibility profile is limited by ROM size, empty title, Nintendo logo, complete header metadata/checksum, entry point, and a 32-byte startup signature.

## Reproduction and verification
Reporter ROM:
- SHA-256: `e65d758628f46109cafb579295c4baefc5c8377ee138879fe7a7d73a17f7aa68`
- CRC32: `15726d8c`
- MD5: `19b50a5f67ef4f0d015e7d813370756e`
- SHA-1: `5ffcda6fa1a3d87c5cbb8ddf743ddbc18242443b`

Before the fix:
- Movie blanks the display and loops at PC `0x3775` while `A000` remains `0xFF`
- Gallery reads the wrong cartridge memory

After the fix:
- Movie advances and renders the synthetic camera capture
- Gallery renders a valid empty photo slot

## Tests
- `/opt/maven/bin/mvn -pl core -Dtest=PocketCameraDebugTesterTest test -q`
- `/opt/maven/bin/mvn -pl core test -q`
- exact-ROM headless runs through Movie and Gallery

Fixes #261