### PR TITLE
Support GPS Boy receiver

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -10,6 +10,7 @@ import eu.rekawek.coffeegb.core.genie.AddPatches
 import eu.rekawek.coffeegb.core.genie.Patch
 import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
 import eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint
+import eu.rekawek.coffeegb.core.serial.GpsReceiverSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
 import java.io.File
@@ -80,6 +81,9 @@ class BasicController private constructor(
   // finished bands are forwarded to the UI as PrinterPrintEvents
   private var printerEnabled = false
 
+  // GPS Boy uses a Trimble receiver connected to the same link port through a software UART.
+  private var gpsReceiverEnabled = false
+
   private val thread = Thread {
     while (!doStop) {
       runFrame()
@@ -121,6 +125,7 @@ class BasicController private constructor(
         // the Barcode Boy and the printer share the link port, so only one at a time
         if (barcodeBoyEnabled) {
           printerEnabled = false
+          gpsReceiverEnabled = false
         }
         reconnectLinkDevice()
       }
@@ -131,6 +136,17 @@ class BasicController private constructor(
         printerEnabled = it.enabled
         if (printerEnabled) {
           barcodeBoyEnabled = false
+          gpsReceiverEnabled = false
+        }
+        reconnectLinkDevice()
+      }
+    }
+    eventQueue.register<Controller.SetGpsReceiverEvent> {
+      if (gpsReceiverEnabled != it.enabled) {
+        gpsReceiverEnabled = it.enabled
+        if (gpsReceiverEnabled) {
+          barcodeBoyEnabled = false
+          printerEnabled = false
         }
         reconnectLinkDevice()
       }
@@ -319,6 +335,9 @@ class BasicController private constructor(
         }
       } else if (barcodeBoyEnabled) {
         BarcodeBoySerialEndpoint().also { barcodeBoy = it }
+      } else if (gpsReceiverEnabled) {
+        barcodeBoy = null
+        GpsReceiverSerialEndpoint()
       } else {
         barcodeBoy = null
         Peer2PeerSerialEndpoint()
@@ -326,7 +345,7 @@ class BasicController private constructor(
 
   /**
    * Plug the currently selected link-port device into the running session without a reset, so
-   * connecting the printer or Barcode Boy doesn't restart the game.
+   * connecting the printer, Barcode Boy or GPS receiver doesn't restart the game.
    */
   private fun reconnectLinkDevice() {
     val session = session ?: return

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -66,6 +66,9 @@ interface Controller : AutoCloseable {
   /** Connects or disconnects the Game Boy Printer on the link port (resets the game). */
   data class SetPrinterEvent(val enabled: Boolean) : Event
 
+  /** Connects or disconnects a simulated Trimble GPS receiver on the CGB link port. */
+  data class SetGpsReceiverEvent(val enabled: Boolean) : Event
+
   /**
    * Emitted each time the game prints a band on the Game Boy Printer. [argb] holds
    * [width]×[height] ARGB pixels (top row first, [width] is always 160). [topMargin] and

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -408,6 +408,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         display.init(eventBus);
         sound.init(eventBus);
         serialPort.init(serialEndpoint);
+        infraredPort.setSerialEndpoint(serialEndpoint);
         infraredPort.init(eventBus, infraredEndpoint);
         codeBreakerRumble.init(eventBus);
         background.init(eventBus);
@@ -428,6 +429,7 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
      */
     public void setSerialEndpoint(SerialEndpoint serialEndpoint) {
         serialPort.init(serialEndpoint);
+        infraredPort.setSerialEndpoint(serialEndpoint);
     }
 
     public void run() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 
 import java.io.Serializable;
 
@@ -29,6 +30,8 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
 
     private transient InfraredEndpoint endpoint = InfraredEndpoint.NULL_ENDPOINT;
 
+    private transient SerialEndpoint serialEndpoint = SerialEndpoint.NULL_ENDPOINT;
+
     // the written bits of RP: bit 0 (own LED) and bits 6-7 (read enable)
     private int rp;
 
@@ -48,9 +51,17 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
         eventBus.register(e -> fullChanger.transform(e.characterId()), FullChanger.TransformEvent.class);
     }
 
+    /** Connects RP bit 4 to the CGB link port's serial-input pin. */
+    public void setSerialEndpoint(SerialEndpoint serialEndpoint) {
+        this.serialEndpoint = serialEndpoint == null
+                ? SerialEndpoint.NULL_ENDPOINT
+                : serialEndpoint;
+    }
+
     public void close() {
         endpoint.setLightOn(false);
         endpoint = InfraredEndpoint.NULL_ENDPOINT;
+        serialEndpoint = SerialEndpoint.NULL_ENDPOINT;
     }
 
     public void tick() {
@@ -78,7 +89,12 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
         // an armed device starts transmitting at a poll of the register, so the polling
         // loop observes the first pulse from its beginning
         fullChanger.onRpRead();
-        int result = rp | 0x3c | 0x02;
+        // Bits 2, 3 and 5 are pulled high. Bit 4 is not unused on CGB hardware: it
+        // exposes link-port pin 4 as a raw digital input for software UARTs.
+        int result = rp | 0x2c | 0x02;
+        if (serialEndpoint.isSerialInputHigh()) {
+            result |= 0x10;
+        }
         int readMode = rp & 0xc0;
         // The intermediate $80 mode pulls the sensor bit low even without a
         // light source. In the normal $C0 receive mode it is active-low only

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/GpsReceiverSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/GpsReceiverSerialEndpoint.java
@@ -1,0 +1,266 @@
+package eu.rekawek.coffeegb.core.serial;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.memento.Memento;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+
+/**
+ * A deterministic Trimble Lassen SK II compatible GPS receiver for the CGB link port.
+ *
+ * <p>GPS Boy connects the receiver's TX line to CGB link-port pin 4 and samples it through
+ * undocumented RP bit 4. It drives the receiver's RX line with a software UART on the serial
+ * output pin. Both directions use 9600 baud, eight data bits, odd parity and one stop bit.
+ * After the receiver is switched to TAIP, GPS Boy polls it with {@code QST}, {@code QAL},
+ * {@code QPV} and {@code QTM} messages.
+ *
+ * <p>This endpoint follows the protocol documented in the original GPS Boy distribution. It
+ * reports a fixed valid position in Seville, Spain so runs and save states remain deterministic.
+ */
+public class GpsReceiverSerialEndpoint implements SerialEndpoint {
+
+    static final int UART_BIT_TICKS = 437;
+
+    static final int STARTUP_DELAY_TICKS = Gameboy.TICKS_PER_SEC / 4;
+
+    static final int STARTUP_BEACON_INTERVAL_TICKS = Gameboy.TICKS_PER_SEC;
+
+    static final int RESPONSE_TURNAROUND_TICKS = UART_BIT_TICKS * 4;
+
+    private static final String VERSION_RESPONSE = ">RVRGPSBOY<";
+
+    private static final String STATUS_RESPONSE = ">RST00015A0200;*00<";
+
+    private static final String ALTITUDE_RESPONSE = ">RAL00000+01520+02512;*00<";
+
+    private static final String POSITION_RESPONSE =
+            ">RPV00000+3738500-0059750000000012;*00<";
+
+    private static final String TIME_RESPONSE = ">RTM1345230000601199000104100000;*00<";
+
+    private final ArrayDeque<Integer> outputBytes = new ArrayDeque<>();
+
+    private long ticks;
+
+    private long nextStartupBeacon = STARTUP_DELAY_TICKS;
+
+    private int startupBeacons;
+
+    private int outputByte = -1;
+
+    /** 0=start, 1-8=data, 9=parity, 10=stop. */
+    private int outputBit = -1;
+
+    private int outputTicksRemaining;
+
+    private int outputDelayTicks;
+
+    private boolean serialInputHigh = true;
+
+    private int sb = 0xff;
+
+    /** -1=waiting for start, 0-7=data, 8=parity, 9=stop. */
+    private int receiveBit = -1;
+
+    private int receiveByte;
+
+    private int receiveOnes;
+
+    private boolean receiveParityValid;
+
+    private boolean capturingTaip;
+
+    private final StringBuilder taipCommand = new StringBuilder();
+
+    @Override
+    public void tick() {
+        ticks++;
+        if (startupBeacons < 2 && ticks >= nextStartupBeacon) {
+            // The real receiver emits periodic data after power-on. GPS Boy only checks
+            // that two non-empty bursts arrive before it configures TAIP.
+            queueAscii("GPS\r");
+            startupBeacons++;
+            nextStartupBeacon += STARTUP_BEACON_INTERVAL_TICKS;
+        }
+
+        if (outputDelayTicks > 0) {
+            outputDelayTicks--;
+            return;
+        }
+        if (outputTicksRemaining > 0 && --outputTicksRemaining > 0) {
+            return;
+        }
+        advanceOutputBit();
+    }
+
+    @Override
+    public boolean isSerialInputHigh() {
+        return serialInputHigh;
+    }
+
+    @Override
+    public void setSb(int sb) {
+        this.sb = sb & 0xff;
+    }
+
+    @Override
+    public void startSending() {
+        receiveUartBit((sb >>> 7) & 1);
+    }
+
+    @Override
+    public int sendBit() {
+        return serialInputHigh ? 1 : 0;
+    }
+
+    @Override
+    public int recvBit() {
+        return -1;
+    }
+
+    private void receiveUartBit(int bit) {
+        if (receiveBit == -1) {
+            if (bit == 0) {
+                receiveBit = 0;
+                receiveByte = 0;
+                receiveOnes = 0;
+            }
+            return;
+        }
+        if (receiveBit < 8) {
+            if (bit != 0) {
+                receiveByte |= 1 << receiveBit;
+                receiveOnes++;
+            }
+            receiveBit++;
+            return;
+        }
+        if (receiveBit == 8) {
+            receiveParityValid = ((receiveOnes + bit) & 1) == 1;
+            receiveBit++;
+            return;
+        }
+
+        if (bit == 1 && receiveParityValid) {
+            byteReceived(receiveByte);
+        }
+        receiveBit = -1;
+    }
+
+    private void byteReceived(int value) {
+        char c = (char) (value & 0xff);
+        if (c == '>') {
+            capturingTaip = true;
+            taipCommand.setLength(0);
+        } else if (capturingTaip && c == '<') {
+            capturingTaip = false;
+            handleTaipCommand(taipCommand.toString());
+        } else if (capturingTaip && taipCommand.length() < 64) {
+            taipCommand.append(c);
+        }
+    }
+
+    private void handleTaipCommand(String command) {
+        switch (command) {
+            case "QVR" -> queueResponse(VERSION_RESPONSE);
+            case "QST" -> queueResponse(STATUS_RESPONSE);
+            case "QAL" -> queueResponse(ALTITUDE_RESPONSE);
+            case "QPV" -> queueResponse(POSITION_RESPONSE);
+            case "QTM" -> queueResponse(TIME_RESPONSE);
+            default -> {
+                // Configuration messages (for example FPV00000000) need no reply.
+            }
+        }
+    }
+
+    private void queueAscii(String value) {
+        for (byte b : value.getBytes(StandardCharsets.US_ASCII)) {
+            outputBytes.addLast(b & 0xff);
+        }
+    }
+
+    private void queueResponse(String value) {
+        queueAscii(value);
+        if (outputByte == -1) {
+            // GPS Boy finishes one more bit-time of its send routine before it starts polling
+            // the input. A real receiver also needs time to turn the half-duplex exchange around.
+            outputDelayTicks = RESPONSE_TURNAROUND_TICKS;
+        }
+    }
+
+    private void advanceOutputBit() {
+        if (outputByte == -1) {
+            if (outputBytes.isEmpty()) {
+                serialInputHigh = true;
+                return;
+            }
+            outputByte = outputBytes.removeFirst();
+            outputBit = 0;
+            serialInputHigh = false;
+            outputTicksRemaining = UART_BIT_TICKS;
+            return;
+        }
+
+        outputBit++;
+        if (outputBit <= 8) {
+            serialInputHigh = ((outputByte >>> (outputBit - 1)) & 1) != 0;
+        } else if (outputBit == 9) {
+            // Choose the parity bit so data + parity contains an odd number of ones.
+            serialInputHigh = (Integer.bitCount(outputByte) & 1) == 0;
+        } else if (outputBit == 10) {
+            serialInputHigh = true;
+        } else {
+            outputByte = -1;
+            outputBit = -1;
+            advanceOutputBit();
+            return;
+        }
+        outputTicksRemaining = UART_BIT_TICKS;
+    }
+
+    @Override
+    public Memento<SerialEndpoint> saveToMemento() {
+        int[] queued = outputBytes.stream().mapToInt(Integer::intValue).toArray();
+        return new GpsReceiverMemento(ticks, nextStartupBeacon, startupBeacons, queued,
+                outputByte, outputBit, outputTicksRemaining, outputDelayTicks, serialInputHigh, sb,
+                receiveBit, receiveByte, receiveOnes, receiveParityValid, capturingTaip,
+                taipCommand.toString());
+    }
+
+    @Override
+    public void restoreFromMemento(Memento<SerialEndpoint> memento) {
+        if (!(memento instanceof GpsReceiverMemento mem)) {
+            throw new IllegalArgumentException("Invalid memento type");
+        }
+        ticks = mem.ticks;
+        nextStartupBeacon = mem.nextStartupBeacon;
+        startupBeacons = mem.startupBeacons;
+        outputBytes.clear();
+        for (int b : mem.outputBytes) {
+            outputBytes.addLast(b);
+        }
+        outputByte = mem.outputByte;
+        outputBit = mem.outputBit;
+        outputTicksRemaining = mem.outputTicksRemaining;
+        outputDelayTicks = mem.outputDelayTicks;
+        serialInputHigh = mem.serialInputHigh;
+        sb = mem.sb;
+        receiveBit = mem.receiveBit;
+        receiveByte = mem.receiveByte;
+        receiveOnes = mem.receiveOnes;
+        receiveParityValid = mem.receiveParityValid;
+        capturingTaip = mem.capturingTaip;
+        taipCommand.setLength(0);
+        taipCommand.append(mem.taipCommand);
+    }
+
+    private record GpsReceiverMemento(long ticks, long nextStartupBeacon, int startupBeacons,
+                                      int[] outputBytes, int outputByte, int outputBit,
+                                      int outputTicksRemaining, int outputDelayTicks,
+                                      boolean serialInputHigh, int sb,
+                                      int receiveBit, int receiveByte, int receiveOnes,
+                                      boolean receiveParityValid, boolean capturingTaip,
+                                      String taipCommand) implements Memento<SerialEndpoint> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -4,6 +4,20 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
 public interface SerialEndpoint extends Originator<SerialEndpoint> {
+    /** Advances external-device wall-clock state by one Game Boy master tick. */
+    default void tick() {
+    }
+
+    /**
+     * Returns the electrical level on the CGB link port's serial-input pin.
+     *
+     * <p>The CGB also exposes this pin through the undocumented bit 4 of RP (FF56),
+     * which software UARTs such as GPS Boy use without arming a hardware transfer.
+     */
+    default boolean isSerialInputHigh() {
+        return true;
+    }
+
     /**
      * Listener waiting for any updates of the SB byte, so it can be shared with the other side.
      */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -54,6 +54,9 @@ public class SerialPort implements AddressSpace, Serializable, Originator<Serial
     }
 
     public void tick() {
+        // Link-port peripherals such as GPS receivers have their own wall clock and keep
+        // driving the input pin even when no hardware serial transfer is armed.
+        serialEndpoint.tick();
         acknowledgeInterruptIfNeeded();
         for (int i = 0; i < speedMode.getSpeedMode(); i++) {
             tickCpuClock();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
@@ -1,6 +1,8 @@
 package eu.rekawek.coffeegb.core.ir;
 
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -19,5 +21,47 @@ public class InfraredPortTest {
         assertEquals(0xbc, port.getByte(0xff56));
         port.setByte(0xff56, 0xc0);
         assertEquals(0xfe, port.getByte(0xff56));
+    }
+
+    @Test
+    public void bit4ReflectsTheCgbLinkPortInputPin() {
+        InfraredPort port = new InfraredPort(true, new SpeedMode(true));
+        port.setSerialEndpoint(new LowSerialInput());
+
+        assertEquals(0x2e, port.getByte(0xff56));
+    }
+
+    private static class LowSerialInput implements SerialEndpoint {
+        @Override
+        public boolean isSerialInputHigh() {
+            return false;
+        }
+
+        @Override
+        public void setSb(int sb) {
+        }
+
+        @Override
+        public int recvBit() {
+            return -1;
+        }
+
+        @Override
+        public void startSending() {
+        }
+
+        @Override
+        public int sendBit() {
+            return 0;
+        }
+
+        @Override
+        public Memento<SerialEndpoint> saveToMemento() {
+            return null;
+        }
+
+        @Override
+        public void restoreFromMemento(Memento<SerialEndpoint> memento) {
+        }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/GpsReceiverSerialEndpointTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/GpsReceiverSerialEndpointTest.java
@@ -1,0 +1,117 @@
+package eu.rekawek.coffeegb.core.serial;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GpsReceiverSerialEndpointTest {
+
+    @Test
+    public void sendsTwoStartupBurstsForReceiverDetection() {
+        GpsReceiverSerialEndpoint gps = new GpsReceiverSerialEndpoint();
+
+        tick(gps, GpsReceiverSerialEndpoint.STARTUP_DELAY_TICKS - 1);
+        assertTrue(gps.isSerialInputHigh());
+        gps.tick();
+        assertFalse(gps.isSerialInputHigh());
+        assertEquals("GPS\r", readAscii(gps, 4, false));
+
+        waitForStart(gps, GpsReceiverSerialEndpoint.STARTUP_BEACON_INTERVAL_TICKS);
+        assertEquals("GPS\r", readAscii(gps, 4, false));
+    }
+
+    @Test
+    public void answersGpsBoyTaipPositionRequest() {
+        GpsReceiverSerialEndpoint gps = new GpsReceiverSerialEndpoint();
+
+        sendAscii(gps, ">QPV<");
+
+        String expected = ">RPV00000+3738500-0059750000000012;*00<";
+        assertEquals(39, expected.length());
+        assertEquals(expected, readAscii(gps, expected.length(), true));
+    }
+
+    @Test
+    public void snapshotPreservesAnInFlightUartFrame() {
+        GpsReceiverSerialEndpoint original = new GpsReceiverSerialEndpoint();
+        sendAscii(original, ">QST<");
+        waitForStart(original, GpsReceiverSerialEndpoint.RESPONSE_TURNAROUND_TICKS + 10);
+        tick(original, 123);
+
+        Memento<SerialEndpoint> memento = original.saveToMemento();
+        GpsReceiverSerialEndpoint restored = new GpsReceiverSerialEndpoint();
+        restored.restoreFromMemento(memento);
+
+        for (int i = 0; i < 20_000; i++) {
+            assertEquals(original.isSerialInputHigh(), restored.isSerialInputHigh());
+            original.tick();
+            restored.tick();
+        }
+    }
+
+    private static void sendAscii(GpsReceiverSerialEndpoint gps, String value) {
+        for (byte b : value.getBytes(StandardCharsets.US_ASCII)) {
+            sendUartByte(gps, b & 0xff);
+        }
+    }
+
+    private static void sendUartByte(GpsReceiverSerialEndpoint gps, int value) {
+        sendUartBit(gps, 0);
+        for (int bit = 0; bit < 8; bit++) {
+            sendUartBit(gps, (value >>> bit) & 1);
+        }
+        sendUartBit(gps, (Integer.bitCount(value) & 1) == 0 ? 1 : 0);
+        sendUartBit(gps, 1);
+    }
+
+    private static void sendUartBit(GpsReceiverSerialEndpoint gps, int bit) {
+        gps.setSb(bit == 0 ? 0x00 : 0xff);
+        gps.startSending();
+    }
+
+    private static String readAscii(GpsReceiverSerialEndpoint gps, int length,
+                                    boolean waitForStart) {
+        if (waitForStart) {
+            waitForStart(gps, GpsReceiverSerialEndpoint.RESPONSE_TURNAROUND_TICKS + 10);
+        }
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            assertFalse("UART start bit", gps.isSerialInputHigh());
+            tick(gps, GpsReceiverSerialEndpoint.UART_BIT_TICKS);
+
+            int value = 0;
+            for (int bit = 0; bit < 8; bit++) {
+                if (gps.isSerialInputHigh()) {
+                    value |= 1 << bit;
+                }
+                tick(gps, GpsReceiverSerialEndpoint.UART_BIT_TICKS);
+            }
+
+            int parity = gps.isSerialInputHigh() ? 1 : 0;
+            assertEquals("UART odd parity", 1, (Integer.bitCount(value) + parity) & 1);
+            tick(gps, GpsReceiverSerialEndpoint.UART_BIT_TICKS);
+            assertTrue("UART stop bit", gps.isSerialInputHigh());
+            tick(gps, GpsReceiverSerialEndpoint.UART_BIT_TICKS);
+            result.append((char) value);
+        }
+        return result.toString();
+    }
+
+    private static void waitForStart(GpsReceiverSerialEndpoint gps, int maxTicks) {
+        for (int i = 0; i < maxTicks && gps.isSerialInputHigh(); i++) {
+            gps.tick();
+        }
+        assertFalse("GPS receiver did not start a UART frame", gps.isSerialInputHigh());
+    }
+
+    private static void tick(GpsReceiverSerialEndpoint gps, int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            gps.tick();
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -100,11 +100,13 @@ class SwingMenu(
 
   private val cheatDatabase: CheatDatabase by lazy { CheatDatabase.loadBundled() }
 
-  // the link port carries one device at a time: the netplay cable, the Barcode Boy or the
-  // printer. These are the menu toggles for each; enabling one disconnects the rest.
+  // the link port carries one device at a time: netplay, Barcode Boy, printer or GPS.
+  // These are the menu toggles for each; enabling one disconnects the rest.
   private lateinit var barcodeBoyItem: JCheckBoxMenuItem
 
   private lateinit var printerItem: JCheckBoxMenuItem
+
+  private lateinit var gpsReceiverItem: JCheckBoxMenuItem
 
   private lateinit var startServerItem: JCheckBoxMenuItem
 
@@ -515,7 +517,7 @@ class SwingMenu(
     val peripheralsMenu = JMenu("Peripherals")
 
     // the Game Boy Camera's webcam source is a cartridge sensor, not a link-port device, so
-    // it is independent of the netplay/Barcode Boy/printer group below
+    // it is independent of the netplay/Barcode Boy/printer/GPS group below
     val camera = JCheckBoxMenuItem("Enable Game Boy Camera", false)
     peripheralsMenu.add(camera)
     camera.addActionListener {
@@ -547,6 +549,16 @@ class SwingMenu(
       eventBus.post(Controller.SetPrinterEvent(printer.state))
       if (printer.state) {
         disconnectOtherLinkPeripherals(printer)
+      }
+    }
+
+    val gpsReceiver = JCheckBoxMenuItem("Enable GPS Receiver (GPS Boy)", false)
+    gpsReceiverItem = gpsReceiver
+    peripheralsMenu.add(gpsReceiver)
+    gpsReceiver.addActionListener {
+      eventBus.post(Controller.SetGpsReceiverEvent(gpsReceiver.state))
+      if (gpsReceiver.state) {
+        disconnectOtherLinkPeripherals(gpsReceiver)
       }
     }
 
@@ -652,7 +664,7 @@ class SwingMenu(
 
   /**
    * Only one device can sit on the link port at a time, so turning one on unplugs the others:
-   * the netplay cable (server/client), the Barcode Boy and the printer.
+   * the netplay cable (server/client), the Barcode Boy, the printer and the GPS receiver.
    */
   private fun disconnectOtherLinkPeripherals(keep: JCheckBoxMenuItem) {
     if (barcodeBoyItem !== keep && barcodeBoyItem.state) {
@@ -662,6 +674,10 @@ class SwingMenu(
     if (printerItem !== keep && printerItem.state) {
       printerItem.state = false
       eventBus.post(Controller.SetPrinterEvent(false))
+    }
+    if (gpsReceiverItem !== keep && gpsReceiverItem.state) {
+      gpsReceiverItem.state = false
+      eventBus.post(Controller.SetGpsReceiverEvent(false))
     }
     if (startServerItem !== keep && startServerItem.state) {
       startServerItem.state = false


### PR DESCRIPTION
## Summary

- expose the CGB link-port serial-input pin through bit 4 of RP (`FF56`)
- add a deterministic Trimble Lassen SK II endpoint implementing GPS Boy's 9600-baud odd-parity software UART and TAIP exchanges
- add a mutually exclusive **Peripherals → Enable GPS Receiver (GPS Boy)** toggle
- preserve in-flight receiver state in save states and rewinds

## Root cause

GPS Boy is not a standalone cartridge: it waits for a Lassen SK II receiver connected to link-port pins 2 and 4. The program samples pin 4 through undocumented CGB RP bit 4 and then communicates using TAIP. Coffee GB previously returned RP bit 4 as a fixed high level and had no matching receiver endpoint, so the exact issue ROM stopped at `ERROR! GPS receiver not detected`.

The simulated responses and framing follow the documentation and source in the [original GPS Boy distribution](https://web.archive.org/web/20060223075808id_/http://members.fortunecity.com:80/kookie/gpsboy.zip). The fixed coordinates are inside the bundled Seville map and remain deterministic.

## Reproduction

- ROM: issue attachment `GPSboy (U) [C].gbc`
- SHA-256: `4459eaf94d847483db95c93add2e6867c53433b351e0056c90c445ec6fb7f4fe`
- system: CGB, skipped boot ROM
- before: blue `GPS receiver not detected` error
- after enabling the GPS receiver: navigation screen at frame 300 with position, heading, altitude, speed, time, and `3D GPS` source

## Tests

- `/opt/maven/bin/mvn -q -pl core -Dtest=GpsReceiverSerialEndpointTest,InfraredPortTest test`
- `/opt/maven/bin/mvn -q -pl swing -am test`
- deterministic replay of the exact attached ROM through frame 700

Fixes #302
