### PR TITLE
Fix SGB palette handling for Donkey Kong scorecard

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
@@ -354,7 +354,7 @@ public class Commands {
         public int getDataSet(int index) {
             int b = packet[6 + (index - 1) / 4];
             int i = (index - 1) % 4;
-            return (b >> (i * 2)) & 0b00000011;
+            return (b >> (2 * (3 - i))) & 0b00000011;
         }
 
         public String toString() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -48,8 +48,6 @@ public class SgbDisplay implements Originator<SgbDisplay> {
 
     private GameboyScreenMask screenMask = GameboyScreenMask.CANCEL;
 
-    private int atfNumber = -1;
-
     private int borderFade;
 
     public SgbDisplay(Rom rom, EventBus sgbBus, boolean sgb, boolean sgbBorder) {
@@ -69,22 +67,10 @@ public class SgbDisplay implements Originator<SgbDisplay> {
             eventBus.register(e -> this.sgbBorder = e.borderEnabled, SetSgbBorder.class);
 
             sgbBus.register(this::onAttrBlk, Commands.AttrBlkCmd.class);
-            sgbBus.register(e -> {
-                palettes[0] = e.getPalette0();
-                palettes[1] = e.getPalette1();
-            }, Commands.Pal01Cmd.class);
-            sgbBus.register(e -> {
-                palettes[0] = e.getPalette0();
-                palettes[3] = e.getPalette3();
-            }, Commands.Pal03Cmd.class);
-            sgbBus.register(e -> {
-                palettes[1] = e.getPalette1();
-                palettes[2] = e.getPalette2();
-            }, Commands.Pal12Cmd.class);
-            sgbBus.register(e -> {
-                palettes[2] = e.getPalette2();
-                palettes[3] = e.getPalette3();
-            }, Commands.Pal23Cmd.class);
+            sgbBus.register(e -> setPalettes(0, e.getPalette0(), 1, e.getPalette1()), Commands.Pal01Cmd.class);
+            sgbBus.register(e -> setPalettes(0, e.getPalette0(), 3, e.getPalette3()), Commands.Pal03Cmd.class);
+            sgbBus.register(e -> setPalettes(1, e.getPalette1(), 2, e.getPalette2()), Commands.Pal12Cmd.class);
+            sgbBus.register(e -> setPalettes(2, e.getPalette2(), 3, e.getPalette3()), Commands.Pal23Cmd.class);
             sgbBus.register(e -> {
                 for (int i = 0; i < 512; i++) {
                     systemPalettes[i] = e.getPalette(i);
@@ -93,8 +79,18 @@ public class SgbDisplay implements Originator<SgbDisplay> {
             sgbBus.register(this::onPalSet, Commands.PalSetCmd.class);
             sgbBus.register(this::onAttrTransfer, Commands.AttrTrnCmd.class);
             sgbBus.register(this::onAttrSet, Commands.AttrSetCmd.class);
+            sgbBus.register(this::onAttrChr, Commands.AttrChrCmd.class);
             sgbBus.register(e -> screenMask = e.getScreenMask(), Commands.MaskEnCmd.class);
         }
+    }
+
+    private void setPalettes(int firstId, int[] first, int secondId, int[] second) {
+        palettes[firstId] = first;
+        palettes[secondId] = second;
+        if (firstId != 0) {
+            palettes[0] = palettes[0].clone();
+        }
+        palettes[0][0] = first[0];
     }
 
     private void onAttrTransfer(Commands.AttrTrnCmd attrTrnCmd) {
@@ -110,7 +106,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
             palettes[i] = systemPalettes[palSetCmd.getPaletteIds()[i]];
         }
         if (palSetCmd.getApplyAtf()) {
-            atfNumber = palSetCmd.getAtfNumber();
+            loadAttributeFile(palSetCmd.getAtfNumber());
         }
         if (palSetCmd.getCancelMaskEn()) {
             screenMask = GameboyScreenMask.CANCEL;
@@ -121,7 +117,44 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         if (attrSetCmd.getCancelMask()) {
             screenMask = GameboyScreenMask.CANCEL;
         }
-        atfNumber = attrSetCmd.getAttributeFileNumber();
+        loadAttributeFile(attrSetCmd.getAttributeFileNumber());
+    }
+
+    private void loadAttributeFile(int id) {
+        if (id >= attributeFiles.length) {
+            return;
+        }
+        System.arraycopy(attributeFiles[id], 0, paletteMap, 0, paletteMap.length);
+    }
+
+    private void onAttrChr(Commands.AttrChrCmd attrChrCmd) {
+        int x = attrChrCmd.getX();
+        int y = attrChrCmd.getY();
+        if (x >= DMG_TILES_WIDTH || y >= DMG_TILES_HEIGHT) {
+            return;
+        }
+        for (int i = 1; i <= attrChrCmd.getDataSetCount(); i++) {
+            paletteMap[x + y * DMG_TILES_WIDTH] = attrChrCmd.getDataSet(i);
+            if (attrChrCmd.getWritingStyle() != 0) {
+                y++;
+                if (y == DMG_TILES_HEIGHT) {
+                    x++;
+                    y = 0;
+                    if (x == DMG_TILES_WIDTH) {
+                        break;
+                    }
+                }
+            } else {
+                x++;
+                if (x == DMG_TILES_WIDTH) {
+                    y++;
+                    x = 0;
+                    if (y == DMG_TILES_HEIGHT) {
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     private void onAttrBlk(Commands.AttrBlkCmd attrBlkCmd) {
@@ -160,12 +193,6 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         int height = sgbBorder ? SGB_DISPLAY_HEIGHT : DISPLAY_HEIGHT;
         int[] result = new int[width * height];
 
-        int lastPaletteId = paletteMap[paletteMap.length - 1];
-        if (atfNumber != -1) {
-            var atf = attributeFiles[atfNumber];
-            lastPaletteId = atf[atf.length - 1];
-        }
-
         for (int x = offsetX; x < offsetX + width; x++) {
             for (int y = offsetY; y < offsetY + height; y++) {
                 int sgbPixel = sgbBuffer[x + y * SGB_DISPLAY_WIDTH];
@@ -178,15 +205,12 @@ public class SgbDisplay implements Originator<SgbDisplay> {
                     int tileY = dmgY / 8;
                     int charId = tileX + tileY * DMG_TILES_WIDTH;
                     int paletteId = paletteMap[charId];
-                    if (atfNumber >= 0) {
-                        paletteId = attributeFiles[atfNumber][charId];
-                    }
                     int p = dmgFrameReadyEvent.pixels()[dmgX + dmgY * DISPLAY_WIDTH];
                     if (screenMask == GameboyScreenMask.BLANK_COLOR0) {
                         p = 0;
                     }
                     if (p == 0) {
-                        paletteId = lastPaletteId;
+                        paletteId = 0;
                     }
                     dmgPixel = palettes[paletteId][p];
                     if (screenMask == GameboyScreenMask.BLANK_BLACK) {
@@ -221,7 +245,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
     @Override
     public Memento<SgbDisplay> saveToMemento() {
         return new SgbDisplayMemento(sgbBuffer.clone(), sgbMask.clone(), clone2(palettes),
-                clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask, atfNumber,
+                clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask,
                 borderFade);
     }
 
@@ -255,7 +279,6 @@ public class SgbDisplay implements Originator<SgbDisplay> {
         System.arraycopy(mem.paletteMap, 0, this.paletteMap, 0, this.paletteMap.length);
         replaceRows(mem.attributeFiles, this.attributeFiles, DMG_TILES_WIDTH * DMG_TILES_HEIGHT);
         this.screenMask = mem.screenMask;
-        this.atfNumber = mem.atfNumber;
         this.borderFade = mem.borderFade;
     }
 
@@ -287,7 +310,7 @@ public class SgbDisplay implements Originator<SgbDisplay> {
 
     private record SgbDisplayMemento(int[] sgbBuffer, int[] sgbMask, int[][] palettes, int[][] systemPalettes,
                                      int[] paletteMap, int[][] attributeFiles, GameboyScreenMask screenMask,
-                                     int atfNumber, int borderFade) implements Memento<SgbDisplay> {
+                                     int borderFade) implements Memento<SgbDisplay> {
     }
 
     public record SgbFrameReadyEvent(int[] buffer, boolean includeBorder) implements Event {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayAttributeTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayAttributeTest.java
@@ -1,0 +1,141 @@
+package eu.rekawek.coffeegb.core.sgb;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static eu.rekawek.coffeegb.core.gpu.Display.GbcFrameReadyEvent.translateGbcRgb;
+import static org.junit.Assert.assertEquals;
+
+public class SgbDisplayAttributeTest {
+
+    private EventBusImpl eventBus;
+
+    private EventBusImpl sgbBus;
+
+    private AtomicReference<int[]> frame;
+
+    @Before
+    public void setUp() throws IOException {
+        eventBus = new EventBusImpl(null, null, false);
+        sgbBus = new EventBusImpl(null, null, false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, false);
+        display.init(eventBus);
+        frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.buffer().clone()), SgbDisplay.SgbFrameReadyEvent.class);
+    }
+
+    @Test
+    public void attrChrUpdatesMapLoadedByAttrSet() {
+        setDirectPalettes();
+        transferAttributeFile(23, 3);
+        sgbBus.post(attrSet(23));
+
+        int[] packet = commandPacket(0x07);
+        packet[1] = 4;
+        packet[2] = 14;
+        packet[3] = 3;
+        packet[5] = 0;
+        packet[6] = 0b00011000; // palettes 0, 1, 2 (most significant pair first)
+        sgbBus.post(Commands.toCommand(packet));
+
+        render(1);
+        assertEquals(translateGbcRgb(0x0111), pixelAtTile(4, 14));
+        assertEquals(translateGbcRgb(0x0222), pixelAtTile(5, 14));
+        assertEquals(translateGbcRgb(0x0333), pixelAtTile(6, 14));
+        assertEquals(translateGbcRgb(0x0444), pixelAtTile(7, 14));
+    }
+
+    @Test
+    public void palSetUsesPaletteZeroColorAsSharedBackdrop() {
+        Commands.PalTrnCmd transfer = (Commands.PalTrnCmd) command(0x0b);
+        int[] data = new int[0x1000];
+        setPaletteColor(data, 0, 0, 0x0111);
+        setPaletteColor(data, 1, 0, 0x0222);
+        setPaletteColor(data, 2, 0, 0x0333);
+        setPaletteColor(data, 3, 0, 0x0444);
+        transfer.setDataTransfer(data);
+        sgbBus.post(transfer);
+
+        int[] packet = commandPacket(0x0a);
+        packet[1] = 0;
+        packet[3] = 1;
+        packet[5] = 2;
+        packet[7] = 3;
+        sgbBus.post(Commands.toCommand(packet));
+        transferAttributeFile(23, 3);
+        sgbBus.post(attrSet(23));
+
+        render(0);
+        assertEquals(translateGbcRgb(0x0111), pixelAtTile(0, 0));
+    }
+
+    private void setDirectPalettes() {
+        int[] pal01 = commandPacket(0x00);
+        setCommandColor(pal01, 3, 0x0111);
+        setCommandColor(pal01, 9, 0x0222);
+        sgbBus.post(Commands.toCommand(pal01));
+
+        int[] pal23 = commandPacket(0x01);
+        setCommandColor(pal23, 3, 0x0333);
+        setCommandColor(pal23, 9, 0x0444);
+        sgbBus.post(Commands.toCommand(pal23));
+    }
+
+    private void transferAttributeFile(int id, int palette) {
+        Commands.AttrTrnCmd transfer = (Commands.AttrTrnCmd) command(0x15);
+        int[] data = new int[0x1000];
+        Arrays.fill(data, id * 90, (id + 1) * 90, palette * 0x55);
+        transfer.setDataTransfer(data);
+        sgbBus.post(transfer);
+    }
+
+    private void render(int color) {
+        int[] pixels = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        Arrays.fill(pixels, color);
+        eventBus.post(new Display.DmgFrameReadyEvent(pixels));
+    }
+
+    private int pixelAtTile(int x, int y) {
+        return frame.get()[x * 8 + y * 8 * Display.DISPLAY_WIDTH];
+    }
+
+    private static Commands.AttrSetCmd attrSet(int id) {
+        int[] packet = commandPacket(0x16);
+        packet[1] = id;
+        return (Commands.AttrSetCmd) Commands.toCommand(packet);
+    }
+
+    private static Commands.AbstractCommand command(int code) {
+        return Commands.toCommand(commandPacket(code));
+    }
+
+    private static int[] commandPacket(int code) {
+        int[] packet = new int[16];
+        packet[0] = (code << 3) | 1;
+        return packet;
+    }
+
+    private static void setCommandColor(int[] packet, int offset, int color) {
+        packet[offset] = color & 0xff;
+        packet[offset + 1] = color >> 8;
+    }
+
+    private static void setPaletteColor(int[] data, int palette, int colorId, int color) {
+        int offset = palette * 8 + colorId * 2;
+        data[offset] = color & 0xff;
+        data[offset + 1] = color >> 8;
+    }
+
+    private static Rom testRom() throws IOException {
+        byte[] bytes = new byte[0x8000];
+        bytes[0x147] = 0;
+        return new Rom(bytes);
+    }
+}


### PR DESCRIPTION
## Summary

Donkey Kong (World) (Rev 1) renders the SGB game area with a magenta backdrop after completing a level. The problem reproduces in SGB mode with ROM SHA-256 `b490c89efe718633b07381def66ce0ed58a5075aabe40c6e644baf2b408a76f4` on `master` at `98a8fc40`.

## Root cause and fix

The scorecard transition loads attribute file 23 and then sends two `ATTR_CHR` commands. Coffee GB kept the attribute file selected by reference and did not handle `ATTR_CHR`, so the game could not update the active attribute map. It also selected color 0 from the palette assigned to the bottom-right tile; with this attribute file that incorrectly made the shared backdrop magenta.

This change:

- copies `ATTR_SET`/`PAL_SET` attribute files into the active attribute map;
- implements horizontal and vertical `ATTR_CHR` writes with the SGB bit order;
- uses palette 0 color 0 as the shared SGB backdrop;
- adds focused coverage for the exact attribute-file/`ATTR_CHR` sequence and shared backdrop behavior.

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=SgbDisplayAttributeTest,SgbMementoTest,SgbDisplayLcdTest test` — 9 tests passed.
- `/opt/maven/bin/mvn -pl core test` — 695 tests passed.
- Re-ran the ROM from a clean boot in SGB mode, completed stage 1-1 with deterministic scripted input (using an invincibility code only to stabilize traversal), and captured the post-level state. The game area now uses the expected off-white backdrop instead of magenta.

Before/after screenshots were captured at the same emulated frame and configuration. The corrected screenshot is retained locally because the available GitHub CLI flow does not support uploading issue/PR attachments; no image was added to the repository.

Fixes #308
