### PR TITLE
Support loading ROMs from 7z archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ is recommended and is the version used by CI and release builds.
    ```
 
 ROMs are not included. Coffee GB accepts `.gb`, `.gbc`, and `.rom` files, as
-well as ZIP archives containing a ROM. On macOS, game-controller support also
-requires SDL2 (`brew install sdl2`); keyboard input works without it.
+well as ZIP and 7z archives containing a ROM. On macOS, game-controller support
+also requires SDL2 (`brew install sdl2`); keyboard input works without it.
 
 For netplay, one player chooses **Link > Start server** and the other chooses
 **Link > Connect to server**.
@@ -88,7 +88,7 @@ btn_select=VK_SHIFT
 - **Hardware-focused accuracy:** a cycle-stepped CPU and high-accuracy PPU, APU,
   timer, DMA, serial, and infrared behavior.
 - **Everyday play:** battery-backed saves, ten save-state slots, pause/reset,
-  hold-to-rewind, recent ROMs, and ZIP archive loading.
+  hold-to-rewind, recent ROMs, and ZIP/7z archive loading.
 - **Rollback netplay:** TCP multiplayer for link-cable games, with local rollback
   hiding normal network latency and synchronized infrared communication.
 - **Broad cartridge support:** MBC1/1M, MBC2, MBC3 with RTC and MBC30, MBC5,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart;
 
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZFile;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -176,14 +178,23 @@ public class Rom {
 
     private static byte[] loadFile(File file) throws IOException {
         String ext = FilenameUtils.getExtension(file.getName());
+        if ("7z".equalsIgnoreCase(ext)) {
+            try (SevenZFile sevenZFile = SevenZFile.builder().setFile(file).get()) {
+                SevenZArchiveEntry entry;
+                while ((entry = sevenZFile.getNextEntry()) != null) {
+                    if (!entry.isDirectory() && isRomFile(entry.getName())) {
+                        return IOUtils.toByteArray(sevenZFile.getInputStream(entry));
+                    }
+                }
+            }
+            throw new IllegalArgumentException("Can't find ROM file inside the 7z.");
+        }
         try (InputStream is = Files.newInputStream(file.toPath())) {
             if ("zip".equalsIgnoreCase(ext)) {
                 try (ZipInputStream zis = new ZipInputStream(is)) {
                     ZipEntry entry;
                     while ((entry = zis.getNextEntry()) != null) {
-                        String name = entry.getName();
-                        String entryExt = FilenameUtils.getExtension(name);
-                        if (Stream.of("gb", "gbc", "rom").anyMatch(e -> e.equalsIgnoreCase(entryExt))) {
+                        if (!entry.isDirectory() && isRomFile(entry.getName())) {
                             return IOUtils.toByteArray(zis, (int) entry.getSize());
                         }
                         zis.closeEntry();
@@ -194,6 +205,11 @@ public class Rom {
                 return IOUtils.toByteArray(is, (int) file.length());
             }
         }
+    }
+
+    private static boolean isRomFile(String name) {
+        String ext = FilenameUtils.getExtension(name);
+        return Stream.of("gb", "gbc", "rom").anyMatch(e -> e.equalsIgnoreCase(ext));
     }
 
     private static int getRomBanks(int id, int romLength) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RomArchiveTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RomArchiveTest.java
@@ -1,0 +1,74 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
+import org.apache.commons.compress.archivers.sevenz.SevenZMethod;
+import org.apache.commons.compress.archivers.sevenz.SevenZOutputFile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+public class RomArchiveTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void shouldLoadRomFromSevenZArchive() throws Exception {
+        File archive = temporaryFolder.newFile("game.7Z");
+        byte[] romBytes = createRom("SEVENZ");
+        romBytes[0x0200] = 0x42;
+        writeSevenZ(archive,
+                new ArchiveFile("README.txt", "not a ROM".getBytes(StandardCharsets.UTF_8)),
+                new ArchiveFile("games/game.GBC", romBytes));
+
+        Rom rom = new Rom(archive);
+
+        assertEquals("SEVENZ", rom.getTitle());
+        assertEquals(0x42, rom.getRom()[0x0200]);
+        assertSame(archive, rom.getFile());
+    }
+
+    @Test
+    public void shouldRejectSevenZArchiveWithoutRom() throws Exception {
+        File archive = temporaryFolder.newFile("empty.7z");
+        writeSevenZ(archive, new ArchiveFile("README.txt", new byte[0]));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new Rom(archive));
+
+        assertEquals("Can't find ROM file inside the 7z.", exception.getMessage());
+    }
+
+    private static byte[] createRom(String title) {
+        byte[] rom = new byte[0x8000];
+        byte[] titleBytes = title.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(titleBytes, 0, rom, 0x0134, titleBytes.length);
+        return rom;
+    }
+
+    private static void writeSevenZ(File archive, ArchiveFile... files) throws IOException {
+        try (SevenZOutputFile output = new SevenZOutputFile(archive)) {
+            output.setContentCompression(SevenZMethod.LZMA2);
+            for (ArchiveFile file : files) {
+                SevenZArchiveEntry entry = new SevenZArchiveEntry();
+                entry.setName(file.name());
+                entry.setSize(file.contents().length);
+                output.putArchiveEntry(entry);
+                output.write(file.contents());
+                output.closeArchiveEntry();
+            }
+        }
+    }
+
+    private record ArchiveFile(String name, byte[] contents) {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,17 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.jline</groupId>


### PR DESCRIPTION
## Summary

Coffee GB could load raw ROM files and ZIP archives, but selecting a 7z archive passed the compressed bytes to the cartridge parser instead of locating the ROM inside it.

This change:
- loads `.7z` archives with Apache Commons Compress `SevenZFile`;
- selects the first `.gb`, `.gbc`, or `.rom` entry, matching existing ZIP behavior;
- includes XZ for the common LZMA/LZMA2 codecs and aligns Commons IO with Commons Compress 1.28.0;
- ignores directory entries and shares ROM-entry detection between ZIP and 7z;
- documents 7z support.

## Regression coverage

`RomArchiveTest` creates an LZMA2-compressed 7z archive containing a non-ROM followed by an uppercase `.GBC` entry and verifies that the ROM loads. It also verifies the existing no-ROM failure contract.

Tests:
- `/opt/maven/bin/mvn -pl core -Dtest=RomArchiveTest test` — 2 passed
- `/opt/maven/bin/mvn -pl core test` — 693 passed
- `/opt/maven/bin/mvn -pl swing -am -DskipTests package` — desktop assembly built successfully; packaged JAR contains Commons Compress and XZ classes

Fixes #301