### PR TITLE
Add four-player adapter emulation and netplay

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/SnapshotManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/SnapshotManager.kt
@@ -43,3 +43,14 @@ fun Memento<Gameboy>.serialize(): ByteArray {
 fun ByteArray.deserializeToGameboyMemento(): Memento<Gameboy> {
   return ObjectInputStream(inputStream()).use { it.readObject() as Memento<Gameboy> }
 }
+
+fun Memento<Session>.serializeSessionMemento(): ByteArray {
+  val baos = ByteArrayOutputStream()
+  ObjectOutputStream(baos).use { it.writeObject(this) }
+  return baos.toByteArray()
+}
+
+fun ByteArray.deserializeToSessionMemento(): Memento<Session> {
+  @Suppress("UNCHECKED_CAST")
+  return ObjectInputStream(inputStream()).use { it.readObject() as Memento<Session> }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkMode.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkMode.kt
@@ -1,0 +1,6 @@
+package eu.rekawek.coffeegb.controller.link
+
+enum class LinkMode(val playerCount: Int) {
+  NORMAL(2),
+  FOUR_PLAYER_ADAPTER(4),
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -11,6 +11,7 @@ import eu.rekawek.coffeegb.controller.Input
 import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.TimingTicker
 import eu.rekawek.coffeegb.controller.deserializeToGameboyMemento
+import eu.rekawek.coffeegb.controller.deserializeToSessionMemento
 import eu.rekawek.coffeegb.controller.events.EventQueue
 import eu.rekawek.coffeegb.controller.events.funnel
 import eu.rekawek.coffeegb.controller.events.register
@@ -19,8 +20,11 @@ import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteResetEven
 import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteStopEvent
 import eu.rekawek.coffeegb.controller.network.Connection.RequestResetEvent
 import eu.rekawek.coffeegb.controller.network.Connection.RequestStopEvent
+import eu.rekawek.coffeegb.controller.network.Connection.SessionCheckpointEvent
+import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerPlayerDisconnectedEvent
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.serialize
+import eu.rekawek.coffeegb.controller.serializeSessionMemento
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.GameboyConfiguration
 import eu.rekawek.coffeegb.core.Gameboy.TICKS_PER_FRAME
@@ -30,6 +34,7 @@ import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.gpu.Display
+import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
@@ -64,6 +69,10 @@ class LinkedController(
 
   private val configs = MutableList<GameboyConfiguration?>(mode.playerCount) { null }
 
+  private val romBuffers = MutableList<ByteArray?>(mode.playerCount) { null }
+
+  private val batteryBuffers = MutableList<ByteArray?>(mode.playerCount) { null }
+
   private val links = StateHistory.createLinks(mode)
 
   @VisibleForTesting internal val stateHistory: StateHistory = StateHistory(mode)
@@ -73,6 +82,8 @@ class LinkedController(
 
   @VisibleForTesting internal fun activeSessionCount() = sessions.count { it != null }
 
+  @VisibleForTesting internal fun currentFrame() = frame
+
   @Volatile private var doStop = false
 
   private var frame = 0L
@@ -81,7 +92,8 @@ class LinkedController(
 
   private var lastInput: Input? = null
 
-  private var initialRosterReady = false
+  private var initialStateSynchronized =
+      mode != LinkMode.FOUR_PLAYER_ADAPTER || localPlayer == 0
 
   private var lastSync: TimeSource.Monotonic.ValueTimeMark = TimeSource.Monotonic.markNow()
 
@@ -98,36 +110,67 @@ class LinkedController(
       sessions[localPlayer]?.close()
       sessions[localPlayer] = null
       configs[localPlayer] = e.config
-      initSession(localPlayer, frame, e.snapshot?.deserializeToGameboyMemento())
+      initSession(localPlayer, frame, e.snapshot?.deserializeToGameboyMemento(), null)
       sendLocalRom(e.snapshot)
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER && localPlayer == 0) {
+        broadcastCurrentState()
+      }
     }
 
     eventQueue.register<StopEmulationEvent> {
       sessions[localPlayer]?.close()
       sessions[localPlayer] = null
-      eventBus.postAsync(RequestStopEvent(frame, localPlayer))
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER && localPlayer == 0) {
+        broadcastCurrentState()
+      } else {
+        eventBus.postAsync(RequestStopEvent(frame, localPlayer))
+      }
     }
 
     eventQueue.register<ResetEmulationEvent> {
       sessions[localPlayer]?.close()
       sessions[localPlayer] = null
-      initSession(localPlayer, frame, null)
+      initSession(localPlayer, frame, null, null)
       eventBus.postAsync(RequestResetEvent(frame, localPlayer))
     }
 
     eventQueue.register<PeerLoadedGameEvent> { e ->
-      if (e.player == localPlayer || e.player !in sessions.indices) {
-        return@register
+      if (!loadPeerState(e)) return@register
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER &&
+          localPlayer == 0 &&
+          e.sessionSnapshot == null) {
+        // The new physical port is now attached at this frame. Publish one checkpoint containing
+        // every active console plus the shared adapter so old and new clients resume together.
+        broadcastCurrentState()
       }
-      configs[e.player] =
-          createGameboyConfig(properties, Rom(e.rom))
-              .setGameboyType(e.gameboyType)
-              .setBootstrapMode(e.bootstrapMode)
-              .setCgb0Revision(e.cgb0Revision)
-              .setBatteryData(e.battery)
-      sessions[e.player]?.close()
-      sessions[e.player] = null
-      initSession(e.player, e.frame, e.snapshot?.deserializeToGameboyMemento())
+    }
+
+    eventQueue.register<SessionCheckpointEvent> { e ->
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER && localPlayer != 0) {
+        val activePlayers = e.states.mapTo(mutableSetOf()) { it.player }
+        sessions.indices.filterNot(activePlayers::contains).forEach { player ->
+          sessions[player]?.close()
+          sessions[player] = null
+          configs[player] = null
+          romBuffers[player] = null
+          batteryBuffers[player] = null
+        }
+        e.states.forEach(::loadPeerState)
+        stateHistory.clear()
+        frame = e.frame
+        initialStateSynchronized = true
+      }
+    }
+
+    eventQueue.register<ServerPlayerDisconnectedEvent> { e ->
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER && localPlayer == 0 && e.player in sessions.indices) {
+        sessions[e.player]?.close()
+        sessions[e.player] = null
+        configs[e.player] = null
+        romBuffers[e.player] = null
+        batteryBuffers[e.player] = null
+        broadcastCurrentState()
+      }
     }
 
     eventQueue.register<RemoteButtonStateEvent> { e ->
@@ -140,7 +183,7 @@ class LinkedController(
       if (e.player != localPlayer && e.player in sessions.indices) {
         sessions[e.player]?.close()
         sessions[e.player] = null
-        initSession(e.player, e.frame, null)
+        initSession(e.player, e.frame, null, null)
       }
     }
 
@@ -148,6 +191,9 @@ class LinkedController(
       if (e.player != localPlayer && e.player in sessions.indices) {
         sessions[e.player]?.close()
         sessions[e.player] = null
+        if (mode == LinkMode.FOUR_PLAYER_ADAPTER && localPlayer == 0) {
+          broadcastCurrentState()
+        }
       }
     }
 
@@ -196,16 +242,18 @@ class LinkedController(
   fun runFrame() {
     eventQueue.dispatch()
 
-    // All peers begin on the same frame. In particular, the four-player server waits for all
-    // three client ROM states instead of letting player 1 advance and making late clients catch
-    // up without the adapter traffic they missed.
-    if (!initialRosterReady && sessions.any { it == null }) {
+    // A DMG-07 host runs with any number of attached ports. A client waits only for the coherent
+    // group checkpoint sent after the host hot-plugs it; normal two-player link keeps its original
+    // both-ROM startup behavior.
+    val waitingForInitialState =
+        if (mode == LinkMode.FOUR_PLAYER_ADAPTER) !initialStateSynchronized
+        else sessions.any { it == null }
+    if (waitingForInitialState) {
       if (!timingTicker.disabled) {
         Thread.sleep(1)
       }
       return
     }
-    initialRosterReady = true
 
     if (stateHistory.merge(configs)) {
       val head = stateHistory.getHead()
@@ -235,7 +283,7 @@ class LinkedController(
         sessions.map { it?.heldButtons ?: emptySet() },
     )
 
-    effectiveInput.send(sessions[localPlayer]!!.eventBus)
+    sessions[localPlayer]?.let { effectiveInput.send(it.eventBus) }
 
     if (!effectiveInput.isEmpty() || lastSync.elapsedNow() > 5.seconds) {
       eventBus.postAsync(LocalButtonStateEvent(frame, effectiveInput, localPlayer))
@@ -250,7 +298,13 @@ class LinkedController(
     frame++
   }
 
-  private fun initSession(player: Int, sessionFrame: Long, state: Memento<Gameboy>?) {
+  private fun initSession(
+      player: Int,
+      sessionFrame: Long,
+      state: Memento<Gameboy>?,
+      sessionState: Memento<Session>?,
+      heldButtons: Set<Button> = emptySet(),
+  ) {
     val config = configs[player] ?: return
     val sessionEventBus = EventBusImpl(null, null, false)
     if (player == localPlayer) {
@@ -269,20 +323,27 @@ class LinkedController(
     }
     val session =
         Session(
-            if (state != null) config.forRestore() else config,
+            if (state != null || sessionState != null) config.forRestore() else config,
             sessionEventBus,
             if (player == localPlayer) console else null,
             links.serial[player],
             links.infrared[player],
         )
-    if (state != null) {
+    if (sessionState != null) {
+      session.restoreFromMemento(sessionState)
+      session.heldButtons = heldButtons
+    } else if (state != null) {
       session.gameboy.restoreFromMemento(state)
     }
 
-    // This is primarily for a ROM reload/reset arriving a few frames late. Initial four-player
-    // startup is held at frame zero until every session exists.
+    // A four-player ROM arriving at the host is a hot-plug at the current adapter phase. Session
+    // checkpoints are already at their advertised frame. Other late reset/reload events retain
+    // the historical catch-up path.
     var current = sessionFrame
-    while (current < frame) {
+    val hotPlug =
+        mode == LinkMode.FOUR_PLAYER_ADAPTER &&
+            (sessionState != null || (localPlayer == 0 && player != localPlayer))
+    while (!hotPlug && current < frame) {
       stateHistory.setPlayerState(player, current, session.saveToMemento(), session.heldButtons)
       repeat(TICKS_PER_FRAME) { session.gameboy.tick() }
       current++
@@ -290,11 +351,38 @@ class LinkedController(
     sessions[player] = session
   }
 
+  private fun loadPeerState(e: PeerLoadedGameEvent): Boolean {
+    if (e.player !in sessions.indices ||
+        (e.player == localPlayer && e.sessionSnapshot == null)) {
+      return false
+    }
+    configs[e.player] =
+        createGameboyConfig(properties, Rom(e.rom))
+            .setGameboyType(e.gameboyType)
+            .setBootstrapMode(e.bootstrapMode)
+            .setCgb0Revision(e.cgb0Revision)
+            .setBatteryData(e.battery)
+    romBuffers[e.player] = e.rom
+    batteryBuffers[e.player] = e.battery
+    sessions[e.player]?.close()
+    sessions[e.player] = null
+    initSession(
+        e.player,
+        e.frame,
+        e.snapshot?.deserializeToGameboyMemento(),
+        e.sessionSnapshot?.deserializeToSessionMemento(),
+        e.heldButtons,
+    )
+    return true
+  }
+
   private fun sendLocalRom(snapshot: ByteArray?) {
     val config = configs[localPlayer] ?: return
     val romBuffer = config.rom.file.toPath().readBytes()
     val saveFile = Cartridge.getSaveName(config.rom.file)
     val batteryBuffer = if (saveFile.exists()) saveFile.toPath().readBytes() else null
+    romBuffers[localPlayer] = romBuffer
+    batteryBuffers[localPlayer] = batteryBuffer
 
     eventBus.post(
         LocalRomLoadedEvent(
@@ -307,6 +395,28 @@ class LinkedController(
             cgb0Revision = config.isCgb0Revision,
             player = localPlayer,
         ))
+  }
+
+  private fun broadcastCurrentState() {
+    val states =
+        sessions.mapIndexedNotNull { player, session ->
+          val config = configs[player] ?: return@mapIndexedNotNull null
+          session ?: return@mapIndexedNotNull null
+          val romBuffer = romBuffers[player] ?: return@mapIndexedNotNull null
+          LocalRomLoadedEvent(
+              romFile = romBuffer,
+              batteryFile = batteryBuffers[player],
+              snapshot = null,
+              gameboyType = config.gameboyType,
+              bootstrapMode = config.bootstrapMode,
+              frame = frame,
+              cgb0Revision = config.isCgb0Revision,
+              player = player,
+              sessionSnapshot = session.saveToMemento().serializeSessionMemento(),
+              heldButtons = session.heldButtons,
+          )
+        }
+    eventBus.post(SessionStateReadyEvent(frame, states))
   }
 
   override fun close() {}
@@ -335,7 +445,11 @@ class LinkedController(
       val frame: Long,
       val cgb0Revision: Boolean = false,
       val player: Int = 0,
+      val sessionSnapshot: ByteArray? = null,
+      val heldButtons: Set<Button> = emptySet(),
   ) : Event
+
+  data class SessionStateReadyEvent(val frame: Long, val states: List<LocalRomLoadedEvent>) : Event
 
   data class LocalButtonStateEvent(
       val frame: Long,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -18,6 +18,7 @@ import eu.rekawek.coffeegb.controller.network.Connection.PeerLoadedGameEvent
 import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteResetEvent
 import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteStopEvent
 import eu.rekawek.coffeegb.controller.network.Connection.RequestResetEvent
+import eu.rekawek.coffeegb.controller.network.Connection.RequestStopEvent
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.serialize
 import eu.rekawek.coffeegb.core.Gameboy
@@ -29,7 +30,6 @@ import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.gpu.Display
-import eu.rekawek.coffeegb.core.ir.Peer2PeerInfraredEndpoint
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
@@ -37,7 +37,6 @@ import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent
-import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay
 import eu.rekawek.coffeegb.core.sound.Sound
 import kotlin.io.path.readBytes
@@ -46,10 +45,13 @@ import kotlin.time.TimeSource
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+/** Runs every Game Boy in a netplay session locally and rolls them back as remote input arrives. */
 class LinkedController(
     parentEventBus: EventBus,
     private val properties: EmulatorProperties,
     private val console: Console?,
+    private val mode: LinkMode = LinkMode.NORMAL,
+    private val localPlayer: Int = 0,
 ) : Controller {
 
   private val eventBus = parentEventBus.fork("session")
@@ -58,33 +60,28 @@ class LinkedController(
 
   @VisibleForTesting internal val timingTicker = TimingTicker()
 
-  private var mainSession: Session? = null
+  private val sessions = MutableList<Session?>(mode.playerCount) { null }
 
-  private var peerSession: Session? = null
+  private val configs = MutableList<GameboyConfiguration?>(mode.playerCount) { null }
 
-  private var mainConfig: GameboyConfiguration? = null
+  private val links = StateHistory.createLinks(mode)
 
-  private var peerConfig: GameboyConfiguration? = null
+  @VisibleForTesting internal val stateHistory: StateHistory = StateHistory(mode)
 
-  @VisibleForTesting internal val stateHistory: StateHistory = StateHistory()
+  @VisibleForTesting
+  internal fun mainHeldButtons() = sessions[localPlayer]?.heldButtons ?: emptySet()
 
-  @VisibleForTesting internal fun mainHeldButtons() = mainSession?.heldButtons ?: emptySet()
+  @VisibleForTesting internal fun activeSessionCount() = sessions.count { it != null }
 
   @Volatile private var doStop = false
-
-  private val mainSerialEndpoint = Peer2PeerSerialEndpoint()
-
-  private val peerSerialEndpoint = Peer2PeerSerialEndpoint()
-
-  private val mainInfraredEndpoint = Peer2PeerInfraredEndpoint()
-
-  private val peerInfraredEndpoint = Peer2PeerInfraredEndpoint()
 
   private var frame = 0L
 
   private var currentInput: Input? = null
 
   private var lastInput: Input? = null
+
+  private var initialRosterReady = false
 
   private var lastSync: TimeSource.Monotonic.ValueTimeMark = TimeSource.Monotonic.markNow()
 
@@ -95,62 +92,80 @@ class LinkedController(
   }
 
   init {
-    peerSerialEndpoint.init(mainSerialEndpoint)
-    peerInfraredEndpoint.init(mainInfraredEndpoint)
+    require(localPlayer in 0 until mode.playerCount)
 
-    eventQueue.register<LoadedMainConfigEvent> { e ->
-      mainSession?.close()
-      mainConfig = e.config
-      initMainSession(e.snapshot)
+    eventQueue.register<LoadedLocalConfigEvent> { e ->
+      sessions[localPlayer]?.close()
+      sessions[localPlayer] = null
+      configs[localPlayer] = e.config
+      initSession(localPlayer, frame, e.snapshot?.deserializeToGameboyMemento())
+      sendLocalRom(e.snapshot)
     }
 
     eventQueue.register<StopEmulationEvent> {
-      mainSession?.close()
-      mainSession = null
+      sessions[localPlayer]?.close()
+      sessions[localPlayer] = null
+      eventBus.postAsync(RequestStopEvent(frame, localPlayer))
     }
 
     eventQueue.register<ResetEmulationEvent> {
-      mainSession?.close()
-      initMainSession(null)
-      eventBus.postAsync(RequestResetEvent(frame))
+      sessions[localPlayer]?.close()
+      sessions[localPlayer] = null
+      initSession(localPlayer, frame, null)
+      eventBus.postAsync(RequestResetEvent(frame, localPlayer))
     }
 
     eventQueue.register<PeerLoadedGameEvent> { e ->
-      peerConfig =
+      if (e.player == localPlayer || e.player !in sessions.indices) {
+        return@register
+      }
+      configs[e.player] =
           createGameboyConfig(properties, Rom(e.rom))
               .setGameboyType(e.gameboyType)
               .setBootstrapMode(e.bootstrapMode)
               .setCgb0Revision(e.cgb0Revision)
               .setBatteryData(e.battery)
-      initPeerSession(e.frame, e.snapshot?.deserializeToGameboyMemento())
+      sessions[e.player]?.close()
+      sessions[e.player] = null
+      initSession(e.player, e.frame, e.snapshot?.deserializeToGameboyMemento())
     }
 
     eventQueue.register<RemoteButtonStateEvent> { e ->
-      stateHistory.addSecondaryInput(e.frame, e.input)
+      if (e.player != localPlayer && e.player in sessions.indices) {
+        stateHistory.addSecondaryInput(e.player, e.frame, e.input)
+      }
     }
 
     eventQueue.register<ReceivedRemoteResetEvent> { e ->
-      peerSession?.close()
-      initPeerSession(e.frame, null)
+      if (e.player != localPlayer && e.player in sessions.indices) {
+        sessions[e.player]?.close()
+        sessions[e.player] = null
+        initSession(e.player, e.frame, null)
+      }
     }
 
-    eventQueue.register<ReceivedRemoteStopEvent> { peerSession?.close() }
+    eventQueue.register<ReceivedRemoteStopEvent> { e ->
+      if (e.player != localPlayer && e.player in sessions.indices) {
+        sessions[e.player]?.close()
+        sessions[e.player] = null
+      }
+    }
 
     eventQueue.register<ButtonPressEvent> { e ->
-      val currentInput = currentInput ?: Input(emptyList(), emptyList())
-      this.currentInput =
-          currentInput.copy(
-              pressedButtons = (currentInput.pressedButtons + e.button).sorted(),
-              releasedButtons = (currentInput.releasedButtons - e.button).sorted(),
+      val input = currentInput ?: Input(emptyList(), emptyList())
+      currentInput =
+          input.copy(
+              pressedButtons = (input.pressedButtons + e.button).sorted(),
+              releasedButtons = (input.releasedButtons - e.button).sorted(),
           )
     }
 
     eventQueue.register<ButtonReleaseEvent> { e ->
-      val currentInput = currentInput ?: Input(emptyList(), emptyList())
-      this.currentInput =
-          currentInput.copy(
-              pressedButtons = (currentInput.pressedButtons - e.button).sorted(),
-              releasedButtons = (currentInput.releasedButtons + e.button).sorted(),
+      val input = currentInput ?: Input(emptyList(), emptyList())
+      currentInput =
+          input.copy(
+              pressedButtons = (input.pressedButtons - e.button).sorted(),
+              releasedButtons = (input.releasedButtons + e.button).sorted(),
           )
     }
 
@@ -161,11 +176,11 @@ class LinkedController(
       eventBus.post(Controller.SessionPauseSupportEvent(false))
       eventBus.post(Controller.SessionSnapshotSupportEvent(null))
       eventBus.post(Controller.EmulationStartedEvent(rom.title))
-      eventBus.post(LoadedMainConfigEvent(config, it.memento?.serialize()))
+      eventBus.post(LoadedLocalConfigEvent(config, it.memento?.serialize()))
     }
 
     eventBus.register<UpdatedSystemMappingEvent> {
-      mainSession?.config?.let { config ->
+      sessions[localPlayer]?.config?.let { config ->
         val newType = Controller.getGameboyType(properties.system, config.rom)
         if (newType != config.gameboyType) {
           eventBus.post(LoadRomEvent(config.rom.file))
@@ -181,17 +196,26 @@ class LinkedController(
   fun runFrame() {
     eventQueue.dispatch()
 
-    val mainSession = mainSession
-    val peerSession = peerSession
-    if (stateHistory.merge(mainSession?.config, peerSession?.config)) {
-      val head = stateHistory.getHead()
-      if (mainSession != null && head.mainMemento != null) {
-        mainSession.restoreFromMemento(head.mainMemento)
-        mainSession.heldButtons = head.mainButtons
+    // All peers begin on the same frame. In particular, the four-player server waits for all
+    // three client ROM states instead of letting player 1 advance and making late clients catch
+    // up without the adapter traffic they missed.
+    if (!initialRosterReady && sessions.any { it == null }) {
+      if (!timingTicker.disabled) {
+        Thread.sleep(1)
       }
-      if (peerSession != null && head.peerMemento != null) {
-        peerSession.restoreFromMemento(head.peerMemento)
-        peerSession.heldButtons = head.peerButtons
+      return
+    }
+    initialRosterReady = true
+
+    if (stateHistory.merge(configs)) {
+      val head = stateHistory.getHead()
+      for (player in sessions.indices) {
+        val session = sessions[player]
+        val memento = head.mementos[player]
+        if (session != null && memento != null) {
+          session.restoreFromMemento(memento)
+          session.heldButtons = head.buttons[player]
+        }
       }
       frame = head.frame
       LOG.atDebug().log("State merged to {}", frame)
@@ -202,118 +226,87 @@ class LinkedController(
     lastInput = input
     currentInput = null
 
-    // Snapshot BEFORE applying this frame's input, exactly like StateHistory.merge does, so a
-    // later rebase that restores this state and replays effectiveInput reproduces the frame
-    // bit-for-bit. The held-button sets are captured too because the joypad keeps them out of
-    // the memento - without them a button held before the rebase base frame is lost (#79).
+    val inputs = MutableList(mode.playerCount) { Input(emptyList(), emptyList()) }
+    inputs[localPlayer] = effectiveInput
     stateHistory.addState(
         frame,
-        effectiveInput,
-        mainSession?.saveToMemento(),
-        peerSession?.saveToMemento(),
-        mainSession?.heldButtons ?: emptySet(),
-        peerSession?.heldButtons ?: emptySet(),
+        inputs,
+        sessions.map { it?.saveToMemento() },
+        sessions.map { it?.heldButtons ?: emptySet() },
     )
 
-    if (mainSession != null) {
-      effectiveInput.send(mainSession.eventBus)
-    }
+    effectiveInput.send(sessions[localPlayer]!!.eventBus)
 
     if (!effectiveInput.isEmpty() || lastSync.elapsedNow() > 5.seconds) {
-      eventBus.postAsync(LocalButtonStateEvent(frame, effectiveInput))
+      eventBus.postAsync(LocalButtonStateEvent(frame, effectiveInput, localPlayer))
       lastSync = TimeSource.Monotonic.markNow()
     }
 
     repeat(TICKS_PER_FRAME) {
-      mainSession?.gameboy?.tick()
-      peerSession?.gameboy?.tick()
+      sessions.forEach { it?.gameboy?.tick() }
       timingTicker.run()
     }
 
     frame++
   }
 
-  private fun initMainSession(snapshot: ByteArray?) {
-    val mainConfig = mainConfig ?: return
-
-    val mainEventBus = EventBusImpl(null, null, false)
-    funnel(
-        mainEventBus,
-        eventBus.fork("main"),
-        setOf(
-            Display.DmgFrameReadyEvent::class,
-            Display.GbcFrameReadyEvent::class,
-            SgbDisplay.SgbFrameReadyEvent::class,
-            Sound.SoundSampleEvent::class,
-            RumbleEvent::class,
-            Joypad.JoypadPressEvent::class,
-        ),
-    )
-    mainSession =
+  private fun initSession(player: Int, sessionFrame: Long, state: Memento<Gameboy>?) {
+    val config = configs[player] ?: return
+    val sessionEventBus = EventBusImpl(null, null, false)
+    if (player == localPlayer) {
+      funnel(
+          sessionEventBus,
+          eventBus.fork("main"),
+          setOf(
+              Display.DmgFrameReadyEvent::class,
+              Display.GbcFrameReadyEvent::class,
+              SgbDisplay.SgbFrameReadyEvent::class,
+              Sound.SoundSampleEvent::class,
+              RumbleEvent::class,
+              Joypad.JoypadPressEvent::class,
+          ),
+      )
+    }
+    val session =
         Session(
-            if (snapshot != null) mainConfig.forRestore() else mainConfig,
-            mainEventBus,
-            console,
-            mainSerialEndpoint,
-            mainInfraredEndpoint,
+            if (state != null) config.forRestore() else config,
+            sessionEventBus,
+            if (player == localPlayer) console else null,
+            links.serial[player],
+            links.infrared[player],
         )
-    if (snapshot != null) {
-      mainSession?.gameboy?.restoreFromMemento(snapshot.deserializeToGameboyMemento())
+    if (state != null) {
+      session.gameboy.restoreFromMemento(state)
     }
 
-    val romBuffer = mainConfig.rom.file.toPath().readBytes()
-    val saveFile = Cartridge.getSaveName(mainConfig.rom.file)
-    val batteryBuffer =
-        if (saveFile.exists()) {
-          saveFile.toPath().readBytes()
-        } else {
-          null
-        }
+    // This is primarily for a ROM reload/reset arriving a few frames late. Initial four-player
+    // startup is held at frame zero until every session exists.
+    var current = sessionFrame
+    while (current < frame) {
+      stateHistory.setPlayerState(player, current, session.saveToMemento(), session.heldButtons)
+      repeat(TICKS_PER_FRAME) { session.gameboy.tick() }
+      current++
+    }
+    sessions[player] = session
+  }
+
+  private fun sendLocalRom(snapshot: ByteArray?) {
+    val config = configs[localPlayer] ?: return
+    val romBuffer = config.rom.file.toPath().readBytes()
+    val saveFile = Cartridge.getSaveName(config.rom.file)
+    val batteryBuffer = if (saveFile.exists()) saveFile.toPath().readBytes() else null
 
     eventBus.post(
         LocalRomLoadedEvent(
             romFile = romBuffer,
             batteryFile = batteryBuffer,
             snapshot = snapshot,
-            mainConfig.gameboyType,
-            mainConfig.bootstrapMode,
-            frame,
-            cgb0Revision = mainConfig.isCgb0Revision,
-        )
-    )
-  }
-
-  private fun initPeerSession(frame: Long, state: Memento<Gameboy>?) {
-    val peerConfig = peerConfig ?: return
-    val peerEventBus = EventBusImpl(null, null, false)
-    val peerSession =
-        Session(
-            if (state != null) peerConfig.forRestore() else peerConfig,
-            peerEventBus,
-            null,
-            peerSerialEndpoint,
-            peerInfraredEndpoint,
-        )
-    if (state != null) {
-      peerSession.gameboy.restoreFromMemento(state)
-    }
-
-    val mainSession = mainSession
-    while (this.frame < frame) {
-      if (mainSession != null) {
-        repeat(TICKS_PER_FRAME) { mainSession.gameboy.tick() }
-      }
-      this.frame++
-    }
-
-    var peerFrame = frame
-    while (this.frame > peerFrame) {
-      stateHistory.setPeerState(peerFrame, peerSession.saveToMemento(), peerSession.heldButtons)
-      repeat(TICKS_PER_FRAME) { peerSession.gameboy.tick() }
-      peerFrame++
-    }
-
-    this.peerSession = peerSession
+            gameboyType = config.gameboyType,
+            bootstrapMode = config.bootstrapMode,
+            frame = frame,
+            cgb0Revision = config.isCgb0Revision,
+            player = localPlayer,
+        ))
   }
 
   override fun close() {}
@@ -322,12 +315,12 @@ class LinkedController(
     doStop = true
     thread.join()
 
+    val localSession = sessions[localPlayer]
     val state =
-        mainSession?.let { Controller.ControllerState(it.gameboy.saveToMemento(), it.config.rom) }
+        localSession?.let { Controller.ControllerState(it.gameboy.saveToMemento(), it.config.rom) }
 
-    mainSession?.eventBus?.post(Controller.EmulationStoppedEvent())
-    mainSession?.close()
-    peerSession?.close()
+    localSession?.eventBus?.post(Controller.EmulationStoppedEvent())
+    sessions.forEach { it?.close() }
     eventBus.close()
 
     return state
@@ -341,19 +334,22 @@ class LinkedController(
       val bootstrapMode: Gameboy.BootstrapMode,
       val frame: Long,
       val cgb0Revision: Boolean = false,
+      val player: Int = 0,
   ) : Event
 
   data class LocalButtonStateEvent(
       val frame: Long,
       val input: Input,
+      val player: Int = 0,
   ) : Event
 
   data class RemoteButtonStateEvent(
       val frame: Long,
       val input: Input,
+      val player: Int = 1,
   ) : Event
 
-  data class LoadedMainConfigEvent(val config: GameboyConfiguration, val snapshot: ByteArray?) :
+  data class LoadedLocalConfigEvent(val config: GameboyConfiguration, val snapshot: ByteArray?) :
       Event
 
   private companion object {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -9,18 +9,21 @@ import eu.rekawek.coffeegb.core.Gameboy.TICKS_PER_FRAME
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.ir.InfraredEndpoint
 import eu.rekawek.coffeegb.core.ir.Peer2PeerInfraredEndpoint
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.Joypad
 import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.core.serial.FourPlayerAdapter
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import java.util.*
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import java.util.LinkedList
 import kotlin.math.max
 import kotlin.math.min
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
-class StateHistory() {
+class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
   private val states = LinkedList<State>()
 
   private val patches = mutableListOf<Patch>()
@@ -30,13 +33,14 @@ class StateHistory() {
   @Synchronized
   fun addState(
       frame: Long,
-      mainInput: Input,
-      mainMemento: Memento<Session>?,
-      peerMemento: Memento<Session>?,
-      mainButtons: Set<Button>,
-      peerButtons: Set<Button>,
+      inputs: List<Input>,
+      mementos: List<Memento<Session>?>,
+      buttons: List<Set<Button>>,
   ) {
-    states.add(State(frame, mainInput, mainMemento, peerMemento, mainButtons, peerButtons))
+    require(inputs.size == mode.playerCount)
+    require(mementos.size == mode.playerCount)
+    require(buttons.size == mode.playerCount)
+    states.add(State(frame, inputs, mementos, buttons))
     LOG.atDebug().log("Adding state on frame {}; state size {}", frame, states.size)
     while (states.size > 60 * 5) {
       states.removeFirst()
@@ -44,25 +48,33 @@ class StateHistory() {
   }
 
   @Synchronized
-  fun addSecondaryInput(
-      frame: Long,
-      secondaryInput: Input,
-  ) {
-    patches.add(Patch(frame, secondaryInput))
-    LOG.atDebug().log("Adding patch on frame {}, patches size {}", frame, patches.size)
+  fun addSecondaryInput(player: Int, frame: Long, input: Input) {
+    require(player in 0 until mode.playerCount)
+    patches.add(Patch(player, frame, input))
+    LOG.atDebug().log(
+        "Adding player {} patch on frame {}, patches size {}", player + 1, frame, patches.size)
   }
 
   @Synchronized
-  fun merge(mainConfig: GameboyConfiguration?, peerConfig: GameboyConfiguration?): Boolean {
+  fun merge(configs: List<GameboyConfiguration?>): Boolean {
+    require(configs.size == mode.playerCount)
     if (patches.isEmpty() || states.isEmpty()) {
       return false
     }
-    val baseFrame = min(patches.first().frame, states.last().frame)
-    val toFrame = max(states.last().frame, patches.last().frame)
+    val baseFrame = min(patches.minOf { it.frame }, states.last().frame)
+    val toFrame = max(states.last().frame, patches.maxOf { it.frame })
     LOG.atDebug().log("Rebasing from $baseFrame to $toFrame")
 
-    val mainInputs = states.groupBy { it.frame }.mapValues { it.value.first().mainInput }
-    val peerInputs = patches.groupBy { it.frame }.mapValues { it.value.first().secondaryInput }
+    // Keep every player's already-applied input. A later packet can arrive out of order and force
+    // a rebase before an earlier remote patch; retaining all inputs prevents that earlier patch
+    // from disappearing during the second replay.
+    val inputsByFrame =
+        states.associate { state -> state.frame to state.inputs.toMutableList() }.toMutableMap()
+    for (patch in patches) {
+      val frameInputs =
+          inputsByFrame.getOrPut(patch.frame) { emptyInputs().toMutableList() }
+      frameInputs[patch.player] = patch.input
+    }
 
     if (baseFrame < states.first().frame) {
       throw IllegalStateException("No frame $baseFrame")
@@ -71,87 +83,55 @@ class StateHistory() {
         states.firstOrNull { it.frame == baseFrame }
             ?: throw IllegalStateException("No frame $baseFrame")
 
-    val mainLink = Peer2PeerSerialEndpoint()
-    val peerLink = Peer2PeerSerialEndpoint()
-    mainLink.init(peerLink)
-    val mainIrLink = Peer2PeerInfraredEndpoint()
-    val peerIrLink = Peer2PeerInfraredEndpoint()
-    mainIrLink.init(peerIrLink)
-
-    val mainEventBus = EventBusImpl(null, null, false)
-    val peerEventBus = EventBusImpl(null, null, false)
-    mainEventBus.register<Joypad.JoypadPressEvent> {
-      debugEventBus?.post(GameboyJoypadPressEvent(it.button, it.tick, 0))
-    }
-    peerEventBus.register<Joypad.JoypadPressEvent> {
-      debugEventBus?.post(GameboyJoypadPressEvent(it.button, it.tick, 1))
-    }
-
-    // the sessions are rebuilt only to be restored from mementos right away: skip the
-    // boot sequence, which FAST_FORWARD would otherwise emulate on every rebase
-    val mainSession =
-        mainConfig?.let {
-          Session(
-              if (baseState.mainMemento != null) it.forRestore() else it,
-              mainEventBus,
-              null,
-              mainLink,
-              mainIrLink,
-          )
+    val links = createLinks(mode)
+    val sessions =
+        configs.mapIndexed { player, config ->
+          val eventBus = EventBusImpl(null, null, false)
+          eventBus.register<Joypad.JoypadPressEvent> {
+            debugEventBus?.post(GameboyJoypadPressEvent(it.button, it.tick, player))
+          }
+          config?.let {
+            Session(
+                if (baseState.mementos[player] != null) it.forRestore() else it,
+                eventBus,
+                null,
+                links.serial[player],
+                links.infrared[player],
+            )
+          }
         }
-    val peerSession =
-        peerConfig?.let {
-          Session(
-              if (baseState.peerMemento != null) it.forRestore() else it,
-              peerEventBus,
-              null,
-              peerLink,
-              peerIrLink,
-          )
-        }
-    if (mainSession != null && baseState.mainMemento != null) {
-      mainSession.restoreFromMemento(baseState.mainMemento)
-      // the joypad's held-button set is not in the memento; restore it explicitly or a button
-      // held before the base frame would be lost for the whole rebase (issue #79 desync)
-      mainSession.heldButtons = baseState.mainButtons
-    }
-    if (peerSession != null && baseState.peerMemento != null) {
-      peerSession.restoreFromMemento(baseState.peerMemento)
-      peerSession.heldButtons = baseState.peerButtons
+
+    for (player in sessions.indices) {
+      val session = sessions[player]
+      val memento = baseState.mementos[player]
+      if (session != null && memento != null) {
+        session.restoreFromMemento(memento)
+        session.heldButtons = baseState.buttons[player]
+      }
     }
 
     states.clear()
     patches.clear()
 
-    for (i in (baseFrame..toFrame + 1)) {
-      val mainInput = mainInputs[i] ?: Input(emptyList(), emptyList())
+    for (frame in baseFrame..toFrame + 1) {
+      val inputs = inputsByFrame[frame]?.toList() ?: emptyInputs()
       states.add(
           State(
-              i,
-              mainInput,
-              mainSession?.saveToMemento(),
-              peerSession?.saveToMemento(),
-              mainSession?.heldButtons ?: emptySet(),
-              peerSession?.heldButtons ?: emptySet(),
+              frame,
+              inputs,
+              sessions.map { it?.saveToMemento() },
+              sessions.map { it?.heldButtons ?: emptySet() },
           ))
 
-      if (i <= toFrame) {
-        mainInput.send(mainEventBus)
-        val peerInput = peerInputs[i]
-        if (peerInput != null) {
-          LOG.atDebug().log("Sending secondary input {} on frame {}", peerInput, i)
-          peerInput.send(peerEventBus)
+      if (frame <= toFrame) {
+        for (player in sessions.indices) {
+          inputs[player].send(sessions[player]?.eventBus ?: continue)
         }
-
-        repeat(TICKS_PER_FRAME) {
-          mainSession?.gameboy?.tick()
-          peerSession?.gameboy?.tick()
-        }
+        repeat(TICKS_PER_FRAME) { sessions.forEach { it?.gameboy?.tick() } }
       }
     }
 
-    mainSession?.close()
-    peerSession?.close()
+    sessions.forEach { it?.close() }
 
     LOG.atDebug().log("Rebase from $baseFrame to $toFrame completed.")
     return true
@@ -159,27 +139,31 @@ class StateHistory() {
 
   fun getHead() = states.last()
 
-  fun setPeerState(peerFrame: Long, peerState: Memento<Session>, peerButtons: Set<Button>) {
-    val index = states.indexOfFirst { it.frame == peerFrame }
+  fun setPlayerState(
+      player: Int,
+      frame: Long,
+      state: Memento<Session>,
+      buttons: Set<Button>,
+  ) {
+    val index = states.indexOfFirst { it.frame == frame }
     if (index == -1) {
       return
     }
-    states[index] = states[index].copy(peerMemento = peerState, peerButtons = peerButtons)
+    val mementos = states[index].mementos.toMutableList().also { it[player] = state }
+    val heldButtons = states[index].buttons.toMutableList().also { it[player] = buttons }
+    states[index] = states[index].copy(mementos = mementos, buttons = heldButtons)
   }
+
+  private fun emptyInputs() = List(mode.playerCount) { Input(emptyList(), emptyList()) }
 
   data class State(
       val frame: Long,
-      val mainInput: Input,
-      val mainMemento: Memento<Session>?,
-      val peerMemento: Memento<Session>?,
-      val mainButtons: Set<Button> = emptySet(),
-      val peerButtons: Set<Button> = emptySet(),
+      val inputs: List<Input>,
+      val mementos: List<Memento<Session>?>,
+      val buttons: List<Set<Button>>,
   )
 
-  private data class Patch(
-      val frame: Long,
-      val secondaryInput: Input,
-  )
+  private data class Patch(val player: Int, val frame: Long, val input: Input)
 
   @VisibleForTesting
   internal data class GameboyJoypadPressEvent(
@@ -190,5 +174,28 @@ class StateHistory() {
 
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(StateHistory::class.java)
+
+    internal fun createLinks(mode: LinkMode): Links {
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        val adapter = FourPlayerAdapter()
+        return Links(
+            List(mode.playerCount) { adapter.endpoint(it) },
+            List(mode.playerCount) { InfraredEndpoint.NULL_ENDPOINT },
+        )
+      }
+
+      val firstSerial = Peer2PeerSerialEndpoint()
+      val secondSerial = Peer2PeerSerialEndpoint()
+      firstSerial.init(secondSerial)
+      val firstInfrared = Peer2PeerInfraredEndpoint()
+      val secondInfrared = Peer2PeerInfraredEndpoint()
+      firstInfrared.init(secondInfrared)
+      return Links(listOf(firstSerial, secondSerial), listOf(firstInfrared, secondInfrared))
+    }
   }
+
+  internal data class Links(
+      val serial: List<SerialEndpoint>,
+      val infrared: List<InfraredEndpoint>,
+  )
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -42,9 +42,7 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
     require(buttons.size == mode.playerCount)
     states.add(State(frame, inputs, mementos, buttons))
     LOG.atDebug().log("Adding state on frame {}; state size {}", frame, states.size)
-    while (states.size > 60 * 5) {
-      states.removeFirst()
-    }
+    trimHistory()
   }
 
   @Synchronized
@@ -110,7 +108,13 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
       }
     }
 
+    // A four-player session receives input over three independent TCP streams. One player's
+    // frame N packet can therefore be merged before another player's frame N-1 packet arrives.
+    // Keep the states before this rebase point: they are unchanged by the replay and remain the
+    // only valid base for that later, earlier packet.
+    val retainedStates = states.takeWhile { it.frame < baseFrame }
     states.clear()
+    states.addAll(retainedStates)
     patches.clear()
 
     for (frame in baseFrame..toFrame + 1) {
@@ -130,6 +134,8 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
         repeat(TICKS_PER_FRAME) { sessions.forEach { it?.gameboy?.tick() } }
       }
     }
+
+    trimHistory()
 
     sessions.forEach { it?.close() }
 
@@ -156,6 +162,12 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
 
   private fun emptyInputs() = List(mode.playerCount) { Input(emptyList(), emptyList()) }
 
+  private fun trimHistory() {
+    while (states.size > MAX_HISTORY_STATES) {
+      states.removeFirst()
+    }
+  }
+
   data class State(
       val frame: Long,
       val inputs: List<Input>,
@@ -174,6 +186,7 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
 
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(StateHistory::class.java)
+    private const val MAX_HISTORY_STATES = 60 * 5
 
     internal fun createLinks(mode: LinkMode): Links {
       if (mode == LinkMode.FOUR_PLAYER_ADAPTER) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -160,6 +160,12 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
     states[index] = states[index].copy(mementos = mementos, buttons = heldButtons)
   }
 
+  @Synchronized
+  fun clear() {
+    states.clear()
+    patches.clear()
+  }
+
   private fun emptyInputs() = List(mode.playerCount) { Input(emptyList(), emptyList()) }
 
   private fun trimHistory() {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -343,7 +343,14 @@ class Connection(
     if (receivedVersion != PROTOCOL_VERSION) {
       throw IOException("Protocol mismatch: expected $PROTOCOL_VERSION, received $receivedVersion")
     }
-    val modeOrdinal = buf[PROTOCOL_NAME.length + 1].toInt()
+    val modeOrdinal = buf[PROTOCOL_NAME.length + 1].toInt() and 0xff
+    if (modeOrdinal == REJECTION_MARKER) {
+      val reasonCode = buf[PROTOCOL_NAME.length + 2].toInt() and 0xff
+      val reason =
+          RejectionReason.entries.firstOrNull { it.wireCode == reasonCode }
+              ?: throw IOException("Server rejected the connection with unknown reason $reasonCode")
+      throw ConnectionRejectedException(reason)
+    }
     if (modeOrdinal !in LinkMode.entries.indices) throw IOException("Invalid link mode $modeOrdinal")
     val receivedMode = LinkMode.entries[modeOrdinal]
     val receivedPlayer = buf[PROTOCOL_NAME.length + 2].toInt()
@@ -355,6 +362,16 @@ class Connection(
   }
 
   private data class Handshake(val mode: LinkMode, val player: Int)
+
+  internal enum class RejectionReason(
+      val wireCode: Int,
+      val userMessage: String,
+  ) {
+    SERVER_FULL(1, "The netplay server is already full."),
+  }
+
+  internal class ConnectionRejectedException(val reason: RejectionReason) :
+      IOException(reason.userMessage)
 
   data class PeerLoadedGameEvent(
       val rom: ByteArray,
@@ -399,12 +416,24 @@ class Connection(
     private val LOG: Logger = LoggerFactory.getLogger(Connection::class.java)
     private const val PROTOCOL_NAME = "CoffeeGB NETPLAY"
     private const val PROTOCOL_VERSION: Byte = 0x05
+    private const val REJECTION_MARKER = 0xff
     private const val MAX_COMPRESSED_PAYLOAD = 64 * 1024 * 1024
     private const val ROM: Byte = 0x01
     private const val INPUT: Byte = 0x03
     private const val RESET: Byte = 0x06
     private const val STOP: Byte = 0x07
     private const val START: Byte = 0x08
+
+    internal fun reject(outputStream: OutputStream, reason: RejectionReason) {
+      val output = DataOutputStream(BufferedOutputStream(outputStream))
+      val buf = ByteArray(PROTOCOL_NAME.length + 3)
+      PROTOCOL_NAME.toByteArray().copyInto(buf)
+      buf[PROTOCOL_NAME.length] = PROTOCOL_VERSION
+      buf[PROTOCOL_NAME.length + 1] = REJECTION_MARKER.toByte()
+      buf[PROTOCOL_NAME.length + 2] = reason.wireCode.toByte()
+      output.write(buf)
+      output.flush()
+    }
 
     fun deflate(data: ByteArray): ByteArray {
       val deflater = Deflater(Deflater.BEST_SPEED)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -51,13 +51,19 @@ class Connection(
 
   private val pendingEvents = mutableListOf<Event>()
 
+  private val pendingCheckpointStates = mutableListOf<PeerLoadedGameEvent>()
+
   init {
     val handshake = handshake(requestedMode, assignedPlayer)
     mode = handshake.mode
     player = handshake.player
 
     eventBus.register<LinkedController.LocalRomLoadedEvent> {
-      if (shouldSendLocal(it.player)) sendRom(it)
+      // Four-player host state is sent as an atomic SessionStateReadyEvent checkpoint. Sending the
+      // ordinary host ROM event as well would let clients run before the adapter memento arrives.
+      if (shouldSendLocal(it.player) && (!server || mode != LinkMode.FOUR_PLAYER_ADAPTER)) {
+        sendRom(it)
+      }
     }
     eventBus.register<LinkedController.LocalButtonStateEvent> {
       if (shouldSendLocal(it.player)) sendButtons(it)
@@ -87,6 +93,12 @@ class Connection(
         sendFrameCommand(STOP, it.event.frame, it.event.player)
       }
     }
+    eventBus.register<LinkedController.SessionStateReadyEvent> {
+      if (server && mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        it.states.forEach(::sendRom)
+        sendSynchronization(it.frame)
+      }
+    }
   }
 
   private fun shouldSendLocal(eventPlayer: Int): Boolean =
@@ -96,24 +108,32 @@ class Connection(
     val rom = deflate(event.romFile)
     val battery = event.batteryFile?.let(::deflate)
     val snapshot = event.snapshot?.let(::deflate)
+    val sessionSnapshot = event.sessionSnapshot?.let(::deflate)
+    val heldButtons = event.heldButtons.sorted()
     val buf =
         ByteBuffer.allocate(
-            1 + 24 + 3 * 4 + rom.size + (battery?.size ?: 0) + (snapshot?.size ?: 0))
+            1 + ROM_HEADER_SIZE + heldButtons.size + rom.size + (battery?.size ?: 0) +
+                (snapshot?.size ?: 0) + (sessionSnapshot?.size ?: 0))
     buf.put(ROM)
     buf.put(event.player.toByte())
     buf.putLong(event.frame)
     buf.put(event.gameboyType.ordinal.toByte())
     buf.put(event.bootstrapMode.ordinal.toByte())
     buf.put(if (event.cgb0Revision) 1.toByte() else 0.toByte())
+    buf.put(heldButtons.size.toByte())
     buf.putInt(event.romFile.size)
     buf.putInt(event.batteryFile?.size ?: 0)
     buf.putInt(event.snapshot?.size ?: 0)
+    buf.putInt(event.sessionSnapshot?.size ?: 0)
     buf.putInt(rom.size)
     buf.putInt(battery?.size ?: 0)
     buf.putInt(snapshot?.size ?: 0)
+    buf.putInt(sessionSnapshot?.size ?: 0)
+    heldButtons.forEach { buf.put(it.ordinal.toByte()) }
     buf.put(rom)
     battery?.let(buf::put)
     snapshot?.let(buf::put)
+    sessionSnapshot?.let(buf::put)
     sendMessage(buf)
     LOG.atInfo().log("Sent player {} ROM ({} -> {} bytes compressed)", event.player + 1,
         event.romFile.size, rom.size)
@@ -142,6 +162,13 @@ class Connection(
     sendMessage(buf)
   }
 
+  private fun sendSynchronization(frame: Long) {
+    val buf = ByteBuffer.allocate(9)
+    buf.put(SYNCHRONIZE)
+    buf.putLong(frame)
+    sendMessage(buf)
+  }
+
   @Synchronized
   private fun sendMessage(buf: ByteBuffer) {
     if (doStop) return
@@ -149,7 +176,7 @@ class Connection(
     output.flush()
   }
 
-  /** Releases a client after every required player has connected to the host. */
+  /** Releases a client after the host has accepted its physical link port. */
   fun startSession() {
     check(server)
     val buf = ByteBuffer.allocate(1)
@@ -172,6 +199,16 @@ class Connection(
         INPUT -> receiveButtons()
         RESET -> receiveReset()
         STOP -> receiveStop()
+        SYNCHRONIZE -> {
+          if (!server) {
+            val frame = input.readLong()
+            val states = pendingCheckpointStates.toList()
+            pendingCheckpointStates.clear()
+            deliver(SessionCheckpointEvent(frame, states))
+          } else {
+            throw IOException("Client sent a server-only synchronization command")
+          }
+        }
         START -> {
           if (!server) {
             sessionActive = true
@@ -189,7 +226,7 @@ class Connection(
   }
 
   private fun receiveRom() {
-    val header = ByteArray(24 + 3 * 4)
+    val header = ByteArray(ROM_HEADER_SIZE)
     input.readFully(header)
     val buf = ByteBuffer.wrap(header)
     val wirePlayer = buf.get().toInt()
@@ -198,25 +235,41 @@ class Connection(
     val gameboyType = GameboyType.entries[buf.get().toInt()]
     val bootstrapMode = BootstrapMode.entries[buf.get().toInt()]
     val cgb0Revision = buf.get().toInt() != 0
+    val heldCount = buf.get().toInt() and 0xff
+    if (heldCount > Button.entries.size) throw IOException("Invalid held button count $heldCount")
     val romSize = buf.getInt()
     val batterySize = buf.getInt()
     val snapshotSize = buf.getInt()
+    val sessionSnapshotSize = buf.getInt()
     val romCompressed = buf.getInt()
     val batteryCompressed = buf.getInt()
     val snapshotCompressed = buf.getInt()
+    val sessionSnapshotCompressed = buf.getInt()
+    val heldButtons = ByteArray(heldCount).also(input::readFully).map {
+      val ordinal = it.toInt() and 0xff
+      if (ordinal !in Button.entries.indices) throw IOException("Invalid held button $ordinal")
+      Button.entries[ordinal]
+    }.toSet()
     val event =
         PeerLoadedGameEvent(
-            inflate(readPayload(romCompressed), romSize)!!,
-            inflate(readPayload(batteryCompressed), batterySize),
-            inflate(readPayload(snapshotCompressed), snapshotSize),
-            gameboyType,
-            bootstrapMode,
-            frame,
-            cgb0Revision,
-            eventPlayer,
+            rom = inflate(readPayload(romCompressed), romSize)!!,
+            battery = inflate(readPayload(batteryCompressed), batterySize),
+            snapshot = inflate(readPayload(snapshotCompressed), snapshotSize),
+            gameboyType = gameboyType,
+            bootstrapMode = bootstrapMode,
+            frame = frame,
+            cgb0Revision = cgb0Revision,
+            player = eventPlayer,
+            sessionSnapshot =
+                inflate(readPayload(sessionSnapshotCompressed), sessionSnapshotSize),
+            heldButtons = heldButtons,
         )
-    deliver(event)
-    if (server) {
+    if (!server && mode == LinkMode.FOUR_PLAYER_ADAPTER && event.sessionSnapshot != null) {
+      pendingCheckpointStates += event
+    } else {
+      deliver(event)
+    }
+    if (server && mode != LinkMode.FOUR_PLAYER_ADAPTER) {
       eventBus.post(
           RelayRomEvent(
               eventPlayer,
@@ -229,6 +282,8 @@ class Connection(
                   event.frame,
                   event.cgb0Revision,
                   event.player,
+                  event.sessionSnapshot,
+                  event.heldButtons,
               )))
     }
     LOG.atInfo().log("Received player {} ROM", eventPlayer + 1)
@@ -275,7 +330,9 @@ class Connection(
     } else {
       val event = ReceivedRemoteStopEvent(frame, eventPlayer)
       deliver(event)
-      if (server) eventBus.post(RelayStopEvent(eventPlayer, event))
+      if (server && mode != LinkMode.FOUR_PLAYER_ADAPTER) {
+        eventBus.post(RelayStopEvent(eventPlayer, event))
+      }
     }
   }
 
@@ -382,6 +439,13 @@ class Connection(
       val frame: Long,
       val cgb0Revision: Boolean = false,
       val player: Int = 1,
+      val sessionSnapshot: ByteArray? = null,
+      val heldButtons: Set<Button> = emptySet(),
+  ) : Event
+
+  data class SessionCheckpointEvent(
+      val frame: Long,
+      val states: List<PeerLoadedGameEvent>,
   ) : Event
 
   data class RequestResetEvent(val frame: Long, val player: Int = 0) : Event
@@ -415,7 +479,7 @@ class Connection(
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(Connection::class.java)
     private const val PROTOCOL_NAME = "CoffeeGB NETPLAY"
-    private const val PROTOCOL_VERSION: Byte = 0x05
+    private const val PROTOCOL_VERSION: Byte = 0x06
     private const val REJECTION_MARKER = 0xff
     private const val MAX_COMPRESSED_PAYLOAD = 64 * 1024 * 1024
     private const val ROM: Byte = 0x01
@@ -423,6 +487,8 @@ class Connection(
     private const val RESET: Byte = 0x06
     private const val STOP: Byte = 0x07
     private const val START: Byte = 0x08
+    private const val SYNCHRONIZE: Byte = 0x09
+    private const val ROM_HEADER_SIZE = 45
 
     internal fun reject(outputStream: OutputStream, reason: RejectionReason) {
       val output = DataOutputStream(BufferedOutputStream(outputStream))

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller.network
 
 import eu.rekawek.coffeegb.controller.Input
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.link.LinkedController
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.GameboyType
@@ -23,105 +24,137 @@ import kotlin.concurrent.Volatile
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-/**
- * The wire protocol of the netplay link. Messages are assembled in memory and written with
- * a single write+flush, so every message leaves as one TCP segment (the sockets run with
- * TCP_NODELAY; unbuffered byte-wise writes would emit a segment per byte). Reads go through
- * a buffered stream and use readFully - a plain read() may return a partial header on a
- * fragmented connection, which would desynchronize the protocol. Large payloads (ROM,
- * battery save, snapshot) are deflate-compressed.
- */
+/** One netplay socket. On a four-player host, three instances share the root event bus. */
 class Connection(
     inputStream: InputStream,
     outputStream: OutputStream,
     mainEventBus: EventBus,
     private val server: Boolean,
+    requestedMode: LinkMode = LinkMode.NORMAL,
+    assignedPlayer: Int = 1,
 ) : Runnable, AutoCloseable {
 
   private val input = DataInputStream(BufferedInputStream(inputStream))
 
   private val output = DataOutputStream(BufferedOutputStream(outputStream))
 
-  private val eventBus: EventBus = mainEventBus.fork("connection")
+  private val eventBus: EventBus = mainEventBus.fork("connection-$assignedPlayer")
+
+  val mode: LinkMode
+
+  /** The player at the remote end when hosting, or this application's player when connected. */
+  val player: Int
 
   @Volatile private var doStop = false
 
-  init {
-    // the handshake must be on the wire before any registered handler can write a
-    // message, otherwise an event arriving between construction and run() would put
-    // its bytes in front of the handshake and desynchronize the peer
-    handshake()
-    eventBus.register<LinkedController.LocalRomLoadedEvent> {
-      val rom = deflate(it.romFile)
-      val battery = it.batteryFile?.let(::deflate)
-      val snapshot = it.snapshot?.let(::deflate)
+  private var sessionActive = server
 
-      val buf =
-          ByteBuffer.allocate(
-              1 +
-                  23 +
-                  3 * 4 +
-                  rom.size +
-                  (battery?.size ?: 0) +
-                  (snapshot?.size ?: 0))
-      buf.put(0x01)
-      buf.putLong(it.frame)
-      buf.put(it.gameboyType.ordinal.toByte())
-      buf.put(it.bootstrapMode.ordinal.toByte())
-      buf.put(if (it.cgb0Revision) 1.toByte() else 0.toByte())
-      buf.putInt(it.romFile.size)
-      buf.putInt(it.batteryFile?.size ?: 0)
-      buf.putInt(it.snapshot?.size ?: 0)
-      buf.putInt(rom.size)
-      buf.putInt(battery?.size ?: 0)
-      buf.putInt(snapshot?.size ?: 0)
-      buf.put(rom)
-      battery?.let(buf::put)
-      snapshot?.let(buf::put)
-      sendMessage(buf)
-      LOG.atInfo().log(
-          "Sent rom ({} -> {} bytes compressed)", it.romFile.size, rom.size)
+  private val pendingEvents = mutableListOf<Event>()
+
+  init {
+    val handshake = handshake(requestedMode, assignedPlayer)
+    mode = handshake.mode
+    player = handshake.player
+
+    eventBus.register<LinkedController.LocalRomLoadedEvent> {
+      if (shouldSendLocal(it.player)) sendRom(it)
     }
     eventBus.register<LinkedController.LocalButtonStateEvent> {
-      val buf = ByteBuffer.allocate(
-          1 + 10 + it.input.pressedButtons.size + it.input.releasedButtons.size)
-      buf.put(0x03)
-      buf.putLong(it.frame)
-      buf.put(it.input.pressedButtons.size.toByte())
-      buf.put(it.input.releasedButtons.size.toByte())
-      for (button in it.input.pressedButtons) {
-        buf.put(button.ordinal.toByte())
-      }
-      for (button in it.input.releasedButtons) {
-        buf.put(button.ordinal.toByte())
-      }
-      sendMessage(buf)
-      LOG.atDebug().log("Sent {}", it)
+      if (shouldSendLocal(it.player)) sendButtons(it)
     }
     eventBus.register<RequestResetEvent> {
-      val buf = ByteBuffer.allocate(9)
-      buf.put(0x06)
-      buf.putLong(it.frame)
-      sendMessage(buf)
-      LOG.atInfo().log("Sent {}", it)
+      if (shouldSendLocal(it.player)) sendFrameCommand(RESET, it.frame, it.player)
     }
     eventBus.register<RequestStopEvent> {
-      val buf = ByteBuffer.allocate(9)
-      buf.put(0x07)
-      buf.putLong(it.frame)
-      sendMessage(buf)
-      LOG.atInfo().log("Sent {}", it)
+      if (shouldSendLocal(it.player)) sendFrameCommand(STOP, it.frame, it.player)
+    }
+
+    // Only host-side connections see relay events. The originating player's connection is
+    // skipped; every other client receives the exact same player-labelled message.
+    eventBus.register<RelayRomEvent> {
+      if (server && player != it.sourcePlayer) sendRom(it.event)
+    }
+    eventBus.register<RelayButtonsEvent> {
+      if (server && player != it.sourcePlayer) sendButtons(it.event)
+    }
+    eventBus.register<RelayResetEvent> {
+      if (server && player != it.sourcePlayer) {
+        sendFrameCommand(RESET, it.event.frame, it.event.player)
+      }
+    }
+    eventBus.register<RelayStopEvent> {
+      if (server && player != it.sourcePlayer) {
+        sendFrameCommand(STOP, it.event.frame, it.event.player)
+      }
     }
   }
 
-  /**
-   * Event handlers run on different event-bus threads; the whole message goes out
-   * atomically and in one flush.
-   */
+  private fun shouldSendLocal(eventPlayer: Int): Boolean =
+      if (server) eventPlayer == 0 else eventPlayer == player
+
+  private fun sendRom(event: LinkedController.LocalRomLoadedEvent) {
+    val rom = deflate(event.romFile)
+    val battery = event.batteryFile?.let(::deflate)
+    val snapshot = event.snapshot?.let(::deflate)
+    val buf =
+        ByteBuffer.allocate(
+            1 + 24 + 3 * 4 + rom.size + (battery?.size ?: 0) + (snapshot?.size ?: 0))
+    buf.put(ROM)
+    buf.put(event.player.toByte())
+    buf.putLong(event.frame)
+    buf.put(event.gameboyType.ordinal.toByte())
+    buf.put(event.bootstrapMode.ordinal.toByte())
+    buf.put(if (event.cgb0Revision) 1.toByte() else 0.toByte())
+    buf.putInt(event.romFile.size)
+    buf.putInt(event.batteryFile?.size ?: 0)
+    buf.putInt(event.snapshot?.size ?: 0)
+    buf.putInt(rom.size)
+    buf.putInt(battery?.size ?: 0)
+    buf.putInt(snapshot?.size ?: 0)
+    buf.put(rom)
+    battery?.let(buf::put)
+    snapshot?.let(buf::put)
+    sendMessage(buf)
+    LOG.atInfo().log("Sent player {} ROM ({} -> {} bytes compressed)", event.player + 1,
+        event.romFile.size, rom.size)
+  }
+
+  private fun sendButtons(event: LinkedController.LocalButtonStateEvent) {
+    val buf =
+        ByteBuffer.allocate(
+            1 + 11 + event.input.pressedButtons.size + event.input.releasedButtons.size)
+    buf.put(INPUT)
+    buf.put(event.player.toByte())
+    buf.putLong(event.frame)
+    buf.put(event.input.pressedButtons.size.toByte())
+    buf.put(event.input.releasedButtons.size.toByte())
+    event.input.pressedButtons.forEach { buf.put(it.ordinal.toByte()) }
+    event.input.releasedButtons.forEach { buf.put(it.ordinal.toByte()) }
+    sendMessage(buf)
+    LOG.atDebug().log("Sent {}", event)
+  }
+
+  private fun sendFrameCommand(command: Byte, frame: Long, eventPlayer: Int) {
+    val buf = ByteBuffer.allocate(10)
+    buf.put(command)
+    buf.put(eventPlayer.toByte())
+    buf.putLong(frame)
+    sendMessage(buf)
+  }
+
   @Synchronized
   private fun sendMessage(buf: ByteBuffer) {
+    if (doStop) return
     output.write(buf.array(), 0, buf.position())
     output.flush()
+  }
+
+  /** Releases a client after every required player has connected to the host. */
+  fun startSession() {
+    check(server)
+    val buf = ByteBuffer.allocate(1)
+    buf.put(START)
+    sendMessage(buf)
   }
 
   override fun run() {
@@ -132,95 +165,149 @@ class Connection(
           } catch (e: IOException) {
             if (doStop) -1 else throw e
           }
-      if (command == -1) {
-        return
-      }
-      val event: Event? =
-          when (command) {
-            // peer loaded game
-            0x01 -> {
-              val header = ByteArray(23 + 3 * 4)
-              input.readFully(header)
-              val buf = ByteBuffer.wrap(header)
+      if (command == -1) return
 
-              val frame = buf.getLong()
-              val gameboyType = GameboyType.entries[buf.get().toInt()]
-              val bootstrapMode = BootstrapMode.entries[buf.get().toInt()]
-              val cgb0Revision = buf.get().toInt() != 0
-              val romSize = buf.getInt()
-              val batterySize = buf.getInt()
-              val snapshotSize = buf.getInt()
-              val romCompressed = buf.getInt()
-              val batteryCompressed = buf.getInt()
-              val snapshotCompressed = buf.getInt()
-
-              val rom = inflate(readPayload(romCompressed), romSize)!!
-              val battery = inflate(readPayload(batteryCompressed), batterySize)
-              val snapshot = inflate(readPayload(snapshotCompressed), snapshotSize)
-
-              PeerLoadedGameEvent(
-                  rom, battery, snapshot, gameboyType, bootstrapMode, frame, cgb0Revision)
-            }
-            // sync
-            0x03 -> {
-              val header = ByteArray(10)
-              input.readFully(header)
-              val buf = ByteBuffer.wrap(header)
-
-              val frame = buf.getLong()
-              val pressedCount = buf.get().toInt()
-              val releasedCount = buf.get().toInt()
-              val buttons = ByteArray(pressedCount + releasedCount)
-              input.readFully(buttons)
-              val pressed = (0 until pressedCount).map { Button.entries[buttons[it].toInt()] }
-              val released =
-                  (0 until releasedCount).map { Button.entries[buttons[pressedCount + it].toInt()] }
-              LinkedController.RemoteButtonStateEvent(frame, Input(pressed, released))
-            }
-
-            // reset
-            0x06 -> {
-              ReceivedRemoteResetEvent(readFrame())
-            }
-
-            // stop
-            0x07 -> {
-              ReceivedRemoteStopEvent(readFrame())
-            }
-
-            else -> {
-              LOG.atWarn().log("Received remote unknown command $command")
-              null
-            }
+      when (command.toByte()) {
+        ROM -> receiveRom()
+        INPUT -> receiveButtons()
+        RESET -> receiveReset()
+        STOP -> receiveStop()
+        START -> {
+          if (!server) {
+            sessionActive = true
+            eventBus.post(ConnectionController.ClientConnectedToServerEvent(mode, player))
+            // The host may have sent its ROM before START. The connection is already listening at
+            // that point, but the LinkedController is created by the event above; deliver cached
+            // state only after that synchronous transition has completed.
+            pendingEvents.forEach(eventBus::post)
+            pendingEvents.clear()
           }
-      if (event != null) {
-        when (event) {
-          is PeerLoadedGameEvent ->
-              LOG.atInfo()
-                  .log("Received remote command $command, posting event: ${event.javaClass}")
-          is LinkedController.RemoteButtonStateEvent ->
-              LOG.atDebug().log("Received remote command $command, posting event: $event")
-          else -> LOG.atInfo().log("Received remote command $command, posting event: $event")
         }
-
-        eventBus.post(event)
+        else -> LOG.atWarn().log("Received remote unknown command $command")
       }
     }
   }
 
-  private fun readFrame(): Long {
-    val buf = ByteArray(8)
-    input.readFully(buf)
-    return ByteBuffer.wrap(buf).getLong()
+  private fun receiveRom() {
+    val header = ByteArray(24 + 3 * 4)
+    input.readFully(header)
+    val buf = ByteBuffer.wrap(header)
+    val wirePlayer = buf.get().toInt()
+    val eventPlayer = receivedPlayer(wirePlayer)
+    val frame = buf.getLong()
+    val gameboyType = GameboyType.entries[buf.get().toInt()]
+    val bootstrapMode = BootstrapMode.entries[buf.get().toInt()]
+    val cgb0Revision = buf.get().toInt() != 0
+    val romSize = buf.getInt()
+    val batterySize = buf.getInt()
+    val snapshotSize = buf.getInt()
+    val romCompressed = buf.getInt()
+    val batteryCompressed = buf.getInt()
+    val snapshotCompressed = buf.getInt()
+    val event =
+        PeerLoadedGameEvent(
+            inflate(readPayload(romCompressed), romSize)!!,
+            inflate(readPayload(batteryCompressed), batterySize),
+            inflate(readPayload(snapshotCompressed), snapshotSize),
+            gameboyType,
+            bootstrapMode,
+            frame,
+            cgb0Revision,
+            eventPlayer,
+        )
+    deliver(event)
+    if (server) {
+      eventBus.post(
+          RelayRomEvent(
+              eventPlayer,
+              LinkedController.LocalRomLoadedEvent(
+                  event.rom,
+                  event.battery,
+                  event.snapshot,
+                  event.gameboyType,
+                  event.bootstrapMode,
+                  event.frame,
+                  event.cgb0Revision,
+                  event.player,
+              )))
+    }
+    LOG.atInfo().log("Received player {} ROM", eventPlayer + 1)
+  }
+
+  private fun receiveButtons() {
+    val header = ByteArray(11)
+    input.readFully(header)
+    val buf = ByteBuffer.wrap(header)
+    val eventPlayer = receivedPlayer(buf.get().toInt())
+    val frame = buf.getLong()
+    val pressedCount = buf.get().toInt()
+    val releasedCount = buf.get().toInt()
+    val buttons = ByteArray(pressedCount + releasedCount)
+    input.readFully(buttons)
+    val pressed = (0 until pressedCount).map { Button.entries[buttons[it].toInt()] }
+    val released =
+        (0 until releasedCount).map { Button.entries[buttons[pressedCount + it].toInt()] }
+    val event = LinkedController.RemoteButtonStateEvent(frame, Input(pressed, released), eventPlayer)
+    deliver(event)
+    if (server) {
+      eventBus.post(
+          RelayButtonsEvent(
+              eventPlayer,
+              LinkedController.LocalButtonStateEvent(event.frame, event.input, event.player),
+          ))
+    }
+  }
+
+  private fun receiveReset() {
+    receiveFrameEvent(RESET)
+  }
+
+  private fun receiveStop() {
+    receiveFrameEvent(STOP)
+  }
+
+  private fun receiveFrameEvent(command: Byte) {
+    val (eventPlayer, frame) = readPlayerAndFrame()
+    if (command == RESET) {
+      val event = ReceivedRemoteResetEvent(frame, eventPlayer)
+      deliver(event)
+      if (server) eventBus.post(RelayResetEvent(eventPlayer, event))
+    } else {
+      val event = ReceivedRemoteStopEvent(frame, eventPlayer)
+      deliver(event)
+      if (server) eventBus.post(RelayStopEvent(eventPlayer, event))
+    }
+  }
+
+  private fun readPlayerAndFrame(): Pair<Int, Long> {
+    val payload = ByteArray(9)
+    input.readFully(payload)
+    val buf = ByteBuffer.wrap(payload)
+    return receivedPlayer(buf.get().toInt()) to buf.getLong()
+  }
+
+  private fun receivedPlayer(wirePlayer: Int): Int {
+    if (server) return player
+    if (wirePlayer !in 0 until mode.playerCount) {
+      throw IOException("Invalid player $wirePlayer for $mode")
+    }
+    return wirePlayer
+  }
+
+  private fun deliver(event: Event) {
+    if (sessionActive) {
+      eventBus.post(event)
+    } else {
+      pendingEvents += event
+    }
   }
 
   private fun readPayload(size: Int): ByteArray? {
-    if (size == 0) {
-      return null
+    if (size == 0) return null
+    if (size < 0 || size > MAX_COMPRESSED_PAYLOAD) {
+      throw IOException("Invalid compressed payload size: $size")
     }
-    val payload = ByteArray(size)
-    input.readFully(payload)
-    return payload
+    return ByteArray(size).also(input::readFully)
   }
 
   fun stop() {
@@ -228,41 +315,46 @@ class Connection(
   }
 
   override fun close() {
+    doStop = true
     eventBus.close()
     input.close()
     output.close()
   }
 
-  private fun handshake() {
-    val buf = ByteArray(PROTOCOL_NAME.length + 1)
+  private fun handshake(requestedMode: LinkMode, assignedPlayer: Int): Handshake {
+    val buf = ByteArray(PROTOCOL_NAME.length + 3)
     if (server) {
+      require(assignedPlayer in 1 until requestedMode.playerCount)
       PROTOCOL_NAME.toByteArray().copyInto(buf)
       buf[PROTOCOL_NAME.length] = PROTOCOL_VERSION
+      buf[PROTOCOL_NAME.length + 1] = requestedMode.ordinal.toByte()
+      buf[PROTOCOL_NAME.length + 2] = assignedPlayer.toByte()
       output.write(buf)
       output.flush()
-      LOG.atInfo().log("Sent protocol name {} and version {}", PROTOCOL_NAME, PROTOCOL_VERSION)
-    } else {
-      input.readFully(buf)
-      val receivedProtocolName = String(buf, 0, PROTOCOL_NAME.length)
-      if (receivedProtocolName != PROTOCOL_NAME) {
-        throw IOException(
-            "Protocol mismatch: expected $PROTOCOL_NAME, received $receivedProtocolName"
-        )
-      }
-      val receivedProtocolVersion = buf[PROTOCOL_NAME.length]
-      if (receivedProtocolVersion != PROTOCOL_VERSION) {
-        throw IOException(
-            "Protocol mismatch: expected $PROTOCOL_VERSION, received $receivedProtocolVersion"
-        )
-      }
-      LOG.atInfo()
-          .log(
-              "Received protocol name {} and version {}",
-              receivedProtocolName,
-              receivedProtocolVersion,
-          )
+      return Handshake(requestedMode, assignedPlayer)
     }
+
+    input.readFully(buf)
+    val receivedProtocolName = String(buf, 0, PROTOCOL_NAME.length)
+    if (receivedProtocolName != PROTOCOL_NAME) {
+      throw IOException("Protocol mismatch: expected $PROTOCOL_NAME, received $receivedProtocolName")
+    }
+    val receivedVersion = buf[PROTOCOL_NAME.length]
+    if (receivedVersion != PROTOCOL_VERSION) {
+      throw IOException("Protocol mismatch: expected $PROTOCOL_VERSION, received $receivedVersion")
+    }
+    val modeOrdinal = buf[PROTOCOL_NAME.length + 1].toInt()
+    if (modeOrdinal !in LinkMode.entries.indices) throw IOException("Invalid link mode $modeOrdinal")
+    val receivedMode = LinkMode.entries[modeOrdinal]
+    val receivedPlayer = buf[PROTOCOL_NAME.length + 2].toInt()
+    if (receivedPlayer !in 1 until receivedMode.playerCount) {
+      throw IOException("Invalid assigned player $receivedPlayer for $receivedMode")
+    }
+    LOG.atInfo().log("Connected as player {} in {} mode", receivedPlayer + 1, receivedMode)
+    return Handshake(receivedMode, receivedPlayer)
   }
+
+  private data class Handshake(val mode: LinkMode, val player: Int)
 
   data class PeerLoadedGameEvent(
       val rom: ByteArray,
@@ -272,20 +364,47 @@ class Connection(
       val bootstrapMode: BootstrapMode,
       val frame: Long,
       val cgb0Revision: Boolean = false,
+      val player: Int = 1,
   ) : Event
 
-  data class RequestResetEvent(val frame: Long) : Event
+  data class RequestResetEvent(val frame: Long, val player: Int = 0) : Event
 
-  data class RequestStopEvent(val frame: Long) : Event
+  data class RequestStopEvent(val frame: Long, val player: Int = 0) : Event
 
-  data class ReceivedRemoteResetEvent(val frame: Long) : Event
+  data class ReceivedRemoteResetEvent(val frame: Long, val player: Int = 1) : Event
 
-  data class ReceivedRemoteStopEvent(val frame: Long) : Event
+  data class ReceivedRemoteStopEvent(val frame: Long, val player: Int = 1) : Event
+
+  private data class RelayRomEvent(
+      val sourcePlayer: Int,
+      val event: LinkedController.LocalRomLoadedEvent,
+  ) : Event
+
+  private data class RelayButtonsEvent(
+      val sourcePlayer: Int,
+      val event: LinkedController.LocalButtonStateEvent,
+  ) : Event
+
+  private data class RelayResetEvent(
+      val sourcePlayer: Int,
+      val event: ReceivedRemoteResetEvent,
+  ) : Event
+
+  private data class RelayStopEvent(
+      val sourcePlayer: Int,
+      val event: ReceivedRemoteStopEvent,
+  ) : Event
 
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(Connection::class.java)
-    private const val PROTOCOL_NAME: String = "CoffeeGB NETPLAY"
-    private const val PROTOCOL_VERSION: Byte = 0x04
+    private const val PROTOCOL_NAME = "CoffeeGB NETPLAY"
+    private const val PROTOCOL_VERSION: Byte = 0x05
+    private const val MAX_COMPRESSED_PAYLOAD = 64 * 1024 * 1024
+    private const val ROM: Byte = 0x01
+    private const val INPUT: Byte = 0x03
+    private const val RESET: Byte = 0x06
+    private const val STOP: Byte = 0x07
+    private const val START: Byte = 0x08
 
     fun deflate(data: ByteArray): ByteArray {
       val deflater = Deflater(Deflater.BEST_SPEED)
@@ -294,27 +413,26 @@ class Connection(
       val out = ByteArrayOutputStream(data.size / 2 + 64)
       val buffer = ByteArray(64 * 1024)
       while (!deflater.finished()) {
-        val n = deflater.deflate(buffer)
-        out.write(buffer, 0, n)
+        val count = deflater.deflate(buffer)
+        out.write(buffer, 0, count)
       }
       deflater.end()
       return out.toByteArray()
     }
 
     fun inflate(data: ByteArray?, originalSize: Int): ByteArray? {
-      if (data == null) {
-        return null
+      if (data == null) return null
+      if (originalSize < 0 || originalSize > MAX_COMPRESSED_PAYLOAD * 4) {
+        throw IOException("Invalid uncompressed payload size: $originalSize")
       }
       val inflater = Inflater()
       inflater.setInput(data)
       val result = ByteArray(originalSize)
       var offset = 0
       while (offset < originalSize && !inflater.finished()) {
-        val n = inflater.inflate(result, offset, originalSize - offset)
-        if (n == 0 && inflater.needsInput()) {
-          throw IOException("Truncated compressed payload")
-        }
-        offset += n
+        val count = inflater.inflate(result, offset, originalSize - offset)
+        if (count == 0 && inflater.needsInput()) throw IOException("Truncated compressed payload")
+        offset += count
       }
       inflater.end()
       if (offset != originalSize) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
@@ -63,6 +63,8 @@ class ConnectionController(private val eventBus: EventBus) {
 
   data class ClientHandshakeCompletedEvent(val mode: LinkMode, val player: Int) : Event
 
+  data class ClientConnectionRejectedEvent(val message: String) : Event
+
   data class ClientConnectedToServerEvent(
       val mode: LinkMode = LinkMode.NORMAL,
       val player: Int = 1,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.network
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 
 class ConnectionController(private val eventBus: EventBus) {
 
@@ -10,16 +11,16 @@ class ConnectionController(private val eventBus: EventBus) {
   private var server: TcpServer? = null
 
   init {
-    eventBus.register<StartServerEvent> { startServer() }
+    eventBus.register<StartServerEvent> { startServer(it.mode) }
     eventBus.register<StopServerEvent> { stopServer() }
     eventBus.register<StartClientEvent> { startClient(it.host) }
     eventBus.register<StopClientEvent> { stopClient() }
   }
 
-  private fun startServer() {
+  private fun startServer(mode: LinkMode) {
     stopClient()
     stopServer()
-    server = TcpServer(eventBus)
+    server = TcpServer(eventBus, mode = mode)
     Thread(server).start()
   }
 
@@ -40,7 +41,7 @@ class ConnectionController(private val eventBus: EventBus) {
     server = null
   }
 
-  class StartServerEvent : Event
+  data class StartServerEvent(val mode: LinkMode = LinkMode.NORMAL) : Event
 
   class StopServerEvent : Event
 
@@ -48,15 +49,30 @@ class ConnectionController(private val eventBus: EventBus) {
 
   class StopClientEvent : Event
 
-  class ServerStartedEvent : Event
+  data class ServerStartedEvent(val mode: LinkMode = LinkMode.NORMAL) : Event
 
   class ServerStoppedEvent : Event
 
-  data class ServerGotConnectionEvent(val host: String) : Event
+  data class ServerGotConnectionEvent(
+      val host: String,
+      val mode: LinkMode = LinkMode.NORMAL,
+      val player: Int = 0,
+  ) : Event
 
   class ServerLostConnectionEvent : Event
 
-  class ClientConnectedToServerEvent : Event
+  data class ClientHandshakeCompletedEvent(val mode: LinkMode, val player: Int) : Event
+
+  data class ClientConnectedToServerEvent(
+      val mode: LinkMode = LinkMode.NORMAL,
+      val player: Int = 1,
+  ) : Event
+
+  data class ServerPlayerCountEvent(
+      val connected: Int,
+      val required: Int,
+      val mode: LinkMode,
+  ) : Event
 
   class ClientDisconnectedFromServerEvent : Event
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt
@@ -76,5 +76,7 @@ class ConnectionController(private val eventBus: EventBus) {
       val mode: LinkMode,
   ) : Event
 
+  data class ServerPlayerDisconnectedEvent(val player: Int) : Event
+
   class ClientDisconnectedFromServerEvent : Event
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpClient.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpClient.kt
@@ -17,9 +17,11 @@ class TcpClient(
     try {
       clientSocket = createSocket(host)
       LOG.info("Connected to {}", clientSocket!!.inetAddress)
-      eventBus.post(ConnectionController.ClientConnectedToServerEvent())
       Connection(clientSocket!!.getInputStream(), clientSocket!!.getOutputStream(), eventBus, false)
-          .use { it.run() }
+          .use {
+            eventBus.post(ConnectionController.ClientHandshakeCompletedEvent(it.mode, it.player))
+            it.run()
+          }
       LOG.info("Disconnected from {}", clientSocket!!.inetAddress)
     } catch (e: SocketException) {
       if (e.message == "Socket closed") {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpClient.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpClient.kt
@@ -23,6 +23,9 @@ class TcpClient(
             it.run()
           }
       LOG.info("Disconnected from {}", clientSocket!!.inetAddress)
+    } catch (e: Connection.ConnectionRejectedException) {
+      LOG.info("Connection rejected: {}", e.reason.userMessage)
+      eventBus.post(ConnectionController.ClientConnectionRejectedEvent(e.reason.userMessage))
     } catch (e: SocketException) {
       if (e.message == "Socket closed") {
         LOG.atInfo().log("Disconnected from server")

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
@@ -35,6 +35,10 @@ class TcpServer(
       serverSocket = listener
       listener.soTimeout = 100
       eventBus.post(ConnectionController.ServerStartedEvent(mode))
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        // The adapter belongs to the host and is live even with no clients attached.
+        eventBus.post(ConnectionController.ServerGotConnectionEvent("localhost", mode, 0))
+      }
       while (!doStop) {
         try {
           accept(listener)
@@ -75,7 +79,11 @@ class TcpServer(
       eventBus.post(
           ConnectionController.ServerPlayerCountEvent(clients.size, mode.playerCount - 1, mode))
       Thread({ runClient(handle) }, "netplay-player-${player + 1}").start()
-      startSessionIfFull(socket.inetAddress.hostAddress)
+      if (mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        connection.startSession()
+      } else {
+        startSessionIfFull(socket.inetAddress.hostAddress)
+      }
     } catch (e: IOException) {
       socket.close()
       throw e
@@ -108,6 +116,27 @@ class TcpServer(
   }
 
   private fun onDisconnected(handle: ClientHandle) {
+    if (mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+      val removed =
+          synchronized(lock) {
+            if (!clients.remove(handle.player, handle)) {
+              false
+            } else {
+              // Queue removal before the slot becomes visible to accept(), so a fast replacement
+              // cannot be attached and then removed by this stale disconnect.
+              if (!doStop) {
+                eventBus.post(ConnectionController.ServerPlayerDisconnectedEvent(handle.player))
+              }
+              true
+            }
+          }
+      if (!removed) {
+        return
+      }
+      eventBus.post(
+          ConnectionController.ServerPlayerCountEvent(clients.size, mode.playerCount - 1, mode))
+      return
+    }
     if (!clients.remove(handle.player, handle)) return
     val endSession =
         synchronized(lock) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
@@ -1,69 +1,150 @@
 package eu.rekawek.coffeegb.controller.network
 
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.core.events.EventBus
 import java.io.IOException
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
 import java.net.SocketTimeoutException
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.Volatile
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+/** Accepts one normal-link client or three fixed-slot DMG-07 clients. */
 class TcpServer(
     private val eventBus: EventBus,
     private val port: Int = PORT,
+    private val mode: LinkMode = LinkMode.NORMAL,
 ) : Runnable {
+
   @Volatile private var doStop = false
 
-  @Volatile private var socket: Socket? = null
+  @Volatile private var serverSocket: ServerSocket? = null
+
+  private val clients = ConcurrentHashMap<Int, ClientHandle>()
+
+  private val lock = Any()
+
+  @Volatile private var sessionStarted = false
 
   override fun run() {
     doStop = false
-    ServerSocket(port).use { serverSocket ->
-      serverSocket.soTimeout = 100
-
-      eventBus.post(ConnectionController.ServerStartedEvent())
+    ServerSocket(port).use { listener ->
+      serverSocket = listener
+      listener.soTimeout = 100
+      eventBus.post(ConnectionController.ServerStartedEvent(mode))
       while (!doStop) {
         try {
-          val socket = serverSocket.accept()
-          TcpClient.configure(socket)
-          this.socket = socket
-          LOG.info("Got new connection: {}", socket.inetAddress)
-          // hostAddress, not hostName: the reverse DNS lookup blocks the accept path
-          // (and thereby the protocol handshake) for seconds on hosts without a resolver
-          eventBus.post(
-              ConnectionController.ServerGotConnectionEvent(socket.inetAddress.hostAddress))
-          try {
-            Connection(socket.getInputStream(), socket.getOutputStream(), eventBus, true).use {
-              it.run()
-            }
-          } finally {
-            LOG.info("Client disconnected: {}", socket.inetAddress)
-            eventBus.post(ConnectionController.ServerLostConnectionEvent())
-          }
+          accept(listener)
         } catch (_: SocketTimeoutException) {
-          // do nothing
+          // Poll doStop.
         } catch (e: SocketException) {
-          if (e.message == "Socket closed") {
-            LOG.info("Client disconnected, server closed")
-          } else {
-            LOG.error("Error in accepting connection", e)
-          }
+          if (!doStop) LOG.error("Error accepting netplay connection", e)
         } catch (e: IOException) {
-          LOG.error("Error in accepting connection", e)
-        } finally {
-          socket = null
+          if (!doStop) LOG.error("Error accepting netplay connection", e)
         }
       }
     }
+    serverSocket = null
+    stopClients()
     eventBus.post(ConnectionController.ServerStoppedEvent())
+  }
+
+  private fun accept(listener: ServerSocket) {
+    val socket = listener.accept()
+    TcpClient.configure(socket)
+    val player = synchronized(lock) { firstAvailablePlayer() }
+    if (player == null) {
+      LOG.info("Rejecting extra connection from {}: {} session is full", socket.inetAddress, mode)
+      socket.close()
+      return
+    }
+
+    try {
+      val connection =
+          Connection(socket.getInputStream(), socket.getOutputStream(), eventBus, true, mode, player)
+      val handle = ClientHandle(player, socket, connection)
+      clients[player] = handle
+      LOG.info("Player {} connected from {}", player + 1, socket.inetAddress.hostAddress)
+      eventBus.post(
+          ConnectionController.ServerPlayerCountEvent(clients.size, mode.playerCount - 1, mode))
+      Thread({ runClient(handle) }, "netplay-player-${player + 1}").start()
+      startSessionIfFull(socket.inetAddress.hostAddress)
+    } catch (e: IOException) {
+      socket.close()
+      throw e
+    }
+  }
+
+  private fun firstAvailablePlayer(): Int? =
+      (1 until mode.playerCount).firstOrNull { !clients.containsKey(it) }
+
+  private fun startSessionIfFull(lastHost: String) {
+    val toStart =
+        synchronized(lock) {
+          if (sessionStarted || clients.size != mode.playerCount - 1) return
+          sessionStarted = true
+          clients.values.sortedBy { it.player }
+        }
+    eventBus.post(ConnectionController.ServerGotConnectionEvent(lastHost, mode, 0))
+    toStart.forEach { it.connection.startSession() }
+  }
+
+  private fun runClient(handle: ClientHandle) {
+    try {
+      handle.connection.use { it.run() }
+    } catch (e: IOException) {
+      if (!doStop) LOG.info("Player {} disconnected: {}", handle.player + 1, e.message)
+    } finally {
+      handle.socket.close()
+      onDisconnected(handle)
+    }
+  }
+
+  private fun onDisconnected(handle: ClientHandle) {
+    if (!clients.remove(handle.player, handle)) return
+    val endSession =
+        synchronized(lock) {
+          if (!sessionStarted) false
+          else {
+            sessionStarted = false
+            true
+          }
+        }
+    if (endSession) {
+      // Rollback state is shared by all players. Once any member leaves, end the group rather than
+      // silently reassigning a physical DMG-07 port in the middle of a game.
+      clients.values.forEach {
+        it.connection.stop()
+        it.socket.close()
+      }
+      eventBus.post(ConnectionController.ServerLostConnectionEvent())
+    }
+    eventBus.post(
+        ConnectionController.ServerPlayerCountEvent(clients.size, mode.playerCount - 1, mode))
   }
 
   fun stop() {
     doStop = true
-    socket?.close()
+    serverSocket?.close()
+    stopClients()
   }
+
+  private fun stopClients() {
+    clients.values.forEach {
+      it.connection.stop()
+      it.socket.close()
+    }
+    clients.clear()
+  }
+
+  private data class ClientHandle(
+      val player: Int,
+      val socket: Socket,
+      val connection: Connection,
+  )
 
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(TcpServer::class.java)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/TcpServer.kt
@@ -58,7 +58,11 @@ class TcpServer(
     val player = synchronized(lock) { firstAvailablePlayer() }
     if (player == null) {
       LOG.info("Rejecting extra connection from {}: {} session is full", socket.inetAddress, mode)
-      socket.close()
+      try {
+        Connection.reject(socket.getOutputStream(), Connection.RejectionReason.SERVER_FULL)
+      } finally {
+        socket.close()
+      }
       return
     }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.controller.Input
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.link.StateHistory.GameboyJoypadPressEvent
 import eu.rekawek.coffeegb.controller.network.Connection.PeerLoadedGameEvent
+import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteStopEvent
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.core.Gameboy
@@ -15,10 +16,72 @@ import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
 import org.junit.Test
 import java.nio.file.Paths
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LinkedControllerTest {
+
+  @Test
+  fun fourPlayerControllerRunsAllConsolesAndLabelsLocalAndRemoteInput() {
+    val eventBus = EventBusImpl()
+    val sut =
+        LinkedController(
+            eventBus,
+            EmulatorProperties(),
+            null,
+            LinkMode.FOUR_PLAYER_ADAPTER,
+            localPlayer = 2,
+        )
+    sut.timingTicker.disabled = true
+    val replayed = mutableListOf<GameboyJoypadPressEvent>()
+    sut.stateHistory.debugEventBus =
+        EventBusImpl().also { debug -> debug.register<GameboyJoypadPressEvent> { replayed += it } }
+    val localInputs = LinkedBlockingQueue<LinkedController.LocalButtonStateEvent>()
+    eventBus.register<LinkedController.LocalButtonStateEvent> { localInputs.add(it) }
+
+    eventBus.post(LoadRomEvent(ROM))
+    for (player in listOf(0, 1, 3)) {
+      eventBus.post(
+          PeerLoadedGameEvent(
+              ROM_BYTES,
+              null,
+              null,
+              GAMEBOY_TYPE,
+              BOOTSTRAP_MODE,
+              0,
+              player = player,
+          ))
+    }
+    sut.runFrame()
+    assertEquals(4, sut.activeSessionCount())
+    eventBus.drainAsyncEvents()
+    localInputs.clear()
+
+    eventBus.post(ButtonPressEvent(Button.B))
+    sut.runFrame()
+    eventBus.drainAsyncEvents()
+    val local = localInputs.poll(5, TimeUnit.SECONDS)
+    assertEquals(2, local.player)
+    assertEquals(listOf(Button.B), local.input.pressedButtons)
+
+    eventBus.post(
+        LinkedController.RemoteButtonStateEvent(0, Input(listOf(Button.A), emptyList()), 0))
+    eventBus.post(
+        LinkedController.RemoteButtonStateEvent(0, Input(listOf(Button.START), emptyList()), 3))
+    sut.runFrame()
+
+    assertTrue(replayed.any { it.gameboy == 0 && it.button == Button.A })
+    assertTrue(replayed.any { it.gameboy == 3 && it.button == Button.START })
+
+    val previousFrame = sut.stateHistory.getHead().frame
+    eventBus.post(ReceivedRemoteStopEvent(previousFrame, player = 3))
+    sut.runFrame()
+    assertEquals(3, sut.activeSessionCount())
+    assertTrue(sut.stateHistory.getHead().frame > previousFrame)
+    eventBus.close()
+  }
 
   @Test
   fun localChangesAreReplayedOnRewind() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -24,6 +24,28 @@ import kotlin.test.assertTrue
 class LinkedControllerTest {
 
   @Test
+  fun peerWithEmptyMbc2SaveStartsSession() {
+    val eventBus = EventBusImpl()
+    val sut = LinkedController(eventBus, EmulatorProperties(), null)
+    sut.timingTicker.disabled = true
+
+    eventBus.post(LoadRomEvent(ROM))
+    eventBus.post(
+        PeerLoadedGameEvent(
+            mbc2Rom(),
+            ByteArray(0),
+            null,
+            GameboyType.DMG,
+            Gameboy.BootstrapMode.SKIP,
+            0,
+        ))
+
+    sut.runFrame()
+    assertEquals(2, sut.activeSessionCount())
+    eventBus.close()
+  }
+
+  @Test
   fun fourPlayerControllerRunsAllConsolesAndLabelsLocalAndRemoteInput() {
     val eventBus = EventBusImpl()
     val sut =
@@ -278,6 +300,12 @@ class LinkedControllerTest {
     val GAMEBOY_TYPE: GameboyType = MAIN_CONFIG.getGameboyType()
 
     val BOOTSTRAP_MODE: Gameboy.BootstrapMode = MAIN_CONFIG.getBootstrapMode()
+
+    fun mbc2Rom() =
+        ByteArray(0x8000).also {
+          it[0x0147] = 0x06
+          it[0x0148] = 0x00
+        }
 
     fun assertJoypadEventsEqual(
         expectedButtons: List<Joypad.JoypadPressEvent>,

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -6,6 +6,8 @@ import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.link.StateHistory.GameboyJoypadPressEvent
 import eu.rekawek.coffeegb.controller.network.Connection.PeerLoadedGameEvent
 import eu.rekawek.coffeegb.controller.network.Connection.ReceivedRemoteStopEvent
+import eu.rekawek.coffeegb.controller.network.Connection.SessionCheckpointEvent
+import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerPlayerDisconnectedEvent
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.core.Gameboy
@@ -19,9 +21,148 @@ import java.nio.file.Paths
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class LinkedControllerTest {
+
+  @Test
+  fun fourPlayerHostRunsImmediatelyWithEmptyAdapterPorts() {
+    val eventBus = EventBusImpl()
+    val sut =
+        LinkedController(
+            eventBus,
+            EmulatorProperties(),
+            null,
+            LinkMode.FOUR_PLAYER_ADAPTER,
+            localPlayer = 0,
+        )
+    sut.timingTicker.disabled = true
+
+    eventBus.post(LoadRomEvent(ROM))
+    repeat(3) { sut.runFrame() }
+
+    assertEquals(1, sut.activeSessionCount())
+    assertEquals(3, sut.currentFrame())
+    assertEquals(2, sut.stateHistory.getHead().frame)
+    eventBus.close()
+  }
+
+  @Test
+  fun lateFourPlayerClientRestoresCoherentHostCheckpoint() {
+    val hostBus = EventBusImpl()
+    val host =
+        LinkedController(
+            hostBus,
+            EmulatorProperties(),
+            null,
+            LinkMode.FOUR_PLAYER_ADAPTER,
+            localPlayer = 0,
+        )
+    host.timingTicker.disabled = true
+    val checkpoints = LinkedBlockingQueue<LinkedController.SessionStateReadyEvent>()
+    hostBus.register<LinkedController.SessionStateReadyEvent> { checkpoints.add(it) }
+
+    hostBus.post(LoadRomEvent(ROM))
+    repeat(3) { host.runFrame() }
+    checkpoints.clear()
+
+    // Player 2 joins after the host has already advanced. Its existing Game Boy is hot-plugged at
+    // the current adapter phase; the host then publishes both complete Session mementos.
+    hostBus.post(
+        PeerLoadedGameEvent(
+            ROM_BYTES,
+            null,
+            null,
+            GAMEBOY_TYPE,
+            BOOTSTRAP_MODE,
+            0,
+            player = 1,
+        ))
+    host.runFrame()
+    val checkpoint = assertNotNull(checkpoints.poll(5, TimeUnit.SECONDS))
+    assertEquals(3, checkpoint.frame)
+    assertEquals(listOf(0, 1), checkpoint.states.map { it.player })
+    assertTrue(checkpoint.states.all { it.sessionSnapshot != null })
+
+    val clientBus = EventBusImpl()
+    val client =
+        LinkedController(
+            clientBus,
+            EmulatorProperties(),
+            null,
+            LinkMode.FOUR_PLAYER_ADAPTER,
+            localPlayer = 1,
+        )
+    client.timingTicker.disabled = true
+    clientBus.post(LoadRomEvent(ROM))
+    client.runFrame()
+    assertEquals(0, client.currentFrame(), "client must wait for the host checkpoint")
+
+    fun deliverCheckpoint(value: LinkedController.SessionStateReadyEvent) {
+      clientBus.post(
+          SessionCheckpointEvent(
+              value.frame,
+              value.states.map { state ->
+                PeerLoadedGameEvent(
+                    rom = state.romFile,
+                    battery = state.batteryFile,
+                    snapshot = state.snapshot,
+                    gameboyType = state.gameboyType,
+                    bootstrapMode = state.bootstrapMode,
+                    frame = state.frame,
+                    cgb0Revision = state.cgb0Revision,
+                    player = state.player,
+                    sessionSnapshot = state.sessionSnapshot,
+                    heldButtons = state.heldButtons,
+                )
+              },
+          ))
+    }
+
+    deliverCheckpoint(checkpoint)
+    client.runFrame()
+
+    assertEquals(2, client.activeSessionCount())
+    assertEquals(host.currentFrame(), client.currentFrame())
+    assertEquals(host.stateHistory.getHead().frame, client.stateHistory.getHead().frame)
+
+    // Another physical port can hot-plug while the original client is already running.
+    hostBus.post(
+        PeerLoadedGameEvent(
+            ROM_BYTES,
+            null,
+            null,
+            GAMEBOY_TYPE,
+            BOOTSTRAP_MODE,
+            0,
+            player = 2,
+        ))
+    host.runFrame()
+    val expandedCheckpoint = assertNotNull(checkpoints.poll(5, TimeUnit.SECONDS))
+    assertEquals(listOf(0, 1, 2), expandedCheckpoint.states.map { it.player })
+    deliverCheckpoint(expandedCheckpoint)
+    client.runFrame()
+    assertEquals(3, host.activeSessionCount())
+    assertEquals(3, client.activeSessionCount())
+    assertEquals(host.currentFrame(), client.currentFrame())
+
+    // Removing Player 3 leaves the other consoles and adapter running from an authoritative
+    // checkpoint, and frees that physical slot for a replacement.
+    hostBus.post(ServerPlayerDisconnectedEvent(2))
+    host.runFrame()
+    val disconnectCheckpoint = assertNotNull(checkpoints.poll(5, TimeUnit.SECONDS))
+    assertEquals(listOf(0, 1), disconnectCheckpoint.states.map { it.player })
+    deliverCheckpoint(disconnectCheckpoint)
+    client.runFrame()
+    assertEquals(2, host.activeSessionCount())
+    assertEquals(2, client.activeSessionCount())
+    assertEquals(host.currentFrame(), client.currentFrame())
+    assertEquals(6, host.currentFrame())
+
+    clientBus.close()
+    hostBus.close()
+  }
 
   @Test
   fun peerWithEmptyMbc2SaveStartsSession() {
@@ -54,7 +195,7 @@ class LinkedControllerTest {
             EmulatorProperties(),
             null,
             LinkMode.FOUR_PLAYER_ADAPTER,
-            localPlayer = 2,
+            localPlayer = 0,
         )
     sut.timingTicker.disabled = true
     val replayed = mutableListOf<GameboyJoypadPressEvent>()
@@ -64,7 +205,7 @@ class LinkedControllerTest {
     eventBus.register<LinkedController.LocalButtonStateEvent> { localInputs.add(it) }
 
     eventBus.post(LoadRomEvent(ROM))
-    for (player in listOf(0, 1, 3)) {
+    for (player in listOf(1, 2, 3)) {
       eventBus.post(
           PeerLoadedGameEvent(
               ROM_BYTES,
@@ -85,16 +226,16 @@ class LinkedControllerTest {
     sut.runFrame()
     eventBus.drainAsyncEvents()
     val local = localInputs.poll(5, TimeUnit.SECONDS)
-    assertEquals(2, local.player)
+    assertEquals(0, local.player)
     assertEquals(listOf(Button.B), local.input.pressedButtons)
 
     eventBus.post(
-        LinkedController.RemoteButtonStateEvent(0, Input(listOf(Button.A), emptyList()), 0))
+        LinkedController.RemoteButtonStateEvent(0, Input(listOf(Button.A), emptyList()), 1))
     eventBus.post(
         LinkedController.RemoteButtonStateEvent(0, Input(listOf(Button.START), emptyList()), 3))
     sut.runFrame()
 
-    assertTrue(replayed.any { it.gameboy == 0 && it.button == Button.A })
+    assertTrue(replayed.any { it.gameboy == 1 && it.button == Button.A })
     assertTrue(replayed.any { it.gameboy == 3 && it.button == Button.START })
 
     val previousFrame = sut.stateHistory.getHead().frame

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/StateHistoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/StateHistoryTest.kt
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.controller.link
+
+import eu.rekawek.coffeegb.controller.Input
+import eu.rekawek.coffeegb.core.joypad.Button
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class StateHistoryTest {
+
+  @Test
+  fun laterEarlierPlayerPacketCanRebaseFromRetainedHistory() {
+    val history = StateHistory(LinkMode.FOUR_PLAYER_ADAPTER)
+    val noInput = Input(emptyList(), emptyList())
+    for (frame in 0L..10L) {
+      history.addState(
+          frame,
+          List(4) { noInput },
+          List(4) { null },
+          List(4) { emptySet() },
+      )
+    }
+
+    history.addSecondaryInput(1, 5, Input(listOf(Button.A), emptyList()))
+    assertTrue(history.merge(List(4) { null }))
+
+    // This arrives on another player's TCP stream after frame 5 was already replayed. Before the
+    // fix, that replay discarded frame 4 and this merge threw "No frame 4".
+    history.addSecondaryInput(2, 4, Input(listOf(Button.B), emptyList()))
+    assertTrue(history.merge(List(4) { null }))
+    assertEquals(12, history.getHead().frame)
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
@@ -104,11 +104,15 @@ class ConnectionTest {
 
   private val threads = mutableListOf<Thread>()
 
-  private fun connect(startSession: Boolean = true) {
+  private fun connect(
+      startSession: Boolean = true,
+      mode: LinkMode = LinkMode.NORMAL,
+  ) {
     val senderToReceiver = Pipe()
     val receiverToSender = Pipe()
 
-    val sender = Connection(receiverToSender.source, senderToReceiver.sink, senderBus, true)
+    val sender =
+        Connection(receiverToSender.source, senderToReceiver.sink, senderBus, true, mode)
     val receiver =
         Connection(TrickleInputStream(senderToReceiver.source), receiverToSender.sink, receiverBus, false)
     this.sender = sender
@@ -163,6 +167,7 @@ class ConnectionTest {
     Random(0).nextBytes(rom, 0, 32 * 1024)
     val battery = ByteArray(8 * 1024) { (it % 7).toByte() }
     val snapshot = ByteArray(64 * 1024)
+    val sessionSnapshot = ByteArray(32 * 1024) { (it % 11).toByte() }
 
     senderBus.post(
         LinkedController.LocalRomLoadedEvent(
@@ -173,6 +178,8 @@ class ConnectionTest {
             Gameboy.BootstrapMode.FAST_FORWARD,
             7,
             cgb0Revision = true,
+            sessionSnapshot = sessionSnapshot,
+            heldButtons = setOf(Button.A, Button.LEFT),
         )
     )
 
@@ -181,10 +188,43 @@ class ConnectionTest {
     assertContentEquals(rom, event.rom)
     assertContentEquals(battery, event.battery)
     assertContentEquals(snapshot, event.snapshot)
+    assertContentEquals(sessionSnapshot, event.sessionSnapshot)
     assertEquals(GameboyType.CGB, event.gameboyType)
     assertEquals(Gameboy.BootstrapMode.FAST_FORWARD, event.bootstrapMode)
     assertTrue(event.cgb0Revision)
+    assertEquals(setOf(Button.A, Button.LEFT), event.heldButtons)
     assertEquals(7, event.frame)
+  }
+
+  @Test
+  fun fourPlayerCheckpointEndsWithSynchronizationFrame() {
+    val received = LinkedBlockingQueue<Connection.PeerLoadedGameEvent>()
+    val synchronized = LinkedBlockingQueue<Connection.SessionCheckpointEvent>()
+    receiverBus.register<Connection.PeerLoadedGameEvent> { received.add(it) }
+    receiverBus.register<Connection.SessionCheckpointEvent> { synchronized.add(it) }
+    connect(mode = LinkMode.FOUR_PLAYER_ADAPTER)
+
+    val state =
+        LinkedController.LocalRomLoadedEvent(
+            romFile = byteArrayOf(1, 2, 3),
+            batteryFile = null,
+            snapshot = null,
+            gameboyType = GameboyType.DMG,
+            bootstrapMode = Gameboy.BootstrapMode.SKIP,
+            frame = 73,
+            player = 0,
+            sessionSnapshot = byteArrayOf(4, 5, 6),
+            heldButtons = setOf(Button.START),
+        )
+    senderBus.post(LinkedController.SessionStateReadyEvent(73, listOf(state)))
+
+    assertEquals(null, received.poll(200, TimeUnit.MILLISECONDS))
+    val checkpoint = assertNotNull(synchronized.poll(5, TimeUnit.SECONDS))
+    assertEquals(1, checkpoint.states.size)
+    val game = checkpoint.states.single()
+    assertContentEquals(byteArrayOf(4, 5, 6), game.sessionSnapshot)
+    assertEquals(setOf(Button.START), game.heldButtons)
+    assertEquals(73, checkpoint.frame)
   }
 
   @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller.network
 
 import eu.rekawek.coffeegb.controller.Input
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.link.LinkedController
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
@@ -103,7 +104,7 @@ class ConnectionTest {
 
   private val threads = mutableListOf<Thread>()
 
-  private fun connect() {
+  private fun connect(startSession: Boolean = true) {
     val senderToReceiver = Pipe()
     val receiverToSender = Pipe()
 
@@ -115,6 +116,7 @@ class ConnectionTest {
     // run() performs the handshake and then reads; both sides need it running
     threads += Thread { sender.run() }.also { it.start() }
     threads += Thread { receiver.run() }.also { it.start() }
+    if (startSession) sender.startSession()
   }
 
   @After
@@ -186,6 +188,30 @@ class ConnectionTest {
   }
 
   @Test
+  fun messagesReceivedBeforeStartAreDeliveredAfterControllerTransition() {
+    val received = LinkedBlockingQueue<Connection.PeerLoadedGameEvent>()
+    receiverBus.register<Connection.PeerLoadedGameEvent> { received.add(it) }
+    connect(startSession = false)
+
+    senderBus.post(
+        LinkedController.LocalRomLoadedEvent(
+            byteArrayOf(1, 2, 3),
+            null,
+            null,
+            GameboyType.DMG,
+            Gameboy.BootstrapMode.SKIP,
+            0,
+        ))
+    assertEquals(null, received.poll(200, TimeUnit.MILLISECONDS))
+
+    sender!!.startSession()
+    assertContentEquals(
+        byteArrayOf(1, 2, 3),
+        assertNotNull(received.poll(5, TimeUnit.SECONDS)).rom,
+    )
+  }
+
+  @Test
   fun resetAndStopRoundTrip() {
     val resets = LinkedBlockingQueue<Connection.ReceivedRemoteResetEvent>()
     val stops = LinkedBlockingQueue<Connection.ReceivedRemoteStopEvent>()
@@ -238,7 +264,9 @@ class ConnectionTest {
     val toSender = Pipe()
 
     // the client-side handshake happens during construction
-    toReceiver.sink.write("CoffeeGB WRONG!!".toByteArray() + byteArrayOf(0x02))
+    toReceiver.sink.write(
+        "CoffeeGB WRONG!!".toByteArray() +
+            byteArrayOf(0x05, LinkMode.NORMAL.ordinal.toByte(), 0x01))
     assertFailsWith<IOException> {
       Connection(toReceiver.source, toSender.sink, receiverBus, false)
     }
@@ -249,7 +277,9 @@ class ConnectionTest {
     val toReceiver = Pipe()
     val toSender = Pipe()
 
-    toReceiver.sink.write("CoffeeGB NETPLAY".toByteArray() + byteArrayOf(0x7f))
+    toReceiver.sink.write(
+        "CoffeeGB NETPLAY".toByteArray() +
+            byteArrayOf(0x7f, LinkMode.NORMAL.ordinal.toByte(), 0x01))
     assertFailsWith<IOException> {
       Connection(toReceiver.source, toSender.sink, receiverBus, false)
     }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.network
 import eu.rekawek.coffeegb.controller.Input
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.link.LinkedController
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
@@ -28,15 +29,21 @@ class TcpConnectionTest {
 
   private var client: TcpClient? = null
 
+  private val extraClients = mutableListOf<TcpClient>()
+
+  private val extraBuses = mutableListOf<EventBusImpl>()
+
   private val threads = mutableListOf<Thread>()
 
   @After
   fun tearDown() {
     client?.stop()
+    extraClients.forEach { it.stop() }
     server?.stop()
     threads.forEach { it.join(3000) }
     serverBus.close()
     clientBus.close()
+    extraBuses.forEach { it.close() }
   }
 
   @Test
@@ -85,12 +92,90 @@ class TcpConnectionTest {
     repeat(20) { i ->
       clientBus.post(
           LinkedController.LocalButtonStateEvent(
-              i.toLong(), Input(listOf(Button.entries[i % Button.entries.size]), emptyList())))
+              i.toLong(),
+              Input(listOf(Button.entries[i % Button.entries.size]), emptyList()),
+              player = 1,
+          ))
     }
     repeat(20) { i ->
       val e = assertNotNull(serverReceivedButtons.poll(5, TimeUnit.SECONDS), "input ${i + 1} lost")
       assertEquals(i.toLong(), e.frame)
       assertEquals(listOf(Button.entries[i % Button.entries.size]), e.input.pressedButtons)
+    }
+  }
+
+  @Test
+  fun fourPlayerServerAssignsSlotsWaitsForAllPlayersAndRelaysInput() {
+    val port = ServerSocket(0).use { it.localPort }
+    val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
+    val sessionStarted = LinkedBlockingQueue<ConnectionController.ServerGotConnectionEvent>()
+    serverBus.register<ConnectionController.ServerStartedEvent> { serverStarted.add(it) }
+    serverBus.register<ConnectionController.ServerGotConnectionEvent> { sessionStarted.add(it) }
+
+    val server = TcpServer(serverBus, port, LinkMode.FOUR_PLAYER_ADAPTER)
+    this.server = server
+    threads += Thread(server).also { it.start() }
+    assertNotNull(serverStarted.poll(5, TimeUnit.SECONDS), "server did not start")
+
+    val buses = List(3) { EventBusImpl().also(extraBuses::add) }
+    val handshakes = buses.map { LinkedBlockingQueue<ConnectionController.ClientHandshakeCompletedEvent>() }
+    val ready = buses.map { LinkedBlockingQueue<ConnectionController.ClientConnectedToServerEvent>() }
+    buses.forEachIndexed { index, bus ->
+      bus.register<ConnectionController.ClientHandshakeCompletedEvent> { handshakes[index].add(it) }
+      bus.register<ConnectionController.ClientConnectedToServerEvent> { ready[index].add(it) }
+      val client = TcpClient("localhost:$port", bus)
+      extraClients += client
+      threads += Thread(client).also { it.start() }
+      val handshake = assertNotNull(handshakes[index].poll(5, TimeUnit.SECONDS))
+      assertEquals(LinkMode.FOUR_PLAYER_ADAPTER, handshake.mode)
+      assertEquals(index + 1, handshake.player)
+      if (index < 2) {
+        assertEquals(null, ready[index].poll(200, TimeUnit.MILLISECONDS))
+      }
+    }
+
+    assertNotNull(sessionStarted.poll(5, TimeUnit.SECONDS), "server did not release session")
+    ready.forEachIndexed { index, queue ->
+      val event = assertNotNull(queue.poll(5, TimeUnit.SECONDS), "player ${index + 2} not released")
+      assertEquals(LinkMode.FOUR_PLAYER_ADAPTER, event.mode)
+      assertEquals(index + 1, event.player)
+    }
+
+    val serverInputs = LinkedBlockingQueue<LinkedController.RemoteButtonStateEvent>()
+    serverBus.register<LinkedController.RemoteButtonStateEvent> { serverInputs.add(it) }
+    val clientInputs =
+        buses.map { bus ->
+          LinkedBlockingQueue<LinkedController.RemoteButtonStateEvent>().also { queue ->
+            bus.register<LinkedController.RemoteButtonStateEvent> { queue.add(it) }
+          }
+        }
+
+    buses[1].post(
+        LinkedController.LocalButtonStateEvent(
+            55,
+            Input(listOf(Button.START), emptyList()),
+            player = 2,
+        ))
+    val atServer = assertNotNull(serverInputs.poll(5, TimeUnit.SECONDS))
+    assertEquals(2, atServer.player)
+    assertEquals(55, atServer.frame)
+    for (clientIndex in listOf(0, 2)) {
+      val relayed = assertNotNull(clientInputs[clientIndex].poll(5, TimeUnit.SECONDS))
+      assertEquals(2, relayed.player)
+      assertEquals(listOf(Button.START), relayed.input.pressedButtons)
+    }
+    assertEquals(null, clientInputs[1].poll(200, TimeUnit.MILLISECONDS))
+
+    serverBus.post(
+        LinkedController.LocalButtonStateEvent(
+            56,
+            Input(listOf(Button.A), emptyList()),
+            player = 0,
+        ))
+    clientInputs.forEachIndexed { index, queue ->
+      val relayed = assertNotNull(queue.poll(5, TimeUnit.SECONDS), "host input missing at $index")
+      assertEquals(0, relayed.player)
+      assertEquals(56, relayed.frame)
     }
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -105,7 +105,7 @@ class TcpConnectionTest {
   }
 
   @Test
-  fun fourPlayerServerAssignsSlotsWaitsForAllPlayersAndRelaysInput() {
+  fun fourPlayerServerStartsImmediatelyAssignsSlotsAndRelaysInput() {
     val port = ServerSocket(0).use { it.localPort }
     val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
     val sessionStarted = LinkedBlockingQueue<ConnectionController.ServerGotConnectionEvent>()
@@ -116,6 +116,9 @@ class TcpConnectionTest {
     this.server = server
     threads += Thread(server).also { it.start() }
     assertNotNull(serverStarted.poll(5, TimeUnit.SECONDS), "server did not start")
+    val active = assertNotNull(sessionStarted.poll(5, TimeUnit.SECONDS), "adapter did not start")
+    assertEquals(LinkMode.FOUR_PLAYER_ADAPTER, active.mode)
+    assertEquals(0, active.player)
 
     val buses = List(3) { EventBusImpl().also(extraBuses::add) }
     val handshakes = buses.map { LinkedBlockingQueue<ConnectionController.ClientHandshakeCompletedEvent>() }
@@ -129,14 +132,7 @@ class TcpConnectionTest {
       val handshake = assertNotNull(handshakes[index].poll(5, TimeUnit.SECONDS))
       assertEquals(LinkMode.FOUR_PLAYER_ADAPTER, handshake.mode)
       assertEquals(index + 1, handshake.player)
-      if (index < 2) {
-        assertEquals(null, ready[index].poll(200, TimeUnit.MILLISECONDS))
-      }
-    }
-
-    assertNotNull(sessionStarted.poll(5, TimeUnit.SECONDS), "server did not release session")
-    ready.forEachIndexed { index, queue ->
-      val event = assertNotNull(queue.poll(5, TimeUnit.SECONDS), "player ${index + 2} not released")
+      val event = assertNotNull(ready[index].poll(5, TimeUnit.SECONDS))
       assertEquals(LinkMode.FOUR_PLAYER_ADAPTER, event.mode)
       assertEquals(index + 1, event.player)
     }
@@ -180,6 +176,51 @@ class TcpConnectionTest {
   }
 
   @Test
+  fun disconnectedFourPlayerSlotCanBeReusedWithoutStoppingServer() {
+    val port = ServerSocket(0).use { it.localPort }
+    val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
+    val disconnected = LinkedBlockingQueue<ConnectionController.ServerPlayerDisconnectedEvent>()
+    serverBus.register<ConnectionController.ServerStartedEvent> { serverStarted.add(it) }
+    serverBus.register<ConnectionController.ServerPlayerDisconnectedEvent> { disconnected.add(it) }
+
+    val server = TcpServer(serverBus, port, LinkMode.FOUR_PLAYER_ADAPTER)
+    this.server = server
+    threads += Thread(server).also { it.start() }
+    assertNotNull(serverStarted.poll(5, TimeUnit.SECONDS))
+
+    val firstBus = EventBusImpl().also(extraBuses::add)
+    val firstHandshake = LinkedBlockingQueue<ConnectionController.ClientHandshakeCompletedEvent>()
+    val firstReady = LinkedBlockingQueue<ConnectionController.ClientConnectedToServerEvent>()
+    firstBus.register<ConnectionController.ClientHandshakeCompletedEvent> { firstHandshake.add(it) }
+    firstBus.register<ConnectionController.ClientConnectedToServerEvent> { firstReady.add(it) }
+    val first = TcpClient("localhost:$port", firstBus)
+    extraClients += first
+    threads += Thread(first).also { it.start() }
+    assertEquals(1, assertNotNull(firstHandshake.poll(5, TimeUnit.SECONDS)).player)
+    assertNotNull(firstReady.poll(5, TimeUnit.SECONDS))
+
+    first.stop()
+    assertEquals(1, assertNotNull(disconnected.poll(5, TimeUnit.SECONDS)).player)
+
+    val replacementBus = EventBusImpl().also(extraBuses::add)
+    val replacementHandshake =
+        LinkedBlockingQueue<ConnectionController.ClientHandshakeCompletedEvent>()
+    val replacementReady = LinkedBlockingQueue<ConnectionController.ClientConnectedToServerEvent>()
+    replacementBus.register<ConnectionController.ClientHandshakeCompletedEvent> {
+      replacementHandshake.add(it)
+    }
+    replacementBus.register<ConnectionController.ClientConnectedToServerEvent> {
+      replacementReady.add(it)
+    }
+    val replacement = TcpClient("localhost:$port", replacementBus)
+    extraClients += replacement
+    threads += Thread(replacement).also { it.start() }
+
+    assertEquals(1, assertNotNull(replacementHandshake.poll(5, TimeUnit.SECONDS)).player)
+    assertNotNull(replacementReady.poll(5, TimeUnit.SECONDS))
+  }
+
+  @Test
   fun fourPlayerServerRejectsAnExtraClientWithAClearReason() {
     val port = ServerSocket(0).use { it.localPort }
     val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
@@ -197,9 +238,7 @@ class TcpConnectionTest {
       val client = TcpClient("localhost:$port", bus)
       extraClients += client
       threads += Thread(client).also { it.start() }
-      if (it == 2) {
-        assertNotNull(ready.poll(5, TimeUnit.SECONDS), "full roster did not start")
-      }
+      assertNotNull(ready.poll(5, TimeUnit.SECONDS), "client ${it + 2} did not start")
     }
 
     val rejectedBus = EventBusImpl().also(extraBuses::add)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -178,4 +178,41 @@ class TcpConnectionTest {
       assertEquals(56, relayed.frame)
     }
   }
+
+  @Test
+  fun fourPlayerServerRejectsAnExtraClientWithAClearReason() {
+    val port = ServerSocket(0).use { it.localPort }
+    val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
+    serverBus.register<ConnectionController.ServerStartedEvent> { serverStarted.add(it) }
+
+    val server = TcpServer(serverBus, port, LinkMode.FOUR_PLAYER_ADAPTER)
+    this.server = server
+    threads += Thread(server).also { it.start() }
+    assertNotNull(serverStarted.poll(5, TimeUnit.SECONDS), "server did not start")
+
+    repeat(3) {
+      val bus = EventBusImpl().also(extraBuses::add)
+      val ready = LinkedBlockingQueue<ConnectionController.ClientConnectedToServerEvent>()
+      bus.register<ConnectionController.ClientConnectedToServerEvent> { ready.add(it) }
+      val client = TcpClient("localhost:$port", bus)
+      extraClients += client
+      threads += Thread(client).also { it.start() }
+      if (it == 2) {
+        assertNotNull(ready.poll(5, TimeUnit.SECONDS), "full roster did not start")
+      }
+    }
+
+    val rejectedBus = EventBusImpl().also(extraBuses::add)
+    val rejected = LinkedBlockingQueue<ConnectionController.ClientConnectionRejectedEvent>()
+    val handshake = LinkedBlockingQueue<ConnectionController.ClientHandshakeCompletedEvent>()
+    rejectedBus.register<ConnectionController.ClientConnectionRejectedEvent> { rejected.add(it) }
+    rejectedBus.register<ConnectionController.ClientHandshakeCompletedEvent> { handshake.add(it) }
+    val extraClient = TcpClient("localhost:$port", rejectedBus)
+    extraClients += extraClient
+    threads += Thread(extraClient).also { it.start() }
+
+    val event = assertNotNull(rejected.poll(5, TimeUnit.SECONDS), "rejection reason not received")
+    assertEquals("The netplay server is already full.", event.message)
+    assertEquals(null, handshake.poll(200, TimeUnit.MILLISECONDS))
+  }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -32,7 +32,7 @@ public final class CartridgeProperties {
         DATEL,
         WISDOM_TREE,
         MBC1,
-        POCKET_CAMERA
+        POCKET_CAMERA,
         MBC5
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
@@ -6,10 +6,11 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery.FileBatteryMemen
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 public class MemoryBattery implements Battery, Originator<Battery> {
 
-    private final byte[] buffer;
+    private byte[] buffer;
 
     public MemoryBattery(byte[] buffer) {
         this.buffer = buffer.clone();
@@ -17,6 +18,7 @@ public class MemoryBattery implements Battery, Originator<Battery> {
 
     @Override
     public void loadRam(int[] ram) {
+        ensureCapacity(ram.length);
         for (int i = 0; i < ram.length; i++) {
             ram[i] = buffer[i] & 0xff;
         }
@@ -24,6 +26,7 @@ public class MemoryBattery implements Battery, Originator<Battery> {
 
     @Override
     public void saveRam(int[] ram) {
+        ensureCapacity(ram.length);
         for (int i = 0; i < ram.length; i++) {
             buffer[i] = (byte) (ram[i]);
         }
@@ -31,10 +34,11 @@ public class MemoryBattery implements Battery, Originator<Battery> {
 
     @Override
     public void loadRamWithClock(int[] ram, long[] clockData) {
+        ensureCapacity(ram.length + clockSize(clockData));
         loadRam(ram);
 
         if (clockData != null) {
-            ByteBuffer buff = ByteBuffer.wrap(buffer, ram.length, buffer.length - ram.length);
+            ByteBuffer buff = ByteBuffer.wrap(buffer, ram.length, clockSize(clockData));
             buff.order(ByteOrder.LITTLE_ENDIAN);
             int i = 0;
             while (buff.hasRemaining()) {
@@ -45,15 +49,13 @@ public class MemoryBattery implements Battery, Originator<Battery> {
 
     @Override
     public void saveRamWithClock(int[] ram, long[] clockData) {
+        ensureCapacity(ram.length + clockSize(clockData));
         saveRam(ram);
 
         if (clockData != null) {
-            ByteBuffer buff = ByteBuffer.wrap(buffer, ram.length, buffer.length - ram.length);
+            ByteBuffer buff = ByteBuffer.wrap(buffer, ram.length, clockSize(clockData));
             buff.order(ByteOrder.LITTLE_ENDIAN);
             for (long d : clockData) {
-                if (buff.limit() - buff.position() < 4) {
-                    break;
-                }
                 buff.putInt((int) d);
             }
         }
@@ -61,6 +63,18 @@ public class MemoryBattery implements Battery, Originator<Battery> {
 
     @Override
     public void flush() {
+    }
+
+    private void ensureCapacity(int capacity) {
+        // Netplay mirrors the save file byte-for-byte, including an existing zero-length or
+        // truncated file. Match FileBattery by treating bytes missing from that file as zeroes.
+        if (buffer.length < capacity) {
+            buffer = Arrays.copyOf(buffer, capacity);
+        }
+    }
+
+    private static int clockSize(long[] clockData) {
+        return clockData == null ? 0 : clockData.length * Integer.BYTES;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -77,7 +77,10 @@ public final class FourPlayerAdapter {
             case PING -> packetByte == 0 ? 0xfe : statusMask();
             case TRANSMISSION_INDICATOR -> 0xcc;
             case PING_INDICATOR -> 0xff;
-            case TRANSMISSION -> transmissionBuffer[packetByte];
+            // The adapter's transmit register leads its reply-capture counter by one byte. The
+            // last byte wraps to the start of the stream; software's receive ring restores the
+            // logical player/byte order. F-1 Race depends on this physical byte phase.
+            case TRANSMISSION -> transmissionBuffer[(packetByte + 1) % packetLength()];
         };
     }
 
@@ -148,7 +151,11 @@ public final class FourPlayerAdapter {
 
         int newSize = replies[0][0];
         int newRate = replies[0][3];
-        if (newRate != 0) {
+        // A correctly aligned switch command starts after the ping header: its first three AA
+        // replies therefore occupy this packet's ACK1, ACK2 and RATE positions, and the fourth
+        // arrives with the next header. The RATE slot is command data in that case, not a new
+        // adapter rate; retain the last complete ping's rate as the hardware does.
+        if (newRate != 0 && consecutiveAa[0] < 3) {
             rate = newRate;
         }
         if (newSize >= 1 && newSize <= 4) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -36,8 +36,6 @@ public final class FourPlayerAdapter {
 
     private final boolean[] connected = new boolean[PLAYER_COUNT];
 
-    private final int[] consecutiveAa = new int[PLAYER_COUNT];
-
     private final int[] consecutiveFf = new int[PLAYER_COUNT];
 
     private final int[][] replies = new int[PLAYER_COUNT][16];
@@ -55,6 +53,8 @@ public final class FourPlayerAdapter {
     private int size = 1;
 
     private Phase phase = Phase.PING;
+
+    private boolean transmissionRequested;
 
     private boolean restartPingRequested;
 
@@ -77,12 +77,7 @@ public final class FourPlayerAdapter {
             case PING -> packetByte == 0 ? 0xfe : statusMask();
             case TRANSMISSION_INDICATOR -> 0xcc;
             case PING_INDICATOR -> 0xff;
-            // The transmitted stream leads the capture counter by one byte. At the packet
-            // boundary, continue with the first reply already captured for the next packet
-            // instead of wrapping to stale data from the old packet.
-            case TRANSMISSION -> packetByte + 1 < packetLength()
-                    ? transmissionBuffer[packetByte + 1]
-                    : replies[0][0];
+            case TRANSMISSION -> transmissionBuffer[packetByte];
         };
     }
 
@@ -145,6 +140,15 @@ public final class FourPlayerAdapter {
     }
 
     private void finishPingPacket() {
+        // The master requests transmission while replying to a ping. The adapter finishes that
+        // four-byte ping before returning the CC indicator packet; bytes from the partial command
+        // are not a new ACK/rate/size packet.
+        if (transmissionRequested) {
+            phase = Phase.TRANSMISSION_INDICATOR;
+            transmissionRequested = false;
+            return;
+        }
+
         for (int player = 0; player < PLAYER_COUNT; player++) {
             // Replies are one byte behind what the Game Boy receives: FE causes software to load
             // ACK1, which is sent alongside STAT1; ACK2 is then sent alongside STAT2.
@@ -153,11 +157,7 @@ public final class FourPlayerAdapter {
 
         int newSize = replies[0][0];
         int newRate = replies[0][3];
-        // A correctly aligned switch command starts after the ping header: its first three AA
-        // replies therefore occupy this packet's ACK1, ACK2 and RATE positions, and the fourth
-        // arrives with the next header. The RATE slot is command data in that case, not a new
-        // adapter rate; retain the last complete ping's rate as the hardware does.
-        if (newRate != 0 && consecutiveAa[0] < 3) {
+        if (newRate != 0) {
             rate = newRate;
         }
         if (newSize >= 1 && newSize <= 4) {
@@ -168,9 +168,9 @@ public final class FourPlayerAdapter {
     private void finishTransmissionPacket() {
         int[] nextBuffer = new int[16];
         for (int player = 0; player < PLAYER_COUNT; player++) {
-            // Each Game Boy loads its packet data before the first transfer. Only its first SIZE
-            // replies enter the DMG-07 buffer; replies during the other players' slots are ignored.
-            System.arraycopy(replies[player], 0, nextBuffer, player * size, size);
+            // Games load byte 1 after receiving byte 0, so the first SIZE replies are physically
+            // transferred in slots 1..SIZE. The other players' outgoing slots are ignored.
+            System.arraycopy(replies[player], 1, nextBuffer, player * size, size);
         }
         transmissionBuffer = nextBuffer;
         if (restartPingRequested) {
@@ -179,15 +179,15 @@ public final class FourPlayerAdapter {
         }
     }
 
-    private boolean observeReplyByte() {
+    private void observeReplyByte() {
         for (int player = 0; player < PLAYER_COUNT; player++) {
             int reply = replies[player][packetByte];
             if (phase == Phase.PING) {
-                consecutiveAa[player] = reply == 0xaa ? consecutiveAa[player] + 1 : 0;
-                if (consecutiveAa[player] >= 4) {
-                    Arrays.fill(consecutiveAa, 0);
-                    phase = Phase.TRANSMISSION_INDICATOR;
-                    return true;
+                // Player 1 is the protocol master. Once it starts the AA command, complete the
+                // current ping packet before switching phases. Only three AA replies fit after
+                // the FE header; games may send the fourth alongside the first CC response.
+                if (player == 0 && reply == 0xaa) {
+                    transmissionRequested = true;
                 }
             } else if (phase == Phase.TRANSMISSION) {
                 consecutiveFf[player] = reply == 0xff ? consecutiveFf[player] + 1 : 0;
@@ -196,7 +196,6 @@ public final class FourPlayerAdapter {
                 }
             }
         }
-        return false;
     }
 
     private AdapterMemento saveState() {
@@ -205,9 +204,9 @@ public final class FourPlayerAdapter {
             repliesCopy[i] = replies[i].clone();
         }
         return new AdapterMemento(sb.clone(), transferArmed.clone(), pendingBits.clone(),
-                connected.clone(), consecutiveAa.clone(), consecutiveFf.clone(), repliesCopy,
+                connected.clone(), consecutiveFf.clone(), repliesCopy,
                 transmissionBuffer.clone(), packetByte, bit, ticksUntilBit, rate, size, phase,
-                restartPingRequested);
+                transmissionRequested, restartPingRequested);
     }
 
     private void restoreState(AdapterMemento state) {
@@ -215,7 +214,6 @@ public final class FourPlayerAdapter {
         System.arraycopy(state.transferArmed, 0, transferArmed, 0, PLAYER_COUNT);
         System.arraycopy(state.pendingBits, 0, pendingBits, 0, PLAYER_COUNT);
         System.arraycopy(state.connected, 0, connected, 0, PLAYER_COUNT);
-        System.arraycopy(state.consecutiveAa, 0, consecutiveAa, 0, PLAYER_COUNT);
         System.arraycopy(state.consecutiveFf, 0, consecutiveFf, 0, PLAYER_COUNT);
         for (int i = 0; i < PLAYER_COUNT; i++) {
             System.arraycopy(state.replies[i], 0, replies[i], 0, replies[i].length);
@@ -227,6 +225,7 @@ public final class FourPlayerAdapter {
         rate = state.rate;
         size = state.size;
         phase = state.phase;
+        transmissionRequested = state.transmissionRequested;
         restartPingRequested = state.restartPingRequested;
     }
 
@@ -238,11 +237,10 @@ public final class FourPlayerAdapter {
     }
 
     private record AdapterMemento(int[] sb, boolean[] transferArmed, int[] pendingBits,
-                                  boolean[] connected, int[] consecutiveAa, int[] consecutiveFf,
-                                  int[][] replies,
+                                  boolean[] connected, int[] consecutiveFf, int[][] replies,
                                   int[] transmissionBuffer, int packetByte, int bit,
                                   int ticksUntilBit, int rate, int size, Phase phase,
-                                  boolean restartPingRequested)
+                                  boolean transmissionRequested, boolean restartPingRequested)
             implements Memento<SerialEndpoint> {
     }
 
@@ -285,11 +283,7 @@ public final class FourPlayerAdapter {
             ticksUntilBit = CLOCK_TICKS_PER_BIT - 1;
             if (--bit < 0) {
                 bit = 7;
-                if (observeReplyByte()) {
-                    packetByte = 0;
-                    ticksUntilBit += PING_BYTE_GAP_TICKS;
-                    return;
-                }
+                observeReplyByte();
                 packetByte++;
                 int packetLength = packetLength();
                 if (packetByte < packetLength) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -1,0 +1,326 @@
+package eu.rekawek.coffeegb.core.serial;
+
+import eu.rekawek.coffeegb.core.cpu.BitUtils;
+import eu.rekawek.coffeegb.core.memento.Memento;
+
+import java.util.Arrays;
+
+/**
+ * Emulates Nintendo's DMG-07 four-player adapter.
+ *
+ * <p>The adapter owns the serial clock and broadcasts one byte to all four ports at once. During
+ * the ping phase it assigns the physical player number and reports the connected-port mask. In the
+ * transmission phase it returns the previous packet's data, ordered by player, while collecting
+ * the next packet from all four Game Boys.</p>
+ */
+public final class FourPlayerAdapter {
+
+    public static final int PLAYER_COUNT = 4;
+
+    // The measured DMG-07 serial clock is 62.66 kHz, or about 66.9 DMG T-cycles per bit.
+    private static final int CLOCK_TICKS_PER_BIT = 67;
+
+    private static final int PING_BYTE_GAP_TICKS = 5_956;
+
+    private static final int PING_PACKET_GAP_TICKS = 51_548;
+
+    private static final int TICKS_PER_MILLISECOND = 4_194;
+
+    private final Endpoint[] endpoints = new Endpoint[PLAYER_COUNT];
+
+    private final int[] sb = new int[PLAYER_COUNT];
+
+    private final boolean[] transferArmed = new boolean[PLAYER_COUNT];
+
+    private final int[] pendingBits = new int[PLAYER_COUNT];
+
+    private final boolean[] connected = new boolean[PLAYER_COUNT];
+
+    private final int[] consecutiveAa = new int[PLAYER_COUNT];
+
+    private final int[] consecutiveFf = new int[PLAYER_COUNT];
+
+    private final int[][] replies = new int[PLAYER_COUNT][16];
+
+    private int[] transmissionBuffer = new int[16];
+
+    private int packetByte;
+
+    private int bit = 7;
+
+    private int ticksUntilBit;
+
+    private int rate = 0x10;
+
+    private int size = 1;
+
+    private Phase phase = Phase.PING;
+
+    private boolean restartPingRequested;
+
+    public FourPlayerAdapter() {
+        Arrays.fill(pendingBits, -1);
+        for (int i = 0; i < PLAYER_COUNT; i++) {
+            endpoints[i] = new Endpoint(i);
+        }
+    }
+
+    public SerialEndpoint endpoint(int player) {
+        if (player < 0 || player >= PLAYER_COUNT) {
+            throw new IllegalArgumentException("Invalid player: " + player);
+        }
+        return endpoints[player];
+    }
+
+    private int outgoingByte() {
+        return switch (phase) {
+            case PING -> packetByte == 0 ? 0xfe : statusMask();
+            case TRANSMISSION_INDICATOR -> 0xcc;
+            case PING_INDICATOR -> 0xff;
+            case TRANSMISSION -> transmissionBuffer[packetByte];
+        };
+    }
+
+    private int statusMask() {
+        int mask = 0;
+        for (int i = 0; i < PLAYER_COUNT; i++) {
+            if (connected[i]) {
+                mask |= 1 << (4 + i);
+            }
+        }
+        // The same connection mask is broadcast, but the low bits are hard-wired per port.
+        return mask;
+    }
+
+    private int outgoingByte(int player) {
+        if (phase == Phase.PING && packetByte != 0) {
+            return statusMask() | (player + 1);
+        }
+        return outgoingByte();
+    }
+
+    private int packetLength() {
+        return switch (phase) {
+            case PING, TRANSMISSION_INDICATOR -> 4;
+            case TRANSMISSION, PING_INDICATOR -> size * PLAYER_COUNT;
+        };
+    }
+
+    private int byteGapTicks() {
+        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR) {
+            return PING_BYTE_GAP_TICKS;
+        }
+        return 3_720 + ((rate >>> 4) & 0x0f) * 445;
+    }
+
+    private int packetGapTicks(int packetLength) {
+        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR) {
+            return PING_PACKET_GAP_TICKS + (rate & 0x0f) * TICKS_PER_MILLISECOND;
+        }
+        int byteGap = byteGapTicks();
+        int elapsed = packetLength * 8 * CLOCK_TICKS_PER_BIT + (packetLength - 1) * byteGap;
+        int minimumPeriod = 17 * TICKS_PER_MILLISECOND
+                + (rate & 0x0f) * TICKS_PER_MILLISECOND;
+        return Math.max(1_510, minimumPeriod - elapsed);
+    }
+
+    private void finishPacket() {
+        switch (phase) {
+            case PING -> finishPingPacket();
+            case TRANSMISSION_INDICATOR -> phase = Phase.TRANSMISSION;
+            case TRANSMISSION -> finishTransmissionPacket();
+            case PING_INDICATOR -> {
+                phase = Phase.PING;
+                Arrays.fill(connected, false);
+            }
+        }
+        for (int[] playerReplies : replies) {
+            Arrays.fill(playerReplies, 0);
+        }
+    }
+
+    private void finishPingPacket() {
+        for (int player = 0; player < PLAYER_COUNT; player++) {
+            // Replies are one byte behind what the Game Boy receives: FE causes software to load
+            // ACK1, which is sent alongside STAT1; ACK2 is then sent alongside STAT2.
+            connected[player] = replies[player][1] == 0x88 && replies[player][2] == 0x88;
+        }
+
+        int newSize = replies[0][0];
+        int newRate = replies[0][3];
+        if (newRate != 0) {
+            rate = newRate;
+        }
+        if (newSize >= 1 && newSize <= 4) {
+            size = newSize;
+        }
+    }
+
+    private void finishTransmissionPacket() {
+        int[] nextBuffer = new int[16];
+        for (int player = 0; player < PLAYER_COUNT; player++) {
+            // Like ping replies, transmitted data is physically one transfer behind the byte it
+            // answers. Games receive byte 0, load their first data byte in the serial ISR, and the
+            // adapter samples it during byte 1.
+            System.arraycopy(replies[player], 1, nextBuffer, player * size, size);
+        }
+        transmissionBuffer = nextBuffer;
+        if (restartPingRequested) {
+            phase = Phase.PING_INDICATOR;
+            restartPingRequested = false;
+        }
+    }
+
+    private boolean observeReplyByte() {
+        for (int player = 0; player < PLAYER_COUNT; player++) {
+            int reply = replies[player][packetByte];
+            if (phase == Phase.PING) {
+                consecutiveAa[player] = reply == 0xaa ? consecutiveAa[player] + 1 : 0;
+                if (consecutiveAa[player] >= 4) {
+                    Arrays.fill(consecutiveAa, 0);
+                    phase = Phase.TRANSMISSION_INDICATOR;
+                    return true;
+                }
+            } else if (phase == Phase.TRANSMISSION) {
+                consecutiveFf[player] = reply == 0xff ? consecutiveFf[player] + 1 : 0;
+                if (consecutiveFf[player] >= 3) {
+                    restartPingRequested = true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private AdapterMemento saveState() {
+        int[][] repliesCopy = new int[PLAYER_COUNT][];
+        for (int i = 0; i < PLAYER_COUNT; i++) {
+            repliesCopy[i] = replies[i].clone();
+        }
+        return new AdapterMemento(sb.clone(), transferArmed.clone(), pendingBits.clone(),
+                connected.clone(), consecutiveAa.clone(), consecutiveFf.clone(), repliesCopy,
+                transmissionBuffer.clone(), packetByte, bit, ticksUntilBit, rate, size, phase,
+                restartPingRequested);
+    }
+
+    private void restoreState(AdapterMemento state) {
+        System.arraycopy(state.sb, 0, sb, 0, PLAYER_COUNT);
+        System.arraycopy(state.transferArmed, 0, transferArmed, 0, PLAYER_COUNT);
+        System.arraycopy(state.pendingBits, 0, pendingBits, 0, PLAYER_COUNT);
+        System.arraycopy(state.connected, 0, connected, 0, PLAYER_COUNT);
+        System.arraycopy(state.consecutiveAa, 0, consecutiveAa, 0, PLAYER_COUNT);
+        System.arraycopy(state.consecutiveFf, 0, consecutiveFf, 0, PLAYER_COUNT);
+        for (int i = 0; i < PLAYER_COUNT; i++) {
+            System.arraycopy(state.replies[i], 0, replies[i], 0, replies[i].length);
+        }
+        transmissionBuffer = state.transmissionBuffer.clone();
+        packetByte = state.packetByte;
+        bit = state.bit;
+        ticksUntilBit = state.ticksUntilBit;
+        rate = state.rate;
+        size = state.size;
+        phase = state.phase;
+        restartPingRequested = state.restartPingRequested;
+    }
+
+    private enum Phase {
+        PING,
+        TRANSMISSION_INDICATOR,
+        TRANSMISSION,
+        PING_INDICATOR
+    }
+
+    private record AdapterMemento(int[] sb, boolean[] transferArmed, int[] pendingBits,
+                                  boolean[] connected, int[] consecutiveAa, int[] consecutiveFf,
+                                  int[][] replies,
+                                  int[] transmissionBuffer, int packetByte, int bit,
+                                  int ticksUntilBit, int rate, int size, Phase phase,
+                                  boolean restartPingRequested)
+            implements Memento<SerialEndpoint> {
+    }
+
+    private final class Endpoint implements SerialEndpoint {
+
+        private final int player;
+
+        private Endpoint(int player) {
+            this.player = player;
+        }
+
+        @Override
+        public void setSb(int value) {
+            sb[player] = value & 0xff;
+        }
+
+        @Override
+        public int recvBit() {
+            if (player == 0) {
+                tickClockForPlayers();
+            }
+            int result = pendingBits[player];
+            pendingBits[player] = -1;
+            return transferArmed[player] ? result : -1;
+        }
+
+        private void tickClockForPlayers() {
+            if (ticksUntilBit > 0) {
+                ticksUntilBit--;
+                return;
+            }
+            if (bit == 7) {
+                for (int p = 0; p < PLAYER_COUNT; p++) {
+                    replies[p][packetByte] = sb[p];
+                }
+            }
+            for (int p = 0; p < PLAYER_COUNT; p++) {
+                pendingBits[p] = BitUtils.getBit(outgoingByte(p), bit) ? 1 : 0;
+            }
+            ticksUntilBit = CLOCK_TICKS_PER_BIT - 1;
+            if (--bit < 0) {
+                bit = 7;
+                if (observeReplyByte()) {
+                    packetByte = 0;
+                    ticksUntilBit += PING_BYTE_GAP_TICKS;
+                    return;
+                }
+                packetByte++;
+                int packetLength = packetLength();
+                if (packetByte < packetLength) {
+                    ticksUntilBit += byteGapTicks();
+                } else {
+                    finishPacket();
+                    packetByte = 0;
+                    ticksUntilBit += packetGapTicks(packetLength);
+                }
+            }
+        }
+
+        @Override
+        public void setExternalTransfer(boolean inProgress) {
+            transferArmed[player] = inProgress;
+        }
+
+        @Override
+        public void startSending() {
+            // The DMG-07 owns framing and clock phase; arming SC does not reset the adapter.
+        }
+
+        @Override
+        public int sendBit() {
+            // Internal clock mode is unsupported by the physical adapter and reads as an idle line.
+            return 1;
+        }
+
+        @Override
+        public Memento<SerialEndpoint> saveToMemento() {
+            return saveState();
+        }
+
+        @Override
+        public void restoreFromMemento(Memento<SerialEndpoint> memento) {
+            if (!(memento instanceof AdapterMemento state)) {
+                throw new IllegalArgumentException("Invalid memento type");
+            }
+            restoreState(state);
+        }
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -159,10 +159,9 @@ public final class FourPlayerAdapter {
     private void finishTransmissionPacket() {
         int[] nextBuffer = new int[16];
         for (int player = 0; player < PLAYER_COUNT; player++) {
-            // Like ping replies, transmitted data is physically one transfer behind the byte it
-            // answers. Games receive byte 0, load their first data byte in the serial ISR, and the
-            // adapter samples it during byte 1.
-            System.arraycopy(replies[player], 1, nextBuffer, player * size, size);
+            // Each Game Boy loads its packet data before the first transfer. Only its first SIZE
+            // replies enter the DMG-07 buffer; replies during the other players' slots are ignored.
+            System.arraycopy(replies[player], 0, nextBuffer, player * size, size);
         }
         transmissionBuffer = nextBuffer;
         if (restartPingRequested) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -77,10 +77,12 @@ public final class FourPlayerAdapter {
             case PING -> packetByte == 0 ? 0xfe : statusMask();
             case TRANSMISSION_INDICATOR -> 0xcc;
             case PING_INDICATOR -> 0xff;
-            // The adapter's transmit register leads its reply-capture counter by one byte. The
-            // last byte wraps to the start of the stream; software's receive ring restores the
-            // logical player/byte order. F-1 Race depends on this physical byte phase.
-            case TRANSMISSION -> transmissionBuffer[(packetByte + 1) % packetLength()];
+            // The transmitted stream leads the capture counter by one byte. At the packet
+            // boundary, continue with the first reply already captured for the next packet
+            // instead of wrapping to stale data from the old packet.
+            case TRANSMISSION -> packetByte + 1 < packetLength()
+                    ? transmissionBuffer[packetByte + 1]
+                    : replies[0][0];
         };
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBatteryTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBatteryTest.java
@@ -19,6 +19,16 @@ public class MemoryBatteryTest {
     }
 
     @Test
+    public void truncatedSaveDataPreservesAvailableBytesAndZeroFillsTheRest() {
+        MemoryBattery battery = new MemoryBattery(new byte[]{1, 2});
+        int[] ram = {0xff, 0xff, 0xff, 0xff};
+
+        battery.loadRam(ram);
+
+        assertArrayEquals(new int[]{1, 2, 0, 0}, ram);
+    }
+
+    @Test
     public void emptySaveDataIsExpandedToMapperRamAndClockSize() {
         MemoryBattery battery = new MemoryBattery(new byte[0]);
         int[] ram = {0xff, 0xff};

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBatteryTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBatteryTest.java
@@ -1,0 +1,34 @@
+package eu.rekawek.coffeegb.core.memory.cart.battery;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class MemoryBatteryTest {
+
+    @Test
+    public void emptySaveDataIsExpandedToMapperRamSize() {
+        MemoryBattery battery = new MemoryBattery(new byte[0]);
+        int[] ram = {0xff, 0xff, 0xff, 0xff};
+
+        battery.loadRam(ram);
+        assertArrayEquals(new int[4], ram);
+
+        ram[0] = 0x0a;
+        battery.saveRam(ram);
+    }
+
+    @Test
+    public void emptySaveDataIsExpandedToMapperRamAndClockSize() {
+        MemoryBattery battery = new MemoryBattery(new byte[0]);
+        int[] ram = {0xff, 0xff};
+        long[] clock = {1, 2, 3};
+
+        battery.loadRamWithClock(ram, clock);
+        assertArrayEquals(new int[2], ram);
+        assertArrayEquals(new long[3], clock);
+
+        clock[0] = 42;
+        battery.saveRamWithClock(ram, clock);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -28,11 +28,12 @@ public class FourPlayerAdapterTest {
     public void transmissionBroadcastsPreviousPacketInPlayerOrder() {
         Rig rig = new Rig();
 
-        enterTransmission(rig);
+        enterTransmission(rig, 1);
 
-        // Packet 1 fills the adapter's next buffer; packet 2 broadcasts it to everyone.
-        rig.transfer(0, 0, 0, 0);
+        // Packet 1 fills the adapter's next buffer from its first transfer; packet 2 broadcasts
+        // it to everyone. Later replies in packet 1 are outside every player's SIZE=1 slot.
         rig.transfer(0x11, 0x22, 0x33, 0x44);
+        rig.transfer(0, 0, 0, 0);
         rig.transfer(0, 0, 0, 0);
         rig.transfer(0, 0, 0, 0);
 
@@ -43,9 +44,34 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
+    public void transmissionCapturesSizeFourDataAtStartOfPacket() {
+        Rig rig = new Rig();
+
+        enterTransmission(rig, 4);
+
+        for (int dataByte = 0; dataByte < 4; dataByte++) {
+            rig.transfer(0x10 + dataByte, 0x20 + dataByte,
+                    0x30 + dataByte, 0x40 + dataByte);
+        }
+        // The remaining twelve transfers belong to the other players' outgoing slots. Their
+        // replies must not displace or overwrite the four bytes each player submitted above.
+        for (int i = 4; i < 16; i++) {
+            rig.transfer(0xee, 0xee, 0xee, 0xee);
+        }
+
+        for (int player = 1; player <= 4; player++) {
+            for (int dataByte = 0; dataByte < 4; dataByte++) {
+                int expected = player * 0x10 + dataByte;
+                assertArrayEquals(new int[]{expected, expected, expected, expected},
+                        rig.transfer(0, 0, 0, 0));
+            }
+        }
+    }
+
+    @Test
     public void restartSequenceReturnsToPingAfterFullFfIndicatorPacket() {
         Rig rig = new Rig();
-        enterTransmission(rig);
+        enterTransmission(rig, 1);
 
         rig.transfer(0, 0, 0, 0);
         rig.transfer(0xff, 0xff, 0xff, 0xff);
@@ -59,10 +85,14 @@ public class FourPlayerAdapterTest {
                 rig.transfer(0, 0, 0, 0));
     }
 
-    private static void enterTransmission(Rig rig) {
+    private static void enterTransmission(Rig rig, int size) {
+        rig.transfer(size, size, size, size);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(0x10, 0x10, 0x10, 0x10);
+
         // Enter transmission mode with the command spanning the ping packet boundary, as real
         // software does after receiving FE and loading the first AA reply.
-        rig.transfer(0x01, 0x01, 0x01, 0x01);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class FourPlayerAdapterTest {
 
@@ -25,7 +26,7 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
-    public void transmissionBroadcastsPreviousPacketInPlayerOrder() {
+    public void transmissionReplyStreamLeadsCaptureByOneByte() {
         Rig rig = new Rig();
 
         enterTransmission(rig, 1);
@@ -37,7 +38,9 @@ public class FourPlayerAdapterTest {
         rig.transfer(0, 0, 0, 0);
         rig.transfer(0, 0, 0, 0);
 
-        for (int expected : new int[]{0x11, 0x22, 0x33, 0x44}) {
+        // The physical reply stream leads the logical packet by one byte. The Game Boy receive
+        // ring wraps the last reply back to byte zero, reconstructing 11, 22, 33, 44.
+        for (int expected : new int[]{0x22, 0x33, 0x44, 0x11}) {
             assertArrayEquals(new int[]{expected, expected, expected, expected},
                     rig.transfer(0, 0, 0, 0));
         }
@@ -59,12 +62,16 @@ public class FourPlayerAdapterTest {
             rig.transfer(0xee, 0xee, 0xee, 0xee);
         }
 
-        for (int player = 1; player <= 4; player++) {
-            for (int dataByte = 0; dataByte < 4; dataByte++) {
-                int expected = player * 0x10 + dataByte;
-                assertArrayEquals(new int[]{expected, expected, expected, expected},
-                        rig.transfer(0, 0, 0, 0));
-            }
+        int[] physicalReplyStream = {
+                0x11, 0x12, 0x13,
+                0x20, 0x21, 0x22, 0x23,
+                0x30, 0x31, 0x32, 0x33,
+                0x40, 0x41, 0x42, 0x43,
+                0x10
+        };
+        for (int expected : physicalReplyStream) {
+            assertArrayEquals(new int[]{expected, expected, expected, expected},
+                    rig.transfer(0, 0, 0, 0));
         }
     }
 
@@ -85,14 +92,41 @@ public class FourPlayerAdapterTest {
                 rig.transfer(0, 0, 0, 0));
     }
 
-    private static void enterTransmission(Rig rig, int size) {
-        rig.transfer(size, size, size, size);
-        rig.transfer(0x88, 0x88, 0x88, 0x88);
-        rig.transfer(0x88, 0x88, 0x88, 0x88);
-        rig.transfer(0x10, 0x10, 0x10, 0x10);
+    @Test
+    public void boundaryAlignedTransmissionCommandDoesNotReplaceRateWithAa() {
+        Rig reference = new Rig();
+        enterTransmission(reference, 4, 0x28);
 
-        // Enter transmission mode with the command spanning the ping packet boundary, as real
-        // software does after receiving FE and loading the first AA reply.
+        Rig boundaryAligned = new Rig();
+        configurePing(boundaryAligned, 4, 0x28);
+        // Software loads the first AA after receiving the header. It is sent alongside STAT1,
+        // so three command bytes finish this ping packet and the fourth crosses into the next.
+        boundaryAligned.transfer(4, 4, 4, 4);
+        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        for (int i = 0; i < 4; i++) {
+            assertArrayEquals(new int[]{0xcc, 0xcc, 0xcc, 0xcc},
+                    boundaryAligned.transfer(0, 0, 0, 0));
+        }
+
+        // RATE affects both inter-byte and inter-packet timing. Matching a command that began on
+        // a packet boundary proves the crossed command retained 0x28 instead of latching 0xAA.
+        for (int i = 0; i < 32; i++) {
+            assertArrayEquals(reference.transfer(0, 0, 0, 0),
+                    boundaryAligned.transfer(0, 0, 0, 0));
+            assertEquals(reference.lastTransferTicks, boundaryAligned.lastTransferTicks);
+        }
+    }
+
+    private static void enterTransmission(Rig rig, int size) {
+        enterTransmission(rig, size, 0x10);
+    }
+
+    private static void enterTransmission(Rig rig, int size, int rate) {
+        configurePing(rig, size, rate);
+
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
@@ -103,8 +137,17 @@ public class FourPlayerAdapterTest {
         }
     }
 
+    private static void configurePing(Rig rig, int size, int rate) {
+        rig.transfer(size, size, size, size);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(rate, rate, rate, rate);
+    }
+
     private static final class Rig {
         private final SerialPort[] ports = new SerialPort[FourPlayerAdapter.PLAYER_COUNT];
+
+        private int lastTransferTicks;
 
         private Rig() {
             FourPlayerAdapter adapter = new FourPlayerAdapter();
@@ -128,6 +171,7 @@ public class FourPlayerAdapterTest {
             if (timeout == 0) {
                 throw new AssertionError("DMG-07 transfer timed out");
             }
+            lastTransferTicks = 100_000 - timeout;
             int[] result = new int[ports.length];
             for (int i = 0; i < ports.length; i++) {
                 result[i] = ports[i].getByte(0xff01);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -5,7 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class FourPlayerAdapterTest {
 
@@ -26,29 +26,22 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
-    public void transmissionReplyStreamLeadsCaptureByOneByte() {
+    public void transmissionBroadcastsPreviousPacketWithoutCrossPacketSplicing() {
         Rig rig = new Rig();
 
         enterTransmission(rig, 1);
 
-        // Packet 1 fills the adapter's next buffer from its first transfer; packet 2 broadcasts
-        // it to everyone. Later replies in packet 1 are outside every player's SIZE=1 slot.
+        // Games load their first data byte after receiving byte 0. Packet 1 captures that reply
+        // during byte 1, and packet 2 broadcasts it without substituting a byte from packet 2.
+        rig.transfer(0, 0, 0, 0);
         rig.transfer(0x11, 0x22, 0x33, 0x44);
         rig.transfer(0, 0, 0, 0);
         rig.transfer(0, 0, 0, 0);
-        rig.transfer(0, 0, 0, 0);
 
-        // The physical reply stream leads the logical packet by one byte. Its final transfer is
-        // the first byte of the packet currently being captured, not the stale first byte of the
-        // packet being sent. The receive ring therefore sees a continuous stream across packets.
-        assertArrayEquals(new int[]{0x22, 0x22, 0x22, 0x22},
-                rig.transfer(0x55, 0x66, 0x77, 0x88));
-        assertArrayEquals(new int[]{0x33, 0x33, 0x33, 0x33},
-                rig.transfer(0, 0, 0, 0));
-        assertArrayEquals(new int[]{0x44, 0x44, 0x44, 0x44},
-                rig.transfer(0, 0, 0, 0));
-        assertArrayEquals(new int[]{0x55, 0x55, 0x55, 0x55},
-                rig.transfer(0, 0, 0, 0));
+        for (int expected : new int[]{0x11, 0x22, 0x33, 0x44}) {
+            assertArrayEquals(new int[]{expected, expected, expected, expected},
+                    rig.transfer(0, 0, 0, 0));
+        }
     }
 
     @Test
@@ -57,28 +50,27 @@ public class FourPlayerAdapterTest {
 
         enterTransmission(rig, 4);
 
+        // Byte 0 is the pipeline slot in which software receives old data and loads byte 1.
+        rig.transfer(0, 0, 0, 0);
         for (int dataByte = 0; dataByte < 4; dataByte++) {
             rig.transfer(0x10 + dataByte, 0x20 + dataByte,
                     0x30 + dataByte, 0x40 + dataByte);
         }
-        // The remaining twelve transfers belong to the other players' outgoing slots. Their
+        // The remaining eleven transfers belong to the other players' outgoing slots. Their
         // replies must not displace or overwrite the four bytes each player submitted above.
-        for (int i = 4; i < 16; i++) {
+        for (int i = 5; i < 16; i++) {
             rig.transfer(0xee, 0xee, 0xee, 0xee);
         }
 
         int[] physicalReplyStream = {
-                0x11, 0x12, 0x13,
+                0x10, 0x11, 0x12, 0x13,
                 0x20, 0x21, 0x22, 0x23,
                 0x30, 0x31, 0x32, 0x33,
-                0x40, 0x41, 0x42, 0x43,
-                0x50
+                0x40, 0x41, 0x42, 0x43
         };
-        for (int i = 0; i < physicalReplyStream.length; i++) {
-            int expected = physicalReplyStream[i];
-            int firstPlayerReply = i == 0 ? 0x50 : 0;
+        for (int expected : physicalReplyStream) {
             assertArrayEquals(new int[]{expected, expected, expected, expected},
-                    rig.transfer(firstPlayerReply, 0, 0, 0));
+                    rig.transfer(0, 0, 0, 0));
         }
     }
 
@@ -100,30 +92,18 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
-    public void boundaryAlignedTransmissionCommandDoesNotReplaceRateWithAa() {
-        Rig reference = new Rig();
-        enterTransmission(reference, 4, 0x28);
+    public void transmissionCommandFinishesCurrentPingAndKeepsConfiguredRate() {
+        Rig rate28 = new Rig();
+        enterTransmission(rate28, 4, 0x28);
+        Rig rate38 = new Rig();
+        enterTransmission(rate38, 4, 0x38);
 
-        Rig boundaryAligned = new Rig();
-        configurePing(boundaryAligned, 4, 0x28);
-        // Software loads the first AA after receiving the header. It is sent alongside STAT1,
-        // so three command bytes finish this ping packet and the fourth crosses into the next.
-        boundaryAligned.transfer(4, 4, 4, 4);
-        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
-        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
-        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
-        boundaryAligned.transfer(0xaa, 0xaa, 0xaa, 0xaa);
-        for (int i = 0; i < 4; i++) {
-            assertArrayEquals(new int[]{0xcc, 0xcc, 0xcc, 0xcc},
-                    boundaryAligned.transfer(0, 0, 0, 0));
-        }
-
-        // RATE affects both inter-byte and inter-packet timing. Matching a command that began on
-        // a packet boundary proves the crossed command retained 0x28 instead of latching 0xAA.
+        // RATE affects inter-byte timing. Distinct configured rates must remain distinct after the
+        // crossed AA command instead of both latching its final 0xAA as a new rate.
         for (int i = 0; i < 32; i++) {
-            assertArrayEquals(reference.transfer(0, 0, 0, 0),
-                    boundaryAligned.transfer(0, 0, 0, 0));
-            assertEquals(reference.lastTransferTicks, boundaryAligned.lastTransferTicks);
+            assertArrayEquals(rate28.transfer(0, 0, 0, 0),
+                    rate38.transfer(0, 0, 0, 0));
+            assertNotEquals(rate28.lastTransferTicks, rate38.lastTransferTicks);
         }
     }
 
@@ -134,13 +114,15 @@ public class FourPlayerAdapterTest {
     private static void enterTransmission(Rig rig, int size, int rate) {
         configurePing(rig, size, rate);
 
-        rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        // The previous SIZE reply is still in SB for the next FE header. Three command bytes then
+        // complete that ping packet; the fourth AA is transferred alongside the first CC.
+        rig.transfer(size, size, size, size);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
         for (int i = 0; i < 4; i++) {
             assertArrayEquals(new int[]{0xcc, 0xcc, 0xcc, 0xcc},
-                    rig.transfer(0, 0, 0, 0));
+                    rig.transfer(i == 0 ? 0xaa : 0, 0, 0, 0));
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -38,12 +38,17 @@ public class FourPlayerAdapterTest {
         rig.transfer(0, 0, 0, 0);
         rig.transfer(0, 0, 0, 0);
 
-        // The physical reply stream leads the logical packet by one byte. The Game Boy receive
-        // ring wraps the last reply back to byte zero, reconstructing 11, 22, 33, 44.
-        for (int expected : new int[]{0x22, 0x33, 0x44, 0x11}) {
-            assertArrayEquals(new int[]{expected, expected, expected, expected},
-                    rig.transfer(0, 0, 0, 0));
-        }
+        // The physical reply stream leads the logical packet by one byte. Its final transfer is
+        // the first byte of the packet currently being captured, not the stale first byte of the
+        // packet being sent. The receive ring therefore sees a continuous stream across packets.
+        assertArrayEquals(new int[]{0x22, 0x22, 0x22, 0x22},
+                rig.transfer(0x55, 0x66, 0x77, 0x88));
+        assertArrayEquals(new int[]{0x33, 0x33, 0x33, 0x33},
+                rig.transfer(0, 0, 0, 0));
+        assertArrayEquals(new int[]{0x44, 0x44, 0x44, 0x44},
+                rig.transfer(0, 0, 0, 0));
+        assertArrayEquals(new int[]{0x55, 0x55, 0x55, 0x55},
+                rig.transfer(0, 0, 0, 0));
     }
 
     @Test
@@ -67,11 +72,13 @@ public class FourPlayerAdapterTest {
                 0x20, 0x21, 0x22, 0x23,
                 0x30, 0x31, 0x32, 0x33,
                 0x40, 0x41, 0x42, 0x43,
-                0x10
+                0x50
         };
-        for (int expected : physicalReplyStream) {
+        for (int i = 0; i < physicalReplyStream.length; i++) {
+            int expected = physicalReplyStream[i];
+            int firstPlayerReply = i == 0 ? 0x50 : 0;
             assertArrayEquals(new int[]{expected, expected, expected, expected},
-                    rig.transfer(0, 0, 0, 0));
+                    rig.transfer(firstPlayerReply, 0, 0, 0));
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -1,0 +1,108 @@
+package eu.rekawek.coffeegb.core.serial;
+
+import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class FourPlayerAdapterTest {
+
+    @Test
+    public void pingReportsPhysicalPlayerNumbersAndConnectedMask() {
+        Rig rig = new Rig();
+
+        // The first valid ACK packet makes all four ports present.
+        rig.transfer(0x01, 0x01, 0x01, 0x01);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(0x88, 0x88, 0x88, 0x88);
+        rig.transfer(0x10, 0x10, 0x10, 0x10);
+
+        assertArrayEquals(new int[]{0xfe, 0xfe, 0xfe, 0xfe},
+                rig.transfer(0x88, 0x88, 0x88, 0x88));
+        assertArrayEquals(new int[]{0xf1, 0xf2, 0xf3, 0xf4},
+                rig.transfer(0x88, 0x88, 0x88, 0x88));
+    }
+
+    @Test
+    public void transmissionBroadcastsPreviousPacketInPlayerOrder() {
+        Rig rig = new Rig();
+
+        enterTransmission(rig);
+
+        // Packet 1 fills the adapter's next buffer; packet 2 broadcasts it to everyone.
+        rig.transfer(0, 0, 0, 0);
+        rig.transfer(0x11, 0x22, 0x33, 0x44);
+        rig.transfer(0, 0, 0, 0);
+        rig.transfer(0, 0, 0, 0);
+
+        for (int expected : new int[]{0x11, 0x22, 0x33, 0x44}) {
+            assertArrayEquals(new int[]{expected, expected, expected, expected},
+                    rig.transfer(0, 0, 0, 0));
+        }
+    }
+
+    @Test
+    public void restartSequenceReturnsToPingAfterFullFfIndicatorPacket() {
+        Rig rig = new Rig();
+        enterTransmission(rig);
+
+        rig.transfer(0, 0, 0, 0);
+        rig.transfer(0xff, 0xff, 0xff, 0xff);
+        rig.transfer(0xff, 0xff, 0xff, 0xff);
+        rig.transfer(0xff, 0xff, 0xff, 0xff);
+        for (int i = 0; i < 4; i++) {
+            assertArrayEquals(new int[]{0xff, 0xff, 0xff, 0xff},
+                    rig.transfer(0, 0, 0, 0));
+        }
+        assertArrayEquals(new int[]{0xfe, 0xfe, 0xfe, 0xfe},
+                rig.transfer(0, 0, 0, 0));
+    }
+
+    private static void enterTransmission(Rig rig) {
+        // Enter transmission mode with the command spanning the ping packet boundary, as real
+        // software does after receiving FE and loading the first AA reply.
+        rig.transfer(0x01, 0x01, 0x01, 0x01);
+        rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        rig.transfer(0xaa, 0xaa, 0xaa, 0xaa);
+        for (int i = 0; i < 4; i++) {
+            assertArrayEquals(new int[]{0xcc, 0xcc, 0xcc, 0xcc},
+                    rig.transfer(0, 0, 0, 0));
+        }
+    }
+
+    private static final class Rig {
+        private final SerialPort[] ports = new SerialPort[FourPlayerAdapter.PLAYER_COUNT];
+
+        private Rig() {
+            FourPlayerAdapter adapter = new FourPlayerAdapter();
+            for (int i = 0; i < ports.length; i++) {
+                ports[i] = new SerialPort(new InterruptManager(false), false, new SpeedMode(false));
+                ports[i].init(adapter.endpoint(i));
+            }
+        }
+
+        private int[] transfer(int... outgoing) {
+            for (int i = 0; i < ports.length; i++) {
+                ports[i].setByte(0xff01, outgoing[i]);
+                ports[i].setByte(0xff02, 0x80);
+            }
+            int timeout = 100_000;
+            while ((ports[0].getByte(0xff02) & 0x80) != 0 && timeout-- > 0) {
+                for (SerialPort port : ports) {
+                    port.tick();
+                }
+            }
+            if (timeout == 0) {
+                throw new AssertionError("DMG-07 transfer timed out");
+            }
+            int[] result = new int[ports.length];
+            for (int i = 0; i < ports.length; i++) {
+                result[i] = ports[i].getByte(0xff01);
+            }
+            return result;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>2.4.0</kotlin.version>
-        <skip.unit.tests>false</skip.unit.tests>
+        <skipTests>false</skipTests>
+        <skip.unit.tests>${skipTests}</skip.unit.tests>
         <integration.test.threadCount>2</integration.test.threadCount>
     </properties>
     <build>

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.swing
 import eu.rekawek.coffeegb.controller.BasicController
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.link.LinkedController
 import eu.rekawek.coffeegb.controller.network.ConnectionController
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
@@ -53,8 +54,12 @@ class SwingEmulator(
 
     controller = BasicController(eventBus, properties, console).also { it.startController() }
 
-    eventBus.register<ConnectionController.ServerGotConnectionEvent> { startLinkedController() }
-    eventBus.register<ConnectionController.ClientConnectedToServerEvent> { startLinkedController() }
+    eventBus.register<ConnectionController.ServerGotConnectionEvent> {
+      startLinkedController(it.mode, it.player)
+    }
+    eventBus.register<ConnectionController.ClientConnectedToServerEvent> {
+      startLinkedController(it.mode, it.player)
+    }
     eventBus.register<ConnectionController.ServerLostConnectionEvent> { startBasicController() }
     eventBus.register<ConnectionController.ClientDisconnectedFromServerEvent> {
       startBasicController()
@@ -69,9 +74,10 @@ class SwingEmulator(
     }
   }
 
-  private fun startLinkedController() {
+  private fun startLinkedController(mode: LinkMode, player: Int) {
     val state = controller.closeWithState()
-    controller = LinkedController(eventBus, properties, console).also { it.startController() }
+    controller =
+        LinkedController(eventBus, properties, console, mode, player).also { it.startController() }
     if (state != null) {
       eventBus.post(Controller.LoadRomEvent(state.rom.file, state.memento))
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -61,6 +61,7 @@ class SwingEmulator(
       startLinkedController(it.mode, it.player)
     }
     eventBus.register<ConnectionController.ServerLostConnectionEvent> { startBasicController() }
+    eventBus.register<ConnectionController.StopServerEvent> { startBasicController() }
     eventBus.register<ConnectionController.ClientDisconnectedFromServerEvent> {
       startBasicController()
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -862,7 +862,11 @@ class SwingMenu(
     }
     eventBus.register<ServerStartedEvent> {
       connectToServer.isEnabled = false
-      setStatus("Waiting for players (0/${it.mode.playerCount - 1})", false)
+      if (it.mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        setStatus("Active as Player 1 (four-player adapter; 1/4 players)", true)
+      } else {
+        setStatus("Waiting for players (0/${it.mode.playerCount - 1})", false)
+      }
     }
     eventBus.register<ServerStoppedEvent> {
       startServer.state = false
@@ -870,13 +874,19 @@ class SwingMenu(
       setStatus("Disconnected", false)
     }
     eventBus.register<ConnectionController.ServerPlayerCountEvent> {
-      if (it.connected < it.required) {
+      if (it.mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        setStatus(
+            "Active as Player 1 (four-player adapter; ${it.connected + 1}/4 players)", true)
+      } else if (it.connected < it.required) {
         setStatus("Waiting for players (${it.connected}/${it.required})", false)
       }
     }
     eventBus.register<ServerGotConnectionEvent> {
-      val mode = if (it.mode == LinkMode.NORMAL) "normal link" else "four-player adapter"
-      setStatus("Connected as Player 1 ($mode)", true)
+      if (it.mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        setStatus("Active as Player 1 (four-player adapter; 1/4 players)", true)
+      } else {
+        setStatus("Connected as Player 1 (normal link)", true)
+      }
     }
     eventBus.register<ServerLostConnectionEvent> { setStatus("Disconnected", false) }
     return linkMenu

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -846,6 +846,16 @@ class SwingMenu(
       val mode = if (it.mode == LinkMode.NORMAL) "normal link" else "four-player adapter"
       setStatus("Connected as Player ${it.player + 1} ($mode)", true)
     }
+    eventBus.register<ConnectionController.ClientConnectionRejectedEvent> {
+      SwingUtilities.invokeLater {
+        JOptionPane.showMessageDialog(
+            window,
+            it.message,
+            "Netplay connection rejected",
+            JOptionPane.ERROR_MESSAGE,
+        )
+      }
+    }
     eventBus.register<ConnectionController.ClientDisconnectedFromServerEvent> {
       setStatus("Disconnected", false)
       connectToServer.state = false

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -14,6 +14,7 @@ import eu.rekawek.coffeegb.controller.Controller.SessionSnapshotSupportEvent
 import eu.rekawek.coffeegb.controller.Controller.StopEmulationEvent
 import eu.rekawek.coffeegb.controller.SnapshotSupport
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.network.ConnectionController
 import eu.rekawek.coffeegb.controller.network.ConnectionController.ClientConnectedToServerEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerGotConnectionEvent
@@ -782,8 +783,30 @@ class SwingMenu(
     linkMenu.add(startServer)
     startServer.addActionListener {
       if (startServer.state) {
-        disconnectOtherLinkPeripherals(startServer)
-        eventBus.post(StartServerEvent())
+        val choices = arrayOf("Normal link (2 players)", "Four-player adapter (4 players)")
+        val selected =
+            JOptionPane.showOptionDialog(
+                window,
+                "Select the link hardware to emulate",
+                "Start link server",
+                JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                choices,
+                choices[0],
+            )
+        val mode =
+            when (selected) {
+              0 -> LinkMode.NORMAL
+              1 -> LinkMode.FOUR_PLAYER_ADAPTER
+              else -> null
+            }
+        if (mode != null) {
+          disconnectOtherLinkPeripherals(startServer)
+          eventBus.post(StartServerEvent(mode))
+        } else {
+          startServer.state = false
+        }
       } else {
         eventBus.post(StopServerEvent())
       }
@@ -808,30 +831,45 @@ class SwingMenu(
     }
 
     val connected = JCheckBoxMenuItem()
-    val setConnected =
-        fun(state: Boolean) {
-          if (state) {
-            connected.text = "\uD83D\uDFE2  Connected"
-          } else {
-            connected.text = "\uD83D\uDD34  Disconnected"
-          }
+    val setStatus =
+        fun(text: String, active: Boolean) {
+          connected.text = if (active) "\uD83D\uDFE2  $text" else "\uD83D\uDD34  $text"
         }
     connected.isEnabled = false
-    setConnected(false)
+    setStatus("Disconnected", false)
     linkMenu.add(connected)
 
-    eventBus.register<ClientConnectedToServerEvent> { setConnected(true) }
+    eventBus.register<ConnectionController.ClientHandshakeCompletedEvent> {
+      val mode = if (it.mode == LinkMode.NORMAL) "normal link" else "four-player adapter"
+      setStatus("Waiting as Player ${it.player + 1} ($mode)", false)
+    }
+    eventBus.register<ClientConnectedToServerEvent> {
+      val mode = if (it.mode == LinkMode.NORMAL) "normal link" else "four-player adapter"
+      setStatus("Connected as Player ${it.player + 1} ($mode)", true)
+    }
     eventBus.register<ConnectionController.ClientDisconnectedFromServerEvent> {
-      setConnected(false)
+      setStatus("Disconnected", false)
       connectToServer.state = false
     }
-    eventBus.register<ServerStartedEvent> { connectToServer.isEnabled = false }
+    eventBus.register<ServerStartedEvent> {
+      connectToServer.isEnabled = false
+      setStatus("Waiting for players (0/${it.mode.playerCount - 1})", false)
+    }
     eventBus.register<ServerStoppedEvent> {
       startServer.state = false
       connectToServer.isEnabled = true
+      setStatus("Disconnected", false)
     }
-    eventBus.register<ServerGotConnectionEvent> { setConnected(true) }
-    eventBus.register<ServerLostConnectionEvent> { setConnected(false) }
+    eventBus.register<ConnectionController.ServerPlayerCountEvent> {
+      if (it.connected < it.required) {
+        setStatus("Waiting for players (${it.connected}/${it.required})", false)
+      }
+    }
+    eventBus.register<ServerGotConnectionEvent> {
+      val mode = if (it.mode == LinkMode.NORMAL) "normal link" else "four-player adapter"
+      setStatus("Connected as Player 1 ($mode)", true)
+    }
+    eventBus.register<ServerLostConnectionEvent> { setStatus("Disconnected", false) }
     return linkMenu
   }
 


### PR DESCRIPTION
Closes #259

## Summary

- emulate the Nintendo DMG-07 four-player adapter, including ping/status negotiation, fixed P1-P4 port IDs, packet timing, delayed replies, transmission mode, and return-to-ping signaling
- let a host choose normal two-player link or four-player adapter mode; clients detect the mode and their assigned player slot automatically
- activate the host's DMG-07 immediately and run every currently attached Game Boy, without waiting for all four physical ports to be occupied
- hot-plug late clients at the host's current frame, then send every active console, the shared adapter phase, and held inputs as one atomic checkpoint so all peers resume coherently
- keep the remaining group active after a client disconnects, publish an authoritative removal checkpoint, and allow the freed physical slot to be reused by a replacement client
- generalize rollback history to four players and relay player-labelled ROM, input, reset, and stop events through the server to every peer
- preserve pre-rebase rollback states so packets arriving out of order over the three client TCP streams can safely trigger an earlier replay
- reject over-capacity clients with an explicit protocol response and show a clear **The netplay server is already full.** message in the UI
- expand empty or truncated battery payloads to the mapper's required RAM/RTC size, preventing MBC2 games such as F-1 Race from crashing when a peer has a zero-byte save file
- finish the current four-byte ping after Player 1 starts the `AA AA AA AA` transmission command, then return the four-byte `CC` indicator without interpreting partial command bytes as a new rate or size
- reproduce the DMG-07's complete one-packet delay: capture each console's `SIZE` replies in physical slots 1 through `SIZE`, then broadcast that finished buffer as P1-P4 data during the next packet
- never splice a newly captured Player 1 byte into the packet currently being broadcast, removing the nondeterministic F-1 Race name/tile corruption that could move between players
- bump the netplay protocol to v6 so older clients fail cleanly instead of misreading the checkpoint wire format
- make the root Surefire unit-test switch inherit Maven's standard `skipTests` property, so `-DskipTests` skips every module while integration profiles retain their existing controls
- repair the missing enum separator introduced on current `master`, which otherwise prevents all PR merge refs from compiling

## Validation

- full local `mvn -q test` suite (725 tests) on implementation commit `31bc0952`; GitHub Maven build and complete integration-ROM matrix on head `99f09832`
- `mvn -DskipTests package` succeeds on `99f09832` and reports `Tests are skipped.` for core, controller, and swing; a normal follow-up invocation ran all 14 selected connection tests
- final runnable JAR: `swing/target/coffee-gb-1.7.12-SNAPSHOT.jar`, SHA-256 `a25d40dc7187e072f17c7a1c867a456b0c9a28807d8cf0eea61f1f3c98f1384b`
- added unit coverage for DMG-07 negotiation, `SIZE=1` and `SIZE=4` delayed buffering, no cross-packet splicing, boundary-crossing mode switching and rate retention, restart signaling, four-console rollback, cross-client packet reordering, immediate host activation, partial rosters, atomic late-join checkpoints, running-client roster expansion, authoritative disconnect checkpoints, automatic slot assignment/reuse, client/server input fan-out, explicit server-full rejection, and empty RAM/RTC save payloads
- reproduced the reported F-1 Race failure with a zero-byte battery payload at `MemoryBattery.loadRam`, then verified the exact **F-1 Race (World) (Rev A)** ROM builds successfully with the same payload after the fix
- drove the exact **F-1 Race (World) (Rev A)** Rev A ROM through the multiplayer flow with two and three attached Game Boys; every active console reached the race setup state without requiring unused DMG-07 ports
- reran the preserved four-console F-1 Race diagnostic through race setup; all four consoles remained synchronized through the distinct-name and group-selection sequence
- ran **F-1 Race (World) (Rev A)** with four networked emulators through three fixed-delay TCP proxies at 100 ms one-way latency; all four remained connected, reported **RACERS LINKED 4**, received cars P1-P4, and advanced to frames 270-275
- reproduced the corrupted name-entry screen without TCP or rollback, then entered distinct `AAA`, `BBB`, `CCC`, and `DDD` initials with the corrected hardware buffer model; every console displayed all four names cleanly, assigned grids 1-4, and advanced to synchronized **GROUP SELECT**
- replayed the exact ROM through the rollback controller with 6-frame host latency and 12-frame peer-to-peer latency; all four state-history heads remained aligned through frame 155
- measured the expected relay path at 100 ms one-way latency: approximately 100 ms from a client to the host and 200 ms between non-host peers
- verified that a disconnected player leaves the remaining group active and that a replacement receives the freed slot; controller tests also restore the expanded/reduced roster from a common frame and adapter phase
- manually ran the public-domain **Den of Snakes** DMG-07 ROM as four local Game Boys, entered gameplay, and exercised player input across 360 frames

The adapter behavior is based on the [Pan Docs DMG-07 protocol description](https://gbdev.io/pandocs/Four_Player_Adapter.html), [DMG-07 hardware traces and protocol notes](https://shonumi.github.io/articles/art9.html), the [hardware-tested GBDK four-player implementation](https://github.com/bbbbbr/gbdk-gb-4-player), and the [F-1 Race manual](https://www.thegameisafootarcade.com/wp-content/uploads/2017/03/F-1-Race-Game-Manual.pdf).

