### PR TITLE
Reduce rewind GC pressure from audio snapshots

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -10,6 +10,7 @@ import eu.rekawek.coffeegb.core.memory.Ram;
 import eu.rekawek.coffeegb.core.timer.Timer;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 public class Sound implements AddressSpace, Serializable, Originator<Sound> {
 
@@ -306,7 +307,14 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         for (int i = 0; i < allModes.length; i++) {
             allModeMementos[i] = allModes[i].saveToMemento();
         }
-        return new SoundMemento(allModeMementos, r.saveToMemento(), frameSequencer.saveToMemento(), channels.clone(), enabled, overriddenEnabled.clone(), buffer.clone(), i, pendingFrameSequencerStep, frameSequencerClockPhase, frameSequencerDivOffset);
+        // Only the prefix before i has been written. The rest is overwritten before the
+        // next SoundSampleEvent can expose it, so retaining the full ~546 KiB frame buffer
+        // in every rewind state wastes memory and creates a G1 humongous allocation.
+        int[] pendingSamples = Arrays.copyOf(buffer, i);
+        return new SoundMemento(allModeMementos, r.saveToMemento(),
+                frameSequencer.saveToMemento(), channels.clone(), enabled,
+                overriddenEnabled.clone(), pendingSamples, i, pendingFrameSequencerStep,
+                frameSequencerClockPhase, frameSequencerDivOffset);
     }
 
     @Override
@@ -323,7 +331,12 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         if (this.overriddenEnabled.length != mem.overriddenEnabled.length) {
             throw new IllegalArgumentException("Memento overriddenEnabled length doesn't match");
         }
-        if (this.buffer.length != mem.buffer.length) {
+        if (mem.i < 0 || mem.i >= this.buffer.length || (mem.i & 1) != 0) {
+            throw new IllegalArgumentException("Memento buffer position is invalid");
+        }
+        // New mementos retain only buffer[0..i). Accept the former full-buffer shape as
+        // well so save states written by older Coffee GB versions remain loadable.
+        if (mem.buffer.length != mem.i && mem.buffer.length != this.buffer.length) {
             throw new IllegalArgumentException("Memento buffer length doesn't match");
         }
         for (int i = 0; i < allModes.length; i++) {
@@ -334,7 +347,7 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
         System.arraycopy(mem.channels, 0, this.channels, 0, this.channels.length);
         this.enabled = mem.enabled();
         System.arraycopy(mem.overriddenEnabled, 0, this.overriddenEnabled, 0, this.overriddenEnabled.length);
-        System.arraycopy(mem.buffer, 0, this.buffer, 0, this.buffer.length);
+        System.arraycopy(mem.buffer, 0, this.buffer, 0, mem.i);
         this.i = mem.i;
         this.pendingFrameSequencerStep = mem.pendingFrameSequencerStep;
         this.frameSequencerClockPhase = mem.frameSequencerClockPhase;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMementoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMementoTest.java
@@ -1,0 +1,72 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.timer.Timer;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SoundMementoTest {
+
+    @Test
+    public void frameBoundaryMementoDoesNotRetainTheEmittedFrameBuffer() throws Exception {
+        Sound sound = newSound();
+        tick(sound, Gameboy.TICKS_PER_FRAME);
+
+        var bytes = new ByteArrayOutputStream();
+        try (var output = new ObjectOutputStream(bytes)) {
+            output.writeObject(sound.saveToMemento());
+        }
+
+        assertTrue("An empty sound memento should not contain the 546 KiB output buffer",
+                bytes.size() < 32 * 1024);
+    }
+
+    @Test
+    public void partialFramePrefixSurvivesMementoRestore() {
+        Sound sound = newSound();
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        List<int[]> frames = new ArrayList<>();
+        eventBus.register(event -> frames.add(event.buffer().clone()), Sound.SoundSampleEvent.class);
+        sound.init(eventBus);
+
+        // An enabled but inactive DAC contributes a constant analog level. That makes the
+        // saved prefix observably different from the zeroes used to overwrite it below.
+        sound.setByte(0xff12, 0xf0);
+        sound.setByte(0xff25, 0x11);
+        int prefixTicks = 127;
+        tick(sound, prefixTicks);
+        var memento = sound.saveToMemento();
+
+        tick(sound, Gameboy.TICKS_PER_FRAME - prefixTicks);
+        int[] expected = frames.remove(0);
+
+        sound.setByte(0xff12, 0);
+        tick(sound, prefixTicks);
+        sound.restoreFromMemento(memento);
+        tick(sound, Gameboy.TICKS_PER_FRAME - prefixTicks);
+
+        assertArrayEquals(expected, frames.remove(0));
+    }
+
+    private static Sound newSound() {
+        SpeedMode speedMode = new SpeedMode(true);
+        Timer timer = new Timer(new InterruptManager(true), speedMode);
+        return new Sound(timer, speedMode, true);
+    }
+
+    private static void tick(Sound sound, int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            sound.tick();
+        }
+    }
+}


### PR DESCRIPTION
Refs #310

## Summary

- retain only the pending prefix of the sound output buffer in emulator mementos
- continue accepting the full-buffer memento shape written by older versions
- add regressions for compact frame-boundary snapshots and exact partial-frame restoration

## Investigation

The exact reported GBC ROM (`8eb56e0d55a04aa3fcf940f172757f4f60baa6c53c82707def8ae4e78844b1da`) did not expose a functional APU mismatch: its captured title audio matched SameBoy channel by channel and contained no inserted silence. It was comparatively expensive to emulate, though. Frames 1100-1500 ran at about 64.1 fps headless on this Linux machine, leaving little margin for UI and audio playback work.

The always-on rewind history was creating avoidable memory and GC pressure at exactly the relevant time:

- rewind records a full emulator memento every 6 frames and retains 300 states
- every sound memento cloned the entire 559,240-byte output buffer, although controller frame-boundary snapshots normally have no pending samples
- with the default G1 layout, that array becomes a humongous allocation
- the reported title music begins around frame 1400 (~23 seconds), after rewind has accumulated about 230 such states

Only `buffer[0..i)` can affect future output; the remainder is overwritten before the next `SoundSampleEvent`. This change therefore stores that prefix and restores it exactly, without changing APU timing or mixing.

## Measurements

Representative CGB rewind runs retaining 300 mementos:

| | Before | After |
| --- | ---: | ---: |
| Retained heap | ~684 MB | ~370 MB |
| Retained per state | ~2,225 KiB | ~1,203 KiB |
| Memento capture | ~0.58 ms | ~0.40 ms |

In a rolling snapshot stress run with `-Xmx768m`, the old shape caused repeated humongous-allocation full GCs with 12-25 ms pauses. The patched run produced no workload full GC and no humongous allocation. This explains why the choppiness can depend on platform, heap sizing, and machine performance even when emulated samples are correct.

## Testing

- `mvn -pl core -Dtest=SoundMementoTest test` — 2 passed
- `mvn -pl core test -Ptest-blargg-individual -Dtest=DmgSound2Test,CgbSoundTest -Dintegration.test.threadCount=2` — 24 passed
- `mvn -pl controller -am test` — 697 core and 35 controller tests passed

The issue should remain open until the reporter can verify playback on an affected machine.
