### PR TITLE
Make repeated ROM loads responsive

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -8,19 +8,42 @@ import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.genie.AddPatches
 import eu.rekawek.coffeegb.core.genie.Patch
-import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
 import eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import java.io.File
+import java.util.concurrent.Callable
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class BasicController(
+class BasicController private constructor(
     parentEventBus: EventBus,
     properties: EmulatorProperties,
     private val console: Console?,
+    private val sessionPreparer: SessionPreparer,
+    private val loadExecutor: ExecutorService,
 ) : Controller, SnapshotSupport {
+
+  constructor(
+      parentEventBus: EventBus,
+      properties: EmulatorProperties,
+      console: Console?,
+  ) : this(parentEventBus, properties, console, RomSessionPreparer(), createLoadExecutor())
+
+  internal constructor(
+      parentEventBus: EventBus,
+      properties: EmulatorProperties,
+      console: Console?,
+      sessionPreparer: SessionPreparer,
+  ) : this(parentEventBus, properties, console, sessionPreparer, createLoadExecutor())
 
   private val timingTicker = TimingTicker()
 
@@ -42,6 +65,11 @@ class BasicController(
 
   private val patches = mutableListOf<Patch>()
 
+  private var loadJob: LoadJob? = null
+
+  /** The user's pause state before the current chain of coalesced load requests. */
+  private var pauseStateBeforeLoading: Boolean? = null
+
   // when the Barcode Boy is connected the session uses a BarcodeBoySerialEndpoint instead
   // of the netplay peer endpoint; scans are routed to it
   private var barcodeBoyEnabled = false
@@ -60,24 +88,32 @@ class BasicController(
 
   init {
     eventQueue.register<AddPatches> { patches.addAll(it.patches) }
-    eventQueue.register<Controller.LoadRomEvent> { loadRom(properties, it) }
+    eventQueue.register<Controller.LoadRomEvent> { requestLoad(properties, it) }
     eventQueue.register<Controller.RestoreSnapshotEvent> { e -> loadSnapshot(e.slot) }
     eventQueue.register<Controller.SaveSnapshotEvent> { e -> saveSnapshot(e.slot) }
     eventQueue.register<Controller.PauseEmulationEvent> {
-      if (!isPaused) {
-        session?.gameboy?.setCartridgeClockPaused(true)
-        isPaused = true
+      if (pauseStateBeforeLoading != null) {
+        pauseStateBeforeLoading = true
       }
+      setPaused(true)
     }
     eventQueue.register<Controller.ResumeEmulationEvent> {
-      if (isPaused) {
-        session?.gameboy?.setCartridgeClockPaused(false)
-        isPaused = false
+      if (pauseStateBeforeLoading != null) {
+        pauseStateBeforeLoading = false
       }
+      setPaused(false)
     }
     eventQueue.register<Controller.RewindEvent> { isRewinding = it.active }
-    eventQueue.register<Controller.ResetEmulationEvent> { reset() }
-    eventQueue.register<Controller.StopEmulationEvent> { stop() }
+    eventQueue.register<Controller.ResetEmulationEvent> {
+      session?.config?.rom?.file?.let {
+        requestLoad(properties, Controller.LoadRomEvent(it), clearPatches = false)
+      }
+    }
+    eventQueue.register<Controller.StopEmulationEvent> {
+      cancelLoadJob()
+      restorePauseStateAfterLoading()
+      stop()
+    }
     eventQueue.register<Controller.SetBarcodeBoyEvent> {
       if (barcodeBoyEnabled != it.enabled) {
         barcodeBoyEnabled = it.enabled
@@ -114,6 +150,7 @@ class BasicController(
 
   private fun runFrame() {
     eventQueue.dispatch()
+    finishPreparedLoad()
 
     // rewinding restores one recorded state and then emulates a single frame from it,
     // so the display and audio play backwards at RewindManager.RECORD_INTERVAL speed
@@ -132,10 +169,19 @@ class BasicController(
     }
   }
 
-  private fun createSession(config: Gameboy.GameboyConfiguration): Session {
+  private fun createSession(
+      config: Gameboy.GameboyConfiguration,
+      prebuiltGameboy: Gameboy? = null,
+  ): Session {
     val sessionBus = eventBus.fork("main")
     try {
-      return Session(config, sessionBus, console, createLinkDevice(sessionBus))
+      return Session(
+          config,
+          sessionBus,
+          console,
+          createLinkDevice(sessionBus),
+          prebuiltGameboy = prebuiltGameboy,
+      )
     } catch (e: Exception) {
       try {
         sessionBus.close()
@@ -146,32 +192,117 @@ class BasicController(
     }
   }
 
-  private fun loadRom(properties: EmulatorProperties, event: Controller.LoadRomEvent) {
-    var nextSession: Session? = null
+  private fun requestLoad(
+      properties: EmulatorProperties,
+      event: Controller.LoadRomEvent,
+      clearPatches: Boolean = true,
+  ) {
+    if (doStop) {
+      return
+    }
+
+    if (pauseStateBeforeLoading == null) {
+      pauseStateBeforeLoading = isPaused
+    }
+    cancelLoadJob()
+
+    // A fallback preparation for an exotic/RTC cartridge may use the real save file. When
+    // reloading that exact file, freeze and flush the old cartridge first so the worker cannot
+    // observe stale RAM. Ordinary cartridges use battery-free boot templates and keep running.
+    if (isCurrentRom(event.rom)) {
+      setPaused(true)
+      session?.gameboy?.flushCartridge()
+    }
+
+    eventBus.post(Controller.RomLoadingEvent(event.rom))
+    val task = PreparedLoadTask { sessionPreparer.prepare(properties, event) }
+    loadJob = LoadJob(event, clearPatches, task)
+    loadExecutor.execute(task)
+  }
+
+  private fun finishPreparedLoad() {
+    val job = loadJob ?: return
+    if (!job.task.isDone) {
+      return
+    }
+    loadJob = null
+
     try {
-      // Validate the ROM before closing the running game. A bad file selected in the picker
-      // should not interrupt the current session, and must never kill the controller thread.
-      val config = Controller.createGameboyConfig(properties, Rom(event.rom))
+      activatePreparedLoad(job, job.task.take())
+    } catch (_: CancellationException) {
+      restorePauseStateAfterLoading()
+    } catch (e: ExecutionException) {
+      reportLoadFailure(job.event, e.cause ?: e)
+    } catch (e: Exception) {
+      reportLoadFailure(job.event, e)
+    }
+  }
+
+  private fun activatePreparedLoad(job: LoadJob, prepared: PreparedSession) {
+    var nextGameboy: Gameboy? = null
+    try {
+      // The expensive BIOS run is complete. Pause only for the short save flush + SKIP/restore
+      // materialization so the old game remains live while the background preparation runs.
+      setPaused(true)
+      session?.gameboy?.flushCartridge()
+      nextGameboy = prepared.materialize()
 
       stop()
-      patches.clear()
+      if (job.clearPatches) {
+        patches.clear()
+      }
       rewindManager.clear()
 
-      nextSession = createSession(config)
-      event.memento?.let { nextSession.gameboy.restoreFromMemento(it) }
-      session = nextSession
-      nextSession = null
+      session = createSession(prepared.config, nextGameboy)
+      nextGameboy = null
+      val pauseNewSession = pauseStateBeforeLoading == true
+      pauseStateBeforeLoading = null
       start()
+      setPaused(pauseNewSession)
     } catch (e: Exception) {
-      try {
-        nextSession?.close()
-      } catch (cleanupException: Exception) {
-        e.addSuppressed(cleanupException)
-      }
-      LOG.error("Can't load ROM ${event.rom}", e)
-      val message = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
-      eventBus.post(Controller.LoadRomFailedEvent(event.rom, message))
+      nextGameboy?.discardUnstarted()
+      reportLoadFailure(job.event, e)
     }
+  }
+
+  private fun reportLoadFailure(event: Controller.LoadRomEvent, error: Throwable) {
+    LOG.error("Can't load ROM ${event.rom}", error)
+    val message = error.message?.takeIf { it.isNotBlank() } ?: error.javaClass.simpleName
+    eventBus.post(Controller.LoadRomFailedEvent(event.rom, message))
+    restorePauseStateAfterLoading()
+  }
+
+  private fun cancelLoadJob() {
+    val job = loadJob ?: return
+    loadJob = null
+    job.task.cancelAndDiscard()
+    eventBus.post(Controller.RomLoadingCancelledEvent(job.event.rom))
+  }
+
+  private fun isCurrentRom(file: File): Boolean {
+    val current = session?.config?.rom?.file ?: return false
+    return canonicalFile(current) == canonicalFile(file)
+  }
+
+  private fun canonicalFile(file: File): File =
+      try {
+        file.canonicalFile
+      } catch (_: Exception) {
+        file.absoluteFile
+      }
+
+  private fun setPaused(paused: Boolean) {
+    if (isPaused == paused) {
+      return
+    }
+    session?.gameboy?.setCartridgeClockPaused(paused)
+    isPaused = paused
+  }
+
+  private fun restorePauseStateAfterLoading() {
+    val restorePaused = pauseStateBeforeLoading ?: return
+    pauseStateBeforeLoading = null
+    setPaused(restorePaused)
   }
 
   private fun createLinkDevice(sessionBus: EventBus): SerialEndpoint =
@@ -216,15 +347,6 @@ class BasicController(
     this.session = null
   }
 
-  private fun reset() {
-    val session = session ?: return
-    val config = session.config
-    stop()
-    rewindManager.clear()
-    this.session = createSession(config)
-    start()
-  }
-
   private fun saveSnapshot(slot: Int) {
     val currentSession = session ?: return
     val manager = snapshotManager ?: return
@@ -253,6 +375,18 @@ class BasicController(
     doStop = true
     thread.join()
 
+    cancelLoadJob()
+    loadExecutor.shutdownNow()
+    try {
+      if (!loadExecutor.awaitTermination(LOAD_EXECUTOR_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) {
+        LOG.warn("ROM loader did not terminate promptly")
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      LOG.warn("Interrupted while waiting for the ROM loader to terminate")
+    }
+    restorePauseStateAfterLoading()
+
     val state =
         session?.let { Controller.ControllerState(it.gameboy.saveToMemento(), it.config.rom) }
 
@@ -264,5 +398,56 @@ class BasicController(
 
   private companion object {
     val LOG: Logger = LoggerFactory.getLogger(BasicController::class.java)
+
+    const val LOAD_EXECUTOR_SHUTDOWN_SECONDS = 5L
+
+    fun createLoadExecutor(): ExecutorService =
+        Executors.newSingleThreadExecutor { runnable ->
+          Thread(runnable, "coffee-gb-rom-loader").apply { isDaemon = true }
+        }
+  }
+
+  private data class LoadJob(
+      val event: Controller.LoadRomEvent,
+      val clearPatches: Boolean,
+      val task: PreparedLoadTask,
+  )
+
+  /** Owns a prepared fallback machine until the controller takes it, even across cancel races. */
+  private class PreparedLoadTask(callable: Callable<PreparedSession>) :
+      FutureTask<PreparedSession>(callable) {
+
+    private val prepared = AtomicReference<PreparedSession>()
+
+    override fun set(value: PreparedSession) {
+      prepared.set(value)
+      super.set(value)
+      if (isCancelled) {
+        prepared.getAndSet(null)?.discard()
+      }
+    }
+
+    override fun done() {
+      if (isCancelled) {
+        prepared.getAndSet(null)?.discard()
+      }
+    }
+
+    fun take(): PreparedSession {
+      val value = get()
+      prepared.compareAndSet(value, null)
+      return value
+    }
+
+    fun cancelAndDiscard() {
+      if (cancel(true)) {
+        return
+      }
+      try {
+        take().discard()
+      } catch (_: Exception) {
+        // A failed/cancelled preparation owns no live session resources.
+      }
+    }
   }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -138,7 +138,8 @@ class BasicController private constructor(
     eventQueue.register<Controller.UpdatedSystemMappingEvent> {
       session?.config?.let { config ->
         val newType = Controller.getGameboyType(properties.system, config.rom)
-        if (newType != config.gameboyType) {
+        val newBootstrapMode = properties.system.bootstrapMode
+        if (newType != config.gameboyType || newBootstrapMode != config.bootstrapMode) {
           eventBus.post(Controller.LoadRomEvent(config.rom.file))
         }
       }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -100,8 +100,9 @@ class BasicController private constructor(
     eventQueue.register<Controller.ResumeEmulationEvent> {
       if (pauseStateBeforeLoading != null) {
         pauseStateBeforeLoading = false
+      } else {
+        setPaused(false)
       }
-      setPaused(false)
     }
     eventQueue.register<Controller.RewindEvent> { isRewinding = it.active }
     eventQueue.register<Controller.ResetEmulationEvent> {
@@ -206,11 +207,15 @@ class BasicController private constructor(
     }
     cancelLoadJob()
 
+    // Keep the last completed frame on screen, but stop the old game immediately. Continuing to
+    // animate while the window says that another ROM is loading makes it look as though the load
+    // request was ignored and also allows the old game to consume input meant for the new one.
+    setPaused(true)
+
     // A fallback preparation for an exotic/RTC cartridge may use the real save file. When
-    // reloading that exact file, freeze and flush the old cartridge first so the worker cannot
-    // observe stale RAM. Ordinary cartridges use battery-free boot templates and keep running.
+    // reloading that exact file, flush the old cartridge first so the worker cannot observe stale
+    // RAM. Ordinary cartridges use battery-free boot templates and don't need this extra flush.
     if (isCurrentRom(event.rom)) {
-      setPaused(true)
       session?.gameboy?.flushCartridge()
     }
 
@@ -241,8 +246,8 @@ class BasicController private constructor(
   private fun activatePreparedLoad(job: LoadJob, prepared: PreparedSession) {
     var nextGameboy: Gameboy? = null
     try {
-      // The expensive BIOS run is complete. Pause only for the short save flush + SKIP/restore
-      // materialization so the old game remains live while the background preparation runs.
+      // The expensive BIOS run is complete. The old game has remained frozen during preparation;
+      // now flush its save and atomically replace the session.
       setPaused(true)
       session?.gameboy?.flushCartridge()
       nextGameboy = prepared.materialize()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -101,17 +101,7 @@ interface Controller : AutoCloseable {
       }
       val gameboyType = getGameboyType(properties.system, rom)
       config.setGameboyType(gameboyType)
-      if (rom.gameboyColorFlag == Rom.GameboyColorFlag.NON_CGB &&
-          gameboyType == GameboyType.CGB &&
-          !isDatel) {
-        // (Datel carts ship a deliberately bad logo; the visible boot ROM would hang on
-        // it forever - FAST_FORWARD times out and falls back to the post-boot presets)
-        config.setBootstrapMode(Gameboy.BootstrapMode.NORMAL)
-      } else {
-        // run the boot ROM invisibly: the post-boot timer/PPU phase relationships are
-        // hardware-exact, which cycle-synced programs rely on (issue #37)
-        config.setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
-      }
+      config.setBootstrapMode(properties.system.bootstrapMode)
       if (config.gameboyType == GameboyType.SGB && !rom.isSuperGameboyFlag) {
         config.setDisplaySgbBorder(false)
       } else {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -22,6 +22,10 @@ interface Controller : AutoCloseable {
 
   data class LoadRomEvent(val rom: File, val memento: Memento<Gameboy>? = null) : Event
 
+  data class RomLoadingEvent(val rom: File) : Event
+
+  data class RomLoadingCancelledEvent(val rom: File) : Event
+
   data class LoadRomFailedEvent(val rom: File, val message: String) : Event
 
   class PauseEmulationEvent : Event

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -1,0 +1,200 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.Gameboy.BootState
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.Gameboy.GameboyConfiguration
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties.Mapper
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeType
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.LinkedHashMap
+import java.util.concurrent.CancellationException
+
+internal fun interface SessionPreparer {
+  fun prepare(properties: EmulatorProperties, event: LoadRomEvent): PreparedSession
+}
+
+/** Performs the CPU-heavy BIOS handoff away from the real-time controller thread. */
+internal class RomSessionPreparer(
+    internal val bootStateCache: BootStateCache = BootStateCache(),
+) : SessionPreparer {
+
+  override fun prepare(properties: EmulatorProperties, event: LoadRomEvent): PreparedSession {
+    ensureActive()
+    val config =
+        Controller.createGameboyConfig(properties, Rom(event.rom))
+            .setBootCancellation { Thread.currentThread().isInterrupted }
+    ensureActive()
+
+    event.memento?.let { return PreparedSession.FromMemento(config, it) }
+
+    bootStateCache.getOrCreate(config)?.let {
+      return PreparedSession.FromBootState(config, it)
+    }
+
+    val gameboy = config.build()
+    if (Thread.currentThread().isInterrupted) {
+      gameboy.discardUnstarted()
+      throw CancellationException("ROM preparation superseded")
+    }
+    return PreparedSession.Ready(config, gameboy)
+  }
+
+  private fun ensureActive() {
+    if (Thread.currentThread().isInterrupted) {
+      throw CancellationException("ROM preparation superseded")
+    }
+  }
+}
+
+/**
+ * Small process-local LRU of exact BIOS handoff states. Cache entries contain no file-backed
+ * battery data and are restored without replacing the new cartridge's RAM/RTC/mapper state.
+ */
+internal class BootStateCache(private val capacity: Int = DEFAULT_CAPACITY) {
+
+  private val states =
+      object : LinkedHashMap<BootKey, BootState>(capacity + 1, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<BootKey, BootState>?): Boolean =
+            size > capacity
+      }
+
+  internal var hitCount = 0
+    private set
+
+  internal val size: Int
+    get() = synchronized(states) { states.size }
+
+  fun getOrCreate(config: GameboyConfiguration): BootState? {
+    val key = BootKey.from(config) ?: return null
+    synchronized(states) {
+      states[key]?.let {
+        hitCount++
+        return it
+      }
+    }
+
+    var template: Gameboy? = null
+    try {
+      template = config.forBootTemplate().build()
+      if (Thread.currentThread().isInterrupted) {
+        throw CancellationException("ROM preparation superseded")
+      }
+      val state = template.saveBootState()
+      synchronized(states) {
+        // Another preparation is not expected for a BasicController's single loader, but keep
+        // the cache correct if it is reused by a different caller.
+        states[key]?.let {
+          hitCount++
+          return it
+        }
+        states[key] = state
+      }
+      return state
+    } finally {
+      template?.discardUnstarted()
+    }
+  }
+
+  private data class BootKey(
+      val romDigest: String,
+      val gameboyType: GameboyType,
+      val displaySgbBorder: Boolean,
+      val cgb0Revision: Boolean,
+      val mealybugDmgBlob: Boolean,
+      val codeBreakerRumble: Boolean,
+  ) {
+    companion object {
+      fun from(config: GameboyConfiguration): BootKey? {
+        val rom = config.rom
+        if (config.bootstrapMode != BootstrapMode.FAST_FORWARD ||
+            config.slotRom != null ||
+            rom.cartridgeProperties.mapper != Mapper.STANDARD ||
+            !isOrdinaryNonRtcCartridge(rom.type)) {
+          return null
+        }
+        return BootKey(
+            digest(rom),
+            config.gameboyType,
+            config.isDisplaySgbBorder,
+            config.isCgb0Revision,
+            config.isMealybugDmgBlob,
+            config.isCodeBreakerRumble,
+        )
+      }
+
+      private fun isOrdinaryNonRtcCartridge(type: CartridgeType): Boolean =
+          type == CartridgeType.ROM ||
+              type == CartridgeType.ROM_RAM ||
+              type == CartridgeType.ROM_RAM_BATTERY ||
+              type.isMbc1 ||
+              type.isMbc2 ||
+              type.isMbc5
+
+      private fun digest(rom: Rom): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        for (value in rom.rom) {
+          digest.update(value.toByte())
+        }
+        return Base64.getEncoder().encodeToString(digest.digest())
+      }
+    }
+  }
+
+  private companion object {
+    const val DEFAULT_CAPACITY = 8
+  }
+}
+
+internal sealed class PreparedSession(open val config: GameboyConfiguration) {
+
+  abstract fun materialize(): Gameboy
+
+  open fun discard() {}
+
+  data class FromBootState(
+      override val config: GameboyConfiguration,
+      val bootState: BootState,
+  ) : PreparedSession(config) {
+    override fun materialize(): Gameboy = materializeRestored { it.restoreBootState(bootState) }
+  }
+
+  data class FromMemento(
+      override val config: GameboyConfiguration,
+      val memento: Memento<Gameboy>,
+  ) : PreparedSession(config) {
+    override fun materialize(): Gameboy = materializeRestored { it.restoreFromMemento(memento) }
+  }
+
+  data class Ready(
+      override val config: GameboyConfiguration,
+      val gameboy: Gameboy,
+  ) : PreparedSession(config) {
+    override fun materialize(): Gameboy = gameboy
+
+    override fun discard() {
+      gameboy.discardUnstarted()
+    }
+  }
+
+  protected fun materializeRestored(restore: (Gameboy) -> Unit): Gameboy {
+    val gameboy = config.forRestore().build()
+    try {
+      restore(gameboy)
+      return gameboy
+    } catch (error: Throwable) {
+      try {
+        gameboy.discardUnstarted()
+      } catch (cleanupError: Throwable) {
+        error.addSuppressed(cleanupError)
+      }
+      throw error
+    }
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
@@ -15,9 +15,10 @@ class Session(
     private val console: Console?,
     serialEndpoint: SerialEndpoint = SerialEndpoint.NULL_ENDPOINT,
     infraredEndpoint: InfraredEndpoint = InfraredEndpoint.NULL_ENDPOINT,
+    prebuiltGameboy: Gameboy? = null,
 ) : AutoCloseable, Originator<Session> {
 
-  internal val gameboy: Gameboy = config.build()
+  internal val gameboy: Gameboy = prebuiltGameboy ?: config.build()
 
   internal var serialEndpoint: SerialEndpoint = serialEndpoint
     private set

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -167,7 +167,8 @@ class LinkedController(
     eventBus.register<UpdatedSystemMappingEvent> {
       mainSession?.config?.let { config ->
         val newType = Controller.getGameboyType(properties.system, config.rom)
-        if (newType != config.gameboyType) {
+        val newBootstrapMode = properties.system.bootstrapMode
+        if (newType != config.gameboyType || newBootstrapMode != config.bootstrapMode) {
           eventBus.post(LoadRomEvent(config.rom.file))
         }
       }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
@@ -41,6 +41,7 @@ class EmulatorProperties() {
   enum class Key(val propertyName: String) {
     DmgGamesType("system.dmgGames"),
     CgbGamesType("system.cgbGames"),
+    BootstrapMode("system.bootstrapMode"),
     DisplayScale("display.scale"),
     DisplayGrayscale("display.grayscale"),
     DisplayBlending("display.blending"),

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/SystemProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/SystemProperties.kt
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.controller.properties
 
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.GameboyType
 
 class SystemProperties(private val properties: EmulatorProperties) {
@@ -12,4 +13,12 @@ class SystemProperties(private val properties: EmulatorProperties) {
     get() =
         GameboyType.valueOf(
             properties.getProperty(EmulatorProperties.Key.CgbGamesType, GameboyType.CGB.name))
+
+  val bootstrapMode
+    get() =
+        BootstrapMode.valueOf(
+            properties.getProperty(
+                EmulatorProperties.Key.BootstrapMode,
+                BootstrapMode.SKIP.name,
+            ))
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1,17 +1,28 @@
 package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.controller.Controller.EmulationStartedEvent
+import eu.rekawek.coffeegb.controller.Controller.EmulationStoppedEvent
 import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
 import eu.rekawek.coffeegb.controller.Controller.LoadRomFailedEvent
+import eu.rekawek.coffeegb.controller.Controller.RomLoadingCancelledEvent
+import eu.rekawek.coffeegb.controller.Controller.RomLoadingEvent
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.gpu.Display.GbcFrameReadyEvent
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class BasicControllerTest {
@@ -48,6 +59,120 @@ class BasicControllerTest {
       eventBus.close()
       invalidRom.delete()
     }
+  }
+
+  @Test
+  fun keepsCurrentSessionRunningWhileNextRomIsPrepared() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val stopped = LinkedBlockingQueue<EmulationStoppedEvent>()
+    val loading = LinkedBlockingQueue<RomLoadingEvent>()
+    val frames = LinkedBlockingQueue<GbcFrameReadyEvent>()
+    eventBus.register<EmulationStartedEvent> { started.add(it) }
+    eventBus.register<EmulationStoppedEvent> { stopped.add(it) }
+    eventBus.register<RomLoadingEvent> { loading.add(it) }
+    eventBus.register<GbcFrameReadyEvent> { frames.add(it) }
+
+    val nextRom = namedRom("NEXT_GAME")
+    val preparing = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val preparer =
+        SessionPreparer { properties, event ->
+          val config =
+              Controller.createGameboyConfig(properties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+          if (event.rom == nextRom) {
+            preparing.countDown()
+            try {
+              release.await()
+            } catch (_: InterruptedException) {
+              throw CancellationException("superseded")
+            }
+          }
+          PreparedSession.Ready(config, config.build())
+        }
+    val controller = BasicController(eventBus, EmulatorProperties(), null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(ROM))
+      assertEquals("CPU_INSTRS", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+      loading.clear()
+      frames.clear()
+
+      eventBus.post(LoadRomEvent(nextRom))
+      assertTrue(preparing.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(nextRom, loading.poll(1, TimeUnit.SECONDS)?.rom)
+      assertNull(stopped.poll(250, TimeUnit.MILLISECONDS), "the old session must stay active")
+      assertNotNull(frames.poll(1, TimeUnit.SECONDS), "the old session should keep producing frames")
+
+      release.countDown()
+      assertEquals("NEXT_GAME", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+    } finally {
+      release.countDown()
+      controller.close()
+      eventBus.close()
+      nextRom.delete()
+    }
+  }
+
+  @Test
+  fun rapidLoadBurstStartsOnlyTheLatestRom() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val cancelled = LinkedBlockingQueue<RomLoadingCancelledEvent>()
+    eventBus.register<EmulationStartedEvent> { started.add(it) }
+    eventBus.register<RomLoadingCancelledEvent> { cancelled.add(it) }
+
+    val firstRom = namedRom("FIRST_GAME")
+    val middleRom = namedRom("MIDDLE_GAME")
+    val lastRom = namedRom("LAST_GAME")
+    val firstPreparationStarted = CountDownLatch(1)
+    val neverReleaseFirst = CountDownLatch(1)
+    val preparer =
+        SessionPreparer { properties, event ->
+          if (event.rom == firstRom) {
+            firstPreparationStarted.countDown()
+            try {
+              neverReleaseFirst.await()
+            } catch (_: InterruptedException) {
+              throw CancellationException("superseded")
+            }
+          }
+          val config =
+              Controller.createGameboyConfig(properties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+          PreparedSession.Ready(config, config.build())
+        }
+    val controller = BasicController(eventBus, EmulatorProperties(), null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(firstRom))
+      assertTrue(firstPreparationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      eventBus.post(LoadRomEvent(middleRom))
+      eventBus.post(LoadRomEvent(lastRom))
+
+      assertEquals("LAST_GAME", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+      assertNull(started.poll(500, TimeUnit.MILLISECONDS), "superseded ROMs must never start")
+      assertEquals(firstRom, cancelled.poll(1, TimeUnit.SECONDS)?.rom)
+      assertEquals(middleRom, cancelled.poll(1, TimeUnit.SECONDS)?.rom)
+    } finally {
+      controller.close()
+      eventBus.close()
+      firstRom.delete()
+      middleRom.delete()
+      lastRom.delete()
+    }
+  }
+
+  private fun namedRom(title: String): File {
+    val bytes = ROM.readBytes()
+    for (address in 0x0134 until 0x0143) {
+      bytes[address] = 0
+    }
+    title.toByteArray(Charsets.US_ASCII).copyInto(bytes, 0x0134, endIndex = title.length.coerceAtMost(15))
+    return Files.createTempFile("coffee-gb-$title", ".gbc").toFile().also { it.writeBytes(bytes) }
   }
 
   private companion object {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -62,7 +62,7 @@ class BasicControllerTest {
   }
 
   @Test
-  fun keepsCurrentSessionRunningWhileNextRomIsPrepared() {
+  fun pausesCurrentSessionWhileNextRomIsPrepared() {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()
     val stopped = LinkedBlockingQueue<EmulationStoppedEvent>()
@@ -104,7 +104,13 @@ class BasicControllerTest {
       assertTrue(preparing.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
       assertEquals(nextRom, loading.poll(1, TimeUnit.SECONDS)?.rom)
       assertNull(stopped.poll(250, TimeUnit.MILLISECONDS), "the old session must stay active")
-      assertNotNull(frames.poll(1, TimeUnit.SECONDS), "the old session should keep producing frames")
+      frames.clear()
+      assertNull(frames.poll(250, TimeUnit.MILLISECONDS), "the old session must be frozen")
+      eventBus.post(Controller.ResumeEmulationEvent())
+      assertNull(
+          frames.poll(250, TimeUnit.MILLISECONDS),
+          "resume during loading must apply to the new session, not restart the old game",
+      )
 
       release.countDown()
       assertEquals("NEXT_GAME", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -17,9 +17,12 @@ class RomSessionPreparerTest {
     val cache = BootStateCache(2)
     val preparer = RomSessionPreparer(cache)
 
-    val first = assertIs<PreparedSession.FromBootState>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+    val first =
+        assertIs<PreparedSession.FromBootState>(
+            preparer.prepare(FAST_FORWARD_PROPERTIES, LoadRomEvent(ROM)))
     val second =
-        assertIs<PreparedSession.FromBootState>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+        assertIs<PreparedSession.FromBootState>(
+            preparer.prepare(FAST_FORWARD_PROPERTIES, LoadRomEvent(ROM)))
 
     assertSame(first.bootState, second.bootState)
     assertEquals(1, cache.size)
@@ -59,5 +62,11 @@ class RomSessionPreparerTest {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
 
     val PROPERTIES = EmulatorProperties()
+
+    val FAST_FORWARD_PROPERTIES =
+        EmulatorProperties().also {
+          it.properties[EmulatorProperties.Key.BootstrapMode.propertyName] =
+              BootstrapMode.FAST_FORWARD.name
+        }
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -1,0 +1,63 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import org.junit.Test
+
+class RomSessionPreparerTest {
+
+  @Test
+  fun reusesExactBootStateForRepeatedRom() {
+    val cache = BootStateCache(2)
+    val preparer = RomSessionPreparer(cache)
+
+    val first = assertIs<PreparedSession.FromBootState>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+    val second =
+        assertIs<PreparedSession.FromBootState>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+
+    assertSame(first.bootState, second.bootState)
+    assertEquals(1, cache.size)
+    assertEquals(1, cache.hitCount)
+
+    val restored = second.materialize()
+    try {
+      assertEquals(0x0100, restored.cpu.registers.pc)
+    } finally {
+      restored.discardUnstarted()
+    }
+  }
+
+  @Test
+  fun suppliedMementoSkipsBootAndRestoresDirectly() {
+    val config =
+        Controller.createGameboyConfig(PROPERTIES, Rom(ROM)).setBootstrapMode(BootstrapMode.SKIP)
+    val source = config.build()
+    source.addressSpace.setByte(0xc123, 0x5a)
+    val memento = source.saveToMemento()
+    source.discardUnstarted()
+
+    val cache = BootStateCache(2)
+    val prepared =
+        assertIs<PreparedSession.FromMemento>(
+            RomSessionPreparer(cache).prepare(PROPERTIES, LoadRomEvent(ROM, memento)))
+    val restored = prepared.materialize()
+    try {
+      assertEquals(0x5a, restored.addressSpace.getByte(0xc123))
+      assertEquals(0, cache.size)
+    } finally {
+      restored.discardUnstarted()
+    }
+  }
+
+  private companion object {
+    val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
+
+    val PROPERTIES = EmulatorProperties()
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/SystemPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/SystemPropertiesTest.kt
@@ -1,0 +1,40 @@
+package eu.rekawek.coffeegb.controller.properties
+
+import eu.rekawek.coffeegb.controller.Controller
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class SystemPropertiesTest {
+
+  @Test
+  fun `bootstrap mode defaults to skip`() {
+    val properties = EmulatorProperties()
+    properties.properties.remove(EmulatorProperties.Key.BootstrapMode.propertyName)
+
+    assertEquals(BootstrapMode.SKIP, properties.system.bootstrapMode)
+  }
+
+  @Test
+  fun `stored bootstrap mode is preserved`() {
+    val properties = EmulatorProperties()
+
+    for (mode in BootstrapMode.entries) {
+      properties.properties[EmulatorProperties.Key.BootstrapMode.propertyName] = mode.name
+      assertEquals(mode, properties.system.bootstrapMode)
+    }
+  }
+
+  @Test
+  fun `controller configuration uses selected bootstrap mode`() {
+    val properties = EmulatorProperties()
+    val rom = Rom(Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile())
+
+    for (mode in BootstrapMode.entries) {
+      properties.properties[EmulatorProperties.Key.BootstrapMode.propertyName] = mode.name
+      assertEquals(mode, Controller.createGameboyConfig(properties, rom).bootstrapMode)
+    }
+  }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -33,6 +33,8 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.concurrent.CancellationException;
+import java.util.function.BooleanSupplier;
 
 public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Closeable {
 
@@ -267,8 +269,17 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             // tricks the boot ROM, corrupt dumps) lock the boot ROM up forever, and
             // then we fall back to the SKIP presets like a flashcart menu would
             long limit = 40_000_000L;
+            if (configuration.bootCancellation.getAsBoolean()) {
+                throw new CancellationException("Boot cancelled");
+            }
             while (cpu.getRegisters().getPC() != 0x100 && limit-- > 0) {
                 tick();
+                // Controller ROM preparation may be superseded by a newer load request.
+                // Poll sparsely so cancellation is prompt without adding a branch to every
+                // one of the 13-24 million boot ticks.
+                if ((limit & 0x3fff) == 0 && configuration.bootCancellation.getAsBoolean()) {
+                    throw new CancellationException("Boot cancelled");
+                }
             }
             if (gbc && !configuration.cgb0Revision && cpu.getRegisters().getPC() == 0x100) {
                 for (int i = 0; i < CGB_BOOT_HANDOFF_TICKS; i++) {
@@ -771,6 +782,14 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         }
     }
 
+    /** Flushes persistent cartridge state without closing the running machine. */
+    public void flushCartridge() {
+        cartridge.flushBattery();
+        if (slotCartridge != null) {
+            slotCartridge.flushBattery();
+        }
+    }
+
     /**
      * Held-button state, snapshotted separately from the memento by rollback netplay so a held
      * button survives a rebase (the joypad deliberately keeps it out of the memento).
@@ -793,8 +812,31 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         if (!(memento instanceof GameboyMemento mem)) {
             throw new IllegalArgumentException();
         }
+        restoreMachineState(mem, true);
+    }
+
+    /**
+     * Captures the authentic boot-ROM handoff for reuse by another machine with the same ROM
+     * and hardware configuration. Production boot templates are created without file-backed
+     * battery data; restoring one deliberately keeps the receiving cartridge's freshly loaded
+     * RAM, RTC and mapper state.
+     */
+    public BootState saveBootState() {
+        return new BootState((GameboyMemento) saveToMemento());
+    }
+
+    public void restoreBootState(BootState bootState) {
+        if (bootState == null) {
+            throw new IllegalArgumentException("Boot state is required");
+        }
+        restoreMachineState(bootState.memento, false);
+    }
+
+    private void restoreMachineState(GameboyMemento mem, boolean restoreCartridge) {
         biosShadow.restoreFromMemento(mem.biosShadowMemento());
-        cartridge.restoreFromMemento(mem.cartridgeMemento());
+        if (restoreCartridge) {
+            cartridge.restoreFromMemento(mem.cartridgeMemento());
+        }
         gpu.restoreFromMemento(mem.gpuMemento());
         statRegister.restoreFromMemento(mem.statRegisterMemento());
         mmu.restoreFromMemento(mem.mmuMemento());
@@ -826,15 +868,28 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         clearCgbBootOamShadowPending = mem.clearCgbBootOamShadowPending();
     }
 
+    /** Releases an asynchronously prepared machine that was never attached to a session. */
+    public void discardUnstarted() {
+        codeBreakerRumble.close();
+        infraredPort.close();
+        sgbBus.close();
+    }
+
     @Override
     public void close() {
         codeBreakerRumble.close();
         infraredPort.close();
-        cartridge.flushBattery();
-        if (slotCartridge != null) {
-            slotCartridge.flushBattery();
-        }
+        flushCartridge();
         sgbBus.close();
+    }
+
+    public static final class BootState {
+
+        private final GameboyMemento memento;
+
+        private BootState(GameboyMemento memento) {
+            this.memento = memento;
+        }
     }
 
     private record GameboyMemento(Memento<BiosShadow> biosShadowMemento, Memento<Cartridge> cartridgeMemento,
@@ -883,6 +938,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         private boolean codeBreakerRumble;
 
         private TimeSource rtcTimeSource = new SystemTimeSource();
+
+        private BooleanSupplier bootCancellation = () -> false;
 
         public GameboyConfiguration(File romFile) throws IOException {
             this(new Rom(romFile));
@@ -951,6 +1008,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             return this;
         }
 
+        public boolean isDisplaySgbBorder() {
+            return displaySgbBorder;
+        }
+
         public GameboyConfiguration setBootstrapMode(BootstrapMode bootstrapMode) {
             this.bootstrapMode = bootstrapMode;
             return this;
@@ -960,6 +1021,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         public GameboyConfiguration setSlotRom(Rom slotRom) {
             this.slotRom = slotRom;
             return this;
+        }
+
+        public Rom getSlotRom() {
+            return slotRom;
         }
 
         public BootstrapMode getBootstrapMode() {
@@ -973,6 +1038,11 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
         public GameboyConfiguration setSupportBatterySave(boolean supportBatterySave) {
             this.supportBatterySave = supportBatterySave;
+            return this;
+        }
+
+        public GameboyConfiguration setBootCancellation(BooleanSupplier bootCancellation) {
+            this.bootCancellation = bootCancellation == null ? () -> false : bootCancellation;
             return this;
         }
 
@@ -993,9 +1063,24 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
          * discarded by the restore.
          */
         public GameboyConfiguration forRestore() {
+            GameboyConfiguration copy = copy();
+            copy.bootstrapMode = BootstrapMode.SKIP;
+            return copy;
+        }
+
+        /** A boot-equivalent copy that cannot read or write a user's battery save. */
+        public GameboyConfiguration forBootTemplate() {
+            GameboyConfiguration copy = copy();
+            copy.batteryData = null;
+            copy.supportBatterySave = false;
+            return copy;
+        }
+
+        private GameboyConfiguration copy() {
             GameboyConfiguration copy = new GameboyConfiguration(rom);
             copy.gameboyType = gameboyType;
-            copy.bootstrapMode = BootstrapMode.SKIP;
+            copy.bootstrapMode = bootstrapMode;
+            copy.slotRom = slotRom;
             copy.batteryData = batteryData;
             copy.supportBatterySave = supportBatterySave;
             copy.displaySgbBorder = displaySgbBorder;
@@ -1003,6 +1088,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
             copy.mealybugDmgBlob = mealybugDmgBlob;
             copy.codeBreakerRumble = codeBreakerRumble;
             copy.rtcTimeSource = rtcTimeSource;
+            copy.bootCancellation = bootCancellation;
             return copy;
         }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -32,7 +32,7 @@ public final class CartridgeProperties {
         DATEL,
         WISDOM_TREE,
         MBC1,
-        POCKET_CAMERA
+        POCKET_CAMERA,
         MBC5
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
@@ -1,0 +1,73 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode;
+import eu.rekawek.coffeegb.core.Gameboy.GameboyConfiguration;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.util.concurrent.CancellationException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class GameboyBootStateTest {
+
+    @Test
+    public void bootStateRestoresMachineButKeepsFreshCartridgeData() throws Exception {
+        Rom rom = new Rom(mbc1BatteryRom());
+        try (Gameboy source = skipped(rom); Gameboy target = skipped(rom)) {
+            source.getAddressSpace().setByte(0x0000, 0x0a);
+            source.getAddressSpace().setByte(0xa000, 0x11);
+            source.getAddressSpace().setByte(0xc123, 0x77);
+            for (int i = 0; i < 128; i++) {
+                source.tick();
+            }
+
+            Gameboy.BootState bootState = source.saveBootState();
+            Memento<Gameboy> fullState = source.saveToMemento();
+
+            target.getAddressSpace().setByte(0x0000, 0x0a);
+            target.getAddressSpace().setByte(0xa000, 0x66);
+            target.getAddressSpace().setByte(0xc123, 0x00);
+            target.restoreBootState(bootState);
+
+            assertEquals(0x77, target.getAddressSpace().getByte(0xc123));
+            assertEquals(source.getCpu().getRegisters().getPC(), target.getCpu().getRegisters().getPC());
+            assertEquals(0x66, target.getAddressSpace().getByte(0xa000));
+
+            // Ordinary save-state restoration must retain its historical whole-machine behavior.
+            target.restoreFromMemento(fullState);
+            assertEquals(0x11, target.getAddressSpace().getByte(0xa000));
+        }
+    }
+
+    @Test
+    public void fastForwardBootCanBeCancelledBeforeTicking() throws Exception {
+        Rom rom = new Rom(mbc1BatteryRom());
+        GameboyConfiguration configuration = new GameboyConfiguration(rom)
+                .setGameboyType(GameboyType.CGB)
+                .setBootstrapMode(BootstrapMode.FAST_FORWARD)
+                .setBootCancellation(() -> true);
+
+        assertThrows(CancellationException.class, configuration::build);
+    }
+
+    private static Gameboy skipped(Rom rom) {
+        return new GameboyConfiguration(rom)
+                .setGameboyType(GameboyType.CGB)
+                .setBootstrapMode(BootstrapMode.SKIP)
+                .build();
+    }
+
+    private static byte[] mbc1BatteryRom() {
+        byte[] rom = new byte[0x8000];
+        byte[] title = "BOOT CACHE".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, rom, 0x0134, title.length);
+        rom[0x0143] = (byte) 0x80;
+        rom[0x0147] = 0x03; // MBC1 + RAM + battery
+        rom[0x0148] = 0x00;
+        rom[0x0149] = 0x02;
+        return rom;
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -3,6 +3,9 @@ package eu.rekawek.coffeegb.swing
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.Controller.EmulationStartedEvent
 import eu.rekawek.coffeegb.controller.Controller.EmulationStoppedEvent
+import eu.rekawek.coffeegb.controller.Controller.LoadRomFailedEvent
+import eu.rekawek.coffeegb.controller.Controller.RomLoadingCancelledEvent
+import eu.rekawek.coffeegb.controller.Controller.RomLoadingEvent
 import eu.rekawek.coffeegb.controller.Controller.StopEmulationEvent
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopClientEvent
@@ -11,6 +14,7 @@ import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import java.awt.Cursor
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.io.File
@@ -30,6 +34,10 @@ class SwingGui private constructor(debug: Boolean, private val initialRom: File?
 
   private lateinit var mainWindow: JFrame
 
+  private var activeWindowTitle = "Coffee GB"
+
+  private var romLoading = false
+
   init {
     eventBus = EventBusImpl()
     emulator = SwingEmulator(eventBus, console, properties)
@@ -39,8 +47,29 @@ class SwingGui private constructor(debug: Boolean, private val initialRom: File?
     mainWindow = JFrame("Coffee GB")
 
     SwingMenu(properties, mainWindow, eventBus).addMenu()
-    eventBus.register<EmulationStartedEvent> { mainWindow.title = "Coffee GB: ${it.romName}" }
-    eventBus.register<EmulationStoppedEvent> { mainWindow.title = "Coffee GB" }
+    eventBus.register<RomLoadingEvent> {
+      romLoading = true
+      updateLoadingUi("Coffee GB: Loading ${it.rom.name}…", true)
+    }
+    eventBus.register<EmulationStartedEvent> {
+      activeWindowTitle = "Coffee GB: ${it.romName}"
+      romLoading = false
+      updateLoadingUi(activeWindowTitle, false)
+    }
+    eventBus.register<LoadRomFailedEvent> {
+      romLoading = false
+      updateLoadingUi(activeWindowTitle, false)
+    }
+    eventBus.register<RomLoadingCancelledEvent> {
+      romLoading = false
+      updateLoadingUi(activeWindowTitle, false)
+    }
+    eventBus.register<EmulationStoppedEvent> {
+      activeWindowTitle = "Coffee GB"
+      if (!romLoading) {
+        updateLoadingUi(activeWindowTitle, false)
+      }
+    }
 
     mainWindow.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
     mainWindow.addWindowListener(
@@ -71,6 +100,14 @@ class SwingGui private constructor(debug: Boolean, private val initialRom: File?
     console?.stop()
     emulator.stop()
     exitProcess(0)
+  }
+
+  private fun updateLoadingUi(title: String, loading: Boolean) {
+    SwingUtilities.invokeLater {
+      mainWindow.title = title
+      mainWindow.cursor =
+          Cursor.getPredefinedCursor(if (loading) Cursor.WAIT_CURSOR else Cursor.DEFAULT_CURSOR)
+    }
   }
 
   companion object {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -105,8 +105,16 @@ class SwingGui private constructor(debug: Boolean, private val initialRom: File?
   private fun updateLoadingUi(title: String, loading: Boolean) {
     SwingUtilities.invokeLater {
       mainWindow.title = title
-      mainWindow.cursor =
+      val cursor =
           Cursor.getPredefinedCursor(if (loading) Cursor.WAIT_CURSOR else Cursor.DEFAULT_CURSOR)
+      mainWindow.cursor = cursor
+      mainWindow.rootPane.cursor = cursor
+      mainWindow.contentPane.cursor = cursor
+      // A child's explicitly configured cursor can override the frame cursor. The transparent
+      // glass pane sits above every child, so making it visible during loading both guarantees the
+      // wait pointer and prevents mouse interaction with the frozen game.
+      mainWindow.glassPane.cursor = cursor
+      mainWindow.glassPane.isVisible = loading
     }
   }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -25,8 +25,12 @@ import eu.rekawek.coffeegb.controller.network.ConnectionController.StartServerEv
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopClientEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopServerEvent
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.BootstrapMode
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.CgbGamesType
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.DmgGamesType
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode.FAST_FORWARD
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode.NORMAL
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode.SKIP
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.genie.AddPatches
@@ -690,6 +694,23 @@ class SwingMenu(
           uncheckAllBut(menu, item)
           eventBus.post(Controller.UpdatedSystemMappingEvent())
         }
+      }
+    }
+
+    val bootstrapMenu = JMenu("Bootstrap")
+    systemMenu.add(bootstrapMenu)
+    for ((mode, title) in
+        listOf(
+            SKIP to "Skip",
+            FAST_FORWARD to "Fast-forward",
+            NORMAL to "Full",
+        )) {
+      val item = JCheckBoxMenuItem(title, mode == properties.system.bootstrapMode)
+      bootstrapMenu.add(item)
+      item.addActionListener {
+        properties.setProperty(BootstrapMode, mode.name)
+        uncheckAllBut(bootstrapMenu, item)
+        eventBus.post(Controller.UpdatedSystemMappingEvent())
       }
     }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -69,6 +69,8 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private volatile long notificationExpiresAt;
 
+    private volatile String persistentNotificationText;
+
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
         this.eventBus = eventBus;
@@ -88,6 +90,14 @@ public class SwingDisplay extends JPanel implements Runnable {
                 Controller.SnapshotSavedEvent.class, callerId);
         eventBus.register(e -> showNotification("State loaded (slot " + e.getSlot() + ")"),
                 Controller.SnapshotRestoredEvent.class, callerId);
+        eventBus.register(e -> showPersistentNotification("Loading…"),
+                Controller.RomLoadingEvent.class);
+        eventBus.register(e -> clearPersistentNotification(),
+                Controller.LoadRomFailedEvent.class);
+        eventBus.register(e -> clearPersistentNotification(),
+                Controller.RomLoadingCancelledEvent.class);
+        eventBus.register(e -> clearPersistentNotification(),
+                Controller.EmulationStartedEvent.class, callerId);
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());
         setBlending(properties.getBlending());
@@ -227,17 +237,37 @@ public class SwingDisplay extends JPanel implements Runnable {
         notificationText = text;
         notificationExpiresAt = System.nanoTime()
                 + TimeUnit.MILLISECONDS.toNanos(NOTIFICATION_DURATION_MS);
+        repaintNotification(NOTIFICATION_DURATION_MS);
+    }
+
+    private void showPersistentNotification(String text) {
+        persistentNotificationText = text;
+        repaintNotification(0);
+    }
+
+    private void clearPersistentNotification() {
+        if (persistentNotificationText == null) {
+            return;
+        }
+        persistentNotificationText = null;
+        repaintNotification(0);
+    }
+
+    private void repaintNotification(int repaintAfterMs) {
         SwingUtilities.invokeLater(() -> {
             repaint();
-            Timer timer = new Timer(NOTIFICATION_DURATION_MS, e -> repaint());
-            timer.setRepeats(false);
-            timer.start();
+            if (repaintAfterMs > 0) {
+                Timer timer = new Timer(repaintAfterMs, e -> repaint());
+                timer.setRepeats(false);
+                timer.start();
+            }
         });
     }
 
     private void paintNotification(Graphics2D g, int width, int height, int localScale) {
-        String text = notificationText;
-        if (text == null || System.nanoTime() >= notificationExpiresAt) {
+        String persistentText = persistentNotificationText;
+        String text = persistentText != null ? persistentText : notificationText;
+        if (text == null || (persistentText == null && System.nanoTime() >= notificationExpiresAt)) {
             return;
         }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.concurrent.CountDownLatch;
@@ -18,6 +19,31 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class SwingDisplayTest {
+
+    @Test
+    public void romLoadingShowsPersistentNotificationUntilLoadingFinishes() throws Exception {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        EventBus session = root.fork("test");
+        SwingDisplay display = new SwingDisplay(
+                new EmulatorProperties().getDisplay(), root, "test");
+        Field textField = SwingDisplay.class.getDeclaredField("persistentNotificationText");
+        textField.setAccessible(true);
+
+        session.post(new Controller.RomLoadingEvent(new File("next.gb")));
+        assertEquals("Loading…", textField.get(display));
+
+        session.post(new Controller.EmulationStartedEvent("NEXT"));
+        assertNull(textField.get(display));
+
+        session.post(new Controller.RomLoadingEvent(new File("broken.gb")));
+        session.post(new Controller.LoadRomFailedEvent(new File("broken.gb"), "broken"));
+        assertNull(textField.get(display));
+
+        session.post(new Controller.RomLoadingEvent(new File("cancelled.gb")));
+        session.post(new Controller.RomLoadingCancelledEvent(new File("cancelled.gb")));
+        assertNull(textField.get(display));
+        root.close();
+    }
 
     @Test
     public void snapshotCompletionEventsShowAnOnScreenNotification() throws Exception {


### PR DESCRIPTION
## Summary

Fixes #161 by removing the multi-second, apparently unresponsive interval from repeated ROM loads while preserving authentic boot-ROM modes as explicit choices. Bootstrap now defaults to **Skip**; users can choose **Skip**, **Fast-forward**, or **Full** under **System > Bootstrap**.

The attached `FREEART Intro V2 (PD) [C].gbc` (SHA-256 `31427c639036b908bd4fc59cb3a2b337096828e22c86d08622bb1229c0885cb2`) reliably loaded, but profiling showed that fast-forwarding every session rebuild synchronously emulated roughly 13 million CGB boot ticks. That consumed about 2.3 seconds of CPU on the controller thread, preventing event dispatch and making Ctrl+L look ignored.

## Changes

- add a persisted `system.bootstrapMode` property, defaulting to `SKIP`;
- add **System > Bootstrap > Skip / Fast-forward / Full** and immediately reload the active session when the mode changes;
- apply the chosen mode consistently to normal and linked controllers;
- prepare ROMs and fast-forward boot handoffs on a cancellable background worker while freezing the current game on its last completed frame;
- show a persistent `Loading…` overlay in the same style as save/load-state notifications until loading succeeds, fails, or is cancelled;
- use a transparent glass pane to provide a reliable wait cursor over every child component and block mouse interaction during loading;
- preserve the requested pause/resume state for the new session without allowing Resume to restart the old game while loading;
- coalesce rapid requests so only the newest selection starts;
- cache up to eight exact SHA-256/configuration-keyed boot handoff states when Fast-forward is selected for ordinary non-RTC cartridges;
- restore cached machine state without overwriting freshly loaded cartridge RAM, RTC, or mapper state;
- exclude RTC, slot-ROM, and compatibility-mapper configurations from the cache and retain the selected boot path for them;
- skip boot execution entirely when a supplied memento will immediately replace machine state;
- reuse the same optimized path for reset;
- retain loading title/cursor cleanup for failure and cancellation;
- make Fast-forward cooperative with cancellation and clean up superseded prepared sessions;
- repair the missing mapper-enum separator on current `master`, which otherwise prevents PR merge refs from compiling.

## Verification

Issue-ROM stress in Fast-forward mode, one `BasicController` instance, deterministic seed `0x161c0ffee0`:

- 100 sequential loads plus 20 three-request bursts (160 requests);
- randomized waits and pseudo-random press/release actions across all buttons;
- zero failures and exactly 40 superseded-request cancellations;
- first load: 2311.8 ms;
- cached reloads: 28.2 ms median, 36.8 ms p95, 74.3 ms maximum.

Latest clean validation:

- `mvn -B clean test -pl controller,swing -am` passes (679 core, 25 controller, and 13 Swing tests);
- property coverage verifies Skip as the default and all three persisted values;
- controller coverage verifies that the old game emits no frames during preparation, including after Resume is requested;
- Swing coverage verifies that `Loading…` persists and is cleared on success, failure, and cancellation.