### PR TITLE
Fix Dungeon Warrior renderer initialization

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -241,6 +241,14 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             mmu.addAddressSpace(infraredPort);
         }
         mmu.indexSpaces();
+        if (cartridgeProperties.has(
+                CartridgeProperties.Feature.CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT)) {
+            // This prototype assumes emulator-style zeroed WRAM for its renderer-record
+            // count at C0BC. With real power-on garbage its record walker mutates stale
+            // entries and adjacent renderer work data, producing persistent wall/floor
+            // seams. Keep the hardware-like WRAM pattern everywhere else.
+            mmu.setByte(0xc0bc, 0);
+        }
         mmu.setBusListener(cartridge.getSachenMmc());
 
         cpu = new Cpu(new DmaCpuAddressSpace(getAddressSpace(), dma, gbc,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -40,6 +40,7 @@ public final class CartridgeProperties {
         LEGACY_SPEED_SWITCH,
         BLANK_CGB_BOOT_TILE,
         CLEAR_BOOT_TILEMAP,
+        CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT,
         DATEL_CGB_HEADER,
         SCRAMBLED_SACHEN_HEADER,
         MBC1_MULTICART,
@@ -122,6 +123,9 @@ public final class CartridgeProperties {
                     Feature.BLANK_CGB_BOOT_TILE),
             features("AudioArts Gameboy Music V1", CartridgeProperties::isAudioArtsMusicV1,
                     Feature.CLEAR_BOOT_TILEMAP),
+            features("Dungeon Warrior prototype renderer state",
+                    CartridgeProperties::isDungeonWarriorPrototype,
+                    Feature.CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT),
             features("FreeArt Intro V2", CartridgeProperties::isFreeArtIntroV2,
                     Feature.MBC1_RAM_ENABLED_AT_POWER_ON),
             features("Helitac V0.01 boot WRAM", CartridgeProperties::isHelitacV001,
@@ -462,6 +466,22 @@ public final class CartridgeProperties {
                 && info.byteAt(0x014e) == 0xc1
                 && info.byteAt(0x014f) == 0x1d
                 && matches(info.data, 0x0150, entryStub);
+    }
+
+    private static boolean isDungeonWarriorPrototype(RomInfo info) {
+        int[] rendererRecordSetup = {
+                0xfa, 0xbc, 0xc0, 0xfe, 0x08, 0xd0, 0xc5, 0x4f,
+                0x87, 0x81, 0x01, 0xa0, 0xc2, 0x81, 0x4f
+        };
+        return info.data.length == 0x10000
+                && info.hasNullTerminatedTitle("DUNGEON WARRIOR ")
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x01
+                && info.byteAt(0x0149) == 0x00
+                && info.byteAt(0x014e) == 0x6b
+                && info.byteAt(0x014f) == 0x86
+                && matches(info.data, 0x1be1, rendererRecordSetup)
+                && info.crc32() == 0x2910429c;
     }
 
     private static boolean isHelitacV001(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/DungeonWarriorBootWramTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/DungeonWarriorBootWramTest.java
@@ -1,0 +1,90 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DungeonWarriorBootWramTest {
+
+    @Test
+    public void clearsOnlyTheUninitializedRendererRecordCount() throws IOException {
+        Rom rom = new Rom(dungeonWarriorPrototype());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT));
+
+        Gameboy compatible = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+
+        byte[] nearMatch = dungeonWarriorPrototype();
+        nearMatch[0x1be1] ^= 1;
+        Gameboy ordinary = new Gameboy.GameboyConfiguration(new Rom(nearMatch))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+
+        assertEquals(0, compatible.getAddressSpace().getByte(0xc0bc));
+        assertEquals(0xf1, ordinary.getAddressSpace().getByte(0xc0bc));
+        for (int address = 0xc000; address < 0xe000; address++) {
+            if (address != 0xc0bc) {
+                assertEquals(Integer.toHexString(address),
+                        ordinary.getAddressSpace().getByte(address),
+                        compatible.getAddressSpace().getByte(address));
+            }
+        }
+        boolean hasNonZeroMinesweeperSeed = false;
+        for (int address = 0xc100; address < 0xc110; address++) {
+            hasNonZeroMinesweeperSeed |= compatible.getAddressSpace().getByte(address) != 0;
+        }
+        assertTrue(hasNonZeroMinesweeperSeed);
+    }
+
+    @Test
+    public void nearMatchKeepsTheHardwarePowerOnValue() throws IOException {
+        byte[] data = dungeonWarriorPrototype();
+        data[0x1be1] ^= 1;
+
+        Rom rom = new Rom(data);
+
+        assertFalse(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT));
+        Gameboy gb = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+        assertEquals(0xf1, gb.getAddressSpace().getByte(0xc0bc));
+    }
+
+    private static byte[] dungeonWarriorPrototype() {
+        byte[] data = new byte[0x10000];
+        byte[] title = "DUNGEON WARRIOR ".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x01;
+        data[0x014d] = 0x6f;
+        data[0x014e] = 0x6b;
+        data[0x014f] = (byte) 0x86;
+        int[] rendererRecordSetup = {
+                0xfa, 0xbc, 0xc0, 0xfe, 0x08, 0xd0, 0xc5, 0x4f,
+                0x87, 0x81, 0x01, 0xa0, 0xc2, 0x81, 0x4f
+        };
+        for (int i = 0; i < rendererRecordSetup.length; i++) {
+            data[0x1be1 + i] = (byte) rendererRecordSetup[i];
+        }
+        // Four synthetic padding bytes give this minimal signature fixture the
+        // prototype's exact CRC32 identity without embedding any game assets.
+        data[0xfffc] = (byte) 0x8d;
+        data[0xfffd] = 0x4a;
+        data[0xfffe] = 0x5b;
+        data[0xffff] = (byte) 0xdf;
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary

Fix persistent wall and floor seams in **Dungeon Warrior (Europe) (Proto)** on DMG/SGB.

The affected attachment is the 64 KiB ROM with SHA-256 `372c25deaabe768ae8e65ce3b976f9ca7fda874cb8690ffbb1229c0885cb2` and CRC32 `2910429c`.

## Root cause

This is not a PPU or mode-3 VRAM-access bug.

Coffee GB's hardware-like deterministic WRAM pattern initializes `C0BC` to `F1`. The prototype does not initialize that byte before its first dungeon render. ROM routine `1C05` treats it as a renderer-record count, walks 241 three-byte entries from `C2A0`, and mutates stale records plus adjacent renderer work data. That corrupted work data becomes the persistent wall/floor seams.

A controlled Gearboy A/B with its pre/post `926af5c` VRAM gate produced byte-identical output, and bypassing every Coffee GB VRAM lock changed zero output bytes or pixels. Gearboy renders clean because its power-on WRAM pattern happens to leave a harmless value here; it is useful comparison evidence, not the specification.

## Fix

Add an exact cartridge compatibility profile for this prototype and initialize only `C0BC` to zero after the ordinary WRAM power-on pattern is established.

All other WRAM bytes remain unchanged, including the nonzero `C100-C10F` entropy used by Minesweeper (#48).

The regression fixture is synthetic and contains no game assets. It verifies:

- exact profile detection;
- `C0BC: F1 -> 00`;
- every other byte in `C000-DFFF` remains unchanged;
- the Minesweeper seed area remains nonzero;
- a near-match ROM retains the normal power-on value.

## Verification

Original deterministic reproduction:

- DMG mode, boot skipped;
- START at frame 380 for 20 frames;
- UP beginning at frame 800;
- captures at frames 780 and 840.

Before the fix, frame 780 differed from the clean reference in 694/23040 pixels. With only `C0BC` corrected, Coffee GB matches Gearboy at both checkpoints: 0/8192 differing VRAM bytes and 0/23040 differing pixel indices. It also matches the preserved gameplay shown by [Hidden Palace](https://hiddenpalace.org/Dungeon_Warrior_%28Prototype%29) and its [preservation video](https://www.youtube.com/watch?v=71PRyEJnltE) after scale/palette normalization.

Local before/after screenshots were captured at the same stable frames; no ROM or screenshot asset is committed.

Commands:

```text
/opt/maven/bin/mvn -q -pl core -Dtest=DungeonWarriorBootWramTest,MmuPowerOnTest test
/opt/maven/bin/mvn -q -pl core test
/opt/maven/bin/mvn -q -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2
/opt/maven/bin/mvn -q -pl core test -Ptest-blargg-individual,test-blargg
```

All pass.

Fixes #282
