### PR TITLE
Add immutable machine state model

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
@@ -8,6 +8,8 @@ import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memento.Originator
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
+import eu.rekawek.coffeegb.controller.state.SessionState
 
 class Session(
     val config: Gameboy.GameboyConfiguration,
@@ -51,6 +53,12 @@ class Session(
   override fun saveToMemento(): Memento<Session> {
     return SessionMemento(gameboy.saveToMemento(), serialEndpoint.saveToMemento())
   }
+
+  /** Captures a detached, deeply owned session state at the controller frame safe point. */
+  internal fun captureDetachedState(): SessionState = DetachedStateAdapter.capture(this)
+
+  /** Applies a fully validated detached state or rolls the complete session back on failure. */
+  internal fun restoreDetachedState(state: SessionState) = DetachedStateAdapter.apply(this, state)
 
   override fun restoreFromMemento(memento: Memento<Session>) {
     if (memento !is SessionMemento) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -12,9 +12,13 @@ import eu.rekawek.coffeegb.controller.NetplayMementoCodec
 import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.StateLimits
 import eu.rekawek.coffeegb.controller.TimingTicker
+import eu.rekawek.coffeegb.controller.state.ApplyStage
+import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.LinkedPlayerState
 import eu.rekawek.coffeegb.controller.state.LinkedSessionState
 import eu.rekawek.coffeegb.controller.state.LinkedTopologyState
+import eu.rekawek.coffeegb.controller.state.SerialPeripheralState
+import eu.rekawek.coffeegb.controller.state.StateApplyException
 import eu.rekawek.coffeegb.controller.events.EventQueue
 import eu.rekawek.coffeegb.controller.events.funnel
 import eu.rekawek.coffeegb.controller.events.register
@@ -123,10 +127,100 @@ class LinkedController(
           localPlayer,
           if (mode == LinkMode.NORMAL) LinkedTopologyState.NORMAL
           else LinkedTopologyState.FOUR_PLAYER_ADAPTER,
-          sessions.mapIndexed { player, session ->
-            LinkedPlayerState(player, session?.captureDetachedState())
+          (0 until CANONICAL_PLAYER_SLOTS).map { player ->
+            LinkedPlayerState(player, sessions.getOrNull(player)?.captureDetachedState())
           },
       )
+
+  /** Applies an already-configured linked group at the owning controller frame safe point. */
+  internal fun restoreDetachedState(
+      state: LinkedSessionState,
+      probe: ((Int, ApplyStage) -> Unit)? = null,
+  ) {
+    validateLinkedState(state)
+    val active =
+        sessions.indices.mapNotNull { player ->
+          val session = sessions[player] ?: return@mapNotNull null
+          val sessionState = state.players[player].session ?: return@mapNotNull null
+          Triple(player, session, DetachedStateAdapter.prepare(session, sessionState))
+        }
+    // Prepare rollback records before the first mutation as part of the same transaction.
+    val rollbackState = captureDetachedState()
+    val rollback =
+        sessions.indices.mapNotNull { player ->
+          val session = sessions[player] ?: return@mapNotNull null
+          val sessionState = rollbackState.players[player].session ?: return@mapNotNull null
+          Triple(player, session, DetachedStateAdapter.prepare(session, sessionState))
+        }
+    val oldFrame = frame
+    val oldRuntimeFrameFloor = runtimeFrameFloor
+    val oldCurrentInput = currentInput
+    val oldLastInput = lastInput
+    try {
+      active.forEach { (player, session, prepared) ->
+        probe?.invoke(player, ApplyStage.BEFORE_LIVE_MUTATION)
+        DetachedStateAdapter.commit(session, prepared) { stage -> probe?.invoke(player, stage) }
+      }
+      frame = state.frame
+      runtimeFrameFloor = frame
+      currentInput = null
+      lastInput = null
+      rebaseHistoryToLiveState()
+    } catch (failure: Throwable) {
+      try {
+        rollback.forEach { (_, session, prepared) ->
+          DetachedStateAdapter.commit(session, prepared)
+        }
+        frame = oldFrame
+        runtimeFrameFloor = oldRuntimeFrameFloor
+        currentInput = oldCurrentInput
+        lastInput = oldLastInput
+      } catch (rollbackFailure: Throwable) {
+        failure.addSuppressed(rollbackFailure)
+      }
+      throw StateApplyException("Linked session state could not be applied atomically", failure)
+    }
+  }
+
+  private fun validateLinkedState(state: LinkedSessionState) {
+    if (state.frame < 0 || state.frame > StateLimits.NETPLAY_MAX_FRAME) {
+      throw StateApplyException("Detached linked frame ${state.frame} is outside the supported range")
+    }
+    if (state.localPlayer != localPlayer) {
+      throw StateApplyException(
+          "Detached local player ${state.localPlayer} does not match controller player $localPlayer")
+    }
+    val expectedTopology =
+        if (mode == LinkMode.NORMAL) LinkedTopologyState.NORMAL
+        else LinkedTopologyState.FOUR_PLAYER_ADAPTER
+    if (state.topology != expectedTopology) {
+      throw StateApplyException(
+          "Detached ${state.topology} topology does not match $expectedTopology")
+    }
+    if (state.players.size != CANONICAL_PLAYER_SLOTS ||
+        state.players.indices.any { state.players[it].player != it }) {
+      throw StateApplyException("Detached linked state requires canonical player indices 0..3")
+    }
+    if (mode == LinkMode.NORMAL && state.players.drop(mode.playerCount).any { it.session != null }) {
+      throw StateApplyException("Normal link state cannot populate four-player-only slots")
+    }
+    sessions.indices.forEach { player ->
+      if ((sessions[player] == null) != (state.players[player].session == null)) {
+        throw StateApplyException("Detached player $player does not match the active-session shape")
+      }
+    }
+    val activeStates = state.players.mapNotNull(LinkedPlayerState::session)
+    val expectedPeripheral =
+        if (mode == LinkMode.NORMAL) SerialPeripheralState.PEER_TO_PEER
+        else SerialPeripheralState.FOUR_PLAYER_ADAPTER
+    if (activeStates.any { it.serialPeripheral != expectedPeripheral }) {
+      throw StateApplyException("Detached serial endpoint identity does not match linked topology")
+    }
+    if (mode == LinkMode.FOUR_PLAYER_ADAPTER &&
+        activeStates.map { it.serialState }.distinct().size > 1) {
+      throw StateApplyException("Detached four-player sessions disagree on shared adapter state")
+    }
+  }
 
   @Volatile private var doStop = false
 
@@ -706,12 +800,14 @@ class LinkedController(
   }
 
   private fun rebaseHistoryToLiveState() {
+    val mementos = sessions.map { it?.saveToMemento() }
+    val heldButtons = sessions.map { it?.heldButtons ?: emptySet() }
     stateHistory.clear()
     stateHistory.addState(
         frame,
         List(mode.playerCount) { Input(emptyList(), emptyList()) },
-        sessions.map { it?.saveToMemento() },
-        sessions.map { it?.heldButtons ?: emptySet() },
+        mementos,
+        heldButtons,
     )
   }
 
@@ -797,6 +893,7 @@ class LinkedController(
   )
 
   private companion object {
+    const val CANONICAL_PLAYER_SLOTS = 4
     val LOG: Logger = LoggerFactory.getLogger(LinkedController::class.java)
   }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -12,6 +12,9 @@ import eu.rekawek.coffeegb.controller.NetplayMementoCodec
 import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.StateLimits
 import eu.rekawek.coffeegb.controller.TimingTicker
+import eu.rekawek.coffeegb.controller.state.LinkedPlayerState
+import eu.rekawek.coffeegb.controller.state.LinkedSessionState
+import eu.rekawek.coffeegb.controller.state.LinkedTopologyState
 import eu.rekawek.coffeegb.controller.events.EventQueue
 import eu.rekawek.coffeegb.controller.events.funnel
 import eu.rekawek.coffeegb.controller.events.register
@@ -112,6 +115,18 @@ class LinkedController(
 
   @VisibleForTesting
   internal fun heldButtonStates(): List<Set<Button>?> = sessions.map { it?.heldButtons }
+
+  /** Captures controller-owned frame, topology, session machines, endpoints, and held input. */
+  internal fun captureDetachedState(): LinkedSessionState =
+      LinkedSessionState(
+          frame,
+          localPlayer,
+          if (mode == LinkMode.NORMAL) LinkedTopologyState.NORMAL
+          else LinkedTopologyState.FOUR_PLAYER_ADAPTER,
+          sessions.mapIndexed { player, session ->
+            LinkedPlayerState(player, session?.captureDetachedState())
+          },
+      )
 
   @Volatile private var doStop = false
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
+import java.nio.charset.StandardCharsets
 import java.util.Collections
 
 /** Fixed-width, service-free value kinds used by the Phase-1 detached state seam. */
@@ -68,6 +69,10 @@ data class Float64State(val value: Double) : StateValue {
 }
 
 data class StringState(val value: String) : StateValue {
+  init {
+    DetachedValueBounds.requireString(value) { message -> throw IllegalArgumentException(message) }
+  }
+
   override val kind = StateKind.STRING
 }
 
@@ -92,18 +97,33 @@ class RecordState(val typeId: Int, fields: Collection<StateField>) : StateValue 
 sealed class PrimitiveArrayState<T>(
     final override val kind: StateKind,
 ) : StateValue {
+  abstract val size: Int
   abstract fun copyValue(): T
 }
 
 class BytesState(value: ByteArray) : PrimitiveArrayState<ByteArray>(StateKind.BYTES) {
+  init {
+    DetachedValueBounds.requireArray(value.size.toLong(), Byte.SIZE_BYTES.toLong()) { message ->
+      throw IllegalArgumentException(message)
+    }
+  }
+
   private val owned = value.clone()
+  override val size: Int get() = owned.size
   override fun copyValue(): ByteArray = owned.clone()
   override fun equals(other: Any?): Boolean = other is BytesState && owned.contentEquals(other.owned)
   override fun hashCode(): Int = owned.contentHashCode()
 }
 
 class Int32ArrayState(value: IntArray) : PrimitiveArrayState<IntArray>(StateKind.INT32_ARRAY) {
+  init {
+    DetachedValueBounds.requireArray(value.size.toLong(), Int.SIZE_BYTES.toLong()) { message ->
+      throw IllegalArgumentException(message)
+    }
+  }
+
   private val owned = value.clone()
+  override val size: Int get() = owned.size
   override fun copyValue(): IntArray = owned.clone()
   override fun equals(other: Any?): Boolean =
       other is Int32ArrayState && owned.contentEquals(other.owned)
@@ -111,7 +131,14 @@ class Int32ArrayState(value: IntArray) : PrimitiveArrayState<IntArray>(StateKind
 }
 
 class Int64ArrayState(value: LongArray) : PrimitiveArrayState<LongArray>(StateKind.INT64_ARRAY) {
+  init {
+    DetachedValueBounds.requireArray(value.size.toLong(), Long.SIZE_BYTES.toLong()) { message ->
+      throw IllegalArgumentException(message)
+    }
+  }
+
   private val owned = value.clone()
+  override val size: Int get() = owned.size
   override fun copyValue(): LongArray = owned.clone()
   override fun equals(other: Any?): Boolean =
       other is Int64ArrayState && owned.contentEquals(other.owned)
@@ -120,7 +147,14 @@ class Int64ArrayState(value: LongArray) : PrimitiveArrayState<LongArray>(StateKi
 
 class BooleanArrayState(value: BooleanArray) :
     PrimitiveArrayState<BooleanArray>(StateKind.BOOLEAN_ARRAY) {
+  init {
+    DetachedValueBounds.requireArray(value.size.toLong(), 1) { message ->
+      throw IllegalArgumentException(message)
+    }
+  }
+
   private val owned = value.clone()
+  override val size: Int get() = owned.size
   override fun copyValue(): BooleanArray = owned.clone()
   override fun equals(other: Any?): Boolean =
       other is BooleanArrayState && owned.contentEquals(other.owned)
@@ -160,7 +194,19 @@ class Int32MapState(entries: Collection<Int32MapEntry>) : StateValue {
 }
 
 /** MBC3 pause bookkeeping kept outside the pinned legacy Java-serialization shape. */
-data class RtcRuntimeState(val emulationPaused: Boolean, val pauseStartedMillis: Long)
+data class Mbc3RtcRuntimeState(val emulationPaused: Boolean, val pauseStartedMillis: Long)
+
+/** Explicit physical cartridge locations; neither location retains its TimeSource service. */
+data class CartridgeRtcRuntimeState(
+    val primary: Mbc3RtcRuntimeState?,
+    val slot: Mbc3RtcRuntimeState?,
+)
+
+enum class MachineHardwareState {
+  DMG,
+  CGB,
+  SGB,
+}
 
 sealed interface SerialRuntimeState
 
@@ -170,7 +216,16 @@ class BarcodeBoyRuntimeState(
     val transferArmed: Boolean,
     pending: IntArray?,
 ) : SerialRuntimeState {
+  init {
+    pending?.let {
+      DetachedValueBounds.requireArray(it.size.toLong(), Int.SIZE_BYTES.toLong()) { message ->
+        throw IllegalArgumentException(message)
+      }
+    }
+  }
+
   private val ownedPending = pending?.clone()
+  val pendingSize: Int? get() = ownedPending?.size
   fun copyPending(): IntArray? = ownedPending?.clone()
 
   override fun equals(other: Any?): Boolean =
@@ -188,14 +243,18 @@ class BarcodeBoyRuntimeState(
 /** One complete, deeply owned Game Boy machine state. */
 class MachineState internal constructor(
     val root: RecordState,
-    val rtcRuntime: RtcRuntimeState?,
+    val rtcRuntime: CartridgeRtcRuntimeState,
+    val hardware: MachineHardwareState,
 ) {
   fun recordCount(className: String): Int =
       StateGraph.countRecords(root, className)
 
   override fun equals(other: Any?): Boolean =
-      other is MachineState && root == other.root && rtcRuntime == other.rtcRuntime
-  override fun hashCode(): Int = 31 * root.hashCode() + (rtcRuntime?.hashCode() ?: 0)
+      other is MachineState &&
+          root == other.root &&
+          rtcRuntime == other.rtcRuntime &&
+          hardware == other.hardware
+  override fun hashCode(): Int = arrayOf(root, rtcRuntime, hardware).contentHashCode()
 }
 
 enum class HeldButtonState {
@@ -227,8 +286,7 @@ class SessionState internal constructor(
     val serialRuntime: SerialRuntimeState,
     heldButtons: Collection<HeldButtonState>,
 ) {
-  val heldButtons: Set<HeldButtonState> =
-      Collections.unmodifiableSet(linkedSetOf<HeldButtonState>().also { it.addAll(heldButtons) })
+  val heldButtons: List<HeldButtonState> = Collections.unmodifiableList(ArrayList(heldButtons))
 
   override fun equals(other: Any?): Boolean =
       other is SessionState &&
@@ -273,6 +331,23 @@ class StateCaptureException(message: String, cause: Throwable? = null) : IOExcep
 
 class StateApplyException(message: String, cause: Throwable? = null) : IOException(message, cause)
 
+internal enum class ApplyStage {
+  BEFORE_LIVE_MUTATION,
+  AFTER_MACHINE_MUTATION,
+}
+
+internal data class PreparedMachineState(
+    val memento: Memento<Gameboy>,
+    val rtcRuntime: Gameboy.RtcRuntimeState,
+)
+
+internal data class PreparedSessionState(
+    val machine: PreparedMachineState,
+    val serialMemento: Memento<SerialEndpoint>?,
+    val serialRuntime: SerialRuntimeState,
+    val heldButtons: Set<Button>,
+)
+
 /**
  * Transitional adapter between the legacy in-memory mementos and the explicit immutable model.
  * This is deliberately not a byte codec; #322 owns the sectioned StateFile representation.
@@ -282,9 +357,8 @@ internal object DetachedStateAdapter {
   fun capture(gameboy: Gameboy): MachineState =
       MachineState(
           StateGraph.captureRoot(gameboy.saveToMemento(), GAMEBOY_ROOT),
-          gameboy.captureRtcRuntimeState()?.let {
-            RtcRuntimeState(it.emulationPaused(), it.pauseStartedMillis())
-          },
+          gameboy.captureRtcRuntimeState().toDetached(),
+          MachineHardwareState.valueOf(gameboy.gameboyType.name),
       )
 
   fun capture(session: Session): SessionState {
@@ -295,28 +369,18 @@ internal object DetachedStateAdapter {
         peripheral,
         serial,
         captureSerialRuntime(session.serialEndpoint),
-        session.heldButtons.map { HeldButtonState.valueOf(it.name) },
+        session.heldButtons.map { HeldButtonState.valueOf(it.name) }.sortedBy { it.ordinal },
     )
   }
 
   fun apply(gameboy: Gameboy, state: MachineState) {
-    val detached = StateGraph.restoreRoot(state.root, GAMEBOY_ROOT)
-    @Suppress("UNCHECKED_CAST") val replacement = detached as Memento<Gameboy>
-    val currentRtc = gameboy.captureRtcRuntimeState()
-    if ((currentRtc == null) != (state.rtcRuntime == null)) {
-      throw StateApplyException("Detached state RTC family does not match the running cartridge")
-    }
-    val rollback = gameboy.saveToMemento()
+    val prepared = prepare(gameboy, state)
+    val rollback = prepare(gameboy, capture(gameboy))
     try {
-      gameboy.restoreFromMemento(replacement)
-      gameboy.restoreRtcRuntimeState(state.rtcRuntime?.let {
-        eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
-            it.emulationPaused, it.pauseStartedMillis)
-      })
+      commit(gameboy, prepared)
     } catch (failure: Throwable) {
       try {
-        gameboy.restoreFromMemento(rollback)
-        gameboy.restoreRtcRuntimeState(currentRtc)
+        commit(gameboy, rollback)
       } catch (rollbackFailure: Throwable) {
         failure.addSuppressed(rollbackFailure)
       }
@@ -324,54 +388,85 @@ internal object DetachedStateAdapter {
     }
   }
 
-  fun apply(session: Session, state: SessionState) {
+  fun apply(
+      session: Session,
+      state: SessionState,
+      probe: ((ApplyStage) -> Unit)? = null,
+  ) {
+    val prepared = prepare(session, state)
+    val rollback = prepare(session, capture(session))
+    try {
+      probe?.invoke(ApplyStage.BEFORE_LIVE_MUTATION)
+      commit(session, prepared, probe)
+    } catch (failure: Throwable) {
+      try {
+        commit(session, rollback)
+      } catch (rollbackFailure: Throwable) {
+        failure.addSuppressed(rollbackFailure)
+      }
+      throw StateApplyException("Detached session state could not be applied atomically", failure)
+    }
+  }
+
+  internal fun prepare(session: Session, state: SessionState): PreparedSessionState {
     val currentPeripheral = serialPeripheral(session.serialEndpoint)
     if (currentPeripheral != state.serialPeripheral) {
       throw StateApplyException(
           "Session peripheral mismatch: expected ${state.serialPeripheral}, found $currentPeripheral")
     }
 
-    val machineValue = StateGraph.restoreRoot(state.machine.root, GAMEBOY_ROOT)
+    val machine = prepare(session.gameboy, state.machine)
+    val currentSerialState = StateGraph.capture(session.serialEndpoint.saveToMemento())
+    if ((state.serialState === NullState) != (currentSerialState === NullState)) {
+      throw StateApplyException("Detached serial memento presence does not match the endpoint")
+    }
+    StateGraph.validateCompatible(state.serialState, currentSerialState, "serial")
     val serialValue = StateGraph.restore(state.serialState)
     if (serialValue != null && serialValue !is Memento<*>) {
       throw StateApplyException("Session serial state has the wrong root type")
     }
-    @Suppress("UNCHECKED_CAST") val machineMemento = machineValue as Memento<Gameboy>
     @Suppress("UNCHECKED_CAST") val serialMemento = serialValue as Memento<SerialEndpoint>?
     validateSerialRuntime(session.serialEndpoint, state.serialRuntime)
-    val currentRtc = session.gameboy.captureRtcRuntimeState()
-    if ((currentRtc == null) != (state.machine.rtcRuntime == null)) {
-      throw StateApplyException("Detached state RTC family does not match the running cartridge")
+    if (state.heldButtons.distinct().size != state.heldButtons.size) {
+      throw StateApplyException("Detached held-button state contains duplicates")
     }
+    val heldButtons = state.heldButtons.map { Button.valueOf(it.name) }.toSet()
+    return PreparedSessionState(machine, serialMemento, state.serialRuntime, heldButtons)
+  }
 
-    // Complete reconstruction above is the validation boundary. No live subsystem is touched
-    // until both graphs and the endpoint identity have been checked.
-    val rollbackMachine = session.gameboy.saveToMemento()
-    val rollbackRtc = currentRtc
-    val rollbackSerial = session.serialEndpoint.saveToMemento()
-    val rollbackSerialRuntime = captureSerialRuntime(session.serialEndpoint)
-    val rollbackButtons = session.heldButtons
-    try {
-      session.gameboy.restoreFromMemento(machineMemento)
-      session.gameboy.restoreRtcRuntimeState(state.machine.rtcRuntime?.let {
-        eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
-            it.emulationPaused, it.pauseStartedMillis)
-      })
-      session.serialEndpoint.restoreFromMemento(serialMemento)
-      applySerialRuntime(session.serialEndpoint, state.serialRuntime)
-      session.heldButtons = state.heldButtons.map { Button.valueOf(it.name) }.toSet()
-    } catch (failure: Throwable) {
-      try {
-        session.gameboy.restoreFromMemento(rollbackMachine)
-        session.gameboy.restoreRtcRuntimeState(rollbackRtc)
-        session.serialEndpoint.restoreFromMemento(rollbackSerial)
-        applySerialRuntime(session.serialEndpoint, rollbackSerialRuntime)
-        session.heldButtons = rollbackButtons
-      } catch (rollbackFailure: Throwable) {
-        failure.addSuppressed(rollbackFailure)
-      }
-      throw StateApplyException("Detached session state could not be applied atomically", failure)
+  internal fun commit(
+      session: Session,
+      prepared: PreparedSessionState,
+      probe: ((ApplyStage) -> Unit)? = null,
+  ) {
+    commit(session.gameboy, prepared.machine)
+    probe?.invoke(ApplyStage.AFTER_MACHINE_MUTATION)
+    session.serialEndpoint.restoreFromMemento(prepared.serialMemento)
+    applySerialRuntime(session.serialEndpoint, prepared.serialRuntime)
+    session.heldButtons = prepared.heldButtons
+  }
+
+  private fun prepare(gameboy: Gameboy, state: MachineState): PreparedMachineState {
+    if (state.hardware != MachineHardwareState.valueOf(gameboy.gameboyType.name)) {
+      throw StateApplyException(
+          "Detached ${state.hardware} state does not match ${gameboy.gameboyType} hardware")
     }
+    val current = StateGraph.captureRoot(gameboy.saveToMemento(), GAMEBOY_ROOT)
+    StateGraph.validateCompatible(state.root, current, "machine")
+    val detached = StateGraph.restoreRoot(state.root, GAMEBOY_ROOT)
+    @Suppress("UNCHECKED_CAST") val memento = detached as Memento<Gameboy>
+    val rtcRuntime = state.rtcRuntime.toCore()
+    try {
+      gameboy.validateRtcRuntimeState(rtcRuntime)
+    } catch (failure: IllegalArgumentException) {
+      throw StateApplyException("Detached cartridge RTC layout is incompatible", failure)
+    }
+    return PreparedMachineState(memento, rtcRuntime)
+  }
+
+  private fun commit(gameboy: Gameboy, prepared: PreparedMachineState) {
+    gameboy.restoreFromMemento(prepared.memento)
+    gameboy.restoreRtcRuntimeState(prepared.rtcRuntime)
   }
 
   private fun serialPeripheral(endpoint: SerialEndpoint): SerialPeripheralState =
@@ -410,6 +505,13 @@ internal object DetachedStateAdapter {
           NoSerialRuntimeState -> endpoint !is BarcodeBoySerialEndpoint
         }
     if (!valid) throw StateApplyException("Detached serial runtime state does not match the endpoint")
+    if (state is BarcodeBoyRuntimeState) {
+      state.pendingSize?.let {
+        DetachedValueBounds.requireArray(it.toLong(), Int.SIZE_BYTES.toLong()) { message ->
+          throw StateApplyException(message)
+        }
+      }
+    }
   }
 
   private fun applySerialRuntime(endpoint: SerialEndpoint, state: SerialRuntimeState) {
@@ -421,6 +523,23 @@ internal object DetachedStateAdapter {
   }
 
   private const val GAMEBOY_ROOT = "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento"
+
+  private fun Gameboy.RtcRuntimeState.toDetached(): CartridgeRtcRuntimeState =
+      CartridgeRtcRuntimeState(primary.toDetached(), slot.toDetached())
+
+  private fun eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState?.toDetached():
+      Mbc3RtcRuntimeState? =
+      this?.let { Mbc3RtcRuntimeState(it.emulationPaused(), it.pauseStartedMillis()) }
+
+  private fun CartridgeRtcRuntimeState.toCore(): Gameboy.RtcRuntimeState =
+      Gameboy.RtcRuntimeState(primary.toCore(), slot.toCore())
+
+  private fun Mbc3RtcRuntimeState?.toCore():
+      eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState? =
+      this?.let {
+        eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
+            it.emulationPaused, it.pauseStartedMillis)
+      }
 }
 
 internal object StateGraph {
@@ -449,6 +568,11 @@ internal object StateGraph {
   }
 
   fun restore(value: StateValue): Any? = Restore().value(value, null, 0)
+
+  /** Validates target-dependent restore preconditions without touching the live target. */
+  fun validateCompatible(candidate: StateValue, target: StateValue, path: String) {
+    Compatibility().value(candidate, target, path, null, null)
+  }
 
   fun countRecords(value: StateValue, className: String): Int {
     var count = 0
@@ -485,15 +609,25 @@ internal object StateGraph {
         is Boolean -> BooleanState(value)
         is Double -> Float64State(value)
         is String -> {
-          if (value.length > StateLimits.LEGACY_MAX_STRING_CHARS) {
-            throw StateCaptureException("State string is too long")
-          }
+          DetachedValueBounds.requireString(value) { message -> throw StateCaptureException(message) }
           StringState(value)
         }
-        is ByteArray -> BytesState(value.also { checkArray(it.size) })
-        is IntArray -> Int32ArrayState(value.also { checkArray(it.size) })
-        is LongArray -> Int64ArrayState(value.also { checkArray(it.size) })
-        is BooleanArray -> BooleanArrayState(value.also { checkArray(it.size) })
+        is ByteArray -> {
+          checkArray(value.size, Byte.SIZE_BYTES)
+          BytesState(value)
+        }
+        is IntArray -> {
+          checkArray(value.size, Int.SIZE_BYTES)
+          Int32ArrayState(value)
+        }
+        is LongArray -> {
+          checkArray(value.size, Long.SIZE_BYTES)
+          Int64ArrayState(value)
+        }
+        is BooleanArray -> {
+          checkArray(value.size, 1)
+          BooleanArrayState(value)
+        }
         is List<*> -> {
           checkCaptureCollection(value.size)
           ListState(value.map { this.value(it, depth + 1) })
@@ -572,13 +706,18 @@ internal object StateGraph {
             is Int64State -> value.value
             is BooleanState -> value.value
             is Float64State -> value.value
-            is StringState -> value.value
+            is StringState -> {
+              DetachedValueBounds.requireString(value.value) { message ->
+                throw StateApplyException(message)
+              }
+              value.value
+            }
             is EnumState -> restoreEnum(value)
             is RecordState -> restoreRecord(value, depth)
-            is BytesState -> value.copyValue()
-            is Int32ArrayState -> value.copyValue()
-            is Int64ArrayState -> value.copyValue()
-            is BooleanArrayState -> value.copyValue()
+            is BytesState -> checkedCopy(value, Byte.SIZE_BYTES)
+            is Int32ArrayState -> checkedCopy(value, Int.SIZE_BYTES)
+            is Int64ArrayState -> checkedCopy(value, Long.SIZE_BYTES)
+            is BooleanArrayState -> checkedCopy(value, 1)
             is ObjectArrayState -> restoreArray(value, expectedType, depth)
             is ListState -> restoreList(value, expectedType, depth)
             is Int32MapState -> restoreMap(value, expectedType, depth)
@@ -664,6 +803,69 @@ internal object StateGraph {
         throw StateApplyException("State has too many references")
       }
     }
+
+    private fun <T> checkedCopy(value: PrimitiveArrayState<T>, width: Int): T {
+      DetachedValueBounds.requireArray(value.size.toLong(), width.toLong()) { message ->
+        throw StateApplyException(message)
+      }
+      return value.copyValue()
+    }
+  }
+
+  private class Compatibility {
+    fun value(
+        candidate: StateValue,
+        target: StateValue,
+        path: String,
+        owner: String?,
+        field: String?,
+    ) {
+      if (candidate === NullState || target === NullState) {
+        val nonNull = if (candidate === NullState) target else candidate
+        if (nonNull is RecordState && !isNullableRecord(owner, field)) {
+          throw StateApplyException("$path has incompatible memento presence")
+        }
+        return
+      }
+      if (candidate.kind != target.kind) {
+        throw StateApplyException("$path has ${candidate.kind}, expected ${target.kind}")
+      }
+      when {
+        candidate is RecordState && target is RecordState -> {
+          if (candidate.typeId != target.typeId) {
+            throw StateApplyException(
+                "$path has ${recordClass(candidate).name}, expected ${recordClass(target).name}")
+          }
+          val type = recordClass(target).name
+          if (candidate.fields.size != target.fields.size) {
+            throw StateApplyException("$path has an incompatible field count")
+          }
+          candidate.fields.indices.forEach { index ->
+            val left = candidate.fields[index]
+            val right = target.fields[index]
+            if (left.name != right.name) {
+              throw StateApplyException("$path has an incompatible field order")
+            }
+            value(left.value, right.value, "$path.${left.name}", type, left.name)
+          }
+        }
+        candidate is PrimitiveArrayState<*> && target is PrimitiveArrayState<*> -> {
+          if (!isVariableArray(owner, field) && candidate.size != target.size) {
+            throw StateApplyException(
+                "$path has length ${candidate.size}, expected invariant length ${target.size}")
+          }
+        }
+        candidate is ObjectArrayState && target is ObjectArrayState -> {
+          if (candidate.values.size != target.values.size) {
+            throw StateApplyException(
+                "$path has length ${candidate.values.size}, expected invariant length ${target.values.size}")
+          }
+          candidate.values.indices.forEach { index ->
+            value(candidate.values[index], target.values[index], "$path[$index]", owner, field)
+          }
+        }
+      }
+    }
   }
 
   private fun checkCaptureDepth(depth: Int) {
@@ -674,11 +876,10 @@ internal object StateGraph {
     if (depth > StateLimits.LEGACY_MAX_DEPTH) throw StateApplyException("State is too deep")
   }
 
-  private fun checkArray(size: Int) {
-    if (size < 0 || size.toLong() > StateLimits.LEGACY_MAX_ARRAY_LENGTH) {
-      throw StateCaptureException("Invalid state array length $size")
-    }
-  }
+  private fun checkArray(size: Int, width: Int) =
+      DetachedValueBounds.requireArray(size.toLong(), width.toLong()) { message ->
+        throw StateCaptureException(message)
+      }
 
   private fun checkCaptureCollection(size: Int) {
     if (size < 0 || size > StateLimits.LEGACY_MAX_COLLECTION_ENTRIES) {
@@ -721,4 +922,74 @@ internal object StateGraph {
 
   private fun Type?.typeArguments(): Array<Type>? =
       (this as? ParameterizedType)?.actualTypeArguments
+
+  private fun isVariableArray(owner: String?, field: String?): Boolean =
+      owner to field in VARIABLE_ARRAY_FIELDS
+
+  private fun isNullableRecord(owner: String?, field: String?): Boolean =
+      owner to field in NULLABLE_RECORD_FIELDS
+
+  private val VARIABLE_ARRAY_FIELDS =
+      setOf(
+          "eu.rekawek.coffeegb.core.sound.Sound\$SoundMemento" to "buffer",
+          "eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint\$BarcodeBoyMemento" to "data",
+          "eu.rekawek.coffeegb.core.ir.FullChanger\$FullChangerMemento" to "schedule",
+          "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento" to
+              "dataTransfer",
+      )
+
+  private val NULLABLE_RECORD_FIELDS =
+      setOf(
+          // Transitional legacy root display copy; new captures use only GpuMemento's display.
+          "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento" to "displayMemento",
+          // These SGB operations are genuinely optional behavior state, not hardware identity.
+          "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento" to
+              "waitingTransferCommandMemento",
+          "eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento" to
+              "pendingPictureMemento",
+      )
+}
+
+/** Checked allocation arithmetic shared by capture, restore, and the future Phase-2 decoder. */
+internal object DetachedValueBounds {
+  fun checkedArrayBytesForApply(elements: Long, width: Long): Long =
+      requireArray(elements, width) { message -> throw StateApplyException(message) }
+
+  fun checkStringMetricsForApply(chars: Long, encodedBytes: Long) {
+    requireStringMetrics(chars, encodedBytes) { message -> throw StateApplyException(message) }
+  }
+
+  fun requireArray(elements: Long, width: Long, fail: (String) -> Nothing): Long {
+    if (elements < 0 || elements > StateLimits.LEGACY_MAX_ARRAY_LENGTH) {
+      fail("State array length $elements exceeds ${StateLimits.LEGACY_MAX_ARRAY_LENGTH}")
+    }
+    if (width <= 0) fail("State array element width must be positive")
+    val bytes =
+        try {
+          Math.multiplyExact(elements, width)
+        } catch (_: ArithmeticException) {
+          fail("State array allocation byte count overflows")
+        }
+    if (bytes > StateLimits.LEGACY_MAX_ARRAY_BYTES) {
+      fail("State array allocation $bytes exceeds ${StateLimits.LEGACY_MAX_ARRAY_BYTES} bytes")
+    }
+    return bytes
+  }
+
+  fun requireString(value: String, fail: (String) -> Nothing) {
+    if (value.length.toLong() > StateLimits.LEGACY_MAX_STRING_CHARS) {
+      fail("State string exceeds ${StateLimits.LEGACY_MAX_STRING_CHARS} characters")
+    }
+    val encodedBytes = value.toByteArray(StandardCharsets.UTF_8).size.toLong()
+    requireStringMetrics(value.length.toLong(), encodedBytes, fail)
+  }
+
+  private fun requireStringMetrics(chars: Long, encodedBytes: Long, fail: (String) -> Nothing) {
+    if (chars < 0 || chars > StateLimits.LEGACY_MAX_STRING_CHARS) {
+      fail("State string character count $chars exceeds ${StateLimits.LEGACY_MAX_STRING_CHARS}")
+    }
+    if (encodedBytes < 0 || encodedBytes > StateLimits.LEGACY_MAX_STRING_BYTES) {
+      fail("State string encoding $encodedBytes exceeds ${StateLimits.LEGACY_MAX_STRING_BYTES} bytes")
+    }
+  }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -350,6 +350,9 @@ internal data class PreparedSessionState(
 
 /**
  * Transitional adapter between the legacy in-memory mementos and the explicit immutable model.
+ * Apply first checks target-dependent structure and explicit nullability, reconstructs the full
+ * candidate, and runs every registered record's semantic policy before the first live mutation.
+ * Rollback remains the guard for unexpected failures in legacy restore implementations.
  * This is deliberately not a byte codec; #322 owns the sectioned StateFile representation.
  */
 internal object DetachedStateAdapter {
@@ -422,6 +425,7 @@ internal object DetachedStateAdapter {
     }
     StateGraph.validateCompatible(state.serialState, currentSerialState, "serial")
     val serialValue = StateGraph.restore(state.serialState)
+    StateSemantics.validate(serialValue)
     if (serialValue != null && serialValue !is Memento<*>) {
       throw StateApplyException("Session serial state has the wrong root type")
     }
@@ -454,6 +458,7 @@ internal object DetachedStateAdapter {
     val current = StateGraph.captureRoot(gameboy.saveToMemento(), GAMEBOY_ROOT)
     StateGraph.validateCompatible(state.root, current, "machine")
     val detached = StateGraph.restoreRoot(state.root, GAMEBOY_ROOT)
+    StateSemantics.validate(detached)
     @Suppress("UNCHECKED_CAST") val memento = detached as Memento<Gameboy>
     val rtcRuntime = state.rtcRuntime.toCore()
     try {
@@ -819,10 +824,10 @@ internal object StateGraph {
         path: String,
         owner: String?,
         field: String?,
+        element: Boolean = false,
     ) {
       if (candidate === NullState || target === NullState) {
-        val nonNull = if (candidate === NullState) target else candidate
-        if (nonNull is RecordState && !isNullableRecord(owner, field)) {
+        if (candidate !== target && !isAuditedNullable(owner, field, element)) {
           throw StateApplyException("$path has incompatible memento presence")
         }
         return
@@ -846,7 +851,7 @@ internal object StateGraph {
             if (left.name != right.name) {
               throw StateApplyException("$path has an incompatible field order")
             }
-            value(left.value, right.value, "$path.${left.name}", type, left.name)
+            value(left.value, right.value, "$path.${left.name}", type, left.name, false)
           }
         }
         candidate is PrimitiveArrayState<*> && target is PrimitiveArrayState<*> -> {
@@ -861,7 +866,7 @@ internal object StateGraph {
                 "$path has length ${candidate.values.size}, expected invariant length ${target.values.size}")
           }
           candidate.values.indices.forEach { index ->
-            value(candidate.values[index], target.values[index], "$path[$index]", owner, field)
+            value(candidate.values[index], target.values[index], "$path[$index]", owner, field, true)
           }
         }
       }
@@ -926,8 +931,8 @@ internal object StateGraph {
   private fun isVariableArray(owner: String?, field: String?): Boolean =
       owner to field in VARIABLE_ARRAY_FIELDS
 
-  private fun isNullableRecord(owner: String?, field: String?): Boolean =
-      owner to field in NULLABLE_RECORD_FIELDS
+  private fun isAuditedNullable(owner: String?, field: String?, element: Boolean): Boolean =
+      owner to field in if (element) AUDITED_NULLABLE_ELEMENTS else AUDITED_NULLABLE_FIELDS
 
   private val VARIABLE_ARRAY_FIELDS =
       setOf(
@@ -938,15 +943,69 @@ internal object StateGraph {
               "dataTransfer",
       )
 
-  private val NULLABLE_RECORD_FIELDS =
+  /**
+   * Exact nullable locations in the pinned legacy graph. Nullability is a field contract, not a
+   * consequence of the value kind: primitive arrays, enums, collections, and records all default
+   * to required unless their precise owner/field pair is listed here.
+   */
+  private val AUDITED_NULLABLE_FIELDS =
       setOf(
           // Transitional legacy root display copy; new captures use only GpuMemento's display.
           "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento" to "displayMemento",
+          // No interrupt has been selected while the CPU is outside interrupt entry.
+          "eu.rekawek.coffeegb.core.cpu.Cpu\$CpuMemento" to "requestedIrq",
+          // Old GPU snapshots predate these caches and dot-machine additions.
+          "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento" to "lastFrame",
+          "eu.rekawek.coffeegb.core.gpu.GpuRegisterValues\$GpuRegisterValuesMemento" to
+              "mixValues",
+          "eu.rekawek.coffeegb.core.gpu.GpuRegisterValues\$GpuRegisterValuesMemento" to
+              "pendingMixValues",
+          "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento" to "pixelMachineMemento",
+          "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento" to "pendingPpuWrites",
+          "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento" to "cpuVisiblePpuRegisters",
+          "eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento" to "delayEntry",
+          "eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento" to "delayStamp",
+          "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento" to "delayEntry",
+          "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento" to "delayStamp",
+          "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento" to
+              "clearedPixels",
+          "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento" to
+              "clearedPalettes",
+          "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento" to
+              "clearedPriorities",
+          "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento" to
+              "fifoMemento",
+          "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento" to
+              "pendingWindowDisplayWrites",
+          "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento" to
+              "pendingWindowXWrites",
+          // Added after the original HDMA memento; absence selects the legacy derivation.
+          // GPU mode is also absent until the first PPU mode publication.
+          "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento" to "gpuMode",
+          "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento" to "cpuRequestArbitration",
+          // ROM-only BasicRom instances have no battery memento.
+          "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomMemento" to
+              "batteryMemento",
+          // A Datel cartridge may have no physical pass-through slot.
+          "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento" to "slotMemento",
+          // Barcode data exists only while a scan is actively streaming.
+          "eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint\$BarcodeBoyMemento" to
+              "data",
           // These SGB operations are genuinely optional behavior state, not hardware identity.
           "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento" to
               "waitingTransferCommandMemento",
           "eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento" to
               "pendingPictureMemento",
+          "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento" to
+              "dataTransfer",
+      )
+
+  private val AUDITED_NULLABLE_ELEMENTS =
+      setOf(
+          // SGB PAL_SET deliberately aliases/clears individual rows; the container is required.
+          "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "palettes",
+          "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "systemPalettes",
+          "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "attributeFiles",
       )
 }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -511,11 +511,7 @@ internal object DetachedStateAdapter {
         }
     if (!valid) throw StateApplyException("Detached serial runtime state does not match the endpoint")
     if (state is BarcodeBoyRuntimeState) {
-      state.pendingSize?.let {
-        DetachedValueBounds.requireArray(it.toLong(), Int.SIZE_BYTES.toLong()) { message ->
-          throw StateApplyException(message)
-        }
-      }
+      StateSemantics.validateBarcodeRuntime(state)
     }
   }
 
@@ -983,11 +979,6 @@ internal object StateGraph {
           // GPU mode is also absent until the first PPU mode publication.
           "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento" to "gpuMode",
           "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento" to "cpuRequestArbitration",
-          // ROM-only BasicRom instances have no battery memento.
-          "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomMemento" to
-              "batteryMemento",
-          // A Datel cartridge may have no physical pass-through slot.
-          "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento" to "slotMemento",
           // Barcode data exists only while a scan is actively streaming.
           "eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint\$BarcodeBoyMemento" to
               "data",
@@ -1002,10 +993,8 @@ internal object StateGraph {
 
   private val AUDITED_NULLABLE_ELEMENTS =
       setOf(
-          // SGB PAL_SET deliberately aliases/clears individual rows; the container is required.
-          "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "palettes",
+          // Historical SGB snapshots can contain unavailable PAL_TRN entries.
           "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "systemPalettes",
-          "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento" to "attributeFiles",
       )
 }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -4,6 +4,8 @@ import eu.rekawek.coffeegb.controller.MementoTypeRegistry
 import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.StateLimits
 import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.gpu.DmgPixelFifo
+import eu.rekawek.coffeegb.core.gpu.Gpu
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
@@ -202,6 +204,22 @@ data class CartridgeRtcRuntimeState(
     val slot: Mbc3RtcRuntimeState?,
 )
 
+/** First-pixel and window-rewind bookkeeping omitted by the pinned legacy DMG FIFO record. */
+data class DmgPixelFifoRuntimeState(
+    val linePixels: Int,
+    val outCount: Int,
+    val firstEntry: Int,
+    val firstBgp: Int,
+    val firstObp0: Int,
+    val firstObp1: Int,
+)
+
+/** Explicit timing-skeleton and pixel-producing FIFO ownership. Null on native CGB hardware. */
+data class DmgFifoRuntimeState(
+    val timing: DmgPixelFifoRuntimeState,
+    val output: DmgPixelFifoRuntimeState,
+)
+
 enum class MachineHardwareState {
   DMG,
   CGB,
@@ -245,6 +263,7 @@ class MachineState internal constructor(
     val root: RecordState,
     val rtcRuntime: CartridgeRtcRuntimeState,
     val hardware: MachineHardwareState,
+    val dmgFifoRuntime: DmgFifoRuntimeState?,
 ) {
   fun recordCount(className: String): Int =
       StateGraph.countRecords(root, className)
@@ -253,8 +272,10 @@ class MachineState internal constructor(
       other is MachineState &&
           root == other.root &&
           rtcRuntime == other.rtcRuntime &&
-          hardware == other.hardware
-  override fun hashCode(): Int = arrayOf(root, rtcRuntime, hardware).contentHashCode()
+          hardware == other.hardware &&
+          dmgFifoRuntime == other.dmgFifoRuntime
+  override fun hashCode(): Int =
+      arrayOf(root, rtcRuntime, hardware, dmgFifoRuntime).contentHashCode()
 }
 
 enum class HeldButtonState {
@@ -339,6 +360,7 @@ internal enum class ApplyStage {
 internal data class PreparedMachineState(
     val memento: Memento<Gameboy>,
     val rtcRuntime: Gameboy.RtcRuntimeState,
+    val dmgFifoRuntime: Gpu.DmgFifoRuntimeState?,
 )
 
 internal data class PreparedSessionState(
@@ -362,6 +384,7 @@ internal object DetachedStateAdapter {
           StateGraph.captureRoot(gameboy.saveToMemento(), GAMEBOY_ROOT),
           gameboy.captureRtcRuntimeState().toDetached(),
           MachineHardwareState.valueOf(gameboy.gameboyType.name),
+          gameboy.captureDmgFifoRuntimeState().toDetached(),
       )
 
   fun capture(session: Session): SessionState {
@@ -461,16 +484,19 @@ internal object DetachedStateAdapter {
     StateSemantics.validate(detached)
     @Suppress("UNCHECKED_CAST") val memento = detached as Memento<Gameboy>
     val rtcRuntime = state.rtcRuntime.toCore()
+    val dmgFifoRuntime = state.dmgFifoRuntime.toCore()
     try {
       gameboy.validateRtcRuntimeState(rtcRuntime)
+      gameboy.validateDmgFifoRuntimeState(dmgFifoRuntime)
     } catch (failure: IllegalArgumentException) {
-      throw StateApplyException("Detached cartridge RTC layout is incompatible", failure)
+      throw StateApplyException("Detached machine runtime layout is incompatible", failure)
     }
-    return PreparedMachineState(memento, rtcRuntime)
+    return PreparedMachineState(memento, rtcRuntime, dmgFifoRuntime)
   }
 
   private fun commit(gameboy: Gameboy, prepared: PreparedMachineState) {
     gameboy.restoreFromMemento(prepared.memento)
+    gameboy.restoreDmgFifoRuntimeState(prepared.dmgFifoRuntime)
     gameboy.restoreRtcRuntimeState(prepared.rtcRuntime)
   }
 
@@ -541,6 +567,22 @@ internal object DetachedStateAdapter {
         eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
             it.emulationPaused, it.pauseStartedMillis)
       }
+
+  private fun Gpu.DmgFifoRuntimeState?.toDetached(): DmgFifoRuntimeState? =
+      this?.let {
+        DmgFifoRuntimeState(it.timing().toDetached(), it.output().toDetached())
+      }
+
+  private fun DmgPixelFifo.RuntimeState.toDetached(): DmgPixelFifoRuntimeState =
+      DmgPixelFifoRuntimeState(
+          linePixels(), outCount(), firstEntry(), firstBgp(), firstObp0(), firstObp1())
+
+  private fun DmgFifoRuntimeState?.toCore(): Gpu.DmgFifoRuntimeState? =
+      this?.let { Gpu.DmgFifoRuntimeState(it.timing.toCore(), it.output.toCore()) }
+
+  private fun DmgPixelFifoRuntimeState.toCore(): DmgPixelFifo.RuntimeState =
+      DmgPixelFifo.RuntimeState(
+          linePixels, outCount, firstEntry, firstBgp, firstObp0, firstObp1)
 }
 
 internal object StateGraph {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -1,0 +1,724 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import eu.rekawek.coffeegb.controller.Session
+import eu.rekawek.coffeegb.controller.StateLimits
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import java.io.IOException
+import java.lang.reflect.Array as ReflectArray
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
+import java.util.Collections
+
+/** Fixed-width, service-free value kinds used by the Phase-1 detached state seam. */
+enum class StateKind {
+  NULL,
+  INT32,
+  INT64,
+  BOOLEAN,
+  FLOAT64,
+  STRING,
+  ENUM,
+  RECORD,
+  BYTES,
+  INT32_ARRAY,
+  INT64_ARRAY,
+  BOOLEAN_ARRAY,
+  OBJECT_ARRAY,
+  LIST,
+  INT32_MAP,
+}
+
+/**
+ * Immutable value in a detached machine snapshot.
+ *
+ * Values contain only fixed-width JVM primitives, explicit audited type IDs, strings, and
+ * recursively owned immutable containers. Threads, callbacks, event buses, streams, clocks,
+ * displays, and other host services cannot be represented by this model.
+ */
+sealed interface StateValue {
+  val kind: StateKind
+}
+
+data object NullState : StateValue {
+  override val kind = StateKind.NULL
+}
+
+data class Int32State(val value: Int) : StateValue {
+  override val kind = StateKind.INT32
+}
+
+data class Int64State(val value: Long) : StateValue {
+  override val kind = StateKind.INT64
+}
+
+data class BooleanState(val value: Boolean) : StateValue {
+  override val kind = StateKind.BOOLEAN
+}
+
+data class Float64State(val value: Double) : StateValue {
+  override val kind = StateKind.FLOAT64
+}
+
+data class StringState(val value: String) : StateValue {
+  override val kind = StateKind.STRING
+}
+
+data class EnumState(val typeId: Int, val ordinal: Int) : StateValue {
+  override val kind = StateKind.ENUM
+}
+
+data class StateField(val name: String, val value: StateValue)
+
+class RecordState(val typeId: Int, fields: Collection<StateField>) : StateValue {
+  override val kind = StateKind.RECORD
+  val fields: List<StateField> = Collections.unmodifiableList(ArrayList(fields))
+
+  override fun equals(other: Any?): Boolean =
+      other is RecordState && typeId == other.typeId && fields == other.fields
+
+  override fun hashCode(): Int = 31 * typeId + fields.hashCode()
+
+  override fun toString(): String = "RecordState(typeId=$typeId, fields=$fields)"
+}
+
+sealed class PrimitiveArrayState<T>(
+    final override val kind: StateKind,
+) : StateValue {
+  abstract fun copyValue(): T
+}
+
+class BytesState(value: ByteArray) : PrimitiveArrayState<ByteArray>(StateKind.BYTES) {
+  private val owned = value.clone()
+  override fun copyValue(): ByteArray = owned.clone()
+  override fun equals(other: Any?): Boolean = other is BytesState && owned.contentEquals(other.owned)
+  override fun hashCode(): Int = owned.contentHashCode()
+}
+
+class Int32ArrayState(value: IntArray) : PrimitiveArrayState<IntArray>(StateKind.INT32_ARRAY) {
+  private val owned = value.clone()
+  override fun copyValue(): IntArray = owned.clone()
+  override fun equals(other: Any?): Boolean =
+      other is Int32ArrayState && owned.contentEquals(other.owned)
+  override fun hashCode(): Int = owned.contentHashCode()
+}
+
+class Int64ArrayState(value: LongArray) : PrimitiveArrayState<LongArray>(StateKind.INT64_ARRAY) {
+  private val owned = value.clone()
+  override fun copyValue(): LongArray = owned.clone()
+  override fun equals(other: Any?): Boolean =
+      other is Int64ArrayState && owned.contentEquals(other.owned)
+  override fun hashCode(): Int = owned.contentHashCode()
+}
+
+class BooleanArrayState(value: BooleanArray) :
+    PrimitiveArrayState<BooleanArray>(StateKind.BOOLEAN_ARRAY) {
+  private val owned = value.clone()
+  override fun copyValue(): BooleanArray = owned.clone()
+  override fun equals(other: Any?): Boolean =
+      other is BooleanArrayState && owned.contentEquals(other.owned)
+  override fun hashCode(): Int = owned.contentHashCode()
+}
+
+sealed class ValuesState(
+    final override val kind: StateKind,
+    values: Collection<StateValue>,
+) : StateValue {
+  val values: List<StateValue> = Collections.unmodifiableList(ArrayList(values))
+
+  protected fun valuesEqual(other: ValuesState): Boolean = values == other.values
+  protected fun valuesHash(): Int = values.hashCode()
+}
+
+class ObjectArrayState(values: Collection<StateValue>) :
+    ValuesState(StateKind.OBJECT_ARRAY, values) {
+  override fun equals(other: Any?): Boolean = other is ObjectArrayState && valuesEqual(other)
+  override fun hashCode(): Int = valuesHash()
+}
+
+class ListState(values: Collection<StateValue>) : ValuesState(StateKind.LIST, values) {
+  override fun equals(other: Any?): Boolean = other is ListState && valuesEqual(other)
+  override fun hashCode(): Int = valuesHash()
+}
+
+data class Int32MapEntry(val key: Int, val value: StateValue)
+
+class Int32MapState(entries: Collection<Int32MapEntry>) : StateValue {
+  override val kind = StateKind.INT32_MAP
+  val entries: List<Int32MapEntry> =
+      Collections.unmodifiableList(ArrayList(entries).also { it.sortBy(Int32MapEntry::key) })
+
+  override fun equals(other: Any?): Boolean = other is Int32MapState && entries == other.entries
+  override fun hashCode(): Int = entries.hashCode()
+}
+
+/** MBC3 pause bookkeeping kept outside the pinned legacy Java-serialization shape. */
+data class RtcRuntimeState(val emulationPaused: Boolean, val pauseStartedMillis: Long)
+
+sealed interface SerialRuntimeState
+
+data object NoSerialRuntimeState : SerialRuntimeState
+
+class BarcodeBoyRuntimeState(
+    val transferArmed: Boolean,
+    pending: IntArray?,
+) : SerialRuntimeState {
+  private val ownedPending = pending?.clone()
+  fun copyPending(): IntArray? = ownedPending?.clone()
+
+  override fun equals(other: Any?): Boolean =
+      other is BarcodeBoyRuntimeState &&
+          transferArmed == other.transferArmed &&
+          when {
+            ownedPending == null -> other.ownedPending == null
+            other.ownedPending == null -> false
+            else -> ownedPending.contentEquals(other.ownedPending)
+          }
+
+  override fun hashCode(): Int = 31 * transferArmed.hashCode() + (ownedPending?.contentHashCode() ?: 0)
+}
+
+/** One complete, deeply owned Game Boy machine state. */
+class MachineState internal constructor(
+    val root: RecordState,
+    val rtcRuntime: RtcRuntimeState?,
+) {
+  fun recordCount(className: String): Int =
+      StateGraph.countRecords(root, className)
+
+  override fun equals(other: Any?): Boolean =
+      other is MachineState && root == other.root && rtcRuntime == other.rtcRuntime
+  override fun hashCode(): Int = 31 * root.hashCode() + (rtcRuntime?.hashCode() ?: 0)
+}
+
+enum class HeldButtonState {
+  RIGHT,
+  LEFT,
+  UP,
+  DOWN,
+  A,
+  B,
+  SELECT,
+  START,
+}
+
+enum class SerialPeripheralState {
+  NONE,
+  BYTE_RECEIVER,
+  PEER_TO_PEER,
+  PRINTER,
+  GPS_RECEIVER,
+  BARCODE_BOY,
+  FOUR_PLAYER_ADAPTER,
+}
+
+/** Detached state owned by one controller Session, including physical held input. */
+class SessionState internal constructor(
+    val machine: MachineState,
+    val serialPeripheral: SerialPeripheralState,
+    val serialState: StateValue,
+    val serialRuntime: SerialRuntimeState,
+    heldButtons: Collection<HeldButtonState>,
+) {
+  val heldButtons: Set<HeldButtonState> =
+      Collections.unmodifiableSet(linkedSetOf<HeldButtonState>().also { it.addAll(heldButtons) })
+
+  override fun equals(other: Any?): Boolean =
+      other is SessionState &&
+          machine == other.machine &&
+          serialPeripheral == other.serialPeripheral &&
+          serialState == other.serialState &&
+          serialRuntime == other.serialRuntime &&
+          heldButtons == other.heldButtons
+
+  override fun hashCode(): Int =
+      arrayOf(machine, serialPeripheral, serialState, serialRuntime, heldButtons).contentHashCode()
+}
+
+enum class LinkedTopologyState {
+  NORMAL,
+  FOUR_PLAYER_ADAPTER,
+}
+
+data class LinkedPlayerState(val player: Int, val session: SessionState?)
+
+/** Service-free topology/checkpoint DTO for linked-session ownership. */
+class LinkedSessionState(
+    val frame: Long,
+    val localPlayer: Int,
+    val topology: LinkedTopologyState,
+    players: Collection<LinkedPlayerState>,
+) {
+  val players: List<LinkedPlayerState> = Collections.unmodifiableList(ArrayList(players))
+
+  override fun equals(other: Any?): Boolean =
+      other is LinkedSessionState &&
+          frame == other.frame &&
+          localPlayer == other.localPlayer &&
+          topology == other.topology &&
+          players == other.players
+
+  override fun hashCode(): Int =
+      arrayOf(frame, localPlayer, topology, players).contentHashCode()
+}
+
+class StateCaptureException(message: String, cause: Throwable? = null) : IOException(message, cause)
+
+class StateApplyException(message: String, cause: Throwable? = null) : IOException(message, cause)
+
+/**
+ * Transitional adapter between the legacy in-memory mementos and the explicit immutable model.
+ * This is deliberately not a byte codec; #322 owns the sectioned StateFile representation.
+ */
+internal object DetachedStateAdapter {
+
+  fun capture(gameboy: Gameboy): MachineState =
+      MachineState(
+          StateGraph.captureRoot(gameboy.saveToMemento(), GAMEBOY_ROOT),
+          gameboy.captureRtcRuntimeState()?.let {
+            RtcRuntimeState(it.emulationPaused(), it.pauseStartedMillis())
+          },
+      )
+
+  fun capture(session: Session): SessionState {
+    val peripheral = serialPeripheral(session.serialEndpoint)
+    val serial = StateGraph.capture(session.serialEndpoint.saveToMemento())
+    return SessionState(
+        capture(session.gameboy),
+        peripheral,
+        serial,
+        captureSerialRuntime(session.serialEndpoint),
+        session.heldButtons.map { HeldButtonState.valueOf(it.name) },
+    )
+  }
+
+  fun apply(gameboy: Gameboy, state: MachineState) {
+    val detached = StateGraph.restoreRoot(state.root, GAMEBOY_ROOT)
+    @Suppress("UNCHECKED_CAST") val replacement = detached as Memento<Gameboy>
+    val currentRtc = gameboy.captureRtcRuntimeState()
+    if ((currentRtc == null) != (state.rtcRuntime == null)) {
+      throw StateApplyException("Detached state RTC family does not match the running cartridge")
+    }
+    val rollback = gameboy.saveToMemento()
+    try {
+      gameboy.restoreFromMemento(replacement)
+      gameboy.restoreRtcRuntimeState(state.rtcRuntime?.let {
+        eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
+            it.emulationPaused, it.pauseStartedMillis)
+      })
+    } catch (failure: Throwable) {
+      try {
+        gameboy.restoreFromMemento(rollback)
+        gameboy.restoreRtcRuntimeState(currentRtc)
+      } catch (rollbackFailure: Throwable) {
+        failure.addSuppressed(rollbackFailure)
+      }
+      throw StateApplyException("Detached machine state could not be applied atomically", failure)
+    }
+  }
+
+  fun apply(session: Session, state: SessionState) {
+    val currentPeripheral = serialPeripheral(session.serialEndpoint)
+    if (currentPeripheral != state.serialPeripheral) {
+      throw StateApplyException(
+          "Session peripheral mismatch: expected ${state.serialPeripheral}, found $currentPeripheral")
+    }
+
+    val machineValue = StateGraph.restoreRoot(state.machine.root, GAMEBOY_ROOT)
+    val serialValue = StateGraph.restore(state.serialState)
+    if (serialValue != null && serialValue !is Memento<*>) {
+      throw StateApplyException("Session serial state has the wrong root type")
+    }
+    @Suppress("UNCHECKED_CAST") val machineMemento = machineValue as Memento<Gameboy>
+    @Suppress("UNCHECKED_CAST") val serialMemento = serialValue as Memento<SerialEndpoint>?
+    validateSerialRuntime(session.serialEndpoint, state.serialRuntime)
+    val currentRtc = session.gameboy.captureRtcRuntimeState()
+    if ((currentRtc == null) != (state.machine.rtcRuntime == null)) {
+      throw StateApplyException("Detached state RTC family does not match the running cartridge")
+    }
+
+    // Complete reconstruction above is the validation boundary. No live subsystem is touched
+    // until both graphs and the endpoint identity have been checked.
+    val rollbackMachine = session.gameboy.saveToMemento()
+    val rollbackRtc = currentRtc
+    val rollbackSerial = session.serialEndpoint.saveToMemento()
+    val rollbackSerialRuntime = captureSerialRuntime(session.serialEndpoint)
+    val rollbackButtons = session.heldButtons
+    try {
+      session.gameboy.restoreFromMemento(machineMemento)
+      session.gameboy.restoreRtcRuntimeState(state.machine.rtcRuntime?.let {
+        eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock.RuntimeState(
+            it.emulationPaused, it.pauseStartedMillis)
+      })
+      session.serialEndpoint.restoreFromMemento(serialMemento)
+      applySerialRuntime(session.serialEndpoint, state.serialRuntime)
+      session.heldButtons = state.heldButtons.map { Button.valueOf(it.name) }.toSet()
+    } catch (failure: Throwable) {
+      try {
+        session.gameboy.restoreFromMemento(rollbackMachine)
+        session.gameboy.restoreRtcRuntimeState(rollbackRtc)
+        session.serialEndpoint.restoreFromMemento(rollbackSerial)
+        applySerialRuntime(session.serialEndpoint, rollbackSerialRuntime)
+        session.heldButtons = rollbackButtons
+      } catch (rollbackFailure: Throwable) {
+        failure.addSuppressed(rollbackFailure)
+      }
+      throw StateApplyException("Detached session state could not be applied atomically", failure)
+    }
+  }
+
+  private fun serialPeripheral(endpoint: SerialEndpoint): SerialPeripheralState =
+      when (endpoint.javaClass.name) {
+        "eu.rekawek.coffeegb.core.serial.SerialEndpoint\$1" -> SerialPeripheralState.NONE
+        "eu.rekawek.coffeegb.core.serial.ByteReceivingSerialEndpoint" ->
+            SerialPeripheralState.BYTE_RECEIVER
+        "eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint" ->
+            SerialPeripheralState.PEER_TO_PEER
+        "eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint" ->
+            SerialPeripheralState.PRINTER
+        "eu.rekawek.coffeegb.core.serial.GpsReceiverSerialEndpoint" ->
+            SerialPeripheralState.GPS_RECEIVER
+        "eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint" ->
+            SerialPeripheralState.BARCODE_BOY
+        "eu.rekawek.coffeegb.core.serial.FourPlayerAdapter\$Endpoint" ->
+            SerialPeripheralState.FOUR_PLAYER_ADAPTER
+        else ->
+            throw StateCaptureException(
+              "Unsupported serial endpoint ${endpoint.javaClass.name}; state was not omitted")
+      }
+
+  private fun captureSerialRuntime(endpoint: SerialEndpoint): SerialRuntimeState =
+      if (endpoint is BarcodeBoySerialEndpoint) {
+        endpoint.captureRuntimeState().let {
+          BarcodeBoyRuntimeState(it.transferArmed(), it.copyPending())
+        }
+      } else {
+        NoSerialRuntimeState
+      }
+
+  private fun validateSerialRuntime(endpoint: SerialEndpoint, state: SerialRuntimeState) {
+    val valid =
+        when (state) {
+          is BarcodeBoyRuntimeState -> endpoint is BarcodeBoySerialEndpoint
+          NoSerialRuntimeState -> endpoint !is BarcodeBoySerialEndpoint
+        }
+    if (!valid) throw StateApplyException("Detached serial runtime state does not match the endpoint")
+  }
+
+  private fun applySerialRuntime(endpoint: SerialEndpoint, state: SerialRuntimeState) {
+    validateSerialRuntime(endpoint, state)
+    if (endpoint is BarcodeBoySerialEndpoint && state is BarcodeBoyRuntimeState) {
+      endpoint.restoreRuntimeState(
+          BarcodeBoySerialEndpoint.RuntimeState(state.transferArmed, state.copyPending()))
+    }
+  }
+
+  private const val GAMEBOY_ROOT = "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento"
+}
+
+internal object StateGraph {
+  private val recordIds by lazy {
+    MementoTypeRegistry.recordClasses.withIndex().associate { (index, type) -> type to index + 1 }
+  }
+  private val enumIds by lazy {
+    MementoTypeRegistry.enumClasses.withIndex().associate { (index, type) -> type to index + 1 }
+  }
+
+  fun captureRoot(value: Any, className: String): RecordState {
+    val root = capture(value)
+    if (root !is RecordState || recordClass(root).name != className) {
+      throw StateCaptureException("Detached state has the wrong root type")
+    }
+    return root
+  }
+
+  fun capture(value: Any?): StateValue = Capture().value(value, 0)
+
+  fun restoreRoot(value: RecordState, className: String): Any {
+    if (recordClass(value).name != className) {
+      throw StateApplyException("Detached state has the wrong root type")
+    }
+    return restore(value) ?: throw StateApplyException("Detached root state is null")
+  }
+
+  fun restore(value: StateValue): Any? = Restore().value(value, null, 0)
+
+  fun countRecords(value: StateValue, className: String): Int {
+    var count = 0
+    fun visit(current: StateValue) {
+      when (current) {
+        is RecordState -> {
+          if (recordClass(current).name == className) count++
+          current.fields.forEach { visit(it.value) }
+        }
+        is ObjectArrayState -> current.values.forEach(::visit)
+        is ListState -> current.values.forEach(::visit)
+        is Int32MapState -> current.entries.forEach { visit(it.value) }
+        else -> Unit
+      }
+    }
+    visit(value)
+    return count
+  }
+
+  private fun recordClass(value: RecordState): Class<*> =
+      MementoTypeRegistry.recordClasses.getOrNull(value.typeId - 1)
+          ?: throw StateApplyException("Unknown detached record type ID ${value.typeId}")
+
+  private class Capture {
+    private var references = 0L
+
+    fun value(value: Any?, depth: Int): StateValue {
+      checkCaptureDepth(depth)
+      if (value == null) return NullState
+      countReference()
+      return when (value) {
+        is Int -> Int32State(value)
+        is Long -> Int64State(value)
+        is Boolean -> BooleanState(value)
+        is Double -> Float64State(value)
+        is String -> {
+          if (value.length > StateLimits.LEGACY_MAX_STRING_CHARS) {
+            throw StateCaptureException("State string is too long")
+          }
+          StringState(value)
+        }
+        is ByteArray -> BytesState(value.also { checkArray(it.size) })
+        is IntArray -> Int32ArrayState(value.also { checkArray(it.size) })
+        is LongArray -> Int64ArrayState(value.also { checkArray(it.size) })
+        is BooleanArray -> BooleanArrayState(value.also { checkArray(it.size) })
+        is List<*> -> {
+          checkCaptureCollection(value.size)
+          ListState(value.map { this.value(it, depth + 1) })
+        }
+        is Map<*, *> -> captureMap(value, depth)
+        is Enum<*> -> {
+          val id = enumIds[value.javaClass]
+              ?: throw StateCaptureException("Unregistered state enum ${value.javaClass.name}")
+          EnumState(id, value.ordinal)
+        }
+        else ->
+            if (value.javaClass.isArray) captureArray(value, depth)
+            else captureRecord(value, depth)
+      }
+    }
+
+    private fun captureArray(value: Any, depth: Int): StateValue {
+      val size = ReflectArray.getLength(value)
+      checkCaptureCollection(size)
+      return ObjectArrayState(List(size) { this.value(ReflectArray.get(value, it), depth + 1) })
+    }
+
+    private fun captureMap(value: Map<*, *>, depth: Int): StateValue {
+      checkCaptureCollection(value.size)
+      val entries = value.entries.map { entry ->
+        val key = entry.key as? Int
+            ?: throw StateCaptureException("Only integer state-map keys are supported")
+        Int32MapEntry(key, this.value(entry.value, depth + 1))
+      }
+      if (entries.map(Int32MapEntry::key).distinct().size != entries.size) {
+        throw StateCaptureException("Duplicate state-map key")
+      }
+      return Int32MapState(entries)
+    }
+
+    private fun captureRecord(value: Any, depth: Int): StateValue {
+      val type = value.javaClass
+      val id = recordIds[type]
+          ?: throw StateCaptureException("Unregistered state record ${type.name}")
+      val fields = type.recordComponents.map { component ->
+        component.accessor.trySetAccessible()
+        val componentValue =
+            try {
+              component.accessor.invoke(value)
+            } catch (failure: ReflectiveOperationException) {
+              throw StateCaptureException("State field ${type.name}.${component.name} failed", failure)
+            }
+        StateField(component.name, this.value(componentValue, depth + 1))
+      }
+      return RecordState(id, fields)
+    }
+
+    private fun countReference() {
+      references++
+      if (references > StateLimits.LEGACY_MAX_REFERENCES) {
+        throw StateCaptureException("State has too many references")
+      }
+    }
+  }
+
+  private class Restore {
+    private var references = 0L
+
+    fun value(value: StateValue, expectedType: Type?, depth: Int): Any? {
+      checkRestoreDepth(depth)
+      if (value === NullState) {
+        if (expectedType.rawClass()?.isPrimitive == true) {
+          throw StateApplyException("Null primitive state value")
+        }
+        return null
+      }
+      countReference()
+      val restored =
+          when (value) {
+            is Int32State -> value.value
+            is Int64State -> value.value
+            is BooleanState -> value.value
+            is Float64State -> value.value
+            is StringState -> value.value
+            is EnumState -> restoreEnum(value)
+            is RecordState -> restoreRecord(value, depth)
+            is BytesState -> value.copyValue()
+            is Int32ArrayState -> value.copyValue()
+            is Int64ArrayState -> value.copyValue()
+            is BooleanArrayState -> value.copyValue()
+            is ObjectArrayState -> restoreArray(value, expectedType, depth)
+            is ListState -> restoreList(value, expectedType, depth)
+            is Int32MapState -> restoreMap(value, expectedType, depth)
+            NullState -> null
+          }
+      requireExpected(restored, expectedType)
+      return restored
+    }
+
+    private fun restoreEnum(value: EnumState): Any {
+      val type = MementoTypeRegistry.enumClasses.getOrNull(value.typeId - 1)
+          ?: throw StateApplyException("Unknown detached enum type ID ${value.typeId}")
+      return type.enumConstants.getOrNull(value.ordinal)
+          ?: throw StateApplyException("Invalid ${type.name} ordinal ${value.ordinal}")
+    }
+
+    private fun restoreRecord(value: RecordState, depth: Int): Any {
+      val type = recordClass(value)
+      val components = type.recordComponents
+      if (value.fields.size != components.size ||
+          value.fields.indices.any { value.fields[it].name != components[it].name }) {
+        throw StateApplyException("Invalid ${type.name} field inventory")
+      }
+      val args =
+          components.indices.map { index ->
+            this.value(value.fields[index].value, components[index].genericType, depth + 1)
+          }.toTypedArray()
+      val constructor = type.getDeclaredConstructor(*components.map { it.type }.toTypedArray())
+      constructor.trySetAccessible()
+      try {
+        return constructor.newInstance(*args)
+      } catch (failure: InvocationTargetException) {
+        throw StateApplyException("Invalid ${type.name} value", failure.targetException)
+      } catch (failure: ReflectiveOperationException) {
+        throw StateApplyException("State record ${type.name} could not be constructed", failure)
+      }
+    }
+
+    private fun restoreArray(value: ObjectArrayState, expectedType: Type?, depth: Int): Any {
+      val type = expectedType.rawClass()
+      if (type?.isArray != true || type.componentType.isPrimitive) {
+        throw StateApplyException("Unexpected detached object array")
+      }
+      checkRestoreCollection(value.values.size)
+      return ReflectArray.newInstance(type.componentType, value.values.size).also { result ->
+        value.values.forEachIndexed { index, item ->
+          ReflectArray.set(result, index, this.value(item, type.componentType, depth + 1))
+        }
+      }
+    }
+
+    private fun restoreList(value: ListState, expectedType: Type?, depth: Int): List<Any?> {
+      checkRestoreCollection(value.values.size)
+      val elementType = expectedType.typeArguments()?.singleOrNull()
+      return ArrayList<Any?>(value.values.size).also { result ->
+        value.values.forEach { result += this.value(it, elementType, depth + 1) }
+      }
+    }
+
+    private fun restoreMap(value: Int32MapState, expectedType: Type?, depth: Int): Map<Int, Any?> {
+      checkRestoreCollection(value.entries.size)
+      val arguments = expectedType.typeArguments()
+      val keyType = arguments?.getOrNull(0) ?: Int::class.javaObjectType
+      val entryType = arguments?.getOrNull(1)
+      if (keyType.rawClass() != Int::class.javaObjectType) {
+        throw StateApplyException("Detached state maps require integer keys")
+      }
+      var previous: Int? = null
+      return LinkedHashMap<Int, Any?>().also { result ->
+        value.entries.forEach { entry ->
+          if (previous != null && entry.key <= checkNotNull(previous)) {
+            throw StateApplyException("Detached state-map keys are not strictly ordered")
+          }
+          previous = entry.key
+          result[entry.key] = this.value(entry.value, entryType, depth + 1)
+        }
+      }
+    }
+
+    private fun countReference() {
+      references++
+      if (references > StateLimits.LEGACY_MAX_REFERENCES) {
+        throw StateApplyException("State has too many references")
+      }
+    }
+  }
+
+  private fun checkCaptureDepth(depth: Int) {
+    if (depth > StateLimits.LEGACY_MAX_DEPTH) throw StateCaptureException("State is too deep")
+  }
+
+  private fun checkRestoreDepth(depth: Int) {
+    if (depth > StateLimits.LEGACY_MAX_DEPTH) throw StateApplyException("State is too deep")
+  }
+
+  private fun checkArray(size: Int) {
+    if (size < 0 || size.toLong() > StateLimits.LEGACY_MAX_ARRAY_LENGTH) {
+      throw StateCaptureException("Invalid state array length $size")
+    }
+  }
+
+  private fun checkCaptureCollection(size: Int) {
+    if (size < 0 || size > StateLimits.LEGACY_MAX_COLLECTION_ENTRIES) {
+      throw StateCaptureException("Invalid state collection length $size")
+    }
+  }
+
+  private fun checkRestoreCollection(size: Int) {
+    if (size < 0 || size > StateLimits.LEGACY_MAX_COLLECTION_ENTRIES) {
+      throw StateApplyException("Invalid state collection length $size")
+    }
+  }
+
+  private fun requireExpected(value: Any?, expectedType: Type?) {
+    if (value == null || expectedType == null) return
+    val expectedClass = expectedType.rawClass() ?: return
+    val boxed =
+        when (expectedClass) {
+          Int::class.javaPrimitiveType -> Int::class.javaObjectType
+          Long::class.javaPrimitiveType -> Long::class.javaObjectType
+          Boolean::class.javaPrimitiveType -> Boolean::class.javaObjectType
+          Double::class.javaPrimitiveType -> Double::class.javaObjectType
+          else -> expectedClass
+        }
+    if (!boxed.isInstance(value)) {
+      throw StateApplyException(
+          "Expected ${expectedClass.name}, received ${value.javaClass.name}")
+    }
+  }
+
+  private fun Type?.rawClass(): Class<*>? =
+      when (this) {
+        is Class<*> -> this
+        is ParameterizedType -> rawType as? Class<*>
+        is GenericArrayType ->
+            genericComponentType.rawClass()?.let { ReflectArray.newInstance(it, 0).javaClass }
+        is WildcardType -> upperBounds.singleOrNull().rawClass()
+        else -> null
+      }
+
+  private fun Type?.typeArguments(): Array<Type>? =
+      (this as? ParameterizedType)?.actualTypeArguments
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -24,6 +24,20 @@ internal object StateSemantics {
     visit(value, "state", IdentityHashMap())
   }
 
+  fun validateBarcodeRuntime(state: BarcodeBoyRuntimeState) {
+    state.copyPending()?.let { pending ->
+      if (pending.size != BARCODE_FRAME_SIZE) {
+        throw StateApplyException(
+            "Barcode runtime has pending frame length ${pending.size}, expected $BARCODE_FRAME_SIZE")
+      }
+      pending.forEachIndexed { index, value ->
+        if (value !in 0..0xff) {
+          throw StateApplyException("Barcode runtime has invalid pending[$index]=$value")
+        }
+      }
+    }
+  }
+
   private fun visit(value: Any?, path: String, visited: IdentityHashMap<Any, Boolean>) {
     if (value == null || value.javaClass.isPrimitive || value is String || value is Enum<*>) return
     if (visited.put(value, true) != null) return
@@ -76,6 +90,7 @@ internal object StateSemantics {
     fun longArray(name: String): LongArray = value(name) as LongArray
     fun objectArray(name: String): Array<*> = value(name) as Array<*>
     fun list(name: String): List<*> = value(name) as List<*>
+    fun map(name: String): Map<*, *> = value(name) as Map<*, *>
 
     fun require(condition: Boolean, message: String) {
       if (!condition) throw StateApplyException("$path $message")
@@ -150,9 +165,9 @@ internal object StateSemantics {
       put("eu.rekawek.coffeegb.core.sound.Lfsr\$LfsrMemento",
           constrained("The noise LFSR is a 15-bit register.") { it.range("lfsr", 0, 0x7fff) })
       put("eu.rekawek.coffeegb.core.sound.PolynomialCounter\$PolynomialCounterMemento",
-          constrained("Noise register/counter widths and countdowns are bounded.") {
+          constrained("Noise register/counter widths, reload alignment, and countdowns are bounded.") {
             it.range("nr43", 0, 0xff); it.range("counter", 0, 0x3fff)
-            it.nonNegative("counterCountdown")
+            it.nonNegative("counterCountdown"); it.range("alignment", 0, 3)
           })
       put("eu.rekawek.coffeegb.core.sound.VolumeEnvelope\$VolumeEnvelopeMemento",
           constrained("Envelope volume, direction, sweep, and reload timer have hardware bounds.") {
@@ -168,8 +183,11 @@ internal object StateSemantics {
             it.range("i", 0, 7); it.nonNegative("freqDivider"); it.nonNegative("justReloadedTicks")
           })
       put("eu.rekawek.coffeegb.core.sound.SoundMode3\$SoundMode3Memento",
-          constrained("Wave-channel sample index and read address are bounded; -1 is the no-read sentinel.") {
-            it.range("i", 0, 31); it.nonNegative("freqDivider"); it.range("lastReadAddr", -1, 15)
+          constrained("Wave-channel sample index and last physical wave-RAM read address are bounded.") {
+            it.range("i", 0, 31); it.nonNegative("freqDivider")
+            val lastReadAddress = it.int("lastReadAddr")
+            it.require(lastReadAddress == 0 || lastReadAddress in 0xff30..0xff3f,
+                "has invalid lastReadAddr=$lastReadAddress")
           })
       put("eu.rekawek.coffeegb.core.sound.LengthCounter\$LengthCounterMemento",
           constrained("All channel length counters are in the shared 0..256 envelope.") {
@@ -270,9 +288,12 @@ internal object StateSemantics {
             it.recordType("waitingTransferCommandMemento", TRANSFER_COMMAND_MEMENTO)
           })
       put("eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento",
-          constrained("Nullable SGB palette rows retain their fixed row widths and fade phase.") {
-            checkRows(it, "palettes", 4); checkRows(it, "systemPalettes", 4)
-            checkRows(it, "attributeFiles", 20 * 18); it.range("borderFade", 0, 32)
+          constrained("SGB palette rows, palette IDs, attribute rows, and fade phase are bounded.") {
+            checkRows(it, "palettes", 4, nullable = false)
+            checkRows(it, "systemPalettes", 4, nullable = true)
+            checkRows(it, "attributeFiles", 20 * 18, nullable = false, values = 0..3)
+            it.intValues("paletteMap", 0, 3)
+            it.range("borderFade", 0, 32)
           })
       put("eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento",
           constrained("The 105-frame border animation and optional picture-command type are validated.") {
@@ -288,11 +309,25 @@ internal object StateSemantics {
           constrained("Pulse schedule index/remaining duration are coherent with armed/running state.") {
             val schedule = it.intArray("schedule")
             it.require(schedule.all { duration -> duration > 0 }, "contains a non-positive pulse duration")
+            it.require(schedule.isEmpty() || schedule.size == FULL_CHANGER_SCHEDULE_SIZE,
+                "has invalid pulse schedule length ${schedule.size}")
+            val armed = it.value("armed") as Boolean
+            val running = it.value("running") as Boolean
+            it.require(!(armed && running), "cannot be both armed and running")
             val index = it.int("index")
-            it.require(index >= 0 && (schedule.isNotEmpty() || index == 0) &&
-                (schedule.isEmpty() || index < schedule.size), "has invalid pulse index $index")
-            if (it.value("running") as Boolean) it.require(schedule.isNotEmpty(), "is running without a schedule")
-            it.nonNegative("remaining")
+            if (schedule.isEmpty()) {
+              it.require(!armed && !running && index == 0 && it.int("remaining") == 0,
+                  "has non-idle state without a pulse schedule")
+            } else {
+              it.range("index", 0, schedule.size)
+              if (running) {
+                it.require(index < schedule.size && it.int("remaining") > 0,
+                    "has an invalid running pulse position")
+              } else if (!armed) {
+                it.require(index == schedule.size && it.int("remaining") <= 0,
+                    "has an invalid completed pulse position")
+              }
+            }
           })
 
       // DMA/PPU queues, phase indices, and delayed-write collections.
@@ -307,7 +342,8 @@ internal object StateSemantics {
           constrained("HDMA block length, source progress, request ages, and line phases are bounded.") {
             it.range("length", 0, 0x7f); it.range("tick", -8, 31)
             it.range("src", 0, 0xffff); it.range("dst", 0, 0xffff)
-            it.range("sourceBytesTransferred", 0, it.intArray("blockData").size)
+            // This is cumulative from the most recent source-register write, not per-block.
+            it.nonNegative("sourceBytesTransferred")
             listOf("hblankRequestAge", "nextHblankRequestAge").forEach { name -> it.nonNegative(name) }
             it.range("gpuLine", 0, 153); it.range("gpuTicksInLine", 0, 455)
           })
@@ -352,7 +388,7 @@ internal object StateSemantics {
           constrained("The CGB palette byte-address register is six bits.") { it.range("index", 0, 63) })
       put("eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento",
           constrained("LCD line/dot and delayed-write phases are bounded.") {
-            it.nonNegative("displayEnabledDelay"); it.range("line", 0, 153); it.range("ticksInLine", 0, 455)
+            it.nonNegative("displayEnabledDelay"); it.range("line", 0, 153); it.range("ticksInLine", -1, 455)
             val lastWrite = it.int("lastCpuVramWriteTick")
             it.require(lastWrite == Int.MIN_VALUE || lastWrite in -1..455,
                 "has invalid lastCpuVramWriteTick=$lastWrite")
@@ -448,8 +484,8 @@ internal object StateSemantics {
       // RTC and mapper command-state indices.
       put("eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento",
           constrained("Live and latched RTC registers plus subsecond phase are hardware-bounded.") {
-            listOf("seconds", "minutes", "latchedSeconds", "latchedMinutes").forEach { name -> it.range(name, 0, 59) }
-            listOf("hours", "latchedHours").forEach { name -> it.range(name, 0, 23) }
+            listOf("seconds", "minutes", "latchedSeconds", "latchedMinutes").forEach { name -> it.range(name, 0, 0x3f) }
+            listOf("hours", "latchedHours").forEach { name -> it.range(name, 0, 0x1f) }
             listOf("days", "latchedDays").forEach { name -> it.range(name, 0, 511) }
             it.range("subSecondTicks", 0L, RTC_TICKS_PER_SECOND - 1L)
           })
@@ -522,6 +558,19 @@ internal object StateSemantics {
       addMapperPolicies(this)
 
       // Serial parser/framing indices.
+      put("eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento",
+          constrained("Cheat map values and elements are non-null registered patch records.") {
+            it.map("patches").forEach { (key, value) ->
+              it.require(key is Int && key in 0..0xffff, "has invalid patch-map key $key")
+              val patches = value as? List<*>
+              it.require(patches != null, "has null or non-list patch-map value at $key")
+              checkNotNull(patches).forEachIndexed { index, patch ->
+                it.require(
+                    patch != null && patch.javaClass.name in REGISTERED_PATCH_TYPES,
+                    "has invalid patch at $key[$index]")
+              }
+            }
+          })
       put("eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint\$Peer2PeerSerialEndpointMemento",
           constrained("Link-cable shift index and pending-bit count cannot underflow.") {
             it.range("sb", 0, 0xff); it.nonNegative("bitsReceived"); it.range("bitIndex", 0, 7)
@@ -531,13 +580,16 @@ internal object StateSemantics {
             it.range("sb", 0, 0xff); it.range("bits", 0, 7)
           })
       put("eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint\$BarcodeBoyMemento",
-          constrained("Barcode handshake and optional scan payload cursors are validated together.") {
+          constrained("Barcode protocol phase and exact scan-frame cursors are validated together.") {
             it.range("handshakeByte", 0, 3); it.range("sendBitIndex", 0, 7)
             it.range("recvBitIndex", 0, 7); it.range("clockDivider", 0, 511)
             val data = it.value("data") as IntArray?
+            val sending = it.enumName("state") == "SENDING"
+            it.require(sending == (data != null), "has scan data inconsistent with protocol state")
             if (data == null) it.require(it.int("dataByte") == 0, "has a data cursor without scan data")
             else {
-              it.require(data.size == 30, "has barcode frame length ${data.size}, expected 30")
+              it.require(data.size == BARCODE_FRAME_SIZE,
+                  "has barcode frame length ${data.size}, expected $BARCODE_FRAME_SIZE")
               it.intValues("data", 0, 0xff); it.range("dataByte", 0, data.lastIndex)
             }
           })
@@ -578,7 +630,7 @@ internal object StateSemantics {
                 "transferArmed must have four entries")
             it.require((it.value("connected") as BooleanArray).size == players,
                 "connected must have four entries")
-            checkRows(it, "replies", 16)
+            checkRows(it, "replies", 16, nullable = false)
             it.require(it.intArray("transmissionBuffer").size == 16, "must have a 16-byte transmission buffer")
             it.range("size", 1, 4); it.range("packetByte", 0, 15); it.range("bit", 0, 7)
             it.nonNegative("ticksUntilBit"); it.range("rate", 0, 0xff)
@@ -603,11 +655,21 @@ internal object StateSemantics {
     }
   }
 
-  private fun checkRows(fields: RecordFields, name: String, expectedLength: Int) {
+  private fun checkRows(
+      fields: RecordFields,
+      name: String,
+      expectedLength: Int,
+      nullable: Boolean,
+      values: IntRange? = null,
+  ) {
     fields.objectArray(name).forEachIndexed { index, row ->
+      fields.require(nullable || row != null, "$name[$index] is unexpectedly null")
       if (row != null) {
-        fields.require(row is IntArray && row.size == expectedLength,
-            "$name[$index] has invalid row length")
+        fields.require(row is IntArray && row.size == expectedLength, "$name[$index] has invalid row length")
+        if (row is IntArray && values != null) {
+          fields.require(row.all { value -> value in values },
+              "$name[$index] contains a value outside ${values.first}..${values.last}")
+        }
       }
     }
   }
@@ -620,8 +682,10 @@ internal object StateSemantics {
       fields.require(entries.size == stamps.size, "has mismatched delay-line lengths")
       fields.require(entries.isNotEmpty(), "has an empty delay line")
       fields.range("delayHead", 0, entries.lastIndex)
-      // The dot model retains a monotonic logical count even after the eight physical slots wrap.
-      fields.nonNegative("delaySize")
+      fields.range("delaySize", 0, entries.size)
+    } else {
+      fields.require(fields.int("delayHead") == 0 && fields.int("delaySize") == 0,
+          "has delay cursors without legacy delay-line arrays")
     }
   }
 
@@ -707,7 +771,6 @@ internal object StateSemantics {
   private fun addPassThroughPolicies(target: MutableMap<String, Policy>) {
     val valueOnly =
         setOf(
-            "eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento",
             "eu.rekawek.coffeegb.core.sound.SoundMode4\$SoundMode4Memento",
             "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento",
             "eu.rekawek.coffeegb.core.memory.BiosShadow\$BiosShadowMemento",
@@ -739,6 +802,8 @@ internal object StateSemantics {
   private const val SOUND_BUFFER_CAPACITY = 70_224 * 2
   private const val MAX_CPU_OPS = 64
   private const val SGB_TRANSFER_SIZE = 0x1000
+  private const val FULL_CHANGER_SCHEDULE_SIZE = 36
+  private const val BARCODE_FRAME_SIZE = 30
   private const val RTC_TICKS_PER_SECOND = 4_194_304L
   private const val CPU_VISIBLE_PPU_REGISTERS = 12
   private const val DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
@@ -760,6 +825,11 @@ internal object StateSemantics {
   private const val MBC5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5Memento"
   private const val MBC7_EEPROM_MEMENTO =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento"
+  private val REGISTERED_PATCH_TYPES =
+      setOf(
+          "eu.rekawek.coffeegb.core.genie.GameGeniePatch",
+          "eu.rekawek.coffeegb.core.genie.GameSharkPatch",
+      )
   private val DELAYED_PPU_REGISTERS = setOf(0xff40, 0xff43, 0xff47, 0xff4b)
   private val TRANSFER_COMMAND_CODES = setOf(0x09, 0x0b, 0x10, 0x13, 0x14, 0x15)
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1,0 +1,765 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import java.lang.reflect.Array as ReflectArray
+import java.util.IdentityHashMap
+
+/**
+ * Semantic preflight for reconstructed detached values.
+ *
+ * [StateGraph] proves that a graph uses the registered schema and matches target-owned invariant
+ * dimensions. This second layer audits relationships inside each admitted record before any live
+ * subsystem is touched. Every registered record has an explicit policy: either executable
+ * constraints or a reviewable explanation of why its captured values need no relationship check.
+ * Phase-2 decoders can call the same validator after graph reconstruction.
+ */
+internal object StateSemantics {
+
+  internal val policyAudit: Map<String, String> by lazy {
+    policies.mapValues { it.value.rationale }
+  }
+
+  fun validate(value: Any?) {
+    verifyPolicyInventory()
+    visit(value, "state", IdentityHashMap())
+  }
+
+  private fun visit(value: Any?, path: String, visited: IdentityHashMap<Any, Boolean>) {
+    if (value == null || value.javaClass.isPrimitive || value is String || value is Enum<*>) return
+    if (visited.put(value, true) != null) return
+    when {
+      value.javaClass.isArray -> {
+        if (!value.javaClass.componentType.isPrimitive) {
+          repeat(ReflectArray.getLength(value)) { index ->
+            visit(ReflectArray.get(value, index), "$path[$index]", visited)
+          }
+        }
+      }
+      value is Iterable<*> -> value.forEachIndexed { index, item -> visit(item, "$path[$index]", visited) }
+      value is Map<*, *> -> value.forEach { (key, item) -> visit(item, "$path[$key]", visited) }
+      value.javaClass.isRecord -> {
+        val type = value.javaClass.name
+        val policy = policies[type]
+            ?: throw StateApplyException("No semantic state policy for $type")
+        val fields = RecordFields(value, path)
+        policy.validate(fields)
+        fields.components.forEach { component ->
+          visit(fields.value(component.name), "$path.${component.name}", visited)
+        }
+      }
+    }
+  }
+
+  private class RecordFields(
+      private val record: Any,
+      private val path: String,
+  ) {
+    val components = record.javaClass.recordComponents.toList()
+
+    fun value(name: String): Any? {
+      val component = components.singleOrNull { it.name == name }
+          ?: throw StateApplyException("$path has no field $name")
+      component.accessor.trySetAccessible()
+      return try {
+        component.accessor.invoke(record)
+      } catch (failure: ReflectiveOperationException) {
+        throw StateApplyException("Could not inspect $path.$name", failure)
+      }
+    }
+
+    fun int(name: String): Int = value(name) as Int
+    fun long(name: String): Long = value(name) as Long
+    fun double(name: String): Double = value(name) as Double
+    fun string(name: String): String = value(name) as String
+    fun enumName(name: String): String = (value(name) as Enum<*>).name
+    fun intArray(name: String): IntArray = value(name) as IntArray
+    fun longArray(name: String): LongArray = value(name) as LongArray
+    fun objectArray(name: String): Array<*> = value(name) as Array<*>
+    fun list(name: String): List<*> = value(name) as List<*>
+
+    fun require(condition: Boolean, message: String) {
+      if (!condition) throw StateApplyException("$path $message")
+    }
+
+    fun range(name: String, minimum: Int, maximum: Int) {
+      val value = int(name)
+      require(value in minimum..maximum, "has invalid $name=$value (expected $minimum..$maximum)")
+    }
+
+    fun range(name: String, minimum: Long, maximum: Long) {
+      val value = long(name)
+      require(value in minimum..maximum, "has invalid $name=$value (expected $minimum..$maximum)")
+    }
+
+    fun oneOf(name: String, vararg allowed: Int) {
+      val value = int(name)
+      require(value in allowed, "has invalid $name=$value (expected ${allowed.joinToString()})")
+    }
+
+    fun nonNegative(name: String) {
+      val value = int(name)
+      require(value >= 0, "has negative $name=$value")
+    }
+
+    fun intValues(name: String, minimum: Int, maximum: Int) {
+      intArray(name).forEachIndexed { index, value ->
+        require(value in minimum..maximum,
+            "has invalid $name[$index]=$value (expected $minimum..$maximum)")
+      }
+    }
+
+    fun recordType(name: String, vararg allowed: String) {
+      val value = value(name) ?: return
+      require(value.javaClass.name in allowed,
+          "has incompatible $name record ${value.javaClass.name}")
+    }
+
+    fun recordElements(name: String, expected: String) {
+      list(name).forEachIndexed { index, value ->
+        require(value != null && value.javaClass.name == expected,
+            "has incompatible $name[$index] record ${value?.javaClass?.name}")
+      }
+    }
+  }
+
+  private data class Policy(
+      val rationale: String,
+      val validate: (RecordFields) -> Unit,
+  )
+
+  private fun constrained(rationale: String, validate: (RecordFields) -> Unit) =
+      Policy(rationale, validate)
+
+  private fun pass(rationale: String) = Policy(rationale) {}
+
+  private val policies: Map<String, Policy> by lazy {
+    buildMap {
+      // Audio and timer phase/counter relationships.
+      put("eu.rekawek.coffeegb.core.sound.FrameSequencer\$FrameSequencerMemento",
+          constrained("The 8-step frame-sequencer index is bounded.") { it.range("step", 0, 7) })
+      put("eu.rekawek.coffeegb.core.sound.FrequencySweep\$FrequencySweepMemento",
+          constrained("Sweep register widths and pending pipeline counters are bounded.") {
+            it.range("period", 0, 7); it.range("shift", 0, 7); it.range("timer", 0, 8)
+            it.range("shadowFreq", 0, 0x7ff); it.nonNegative("calculationDelay")
+            it.nonNegative("restartHold")
+          })
+      put("eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento",
+          constrained("NR register latches are bytes; the nested length counter is validated separately.") {
+            listOf("nr0", "nr1", "nr2", "nr3", "nr4").forEach { name -> it.range(name, 0, 0xff) }
+          })
+      put("eu.rekawek.coffeegb.core.sound.Lfsr\$LfsrMemento",
+          constrained("The noise LFSR is a 15-bit register.") { it.range("lfsr", 0, 0x7fff) })
+      put("eu.rekawek.coffeegb.core.sound.PolynomialCounter\$PolynomialCounterMemento",
+          constrained("Noise register/counter widths and countdowns are bounded.") {
+            it.range("nr43", 0, 0xff); it.range("counter", 0, 0x3fff)
+            it.nonNegative("counterCountdown")
+          })
+      put("eu.rekawek.coffeegb.core.sound.VolumeEnvelope\$VolumeEnvelopeMemento",
+          constrained("Envelope volume, direction, sweep, and reload timer have hardware bounds.") {
+            it.range("initialVolume", 0, 15); it.oneOf("envelopeDirection", -1, 0, 1)
+            it.range("sweep", 0, 7); it.range("volume", 0, 15); it.range("timer", 0, 8)
+          })
+      put("eu.rekawek.coffeegb.core.sound.SoundMode1\$SoundMode1Memento",
+          constrained("Pulse-channel waveform and delayed-clock indices are bounded.") {
+            it.range("i", 0, 7); it.nonNegative("freqDivider"); it.nonNegative("justReloadedTicks")
+          })
+      put("eu.rekawek.coffeegb.core.sound.SoundMode2\$SoundMode2Memento",
+          constrained("Pulse-channel waveform and delayed-clock indices are bounded.") {
+            it.range("i", 0, 7); it.nonNegative("freqDivider"); it.nonNegative("justReloadedTicks")
+          })
+      put("eu.rekawek.coffeegb.core.sound.SoundMode3\$SoundMode3Memento",
+          constrained("Wave-channel sample index and read address are bounded; -1 is the no-read sentinel.") {
+            it.range("i", 0, 31); it.nonNegative("freqDivider"); it.range("lastReadAddr", -1, 15)
+          })
+      put("eu.rekawek.coffeegb.core.sound.LengthCounter\$LengthCounterMemento",
+          constrained("All channel length counters are in the shared 0..256 envelope.") {
+            it.range("length", 0, 256)
+          })
+      put("eu.rekawek.coffeegb.core.sound.Sound\$SoundMemento",
+          constrained("APU collection sizes, sample write index, and sequencer phases are validated together.") {
+            it.require(it.objectArray("allModeMementos").size == 4, "must contain four sound modes")
+            it.require(it.intArray("channels").size == 4, "must contain four channel outputs")
+            it.require((it.value("overriddenEnabled") as BooleanArray).size == 4,
+                "must contain four channel overrides")
+            val index = it.int("i")
+            val samples = it.intArray("buffer")
+            it.require(index in 0 until SOUND_BUFFER_CAPACITY && index % 2 == 0,
+                "has invalid stereo sample index $index")
+            it.require(samples.size == index || samples.size == SOUND_BUFFER_CAPACITY,
+                "buffer length ${samples.size} does not match index $index or the legacy capacity")
+            it.range("pendingFrameSequencerStep", -1, 7)
+            it.range("frameSequencerClockPhase", 0, 3)
+          })
+      put("eu.rekawek.coffeegb.core.timer.Timer\$TimerMemento",
+          constrained("Divider/timer registers and delayed edge counters are bounded; MAX_VALUE is a documented sentinel.") {
+            it.range("div", 0, 0xffff)
+            listOf("tac", "tma", "tima").forEach { name -> it.range(name, 0, 0xff) }
+            it.nonNegative("ticksSinceOverflow"); it.nonNegative("haltWakeDelay")
+            it.nonNegative("ticksSinceDivReset")
+          })
+      put("eu.rekawek.coffeegb.core.memory.GbcRam\$GbcRamMemento",
+          constrained("The CGB work-RAM bank selector is a three-bit register.") {
+            it.range("svbk", 0, 7)
+          })
+      put("eu.rekawek.coffeegb.core.memory.UndocumentedGbcRegisters\$UndocumentedGbcRegistersMemento",
+          constrained("The FF6C compatibility register is byte-sized.") { it.range("xff6c", 0, 0xff) })
+      put("eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento",
+          constrained("Root LCD-off and speed-switch countdowns cannot be negative.") {
+            it.nonNegative("lcdOffTicks"); it.nonNegative("speedSwitchTailTicks")
+            it.recordType("displayMemento", DISPLAY_MEMENTO)
+          })
+
+      // CPU and controller parser indices.
+      put("eu.rekawek.coffeegb.core.cpu.Registers\$RegistersMemento",
+          constrained("8-bit registers/flags and 16-bit SP/PC are range checked.") {
+            listOf("a", "b", "c", "d", "e", "h", "l").forEach { name -> it.range(name, 0, 0xff) }
+            it.range("sp", 0, 0xffff); it.range("pc", 0, 0xffff); it.range("flags", 0, 0xf0)
+            it.require((it.int("flags") and 0x0f) == 0, "has non-zero reserved flag bits")
+          })
+      put("eu.rekawek.coffeegb.core.cpu.Cpu\$CpuMemento",
+          constrained("Opcode, operand, micro-op, and clock-phase indices are bounded before opcode reconstruction.") {
+            it.range("opcode1", 0, 0xff); it.range("opcode2", 0, 0xff)
+            val operand = it.intArray("operand")
+            it.require(operand.size == 2, "must have a two-byte operand latch")
+            it.range("operandIndex", 0, operand.size); it.range("opIndex", 0, MAX_CPU_OPS)
+            it.range("clockCycle", -1, 4); it.nonNegative("haltEntrySampleTicks")
+            it.nonNegative("haltedCpuCycles"); it.nonNegative("speedSwitchTicks")
+          })
+      put("eu.rekawek.coffeegb.core.cpu.InterruptManager\$InterruptManagerMemento",
+          constrained("Interrupt registers, delayed-enable sentinel, source masks, and read-mask timers are bounded.") {
+            listOf("interruptFlag", "interruptEnabled").forEach { name -> it.range(name, 0, 0xff) }
+            it.range("pendingEnableInterrupts", -1, 1)
+            listOf("haltBlockedInterrupts", "cpuBlockedInterrupts", "cpuPhasedPpuInterrupts",
+                "cpuPhasedMode2Interrupts", "cpuFirstLineMode2Interrupts",
+                "cpuInstructionBlockedInterrupts", "cpuReadInterruptPreview")
+                .forEach { name -> it.range(name, 0, 0x1f) }
+            it.nonNegative("maskMode0LcdcReadTicks")
+          })
+      put("eu.rekawek.coffeegb.core.joypad.Joypad\$JoypadMemento",
+          constrained("SGB packet and multiplayer controller indices are checked against owned buffers.") {
+            it.require((it.int("p1") and 0xcf) == 0, "has invalid JOYP selector bits")
+            it.range("players", 0, 4); it.range("currentPlayer", 0, it.int("players"))
+            it.range("pendingTransferBit", -1, 1); it.range("currentByte", 0, 0xff)
+            it.range("currentByteIndex", 0, 7)
+            it.range("currentPacketIndex", 0, it.intArray("currentPacket").size)
+          })
+
+      // SGB, IR, and display/parser schedules.
+      put("eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento",
+          constrained("Transfer command packet length/code and optional 4 KiB VRAM payload are coherent.") {
+            val packet = it.intArray("packet")
+            it.require(packet.isNotEmpty(), "has an empty transfer-command packet")
+            val declared = packet[0] and 7
+            it.require(declared in 1..7 && packet.size == declared * 16,
+                "has packet length ${packet.size} inconsistent with declared length $declared")
+            it.require(packet[0] / 8 in TRANSFER_COMMAND_CODES,
+                "does not encode an SGB transfer command")
+            (it.value("dataTransfer") as IntArray?)?.let { data ->
+              it.require(data.size == SGB_TRANSFER_SIZE, "has transfer payload length ${data.size}")
+            }
+          })
+      put("eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento",
+          constrained("Multipacket assembly indices and delayed transfer countdown are bounded.") {
+            val packets = it.objectArray("multipacket")
+            it.range("multipacketLength", 0, packets.size)
+            it.range("multipacketIndex", 0, packets.size)
+            it.require(it.int("multipacketLength") == 0 ||
+                it.int("multipacketIndex") < it.int("multipacketLength"),
+                "has multipacket index beyond the active packet count")
+            it.range("transferCountdown", 0, 3)
+            it.recordType("waitingTransferCommandMemento", TRANSFER_COMMAND_MEMENTO)
+          })
+      put("eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento",
+          constrained("Nullable SGB palette rows retain their fixed row widths and fade phase.") {
+            checkRows(it, "palettes", 4); checkRows(it, "systemPalettes", 4)
+            checkRows(it, "attributeFiles", 20 * 18); it.range("borderFade", 0, 32)
+          })
+      put("eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento",
+          constrained("The 105-frame border animation and optional picture-command type are validated.") {
+            it.range("borderAnimation", 0, 105)
+            it.value("pendingPictureMemento")?.let { pending ->
+              it.recordType("pendingPictureMemento", TRANSFER_COMMAND_MEMENTO)
+              val transfer = RecordFields(pending, "background.pendingPictureMemento")
+              it.require(transfer.intArray("packet")[0] / 8 == 0x14,
+                  "pending picture is not a PCT_TRN command")
+            }
+          })
+      put("eu.rekawek.coffeegb.core.ir.FullChanger\$FullChangerMemento",
+          constrained("Pulse schedule index/remaining duration are coherent with armed/running state.") {
+            val schedule = it.intArray("schedule")
+            it.require(schedule.all { duration -> duration > 0 }, "contains a non-positive pulse duration")
+            val index = it.int("index")
+            it.require(index >= 0 && (schedule.isNotEmpty() || index == 0) &&
+                (schedule.isEmpty() || index < schedule.size), "has invalid pulse index $index")
+            if (it.value("running") as Boolean) it.require(schedule.isNotEmpty(), "is running without a schedule")
+            it.nonNegative("remaining")
+          })
+
+      // DMA/PPU queues, phase indices, and delayed-write collections.
+      put("eu.rekawek.coffeegb.core.memory.Dma\$DmaMemento",
+          constrained("OAM DMA address/clock phases and byte latches are bounded; -1 write byte is a sentinel.") {
+            it.range("from", 0, 0xffff); it.nonNegative("ticks"); it.nonNegative("transferClocks")
+            it.nonNegative("pauseEntryClocks"); it.range("currentByte", 0, 0xff)
+            it.range("regValue", 0, 0xff); it.range("pendingInterruptWriteByte", -1, 0xff)
+            it.range("pendingInterruptWriteValue", 0, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento",
+          constrained("HDMA block length, source progress, request ages, and line phases are bounded.") {
+            it.range("length", 0, 0x7f); it.range("tick", -8, 31)
+            it.range("src", 0, 0xffff); it.range("dst", 0, 0xffff)
+            it.range("sourceBytesTransferred", 0, it.intArray("blockData").size)
+            listOf("hblankRequestAge", "nextHblankRequestAge").forEach { name -> it.nonNegative(name) }
+            it.range("gpuLine", 0, 153); it.range("gpuTicksInLine", 0, 455)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.IntQueue\$IntQueueMemento",
+          constrained("Circular-queue size and offset are checked against capacity.") {
+            val capacity = it.intArray("array").size
+            it.require(capacity > 0, "has zero queue capacity")
+            it.range("size", 0, capacity); it.range("offset", 0, capacity - 1)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento",
+          constrained("The display write cursor cannot leave the owned scanout buffer.") {
+            val buffer = it.intArray("buffer")
+            it.range("i", 0, buffer.size)
+            (it.value("lastFrame") as IntArray?)?.let { lastFrame ->
+              it.require(lastFrame.size == buffer.size,
+                  "has last-frame length ${lastFrame.size}, expected ${buffer.size}")
+            }
+          })
+      put("eu.rekawek.coffeegb.core.gpu.VRamTransfer\$VRamTransferMemento",
+          constrained("The SGB frame pixel cursor covers exactly one 160x144 source frame.") {
+            it.range("i", 0, 160 * 144)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.SpriteFifo\$SpriteFifoMemento",
+          constrained("Object FIFO head/size and rewind underflow are bounded by its eight slots.") {
+            it.range("head", 0, 7); it.range("size", 0, 8); it.nonNegative("underflow")
+          })
+      put("eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento",
+          constrained("Legacy-null or present delay-line arrays must be paired and cursor-bounded.") {
+            checkDelayLine(it)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento",
+          constrained("CGB delay lines and optional cleared-FIFO triplet have coherent presence and indices.") {
+            checkDelayLine(it)
+            val cleared = listOf("clearedPixels", "clearedPalettes", "clearedPriorities").map(it::value)
+            it.require(cleared.all { value -> value == null } || cleared.all { value -> value != null },
+                "has a partially present cleared-FIFO triplet")
+            listOf("clearedPixels", "clearedPalettes", "clearedPriorities")
+                .forEach { name -> it.recordType(name, INT_QUEUE_MEMENTO) }
+            it.range("linePixels", 0, 160)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.ColorPalette\$ColorPaletteMemento",
+          constrained("The CGB palette byte-address register is six bits.") { it.range("index", 0, 63) })
+      put("eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento",
+          constrained("LCD line/dot and delayed-write phases are bounded.") {
+            it.nonNegative("displayEnabledDelay"); it.range("line", 0, 153); it.range("ticksInLine", 0, 455)
+            val lastWrite = it.int("lastCpuVramWriteTick")
+            it.require(lastWrite == Int.MIN_VALUE || lastWrite in -1..455,
+                "has invalid lastCpuVramWriteTick=$lastWrite")
+            it.recordType("pixelMachineMemento", PIXEL_TRANSFER_MEMENTO)
+            if (it.value("pendingPpuWrites") != null) {
+              it.recordElements("pendingPpuWrites", PENDING_PPU_WRITE)
+            }
+            (it.value("cpuVisiblePpuRegisters") as IntArray?)?.let { registers ->
+              it.require(registers.size == CPU_VISIBLE_PPU_REGISTERS,
+                  "has ${registers.size} CPU-visible PPU registers")
+              it.require(registers.all { value -> value in -1..0xff },
+                  "has an invalid CPU-visible PPU register")
+            }
+          })
+      put("eu.rekawek.coffeegb.core.gpu.phase.OamSearch\$OamSearchMemento",
+          constrained("Mode-2 OAM reader and selected-sprite indices match their fixed arrays.") {
+            it.range("spritePosIndex", 0, it.objectArray("sprites").size)
+            it.range("i", 0, it.intArray("oamReaderY").size)
+            it.range("spriteHeight", 0, 16); it.range("previousOamSpriteHeight", 0, 16)
+            it.nonNegative("oamReaderSourceChangeTicks")
+          })
+      put("eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento",
+          constrained("Mode-3 sprite/fetch/window indices and nullable legacy lists are coherent.") {
+            val spriteOrder = it.intArray("spriteOrder")
+            it.range("spriteCount", 0, spriteOrder.size)
+            it.require(spriteOrder.all { index -> index in 0..9 },
+                "has a sprite-order index outside the ten OAM slots")
+            it.range("spriteHead", 0, it.int("spriteCount")); it.range("objStep", -1, 5)
+            it.range("position", -16, 160); it.range("objAttributesValue", -1, 0xff)
+            it.range("objRefreshAttrsValue", -1, 0xff); it.range("objRefreshPops", 0, 8)
+            it.nonNegative("entryTicks"); it.nonNegative("windowPendingTicks")
+            it.recordType("fifoMemento", DMG_FIFO_MEMENTO, COLOR_FIFO_MEMENTO)
+            if (it.value("pendingWindowDisplayWrites") != null) {
+              it.recordElements("pendingWindowDisplayWrites", DELAYED_WINDOW_WRITE)
+            }
+            if (it.value("pendingWindowXWrites") != null) {
+              it.recordElements("pendingWindowXWrites", DELAYED_WINDOW_WRITE)
+            }
+          })
+      put("eu.rekawek.coffeegb.core.gpu.Fetcher\$FetcherMemento",
+          constrained("Fetcher state and attribute sentinel are bounded to the seven-stage machine.") {
+            it.range("state", 0, 6); it.range("tileAttributesValue", -1, 0xff)
+            it.nonNegative("data2Delay")
+          })
+      put("eu.rekawek.coffeegb.core.gpu.Gpu\$PendingPpuWrite",
+          constrained("Pending PPU writes retain a 16-bit address and non-negative dot delay.") {
+            val address = it.int("address")
+            it.require(address in DELAYED_PPU_REGISTERS,
+                "has unsupported delayed PPU address ${address.toString(16)}")
+            it.range("value", 0, 0xff); it.range("mask", 0, 0xff)
+            it.require(it.int("mask") == when (address) {
+              0xff40 -> 0x20
+              0xff43 -> 0x07
+              else -> 0xff
+            }, "has an invalid mask for its delayed PPU register")
+            it.range("remainingDots", 0, 4)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$DelayedWindowWrite",
+          constrained("Delayed window-register writes carry a byte and non-negative dot delay.") {
+            it.range("value", 0, 0xff); it.range("remainingDots", 0, 4)
+          })
+
+      put("eu.rekawek.coffeegb.core.gpu.GpuRegisterValues\$GpuRegisterValuesMemento",
+          constrained("GPU register arrays, nullable legacy mix arrays, and old-value sentinels are coherent.") {
+            val values = it.intArray("values")
+            it.intValues("values", 0, 0xff)
+            val mix = it.value("mixValues") as IntArray?
+            val pending = it.value("pendingMixValues") as IntArray?
+            it.require((mix == null) == (pending == null), "has only one palette-mix array")
+            listOfNotNull(mix, pending).forEach { array ->
+              it.require(array.size == values.size, "has a palette-mix length different from the register array")
+              it.require(array.all { value -> value in -1..0xff }, "has an invalid palette-mix value")
+            }
+            it.range("wxJustChangedTicks", 0, 2)
+            it.range("scxOldValue", -1, 0xff); it.range("pendingScxOldValue", -1, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.gpu.Lcdc\$LcdcMemento",
+          constrained("LCDC latches are bytes or the documented -1 mix sentinel; glitch timers are non-negative.") {
+            it.range("value", 0, 0xff); it.range("mixValue", -1, 0xff)
+            it.range("pendingMixValue", -1, 0xff); it.nonNegative("tileSelectGlitchTicks")
+            it.nonNegative("pendingTileSelectGlitchTicks")
+          })
+      put("eu.rekawek.coffeegb.core.gpu.phase.HBlankPhase\$HBlankPhaseMemento",
+          constrained("HBlank elapsed-dot count cannot be negative.") { it.nonNegative("ticks") })
+      put("eu.rekawek.coffeegb.core.gpu.phase.VBlankPhase\$VBlankPhaseMemento",
+          constrained("VBlank elapsed-dot count cannot be negative.") { it.nonNegative("ticks") })
+      put("eu.rekawek.coffeegb.core.gpu.phase.OamSearch\$SpritePosition\$SpritePositionMemento",
+          constrained("Enabled sprite entries retain byte coordinates and an address inside OAM.") {
+            it.range("x", 0, 0xff); it.range("y", 0, 0xff)
+            if (it.value("enabled") as Boolean) it.range("address", 0xfe00, 0xfe9c)
+          })
+
+      // RTC and mapper command-state indices.
+      put("eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento",
+          constrained("Live and latched RTC registers plus subsecond phase are hardware-bounded.") {
+            listOf("seconds", "minutes", "latchedSeconds", "latchedMinutes").forEach { name -> it.range(name, 0, 59) }
+            listOf("hours", "latchedHours").forEach { name -> it.range(name, 0, 23) }
+            listOf("days", "latchedDays").forEach { name -> it.range(name, 0, 511) }
+            it.range("subSecondTicks", 0L, RTC_TICKS_PER_SECOND - 1L)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Mbc6\$Mbc6Memento",
+          constrained("AMD flash unlock/erase transaction state is one of six stages.") {
+            it.range("flashCommandState", 0, 5)
+            listOf("ramBankA", "ramBankB", "romBankA", "romBankB")
+                .forEach { name -> it.range(name, 0, 0xff) }
+            if (it.value("flashProgramMode") as Boolean) {
+              it.require(it.int("flashCommandState") == 2,
+                  "has program mode without the completed unlock prefix")
+            }
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento",
+          constrained("EEPROM serial phase, bit count, address sentinel, and output bit are coherent.") {
+            val state = it.enumName("state")
+            val maxBits = when (state) { "COMMAND" -> 9; "READING" -> 16; "WRITING" -> 15; else -> 17 }
+            it.range("bitsRead", 0, maxBits); it.range("address", -1, 127); it.range("doBit", 0, 1)
+            it.range("command", 0, 0x3ff); it.range("writeValue", 0, 0xffff)
+            it.intValues("eeprom", 0, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Mbc7\$Mbc7Memento",
+          constrained("Accelerometer latch, ROM bank, finite input, and EEPROM root are validated.") {
+            it.range("selectedRomBank", 0, 0x1ff); it.range("latchState", 0, 2)
+            it.require(it.double("x").isFinite() && it.double("y").isFinite(),
+                "has a non-finite accelerometer input")
+            it.recordType("eepromMemento", MBC7_EEPROM_MEMENTO)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3Memento",
+          constrained("HuC3 command address/flags/read latches are byte-sized.") {
+            it.range("romBank", 0, 0x7f); it.range("ramBank", 0, 0x0f); it.range("mode", 0, 0x0f)
+            it.range("accessIndex", 0, 0xff); it.range("accessFlags", 0, 0xff); it.range("readValue", 0, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.DuzMulticart\$DuzMulticartMemento",
+          constrained("DÜZ register, ROM, and RAM selectors retain their hardware widths.") {
+            it.range("regIndex", 0, 0xff); it.range("selectedBank", 1, 0x7f)
+            it.range("selectedRamBank", 0, 0xff); it.nonNegative("baseBank")
+            it.intValues("regs", 0, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc\$SachenMemento",
+          constrained("Sachen lock and boot-logo transition machines have finite stages.") {
+            listOf("unmaskedBank", "mask", "base").forEach { name -> it.range(name, 0, 0xff) }
+            it.range("lockState", 0, 2); it.range("transition", 0, 0x30)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.SlMulticart\$SlMulticartMemento",
+          constrained("SL configuration command is either a byte command or the idle sentinel 0x100.") {
+            val command = it.int("configCommand")
+            it.require(command in 0..0xff || command == 0x100, "has invalid configCommand=$command")
+            it.range("baseRomBank", 0, 0x3ff); it.range("selectedRomBank", 0, 0xff)
+            val romMask = it.int("romBankMask")
+            it.require(romMask in 1..0xff && (romMask and (romMask + 1)) == 0,
+                "has invalid ROM bank mask $romMask")
+            it.range("zeroRemap", 0, 1); it.range("baseRamBank", 0, 0x0f)
+            it.range("selectedRamBank", 0, 0x0f); it.oneOf("ramBankMask", 0, 3)
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Tama5\$Tama5Memento",
+          constrained("TAMA5 command selector and nibble register/page values are bounded.") {
+            it.range("selectedReg", 0, 15)
+            listOf("registers", "rtcTimerPage", "rtcAlarmPage", "rtcFreePage0", "rtcFreePage1")
+                .forEach { name ->
+                  it.require(it.intArray(name).all { value -> value in 0..15 }, "$name contains a non-nibble value")
+                }
+          })
+      put("eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento",
+          constrained("Outer Datel flash transaction state is a four-stage JEDEC sequence.") {
+            it.range("flashCycle", 0, 3)
+          })
+
+      // Mapper bank/mode registers that can become array indices or table selectors.
+      addMapperPolicies(this)
+
+      // Serial parser/framing indices.
+      put("eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint\$Peer2PeerSerialEndpointMemento",
+          constrained("Link-cable shift index and pending-bit count cannot underflow.") {
+            it.range("sb", 0, 0xff); it.nonNegative("bitsReceived"); it.range("bitIndex", 0, 7)
+          })
+      put("eu.rekawek.coffeegb.core.serial.ByteReceivingSerialEndpoint\$ByteReceivingSerialEndpointMemento",
+          constrained("Byte-receiver byte and bit count are bounded.") {
+            it.range("sb", 0, 0xff); it.range("bits", 0, 7)
+          })
+      put("eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint\$BarcodeBoyMemento",
+          constrained("Barcode handshake and optional scan payload cursors are validated together.") {
+            it.range("handshakeByte", 0, 3); it.range("sendBitIndex", 0, 7)
+            it.range("recvBitIndex", 0, 7); it.range("clockDivider", 0, 511)
+            val data = it.value("data") as IntArray?
+            if (data == null) it.require(it.int("dataByte") == 0, "has a data cursor without scan data")
+            else {
+              it.require(data.size == 30, "has barcode frame length ${data.size}, expected 30")
+              it.intValues("data", 0, 0xff); it.range("dataByte", 0, data.lastIndex)
+            }
+          })
+      put("eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint\$PrinterMemento",
+          constrained("Printer parser, command/image cursors, compression run, and bit phase are bounded.") {
+            it.range("state", 0, 10); it.nonNegative("lengthLeft")
+            it.range("commandLength", 0, it.intArray("commandData").size)
+            it.range("imageOffset", 0, it.intArray("image").size)
+            it.nonNegative("compressionRunLength"); it.nonNegative("printCountdown")
+            listOf("commandId", "status", "byteToSend", "currentReply", "sb")
+                .forEach { name -> it.range(name, 0, 0xff) }
+            it.range("checksum", 0, 0xffff); it.range("compressionRunLength", 0, 128)
+            it.range("sendBits", 0, 7)
+          })
+      put("eu.rekawek.coffeegb.core.serial.GpsReceiverSerialEndpoint\$GpsReceiverMemento",
+          constrained("UART transmit/receive phases, queue bytes, timers, and bounded TAIP parser are checked.") {
+            it.range("startupBeacons", 0, 2)
+            it.require(it.intArray("outputBytes").all { value -> value in 0..0xff }, "output queue contains a non-byte")
+            it.range("outputByte", -1, 0xff); it.range("outputBit", -1, 10)
+            it.nonNegative("outputTicksRemaining"); it.nonNegative("outputDelayTicks")
+            it.range("receiveBit", -1, 9); it.range("receiveByte", 0, 0xff)
+            it.range("receiveOnes", 0, 8)
+            it.require(it.string("taipCommand").length <= 64, "has an oversized TAIP command")
+          })
+      put("eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento",
+          constrained("Serial byte/register and receive/clock phases are bounded.") {
+            it.range("sb", 0, 0xff); it.range("sc", 0, 0xff)
+            it.nonNegative("serialClocks"); it.range("receivedBits", 0, 7); it.nonNegative("haltWakeDelay")
+          })
+      put("eu.rekawek.coffeegb.core.serial.FourPlayerAdapter\$AdapterMemento",
+          constrained("DMG-07 player arrays, packet/bit cursors, rate/size, and delayed clock are coherent.") {
+            val players = 4
+            listOf("sb", "pendingBits", "consecutiveFf").forEach { name ->
+              it.require(it.intArray(name).size == players, "$name must have four player entries")
+            }
+            it.require(it.intArray("sb").all { value -> value in 0..0xff }, "has an invalid player byte")
+            it.require((it.value("transferArmed") as BooleanArray).size == players,
+                "transferArmed must have four entries")
+            it.require((it.value("connected") as BooleanArray).size == players,
+                "connected must have four entries")
+            checkRows(it, "replies", 16)
+            it.require(it.intArray("transmissionBuffer").size == 16, "must have a 16-byte transmission buffer")
+            it.range("size", 1, 4); it.range("packetByte", 0, 15); it.range("bit", 0, 7)
+            it.nonNegative("ticksUntilBit"); it.range("rate", 0, 0xff)
+            it.require(it.intArray("pendingBits").all { bit -> bit in -1..1 }, "has an invalid pending bit")
+            it.require(it.intArray("consecutiveFf").all { count -> count >= 0 }, "has a negative FF counter")
+          })
+
+      put("eu.rekawek.coffeegb.core.genie.GameGeniePatch",
+          constrained("Game Genie addresses/data are fixed-width; -1 is the no-old-value sentinel.") {
+            it.range("newData", 0, 0xff); it.range("address", 0, 0xffff)
+            it.range("oldData", -1, 0xff)
+          })
+      put("eu.rekawek.coffeegb.core.genie.GameSharkPatch",
+          constrained("GameShark mode/bank/data are bytes and the destination is a 16-bit address.") {
+            it.range("mode", 0, 0xff); it.range("bank", 0, 0xff)
+            it.range("address", 0, 0xffff); it.range("data", 0, 0xff)
+          })
+
+      // Explicitly audited records with no scalar relationship beyond schema, target dimensions,
+      // enum validity, or validators on their nested records.
+      addPassThroughPolicies(this)
+    }
+  }
+
+  private fun checkRows(fields: RecordFields, name: String, expectedLength: Int) {
+    fields.objectArray(name).forEachIndexed { index, row ->
+      if (row != null) {
+        fields.require(row is IntArray && row.size == expectedLength,
+            "$name[$index] has invalid row length")
+      }
+    }
+  }
+
+  private fun checkDelayLine(fields: RecordFields) {
+    val entries = fields.value("delayEntry") as IntArray?
+    val stamps = fields.value("delayStamp") as LongArray?
+    fields.require((entries == null) == (stamps == null), "has only one delay-line array")
+    if (entries != null && stamps != null) {
+      fields.require(entries.size == stamps.size, "has mismatched delay-line lengths")
+      fields.require(entries.isNotEmpty(), "has an empty delay line")
+      fields.range("delayHead", 0, entries.lastIndex)
+      // The dot model retains a monotonic logical count even after the eight physical slots wrap.
+      fields.nonNegative("delaySize")
+    }
+  }
+
+  private fun addMapperPolicies(target: MutableMap<String, Policy>) {
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mbc1\$Mbc1Memento"] =
+        constrained("MBC1 bank/model registers and cached bank sentinels retain their hardware widths.") {
+          it.range("selectedRamBank", 0, 3); it.range("selectedRomBank", 0, 0x7f)
+          it.range("memoryModel", 0, 1)
+          it.range("cachedRomBankFor0x0000", -1, 0x7f)
+          it.range("cachedRomBankFor0x4000", -1, 0x7f)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.BungEms\$BungEmsMemento"] =
+        constrained("Bung/EMS ROM latches are bytes, its high bit is binary, and RAM has four banks.") {
+          listOf("romBankLow", "romBankMask", "romBankLatch").forEach { name -> it.range(name, 0, 0xff) }
+          it.range("romBankHigh", 0, 1); it.range("selectedRamBank", 0, 3)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mbc2\$Mbc2Memento"] =
+        constrained("MBC2's selected ROM bank is the 4-bit value or audited 5-bit compatibility value.") {
+          it.range("selectedRomBank", 1, 0x1f)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomMemento"] =
+        constrained("Plain-ROM battery state, when present, must be a registered battery memento.") {
+          it.recordType("batteryMemento", MEMORY_BATTERY_MEMENTO, FILE_BATTERY_MEMENTO)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5Memento"] =
+        constrained("MBC5 exposes a nine-bit ROM bank and four-bit RAM/rumble register.") {
+          it.range("selectedRamBank", 0, 0x0f); it.range("selectedRomBank", 0, 0x1ff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera\$PocketCameraMemento"] =
+        constrained("Pocket Camera ROM/RAM selectors and camera register bytes are bounded.") {
+          it.range("romBank", 0, 0x3f); it.range("ramBank", 0, 0x0f)
+          it.intValues("cameraRegisters", 0, 0xff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.BhgosMulticart\$BhgosMulticartMemento"] =
+        constrained("GBOS RAM-bank indexing and non-negative block-selection progress are bounded.") {
+          it.range("selectedRomBank", 1, 0xff); it.range("selectedRamBank", 0, 3)
+          it.nonNegative("baseRomBank"); it.nonNegative("blockSelectWrites")
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.MakonNtOld2\$MakonNtOld2Memento"] =
+        constrained("Makon bank latches and contiguous low-bit game mask are coherent.") {
+          it.range("selectedRomBank", 1, 0xff); it.range("mappedRomBank", 0, 0xff)
+          it.range("baseRomBank", 0, 0x7e)
+          val mask = it.int("gameRomBankMask")
+          it.require(mask >= 0 && (mask and (mask + 1)) == 0, "has invalid game ROM mask $mask")
+          it.require(it.int("mappedRomBank") <= mask, "has mapped bank outside the selected game mask")
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Sintax\$SintaxMemento"] =
+        constrained("Sintax table mode, bank byte, XOR bytes, and nested MBC5 root are validated.") {
+          it.recordType("delegateMemento", MBC5_MEMENTO); it.range("mode", 0, 15)
+          it.range("bankNo", 0, 0xff); it.range("romBankXor", 0, 0xff)
+          it.intValues("xorValues", 0, 0xff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.WisdomTree\$WisdomTreeMemento"] =
+        constrained("Wisdom Tree's address-selected 32 KiB bank cannot be negative or overflow its product.") {
+          it.range("bank", 0, 0x7fff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mani32kMulticart\$Mani32kMemento"] =
+        constrained("The Mani block selector originates from an unsigned cartridge write.") {
+          it.range("block", 0, 0xff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Huc1\$Huc1Memento"] =
+        constrained("HuC1 ROM/RAM selectors retain their six-bit and three-bit widths.") {
+          it.range("romBank", 0, 0x3f); it.range("ramBank", 0, 7)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3Memento"] =
+        constrained("MBC3 ROM and RAM/RTC selectors originate from seven-bit and byte registers.") {
+          it.range("selectedRomBank", 0, 0x7f); it.range("selectedRamBank", 0, 0xff)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Bbd\$BbdMemento"] =
+        constrained("BBD data/bank permutation selectors index eight-entry tables.") {
+          it.recordType("delegateMemento", MBC5_MEMENTO)
+          it.range("dataSwapMode", 0, 7); it.range("bankSwapMode", 0, 7)
+        }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Mmm01\$Mmm01Memento"] =
+        constrained("MMM01 bank fields and masks retain their documented hardware bit widths.") {
+          it.range("romBankLow", 0, 0x1f); it.range("romBankMid", 0, 3)
+          it.range("romBankHigh", 0, 3); it.range("romBankMask", 0, 0x0f)
+          it.range("ramBankLow", 0, 3); it.range("ramBankHigh", 0, 3)
+          it.range("ramBankMask", 0, 3)
+        }
+  }
+
+  private fun addPassThroughPolicies(target: MutableMap<String, Policy>) {
+    val valueOnly =
+        setOf(
+            "eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento",
+            "eu.rekawek.coffeegb.core.sound.SoundMode4\$SoundMode4Memento",
+            "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento",
+            "eu.rekawek.coffeegb.core.memory.BiosShadow\$BiosShadowMemento",
+            "eu.rekawek.coffeegb.core.memory.Ram\$RamMemento",
+            "eu.rekawek.coffeegb.core.memory.Mmu\$MmuMemento",
+            "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryMemento",
+            "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryMemento",
+            "eu.rekawek.coffeegb.core.memory.cart.Cartridge\$CartridgeMemento",
+            "eu.rekawek.coffeegb.core.memory.OamEchoRam\$OamEchoRamMemento",
+            "eu.rekawek.coffeegb.core.gpu.StatRegister\$StatRegisterMemento",
+            "eu.rekawek.coffeegb.core.ir.InfraredPort\$InfraredPortMemento",
+            "eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble\$CodeBreakerRumbleMemento",
+        )
+    valueOnly.forEach { name ->
+      target[name] = pass("Fields are direct value/latch state; array dimensions, enum tags, nested records, and nullability are validated elsewhere. Signed clocks and -1 sentinels are intentionally unconstrained.")
+    }
+
+  }
+
+  private fun verifyPolicyInventory() {
+    val registered = MementoTypeRegistry.recordClassNames.toSet()
+    val missing = registered - policies.keys
+    val extra = policies.keys - registered
+    if (missing.isNotEmpty() || extra.isNotEmpty()) {
+      throw StateApplyException("Semantic policy inventory mismatch; missing=$missing extra=$extra")
+    }
+  }
+
+  private const val SOUND_BUFFER_CAPACITY = 70_224 * 2
+  private const val MAX_CPU_OPS = 64
+  private const val SGB_TRANSFER_SIZE = 0x1000
+  private const val RTC_TICKS_PER_SECOND = 4_194_304L
+  private const val CPU_VISIBLE_PPU_REGISTERS = 12
+  private const val DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
+  private const val PIXEL_TRANSFER_MEMENTO =
+      "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento"
+  private const val DMG_FIFO_MEMENTO = "eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento"
+  private const val COLOR_FIFO_MEMENTO =
+      "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento"
+  private const val INT_QUEUE_MEMENTO = "eu.rekawek.coffeegb.core.gpu.IntQueue\$IntQueueMemento"
+  private const val PENDING_PPU_WRITE = "eu.rekawek.coffeegb.core.gpu.Gpu\$PendingPpuWrite"
+  private const val DELAYED_WINDOW_WRITE =
+      "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$DelayedWindowWrite"
+  private const val TRANSFER_COMMAND_MEMENTO =
+      "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento"
+  private const val MEMORY_BATTERY_MEMENTO =
+      "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryMemento"
+  private const val FILE_BATTERY_MEMENTO =
+      "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryMemento"
+  private const val MBC5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5Memento"
+  private const val MBC7_EEPROM_MEMENTO =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento"
+  private val DELAYED_PPU_REGISTERS = setOf(0xff40, 0xff43, 0xff47, 0xff4b)
+  private val TRANSFER_COMMAND_CODES = setOf(0x09, 0x0b, 0x10, 0x13, 0x14, 0x15)
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -25,11 +25,13 @@ internal object StateSemantics {
   }
 
   fun validateBarcodeRuntime(state: BarcodeBoyRuntimeState) {
-    state.copyPending()?.let { pending ->
-      if (pending.size != BARCODE_FRAME_SIZE) {
-        throw StateApplyException(
-            "Barcode runtime has pending frame length ${pending.size}, expected $BARCODE_FRAME_SIZE")
-      }
+    val pendingSize = state.pendingSize
+    if (pendingSize != null && pendingSize != BARCODE_FRAME_SIZE) {
+      throw StateApplyException(
+          "Barcode runtime has pending frame length $pendingSize, expected $BARCODE_FRAME_SIZE")
+    }
+    if (pendingSize != null) {
+      val pending = checkNotNull(state.copyPending())
       pending.forEachIndexed { index, value ->
         if (value !in 0..0xff) {
           throw StateApplyException("Barcode runtime has invalid pending[$index]=$value")
@@ -339,11 +341,12 @@ internal object StateSemantics {
             it.range("pendingInterruptWriteValue", 0, 0xff)
           })
       put("eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento",
-          constrained("HDMA block length, source progress, request ages, and line phases are bounded.") {
+          constrained("HDMA block length, signed source progress, request ages, and line phases are audited.") {
             it.range("length", 0, 0x7f); it.range("tick", -8, 31)
             it.range("src", 0, 0xffff); it.range("dst", 0, 0xffff)
-            // This is cumulative from the most recent source-register write, not per-block.
-            it.nonNegative("sourceBytesTransferred")
+            // This cumulative diagnostic/arbitration counter intentionally wraps as an Int
+            // across repeated HDMA5 starts. It is neither an allocation size nor an array cursor.
+            it.int("sourceBytesTransferred")
             listOf("hblankRequestAge", "nextHblankRequestAge").forEach { name -> it.nonNegative(name) }
             it.range("gpuLine", 0, 153); it.range("gpuTicksInLine", 0, 455)
           })

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -21,6 +21,7 @@ import eu.rekawek.coffeegb.controller.network.Connection.ValidatedPeerStopEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerPlayerDisconnectedEvent
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.state.LinkedTopologyState
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
@@ -61,6 +62,11 @@ class LinkedControllerTest {
     assertEquals(1, sut.activeSessionCount())
     assertEquals(3, sut.currentFrame())
     assertEquals(2, sut.stateHistory.getHead().frame)
+    val detached = sut.captureDetachedState()
+    assertEquals(LinkedTopologyState.FOUR_PLAYER_ADAPTER, detached.topology)
+    assertEquals(4, detached.players.size)
+    assertNotNull(detached.players[0].session)
+    assertTrue(detached.players.drop(1).all { it.session == null })
     eventBus.close()
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -21,12 +21,23 @@ import eu.rekawek.coffeegb.controller.network.Connection.ValidatedPeerStopEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerPlayerDisconnectedEvent
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.state.ApplyStage
+import eu.rekawek.coffeegb.controller.state.Int32State
+import eu.rekawek.coffeegb.controller.state.LinkedPlayerState
+import eu.rekawek.coffeegb.controller.state.LinkedSessionState
 import eu.rekawek.coffeegb.controller.state.LinkedTopologyState
+import eu.rekawek.coffeegb.controller.state.RecordState
+import eu.rekawek.coffeegb.controller.state.SerialPeripheralState
+import eu.rekawek.coffeegb.controller.state.SessionState
+import eu.rekawek.coffeegb.controller.state.StateApplyException
+import eu.rekawek.coffeegb.controller.state.StateField
+import eu.rekawek.coffeegb.controller.state.StateValue
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
+import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.joypad.Joypad
 import org.junit.Test
 import java.io.IOException
@@ -1151,6 +1162,148 @@ class LinkedControllerTest {
     assertJoypadEventsEqual(buttons1, buttons2)
   }
 
+  @Test
+  fun normalLinkedStateRestoresHeldInputAndContinuesDeterministically() {
+    val (eventBus, sut) = configuredController(LinkMode.NORMAL, 2)
+    eventBus.post(ButtonPressEvent(Button.A))
+    eventBus.post(
+        LinkedController.RemoteButtonStateEvent(
+            sut.currentFrame(),
+            Input(listOf(Button.B), emptyList()),
+            player = 1,
+        ))
+    sut.runFrame()
+    val captured = sut.captureDetachedState()
+    assertEquals(4, captured.players.size)
+    assertTrue(captured.players.drop(2).all { it.session == null })
+    assertEquals(setOf(Button.A), sut.heldButtonStates()[0])
+    assertEquals(setOf(Button.B), sut.heldButtonStates()[1])
+
+    sut.runFrame()
+    val expected = sut.captureDetachedState()
+    eventBus.post(ButtonReleaseEvent(Button.A))
+    sut.runFrame()
+
+    sut.restoreDetachedState(captured)
+    sut.runFrame()
+    assertEquals(expected, sut.captureDetachedState())
+    eventBus.close()
+  }
+
+  @Test
+  fun fourPlayerLinkedStateRestoresAtomicallyAndRejectsIncoherentAdapterCopies() {
+    val (eventBus, sut) = configuredController(LinkMode.FOUR_PLAYER_ADAPTER, 3)
+    eventBus.post(ButtonPressEvent(Button.SELECT))
+    eventBus.post(
+        LinkedController.RemoteButtonStateEvent(
+            sut.currentFrame(),
+            Input(listOf(Button.START), emptyList()),
+            player = 2,
+        ))
+    sut.runFrame()
+    val target = sut.captureDetachedState()
+    assertEquals(setOf(Button.SELECT), sut.heldButtonStates()[0])
+    assertEquals(setOf(Button.START), sut.heldButtonStates()[2])
+    val activeStates = target.players.mapNotNull { it.session }
+    assertEquals(1, activeStates.map { it.serialState }.distinct().size)
+
+    sut.runFrame()
+    val expectedContinuation = sut.captureDetachedState()
+    sut.runFrame()
+    sut.restoreDetachedState(target)
+    sut.runFrame()
+    assertEquals(expectedContinuation, sut.captureDetachedState())
+
+    val coherent = sut.captureDetachedState()
+    val playerOne = assertNotNull(coherent.players[1].session)
+    val adapter = playerOne.serialState as RecordState
+    val inconsistentAdapter =
+        RecordState(
+            adapter.typeId,
+            adapter.fields.map { field ->
+              if (field.name == "packetByte") {
+                StateField(field.name, Int32State((field.value as Int32State).value + 1))
+              } else {
+                field
+              }
+            },
+        )
+    val inconsistentSession = copySession(playerOne, serialState = inconsistentAdapter)
+    val inconsistent =
+        linkedCopy(
+            coherent,
+            players =
+                coherent.players.map {
+                  if (it.player == 1) LinkedPlayerState(1, inconsistentSession) else it
+                },
+        )
+    assertFailsWith<StateApplyException> { sut.restoreDetachedState(inconsistent) }
+    assertEquals(coherent, sut.captureDetachedState())
+
+    sut.runFrame()
+    val beforeInjectedFailure = sut.captureDetachedState()
+    assertFailsWith<StateApplyException> {
+      sut.restoreDetachedState(coherent) { player, stage ->
+        if (player == 1 && stage == ApplyStage.AFTER_MACHINE_MUTATION) {
+          throw IllegalStateException("injected linked restore failure")
+        }
+      }
+    }
+    assertEquals(beforeInjectedFailure, sut.captureDetachedState())
+    eventBus.close()
+  }
+
+  @Test
+  fun linkedStateRejectsMalformedTopologyBeforeMutation() {
+    val (eventBus, sut) = configuredController(LinkMode.FOUR_PLAYER_ADAPTER, 2)
+    val valid = sut.captureDetachedState()
+    val session = assertNotNull(valid.players[0].session)
+    val invalidStates =
+        listOf(
+            linkedCopy(valid, frame = -1),
+            linkedCopy(valid, localPlayer = 1),
+            linkedCopy(valid, topology = LinkedTopologyState.NORMAL),
+            linkedCopy(valid, players = valid.players.dropLast(1)),
+            linkedCopy(
+                valid,
+                players =
+                    valid.players.map {
+                      if (it.player == 1) LinkedPlayerState(0, it.session) else it
+                    },
+            ),
+            linkedCopy(
+                valid,
+                players =
+                    valid.players.map {
+                      if (it.player == 1) LinkedPlayerState(1, null) else it
+                    },
+            ),
+            linkedCopy(
+                valid,
+                players =
+                    valid.players.map {
+                      if (it.player == 0) {
+                        LinkedPlayerState(
+                            0,
+                            copySession(
+                                session,
+                                serialPeripheral = SerialPeripheralState.PEER_TO_PEER,
+                            ),
+                        )
+                      } else {
+                        it
+                      }
+                    },
+            ),
+        )
+    invalidStates.forEach { invalid ->
+      val before = sut.captureDetachedState()
+      assertFailsWith<StateApplyException> { sut.restoreDetachedState(invalid) }
+      assertEquals(before, sut.captureDetachedState())
+    }
+    eventBus.close()
+  }
+
   private companion object {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
 
@@ -1195,6 +1348,55 @@ class LinkedControllerTest {
         field.setLong(controller, frame)
       }
     }
+
+    fun configuredController(
+        mode: LinkMode,
+        activePlayers: Int,
+    ): Pair<EventBusImpl, LinkedController> {
+      val eventBus = EventBusImpl()
+      val controller =
+          LinkedController(eventBus, EmulatorProperties(), null, mode, localPlayer = 0).also {
+            it.timingTicker.disabled = true
+          }
+      eventBus.post(LoadRomEvent(ROM))
+      controller.runFrame()
+      for (player in 1 until activePlayers) {
+        eventBus.post(
+            PeerLoadedGameEvent(
+                ROM_BYTES,
+                null,
+                null,
+                GAMEBOY_TYPE,
+                BOOTSTRAP_MODE,
+                controller.currentFrame(),
+                player = player,
+            ))
+        controller.runFrame()
+      }
+      assertEquals(activePlayers, controller.activeSessionCount())
+      return eventBus to controller
+    }
+
+    fun copySession(
+        state: SessionState,
+        serialPeripheral: SerialPeripheralState = state.serialPeripheral,
+        serialState: StateValue = state.serialState,
+    ) =
+        SessionState(
+            state.machine,
+            serialPeripheral,
+            serialState,
+            state.serialRuntime,
+            state.heldButtons,
+        )
+
+    fun linkedCopy(
+        state: LinkedSessionState,
+        frame: Long = state.frame,
+        localPlayer: Int = state.localPlayer,
+        topology: LinkedTopologyState = state.topology,
+        players: Collection<LinkedPlayerState> = state.players,
+    ) = LinkedSessionState(frame, localPlayer, topology, players)
 
     fun peerState(frame: Long, source: PeerEventSource) =
         PeerLoadedGameEvent(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -5,6 +5,9 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.genie.AddPatches
+import eu.rekawek.coffeegb.core.genie.GameGeniePatch
+import eu.rekawek.coffeegb.core.genie.GameSharkPatch
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
@@ -197,6 +200,13 @@ class DetachedStateTest {
       val before = session.captureDetachedState()
       val display = before.machine.record(DISPLAY_MEMENTO)
       val queue = before.machine.record(INT_QUEUE_MEMENTO)
+      val dmgFifo = before.machine.record(DMG_FIFO_MEMENTO)
+      val sgbDisplay = before.machine.record(SGB_DISPLAY_MEMENTO)
+      val attributeFiles = sgbDisplay.field("attributeFiles") as ObjectArrayState
+      val firstAttributeFile = attributeFiles.values.first() as Int32ArrayState
+      val invalidAttributeFile =
+          Int32ArrayState(firstAttributeFile.copyValue().also { it[0] = 4 })
+      val paletteMap = sgbDisplay.intArray("paletteMap").also { it[0] = 4 }
 
       val invalidRoots =
           listOf(
@@ -219,6 +229,48 @@ class DetachedStateTest {
                   "i",
                   Int32State(display.intArray("buffer").size + 1),
               ),
+              before.machine.root.replaceRecordField(
+                  DMG_FIFO_MEMENTO,
+                  "delaySize",
+                  Int32State(dmgFifo.intArray("delayEntry").size + 1),
+              ),
+              before.machine.root.replaceRecordField(
+                  POLYNOMIAL_COUNTER_MEMENTO,
+                  "alignment",
+                  Int32State(4),
+              ),
+              before.machine.root.replaceRecordField(
+                  SGB_DISPLAY_MEMENTO,
+                  "paletteMap",
+                  Int32ArrayState(paletteMap),
+              ),
+              before.machine.root.replaceRecordField(
+                  SGB_DISPLAY_MEMENTO,
+                  "attributeFiles",
+                  ObjectArrayState(
+                      attributeFiles.values.mapIndexed { index, value ->
+                        if (index == 0) invalidAttributeFile else value
+                      }),
+              ),
+              before.machine.root.replaceRecordField(
+                  SGB_DISPLAY_MEMENTO,
+                  "attributeFiles",
+                  ObjectArrayState(
+                      attributeFiles.values.mapIndexed { index, value ->
+                        if (index == 0) NullState else value
+                      }),
+              ),
+              before.machine.root.replaceRecordField(
+                  GENIE_MEMENTO,
+                  "patches",
+                  Int32MapState(listOf(Int32MapEntry(0x1234, NullState))),
+              ),
+              before.machine.root.replaceRecordField(
+                  GENIE_MEMENTO,
+                  "patches",
+                  Int32MapState(
+                      listOf(Int32MapEntry(0x1234, ListState(listOf(NullState))))),
+              ),
           )
 
       invalidRoots.forEachIndexed { index, root ->
@@ -240,6 +292,32 @@ class DetachedStateTest {
               queue
                   .replaceField("size", Int32State(queue.intArray("array").size))
                   .replaceField("offset", Int32State(queue.intArray("array").lastIndex))))
+      StateSemantics.validate(
+          StateGraph.restore(
+              dmgFifo.replaceField(
+                  "delaySize",
+                  Int32State(dmgFifo.intArray("delayEntry").size),
+              )))
+    }
+
+    session(configuration(cgbIdleRom()).setGameboyType(GameboyType.CGB)).use { session ->
+      repeat(2_000) { session.gameboy.tick() }
+      val before = session.captureDetachedState()
+      val fifo = before.machine.record(COLOR_FIFO_MEMENTO)
+      val invalid =
+          before.withMachineRoot(
+              before.machine.root.replaceRecordField(
+                  COLOR_FIFO_MEMENTO,
+                  "delaySize",
+                  Int32State(fifo.intArray("delayEntry").size + 1),
+              ))
+      assertRejectedBeforeMutation(session, before, invalid, "CGB delay-line capacity")
+      StateSemantics.validate(
+          StateGraph.restore(
+              fifo.replaceField(
+                  "delaySize",
+                  Int32State(fifo.intArray("delayEntry").size),
+              )))
     }
   }
 
@@ -270,13 +348,16 @@ class DetachedStateTest {
           "legacy-pending-writes",
       )
 
-      // SGB row elements are independently nullable by PAL_SET/legacy state.
+      // Historical PAL_TRN state may have an unavailable system-palette row.
       val display = state.record(SGB_DISPLAY_MEMENTO)
-      val palettes = display.field("palettes") as ObjectArrayState
+      val systemPalettes = display.field("systemPalettes") as ObjectArrayState
       val withNullRow =
           display.replaceField(
-              "palettes",
-              ObjectArrayState(palettes.values.mapIndexed { index, value -> if (index == 0) NullState else value }),
+              "systemPalettes",
+              ObjectArrayState(
+                  systemPalettes.values.mapIndexed { index, value ->
+                    if (index == 0) NullState else value
+                  }),
           )
       StateGraph.validateCompatible(withNullRow, display, "nullable-sgb-row")
     }
@@ -297,18 +378,173 @@ class DetachedStateTest {
     StateSemantics.validate(StateGraph.restore(withPicture))
 
     val barcode = BarcodeBoySerialEndpoint()
-    val barcodeState = StateGraph.capture(barcode.saveToMemento()) as RecordState
-    val barcodeWithData = barcodeState.replaceField("data", Int32ArrayState(IntArray(30)))
-    StateGraph.validateCompatible(barcodeWithData, barcodeState, "optional-barcode-data")
+    val idleBarcode = StateGraph.capture(barcode.saveToMemento())
+    repeat(4) {
+      barcode.startSending()
+      repeat(8) { barcode.sendBit() }
+    }
+    barcode.scan("4901234567894")
+    barcode.setExternalTransfer(true)
+    barcode.recvBit()
+    val sendingBarcode = StateGraph.capture(barcode.saveToMemento())
+    StateGraph.validateCompatible(sendingBarcode, idleBarcode, "active-barcode-data")
+    StateSemantics.validate(StateGraph.restore(sendingBarcode))
+  }
 
-    session(configuration(datelRom())).use { emptySlot ->
-      session(datelConfiguration(mbc3Rom(), VirtualTimeSource(120_000))).use { populatedSlot ->
-        StateGraph.validateCompatible(
-            populatedSlot.captureDetachedState().machine.record(DATEL_MEMENTO),
-            emptySlot.captureDetachedState().machine.record(DATEL_MEMENTO),
-            "optional-datel-slot",
-        )
+  @Test
+  fun batteryAndDatelSlotPresenceAreTargetIdentityAndRejectBeforeMutation() {
+    val basicWithoutBattery = configuration(basicRom()).setSupportBatterySave(false)
+    val basicWithBattery =
+        configuration(basicRom())
+            .setBatteryData(ByteArray(0x2000))
+            .setSupportBatterySave(false)
+    assertCrossPresenceRejected(basicWithoutBattery, basicWithBattery)
+    assertCrossPresenceRejected(basicWithBattery, basicWithoutBattery)
+
+    val time = VirtualTimeSource(120_000)
+    val datelWithoutSlot =
+        configuration(datelRom())
+            .setGameboyType(GameboyType.CGB)
+            .setRtcTimeSource(time)
+            .setSupportBatterySave(false)
+    val datelWithSlot = datelConfiguration(mbc3Rom(), time)
+    assertCrossPresenceRejected(datelWithoutSlot, datelWithSlot)
+    assertCrossPresenceRejected(datelWithSlot, datelWithoutSlot)
+  }
+
+  @Test
+  fun malformedBarcodeMementoAndRuntimeRejectBeforeMutation() {
+    val endpoint = BarcodeBoySerialEndpoint()
+    session(endpoint).use { session ->
+      repeat(4) {
+        endpoint.startSending()
+        repeat(8) { endpoint.sendBit() }
       }
+      endpoint.scan("4901234567894")
+      endpoint.setExternalTransfer(true)
+      endpoint.recvBit()
+      val before = session.captureDetachedState()
+      val serial = before.serialState as RecordState
+      val idleState = StateGraph.capture(BarcodeBoySerialEndpoint().saveToMemento()) as RecordState
+      val activeData = serial.intArray("data")
+      val malformedSerial =
+          listOf(
+              serial.replaceField("data", NullState),
+              serial.replaceField("state", idleState.field("state")),
+              serial.replaceField("data", Int32ArrayState(activeData.copyOf(29))),
+              serial.replaceField(
+                  "data",
+                  Int32ArrayState(activeData.clone().also { it[0] = 0x100 }),
+              ),
+          )
+      val malformedRuntime =
+          listOf(
+              BarcodeBoyRuntimeState(true, IntArray(29)),
+              BarcodeBoyRuntimeState(true, IntArray(30).also { it[0] = 0x100 }),
+          )
+
+      malformedSerial.forEachIndexed { index, serialState ->
+        val invalid =
+            SessionState(
+                before.machine,
+                before.serialPeripheral,
+                serialState,
+                before.serialRuntime,
+                before.heldButtons,
+            )
+        assertRejectedBeforeMutation(session, before, invalid, "serial case $index")
+      }
+      malformedRuntime.forEachIndexed { index, runtime ->
+        val invalid =
+            SessionState(
+                before.machine,
+                before.serialPeripheral,
+                before.serialState,
+                runtime,
+                before.heldButtons,
+            )
+        assertRejectedBeforeMutation(session, before, invalid, "runtime case $index")
+      }
+    }
+  }
+
+  @Test
+  fun reachableWaveRtcHdmaAndLcdEnableStatesApplyAndContinueDeterministically() {
+    session().use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff26, 0x80)
+      bus.setByte(0xff30, 0xab)
+      bus.setByte(0xff1a, 0x80)
+      bus.setByte(0xff1c, 0x20)
+      bus.setByte(0xff1d, 0xff)
+      bus.setByte(0xff1e, 0x87)
+      repeat(24) { session.gameboy.tick() }
+      val wave = session.captureDetachedState()
+      assertTrue(wave.machine.record(SOUND_MODE3_MEMENTO).int("lastReadAddr") in 0xff30..0xff3f)
+      assertContinuation(session, wave, 192)
+    }
+
+    session(configuration(mbc3Rom())).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0x0000, 0x0a)
+      listOf(0x08 to 63, 0x09 to 63, 0x0a to 31).forEach { (register, value) ->
+        bus.setByte(0x4000, register)
+        bus.setByte(0xa000, value)
+      }
+      bus.setByte(0x6000, 0)
+      bus.setByte(0x6000, 1)
+      val rtc = session.captureDetachedState()
+      val clock = rtc.machine.record(RTC_MEMENTO)
+      assertEquals(63, clock.int("seconds"))
+      assertEquals(63, clock.int("minutes"))
+      assertEquals(31, clock.int("hours"))
+      assertEquals(63, clock.int("latchedSeconds"))
+      assertEquals(63, clock.int("latchedMinutes"))
+      assertEquals(31, clock.int("latchedHours"))
+      assertContinuation(session, rtc, 4_096)
+    }
+
+    session(configuration(cgbIdleRom()).setGameboyType(GameboyType.CGB)).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff51, 0xc0)
+      bus.setByte(0xff52, 0x00)
+      bus.setByte(0xff53, 0x00)
+      bus.setByte(0xff54, 0x00)
+      bus.setByte(0xff55, 0x01)
+      var hdma = session.captureDetachedState()
+      repeat(256) {
+        if (hdma.machine.record(HDMA_MEMENTO).int("sourceBytesTransferred") <= 16) {
+          session.gameboy.tick()
+          hdma = session.captureDetachedState()
+        }
+      }
+      assertTrue(hdma.machine.record(HDMA_MEMENTO).bool("transferInProgress"))
+      assertTrue(hdma.machine.record(HDMA_MEMENTO).int("sourceBytesTransferred") > 16)
+      assertContinuation(session, hdma, 64)
+    }
+
+    session().use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff40, 0x11)
+      bus.setByte(0xff40, 0x91)
+      val lcdEnable = session.captureDetachedState()
+      assertEquals(-1, lcdEnable.machine.record(GPU_MEMENTO).int("ticksInLine"))
+      assertContinuation(session, lcdEnable, 256)
+    }
+  }
+
+  @Test
+  fun registeredCheatPatchListsApplyAndContinue() {
+    session().use { session ->
+      session.eventBus.post(
+          AddPatches(
+              listOf(
+                  GameGeniePatch(0x42, 0x1234, -1),
+                  GameSharkPatch(8, 2, 0xa123, 0x99),
+              )))
+      val captured = session.captureDetachedState()
+      StateSemantics.validate(StateGraph.restore(captured.machine.record(GENIE_MEMENTO)))
+      assertContinuation(session, captured, 128)
     }
   }
 
@@ -476,6 +712,46 @@ class DetachedStateTest {
   private fun configuration(bytes: ByteArray): Gameboy.GameboyConfiguration =
       Gameboy.GameboyConfiguration(Rom(bytes)).setBootstrapMode(BootstrapMode.SKIP)
 
+  private fun assertContinuation(session: Session, captured: SessionState, ticks: Int) {
+    repeat(ticks) { session.gameboy.tick() }
+    val expected = session.captureDetachedState()
+    repeat(31) { session.gameboy.tick() }
+    session.restoreDetachedState(captured)
+    repeat(ticks) { session.gameboy.tick() }
+    assertEquals(expected, session.captureDetachedState())
+  }
+
+  private fun assertCrossPresenceRejected(
+      targetConfiguration: Gameboy.GameboyConfiguration,
+      candidateConfiguration: Gameboy.GameboyConfiguration,
+  ) {
+    session(targetConfiguration).use { target ->
+      session(candidateConfiguration).use { candidate ->
+        val before = target.captureDetachedState()
+        assertRejectedBeforeMutation(
+            target,
+            before,
+            candidate.captureDetachedState(),
+            "configuration identity",
+        )
+      }
+    }
+  }
+
+  private fun assertRejectedBeforeMutation(
+      session: Session,
+      before: SessionState,
+      invalid: SessionState,
+      label: String,
+  ) {
+    val stages = mutableListOf<ApplyStage>()
+    assertFailsWith<StateApplyException>(label) {
+      DetachedStateAdapter.apply(session, invalid) { stages += it }
+    }
+    assertTrue(stages.isEmpty(), "$label reached live mutation")
+    assertEquals(before, session.captureDetachedState(), "$label changed the session")
+  }
+
   private fun MachineState.record(className: String): RecordState {
     fun find(value: StateValue): RecordState? =
         when (value) {
@@ -619,6 +895,15 @@ class DetachedStateTest {
 
   private fun mbc3Rom(): ByteArray = slotRom(0x10, 0x03)
 
+  private fun basicRom(): ByteArray = slotRom(0x08, 0x02)
+
+  private fun cgbIdleRom(): ByteArray =
+      ByteArray(0x8000).also {
+        it[0x100] = 0x18
+        it[0x101] = 0xfe.toByte()
+        it[0x143] = 0x80.toByte()
+      }
+
   private fun slotRom(type: Int, ramSize: Int): ByteArray =
       ByteArray(0x8000).also {
         intArrayOf(0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d).forEachIndexed { index, value ->
@@ -659,16 +944,23 @@ class DetachedStateTest {
     const val HDMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento"
     const val SPEED_MEMENTO = "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento"
     const val SOUND_MODE_MEMENTO = "eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento"
+    const val SOUND_MODE3_MEMENTO = "eu.rekawek.coffeegb.core.sound.SoundMode3\$SoundMode3Memento"
+    const val POLYNOMIAL_COUNTER_MEMENTO =
+        "eu.rekawek.coffeegb.core.sound.PolynomialCounter\$PolynomialCounterMemento"
     const val SERIAL_PORT_MEMENTO = "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
     const val CARTRIDGE_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.Cartridge\$CartridgeMemento"
     const val MBC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3Memento"
     const val INT_QUEUE_MEMENTO = "eu.rekawek.coffeegb.core.gpu.IntQueue\$IntQueueMemento"
+    const val DMG_FIFO_MEMENTO = "eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento"
+    const val COLOR_FIFO_MEMENTO =
+        "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento"
     const val SGB_DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento"
     const val SUPER_GAMEBOY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento"
     const val BACKGROUND_MEMENTO = "eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento"
     const val TRANSFER_MEMENTO =
         "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento"
     const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento"
+    const val GENIE_MEMENTO = "eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento"
     const val RTC_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento"
     const val HUC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3Memento"
     const val TAMA5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Tama5\$Tama5Memento"

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -7,10 +7,13 @@ import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
 import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
 import eu.rekawek.coffeegb.core.serial.ByteReceivingSerialEndpoint
+import eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -120,7 +123,7 @@ class DetachedStateTest {
       val before = session.captureDetachedState()
       val invalidRoot = RecordState(before.machine.root.typeId, before.machine.root.fields.dropLast(1))
       val invalid = SessionState(
-          MachineState(invalidRoot, before.machine.rtcRuntime),
+          MachineState(invalidRoot, before.machine.rtcRuntime, before.machine.hardware),
           before.serialPeripheral,
           before.serialState,
           before.serialRuntime,
@@ -129,6 +132,150 @@ class DetachedStateTest {
 
       assertFailsWith<StateApplyException> { session.restoreDetachedState(invalid) }
       assertEquals(before, session.captureDetachedState())
+    }
+  }
+
+  @Test
+  fun mapperEndpointAndInvariantDimensionsAreRejectedBeforeLiveMutation() {
+    session().use { target ->
+      session(configuration(mbc3Rom())).use { differentMapper ->
+        val before = target.captureDetachedState()
+        val mbc3 = differentMapper.captureDetachedState().machine.record(MBC3_MEMENTO)
+        val wrongRoot =
+            before.machine.root.replaceRecordField(
+                CARTRIDGE_MEMENTO, "memoryControllerMemento", mbc3)
+        val wrongMapper = before.withMachineRoot(wrongRoot)
+        val stages = mutableListOf<ApplyStage>()
+
+        assertFailsWith<StateApplyException> {
+          DetachedStateAdapter.apply(target, wrongMapper) { stages += it }
+        }
+        assertTrue(stages.isEmpty())
+        assertEquals(before, target.captureDetachedState())
+
+        val display = before.machine.record(DISPLAY_MEMENTO)
+        val shortBuffer =
+            Int32ArrayState(display.intArray("buffer").copyOf(display.intArray("buffer").size - 1))
+        val wrongDimensions =
+            before.withMachineRoot(
+                before.machine.root.replaceRecordField(DISPLAY_MEMENTO, "buffer", shortBuffer))
+        assertFailsWith<StateApplyException> {
+          DetachedStateAdapter.apply(target, wrongDimensions) { stages += it }
+        }
+        assertTrue(stages.isEmpty())
+        assertEquals(before, target.captureDetachedState())
+      }
+    }
+
+    val receiver = ByteReceivingSerialEndpoint { _ -> }
+    session(receiver).use { target ->
+      session(GameboyPrinterSerialEndpoint { _, _, _, _, _, _ -> }).use { printer ->
+        val before = target.captureDetachedState()
+        val printerState = printer.captureDetachedState().serialState
+        val wrongEndpoint =
+            SessionState(
+                before.machine,
+                before.serialPeripheral,
+                printerState,
+                before.serialRuntime,
+                before.heldButtons,
+            )
+        val stages = mutableListOf<ApplyStage>()
+        assertFailsWith<StateApplyException> {
+          DetachedStateAdapter.apply(target, wrongEndpoint) { stages += it }
+        }
+        assertTrue(stages.isEmpty())
+        assertEquals(before, target.captureDetachedState())
+      }
+    }
+  }
+
+  @Test
+  fun unexpectedLiveFailureRollsBackMachineRtcEndpointRuntimeAndHeldInput() {
+    val time = VirtualTimeSource(120_000)
+    val endpoint = BarcodeBoySerialEndpoint()
+    val config = configuration(mbc3Rom()).setRtcTimeSource(time)
+    session(config, endpoint).use { session ->
+      repeat(32) {
+        endpoint.startSending()
+        repeat(8) { endpoint.sendBit() }
+      }
+      endpoint.scan("4901234567894")
+      endpoint.setExternalTransfer(true)
+      session.heldButtons = setOf(Button.START)
+      session.gameboy.setCartridgeClockPaused(true)
+      val target = session.captureDetachedState()
+
+      time.forward(2, TimeUnit.SECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      repeat(2_000) { session.gameboy.tick() }
+      repeat(64) { endpoint.recvBit() }
+      endpoint.setExternalTransfer(false)
+      session.heldButtons = setOf(Button.B)
+      val beforeFailure = session.captureDetachedState()
+      var reachedLiveFailure = false
+
+      assertFailsWith<StateApplyException> {
+        DetachedStateAdapter.apply(session, target) { stage ->
+          if (stage == ApplyStage.AFTER_MACHINE_MUTATION) {
+            reachedLiveFailure = true
+            throw InjectedApplyFailure()
+          }
+        }
+      }
+
+      assertTrue(reachedLiveFailure)
+      assertEquals(beforeFailure, session.captureDetachedState())
+    }
+  }
+
+  @Test
+  fun datelSlotRtcLocationsUseInjectedTimeAndRoundTripIndependently() {
+    val time = VirtualTimeSource(120_000)
+    val config = datelConfiguration(mbc3Rom(), time)
+    session(config).use { session ->
+      repeat(Gameboy.TICKS_PER_SEC / 4) { session.gameboy.tick() }
+      session.gameboy.setCartridgeClockPaused(true)
+      time.forward(1500, TimeUnit.MILLISECONDS)
+      val captured = session.captureDetachedState()
+      assertEquals(null, captured.machine.rtcRuntime.primary)
+      assertTrue(captured.machine.rtcRuntime.slot?.emulationPaused == true)
+      assertEquals(
+          3L * Gameboy.TICKS_PER_SEC / 4,
+          captured.machine.record(RTC_MEMENTO).long("subSecondTicks"),
+      )
+
+      val capturedTime = time.currentTimeMillis()
+      time.forward(250, TimeUnit.MILLISECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      repeat(128) { session.gameboy.tick() }
+      val expected = session.captureDetachedState()
+
+      time.forward(5, TimeUnit.SECONDS)
+      repeat(1_000) { session.gameboy.tick() }
+      session.restoreDetachedState(captured)
+      time.setCurrentTimeMillis(capturedTime)
+      time.forward(250, TimeUnit.MILLISECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      repeat(128) { session.gameboy.tick() }
+      assertEquals(expected, session.captureDetachedState())
+    }
+
+    listOf(HUC3_MEMENTO to slotRom(0xfe, 0x03), TAMA5_MEMENTO to slotRom(0xfd, 0)).forEach {
+        (mementoName, slotRom) ->
+      val familyTime = VirtualTimeSource(120_000)
+      session(datelConfiguration(slotRom, familyTime)).use { session ->
+        familyTime.forward(2, TimeUnit.MINUTES)
+        val bus = session.gameboy.addressSpace
+        bus.setByte(0x7fe5, 0x10)
+        if (mementoName == HUC3_MEMENTO) {
+          readHuc3Register(bus, 0)
+        } else {
+          readTama5Minutes(bus)
+        }
+        val reference = session.captureDetachedState().machine.record(mementoName).long("lastRtcSecond")
+        assertEquals(240L, reference, mementoName)
+      }
     }
   }
 
@@ -232,6 +379,46 @@ class DetachedStateTest {
   private fun RecordState.bool(name: String): Boolean =
       (fields.single { it.name == name }.value as BooleanState).value
 
+  private fun RecordState.long(name: String): Long =
+      (fields.single { it.name == name }.value as Int64State).value
+
+  private fun SessionState.withMachineRoot(root: RecordState): SessionState =
+      SessionState(
+          MachineState(root, machine.rtcRuntime, machine.hardware),
+          serialPeripheral,
+          serialState,
+          serialRuntime,
+          heldButtons,
+      )
+
+  private fun RecordState.replaceRecordField(
+      ownerClass: String,
+      fieldName: String,
+      replacement: StateValue,
+  ): RecordState {
+    fun replace(value: StateValue): StateValue =
+        when (value) {
+          is RecordState -> {
+            val owner = MementoClassNames.record(value.typeId) == ownerClass
+            RecordState(
+                value.typeId,
+                value.fields.map { field ->
+                  StateField(
+                      field.name,
+                      if (owner && field.name == fieldName) replacement else replace(field.value),
+                  )
+                },
+            )
+          }
+          is ObjectArrayState -> ObjectArrayState(value.values.map(::replace))
+          is ListState -> ListState(value.values.map(::replace))
+          is Int32MapState ->
+              Int32MapState(value.entries.map { Int32MapEntry(it.key, replace(it.value)) })
+          else -> value
+        }
+    return replace(this) as RecordState
+  }
+
   private fun firstDifference(expected: StateValue, actual: StateValue, path: String = "root"): String {
     if (expected == actual) return "states are equal"
     if (expected::class != actual::class) return "$path: ${expected::class} != ${actual::class}"
@@ -275,6 +462,56 @@ class DetachedStateTest {
     return rom
   }
 
+  private fun datelConfiguration(slot: ByteArray, time: VirtualTimeSource) =
+      configuration(datelRom())
+          .setGameboyType(GameboyType.CGB)
+          .setSlotRom(Rom(slot))
+          .setRtcTimeSource(time)
+          .setSupportBatterySave(false)
+
+  private fun datelRom(): ByteArray =
+      ByteArray(0x20000).also {
+        it[0x100] = 0x00
+        it[0x101] = 0xc3.toByte()
+        it[0x104] = 0x44 // invalid Nintendo logo selects the Datel mapper
+        it[0x147] = 0x00
+        it[0x148] = 0x02
+      }
+
+  private fun mbc3Rom(): ByteArray = slotRom(0x10, 0x03)
+
+  private fun slotRom(type: Int, ramSize: Int): ByteArray =
+      ByteArray(0x8000).also {
+        intArrayOf(0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d).forEachIndexed { index, value ->
+          it[0x104 + index] = value.toByte()
+        }
+        it[0x100] = 0x18
+        it[0x101] = 0xfe.toByte()
+        it[0x147] = type.toByte()
+        it[0x148] = 0x00
+        it[0x149] = ramSize.toByte()
+      }
+
+  private fun readHuc3Register(bus: eu.rekawek.coffeegb.core.AddressSpace, register: Int): Int {
+    bus.setByte(0x0000, 0x0b)
+    bus.setByte(0xa000, 0x40 or (register and 0x0f))
+    bus.setByte(0xa000, 0x50 or ((register shr 4) and 0x0f))
+    bus.setByte(0xa000, 0x10)
+    bus.setByte(0x0000, 0x0c)
+    return bus.getByte(0xa000)
+  }
+
+  private fun readTama5Minutes(bus: eu.rekawek.coffeegb.core.AddressSpace): Int {
+    bus.setByte(0xa001, 0x6)
+    bus.setByte(0xa000, 0x4)
+    bus.setByte(0xa001, 0x7)
+    bus.setByte(0xa000, 0x6)
+    bus.setByte(0xa001, 0xc)
+    return bus.getByte(0xa000) and 0x0f
+  }
+
+  private class InjectedApplyFailure : RuntimeException()
+
   private companion object {
     const val DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
     const val DMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Dma\$DmaMemento"
@@ -282,6 +519,11 @@ class DetachedStateTest {
     const val SPEED_MEMENTO = "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento"
     const val SOUND_MODE_MEMENTO = "eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento"
     const val SERIAL_PORT_MEMENTO = "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
+    const val CARTRIDGE_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.Cartridge\$CartridgeMemento"
+    const val MBC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3Memento"
+    const val RTC_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento"
+    const val HUC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3Memento"
+    const val TAMA5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Tama5\$Tama5Memento"
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -191,6 +191,128 @@ class DetachedStateTest {
   }
 
   @Test
+  fun requiredArraysAndSemanticCursorsAreRejectedBeforeAnyLiveMutation() {
+    session(configuration(mbc3Rom())).use { session ->
+      repeat(2_000) { session.gameboy.tick() }
+      val before = session.captureDetachedState()
+      val display = before.machine.record(DISPLAY_MEMENTO)
+      val queue = before.machine.record(INT_QUEUE_MEMENTO)
+
+      val invalidRoots =
+          listOf(
+              before.machine.root.replaceRecordField(DISPLAY_MEMENTO, "buffer", NullState),
+              before.machine.root.replaceRecordField(INT_QUEUE_MEMENTO, "array", NullState),
+              before.machine.root.replaceRecordField(MBC3_MEMENTO, "ram", NullState),
+              before.machine.root.replaceRecordField(SGB_DISPLAY_MEMENTO, "palettes", NullState),
+              before.machine.root.replaceRecordField(
+                  INT_QUEUE_MEMENTO,
+                  "size",
+                  Int32State(queue.intArray("array").size + 1),
+              ),
+              before.machine.root.replaceRecordField(
+                  INT_QUEUE_MEMENTO,
+                  "offset",
+                  Int32State(queue.intArray("array").size),
+              ),
+              before.machine.root.replaceRecordField(
+                  DISPLAY_MEMENTO,
+                  "i",
+                  Int32State(display.intArray("buffer").size + 1),
+              ),
+          )
+
+      invalidRoots.forEachIndexed { index, root ->
+        val stages = mutableListOf<ApplyStage>()
+        assertFailsWith<StateApplyException>("invalid case $index") {
+          DetachedStateAdapter.apply(session, before.withMachineRoot(root)) { stages += it }
+        }
+        assertTrue(stages.isEmpty(), "invalid case $index reached live mutation")
+        assertEquals(before, session.captureDetachedState(), "invalid case $index changed the session")
+      }
+
+      // Inclusive display completion and a full circular queue at its last physical slot are
+      // valid boundary states. Validate the reconstructed records without mutating the session.
+      StateSemantics.validate(
+          StateGraph.restore(
+              display.replaceField("i", Int32State(display.intArray("buffer").size))))
+      StateSemantics.validate(
+          StateGraph.restore(
+              queue
+                  .replaceField("size", Int32State(queue.intArray("array").size))
+                  .replaceField("offset", Int32State(queue.intArray("array").lastIndex))))
+    }
+  }
+
+  @Test
+  fun auditedNullableRecordArrayEnumCollectionPayloadAndRowCategoriesRemainCompatible() {
+    session().use { session ->
+      repeat(2_000) { session.gameboy.tick() }
+      val state = session.captureDetachedState().machine
+
+      // Legacy duplicate root display record (record), last-frame cache (primitive array),
+      // unpublished HDMA mode (enum), and old pending-write inventory (list).
+      val legacyDisplayRoot =
+          state.root.replaceRecordField(GAMEBOY_MEMENTO, "displayMemento", state.record(DISPLAY_MEMENTO))
+      StateGraph.validateCompatible(legacyDisplayRoot, state.root, "legacy-root-display")
+      StateGraph.validateCompatible(
+          state.root.replaceRecordField(DISPLAY_MEMENTO, "lastFrame", NullState),
+          state.root,
+          "legacy-last-frame",
+      )
+      StateGraph.validateCompatible(
+          state.root.replaceRecordField(HDMA_MEMENTO, "gpuMode", NullState),
+          state.root,
+          "unpublished-hdma-mode",
+      )
+      StateGraph.validateCompatible(
+          state.root.replaceRecordField(GPU_MEMENTO, "pendingPpuWrites", NullState),
+          state.root,
+          "legacy-pending-writes",
+      )
+
+      // SGB row elements are independently nullable by PAL_SET/legacy state.
+      val display = state.record(SGB_DISPLAY_MEMENTO)
+      val palettes = display.field("palettes") as ObjectArrayState
+      val withNullRow =
+          display.replaceField(
+              "palettes",
+              ObjectArrayState(palettes.values.mapIndexed { index, value -> if (index == 0) NullState else value }),
+          )
+      StateGraph.validateCompatible(withNullRow, display, "nullable-sgb-row")
+    }
+
+    val transfer = transferCommand(0x14)
+    val transferWithPayload = transfer.replaceField("dataTransfer", Int32ArrayState(IntArray(0x1000)))
+    StateGraph.validateCompatible(transferWithPayload, transfer, "optional-transfer-payload")
+    StateSemantics.validate(StateGraph.restore(transferWithPayload))
+
+    val superGameboy = session().use { it.captureDetachedState().machine.record(SUPER_GAMEBOY_MEMENTO) }
+    val withWaiting = superGameboy.replaceField("waitingTransferCommandMemento", transfer)
+    StateGraph.validateCompatible(withWaiting, superGameboy, "optional-waiting-transfer")
+    StateSemantics.validate(StateGraph.restore(withWaiting))
+
+    val background = session().use { it.captureDetachedState().machine.record(BACKGROUND_MEMENTO) }
+    val withPicture = background.replaceField("pendingPictureMemento", transfer)
+    StateGraph.validateCompatible(withPicture, background, "optional-pending-picture")
+    StateSemantics.validate(StateGraph.restore(withPicture))
+
+    val barcode = BarcodeBoySerialEndpoint()
+    val barcodeState = StateGraph.capture(barcode.saveToMemento()) as RecordState
+    val barcodeWithData = barcodeState.replaceField("data", Int32ArrayState(IntArray(30)))
+    StateGraph.validateCompatible(barcodeWithData, barcodeState, "optional-barcode-data")
+
+    session(configuration(datelRom())).use { emptySlot ->
+      session(datelConfiguration(mbc3Rom(), VirtualTimeSource(120_000))).use { populatedSlot ->
+        StateGraph.validateCompatible(
+            populatedSlot.captureDetachedState().machine.record(DATEL_MEMENTO),
+            emptySlot.captureDetachedState().machine.record(DATEL_MEMENTO),
+            "optional-datel-slot",
+        )
+      }
+    }
+  }
+
+  @Test
   fun unexpectedLiveFailureRollsBackMachineRtcEndpointRuntimeAndHeldInput() {
     val time = VirtualTimeSource(120_000)
     val endpoint = BarcodeBoySerialEndpoint()
@@ -215,7 +337,7 @@ class DetachedStateTest {
       val beforeFailure = session.captureDetachedState()
       var reachedLiveFailure = false
 
-      assertFailsWith<StateApplyException> {
+      val failure = assertFailsWith<StateApplyException> {
         DetachedStateAdapter.apply(session, target) { stage ->
           if (stage == ApplyStage.AFTER_MACHINE_MUTATION) {
             reachedLiveFailure = true
@@ -224,7 +346,7 @@ class DetachedStateTest {
         }
       }
 
-      assertTrue(reachedLiveFailure)
+      assertTrue(reachedLiveFailure, failure.toString())
       assertEquals(beforeFailure, session.captureDetachedState())
     }
   }
@@ -371,6 +493,23 @@ class DetachedStateTest {
   private fun RecordState.arrayState(name: String): Int32ArrayState =
       fields.single { it.name == name }.value as Int32ArrayState
 
+  private fun RecordState.field(name: String): StateValue = fields.single { it.name == name }.value
+
+  private fun RecordState.replaceField(name: String, replacement: StateValue): RecordState =
+      RecordState(
+          typeId,
+          fields.map { field -> if (field.name == name) StateField(name, replacement) else field },
+      )
+
+  private fun transferCommand(code: Int): RecordState =
+      RecordState(
+          eu.rekawek.coffeegb.controller.MementoTypeRegistry.recordClassNames.indexOf(TRANSFER_MEMENTO) + 1,
+          listOf(
+              StateField("packet", Int32ArrayState(IntArray(16).also { it[0] = (code shl 3) or 1 })),
+              StateField("dataTransfer", NullState),
+          ),
+      )
+
   private fun RecordState.intArray(name: String): IntArray = arrayState(name).copyValue()
 
   private fun RecordState.int(name: String): Int =
@@ -514,6 +653,8 @@ class DetachedStateTest {
 
   private companion object {
     const val DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
+    const val GAMEBOY_MEMENTO = "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento"
+    const val GPU_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuMemento"
     const val DMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Dma\$DmaMemento"
     const val HDMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento"
     const val SPEED_MEMENTO = "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento"
@@ -521,6 +662,13 @@ class DetachedStateTest {
     const val SERIAL_PORT_MEMENTO = "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
     const val CARTRIDGE_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.Cartridge\$CartridgeMemento"
     const val MBC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3Memento"
+    const val INT_QUEUE_MEMENTO = "eu.rekawek.coffeegb.core.gpu.IntQueue\$IntQueueMemento"
+    const val SGB_DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento"
+    const val SUPER_GAMEBOY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento"
+    const val BACKGROUND_MEMENTO = "eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento"
+    const val TRANSFER_MEMENTO =
+        "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento"
+    const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento"
     const val RTC_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento"
     const val HUC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3Memento"
     const val TAMA5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Tama5\$Tama5Memento"

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -140,7 +140,7 @@ class DetachedStateTest {
       assertTrue(timingRuntime.linePixels > 0)
       assertTrue(timingRuntime.outCount > 0)
       assertTrue(pendingRuntime.linePixels > 0)
-      assertTrue(pendingRuntime.outCount > 0)
+      assertEquals(1, pendingRuntime.outCount)
       assertTrue(pendingRuntime.firstEntry in 0..0x3f)
       assertTrue(pendingRuntime.firstBgp in 0..0xff)
       assertTrue(pendingRuntime.firstObp0 in 0..0xff)
@@ -200,6 +200,125 @@ class DetachedStateTest {
       val actual = session.captureDetachedState()
       assertEquals(expectedDisplay, actual.machine.record(DISPLAY_MEMENTO))
       assertEquals(expected, actual)
+    }
+  }
+
+  @Test
+  fun invalidDmgFifoRuntimeIsRejectedBeforeAnyLiveMutation() {
+    session(configuration().setGameboyType(GameboyType.DMG)).use { session ->
+      repeat(400) { session.gameboy.tick() }
+      val before = session.captureDetachedState()
+      val capturedRuntime = requireNotNull(before.machine.dmgFifoRuntime)
+      val neutral = DmgPixelFifoRuntimeState(0, 0, -1, 0, 0, 0)
+      val invalidStates =
+          listOf<Pair<String, DmgPixelFifoRuntimeState>>(
+              "linePixels below zero" to neutral.copy(linePixels = -1),
+              "linePixels above the visible line" to neutral.copy(linePixels = 161),
+              "negative outCount" to neutral.copy(outCount = -1),
+              "firstEntry below its sentinel" to neutral.copy(firstEntry = -2),
+              "firstEntry above its packed range" to neutral.copy(firstEntry = 0x40),
+              "pending firstEntry without its first output" to
+                  neutral.copy(outCount = 0, firstEntry = 0),
+              "pending firstEntry after the first output" to
+                  neutral.copy(outCount = 2, firstEntry = 0),
+              "BGP below byte range" to neutral.copy(firstBgp = -1),
+              "BGP above byte range" to neutral.copy(firstBgp = 0x100),
+              "OBP0 below byte range" to neutral.copy(firstObp0 = -1),
+              "OBP0 above byte range" to neutral.copy(firstObp0 = 0x100),
+              "OBP1 below byte range" to neutral.copy(firstObp1 = -1),
+              "OBP1 above byte range" to neutral.copy(firstObp1 = 0x100),
+          )
+
+      invalidStates.forEach { (case, invalidRuntime) ->
+        val timingCandidate =
+            before.withDmgFifoRuntime(capturedRuntime.copy(timing = invalidRuntime))
+        assertRejectedBeforeMutation(session, before, timingCandidate, "timing FIFO: $case")
+
+        val outputCandidate =
+            before.withDmgFifoRuntime(capturedRuntime.copy(output = invalidRuntime))
+        assertRejectedBeforeMutation(session, before, outputCandidate, "output FIFO: $case")
+      }
+    }
+  }
+
+  @Test
+  fun dmgFifoRuntimePresenceMatchesHardwareBeforeAnyLiveMutation() {
+    listOf(GameboyType.DMG, GameboyType.SGB).forEach { hardware ->
+      session(configuration().setGameboyType(hardware)).use { session ->
+        val before = session.captureDetachedState()
+        assertRejectedBeforeMutation(
+            session,
+            before,
+            before.withDmgFifoRuntime(null),
+            "$hardware state without its FIFO supplement",
+        )
+      }
+    }
+
+    val dmgRuntime =
+        session(configuration().setGameboyType(GameboyType.DMG)).use {
+          requireNotNull(it.captureDetachedState().machine.dmgFifoRuntime)
+        }
+    session(configuration(cgbIdleRom()).setGameboyType(GameboyType.CGB)).use { session ->
+      val before = session.captureDetachedState()
+      assertRejectedBeforeMutation(
+          session,
+          before,
+          before.withDmgFifoRuntime(dmgRuntime),
+          "native CGB state with a DMG FIFO supplement",
+      )
+    }
+  }
+
+  @Test
+  fun reachableDmgAndSgbFifoRuntimeBoundariesApplyAtTheAtomicBoundary() {
+    listOf(GameboyType.DMG, GameboyType.SGB).forEach { hardware ->
+      session(configuration().setGameboyType(hardware)).use { session ->
+        val initial = session.captureDetachedState()
+        val initialRuntime = requireNotNull(initial.machine.dmgFifoRuntime)
+        listOf(initialRuntime.timing, initialRuntime.output).forEach {
+          assertEquals(0, it.linePixels, "$hardware FIFO did not begin at line position zero")
+          assertEquals(0, it.outCount, "$hardware FIFO did not begin before output")
+          assertEquals(-1, it.firstEntry, "$hardware FIFO began with a pending first pixel")
+        }
+        assertAcceptedAtMutationBoundary(session, initial, "$hardware initial FIFO boundary")
+
+        val sawLineEnd = BooleanArray(2)
+        var sawPendingFirst = false
+        var sawActiveProgress = false
+        repeat(5_000) {
+          session.gameboy.tick()
+          val coreRuntime = requireNotNull(session.gameboy.captureDmgFifoRuntimeState())
+          val runtime = listOf(coreRuntime.timing(), coreRuntime.output())
+          var sample = false
+          runtime.forEachIndexed { index, fifo ->
+            if (!sawLineEnd[index] && fifo.linePixels() == 160) {
+              sawLineEnd[index] = true
+              sample = true
+            }
+            if (!sawPendingFirst && fifo.firstEntry() >= 0) {
+              assertEquals(1, fifo.outCount())
+              sawPendingFirst = true
+              sample = true
+            }
+            if (!sawActiveProgress && fifo.linePixels() in 1..159) {
+              sawActiveProgress = true
+              sample = true
+            }
+          }
+          if (sample) {
+            assertAcceptedAtMutationBoundary(
+                session,
+                session.captureDetachedState(),
+                "$hardware reachable FIFO sample",
+            )
+          }
+        }
+
+        assertTrue(sawLineEnd.all { it }, "$hardware FIFOs never reached line position 160")
+        assertTrue(sawPendingFirst, "$hardware FIFO never held the first output entry")
+        assertTrue(sawActiveProgress, "$hardware FIFO never showed active line progress")
+      }
     }
   }
 
@@ -916,6 +1035,21 @@ class DetachedStateTest {
     assertEquals(before, session.captureDetachedState(), "$label changed the session")
   }
 
+  private fun assertAcceptedAtMutationBoundary(
+      session: Session,
+      state: SessionState,
+      label: String,
+  ) {
+    val stages = mutableListOf<ApplyStage>()
+    DetachedStateAdapter.apply(session, state) { stages += it }
+    assertEquals(
+        listOf(ApplyStage.BEFORE_LIVE_MUTATION, ApplyStage.AFTER_MACHINE_MUTATION),
+        stages,
+        "$label did not cross the expected apply stages",
+    )
+    assertEquals(state, session.captureDetachedState(), "$label did not restore exactly")
+  }
+
   private fun MachineState.record(className: String): RecordState {
     return requireNotNull(records(className).firstOrNull()) { "Missing $className" }
   }
@@ -983,6 +1117,15 @@ class DetachedStateTest {
   private fun SessionState.withMachineRoot(root: RecordState): SessionState =
       SessionState(
           MachineState(root, machine.rtcRuntime, machine.hardware, machine.dmgFifoRuntime),
+          serialPeripheral,
+          serialState,
+          serialRuntime,
+          heldButtons,
+      )
+
+  private fun SessionState.withDmgFifoRuntime(runtime: DmgFifoRuntimeState?): SessionState =
+      SessionState(
+          MachineState(machine.root, machine.rtcRuntime, machine.hardware, runtime),
           serialPeripheral,
           serialState,
           serialRuntime,

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -1,0 +1,287 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.Session
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
+import eu.rekawek.coffeegb.core.serial.ByteReceivingSerialEndpoint
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint
+import java.nio.file.Paths
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DetachedStateTest {
+
+  @Test
+  fun nontrivialPpuAndDisplayStateRoundTripsAndContinuesDeterministically() {
+    session().use { session ->
+      repeat(31_337) { session.gameboy.tick() }
+      assertNotEquals(0, session.gameboy.gpu.ticksInLine)
+      session.heldButtons = setOf(Button.A, Button.RIGHT)
+
+      val captured = session.captureDetachedState()
+      val display = captured.machine.record(DISPLAY_MEMENTO)
+      val buffer = display.intArray("buffer")
+      val lastFrame = display.intArray("lastFrame")
+      assertEquals(160 * 144, buffer.size)
+      assertEquals(160 * 144, lastFrame.size)
+
+      repeat(4_321) { session.gameboy.tick() }
+      val expectedContinuation = session.captureDetachedState().machine
+      session.heldButtons = setOf(Button.B)
+
+      session.restoreDetachedState(captured)
+      assertEquals(setOf(Button.A, Button.RIGHT), session.heldButtons)
+      val restoredDisplay = session.captureDetachedState().machine.record(DISPLAY_MEMENTO)
+      assertContentEquals(buffer, restoredDisplay.intArray("buffer"))
+      assertContentEquals(lastFrame, restoredDisplay.intArray("lastFrame"))
+
+      repeat(4_321) { session.gameboy.tick() }
+      val actualContinuation = session.captureDetachedState().machine
+      assertEquals(expectedContinuation, actualContinuation, firstDifference(expectedContinuation.root, actualContinuation.root))
+    }
+  }
+
+  @Test
+  fun doubleSpeedActiveDmaHdmaSerialAndAudioContinueDeterministically() {
+    session(configuration(cgbSpeedSwitchRom()).setGameboyType(GameboyType.CGB)).use { session ->
+      repeat(140_000) {
+        if (session.gameboy.speedMode.speedMode == 1 || session.gameboy.cpu.isSpeedSwitching) {
+          session.gameboy.tick()
+        }
+      }
+      assertEquals(2, session.gameboy.speedMode.speedMode)
+
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff26, 0x80)
+      bus.setByte(0xff11, 0x80)
+      bus.setByte(0xff12, 0xf3)
+      bus.setByte(0xff13, 0x40)
+      bus.setByte(0xff14, 0x87)
+      bus.setByte(0xff01, 0xa5)
+      bus.setByte(0xff02, 0x81)
+      bus.setByte(0xff51, 0xc0)
+      bus.setByte(0xff52, 0x00)
+      bus.setByte(0xff53, 0x00)
+      bus.setByte(0xff54, 0x00)
+      bus.setByte(0xff55, 0x80)
+      bus.setByte(0xff46, 0xc0)
+
+      val captured = session.captureDetachedState()
+      assertTrue(captured.machine.record(DMA_MEMENTO).bool("transferInProgress"))
+      assertTrue(captured.machine.record(HDMA_MEMENTO).bool("transferInProgress"))
+      assertTrue(captured.machine.record(SPEED_MEMENTO).bool("currentSpeed"))
+      assertTrue(captured.machine.record(SOUND_MODE_MEMENTO).bool("channelEnabled"))
+      assertEquals(0x81, captured.machine.record(SERIAL_PORT_MEMENTO).int("sc"))
+
+      repeat(96) { session.gameboy.tick() }
+      val expected = session.captureDetachedState()
+      session.restoreDetachedState(captured)
+      repeat(96) { session.gameboy.tick() }
+      assertEquals(expected, session.captureDetachedState())
+    }
+  }
+
+  @Test
+  fun rootOwnsExactlyOneDisplayAndArraysAreDetachedAcrossCaptures() {
+    session().use { session ->
+      repeat(8_765) { session.gameboy.tick() }
+      val first = session.captureDetachedState()
+
+      assertEquals(1, first.machine.recordCount(DISPLAY_MEMENTO))
+      val owned = first.machine.record(DISPLAY_MEMENTO).arrayState("buffer")
+      val original = owned.copyValue()
+      val escapedCopy = owned.copyValue().also { it[0] = it[0] xor 0x00ffffff }
+      assertNotEquals(escapedCopy[0], owned.copyValue()[0])
+
+      repeat(1_111) { session.gameboy.tick() }
+      val second = session.captureDetachedState()
+      session.restoreDetachedState(first)
+      assertContentEquals(original, first.machine.record(DISPLAY_MEMENTO).intArray("buffer"))
+
+      session.restoreDetachedState(second)
+      assertEquals(second, session.captureDetachedState())
+      assertContentEquals(original, first.machine.record(DISPLAY_MEMENTO).intArray("buffer"))
+    }
+  }
+
+  @Test
+  fun completeGraphIsValidatedBeforeMutationAndFailedApplyIsAtomic() {
+    session().use { session ->
+      repeat(2_000) { session.gameboy.tick() }
+      val before = session.captureDetachedState()
+      val invalidRoot = RecordState(before.machine.root.typeId, before.machine.root.fields.dropLast(1))
+      val invalid = SessionState(
+          MachineState(invalidRoot, before.machine.rtcRuntime),
+          before.serialPeripheral,
+          before.serialState,
+          before.serialRuntime,
+          before.heldButtons,
+      )
+
+      assertFailsWith<StateApplyException> { session.restoreDetachedState(invalid) }
+      assertEquals(before, session.captureDetachedState())
+    }
+  }
+
+  @Test
+  fun statefulEndpointAndHeldInputAreOwnedWhileCallbackIsExcluded() {
+    val received = mutableListOf<Int>()
+    val endpoint = ByteReceivingSerialEndpoint(received::add)
+    session(endpoint).use { session ->
+      endpoint.setSb(0xa5)
+      endpoint.startSending()
+      repeat(3) { endpoint.sendBit() }
+      session.heldButtons = setOf(Button.START)
+      val captured = session.captureDetachedState()
+
+      repeat(5) { endpoint.sendBit() }
+      session.heldButtons = emptySet()
+      assertEquals(listOf(0xa5), received)
+
+      session.restoreDetachedState(captured)
+      assertEquals(setOf(Button.START), session.heldButtons)
+      repeat(5) { endpoint.sendBit() }
+      assertEquals(listOf(0xa5, 0xa5), received)
+    }
+  }
+
+  @Test
+  fun barcodePendingPayloadAndExternalTransferLatchAreDetachedAndRestored() {
+    val endpoint = BarcodeBoySerialEndpoint()
+    session(endpoint).use { session ->
+      repeat(32) {
+        endpoint.startSending()
+        repeat(8) { endpoint.sendBit() }
+      }
+      endpoint.scan("4901234567894")
+      endpoint.setExternalTransfer(true)
+      val captured = session.captureDetachedState()
+
+      repeat(512) { endpoint.recvBit() }
+      endpoint.setExternalTransfer(false)
+      assertTrue(endpoint.isScanPending)
+
+      session.restoreDetachedState(captured)
+      assertEquals(captured, session.captureDetachedState())
+      assertTrue(endpoint.isScanPending)
+      assertTrue((captured.serialRuntime as BarcodeBoyRuntimeState).transferArmed)
+    }
+  }
+
+  @Test
+  fun unknownStatefulPeripheralFailsExplicitlyInsteadOfBeingOmitted() {
+    val endpoint = object : SerialEndpoint {
+      override fun setSb(sb: Int) = Unit
+      override fun recvBit(): Int = -1
+      override fun startSending() = Unit
+      override fun sendBit(): Int = 1
+      override fun saveToMemento() = null
+      override fun restoreFromMemento(memento: eu.rekawek.coffeegb.core.memento.Memento<SerialEndpoint>?) = Unit
+    }
+    session(endpoint).use { session ->
+      val failure = assertFailsWith<StateCaptureException> { session.captureDetachedState() }
+      assertTrue(failure.message.orEmpty().contains("Unsupported serial endpoint"))
+    }
+  }
+
+  private fun session(endpoint: SerialEndpoint = SerialEndpoint.NULL_ENDPOINT): Session =
+      session(configuration(), endpoint)
+
+  private fun session(
+      configuration: Gameboy.GameboyConfiguration,
+      endpoint: SerialEndpoint = SerialEndpoint.NULL_ENDPOINT,
+  ): Session = Session(configuration, EventBusImpl(), null, endpoint)
+
+  private fun configuration(): Gameboy.GameboyConfiguration =
+      Gameboy.GameboyConfiguration(Rom(ROM)).setBootstrapMode(BootstrapMode.SKIP)
+
+  private fun configuration(bytes: ByteArray): Gameboy.GameboyConfiguration =
+      Gameboy.GameboyConfiguration(Rom(bytes)).setBootstrapMode(BootstrapMode.SKIP)
+
+  private fun MachineState.record(className: String): RecordState {
+    fun find(value: StateValue): RecordState? =
+        when (value) {
+          is RecordState ->
+              if (MementoClassNames.record(value.typeId) == className) value
+              else value.fields.firstNotNullOfOrNull { find(it.value) }
+          is ObjectArrayState -> value.values.firstNotNullOfOrNull(::find)
+          is ListState -> value.values.firstNotNullOfOrNull(::find)
+          is Int32MapState -> value.entries.firstNotNullOfOrNull { find(it.value) }
+          else -> null
+        }
+    return requireNotNull(find(root)) { "Missing $className" }
+  }
+
+  private fun RecordState.arrayState(name: String): Int32ArrayState =
+      fields.single { it.name == name }.value as Int32ArrayState
+
+  private fun RecordState.intArray(name: String): IntArray = arrayState(name).copyValue()
+
+  private fun RecordState.int(name: String): Int =
+      (fields.single { it.name == name }.value as Int32State).value
+
+  private fun RecordState.bool(name: String): Boolean =
+      (fields.single { it.name == name }.value as BooleanState).value
+
+  private fun firstDifference(expected: StateValue, actual: StateValue, path: String = "root"): String {
+    if (expected == actual) return "states are equal"
+    if (expected::class != actual::class) return "$path: ${expected::class} != ${actual::class}"
+    return when {
+      expected is RecordState && actual is RecordState ->
+          expected.fields.indices.firstNotNullOfOrNull { index ->
+            val left = expected.fields[index]
+            val right = actual.fields.getOrNull(index) ?: return@firstNotNullOfOrNull "$path: missing field"
+            if (left.value == right.value) null else firstDifference(left.value, right.value, "$path.${left.name}")
+          } ?: "$path: record metadata differs"
+      expected is ObjectArrayState && actual is ObjectArrayState ->
+          expected.values.indices.firstNotNullOfOrNull { index ->
+            if (expected.values[index] == actual.values[index]) null
+            else firstDifference(expected.values[index], actual.values[index], "$path[$index]")
+          } ?: "$path: array metadata differs"
+      expected is ListState && actual is ListState ->
+          expected.values.indices.firstNotNullOfOrNull { index ->
+            if (expected.values[index] == actual.values[index]) null
+            else firstDifference(expected.values[index], actual.values[index], "$path[$index]")
+          } ?: "$path: list metadata differs"
+      else -> "$path: $expected != $actual"
+    }
+  }
+
+  private object MementoClassNames {
+    fun record(typeId: Int): String =
+        eu.rekawek.coffeegb.controller.MementoTypeRegistry.recordClasses[typeId - 1].name
+  }
+
+  private fun cgbSpeedSwitchRom(): ByteArray {
+    val rom = ByteArray(0x8000)
+    rom[0x100] = 0x3e
+    rom[0x101] = 0x01
+    rom[0x102] = 0xe0.toByte()
+    rom[0x103] = 0x4d
+    rom[0x104] = 0x10
+    rom[0x105] = 0x00
+    rom[0x106] = 0x18
+    rom[0x107] = 0xfe.toByte()
+    rom[0x143] = 0x80.toByte()
+    return rom
+  }
+
+  private companion object {
+    const val DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
+    const val DMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Dma\$DmaMemento"
+    const val HDMA_MEMENTO = "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento"
+    const val SPEED_MEMENTO = "eu.rekawek.coffeegb.core.cpu.SpeedMode\$SpeedModeMomento"
+    const val SOUND_MODE_MEMENTO = "eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento"
+    const val SERIAL_PORT_MEMENTO = "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
+    val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -120,13 +120,102 @@ class DetachedStateTest {
   }
 
   @Test
+  fun dmgFirstPixelLatchAndWindowRewindBookkeepingRestoreObservableContinuation() {
+    session(configuration().setGameboyType(GameboyType.DMG)).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff47, 0xe4)
+      var pending = session.captureDetachedState()
+      var found = false
+      repeat(1_000) {
+        if (!found) {
+          session.gameboy.tick()
+          pending = session.captureDetachedState()
+          found = pending.machine.dmgFifoRuntime!!.output.firstEntry >= 0
+        }
+      }
+      assertTrue(found, "pixel-producing FIFO never entered its pending first-pixel phase")
+      val fifoRuntime = requireNotNull(pending.machine.dmgFifoRuntime)
+      val timingRuntime = fifoRuntime.timing
+      val pendingRuntime = fifoRuntime.output
+      assertTrue(timingRuntime.linePixels > 0)
+      assertTrue(timingRuntime.outCount > 0)
+      assertTrue(pendingRuntime.linePixels > 0)
+      assertTrue(pendingRuntime.outCount > 0)
+      assertTrue(pendingRuntime.firstEntry in 0..0x3f)
+      assertTrue(pendingRuntime.firstBgp in 0..0xff)
+      assertTrue(pendingRuntime.firstObp0 in 0..0xff)
+      assertTrue(pendingRuntime.firstObp1 in 0..0xff)
+
+      val changedBgp = pendingRuntime.firstBgp xor 0xff
+      bus.setByte(0xff47, changedBgp)
+      session.gameboy.tick()
+      val expected = session.captureDetachedState()
+      val expectedDisplay = expected.machine.record(DISPLAY_MEMENTO)
+      assertTrue(
+          expectedDisplay.int("i") >
+              pending.machine.record(DISPLAY_MEMENTO).int("i"),
+          "pending first pixel did not reach the visible display",
+      )
+
+      advanceToFreshDmgOutputLine(session)
+      session.restoreDetachedState(pending)
+      bus.setByte(0xff47, changedBgp)
+      session.gameboy.tick()
+      val actual = session.captureDetachedState()
+      assertEquals(expectedDisplay, actual.machine.record(DISPLAY_MEMENTO))
+      assertEquals(expected, actual)
+    }
+
+    session(configuration().setGameboyType(GameboyType.DMG)).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff47, 0xe4)
+      bus.setByte(0xff4a, 0)
+      bus.setByte(0xff4b, 40)
+      bus.setByte(0xff40, 0xb1)
+      var pending = session.captureDetachedState()
+      var found = false
+      repeat(1_000) {
+        if (!found) {
+          session.gameboy.tick()
+          pending = session.captureDetachedState()
+          val pixelMachine = pending.machine.records(PIXEL_TRANSFER_MEMENTO)[1]
+          found =
+              pixelMachine.int("windowPendingTicks") == 1 &&
+                  !pixelMachine.bool("windowActivatedThisLine") &&
+                  pending.machine.dmgFifoRuntime!!.output.linePixels > 0
+        }
+      }
+      assertTrue(found, "pixel-producing FIFO never reached a pending window rewind")
+      val pendingRuntime = pending.machine.dmgFifoRuntime!!.output
+      assertTrue(pendingRuntime.linePixels > 0)
+
+      session.gameboy.tick()
+      val expected = session.captureDetachedState()
+      assertTrue(expected.machine.records(PIXEL_TRANSFER_MEMENTO)[1].bool("windowActivatedThisLine"))
+      val expectedDisplay = expected.machine.record(DISPLAY_MEMENTO)
+
+      advanceToFreshDmgOutputLine(session)
+      session.restoreDetachedState(pending)
+      session.gameboy.tick()
+      val actual = session.captureDetachedState()
+      assertEquals(expectedDisplay, actual.machine.record(DISPLAY_MEMENTO))
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Test
   fun completeGraphIsValidatedBeforeMutationAndFailedApplyIsAtomic() {
     session().use { session ->
       repeat(2_000) { session.gameboy.tick() }
       val before = session.captureDetachedState()
       val invalidRoot = RecordState(before.machine.root.typeId, before.machine.root.fields.dropLast(1))
       val invalid = SessionState(
-          MachineState(invalidRoot, before.machine.rtcRuntime, before.machine.hardware),
+          MachineState(
+              invalidRoot,
+              before.machine.rtcRuntime,
+              before.machine.hardware,
+              before.machine.dmgFifoRuntime,
+          ),
           before.serialPeripheral,
           before.serialState,
           before.serialRuntime,
@@ -202,6 +291,7 @@ class DetachedStateTest {
       val queue = before.machine.record(INT_QUEUE_MEMENTO)
       val dmgFifo = before.machine.record(DMG_FIFO_MEMENTO)
       val sgbDisplay = before.machine.record(SGB_DISPLAY_MEMENTO)
+      val palettes = sgbDisplay.field("palettes") as ObjectArrayState
       val attributeFiles = sgbDisplay.field("attributeFiles") as ObjectArrayState
       val firstAttributeFile = attributeFiles.values.first() as Int32ArrayState
       val invalidAttributeFile =
@@ -246,6 +336,14 @@ class DetachedStateTest {
               ),
               before.machine.root.replaceRecordField(
                   SGB_DISPLAY_MEMENTO,
+                  "palettes",
+                  ObjectArrayState(
+                      palettes.values.mapIndexed { index, value ->
+                        if (index == 0) NullState else value
+                      }),
+              ),
+              before.machine.root.replaceRecordField(
+                  SGB_DISPLAY_MEMENTO,
                   "attributeFiles",
                   ObjectArrayState(
                       attributeFiles.values.mapIndexed { index, value ->
@@ -270,6 +368,12 @@ class DetachedStateTest {
                   "patches",
                   Int32MapState(
                       listOf(Int32MapEntry(0x1234, ListState(listOf(NullState))))),
+              ),
+              before.machine.root.replaceRecordField(
+                  GENIE_MEMENTO,
+                  "patches",
+                  Int32MapState(
+                      listOf(Int32MapEntry(0x1234, ListState(listOf(queue))))),
               ),
           )
 
@@ -400,6 +504,11 @@ class DetachedStateTest {
             .setSupportBatterySave(false)
     assertCrossPresenceRejected(basicWithoutBattery, basicWithBattery)
     assertCrossPresenceRejected(basicWithBattery, basicWithoutBattery)
+    session(basicWithoutBattery).use { session ->
+      val captured = session.captureDetachedState()
+      assertEquals(NullState, captured.machine.record(BASIC_ROM_MEMENTO).field("batteryMemento"))
+      assertContinuation(session, captured, 96)
+    }
 
     val time = VirtualTimeSource(120_000)
     val datelWithoutSlot =
@@ -410,6 +519,11 @@ class DetachedStateTest {
     val datelWithSlot = datelConfiguration(mbc3Rom(), time)
     assertCrossPresenceRejected(datelWithoutSlot, datelWithSlot)
     assertCrossPresenceRejected(datelWithSlot, datelWithoutSlot)
+    session(datelWithoutSlot).use { session ->
+      val captured = session.captureDetachedState()
+      assertEquals(NullState, captured.machine.record(DATEL_MEMENTO).field("slotMemento"))
+      assertContinuation(session, captured, 96)
+    }
   }
 
   @Test
@@ -440,6 +554,7 @@ class DetachedStateTest {
       val malformedRuntime =
           listOf(
               BarcodeBoyRuntimeState(true, IntArray(29)),
+              BarcodeBoyRuntimeState(true, IntArray(31)),
               BarcodeBoyRuntimeState(true, IntArray(30).also { it[0] = 0x100 }),
           )
 
@@ -530,6 +645,40 @@ class DetachedStateTest {
       val lcdEnable = session.captureDetachedState()
       assertEquals(-1, lcdEnable.machine.record(GPU_MEMENTO).int("ticksInLine"))
       assertContinuation(session, lcdEnable, 256)
+    }
+  }
+
+  @Test
+  fun signedWrappedHdmaSourceProgressAppliesAndContinuesDeterministically() {
+    session(configuration(cgbIdleRom()).setGameboyType(GameboyType.CGB)).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0xff51, 0xc0)
+      bus.setByte(0xff52, 0x00)
+      bus.setByte(0xff53, 0x00)
+      bus.setByte(0xff54, 0x00)
+      val before = session.captureDetachedState()
+      val wrapped =
+          before.withMachineRoot(
+              before.machine.root.replaceRecordField(
+                  HDMA_MEMENTO,
+                  "sourceBytesTransferred",
+                  Int32State(Int.MIN_VALUE),
+              ))
+
+      session.restoreDetachedState(wrapped)
+      assertEquals(
+          Int.MIN_VALUE,
+          session.captureDetachedState().machine.record(HDMA_MEMENTO)
+              .int("sourceBytesTransferred"),
+      )
+      bus.setByte(0xff55, 0)
+      val started = session.captureDetachedState()
+      assertTrue(started.machine.record(HDMA_MEMENTO).bool("transferInProgress"))
+      assertEquals(
+          Int.MIN_VALUE,
+          started.machine.record(HDMA_MEMENTO).int("sourceBytesTransferred"),
+      )
+      assertContinuation(session, started, 48)
     }
   }
 
@@ -721,6 +870,21 @@ class DetachedStateTest {
     assertEquals(expected, session.captureDetachedState())
   }
 
+  private fun advanceToFreshDmgOutputLine(session: Session) {
+    var reached = false
+    repeat(1_000) {
+      if (!reached) {
+        session.gameboy.tick()
+        val output = session.captureDetachedState().machine.dmgFifoRuntime!!.output
+        reached =
+            output.linePixels == 0 &&
+                output.outCount == 0 &&
+                output.firstEntry == -1
+      }
+    }
+    assertTrue(reached, "DMG FIFO did not reach a fresh output line")
+  }
+
   private fun assertCrossPresenceRejected(
       targetConfiguration: Gameboy.GameboyConfiguration,
       candidateConfiguration: Gameboy.GameboyConfiguration,
@@ -753,17 +917,36 @@ class DetachedStateTest {
   }
 
   private fun MachineState.record(className: String): RecordState {
+    return requireNotNull(records(className).firstOrNull()) { "Missing $className" }
+  }
+
+  private fun MachineState.records(className: String): List<RecordState> {
+    val matches = mutableListOf<RecordState>()
     fun find(value: StateValue): RecordState? =
         when (value) {
-          is RecordState ->
-              if (MementoClassNames.record(value.typeId) == className) value
-              else value.fields.firstNotNullOfOrNull { find(it.value) }
-          is ObjectArrayState -> value.values.firstNotNullOfOrNull(::find)
-          is ListState -> value.values.firstNotNullOfOrNull(::find)
-          is Int32MapState -> value.entries.firstNotNullOfOrNull { find(it.value) }
+          is RecordState -> {
+            if (MementoClassNames.record(value.typeId) == className) {
+              matches += value
+            }
+            value.fields.forEach { find(it.value) }
+            null
+          }
+          is ObjectArrayState -> {
+            value.values.forEach { find(it) }
+            null
+          }
+          is ListState -> {
+            value.values.forEach { find(it) }
+            null
+          }
+          is Int32MapState -> {
+            value.entries.forEach { find(it.value) }
+            null
+          }
           else -> null
         }
-    return requireNotNull(find(root)) { "Missing $className" }
+    find(root)
+    return matches
   }
 
   private fun RecordState.arrayState(name: String): Int32ArrayState =
@@ -799,7 +982,7 @@ class DetachedStateTest {
 
   private fun SessionState.withMachineRoot(root: RecordState): SessionState =
       SessionState(
-          MachineState(root, machine.rtcRuntime, machine.hardware),
+          MachineState(root, machine.rtcRuntime, machine.hardware, machine.dmgFifoRuntime),
           serialPeripheral,
           serialState,
           serialRuntime,
@@ -954,12 +1137,16 @@ class DetachedStateTest {
     const val DMG_FIFO_MEMENTO = "eu.rekawek.coffeegb.core.gpu.DmgPixelFifo\$DmgPixelFifoMemento"
     const val COLOR_FIFO_MEMENTO =
         "eu.rekawek.coffeegb.core.gpu.ColorPixelFifo\$ColorPixelFifoMemento"
+    const val PIXEL_TRANSFER_MEMENTO =
+        "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$PixelTransferMemento"
     const val SGB_DISPLAY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento"
     const val SUPER_GAMEBOY_MEMENTO = "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento"
     const val BACKGROUND_MEMENTO = "eu.rekawek.coffeegb.core.sgb.Background\$BackgroundMemento"
     const val TRANSFER_MEMENTO =
         "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandMemento"
     const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento"
+    const val BASIC_ROM_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomMemento"
     const val GENIE_MEMENTO = "eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento"
     const val RTC_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockMemento"
     const val HUC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3Memento"

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedValueBoundsTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedValueBoundsTest.kt
@@ -1,0 +1,62 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.StateLimits
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.Test
+
+class DetachedValueBoundsTest {
+
+  @Test
+  fun primitiveArrayElementAndByteBoundariesUseCheckedArithmetic() {
+    assertEquals(
+        StateLimits.LEGACY_MAX_ARRAY_LENGTH,
+        DetachedValueBounds.checkedArrayBytesForApply(
+            StateLimits.LEGACY_MAX_ARRAY_LENGTH, Byte.SIZE_BYTES.toLong()),
+    )
+    assertFailsWith<StateApplyException> {
+      DetachedValueBounds.checkedArrayBytesForApply(
+          StateLimits.LEGACY_MAX_ARRAY_LENGTH + 1, Byte.SIZE_BYTES.toLong())
+    }
+
+    val maximumIntElements = StateLimits.LEGACY_MAX_ARRAY_BYTES / Int.SIZE_BYTES
+    assertEquals(
+        StateLimits.LEGACY_MAX_ARRAY_BYTES,
+        DetachedValueBounds.checkedArrayBytesForApply(
+            maximumIntElements, Int.SIZE_BYTES.toLong()),
+    )
+    assertFailsWith<StateApplyException> {
+      DetachedValueBounds.checkedArrayBytesForApply(
+          maximumIntElements + 1, Int.SIZE_BYTES.toLong())
+    }
+    assertFailsWith<StateApplyException> {
+      DetachedValueBounds.checkedArrayBytesForApply(2, Long.MAX_VALUE)
+    }
+  }
+
+  @Test
+  fun stringCharacterAndEncodingBoundariesAreEnforcedBeforeDecodeAllocation() {
+    DetachedValueBounds.checkStringMetricsForApply(
+        StateLimits.LEGACY_MAX_STRING_CHARS.toLong(),
+        StateLimits.LEGACY_MAX_STRING_BYTES,
+    )
+    assertFailsWith<StateApplyException> {
+      DetachedValueBounds.checkStringMetricsForApply(
+          StateLimits.LEGACY_MAX_STRING_CHARS + 1L,
+          StateLimits.LEGACY_MAX_STRING_BYTES,
+      )
+    }
+    assertFailsWith<StateApplyException> {
+      DetachedValueBounds.checkStringMetricsForApply(
+          StateLimits.LEGACY_MAX_STRING_CHARS.toLong(),
+          StateLimits.LEGACY_MAX_STRING_BYTES + 1,
+      )
+    }
+
+    val boundary = "x".repeat(StateLimits.LEGACY_MAX_STRING_CHARS)
+    assertEquals(boundary, StateGraph.restore(StringState(boundary)))
+    assertFailsWith<IllegalArgumentException> {
+      StringState("x".repeat(StateLimits.LEGACY_MAX_STRING_CHARS + 1))
+    }
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -262,6 +262,44 @@ class StateCoverageMatrixTest {
       val actualTrace = continueInfrared(infrared, 500)
       assertEquals(expectedTrace, actualTrace)
       assertEquals(expected, StateGraph.capture(infrared.saveToMemento()))
+
+      irBus.post(FullChanger.TransformEvent(12))
+      val armed = StateGraph.capture(infrared.saveToMemento())
+      val armedChanger = armed.record(FULL_CHANGER_MEMENTO)
+      assertTrue(armedChanger.bool("armed"))
+      assertTrue(!armedChanger.bool("running"))
+      StateSemantics.validate(StateGraph.restore(armed))
+
+      infrared.getByte(0xff56)
+      repeat(30) { infrared.tick() }
+      val running = StateGraph.capture(infrared.saveToMemento())
+      val runningChanger = running.record(FULL_CHANGER_MEMENTO)
+      assertTrue(!runningChanger.bool("armed"))
+      assertTrue(runningChanger.bool("running"))
+      StateSemantics.validate(StateGraph.restore(running))
+
+      repeat(100_000) { infrared.tick() }
+      val completed = StateGraph.capture(infrared.saveToMemento())
+      val completedChanger = completed.record(FULL_CHANGER_MEMENTO)
+      assertTrue(!completedChanger.bool("armed"))
+      assertTrue(!completedChanger.bool("running"))
+      assertEquals(
+          completedChanger.intArray("schedule").size,
+          completedChanger.int("index"),
+      )
+      StateSemantics.validate(StateGraph.restore(completed))
+
+      irBus.post(FullChanger.TransformEvent(17))
+      infrared.getByte(0xff56)
+      val completedContinuation = continueInfrared(infrared, 600)
+      val completedExpected = StateGraph.capture(infrared.saveToMemento())
+      @Suppress("UNCHECKED_CAST")
+      infrared.restoreFromMemento(
+          StateGraph.restore(completed) as Memento<InfraredPort>)
+      irBus.post(FullChanger.TransformEvent(17))
+      infrared.getByte(0xff56)
+      assertEquals(completedContinuation, continueInfrared(infrared, 600))
+      assertEquals(completedExpected, StateGraph.capture(infrared.saveToMemento()))
     }
   }
 
@@ -596,6 +634,7 @@ class StateCoverageMatrixTest {
   private fun RecordState.field(name: String): StateValue = fields.single { it.name == name }.value
   private fun RecordState.int(name: String): Int = (field(name) as Int32State).value
   private fun RecordState.bool(name: String): Boolean = (field(name) as BooleanState).value
+  private fun RecordState.intArray(name: String): IntArray = (field(name) as Int32ArrayState).copyValue()
   private fun RecordState.enumName(name: String): String {
     val enum = field(name) as EnumState
     return (MementoTypeRegistry.enumClasses[enum.typeId - 1].enumConstants[enum.ordinal] as Enum<*>).name
@@ -641,6 +680,7 @@ class StateCoverageMatrixTest {
     const val MBC7_EEPROM_MEMENTO =
         "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento"
     const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento"
+    const val FULL_CHANGER_MEMENTO = "eu.rekawek.coffeegb.core.ir.FullChanger\$FullChangerMemento"
     val DEFAULT_MAPPER_PROBES = listOf(0x0100, 0x4000, 0x7000, 0x7fe1, 0xa000, 0xa001)
 
     val EXPECTED_MAPPER_FAMILIES =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -24,44 +24,106 @@ class StateCoverageMatrixTest {
     val rom = mutableRom()
     val cases =
         listOf(
-            mapper("BasicRom") { BasicRom(it, Battery.NULL_BATTERY) },
-            mapper("Mbc1") { Mbc1(it, Battery.NULL_BATTERY) },
-            mapper("Mbc2") { Mbc2(it, Battery.NULL_BATTERY) },
-            mapper("Mbc3") { Mbc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
-            mapper("Mbc5") { Mbc5(it, Battery.NULL_BATTERY) },
-            mapper("Mbc6") { Mbc6(it, Battery.NULL_BATTERY) },
-            mapper("Mbc7") { Mbc7(it, Battery.NULL_BATTERY) },
-            mapper("Mmm01") { Mmm01(it, Battery.NULL_BATTERY, false) },
-            mapper("PocketCamera") { PocketCamera(it, Battery.NULL_BATTERY) },
-            mapper("Huc1") { Huc1(it, Battery.NULL_BATTERY) },
-            mapper("Huc3") { Huc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
-            mapper("Tama5") { Tama5(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
-            mapper("BungEms") { BungEms(it, Battery.NULL_BATTERY) },
-            mapper("BhgosMulticart") { BhgosMulticart(it, Battery.NULL_BATTERY) },
-            mapper("MakonNtOld2") { MakonNtOld2(it, Battery.NULL_BATTERY) },
-            mapper("DuzMulticart") { DuzMulticart(it, Battery.NULL_BATTERY) },
-            mapper("Mani32kMulticart") { Mani32kMulticart(it) },
-            mapper("SlMulticart") { SlMulticart(it, Battery.NULL_BATTERY) },
-            mapper("Sintax") { Sintax(it, Battery.NULL_BATTERY) },
-            mapper("Bbd") { Bbd(it, Battery.NULL_BATTERY) },
-            mapper("SachenMmc1") { SachenMmc(it, false, false) },
-            mapper("SachenMmc2") { SachenMmc(it, true, false) },
-            mapper("WisdomTree") { WisdomTree(it) },
-            mapper("Datel") { Datel(it, Battery.NULL_BATTERY) },
+            mapper("BasicRom", listOf(0xa000 to 0x31), listOf(0xa000)) {
+              BasicRom(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mbc1", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0xa000 to 0x32)) {
+              Mbc1(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mbc2", listOf(0x0000 to 0x0a, 0x2100 to 0x05, 0xa000 to 0x03)) {
+              Mbc2(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mbc3", rtcSetup(0x13), listOf(0xa000, 0x4000)) {
+              Mbc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000))
+            },
+            mapper("Mbc5", listOf(0x0000 to 0x0a, 0x2000 to 0x25, 0x4000 to 0x02, 0xa000 to 0x34)) {
+              Mbc5(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mbc6", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0x3000 to 0x04, 0xa000 to 0x35)) {
+              Mbc6(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mbc7", listOf(0x0000 to 0x0a, 0x2000 to 0x07, 0xa000 to 0x36)) {
+              Mbc7(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mmm01", listOf(0x0000 to 0x0a, 0x2000 to 0x06, 0x4000 to 0x02)) {
+              Mmm01(it, Battery.NULL_BATTERY, false)
+            },
+            mapper("PocketCamera", listOf(0x0000 to 0x0a, 0x4000 to 0x10, 0xa001 to 0x37)) {
+              PocketCamera(it, Battery.NULL_BATTERY)
+            },
+            mapper("Huc1", listOf(0x0000 to 0x0a, 0x2000 to 0x09, 0xa000 to 0x38)) {
+              Huc1(it, Battery.NULL_BATTERY)
+            },
+            mapper("Huc3", listOf(0x0000 to 0x0a, 0x4000 to 0x0b, 0xa000 to 0x39)) {
+              Huc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000))
+            },
+            mapper("Tama5", listOf(0xa001 to 0x04, 0xa000 to 0x0a, 0xa001 to 0x00), listOf(0xa000)) {
+              Tama5(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000))
+            },
+            mapper("BungEms", listOf(0x2000 to 0x0a, 0x4000 to 0x03, 0xa000 to 0x3a)) {
+              BungEms(it, Battery.NULL_BATTERY)
+            },
+            mapper("BhgosMulticart", listOf(0x2000 to 0x0b, 0x6000 to 0x01)) {
+              BhgosMulticart(it, Battery.NULL_BATTERY)
+            },
+            mapper("MakonNtOld2", listOf(0x2000 to 0x0c, 0x5000 to 0x06)) {
+              MakonNtOld2(it, Battery.NULL_BATTERY)
+            },
+            mapper("DuzMulticart", listOf(0x2000 to 0x0d, 0x4000 to 0x02)) {
+              DuzMulticart(it, Battery.NULL_BATTERY)
+            },
+            mapper("Mani32kMulticart", listOf(0x4000 to 0x0e)) {
+              Mani32kMulticart(it)
+            },
+            mapper("SlMulticart", listOf(0x2000 to 0x0f, 0x5000 to 0x06)) {
+              SlMulticart(it, Battery.NULL_BATTERY)
+            },
+            mapper("Sintax", listOf(0x2000 to 0x10, 0x5000 to 0x06, 0x7000 to 0x02)) {
+              Sintax(it, Battery.NULL_BATTERY)
+            },
+            mapper("Bbd", listOf(0x2000 to 0x11, 0x4000 to 0x03)) {
+              Bbd(it, Battery.NULL_BATTERY)
+            },
+            mapper("SachenMmc1", listOf(0x0000 to 0x0a, 0x2000 to 0x12, 0x4000 to 0x02)) {
+              SachenMmc(it, false, false)
+            },
+            mapper("SachenMmc2", listOf(0x0000 to 0x0a, 0x2000 to 0x13, 0x4000 to 0x03)) {
+              SachenMmc(it, true, false)
+            },
+            mapper("WisdomTree", listOf(0x0011 to 0x00), listOf(0x4000, 0x7fff)) {
+              WisdomTree(it)
+            },
+            mapper(
+                "Datel",
+                listOf(
+                    0x7fe5 to 0x01,
+                    0x0000 to 0x0a,
+                    0x4000 to 0x08,
+                    0xa000 to 0x21,
+                    0x7fe5 to 0x10,
+                ),
+                listOf(0xa000, 0x4000, 0x7fe5),
+            ) { datelWithRtcSlot(it) },
         )
 
     val covered = linkedSetOf<String>()
     cases.forEach { case ->
       val controller = case.factory(rom)
       EventBusImpl().use(controller::init)
+      val idle = StateGraph.capture(controller.saveToMemento())
+      case.setup(controller)
       val captured = StateGraph.capture(controller.saveToMemento())
-      mutate(controller)
-      val mutated = StateGraph.capture(controller.saveToMemento())
-      assertNotEquals(captured, mutated, "${case.name} mutation did not exercise owned state")
+      assertNotEquals(idle, captured, "${case.name} setup did not exercise owned state")
+
+      val expectedTrace = continueMapper(controller, case.probes)
+      val expectedState = StateGraph.capture(controller.saveToMemento())
+      disturbMapper(controller)
 
       @Suppress("UNCHECKED_CAST")
       controller.restoreFromMemento(StateGraph.restore(captured) as Memento<MemoryController>)
-      assertEquals(captured, StateGraph.capture(controller.saveToMemento()), case.name)
+      val actualTrace = continueMapper(controller, case.probes)
+      assertEquals(expectedTrace, actualTrace, "${case.name} continuation trace")
+      assertEquals(expectedState, StateGraph.capture(controller.saveToMemento()), case.name)
       covered += case.name
     }
 
@@ -75,37 +137,75 @@ class StateCoverageMatrixTest {
 
   @Test
   fun everyStatefulSerialPeripheralRoundTripsWithoutCapturingCallbacks() {
+    val receivedBytes = mutableListOf<Int>()
     val peer = Peer2PeerSerialEndpoint()
     val otherPeer = Peer2PeerSerialEndpoint().also(peer::init)
     val adapter = FourPlayerAdapter()
     val cases =
         listOf(
-            "ByteReceiving" to ByteReceivingSerialEndpoint { _ -> },
-            "Peer2Peer" to otherPeer,
-            "Printer" to GameboyPrinterSerialEndpoint { _, _, _, _, _, _ -> },
-            "GpsReceiver" to GpsReceiverSerialEndpoint(),
-            "BarcodeBoy" to BarcodeBoySerialEndpoint(),
-            "FourPlayerAdapter" to adapter.endpoint(2),
+            peripheral(
+                "ByteReceiving",
+                ByteReceivingSerialEndpoint(receivedBytes::add),
+                observed = { receivedBytes.toList() },
+                clearObserved = receivedBytes::clear,
+            ) {
+              setSb(0xa5)
+              startSending()
+              repeat(3) { sendBit() }
+            },
+            peripheral("Peer2Peer", otherPeer) {
+              peer.setSb(0x3c)
+              peer.startSending()
+              setSb(0xc3)
+              startSending()
+              repeat(3) {
+                peer.sendBit()
+                sendBit()
+              }
+            },
+            peripheral("Printer", GameboyPrinterSerialEndpoint { _, _, _, _, _, _ -> }) {
+              setSb(0x88)
+              startSending()
+              repeat(5) { sendBit() }
+            },
+            peripheral("GpsReceiver", GpsReceiverSerialEndpoint()) {
+              setSb(0x47)
+              startSending()
+              repeat(4) { sendBit() }
+              repeat(12) { tick() }
+            },
+            peripheral("BarcodeBoy", BarcodeBoySerialEndpoint()) {
+              startSending()
+              repeat(11) { sendBit() }
+            },
+            peripheral("FourPlayerAdapter", adapter.endpoint(2)) {
+              setSb(0x88)
+              setExternalTransfer(true)
+              startSending()
+              repeat(140) { tick() }
+            },
         )
 
-    cases.forEach { (name, endpoint) ->
-      endpoint.setSb(0xa5)
+    cases.forEach { case ->
+      val endpoint = case.endpoint
+      val idle = StateGraph.capture(endpoint.saveToMemento())
+      case.setup(endpoint)
       val captured = StateGraph.capture(endpoint.saveToMemento())
-      endpoint.startSending()
-      endpoint.setExternalTransfer(true)
-      repeat(3) {
-        endpoint.sendBit()
-        endpoint.tick()
-      }
-      val mutated = StateGraph.capture(endpoint.saveToMemento())
-      assertNotEquals(captured, mutated, "$name mutation did not exercise owned state")
+      assertNotEquals(idle, captured, "${case.name} setup did not exercise owned state")
+      case.clearObserved()
+      val expectedTrace = continuePeripheral(endpoint) + case.observed()
+      val expectedState = StateGraph.capture(endpoint.saveToMemento())
+      disturbPeripheral(endpoint)
 
       @Suppress("UNCHECKED_CAST")
       endpoint.restoreFromMemento(StateGraph.restore(captured) as Memento<SerialEndpoint>?)
-      assertEquals(captured, StateGraph.capture(endpoint.saveToMemento()), name)
+      case.clearObserved()
+      val actualTrace = continuePeripheral(endpoint) + case.observed()
+      assertEquals(expectedTrace, actualTrace, "${case.name} continuation trace")
+      assertEquals(expectedState, StateGraph.capture(endpoint.saveToMemento()), case.name)
     }
 
-    assertEquals(EXPECTED_SERIAL_FAMILIES, cases.map { it.first }.toSet())
+    assertEquals(EXPECTED_SERIAL_FAMILIES, cases.map { it.name }.toSet())
   }
 
   @Test
@@ -141,11 +241,16 @@ class StateCoverageMatrixTest {
       val active = StateGraph.capture(infrared.saveToMemento())
       assertNotEquals(idle, active)
 
-      repeat(500) { infrared.tick() }
+      val expectedTrace = continueInfrared(infrared, 500)
       val expected = StateGraph.capture(infrared.saveToMemento())
+      infrared.setByte(0xff56, 0xc0)
+      irBus.post(FullChanger.TransformEvent(9))
+      infrared.getByte(0xff56)
+      repeat(41) { infrared.tick() }
       @Suppress("UNCHECKED_CAST")
       infrared.restoreFromMemento(StateGraph.restore(active) as Memento<InfraredPort>)
-      repeat(500) { infrared.tick() }
+      val actualTrace = continueInfrared(infrared, 500)
+      assertEquals(expectedTrace, actualTrace)
       assertEquals(expected, StateGraph.capture(infrared.saveToMemento()))
     }
   }
@@ -153,12 +258,79 @@ class StateCoverageMatrixTest {
   private data class MapperCase(
       val name: String,
       val factory: (Rom) -> MemoryController,
+      val setup: (MemoryController) -> Unit,
+      val probes: List<Int>,
   )
 
-  private fun mapper(name: String, factory: (Rom) -> MemoryController) = MapperCase(name, factory)
+  private data class PeripheralCase(
+      val name: String,
+      val endpoint: SerialEndpoint,
+      val setup: SerialEndpoint.() -> Unit,
+      val observed: () -> List<Int>,
+      val clearObserved: () -> Unit,
+  )
 
-  private fun mutate(controller: MemoryController) {
+  private fun mapper(
+      name: String,
+      setup: List<Pair<Int, Int>>,
+      probes: List<Int> = DEFAULT_MAPPER_PROBES,
+      factory: (Rom) -> MemoryController,
+  ) =
+      MapperCase(
+          name,
+          factory,
+          { controller -> setup.forEach { (address, value) -> controller.setByte(address, value) } },
+          probes,
+      )
+
+  private fun peripheral(
+      name: String,
+      endpoint: SerialEndpoint,
+      observed: () -> List<Int> = { emptyList() },
+      clearObserved: () -> Unit = {},
+      setup: SerialEndpoint.() -> Unit,
+  ) = PeripheralCase(name, endpoint, setup, observed, clearObserved)
+
+  private fun continueMapper(
+      controller: MemoryController,
+      probes: List<Int>,
+  ): List<Int> {
+    val trace = mutableListOf<Int>()
+    repeat(4) { round ->
+      probes.forEach { trace += controller.getByte(it) }
+      controller.tick()
+      controller.setByte(0xa010 + round, 0x40 + round)
+      probes.forEach { trace += controller.getByte(it) }
+    }
+    return trace
+  }
+
+  private fun continuePeripheral(endpoint: SerialEndpoint): List<Int> {
+    val trace = mutableListOf<Int>()
+    endpoint.setExternalTransfer(true)
+    repeat(6) {
+      trace += endpoint.sendBit()
+      trace += endpoint.recvBit()
+      repeat(19) { endpoint.tick() }
+      trace += if (endpoint.isSerialInputHigh) 1 else 0
+    }
+    repeat(3) { byte ->
+      endpoint.setSb(0x31 + byte)
+      endpoint.startSending()
+      repeat(8) {
+        trace += endpoint.sendBit()
+        trace += endpoint.recvBit()
+        repeat(19) { endpoint.tick() }
+        trace += if (endpoint.isSerialInputHigh) 1 else 0
+      }
+    }
+    endpoint.setExternalTransfer(false)
+    return trace
+  }
+
+  private fun disturbMapper(controller: MemoryController) {
     listOf(
+            0x0000 to 0x0a,
             0x2001 to 0x25,
             0x2011 to 0x11,
             0x4000 to 0x03,
@@ -166,18 +338,48 @@ class StateCoverageMatrixTest {
             0x6000 to 0x01,
             0x7fff to 0x02,
             0xa001 to 0x07,
-            0x0000 to 0x0a,
             0xa000 to 0x09,
         )
         .forEach { (address, value) -> controller.setByte(address, value) }
-    when (controller) {
-      is WisdomTree -> controller.setByte(0x0011, 0)
-      is Mbc2 -> {
-        controller.setByte(0x0000, 0x0a)
-        controller.setByte(0xa000, 0x09)
-      }
-    }
+    if (controller is WisdomTree) controller.setByte(0x0029, 0)
     repeat(3) { controller.tick() }
+  }
+
+  private fun disturbPeripheral(endpoint: SerialEndpoint) {
+    endpoint.setSb(0xe7)
+    endpoint.startSending()
+    repeat(5) {
+      endpoint.sendBit()
+      repeat(37) { endpoint.tick() }
+    }
+    endpoint.setExternalTransfer(false)
+  }
+
+  private fun continueInfrared(infrared: InfraredPort, ticks: Int): List<Int> {
+    val trace = mutableListOf<Int>()
+    repeat(ticks) { tick ->
+      infrared.tick()
+      if (tick % 11 == 0) trace += infrared.getByte(0xff56)
+    }
+    return trace
+  }
+
+  private fun rtcSetup(seconds: Int) =
+      listOf(
+          0x0000 to 0x0a,
+          0x4000 to 0x08,
+          0xa000 to seconds,
+          0x6000 to 0x00,
+          0x6000 to 0x01,
+      )
+
+  private fun datelWithRtcSlot(rom: Rom): Datel {
+    val datel = Datel(rom, Battery.NULL_BATTERY)
+    datel.setSlotCartridge(
+        Mbc3(rom, Battery.NULL_BATTERY, VirtualTimeSource(120_000)),
+        false,
+    )
+    return datel
   }
 
   private fun mutableRom(): Rom {
@@ -189,6 +391,8 @@ class StateCoverageMatrixTest {
   }
 
   private companion object {
+    val DEFAULT_MAPPER_PROBES = listOf(0x0100, 0x4000, 0x7000, 0x7fe1, 0xa000, 0xa001)
+
     val EXPECTED_MAPPER_FAMILIES =
         setOf(
             "BasicRom",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -1,0 +1,230 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import eu.rekawek.coffeegb.core.cpu.SpeedMode
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.ir.FullChanger
+import eu.rekawek.coffeegb.core.ir.InfraredPort
+import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
+import eu.rekawek.coffeegb.core.memory.cart.type.*
+import eu.rekawek.coffeegb.core.serial.*
+import eu.rekawek.coffeegb.core.sgb.SuperGameboy
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.Test
+
+class StateCoverageMatrixTest {
+
+  @Test
+  fun everyMutableMapperRoundTripsThroughDetachedGraphAfterMutation() {
+    val rom = mutableRom()
+    val cases =
+        listOf(
+            mapper("BasicRom") { BasicRom(it, Battery.NULL_BATTERY) },
+            mapper("Mbc1") { Mbc1(it, Battery.NULL_BATTERY) },
+            mapper("Mbc2") { Mbc2(it, Battery.NULL_BATTERY) },
+            mapper("Mbc3") { Mbc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
+            mapper("Mbc5") { Mbc5(it, Battery.NULL_BATTERY) },
+            mapper("Mbc6") { Mbc6(it, Battery.NULL_BATTERY) },
+            mapper("Mbc7") { Mbc7(it, Battery.NULL_BATTERY) },
+            mapper("Mmm01") { Mmm01(it, Battery.NULL_BATTERY, false) },
+            mapper("PocketCamera") { PocketCamera(it, Battery.NULL_BATTERY) },
+            mapper("Huc1") { Huc1(it, Battery.NULL_BATTERY) },
+            mapper("Huc3") { Huc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
+            mapper("Tama5") { Tama5(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000)) },
+            mapper("BungEms") { BungEms(it, Battery.NULL_BATTERY) },
+            mapper("BhgosMulticart") { BhgosMulticart(it, Battery.NULL_BATTERY) },
+            mapper("MakonNtOld2") { MakonNtOld2(it, Battery.NULL_BATTERY) },
+            mapper("DuzMulticart") { DuzMulticart(it, Battery.NULL_BATTERY) },
+            mapper("Mani32kMulticart") { Mani32kMulticart(it) },
+            mapper("SlMulticart") { SlMulticart(it, Battery.NULL_BATTERY) },
+            mapper("Sintax") { Sintax(it, Battery.NULL_BATTERY) },
+            mapper("Bbd") { Bbd(it, Battery.NULL_BATTERY) },
+            mapper("SachenMmc1") { SachenMmc(it, false, false) },
+            mapper("SachenMmc2") { SachenMmc(it, true, false) },
+            mapper("WisdomTree") { WisdomTree(it) },
+            mapper("Datel") { Datel(it, Battery.NULL_BATTERY) },
+        )
+
+    val covered = linkedSetOf<String>()
+    cases.forEach { case ->
+      val controller = case.factory(rom)
+      EventBusImpl().use(controller::init)
+      val captured = StateGraph.capture(controller.saveToMemento())
+      mutate(controller)
+      val mutated = StateGraph.capture(controller.saveToMemento())
+      assertNotEquals(captured, mutated, "${case.name} mutation did not exercise owned state")
+
+      @Suppress("UNCHECKED_CAST")
+      controller.restoreFromMemento(StateGraph.restore(captured) as Memento<MemoryController>)
+      assertEquals(captured, StateGraph.capture(controller.saveToMemento()), case.name)
+      covered += case.name
+    }
+
+    assertEquals(EXPECTED_MAPPER_FAMILIES, covered)
+    val registeredMapperRecords =
+        MementoTypeRegistry.recordClassNames.filter {
+          it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
+        }
+    assertEquals(24, registeredMapperRecords.size)
+  }
+
+  @Test
+  fun everyStatefulSerialPeripheralRoundTripsWithoutCapturingCallbacks() {
+    val peer = Peer2PeerSerialEndpoint()
+    val otherPeer = Peer2PeerSerialEndpoint().also(peer::init)
+    val adapter = FourPlayerAdapter()
+    val cases =
+        listOf(
+            "ByteReceiving" to ByteReceivingSerialEndpoint { _ -> },
+            "Peer2Peer" to otherPeer,
+            "Printer" to GameboyPrinterSerialEndpoint { _, _, _, _, _, _ -> },
+            "GpsReceiver" to GpsReceiverSerialEndpoint(),
+            "BarcodeBoy" to BarcodeBoySerialEndpoint(),
+            "FourPlayerAdapter" to adapter.endpoint(2),
+        )
+
+    cases.forEach { (name, endpoint) ->
+      endpoint.setSb(0xa5)
+      val captured = StateGraph.capture(endpoint.saveToMemento())
+      endpoint.startSending()
+      endpoint.setExternalTransfer(true)
+      repeat(3) {
+        endpoint.sendBit()
+        endpoint.tick()
+      }
+      val mutated = StateGraph.capture(endpoint.saveToMemento())
+      assertNotEquals(captured, mutated, "$name mutation did not exercise owned state")
+
+      @Suppress("UNCHECKED_CAST")
+      endpoint.restoreFromMemento(StateGraph.restore(captured) as Memento<SerialEndpoint>?)
+      assertEquals(captured, StateGraph.capture(endpoint.saveToMemento()), name)
+    }
+
+    assertEquals(EXPECTED_SERIAL_FAMILIES, cases.map { it.first }.toSet())
+  }
+
+  @Test
+  fun activeSgbMultipacketAndInfraredPulsePhasesContinueDeterministically() {
+    EventBusImpl().use { sgbBus ->
+      val sgb = SuperGameboy(sgbBus)
+      val idle = StateGraph.capture(sgb.saveToMemento())
+      val firstPacket = IntArray(16).also {
+        it[0] = 2 // first half of a two-packet PAL01 command
+        it[1] = 0x34
+        it[2] = 0x12
+      }
+      sgbBus.post(SuperGameboy.PacketReceivedEvent(firstPacket))
+      val partial = StateGraph.capture(sgb.saveToMemento())
+      assertNotEquals(idle, partial)
+
+      sgbBus.post(SuperGameboy.PacketReceivedEvent(IntArray(16)))
+      val expected = StateGraph.capture(sgb.saveToMemento())
+      @Suppress("UNCHECKED_CAST")
+      sgb.restoreFromMemento(StateGraph.restore(partial) as Memento<SuperGameboy>)
+      sgbBus.post(SuperGameboy.PacketReceivedEvent(IntArray(16)))
+      assertEquals(expected, StateGraph.capture(sgb.saveToMemento()))
+    }
+
+    EventBusImpl().use { irBus ->
+      val infrared = InfraredPort(true, SpeedMode(true))
+      infrared.init(irBus)
+      val idle = StateGraph.capture(infrared.saveToMemento())
+      infrared.setByte(0xff56, 0xc0)
+      irBus.post(FullChanger.TransformEvent(5))
+      infrared.getByte(0xff56) // arm the first pulse at the emulated polling edge
+      repeat(30) { infrared.tick() }
+      val active = StateGraph.capture(infrared.saveToMemento())
+      assertNotEquals(idle, active)
+
+      repeat(500) { infrared.tick() }
+      val expected = StateGraph.capture(infrared.saveToMemento())
+      @Suppress("UNCHECKED_CAST")
+      infrared.restoreFromMemento(StateGraph.restore(active) as Memento<InfraredPort>)
+      repeat(500) { infrared.tick() }
+      assertEquals(expected, StateGraph.capture(infrared.saveToMemento()))
+    }
+  }
+
+  private data class MapperCase(
+      val name: String,
+      val factory: (Rom) -> MemoryController,
+  )
+
+  private fun mapper(name: String, factory: (Rom) -> MemoryController) = MapperCase(name, factory)
+
+  private fun mutate(controller: MemoryController) {
+    listOf(
+            0x2001 to 0x25,
+            0x2011 to 0x11,
+            0x4000 to 0x03,
+            0x5000 to 0x06,
+            0x6000 to 0x01,
+            0x7fff to 0x02,
+            0xa001 to 0x07,
+            0x0000 to 0x0a,
+            0xa000 to 0x09,
+        )
+        .forEach { (address, value) -> controller.setByte(address, value) }
+    when (controller) {
+      is WisdomTree -> controller.setByte(0x0011, 0)
+      is Mbc2 -> {
+        controller.setByte(0x0000, 0x0a)
+        controller.setByte(0xa000, 0x09)
+      }
+    }
+    repeat(3) { controller.tick() }
+  }
+
+  private fun mutableRom(): Rom {
+    val bytes = ByteArray(0x200000)
+    bytes[0x147] = 0x1b // MBC5 + RAM + battery; constructors are selected explicitly.
+    bytes[0x148] = 0x06
+    bytes[0x149] = 0x03
+    return Rom(bytes)
+  }
+
+  private companion object {
+    val EXPECTED_MAPPER_FAMILIES =
+        setOf(
+            "BasicRom",
+            "Mbc1",
+            "Mbc2",
+            "Mbc3",
+            "Mbc5",
+            "Mbc6",
+            "Mbc7",
+            "Mmm01",
+            "PocketCamera",
+            "Huc1",
+            "Huc3",
+            "Tama5",
+            "BungEms",
+            "BhgosMulticart",
+            "MakonNtOld2",
+            "DuzMulticart",
+            "Mani32kMulticart",
+            "SlMulticart",
+            "Sintax",
+            "Bbd",
+            "SachenMmc1",
+            "SachenMmc2",
+            "WisdomTree",
+            "Datel",
+        )
+
+    val EXPECTED_SERIAL_FAMILIES =
+        setOf(
+            "ByteReceiving",
+            "Peer2Peer",
+            "Printer",
+            "GpsReceiver",
+            "BarcodeBoy",
+            "FourPlayerAdapter",
+        )
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -13,8 +13,10 @@ import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
 import eu.rekawek.coffeegb.core.memory.cart.type.*
 import eu.rekawek.coffeegb.core.serial.*
 import eu.rekawek.coffeegb.core.sgb.SuperGameboy
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class StateCoverageMatrixTest {
@@ -36,8 +38,8 @@ class StateCoverageMatrixTest {
             mapper("Mbc3", rtcSetup(0x13), listOf(0xa000, 0x4000)) {
               Mbc3(it, Battery.NULL_BATTERY, VirtualTimeSource(120_000))
             },
-            mapper("Mbc5", listOf(0x0000 to 0x0a, 0x2000 to 0x25, 0x4000 to 0x02, 0xa000 to 0x34)) {
-              Mbc5(it, Battery.NULL_BATTERY)
+            mapper("Mbc5", listOf(0x0000 to 0x0a, 0x2000 to 0x25, 0x4000 to 0x0a, 0xa000 to 0x34)) {
+              Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
             },
             mapper("Mbc6", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0x3000 to 0x04, 0xa000 to 0x35)) {
               Mbc6(it, Battery.NULL_BATTERY)
@@ -119,8 +121,10 @@ class StateCoverageMatrixTest {
       val expectedState = StateGraph.capture(controller.saveToMemento())
       disturbMapper(controller)
 
+      val restored = StateGraph.restore(captured)
+      StateSemantics.validate(restored)
       @Suppress("UNCHECKED_CAST")
-      controller.restoreFromMemento(StateGraph.restore(captured) as Memento<MemoryController>)
+      controller.restoreFromMemento(restored as Memento<MemoryController>)
       val actualTrace = continueMapper(controller, case.probes)
       assertEquals(expectedTrace, actualTrace, "${case.name} continuation trace")
       assertEquals(expectedState, StateGraph.capture(controller.saveToMemento()), case.name)
@@ -197,8 +201,10 @@ class StateCoverageMatrixTest {
       val expectedState = StateGraph.capture(endpoint.saveToMemento())
       disturbPeripheral(endpoint)
 
+      val restored = StateGraph.restore(captured)
+      StateSemantics.validate(restored)
       @Suppress("UNCHECKED_CAST")
-      endpoint.restoreFromMemento(StateGraph.restore(captured) as Memento<SerialEndpoint>?)
+      endpoint.restoreFromMemento(restored as Memento<SerialEndpoint>?)
       case.clearObserved()
       val actualTrace = continuePeripheral(endpoint) + case.observed()
       assertEquals(expectedTrace, actualTrace, "${case.name} continuation trace")
@@ -224,8 +230,10 @@ class StateCoverageMatrixTest {
 
       sgbBus.post(SuperGameboy.PacketReceivedEvent(IntArray(16)))
       val expected = StateGraph.capture(sgb.saveToMemento())
+      val restored = StateGraph.restore(partial)
+      StateSemantics.validate(restored)
       @Suppress("UNCHECKED_CAST")
-      sgb.restoreFromMemento(StateGraph.restore(partial) as Memento<SuperGameboy>)
+      sgb.restoreFromMemento(restored as Memento<SuperGameboy>)
       sgbBus.post(SuperGameboy.PacketReceivedEvent(IntArray(16)))
       assertEquals(expected, StateGraph.capture(sgb.saveToMemento()))
     }
@@ -247,11 +255,156 @@ class StateCoverageMatrixTest {
       irBus.post(FullChanger.TransformEvent(9))
       infrared.getByte(0xff56)
       repeat(41) { infrared.tick() }
+      val restored = StateGraph.restore(active)
+      StateSemantics.validate(restored)
       @Suppress("UNCHECKED_CAST")
-      infrared.restoreFromMemento(StateGraph.restore(active) as Memento<InfraredPort>)
+      infrared.restoreFromMemento(restored as Memento<InfraredPort>)
       val actualTrace = continueInfrared(infrared, 500)
       assertEquals(expectedTrace, actualTrace)
       assertEquals(expected, StateGraph.capture(infrared.saveToMemento()))
+    }
+  }
+
+  @Test
+  fun mbc6FlashUnlockIdAndProgramPhasesContinueDeterministically() {
+    val mbc6 = Mbc6(mutableRom(), Battery.NULL_BATTERY)
+    EventBusImpl().use(mbc6::init)
+    enableMbc6Flash(mbc6)
+
+    // Capture after AA; the continuation completes the unlock and enters software-ID mode.
+    mbc6.setByte(0x5555, 0xaa)
+    val unlock = StateGraph.capture(mbc6.saveToMemento())
+    assertEquals(1, unlock.record(MBC6_MEMENTO).int("flashCommandState"))
+    assertMapperContinuation(
+        mbc6,
+        unlock,
+        disturb = { resetMbc6Flash(it) },
+    ) {
+      it.setByte(0x4aaa, 0x55)
+      it.setByte(0x5555, 0x90)
+      listOf(it.getByte(0x4000), it.getByte(0x4001))
+    }
+    assertTrue(StateGraph.capture(mbc6.saveToMemento()).record(MBC6_MEMENTO).bool("flashIdMode"))
+
+    resetMbc6Flash(mbc6)
+    mbc6.setByte(0x5555, 0xaa)
+    mbc6.setByte(0x4aaa, 0x55)
+    mbc6.setByte(0x5555, 0xa0)
+    val program = StateGraph.capture(mbc6.saveToMemento())
+    assertTrue(program.record(MBC6_MEMENTO).bool("flashProgramMode"))
+    assertMapperContinuation(
+        mbc6,
+        program,
+        disturb = { resetMbc6Flash(it) },
+    ) {
+      it.setByte(0x4321, 0x12)
+      listOf(it.getByte(0x4321))
+    }
+  }
+
+  @Test
+  fun mbc7EepromMidWriteContinuesDeterministically() {
+    val mbc7 = Mbc7(mutableRom(), Battery.NULL_BATTERY)
+    EventBusImpl().use(mbc7::init)
+    mbc7.setByte(0x0000, 0x0a)
+    mbc7.setByte(0x4000, 0x40)
+    mbc7Command(mbc7, 0b00, 0b11000000) // EWEN
+    mbc7.setByte(0xa080, 0)
+    mbc7Command(mbc7, 0b01, 0x12) // WRITE
+    mbc7SendBits(mbc7, 0xbe, 8)
+
+    val captured = StateGraph.capture(mbc7.saveToMemento())
+    val eeprom = captured.record(MBC7_EEPROM_MEMENTO)
+    assertEquals("WRITING", eeprom.enumName("state"))
+    assertEquals(8, eeprom.int("bitsRead"))
+    assertEquals(0xbe, eeprom.int("writeValue"))
+
+    assertMapperContinuation(
+        mbc7,
+        captured,
+        disturb = {
+          it.setByte(0xa080, 0)
+          mbc7Command(it, 0b01, 0x12)
+          mbc7SendBits(it, 0, 16)
+          it.setByte(0xa080, 0)
+        },
+    ) {
+      mbc7SendBits(it, 0xef, 8)
+      it.setByte(0xa080, 0)
+      mbc7Command(it, 0b10, 0x12)
+      val word = mbc7ReadWord(it)
+      it.setByte(0xa080, 0)
+      listOf(word)
+    }
+  }
+
+  @Test
+  fun mbc5RumbleLatchContinuesDeterministically() {
+    val log = mutableListOf<Boolean>()
+    val mbc5 = Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
+    EventBusImpl().use { bus ->
+      bus.register({ event -> log += event.on() }, RumbleEvent::class.java)
+      mbc5.init(bus)
+      mbc5.setByte(0x0000, 0x0a)
+      mbc5.setByte(0x4000, 0x0b) // RAM bank 3 + motor on
+      val captured = StateGraph.capture(mbc5.saveToMemento())
+      assertTrue(captured.record(MBC5_MEMENTO).bool("motorOn"))
+      assertEquals(3, captured.record(MBC5_MEMENTO).int("selectedRamBank"))
+
+      log.clear()
+      val expectedTrace = run {
+        mbc5.setByte(0x4000, 0x03)
+        log.toList()
+      }
+      val expectedState = StateGraph.capture(mbc5.saveToMemento())
+      mbc5.setByte(0x4000, 0x08)
+      @Suppress("UNCHECKED_CAST")
+      mbc5.restoreFromMemento(StateGraph.restore(captured) as Memento<MemoryController>)
+      log.clear()
+      mbc5.setByte(0x4000, 0x03)
+      assertEquals(listOf(false), expectedTrace)
+      assertEquals(expectedTrace, log)
+      assertEquals(expectedState, StateGraph.capture(mbc5.saveToMemento()))
+    }
+  }
+
+  @Test
+  fun datelOuterFlashProgramEraseAndIdPhasesContinueDeterministically() {
+    val datel = datelWithRtcSlot(mutableFlashRom())
+    EventBusImpl().use(datel::init)
+
+    datel.setByte(0x5555, 0xaa)
+    datel.setByte(0x2aaa, 0x55)
+    datel.setByte(0x5555, 0xa0)
+    val program = StateGraph.capture(datel.saveToMemento())
+    assertEquals(3, program.record(DATEL_MEMENTO).int("flashCycle"))
+    assertTrue(program.record(DATEL_MEMENTO).field("slotMemento") is RecordState)
+    assertMapperContinuation(datel, program, disturb = { resetDatelFlash(it) }) {
+      it.setByte(0x3000, 0x12)
+      listOf(it.getByte(0x3000))
+    }
+
+    datel.setByte(0x5555, 0xaa)
+    datel.setByte(0x2aaa, 0x55)
+    datel.setByte(0x5555, 0x80)
+    datel.setByte(0x5555, 0xaa)
+    val erase = StateGraph.capture(datel.saveToMemento())
+    val eraseRecord = erase.record(DATEL_MEMENTO)
+    assertTrue(eraseRecord.bool("flashErasePending"))
+    assertEquals(1, eraseRecord.int("flashCycle"))
+    assertMapperContinuation(datel, erase, disturb = { resetDatelFlash(it) }) {
+      it.setByte(0x2aaa, 0x55)
+      it.setByte(0x3000, 0x30)
+      listOf(it.getByte(0x3000))
+    }
+
+    datel.setByte(0x5555, 0xaa)
+    datel.setByte(0x2aaa, 0x55)
+    datel.setByte(0x5555, 0x90)
+    val id = StateGraph.capture(datel.saveToMemento())
+    assertTrue(id.record(DATEL_MEMENTO).bool("flashIdMode"))
+    assertMapperContinuation(datel, id, disturb = { resetDatelFlash(it) }) {
+      listOf(it.getByte(0), it.getByte(1))
     }
   }
 
@@ -364,6 +517,90 @@ class StateCoverageMatrixTest {
     return trace
   }
 
+  private fun assertMapperContinuation(
+      controller: MemoryController,
+      captured: StateValue,
+      disturb: (MemoryController) -> Unit,
+      continuation: (MemoryController) -> List<Int>,
+  ) {
+    val expectedTrace = continuation(controller)
+    val expectedState = StateGraph.capture(controller.saveToMemento())
+    disturb(controller)
+    val restored = StateGraph.restore(captured)
+    StateSemantics.validate(restored)
+    @Suppress("UNCHECKED_CAST")
+    controller.restoreFromMemento(restored as Memento<MemoryController>)
+    val actualTrace = continuation(controller)
+    assertEquals(expectedTrace, actualTrace)
+    assertEquals(expectedState, StateGraph.capture(controller.saveToMemento()))
+  }
+
+  private fun enableMbc6Flash(controller: MemoryController) {
+    controller.setByte(0x1000, 1)
+    controller.setByte(0x0c00, 1)
+    controller.setByte(0x2800, 0x08)
+  }
+
+  private fun resetMbc6Flash(controller: MemoryController) {
+    controller.setByte(0x5555, 0xaa)
+    controller.setByte(0x4aaa, 0x55)
+    controller.setByte(0x5555, 0xf0)
+  }
+
+  private fun mbc7SendBit(controller: MemoryController, bit: Boolean) {
+    val data = if (bit) 0x02 else 0
+    controller.setByte(0xa080, 0x80 or data)
+    controller.setByte(0xa080, 0xc0 or data)
+  }
+
+  private fun mbc7SendBits(controller: MemoryController, value: Int, count: Int) {
+    for (bit in count - 1 downTo 0) mbc7SendBit(controller, ((value shr bit) and 1) != 0)
+  }
+
+  private fun mbc7Command(controller: MemoryController, op: Int, address: Int) {
+    mbc7SendBit(controller, true)
+    mbc7SendBits(controller, op, 2)
+    mbc7SendBits(controller, address, 8)
+  }
+
+  private fun mbc7ReadWord(controller: MemoryController): Int {
+    var result = 0
+    repeat(17) { index ->
+      controller.setByte(0xa080, 0x80)
+      controller.setByte(0xa080, 0xc0)
+      if (index > 0) result = (result shl 1) or (controller.getByte(0xa080) and 1)
+    }
+    return result
+  }
+
+  private fun resetDatelFlash(controller: MemoryController) {
+    controller.setByte(0x5555, 0xaa)
+    controller.setByte(0x2aaa, 0x55)
+    controller.setByte(0x5555, 0xf0)
+  }
+
+  private fun StateValue.record(className: String): RecordState {
+    fun find(value: StateValue): RecordState? =
+        when (value) {
+          is RecordState ->
+              if (MementoTypeRegistry.recordClassNames[value.typeId - 1] == className) value
+              else value.fields.firstNotNullOfOrNull { find(it.value) }
+          is ObjectArrayState -> value.values.firstNotNullOfOrNull(::find)
+          is ListState -> value.values.firstNotNullOfOrNull(::find)
+          is Int32MapState -> value.entries.firstNotNullOfOrNull { find(it.value) }
+          else -> null
+        }
+    return requireNotNull(find(this)) { "Missing $className" }
+  }
+
+  private fun RecordState.field(name: String): StateValue = fields.single { it.name == name }.value
+  private fun RecordState.int(name: String): Int = (field(name) as Int32State).value
+  private fun RecordState.bool(name: String): Boolean = (field(name) as BooleanState).value
+  private fun RecordState.enumName(name: String): String {
+    val enum = field(name) as EnumState
+    return (MementoTypeRegistry.enumClasses[enum.typeId - 1].enumConstants[enum.ordinal] as Enum<*>).name
+  }
+
   private fun rtcSetup(seconds: Int) =
       listOf(
           0x0000 to 0x0a,
@@ -382,15 +619,28 @@ class StateCoverageMatrixTest {
     return datel
   }
 
-  private fun mutableRom(): Rom {
+  private fun mutableRom(type: Int = 0x1b): Rom {
     val bytes = ByteArray(0x200000)
-    bytes[0x147] = 0x1b // MBC5 + RAM + battery; constructors are selected explicitly.
+    bytes[0x147] = type.toByte() // constructors are selected explicitly except MBC5 rumble wiring.
+    bytes[0x148] = 0x06
+    bytes[0x149] = 0x03
+    return Rom(bytes)
+  }
+
+  private fun mutableFlashRom(): Rom {
+    val bytes = ByteArray(0x200000) { 0xff.toByte() }
+    bytes[0x147] = 0x1b
     bytes[0x148] = 0x06
     bytes[0x149] = 0x03
     return Rom(bytes)
   }
 
   private companion object {
+    const val MBC5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5Memento"
+    const val MBC6_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc6\$Mbc6Memento"
+    const val MBC7_EEPROM_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento"
+    const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelMemento"
     val DEFAULT_MAPPER_PROBES = listOf(0x0100, 0x4000, 0x7000, 0x7fe1, 0xa000, 0xa001)
 
     val EXPECTED_MAPPER_FAMILIES =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Paths
 import kotlin.io.path.readLines
 import kotlin.io.path.readText
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class StateInventoryTest {
@@ -58,6 +59,13 @@ class StateInventoryTest {
 
     assertEquals(97, discovered.size)
     assertEquals(discovered, documented)
+  }
+
+  @Test
+  fun everyAdmittedRecordHasAnExplicitSemanticPolicyAndRationale() {
+    assertEquals(MementoTypeRegistry.recordClassNames.toSet(), StateSemantics.policyAudit.keys)
+    assertEquals(91, StateSemantics.policyAudit.size)
+    assertTrue(StateSemantics.policyAudit.values.all { it.isNotBlank() })
   }
 
   private companion object {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import java.nio.file.Paths
+import kotlin.io.path.readLines
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class StateInventoryTest {
+
+  @Test
+  fun committedFieldInventoryExactlyMatchesAuditedProductionRegistry() {
+    val documented =
+        Paths.get("../docs/state-memento-schema.md")
+            .readLines()
+            .filter { it.startsWith("- `") }
+    val runtime =
+        MementoTypeRegistry.recordClasses.map { type ->
+          val fields = type.recordComponents.joinToString(", ") { it.name }
+          "- `${type.name}`: $fields"
+        }
+
+    assertEquals(91, runtime.size)
+    assertEquals(runtime, documented)
+    assertEquals(11, MementoTypeRegistry.enumClasses.size)
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -1,8 +1,10 @@
 package eu.rekawek.coffeegb.controller.state
 
 import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.io.path.readLines
+import kotlin.io.path.readText
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -23,5 +25,42 @@ class StateInventoryTest {
     assertEquals(91, runtime.size)
     assertEquals(runtime, documented)
     assertEquals(11, MementoTypeRegistry.enumClasses.size)
+  }
+
+  @Test
+  fun everyProductionOriginatorAndCaptureSiteIsInTheOwnershipAudit() {
+    val repository = Paths.get("..").toAbsolutePath().normalize()
+    val productionRoots =
+        listOf(repository.resolve("core/src/main/java"), repository.resolve("controller/src/main/java"))
+    val discovered =
+        productionRoots
+            .flatMap { root ->
+              Files.walk(root).use { paths ->
+                paths
+                    .filter { Files.isRegularFile(it) }
+                    .filter {
+                      val source = it.readText()
+                      "saveToMemento(" in source || "Originator<" in source
+                    }
+                    .map { repository.relativize(it).toString() }
+                    .toList()
+              }
+            }
+            .sorted()
+    val documented =
+        repository
+            .resolve("docs/state-originator-sites.md")
+            .readLines()
+            .mapNotNull { line ->
+              ORIGINATOR_AUDIT_LINE.matchEntire(line)?.groupValues?.get(1)
+            }
+            .sorted()
+
+    assertEquals(97, discovered.size)
+    assertEquals(discovered, documented)
+  }
+
+  private companion object {
+    val ORIGINATOR_AUDIT_LINE = Regex("- (?:OWNER|COMPOSITE|WORKFLOW|CONTRACT) `([^`]+)`")
   }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -18,6 +18,7 @@ import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble;
@@ -792,6 +793,14 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         }
     }
 
+    public RealTimeClock.RuntimeState captureRtcRuntimeState() {
+        return cartridge.captureRtcRuntimeState();
+    }
+
+    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
+        cartridge.restoreRtcRuntimeState(state);
+    }
+
     /** Flushes persistent cartridge state without closing the running machine. */
     public void flushCartridge() {
         cartridge.flushBattery();
@@ -814,7 +823,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     @Override
     public Memento<Gameboy> saveToMemento() {
-        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), display.saveToMemento(), sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), codeBreakerRumble.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, speedSwitchTailTicks, speedSwitchClockPhaseShifted, blankCgbBootTilePending, clearBootTilemapPending, clearCgbBootOamShadowPending);
+        // Gpu owns the sole display snapshot. Keep the nullable root component in the legacy
+        // record shape so Phase-0 fixtures still decode, but do not clone the two 160x144 buffers
+        // a second time for new captures.
+        return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), null, sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), codeBreakerRumble.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, speedSwitchTailTicks, speedSwitchClockPhaseShifted, blankCgbBootTilePending, clearBootTilemapPending, clearCgbBootOamShadowPending);
     }
 
     @Override
@@ -856,7 +868,11 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         timer.restoreFromMemento(mem.timerMemento());
         dma.restoreFromMemento(mem.dmaMemento());
         hdma.restoreFromMemento(mem.hdmaMemento());
-        display.restoreFromMemento(mem.displayMemento());
+        // Older snapshots contain the former duplicate. Gpu has already restored the same
+        // display state; applying this copy preserves byte-for-byte legacy behavior.
+        if (mem.displayMemento() != null) {
+            display.restoreFromMemento(mem.displayMemento());
+        }
         sound.restoreFromMemento(mem.soundMemento());
         serialPort.restoreFromMemento(mem.serialPortMemento());
         infraredPort.restoreFromMemento(mem.infraredPortMemento());

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -826,6 +826,19 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         }
     }
 
+    /** Captures DMG FIFO fields kept outside the pinned legacy Java memento. */
+    public Gpu.DmgFifoRuntimeState captureDmgFifoRuntimeState() {
+        return gpu.captureDmgFifoRuntimeState();
+    }
+
+    public void validateDmgFifoRuntimeState(Gpu.DmgFifoRuntimeState state) {
+        gpu.validateDmgFifoRuntimeState(state);
+    }
+
+    public void restoreDmgFifoRuntimeState(Gpu.DmgFifoRuntimeState state) {
+        gpu.restoreDmgFifoRuntimeState(state);
+    }
+
     /** Service-free runtime state that is intentionally outside the pinned legacy memento. */
     public record RtcRuntimeState(RealTimeClock.RuntimeState primary,
                                   RealTimeClock.RuntimeState slot) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -160,7 +160,10 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
 
     private final boolean gbc;
 
+    private final GameboyType gameboyType;
+
     public Gameboy(GameboyConfiguration configuration) {
+        this.gameboyType = configuration.gameboyType;
         this.gbc = configuration.gameboyType == GameboyType.CGB;
         boolean gbc = this.gbc;
         boolean sgb = configuration.gameboyType == GameboyType.SGB;
@@ -215,7 +218,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         }
         if (configuration.slotRom != null && cartridge.getDatel() != null) {
             // the game cartridge in the Action Replay's pass-through slot
-            slotCartridge = new Cartridge(configuration.slotRom, configuration.supportBatterySave);
+            slotCartridge = new Cartridge(configuration.slotRom, configuration.supportBatterySave,
+                    configuration.rtcTimeSource);
             cartridge.getDatel().setSlotCartridge(slotCartridge.getMemoryController(),
                     configuration.slotRom.getGameboyColorFlag() == Rom.GameboyColorFlag.NON_CGB);
         } else {
@@ -793,12 +797,42 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         }
     }
 
-    public RealTimeClock.RuntimeState captureRtcRuntimeState() {
-        return cartridge.captureRtcRuntimeState();
+    /** Captures MBC3 pause bookkeeping for each physical cartridge location. */
+    public RtcRuntimeState captureRtcRuntimeState() {
+        return new RtcRuntimeState(
+                cartridge.captureRtcRuntimeState(),
+                slotCartridge == null ? null : slotCartridge.captureRtcRuntimeState());
     }
 
-    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
-        cartridge.restoreRtcRuntimeState(state);
+    public void validateRtcRuntimeState(RtcRuntimeState state) {
+        if (state == null) {
+            throw new IllegalArgumentException("Cartridge RTC runtime state is missing");
+        }
+        cartridge.validateRtcRuntimeState(state.primary());
+        if (slotCartridge == null) {
+            if (state.slot() != null) {
+                throw new IllegalArgumentException("Slot RTC runtime state supplied without a slot cartridge");
+            }
+        } else {
+            slotCartridge.validateRtcRuntimeState(state.slot());
+        }
+    }
+
+    public void restoreRtcRuntimeState(RtcRuntimeState state) {
+        validateRtcRuntimeState(state);
+        cartridge.restoreRtcRuntimeState(state.primary());
+        if (slotCartridge != null) {
+            slotCartridge.restoreRtcRuntimeState(state.slot());
+        }
+    }
+
+    /** Service-free runtime state that is intentionally outside the pinned legacy memento. */
+    public record RtcRuntimeState(RealTimeClock.RuntimeState primary,
+                                  RealTimeClock.RuntimeState slot) {
+    }
+
+    public GameboyType getGameboyType() {
+        return gameboyType;
     }
 
     /** Flushes persistent cartridge state without closing the running machine. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -317,14 +317,22 @@ public class DmgPixelFifo implements PixelFifo, Serializable, Originator<DmgPixe
         if (state == null) {
             throw new IllegalArgumentException("DMG pixel FIFO runtime state is missing");
         }
-        if (state.linePixels < 0 || state.outCount < 0) {
-            throw new IllegalArgumentException("DMG pixel FIFO counters cannot be negative");
+        if (state.linePixels < 0 || state.linePixels > 160) {
+            throw new IllegalArgumentException("DMG pixel FIFO line position is outside 0..160");
+        }
+        if (state.outCount < 0) {
+            throw new IllegalArgumentException("DMG pixel FIFO output count cannot be negative");
         }
         if (state.firstEntry < -1 || state.firstEntry > 0x3f) {
             throw new IllegalArgumentException("Invalid pending DMG first-pixel entry");
         }
-        if (state.firstEntry >= 0 && state.outCount == 0) {
-            throw new IllegalArgumentException("Pending DMG first pixel has no output count");
+        // The latch is installed only for the first due output entry, which increments
+        // outCount from zero to one. The following output tick clears firstEntry before it
+        // considers another due entry, so firstEntry == -1 does not imply any outCount value.
+        // outCount deliberately has no upper bound: it is bookkeeping, not an array cursor,
+        // and window/timing rewinds do not establish a tighter invariant.
+        if (state.firstEntry >= 0 && state.outCount != 1) {
+            throw new IllegalArgumentException("Pending DMG first pixel requires output count 1");
         }
         if (!isByte(state.firstBgp) || !isByte(state.firstObp0) || !isByte(state.firstObp1)) {
             throw new IllegalArgumentException("Invalid pending DMG first-pixel palette");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -300,6 +300,51 @@ public class DmgPixelFifo implements PixelFifo, Serializable, Originator<DmgPixe
                 delayEntry.clone(), delayStamp.clone(), delayHead, delaySize, outputTicks);
     }
 
+    /**
+     * Captures fields added after the pinned legacy Java-memento shape was established.
+     *
+     * <p>The first-pixel latch is deliberately outside {@link DmgPixelFifoMemento}: changing
+     * that record would change its Java serialization descriptor and reject the supported
+     * 1.7.13/1.7.14 fixtures. The Phase-1 detached machine seam owns this supplement for both
+     * PPU dot machines.
+     */
+    public RuntimeState captureRuntimeState() {
+        return new RuntimeState(
+                linePixels, outCount, firstEntry, firstBgp, firstObp0, firstObp1);
+    }
+
+    public void validateRuntimeState(RuntimeState state) {
+        if (state == null) {
+            throw new IllegalArgumentException("DMG pixel FIFO runtime state is missing");
+        }
+        if (state.linePixels < 0 || state.outCount < 0) {
+            throw new IllegalArgumentException("DMG pixel FIFO counters cannot be negative");
+        }
+        if (state.firstEntry < -1 || state.firstEntry > 0x3f) {
+            throw new IllegalArgumentException("Invalid pending DMG first-pixel entry");
+        }
+        if (state.firstEntry >= 0 && state.outCount == 0) {
+            throw new IllegalArgumentException("Pending DMG first pixel has no output count");
+        }
+        if (!isByte(state.firstBgp) || !isByte(state.firstObp0) || !isByte(state.firstObp1)) {
+            throw new IllegalArgumentException("Invalid pending DMG first-pixel palette");
+        }
+    }
+
+    public void restoreRuntimeState(RuntimeState state) {
+        validateRuntimeState(state);
+        linePixels = state.linePixels;
+        outCount = state.outCount;
+        firstEntry = state.firstEntry;
+        firstBgp = state.firstBgp;
+        firstObp0 = state.firstObp0;
+        firstObp1 = state.firstObp1;
+    }
+
+    private static boolean isByte(int value) {
+        return value >= 0 && value <= 0xff;
+    }
+
     @Override
     public void restoreFromMemento(Memento<DmgPixelFifo> memento) {
         if (!(memento instanceof DmgPixelFifoMemento mem)) {
@@ -324,5 +369,15 @@ public class DmgPixelFifo implements PixelFifo, Serializable, Originator<DmgPixe
                                        int[] delayEntry, long[] delayStamp, int delayHead,
                                        int delaySize, long outputTicks)
             implements Memento<DmgPixelFifo> {
+    }
+
+    /** Service-free supplement retained by the immutable machine-state seam. */
+    public record RuntimeState(
+            int linePixels,
+            int outCount,
+            int firstEntry,
+            int firstBgp,
+            int firstObp0,
+            int firstObp1) {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -463,6 +463,11 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         }
         pixelTransferPhase.checkWindowY(line, ticksInLine);
         pixelMachine.checkWindowY(line, ticksInLine);
+        // Both dot machines enqueue popped pixels into an eight-slot LCD delay line.
+        // The timing-only skeleton has a throwaway Display, but its delay line still
+        // participates in window rewind/refresh bookkeeping and must advance as a
+        // bounded ring just like the shifted output machine.
+        pixelTransferPhase.outputTick();
         pixelMachine.outputTick();
         pixelMachine.machineTick();
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1909,6 +1909,47 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         return speedMode.isDmgCompat();
     }
 
+    /**
+     * Captures the two DMG FIFO supplements without changing the pinned legacy mementos.
+     * Native CGB hardware uses {@link ColorPixelFifo} and therefore has no supplement.
+     */
+    public DmgFifoRuntimeState captureDmgFifoRuntimeState() {
+        if (gbc) {
+            return null;
+        }
+        return new DmgFifoRuntimeState(
+                pixelTransferPhase.captureDmgFifoRuntimeState(),
+                pixelMachine.captureDmgFifoRuntimeState());
+    }
+
+    public void validateDmgFifoRuntimeState(DmgFifoRuntimeState state) {
+        if (gbc) {
+            if (state != null) {
+                throw new IllegalArgumentException("DMG FIFO state supplied for CGB hardware");
+            }
+            return;
+        }
+        if (state == null) {
+            throw new IllegalArgumentException("DMG FIFO state is missing");
+        }
+        pixelTransferPhase.validateDmgFifoRuntimeState(state.timing());
+        pixelMachine.validateDmgFifoRuntimeState(state.output());
+    }
+
+    public void restoreDmgFifoRuntimeState(DmgFifoRuntimeState state) {
+        validateDmgFifoRuntimeState(state);
+        if (!gbc) {
+            pixelTransferPhase.restoreDmgFifoRuntimeState(state.timing());
+            pixelMachine.restoreDmgFifoRuntimeState(state.output());
+        }
+    }
+
+    /** Service-free state for the timing and pixel-producing DMG FIFOs. */
+    public record DmgFifoRuntimeState(
+            DmgPixelFifo.RuntimeState timing,
+            DmgPixelFifo.RuntimeState output) {
+    }
+
     public ColorPalette getBgPalette() {
         return bgPalette;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -331,6 +331,27 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
         fifo.outputTick();
     }
 
+    public DmgPixelFifo.RuntimeState captureDmgFifoRuntimeState() {
+        return fifo instanceof DmgPixelFifo dmgFifo ? dmgFifo.captureRuntimeState() : null;
+    }
+
+    public void validateDmgFifoRuntimeState(DmgPixelFifo.RuntimeState state) {
+        if (!(fifo instanceof DmgPixelFifo dmgFifo)) {
+            if (state != null) {
+                throw new IllegalArgumentException("DMG pixel FIFO state supplied for a CGB FIFO");
+            }
+            return;
+        }
+        dmgFifo.validateRuntimeState(state);
+    }
+
+    public void restoreDmgFifoRuntimeState(DmgPixelFifo.RuntimeState state) {
+        validateDmgFifoRuntimeState(state);
+        if (fifo instanceof DmgPixelFifo dmgFifo) {
+            dmgFifo.restoreRuntimeState(state);
+        }
+    }
+
     /** Ticks the pixel-machine instance; called by the GPU every T-cycle. */
     public void machineTick() {
         if (machineActive && !tick()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.type.*;
@@ -73,9 +74,9 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         } else if (type.isHuc1()) {
             return new Huc1(rom, battery);
         } else if (type.isHuc3()) {
-            return new Huc3(rom, battery);
+            return new Huc3(rom, battery, rtcTimeSource);
         } else if (type.isTama5()) {
-            return new Tama5(rom, battery);
+            return new Tama5(rom, battery, rtcTimeSource);
         } else if (type.isMbc1()) {
             return new Mbc1(rom, battery);
         } else if (type.isMbc2()) {
@@ -126,6 +127,24 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
     /** Notifies independent cartridge clocks that emulation has paused or resumed. */
     public void setClockPaused(boolean paused) {
         addressSpace.setClockPaused(paused);
+    }
+
+    /** Returns detached MBC3 pause bookkeeping, or null for mappers without that clock. */
+    public RealTimeClock.RuntimeState captureRtcRuntimeState() {
+        return addressSpace instanceof Mbc3 mbc3 ? mbc3.captureRtcRuntimeState() : null;
+    }
+
+    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
+        if (!(addressSpace instanceof Mbc3 mbc3)) {
+            if (state != null) {
+                throw new IllegalArgumentException("RTC runtime state supplied for a non-MBC3 cartridge");
+            }
+            return;
+        }
+        if (state == null) {
+            throw new IllegalArgumentException("MBC3 RTC runtime state is missing");
+        }
+        mbc3.restoreRtcRuntimeState(state);
     }
 
     /** The Sachen MMC2 needs to observe reads on the upper half of the bus (see Mmu). */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -134,7 +134,7 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         return addressSpace instanceof Mbc3 mbc3 ? mbc3.captureRtcRuntimeState() : null;
     }
 
-    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
+    public void validateRtcRuntimeState(RealTimeClock.RuntimeState state) {
         if (!(addressSpace instanceof Mbc3 mbc3)) {
             if (state != null) {
                 throw new IllegalArgumentException("RTC runtime state supplied for a non-MBC3 cartridge");
@@ -144,7 +144,16 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
         if (state == null) {
             throw new IllegalArgumentException("MBC3 RTC runtime state is missing");
         }
-        mbc3.restoreRtcRuntimeState(state);
+        if (!state.emulationPaused() && state.pauseStartedMillis() != 0) {
+            throw new IllegalArgumentException("Running MBC3 RTC has a stale pause reference");
+        }
+    }
+
+    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
+        validateRtcRuntimeState(state);
+        if (addressSpace instanceof Mbc3 mbc3) {
+            mbc3.restoreRtcRuntimeState(state);
+        }
     }
 
     /** The Sachen MMC2 needs to observe reads on the upper half of the bus (see Mmu). */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
@@ -150,6 +150,7 @@ public class RealTimeClock implements Serializable, Originator<RealTimeClock> {
         } else {
             catchUpPausedTime();
             emulationPaused = false;
+            pauseStartedMillis = 0;
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java
@@ -294,6 +294,23 @@ public class RealTimeClock implements Serializable, Originator<RealTimeClock> {
         }
     }
 
+    /**
+     * Captures controller-owned pause bookkeeping that is deliberately absent from the pinned
+     * legacy memento shape. The TimeSource service itself is never retained.
+     */
+    public RuntimeState captureRuntimeState() {
+        catchUpPausedTime();
+        return new RuntimeState(emulationPaused, pauseStartedMillis);
+    }
+
+    public void restoreRuntimeState(RuntimeState state) {
+        emulationPaused = state.emulationPaused;
+        pauseStartedMillis = state.emulationPaused ? state.pauseStartedMillis : 0;
+    }
+
+    public record RuntimeState(boolean emulationPaused, long pauseStartedMillis) {
+    }
+
     private record RealTimeClockMemento(int seconds, int minutes, int hours, int days, boolean halt,
                                         boolean counterOverflow, long subSecondTicks,
                                         boolean latched, int latchedSeconds, int latchedMinutes, int latchedHours,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/VirtualTimeSource.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/VirtualTimeSource.java
@@ -25,4 +25,8 @@ public class VirtualTimeSource implements TimeSource, Serializable {
     public void forward(long i, TimeUnit unit) {
         clock += unit.toMillis(i);
     }
+
+    public void setCurrentTimeMillis(long clock) {
+        this.clock = clock;
+    }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/VirtualTimeSource.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/VirtualTimeSource.java
@@ -5,7 +5,17 @@ import java.util.concurrent.TimeUnit;
 
 public class VirtualTimeSource implements TimeSource, Serializable {
 
-    private long clock = System.currentTimeMillis();
+    private long clock;
+
+    public VirtualTimeSource() {
+        // Battery formats reserve zero as "no persisted wall-clock reference".
+        // Keep the test clock deterministic while starting beyond that sentinel.
+        this(946_684_800_000L);
+    }
+
+    public VirtualTimeSource(long initialMillis) {
+        this.clock = initialMillis;
+    }
 
     @Override
     public long currentTimeMillis() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
@@ -4,6 +4,8 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 
 import java.util.Arrays;
 
@@ -25,6 +27,8 @@ public class Huc3 implements MemoryController {
     private final int ramBanks;
 
     private final Battery battery;
+
+    private final TimeSource timeSource;
 
     private int romBank = 1;
 
@@ -49,17 +53,23 @@ public class Huc3 implements MemoryController {
 
     private int readValue;
 
-    private long lastRtcSecond = System.currentTimeMillis() / 1000;
+    private long lastRtcSecond;
 
     private boolean ramUpdated;
 
     public Huc3(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource());
+    }
+
+    public Huc3(Rom rom, Battery battery, TimeSource timeSource) {
         this.cartridge = rom.getRom();
         this.romBanks = rom.getRomBanks();
         this.ramBanks = Math.max(rom.getRamBanks(), 1);
         this.ram = new int[0x2000 * this.ramBanks];
         Arrays.fill(ram, 0xff);
         this.battery = battery;
+        this.timeSource = timeSource;
+        this.lastRtcSecond = timeSource.currentTimeMillis() / 1000;
 
         long[] clockData = new long[12];
         battery.loadRamWithClock(ram, clockData);
@@ -75,7 +85,7 @@ public class Huc3 implements MemoryController {
     }
 
     private void updateRtc() {
-        long now = System.currentTimeMillis() / 1000;
+        long now = timeSource.currentTimeMillis() / 1000;
         while (lastRtcSecond / 60 < now / 60) {
             lastRtcSecond += 60;
             minutes++;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -87,6 +87,14 @@ public class Mbc3 implements MemoryController {
         clock.setEmulationPaused(paused);
     }
 
+    public RealTimeClock.RuntimeState captureRtcRuntimeState() {
+        return clock.captureRuntimeState();
+    }
+
+    public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
+        clock.restoreRuntimeState(state);
+    }
+
     private void selectRomBank(int bank) {
         if (bank == 0) {
             bank = 1;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
@@ -4,6 +4,8 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 
 /**
  * Bandai TAMA5 mapper (Game de Hakken!! Tamagotchi - Osutchi to Mesutchi). The cartridge is
@@ -69,6 +71,8 @@ public class Tama5 implements MemoryController {
 
     private final Battery battery;
 
+    private final TimeSource timeSource;
+
     private int selectedReg;
 
     private final int[] registers = new int[MAX_REG];
@@ -83,14 +87,20 @@ public class Tama5 implements MemoryController {
 
     private boolean rtcDisabled;
 
-    private long lastRtcSecond = System.currentTimeMillis() / 1000;
+    private long lastRtcSecond;
 
     private boolean ramUpdated;
 
     public Tama5(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource());
+    }
+
+    public Tama5(Rom rom, Battery battery, TimeSource timeSource) {
         this.cartridge = rom.getRom();
         this.romBanks = rom.getRomBanks();
         this.battery = battery;
+        this.timeSource = timeSource;
+        this.lastRtcSecond = timeSource.currentTimeMillis() / 1000;
 
         rtcAlarmPage[RTC_PAGE] = 1;
         rtcFreePage0[RTC_PAGE] = 2;
@@ -310,7 +320,7 @@ public class Tama5 implements MemoryController {
      * last latch.
      */
     private void latchRtc() {
-        long now = System.currentTimeMillis() / 1000;
+        long now = timeSource.currentTimeMillis() / 1000;
         long t = now - lastRtcSecond;
         lastRtcSecond = now;
         if (t <= 0 || rtcDisabled) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/BarcodeBoySerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/BarcodeBoySerialEndpoint.java
@@ -87,6 +87,34 @@ public class BarcodeBoySerialEndpoint implements SerialEndpoint {
         return pending != null || state == State.SENDING;
     }
 
+    /** Controller-owned state kept outside the pinned legacy memento record. */
+    public RuntimeState captureRuntimeState() {
+        return new RuntimeState(transferArmed, pending);
+    }
+
+    public void restoreRuntimeState(RuntimeState runtimeState) {
+        transferArmed = runtimeState.transferArmed;
+        pending = runtimeState.copyPending();
+    }
+
+    public static final class RuntimeState {
+        private final boolean transferArmed;
+        private final int[] pending;
+
+        public RuntimeState(boolean transferArmed, int[] pending) {
+            this.transferArmed = transferArmed;
+            this.pending = pending == null ? null : pending.clone();
+        }
+
+        public boolean transferArmed() {
+            return transferArmed;
+        }
+
+        public int[] copyPending() {
+            return pending == null ? null : pending.clone();
+        }
+    }
+
     @Override
     public void setSb(int sb) {
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PixelFifoTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PixelFifoTest.java
@@ -17,9 +17,11 @@ public class PixelFifoTest {
 
     @Before
     public void createFifo() {
-        GpuRegisterValues r = new GpuRegisterValues();
-        r.put(GpuRegister.BGP, 0b11100100);
-        fifo = new DmgPixelFifo(new Display(false), new Lcdc(), r, null);
+        GpuRegisterValues registers = new GpuRegisterValues();
+        registers.put(GpuRegister.BGP, 0b11100100);
+        registers.put(GpuRegister.OBP0, 0);
+        registers.put(GpuRegister.OBP1, 0xff);
+        fifo = new DmgPixelFifo(new Display(false), new Lcdc(), registers, null);
     }
 
     @Test
@@ -37,6 +39,44 @@ public class PixelFifoTest {
         assertEquals(0b10, fifo.dequeuePixel());
         assertEquals(0b10, fifo.dequeuePixel());
         assertEquals(0b01, fifo.dequeuePixel());
+    }
+
+    @Test
+    public void firstPixelLatchClearsBeforeAnotherOutputIsRequired() {
+        DmgPixelFifo.RuntimeState initial = fifo.captureRuntimeState();
+        assertEquals(0, initial.linePixels());
+        assertEquals(0, initial.outCount());
+        assertEquals(-1, initial.firstEntry());
+
+        fifo.enqueue8Pixels(zip(0b11001001, 0b11110000, false), TileAttributes.EMPTY);
+        fifo.setOverlay(
+                new int[]{3, 0, 0, 0, 0, 0, 0, 0},
+                0,
+                TileAttributes.valueOf(0x90),
+                0);
+        fifo.putPixelToScreen();
+        fifo.outputTick();
+        fifo.outputTick();
+        fifo.outputTick();
+
+        DmgPixelFifo.RuntimeState pending = fifo.captureRuntimeState();
+        assertEquals(1, pending.linePixels());
+        assertEquals(1, pending.outCount());
+        assertEquals(0x3f, pending.firstEntry());
+        assertEquals(0b11100100, pending.firstBgp());
+        assertEquals(0, pending.firstObp0());
+        assertEquals(0xff, pending.firstObp1());
+
+        fifo.outputTick();
+        DmgPixelFifo.RuntimeState emitted = fifo.captureRuntimeState();
+        assertEquals(1, emitted.linePixels());
+        assertEquals(1, emitted.outCount());
+        assertEquals(-1, emitted.firstEntry());
+
+        fifo.restoreRuntimeState(pending);
+        assertEquals(pending, fifo.captureRuntimeState());
+        fifo.restoreRuntimeState(emitted);
+        assertEquals(emitted, fifo.captureRuntimeState());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/RtcTimeSourceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/RtcTimeSourceTest.java
@@ -1,0 +1,178 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RtcTimeSourceTest {
+
+    @Test
+    public void mbc3OwnsSubsecondLatchHaltAndPauseStateWithoutOwningClockService() throws Exception {
+        VirtualTimeSource time = new VirtualTimeSource(120_000);
+        Mbc3 mbc3 = (Mbc3) cartridge(0x13, 0x03, new MemoryBattery(new byte[0]), time)
+                .getMemoryController();
+        enableMbc3(mbc3);
+        writeMbc3(mbc3, 0x08, 7);
+        for (int i = 0; i < Gameboy.TICKS_PER_SEC / 4; i++) {
+            mbc3.tick();
+        }
+        mbc3.setByte(0x6000, 1); // latch at 7.25 seconds
+        mbc3.setClockPaused(true);
+        time.forward(1500, TimeUnit.MILLISECONDS);
+        Memento<MemoryController> captured = mbc3.saveToMemento();
+        var capturedRuntime = mbc3.captureRtcRuntimeState();
+
+        Object capturedClock = component(captured, "clockMemento");
+        assertEquals(8, component(capturedClock, "seconds"));
+        assertEquals(3L * Gameboy.TICKS_PER_SEC / 4, component(capturedClock, "subSecondTicks"));
+        assertTrue((boolean) component(capturedClock, "latched"));
+        assertEquals(7, component(capturedClock, "latchedSeconds"));
+        assertTrue(capturedRuntime.emulationPaused());
+
+        writeMbc3(mbc3, 0x08, 33);
+        writeMbc3(mbc3, 0x0c, 0x40);
+        mbc3.setClockPaused(false);
+        mbc3.restoreFromMemento(captured);
+        mbc3.restoreRtcRuntimeState(capturedRuntime);
+
+        time.forward(250, TimeUnit.MILLISECONDS);
+        mbc3.setClockPaused(false);
+        Object continuedClock = component(mbc3.saveToMemento(), "clockMemento");
+        assertEquals(9, component(continuedClock, "seconds"));
+        assertEquals(0L, component(continuedClock, "subSecondTicks"));
+        assertEquals(7, readMbc3(mbc3, 0x08)); // the captured latch remains authoritative
+        assertFalse(mbc3.captureRtcRuntimeState().emulationPaused());
+
+        writeMbc3(mbc3, 0x0c, 0x40);
+        Memento<MemoryController> halted = mbc3.saveToMemento();
+        writeMbc3(mbc3, 0x0c, 0);
+        mbc3.restoreFromMemento(halted);
+        assertTrue((boolean) component(component(mbc3.saveToMemento(), "clockMemento"), "halt"));
+    }
+
+    @Test
+    public void mbc3BatteryReferenceUsesInjectedVirtualTime() throws Exception {
+        VirtualTimeSource time = new VirtualTimeSource(120_000);
+        MemoryBattery battery = new MemoryBattery(new byte[0]);
+        Mbc3 first = (Mbc3) cartridge(0x13, 0x03, battery, time).getMemoryController();
+        enableMbc3(first);
+        writeMbc3(first, 0x08, 10);
+        first.flushRam();
+
+        time.forward(5, TimeUnit.SECONDS);
+        Mbc3 restored = (Mbc3) cartridge(0x13, 0x03, battery, time).getMemoryController();
+        assertEquals(15, component(component(restored.saveToMemento(), "clockMemento"), "seconds"));
+    }
+
+    @Test
+    public void huc3AdvancesRestoresAndPersistsAgainstInjectedTime() throws Exception {
+        VirtualTimeSource time = new VirtualTimeSource(120_000);
+        MemoryBattery battery = new MemoryBattery(new byte[0]);
+        Huc3 huc3 = (Huc3) cartridge(0xfe, 0x03, battery, time).getMemoryController();
+
+        time.forward(2, TimeUnit.MINUTES);
+        readHuc3Register(huc3, 0);
+        Memento<MemoryController> captured = huc3.saveToMemento();
+        assertEquals(2, component(captured, "minutes"));
+
+        time.forward(3, TimeUnit.MINUTES);
+        readHuc3Register(huc3, 0);
+        assertEquals(5, component(huc3.saveToMemento(), "minutes"));
+        huc3.restoreFromMemento(captured);
+        readHuc3Register(huc3, 0);
+        assertEquals(5, component(huc3.saveToMemento(), "minutes"));
+
+        huc3.flushRam();
+        time.forward(2, TimeUnit.MINUTES);
+        Huc3 fromBattery = (Huc3) cartridge(0xfe, 0x03, battery, time).getMemoryController();
+        assertEquals(7, component(fromBattery.saveToMemento(), "minutes"));
+    }
+
+    @Test
+    public void tama5AdvancesRestoresAndPersistsAgainstInjectedTime() throws Exception {
+        VirtualTimeSource time = new VirtualTimeSource(120_000);
+        MemoryBattery battery = new MemoryBattery(new byte[0]);
+        Tama5 tama5 = (Tama5) cartridge(0xfd, 0, battery, time).getMemoryController();
+
+        time.forward(65, TimeUnit.SECONDS);
+        assertEquals(1, readTama5Minutes(tama5));
+        Memento<MemoryController> captured = tama5.saveToMemento();
+
+        time.forward(125, TimeUnit.SECONDS);
+        assertEquals(3, readTama5Minutes(tama5));
+        tama5.restoreFromMemento(captured);
+        assertEquals(3, readTama5Minutes(tama5));
+
+        tama5.flushRam();
+        time.forward(2, TimeUnit.MINUTES);
+        Tama5 fromBattery = (Tama5) cartridge(0xfd, 0, battery, time).getMemoryController();
+        assertEquals(5, readTama5Minutes(fromBattery));
+    }
+
+    private static Cartridge cartridge(int type, int ramSize, MemoryBattery battery,
+                                       VirtualTimeSource time) throws IOException {
+        byte[] data = new byte[0x200000];
+        data[0x147] = (byte) type;
+        data[0x148] = 0x06;
+        data[0x149] = (byte) ramSize;
+        return new Cartridge(new Rom(data), battery, time);
+    }
+
+    private static void enableMbc3(Mbc3 mbc3) {
+        mbc3.setByte(0x0000, 0x0a);
+    }
+
+    private static void writeMbc3(Mbc3 mbc3, int register, int value) {
+        mbc3.setByte(0x4000, register);
+        mbc3.setByte(0xa000, value);
+    }
+
+    private static int readMbc3(Mbc3 mbc3, int register) {
+        mbc3.setByte(0x4000, register);
+        return mbc3.getByte(0xa000);
+    }
+
+    private static int readHuc3Register(Huc3 huc3, int register) {
+        huc3.setByte(0x0000, 0x0b);
+        huc3.setByte(0xa000, 0x40 | (register & 0x0f));
+        huc3.setByte(0xa000, 0x50 | ((register >> 4) & 0x0f));
+        huc3.setByte(0xa000, 0x10);
+        huc3.setByte(0x0000, 0x0c);
+        return huc3.getByte(0xa000);
+    }
+
+    private static int readTama5Minutes(Tama5 tama5) {
+        writeTama5Register(tama5, 0x6, 0x4); // command space
+        writeTama5Register(tama5, 0x7, 0x6); // minute-read command
+        tama5.setByte(0xa001, 0xc);
+        return tama5.getByte(0xa000) & 0x0f;
+    }
+
+    private static void writeTama5Register(Tama5 tama5, int register, int value) {
+        tama5.setByte(0xa001, register);
+        tama5.setByte(0xa000, value);
+    }
+
+    private static Object component(Object record, String name)
+            throws InvocationTargetException, IllegalAccessException {
+        var component = java.util.Arrays.stream(record.getClass().getRecordComponents())
+                .filter(c -> c.getName().equals(name))
+                .findFirst()
+                .orElseThrow();
+        component.getAccessor().setAccessible(true);
+        return component.getAccessor().invoke(record);
+    }
+}

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -6,10 +6,13 @@
 for the future portable state format. A capture owns every array and collection it exposes. Before
 mutation, apply checks the hardware tag, nested record/mapper tree, invariant array dimensions,
 serial endpoint and memento root, cartridge RTC locations, runtime DTO, held input, and linked
-topology against the already-configured target. It then reconstructs the complete replacement and
-rollback graphs. If a live restore nevertheless throws, the adapter restores the machine, both RTC
-locations, serial endpoint/runtime, held buttons, and—when linked—the other sessions and controller
-frame from those rollback captures.
+topology against the already-configured target. Null is admitted only for audited owner/field or
+array-element positions, not inferred from the non-null value's type. The adapter then reconstructs
+the complete replacement and applies the semantic policy registered for each of the 91 admitted
+record types. Those policies reject invalid indices, counts, capacities, command phases, and scalar
+relationships before the first live mutation. If a legacy live restore nevertheless throws, the
+adapter restores the machine, both RTC locations, serial endpoint/runtime, held buttons, and—when
+linked—the other sessions and controller frame from rollback captures.
 
 The model contains only `Int`, `Long`, `Boolean`, `Double`, `String`, explicit enum/type IDs, and
 deep-owned immutable containers. It cannot represent a thread, callback, event bus, stream, file,
@@ -23,7 +26,9 @@ production `Originator` declarations and `saveToMemento` owner/call-site files i
 allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral an
 explicit non-idle setup and compares a fixed continuation trace plus final state;
 `DetachedStateTest` exercises the complete root graph, deep ownership, failure atomicity, display,
-held input, endpoint runtime state, and difficult-cycle deterministic continuation.
+held input, endpoint runtime state, required-value null rejection, semantic cursor boundaries, and
+difficult-cycle deterministic continuation. `StateInventoryTest` independently scans production
+capture sites and proves every admitted record has a non-empty semantic-policy rationale.
 
 ## Supported safe points and thread ownership
 
@@ -81,10 +86,31 @@ Every supported mutable mapper family is explicit and executable: `BasicRom`, `M
 `SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
 pass-through slot. For each family the matrix captures a non-idle setup, runs address/tick probes,
 restores through the detached graph, reruns the same probes, and compares both observable trace and
-final state. Nested `Mbc7Eeprom` state is exercised as part of MBC7. Mapper ROM-bank masks/counts
-and immutable ROM arrays are derived from the required matching ROM; all writable arrays/registers
-are owned state. Separate virtual-time tests cover MBC3 subsecond/latch/halt/pause continuation and
-MBC3, HuC3, and TAMA5 battery references, including all three families in a Datel slot.
+final state. Dedicated mid-operation cases capture MBC6 during JEDEC unlock/ID/program sequences,
+MBC7 after EEPROM write-enable and halfway through a serial write, MBC5 with a real rumble cartridge
+and an active motor latch, and the outer Datel flash during program, erase, and ID modes while a real
+slot cartridge is present. Each case asserts the nested phase is non-default before comparing its
+observable continuation and final detached state. Mapper ROM-bank masks/counts and immutable ROM
+arrays are derived from the required matching ROM; all writable arrays/registers are owned state.
+Separate virtual-time tests cover MBC3 subsecond/latch/halt/pause continuation and MBC3, HuC3, and
+TAMA5 battery references, including all three families in a Datel slot.
+
+## Semantic preflight audit
+
+`StateGraph` enforces the registered schema, target mapper/endpoint tree, invariant dimensions,
+container shape, graph limits, and exact audited nullable positions. `StateSemantics` then walks the
+fully reconstructed candidate and dispatches by the same stable record class names used by the
+allowlist. Its constrained policies cover every scalar that is later used as an array cursor,
+queue size/offset, copy length, parser bit/count, GPU/PPU/DMA phase, audio buffer/channel counter,
+IR/SGB packet/schedule index, RTC field, or mapper EEPROM/flash command phase.
+
+Records whose fields are deliberately not range-constrained still have an explicit policy and
+rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
+documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
+are validated by nested records. `StateInventoryTest` requires the policy-key set to equal all 91
+admitted record types, so a new memento cannot enter the model without an audited choice. Rollback
+is retained for unexpected failures in legacy restore code; it is not the validation path for a
+deterministically malformed detached candidate.
 
 ## Compatibility and display ownership
 
@@ -101,11 +127,13 @@ does not change payload, graph, queue, frame, or work limits.
 ## Failure and extension policy
 
 Unknown record/enum IDs, wrong field names/order/counts, mapper or endpoint roots, invariant array
-dimensions, type mismatches, invalid enum ordinals, oversized/deep graphs/primitive arrays/strings,
-RTC-location mismatches, malformed held input, and linked frame/player/topology/adapter mismatches
-are rejected before live mutation. Optional SGB operation records and the nullable legacy display
-record remain value-state exceptions rather than hardware-identity fields. A serial endpoint
-outside the enumerated endpoint families throws
+dimensions, required-value nulls, type mismatches, invalid enum ordinals, oversized/deep
+graphs/primitive arrays/strings, invalid semantic indices/counts/phases, RTC-location mismatches,
+malformed held input, and linked frame/player/topology/adapter mismatches are rejected before live
+mutation. Optional SGB operation records, nullable SGB display rows, optional barcode/transfer
+payloads, an absent Datel slot memento, and the nullable legacy display record are explicit
+owner/field exceptions rather than type-category exceptions. A serial endpoint outside the
+enumerated endpoint families throws
 `StateCaptureException`; it is never silently serialized as null. Adding mutable production state
 requires all of: a memento/runtime DTO field, registry/schema and capture-site inventory updates,
 deep-ownership rule, and a deterministic-continuation regression.

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -56,8 +56,8 @@ volatiles, monitor state) remain controller services and are not portable machin
 | Timer/divider | DIV/TIMA/TMA/TAC, selected-bit history, overflow/reload, DIV reset, HALT wake/ripple and interrupt suppression edges | Speed/interrupt object references are wiring |
 | Speed switch | Current multiplier, prepare latch, DMG compatibility plus Gameboy clock-mux tail/phase flags | Cartridge compatibility flags are immutable configuration |
 | Boot/memory mapping | BIOS enabled shadow, MMU fixed RAM/WRAM/HRAM banks, SVBK, undocumented registers and OAM echo | BIOS bytes, address-space index and component references are reconstructed from configuration |
-| DMA/HDMA | OAM ownership/restart/source/ticks/bus samples/interrupt collision state; VRAM-DMA registers, mode, block bytes, CPU arbitration, HBlank/LCD/speed/halt request history | Source/destination address-space references are wiring; all temporal arbitration caches that affect behavior are captured |
-| GPU/PPU | VRAM banks, registers/mix/write delays, LCDC/STAT, LY/mode/dot, palettes, OAM-search state/sprites, fetcher, pixel and sprite FIFOs, window/object penalties and delayed writes, VRAM transfer | Palette decoding and component references are derived; behavior-affecting FIFO/cache/edge state is captured |
+| DMA/HDMA | OAM ownership/restart/source/ticks/bus samples/interrupt collision state; VRAM-DMA registers, mode, block bytes, cumulative source-byte progress since the source-register write, CPU arbitration, HBlank/LCD/speed/halt request history | Source/destination address-space references are wiring; all temporal arbitration caches that affect behavior are captured |
+| GPU/PPU | VRAM banks, registers/mix/write delays, LCDC/STAT, LY/mode/dot (including the LCD-enable `-1` dot), palettes, OAM-search state/sprites, fetcher, pixel and sprite FIFOs, window/object penalties and delayed writes, VRAM transfer | Palette decoding and component references are derived; both dot machines advance their owned eight-slot LCD delay rings, and behavior-affecting FIFO/cache/edge state is captured |
 | Display/panel | Exactly one GPU-owned `DisplayMemento`: partial write buffer/index, enabled flag, complete visible frame and first-frame-after-enable state | Root `displayMemento` is null for new captures, retained only as a nullable legacy-fixture input; buses/listeners are services |
 | APU/channels | Master registers/output buffer/index, channel masks/enables, frame sequencer and divider phase, pulse/wave/noise phases, length/envelope/sweep/LFSR/polynomial counters and pending clocks | Host audio sink/mixer callback is a service; waveform/output behavior is captured |
 | Joypad | P1, debounced input history/lines, pending edge, SGB multiplayer transfer packet/bit/player state | Physical held buttons are intentionally session-owned and captured separately so rewind policy can differ |
@@ -66,15 +66,15 @@ volatiles, monitor state) remain controller services and are not portable machin
 | Peer cable endpoint | SB, received-bit count and bit index | Peer object pointer is reconstructed by link topology |
 | Printer endpoint | Protocol parser, command/image buffers, checksum/status/reply framing and print delay | `PrintCallback` is a host/UI service |
 | GPS endpoint | Master ticks, startup beacons, UART output queue/bit delay, RX parser/parity and TAIP command | No time/network/location service is retained; emulated response data is deterministic |
-| Barcode Boy endpoint | Handshake/send/receive phase and active data in the pinned memento; queued barcode and external-transfer latch in deep-owned `BarcodeBoyRuntimeState` | No callback/service is retained; pending payload arrays are cloned on capture and access |
+| Barcode Boy endpoint | Handshake/send/receive phase and exact 30-byte active frame in the pinned memento; exact 30-byte queued frame and external-transfer latch in deep-owned `BarcodeBoyRuntimeState` | No callback/service is retained; active data exists exactly in `SENDING`, and pending payload arrays are cloned on capture and access |
 | Four-player adapter | Shared SB/armed/connected/pending arrays, reply/transmit buffers, packet/bit/timing/rate/size/phase and restart requests | Endpoint objects and player-slot association are reconstructed from `LinkedTopologyState` |
 | Infrared | RP register plus Full Changer schedule/armed/running/index/remaining phase | Physical/peer IR endpoint callback is topology/service state |
-| Cartridge/battery | Mapper memento, RAM/EEPROM/flash, bank/register/mode gates, write-dirty state; memory/file battery byte buffers, clock-presence and dirty flag | Immutable ROM bytes, file path/stream and battery object identity are construction services |
-| MBC3 RTC | Seconds/minutes/hours/day/control, subsecond ticks, latch snapshot, halt/overflow; separately tagged primary and Datel-slot pause flag/reference in `CartridgeRtcRuntimeState` | Injected `TimeSource` is never captured; both physical cartridge constructors receive the configured service |
+| Cartridge/battery | Mapper memento, RAM/EEPROM/flash, bank/register/mode gates, write-dirty state; memory/file battery byte buffers, clock-presence and dirty flag | Immutable ROM bytes, file path/stream and battery object identity are construction services; BasicRom battery and Datel slot presence must match the configured target |
+| MBC3 RTC | Six-bit seconds/minutes, five-bit hours, day/control, subsecond ticks, latch snapshot, halt/overflow; separately tagged primary and Datel-slot pause flag/reference in `CartridgeRtcRuntimeState` | Injected `TimeSource` is never captured; both physical cartridge constructors receive the configured service |
 | HuC3 RTC/IR | Minute/day/alarm registers, command index/flags/read latch, primitive last-second reference and RAM | Injected `TimeSource` is never captured |
 | TAMA5/TAMA6 | Command registers, RAM, four RTC pages, disable/alarm state and primitive last-second reference | Injected `TimeSource` is never captured |
-| SGB | Command packet transfer, multiplayer joypad state, character/background/attribute/palette/border buffers, mask and fade/animation | SGB event buses and render listeners are services |
-| Cheats/rumble | Genie/Shark patch values and maps; CodeBreaker/MBC5/Makon motor state | Event-bus rumble consumers are services |
+| SGB | Command packet transfer, multiplayer joypad state, character/background/attribute/palette/border buffers, mask and fade/animation; palette-map and attribute IDs are 0..3 | SGB event buses and render listeners are services; only historical `systemPalettes` rows are nullable |
+| Cheats/rumble | Non-null registered Genie/Shark patch lists/maps; CodeBreaker/MBC5/Makon motor state | Event-bus rumble consumers are services |
 | Session | Detached machine, serial endpoint tag/state/runtime and canonical unique held-button enum list (a list on input so malformed duplicates can be rejected) | ROM/configuration, event bus, console and endpoint callback objects are services |
 | Linked session | Authoritative frame, local player, explicit normal/four-player topology tag, exactly four canonical player slots, session states and held input; four-player copies must describe one coherent shared adapter | Network connections, peers, event queues and worker thread are controller services; apply requires the same already-configured active-session shape and rebases history at the safe point |
 
@@ -104,6 +104,12 @@ allowlist. Its constrained policies cover every scalar that is later used as an 
 queue size/offset, copy length, parser bit/count, GPU/PPU/DMA phase, audio buffer/channel counter,
 IR/SGB packet/schedule index, RTC field, or mapper EEPROM/flash command phase.
 
+Reachable boundary regressions exercise CH3 after a physical wave-RAM read, MBC3's 63/63/31
+live-and-latched register values, Full Changer armed/running/completed phases, HDMA in its second
+block, LCD enable at dot `-1`, and both FIFO delay rings at capacity. Barcode protocol/runtime
+coherence, SGB palette IDs, polynomial reload alignment, and Genie map element types are rejected
+through the adapter before its live-mutation callback.
+
 Records whose fields are deliberately not range-constrained still have an explicit policy and
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
 documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
@@ -130,10 +136,11 @@ Unknown record/enum IDs, wrong field names/order/counts, mapper or endpoint root
 dimensions, required-value nulls, type mismatches, invalid enum ordinals, oversized/deep
 graphs/primitive arrays/strings, invalid semantic indices/counts/phases, RTC-location mismatches,
 malformed held input, and linked frame/player/topology/adapter mismatches are rejected before live
-mutation. Optional SGB operation records, nullable SGB display rows, optional barcode/transfer
-payloads, an absent Datel slot memento, and the nullable legacy display record are explicit
-owner/field exceptions rather than type-category exceptions. A serial endpoint outside the
-enumerated endpoint families throws
+mutation. Optional SGB operation records, optional barcode/transfer payloads, historical nullable
+`systemPalettes` rows, and the nullable legacy display record are explicit owner/field exceptions
+rather than type-category exceptions. BasicRom battery and Datel slot presence are target identity
+and cannot cross null/non-null configurations. A serial endpoint outside the enumerated endpoint
+families throws
 `StateCaptureException`; it is never silently serialized as null. Adding mutable production state
 requires all of: a memento/runtime DTO field, registry/schema and capture-site inventory updates,
 deep-ownership rule, and a deterministic-continuation regression.

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -2,11 +2,14 @@
 
 ## Invariant established by Phase 1
 
-`MachineState`, `SessionState`, and `LinkedSessionState` are the service-free capture boundary for
-the future portable state format. A capture owns every array and collection it exposes. A restore
-first reconstructs and validates the complete detached graph, checks the cartridge/serial runtime
-families, and only then mutates the running machine. If a live restore throws, the adapter restores
-the machine, RTC runtime, serial endpoint/runtime, and held buttons from rollback captures.
+`MachineState`, `SessionState`, and `LinkedSessionState` are the service-free capture/apply boundary
+for the future portable state format. A capture owns every array and collection it exposes. Before
+mutation, apply checks the hardware tag, nested record/mapper tree, invariant array dimensions,
+serial endpoint and memento root, cartridge RTC locations, runtime DTO, held input, and linked
+topology against the already-configured target. It then reconstructs the complete replacement and
+rollback graphs. If a live restore nevertheless throws, the adapter restores the machine, both RTC
+locations, serial endpoint/runtime, held buttons, and—when linked—the other sessions and controller
+frame from those rollback captures.
 
 The model contains only `Int`, `Long`, `Boolean`, `Double`, `String`, explicit enum/type IDs, and
 deep-owned immutable containers. It cannot represent a thread, callback, event bus, stream, file,
@@ -14,10 +17,13 @@ clock service, AWT/Swing object, or live mutable array. The Phase 2 byte envelop
 are deliberately not part of this phase.
 
 The exact field-by-field inventory of all 91 admitted production record types is committed in
-[state-memento-schema.md](state-memento-schema.md). `MementoTypeRegistry` is the executable type
-allowlist. `StateCoverageMatrixTest` exercises every mutable mapper and stateful serial peripheral;
+[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 97
+production `Originator` declarations and `saveToMemento` owner/call-site files is committed in
+[state-originator-sites.md](state-originator-sites.md). `MementoTypeRegistry` is the executable type
+allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral an
+explicit non-idle setup and compares a fixed continuation trace plus final state;
 `DetachedStateTest` exercises the complete root graph, deep ownership, failure atomicity, display,
-held input, endpoint runtime state, and deterministic continuation.
+held input, endpoint runtime state, and difficult-cycle deterministic continuation.
 
 ## Supported safe points and thread ownership
 
@@ -59,23 +65,26 @@ volatiles, monitor state) remain controller services and are not portable machin
 | Four-player adapter | Shared SB/armed/connected/pending arrays, reply/transmit buffers, packet/bit/timing/rate/size/phase and restart requests | Endpoint objects and player-slot association are reconstructed from `LinkedTopologyState` |
 | Infrared | RP register plus Full Changer schedule/armed/running/index/remaining phase | Physical/peer IR endpoint callback is topology/service state |
 | Cartridge/battery | Mapper memento, RAM/EEPROM/flash, bank/register/mode gates, write-dirty state; memory/file battery byte buffers, clock-presence and dirty flag | Immutable ROM bytes, file path/stream and battery object identity are construction services |
-| MBC3 RTC | Seconds/minutes/hours/day/control, subsecond ticks, latch snapshot, halt/overflow; pause flag/reference in `RtcRuntimeState` | Injected `TimeSource` is never captured |
+| MBC3 RTC | Seconds/minutes/hours/day/control, subsecond ticks, latch snapshot, halt/overflow; separately tagged primary and Datel-slot pause flag/reference in `CartridgeRtcRuntimeState` | Injected `TimeSource` is never captured; both physical cartridge constructors receive the configured service |
 | HuC3 RTC/IR | Minute/day/alarm registers, command index/flags/read latch, primitive last-second reference and RAM | Injected `TimeSource` is never captured |
 | TAMA5/TAMA6 | Command registers, RAM, four RTC pages, disable/alarm state and primitive last-second reference | Injected `TimeSource` is never captured |
 | SGB | Command packet transfer, multiplayer joypad state, character/background/attribute/palette/border buffers, mask and fade/animation | SGB event buses and render listeners are services |
 | Cheats/rumble | Genie/Shark patch values and maps; CodeBreaker/MBC5/Makon motor state | Event-bus rumble consumers are services |
-| Session | Detached machine, serial endpoint tag/state/runtime and physical held-button enum set | ROM/configuration, event bus, console and endpoint callback objects are services |
-| Linked session | Authoritative frame, local player, explicit normal/four-player topology tag and fixed player-slot list of session states | Network connections, peers, event queues, histories and worker thread are controller services rebuilt around an authoritative checkpoint |
+| Session | Detached machine, serial endpoint tag/state/runtime and canonical unique held-button enum list (a list on input so malformed duplicates can be rejected) | ROM/configuration, event bus, console and endpoint callback objects are services |
+| Linked session | Authoritative frame, local player, explicit normal/four-player topology tag, exactly four canonical player slots, session states and held input; four-player copies must describe one coherent shared adapter | Network connections, peers, event queues and worker thread are controller services; apply requires the same already-configured active-session shape and rebases history at the safe point |
 
 ## Mapper coverage matrix
 
 Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
 `Mbc3`/RTC, `Mbc5`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`, `PocketCamera`, `Huc1`, `Huc3`,
 `Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
-`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel`. The matrix
-captures, mutates/ticks, restores through the detached graph, and recaptures each instance. Nested
-`Mbc7Eeprom` state is exercised as part of MBC7. Mapper ROM-bank masks/counts and immutable ROM
-arrays are derived from the required matching ROM; all writable arrays/registers are owned state.
+`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
+pass-through slot. For each family the matrix captures a non-idle setup, runs address/tick probes,
+restores through the detached graph, reruns the same probes, and compares both observable trace and
+final state. Nested `Mbc7Eeprom` state is exercised as part of MBC7. Mapper ROM-bank masks/counts
+and immutable ROM arrays are derived from the required matching ROM; all writable arrays/registers
+are owned state. Separate virtual-time tests cover MBC3 subsecond/latch/halt/pause continuation and
+MBC3, HuC3, and TAMA5 battery references, including all three families in a Datel slot.
 
 ## Compatibility and display ownership
 
@@ -91,9 +100,12 @@ does not change payload, graph, queue, frame, or work limits.
 
 ## Failure and extension policy
 
-Unknown record/enum IDs, wrong field names/order/counts, type mismatches, invalid enum ordinals,
-oversized/deep graphs, RTC-family mismatches, and endpoint/runtime mismatches are rejected before
-live mutation. A serial endpoint outside the enumerated endpoint families throws
+Unknown record/enum IDs, wrong field names/order/counts, mapper or endpoint roots, invariant array
+dimensions, type mismatches, invalid enum ordinals, oversized/deep graphs/primitive arrays/strings,
+RTC-location mismatches, malformed held input, and linked frame/player/topology/adapter mismatches
+are rejected before live mutation. Optional SGB operation records and the nullable legacy display
+record remain value-state exceptions rather than hardware-identity fields. A serial endpoint
+outside the enumerated endpoint families throws
 `StateCaptureException`; it is never silently serialized as null. Adding mutable production state
-requires all of: a memento/runtime DTO field, registry/schema inventory update, deep-ownership rule,
-and a coverage-matrix or deterministic-continuation regression.
+requires all of: a memento/runtime DTO field, registry/schema and capture-site inventory updates,
+deep-ownership rule, and a deterministic-continuation regression.

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -129,6 +129,11 @@ deterministically malformed detached candidate.
 The legacy Java serialization shape and pinned manifest remain unchanged. The six DMG FIFO fields
 introduced after that manifest are captured once per dot machine by `DmgFifoRuntimeState`; adding
 them to `DmgPixelFifoMemento` would change its Java descriptor and break the supported fixtures.
+`linePixels` is the inclusive 0..160 LCD position; `outCount` is nonnegative but deliberately has
+no unsound upper bound because it is bookkeeping rather than an array cursor. A pending packed
+6-bit `firstEntry` is created only by the first due output and requires `outCount == 1`; an absent
+entry permits any nonnegative count because the next tick clears the latch before considering
+another due entry. Its three palette latches are bytes.
 Existing fixtures may still carry the historical root display copy; restore accepts it after GPU
 restore. New captures set that nullable compatibility component to null, so only
 `GpuMemento.displayMemento` owns the two 160x144 panel arrays. Visible frame, partial scanout/index,

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -1,0 +1,99 @@
+# Machine/session state inventory and ownership contract
+
+## Invariant established by Phase 1
+
+`MachineState`, `SessionState`, and `LinkedSessionState` are the service-free capture boundary for
+the future portable state format. A capture owns every array and collection it exposes. A restore
+first reconstructs and validates the complete detached graph, checks the cartridge/serial runtime
+families, and only then mutates the running machine. If a live restore throws, the adapter restores
+the machine, RTC runtime, serial endpoint/runtime, and held buttons from rollback captures.
+
+The model contains only `Int`, `Long`, `Boolean`, `Double`, `String`, explicit enum/type IDs, and
+deep-owned immutable containers. It cannot represent a thread, callback, event bus, stream, file,
+clock service, AWT/Swing object, or live mutable array. The Phase 2 byte envelope and section codec
+are deliberately not part of this phase.
+
+The exact field-by-field inventory of all 91 admitted production record types is committed in
+[state-memento-schema.md](state-memento-schema.md). `MementoTypeRegistry` is the executable type
+allowlist. `StateCoverageMatrixTest` exercises every mutable mapper and stateful serial peripheral;
+`DetachedStateTest` exercises the complete root graph, deep ownership, failure atomicity, display,
+held input, endpoint runtime state, and deterministic continuation.
+
+## Supported safe points and thread ownership
+
+There are only two supported capture/apply safe points:
+
+1. The owning controller/emulator thread at a frame boundary, after queued topology/input events
+   and history reconciliation have completed and before the next group of machine ticks. Linked
+   capture includes the authoritative frame, fixed topology tag, player slots, each session, and
+   physical held buttons.
+2. A single-machine controller operation (disk snapshot, rewind, boot-state reuse) while that
+   controller has quiesced its emulator thread. Capture/apply must run on that same owner thread.
+
+Calling the detached adapter concurrently with `Gameboy.tick`, endpoint I/O, mapper battery flush,
+or topology mutation is unsupported. UI threads may request an operation through the controller,
+but never capture/apply a machine directly. Execution-control flags (`Thread`, stop/pause request
+volatiles, monitor state) remain controller services and are not portable machine behavior.
+
+## Complete behavior-affecting ownership inventory
+
+| Owner | Captured behavior | Excluded/derived state and rationale |
+|---|---|---|
+| Gameboy root | Boot shadow, cartridge, GPU/display, STAT, MMU/OAM, CPU, interrupts, timer, DMA/HDMA, sound, serial/IR, rumble, joypad, speed, SGB, cheats, LCD refresh/off and speed-switch/boot handoff flags | Component wiring, immutable ROM/configuration, console, buses, thread and stop/pause control are host construction/ownership services |
+| CPU/registers | A/B/C/D/E/H/L, SP, PC, flags, decoded opcode/operand pipeline, operation context/index, IRQ entry, HALT/STOP/halt-bug, clock cycle, HDMA prefetch/arbitration and speed-switch phase | Instruction tables and address-space references are immutable code/wiring |
+| Interrupts | IME, IF/IE, delayed enable, blocked/phased sources, acknowledgement and PPU/timer/serial edge latches | Interrupt source object references are wiring |
+| Timer/divider | DIV/TIMA/TMA/TAC, selected-bit history, overflow/reload, DIV reset, HALT wake/ripple and interrupt suppression edges | Speed/interrupt object references are wiring |
+| Speed switch | Current multiplier, prepare latch, DMG compatibility plus Gameboy clock-mux tail/phase flags | Cartridge compatibility flags are immutable configuration |
+| Boot/memory mapping | BIOS enabled shadow, MMU fixed RAM/WRAM/HRAM banks, SVBK, undocumented registers and OAM echo | BIOS bytes, address-space index and component references are reconstructed from configuration |
+| DMA/HDMA | OAM ownership/restart/source/ticks/bus samples/interrupt collision state; VRAM-DMA registers, mode, block bytes, CPU arbitration, HBlank/LCD/speed/halt request history | Source/destination address-space references are wiring; all temporal arbitration caches that affect behavior are captured |
+| GPU/PPU | VRAM banks, registers/mix/write delays, LCDC/STAT, LY/mode/dot, palettes, OAM-search state/sprites, fetcher, pixel and sprite FIFOs, window/object penalties and delayed writes, VRAM transfer | Palette decoding and component references are derived; behavior-affecting FIFO/cache/edge state is captured |
+| Display/panel | Exactly one GPU-owned `DisplayMemento`: partial write buffer/index, enabled flag, complete visible frame and first-frame-after-enable state | Root `displayMemento` is null for new captures, retained only as a nullable legacy-fixture input; buses/listeners are services |
+| APU/channels | Master registers/output buffer/index, channel masks/enables, frame sequencer and divider phase, pulse/wave/noise phases, length/envelope/sweep/LFSR/polynomial counters and pending clocks | Host audio sink/mixer callback is a service; waveform/output behavior is captured |
+| Joypad | P1, debounced input history/lines, pending edge, SGB multiplayer transfer packet/bit/player state | Physical held buttons are intentionally session-owned and captured separately so rewind policy can differ |
+| Serial port | SB/SC, internal clock phase/count, received bits and HALT-wake delay | Active endpoint reference is session topology, not machine data |
+| Byte receiver endpoint | SB and bit index | `ByteReceiver` callback is a host service |
+| Peer cable endpoint | SB, received-bit count and bit index | Peer object pointer is reconstructed by link topology |
+| Printer endpoint | Protocol parser, command/image buffers, checksum/status/reply framing and print delay | `PrintCallback` is a host/UI service |
+| GPS endpoint | Master ticks, startup beacons, UART output queue/bit delay, RX parser/parity and TAIP command | No time/network/location service is retained; emulated response data is deterministic |
+| Barcode Boy endpoint | Handshake/send/receive phase and active data in the pinned memento; queued barcode and external-transfer latch in deep-owned `BarcodeBoyRuntimeState` | No callback/service is retained; pending payload arrays are cloned on capture and access |
+| Four-player adapter | Shared SB/armed/connected/pending arrays, reply/transmit buffers, packet/bit/timing/rate/size/phase and restart requests | Endpoint objects and player-slot association are reconstructed from `LinkedTopologyState` |
+| Infrared | RP register plus Full Changer schedule/armed/running/index/remaining phase | Physical/peer IR endpoint callback is topology/service state |
+| Cartridge/battery | Mapper memento, RAM/EEPROM/flash, bank/register/mode gates, write-dirty state; memory/file battery byte buffers, clock-presence and dirty flag | Immutable ROM bytes, file path/stream and battery object identity are construction services |
+| MBC3 RTC | Seconds/minutes/hours/day/control, subsecond ticks, latch snapshot, halt/overflow; pause flag/reference in `RtcRuntimeState` | Injected `TimeSource` is never captured |
+| HuC3 RTC/IR | Minute/day/alarm registers, command index/flags/read latch, primitive last-second reference and RAM | Injected `TimeSource` is never captured |
+| TAMA5/TAMA6 | Command registers, RAM, four RTC pages, disable/alarm state and primitive last-second reference | Injected `TimeSource` is never captured |
+| SGB | Command packet transfer, multiplayer joypad state, character/background/attribute/palette/border buffers, mask and fade/animation | SGB event buses and render listeners are services |
+| Cheats/rumble | Genie/Shark patch values and maps; CodeBreaker/MBC5/Makon motor state | Event-bus rumble consumers are services |
+| Session | Detached machine, serial endpoint tag/state/runtime and physical held-button enum set | ROM/configuration, event bus, console and endpoint callback objects are services |
+| Linked session | Authoritative frame, local player, explicit normal/four-player topology tag and fixed player-slot list of session states | Network connections, peers, event queues, histories and worker thread are controller services rebuilt around an authoritative checkpoint |
+
+## Mapper coverage matrix
+
+Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
+`Mbc3`/RTC, `Mbc5`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`, `PocketCamera`, `Huc1`, `Huc3`,
+`Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
+`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel`. The matrix
+captures, mutates/ticks, restores through the detached graph, and recaptures each instance. Nested
+`Mbc7Eeprom` state is exercised as part of MBC7. Mapper ROM-bank masks/counts and immutable ROM
+arrays are derived from the required matching ROM; all writable arrays/registers are owned state.
+
+## Compatibility and display ownership
+
+The legacy Java serialization shape and pinned manifest remain unchanged. Existing fixtures may
+still carry the historical root display copy; restore accepts it after GPU restore. New captures set
+that nullable compatibility component to null, so only `GpuMemento.displayMemento` owns the two
+160x144 panel arrays. Visible frame, partial scanout/index, LCD enable and repeat behavior therefore
+remain restorable without duplicate payload.
+
+Disk snapshots, rewind, boot-state reuse, and current netplay continue to use their existing bounded
+legacy/netplay adapters in this phase. The detached model is a new internal seam for Phase 2; it
+does not change payload, graph, queue, frame, or work limits.
+
+## Failure and extension policy
+
+Unknown record/enum IDs, wrong field names/order/counts, type mismatches, invalid enum ordinals,
+oversized/deep graphs, RTC-family mismatches, and endpoint/runtime mismatches are rejected before
+live mutation. A serial endpoint outside the enumerated endpoint families throws
+`StateCaptureException`; it is never silently serialized as null. Adding mutable production state
+requires all of: a memento/runtime DTO field, registry/schema inventory update, deep-ownership rule,
+and a coverage-matrix or deterministic-continuation regression.

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -56,8 +56,8 @@ volatiles, monitor state) remain controller services and are not portable machin
 | Timer/divider | DIV/TIMA/TMA/TAC, selected-bit history, overflow/reload, DIV reset, HALT wake/ripple and interrupt suppression edges | Speed/interrupt object references are wiring |
 | Speed switch | Current multiplier, prepare latch, DMG compatibility plus Gameboy clock-mux tail/phase flags | Cartridge compatibility flags are immutable configuration |
 | Boot/memory mapping | BIOS enabled shadow, MMU fixed RAM/WRAM/HRAM banks, SVBK, undocumented registers and OAM echo | BIOS bytes, address-space index and component references are reconstructed from configuration |
-| DMA/HDMA | OAM ownership/restart/source/ticks/bus samples/interrupt collision state; VRAM-DMA registers, mode, block bytes, cumulative source-byte progress since the source-register write, CPU arbitration, HBlank/LCD/speed/halt request history | Source/destination address-space references are wiring; all temporal arbitration caches that affect behavior are captured |
-| GPU/PPU | VRAM banks, registers/mix/write delays, LCDC/STAT, LY/mode/dot (including the LCD-enable `-1` dot), palettes, OAM-search state/sprites, fetcher, pixel and sprite FIFOs, window/object penalties and delayed writes, VRAM transfer | Palette decoding and component references are derived; both dot machines advance their owned eight-slot LCD delay rings, and behavior-affecting FIFO/cache/edge state is captured |
+| DMA/HDMA | OAM ownership/restart/source/ticks/bus samples/interrupt collision state; VRAM-DMA registers, mode, block bytes, signed wrapping cumulative source-byte progress since the source-register write, CPU arbitration, HBlank/LCD/speed/halt request history | Source/destination address-space references are wiring; source-byte progress is an emulated `int` counter used for bus/start arbitration, not an allocation or array cursor |
+| GPU/PPU | VRAM banks, registers/mix/write delays, LCDC/STAT, LY/mode/dot (including the LCD-enable `-1` dot), palettes, OAM-search state/sprites, fetcher, pixel and sprite FIFOs, window/object penalties and delayed writes, VRAM transfer | Both dot machines advance their owned eight-slot LCD delay rings; the DMG timing/output FIFOs additionally own `linePixels`, `outCount`, `firstEntry`, `firstBgp`, `firstObp0`, and `firstObp1` in a primitive detached supplement because the pinned legacy record predates them |
 | Display/panel | Exactly one GPU-owned `DisplayMemento`: partial write buffer/index, enabled flag, complete visible frame and first-frame-after-enable state | Root `displayMemento` is null for new captures, retained only as a nullable legacy-fixture input; buses/listeners are services |
 | APU/channels | Master registers/output buffer/index, channel masks/enables, frame sequencer and divider phase, pulse/wave/noise phases, length/envelope/sweep/LFSR/polynomial counters and pending clocks | Host audio sink/mixer callback is a service; waveform/output behavior is captured |
 | Joypad | P1, debounced input history/lines, pending edge, SGB multiplayer transfer packet/bit/player state | Physical held buttons are intentionally session-owned and captured separately so rewind policy can differ |
@@ -77,6 +77,11 @@ volatiles, monitor state) remain controller services and are not portable machin
 | Cheats/rumble | Non-null registered Genie/Shark patch lists/maps; CodeBreaker/MBC5/Makon motor state | Event-bus rumble consumers are services |
 | Session | Detached machine, serial endpoint tag/state/runtime and canonical unique held-button enum list (a list on input so malformed duplicates can be rejected) | ROM/configuration, event bus, console and endpoint callback objects are services |
 | Linked session | Authoritative frame, local player, explicit normal/four-player topology tag, exactly four canonical player slots, session states and held input; four-player copies must describe one coherent shared adapter | Network connections, peers, event queues and worker thread are controller services; apply requires the same already-configured active-session shape and rebases history at the safe point |
+
+The repeat DMG FIFO audit found no further mutable behavior state: `pixels`, `spriteFifo`,
+`delayEntry`, `delayStamp`, `delayHead`, `delaySize`, and `outputTicks` remain in the pinned
+memento; the six fields named above are in the detached supplement; and `display`, `lcdc`,
+`registers`, and `vRamTransfer` are final reconstructed wiring.
 
 ## Mapper coverage matrix
 
@@ -106,9 +111,10 @@ IR/SGB packet/schedule index, RTC field, or mapper EEPROM/flash command phase.
 
 Reachable boundary regressions exercise CH3 after a physical wave-RAM read, MBC3's 63/63/31
 live-and-latched register values, Full Changer armed/running/completed phases, HDMA in its second
-block, LCD enable at dot `-1`, and both FIFO delay rings at capacity. Barcode protocol/runtime
-coherence, SGB palette IDs, polynomial reload alignment, and Genie map element types are rejected
-through the adapter before its live-mutation callback.
+block, a signed-wrapped HDMA source counter, LCD enable at dot `-1`, both FIFO delay rings at
+capacity, a pending DMG first-pixel palette latch, and a pending window rewind. Barcode
+protocol/runtime coherence, SGB palette IDs, polynomial reload alignment, and Genie map element
+types are rejected through the adapter before its live-mutation callback.
 
 Records whose fields are deliberately not range-constrained still have an explicit policy and
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
@@ -120,11 +126,13 @@ deterministically malformed detached candidate.
 
 ## Compatibility and display ownership
 
-The legacy Java serialization shape and pinned manifest remain unchanged. Existing fixtures may
-still carry the historical root display copy; restore accepts it after GPU restore. New captures set
-that nullable compatibility component to null, so only `GpuMemento.displayMemento` owns the two
-160x144 panel arrays. Visible frame, partial scanout/index, LCD enable and repeat behavior therefore
-remain restorable without duplicate payload.
+The legacy Java serialization shape and pinned manifest remain unchanged. The six DMG FIFO fields
+introduced after that manifest are captured once per dot machine by `DmgFifoRuntimeState`; adding
+them to `DmgPixelFifoMemento` would change its Java descriptor and break the supported fixtures.
+Existing fixtures may still carry the historical root display copy; restore accepts it after GPU
+restore. New captures set that nullable compatibility component to null, so only
+`GpuMemento.displayMemento` owns the two 160x144 panel arrays. Visible frame, partial scanout/index,
+LCD enable and repeat behavior therefore remain restorable without duplicate payload.
 
 Disk snapshots, rewind, boot-state reuse, and current netplay continue to use their existing bounded
 legacy/netplay adapters in this phase. The detached model is a new internal seam for Phase 2; it

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -1,0 +1,108 @@
+# Audited state-memento schema
+
+This is the exact captured-field inventory for all 91 production record types admitted by
+`MementoTypeRegistry` at Phase 1. Each line names the concrete record and every record component
+captured by `saveToMemento`. The executable state inventory test prevents the registry, this
+appendix, and the detached graph adapter from drifting independently.
+
+Array and collection fields are deep-owned by the detached state adapter. The ownership contract,
+safe points, derived/excluded state, and subsystem grouping are in
+[state-machine-inventory.md](state-machine-inventory.md).
+
+The 11 explicit behavior tags are `Cpu.State`, `InterruptManager.InterruptType`, `Gpu.Mode`,
+`OamSearch.State`, `Hdma.CpuRequestArbitration`, `Hdma.HaltHdmaState`,
+`Hdma.WakeRequestArbitration`, `Mbc7Eeprom.State`, `BarcodeBoySerialEndpoint.State`,
+`FourPlayerAdapter.Phase`, and `Commands.MaskEnCmd.GameboyScreenMask`. Their portable form is the
+audited enum type ID plus ordinal; a missing type or out-of-range ordinal is rejected.
+
+- `eu.rekawek.coffeegb.core.genie.Genie$GenieMemento`: patches
+- `eu.rekawek.coffeegb.core.sound.FrameSequencer$FrameSequencerMemento`: step, previousBit, skipNextEdge
+- `eu.rekawek.coffeegb.core.sound.FrequencySweep$FrequencySweepMemento`: period, negate, shift, timer, shadowFreq, nr13, nr14, overflow, counterEnabled, negging, calculationDelay, unshiftedCalculation, restartHold, frequencyUpdatePending
+- `eu.rekawek.coffeegb.core.sound.AbstractSoundMode$AbstractSoundModeMemento`: channelEnabled, dacEnabled, nr0, nr1, nr2, nr3, nr4, lengthMemento
+- `eu.rekawek.coffeegb.core.sound.Lfsr$LfsrMemento`: lfsr
+- `eu.rekawek.coffeegb.core.sound.PolynomialCounter$PolynomialCounterMemento`: nr43, counter, counterCountdown, clock2Mhz, alignment, backgroundActive, countdownReloaded
+- `eu.rekawek.coffeegb.core.sound.VolumeEnvelope$VolumeEnvelopeMemento`: initialVolume, envelopeDirection, sweep, volume, timer, finished, pendingEnvelopeClock
+- `eu.rekawek.coffeegb.core.sound.SoundMode4$SoundMode4Memento`: abstractSoundMemento, volumeEnvelopeMemento, polynomialCounterMemento, lastResult, lfsrMemento
+- `eu.rekawek.coffeegb.core.sound.SoundMode3$SoundMode3Memento`: abstractSoundMemento, waveRamMemento, freqDivider, lastOutput, i, ticksSinceRead, lastReadAddr, buffer, triggered, clock2Mhz
+- `eu.rekawek.coffeegb.core.sound.SoundMode2$SoundMode2Memento`: abstractSoundMemento, freqDivider, lastOutput, i, sampleSuppressed, activeBeforeTrigger, clock2Mhz, lowFrequencyPhase, volumeEnvelopeMemento, justReloadedTicks
+- `eu.rekawek.coffeegb.core.sound.SoundMode1$SoundMode1Memento`: abstractSoundMemento, freqDivider, lastOutput, i, sampleSuppressed, activeBeforeTrigger, clock2Mhz, lowFrequencyPhase, frequencySweepMemento, justReloadedTicks, justReloadedFromSweep, volumeEnvelopeMemento
+- `eu.rekawek.coffeegb.core.sound.LengthCounter$LengthCounterMemento`: length, enabled
+- `eu.rekawek.coffeegb.core.sound.Sound$SoundMemento`: allModeMementos, ramMemento, frameSequencerMemento, channels, enabled, overriddenEnabled, buffer, i, pendingFrameSequencerStep, frameSequencerClockPhase, frameSequencerDivOffset
+- `eu.rekawek.coffeegb.core.timer.Timer$TimerMemento`: div, tac, tma, tima, previousBit, overflow, ticksSinceOverflow, divReset, haltWakeDelay, ticksSinceDivReset, haltBugDivRipplePending, haltBugDivRippleVisible, suppressNextInterruptRequest
+- `eu.rekawek.coffeegb.core.cpu.SpeedMode$SpeedModeMomento`: currentSpeed, prepareSpeedSwitch, dmgCompat
+- `eu.rekawek.coffeegb.core.cpu.InterruptManager$InterruptManagerMemento`: ime, interruptFlag, interruptEnabled, pendingEnableInterrupts, haltBlockedInterrupts, cpuBlockedInterrupts, cpuPhasedPpuInterrupts, cpuPhasedMode2Interrupts, cpuFirstLineMode2Interrupts, cpuInstructionBlockedInterrupts, maskVBlankOnNextRead, maskLcdcUntilNextPeripheralTick, maskMode0LcdcReadTicks, cpuReadInterruptPreview, serialInterruptAcknowledge, timerInterruptAcknowledge, lcdcInterruptAcknowledge, vBlankInterruptAcknowledge, lcdcInterruptFlagWriteClear
+- `eu.rekawek.coffeegb.core.cpu.Registers$RegistersMemento`: a, b, c, d, e, h, l, sp, pc, flags
+- `eu.rekawek.coffeegb.core.cpu.Cpu$CpuMemento`: registersMemento, opcode1, opcode2, operand, operandIndex, opIndex, state, opContext, interruptFlag, interruptEnabled, requestedIrq, clockCycle, haltBugMode, haltEntrySampleTicks, synchronousHaltEntryStatPhase, asynchronousHaltEntryStatPhase, ordinaryHaltWakeStatPhase, haltedCpuCycles, hdmaOpcodePrefetched, hdmaArbitrationOpcode, hdmaArbitrationOpcodeValid, haltPrefetchedOpcode, haltOpcodePrefetchValid, speedSwitchPaddingOpcode, speedSwitchPaddingReplayValid, speedSwitchTicks, phasedPpuInputHigh, fastPhasedPpuDispatch
+- `eu.rekawek.coffeegb.core.joypad.Joypad$JoypadMemento`: p1, tick, inputHistory, filteredInputLines, inputChangedSinceLastTick, players, currentPlayer, transferInProgress, transferReadyForData, pendingTransferBit, currentByte, currentPacket, currentByteIndex, currentPacketIndex
+- `eu.rekawek.coffeegb.core.sgb.Commands$TransferCommand$TransferCommandMemento`: packet, dataTransfer
+- `eu.rekawek.coffeegb.core.sgb.SuperGameboy$SuperGameboyMemento`: multipacket, multipacketIndex, multipacketLength, transferCountdown, waitingTransferCommandMemento
+- `eu.rekawek.coffeegb.core.sgb.SgbDisplay$SgbDisplayMemento`: sgbBuffer, sgbMask, palettes, systemPalettes, paletteMap, attributeFiles, screenMask, borderFade
+- `eu.rekawek.coffeegb.core.sgb.Background$BackgroundMemento`: tiles, pendingPictureMemento, borderAnimation
+- `eu.rekawek.coffeegb.core.memory.Hdma$HdmaMemento`: gpuMode, transferInProgress, hblankTransfer, lcdEnabled, length, src, dst, tick, blockData, hblankRequestTicks, hblankRequestAge, nextHblankRequestTicks, nextHblankRequestAge, sourceBytesTransferred, cpuBusValue, stopAfterCurrentBlock, preserveLengthAfterCurrentBlock, speedSwitchInProgress, speedSwitchStartedWithoutRequest, pauseOamDmaForSpeedSwitchBurst, wakeRequestArbitration, gpuLine, gpuTicksInLine, gpuCpuClockRephased, hblankStartTicksInLine, cpuHalted, haltHdmaState, haltEnteredThisTick, requestOverlappedCpuWrite, interruptEntryWonArbitration, cpuRequestArbitration, cpuRequestAllowsLateInterrupt, haltOpcodeRequestLatched
+- `eu.rekawek.coffeegb.core.memory.GbcRam$GbcRamMemento`: ram, svbk
+- `eu.rekawek.coffeegb.core.memory.BiosShadow$BiosShadowMemento`: isEnabled
+- `eu.rekawek.coffeegb.core.memory.Ram$RamMemento`: space
+- `eu.rekawek.coffeegb.core.memory.Mmu$MmuMemento`: ramC000Memento, ramD000Memento, ramFF80Memento, gbcRamMemento, undocumentedGbcRegistersMemento, oamEchoRamMemento
+- `eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery$MemoryBatteryMemento`: buffer
+- `eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery$FileBatteryMemento`: clockBuffer, ramBuffer, isClockPresent, isDirty
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc1$Mbc1Memento`: batteryMemento, ram, selectedRamBank, selectedRomBank, memoryModel, ramWriteEnabled, cachedRomBankFor0x0000, cachedRomBankFor0x4000, ramUpdated, wideBank, upperRegisterUsed
+- `eu.rekawek.coffeegb.core.memory.cart.type.BungEms$BungEmsMemento`: batteryMemento, ram, romBankLow, romBankHigh, romBankMask, romBankLatch, selectedRamBank, configureMode, ramEnabled, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc2$Mbc2Memento`: batteryMemento, ram, selectedRomBank, ramWriteEnabled, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom$EepromMemento`: eeprom, state, bitsRead, command, address, writeValue, writeEnabled, sk, doBit
+- `eu.rekawek.coffeegb.core.memory.cart.type.BasicRom$BasicRomMemento`: batteryMemento, ram, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc5$Mbc5Memento`: batteryMemento, ram, selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated, motorOn
+- `eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera$PocketCameraMemento`: ram, cameraRegisters, romBank, ramBank, ramEnabled, cameraMapped
+- `eu.rekawek.coffeegb.core.memory.cart.type.BhgosMulticart$BhgosMulticartMemento`: batteryMemento, ram, selectedRomBank, selectedRamBank, baseRomBank, blockSelectWrites, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc7$Mbc7Memento`: selectedRomBank, ramWriteEnabled1, ramWriteEnabled2, x, y, latchX, latchY, latchState, eepromMemento
+- `eu.rekawek.coffeegb.core.memory.cart.type.MakonNtOld2$MakonNtOld2Memento`: batteryMemento, ram, selectedRomBank, mappedRomBank, baseRomBank, gameRomBankMask, weirdMode, rumbleEnabled, motorOn, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Sintax$SintaxMemento`: delegateMemento, xorValues, mode, bankNo, romBankXor
+- `eu.rekawek.coffeegb.core.memory.cart.type.WisdomTree$WisdomTreeMemento`: bank
+- `eu.rekawek.coffeegb.core.memory.cart.type.Huc3$Huc3Memento`: batteryMemento, ram, romBank, ramBank, mode, minutes, days, alarmMinutes, alarmDays, alarmEnabled, accessIndex, accessFlags, readValue, lastRtcSecond, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.DuzMulticart$DuzMulticartMemento`: ram, regs, selectedBank, selectedRamBank, baseBank, regIndex, ramWriteEnabled
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mani32kMulticart$Mani32kMemento`: block
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc6$Mbc6Memento`: ram, flash, ramEnabled, ramBankA, ramBankB, romBankA, romBankB, romBankAFlash, romBankBFlash, flashEnabled, flashWriteEnable, flashCommandState, flashIdMode, flashProgramMode
+- `eu.rekawek.coffeegb.core.memory.cart.type.Huc1$Huc1Memento`: batteryMemento, ram, romBank, ramBank, irMode, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.SachenMmc$SachenMemento`: unmaskedBank, mask, base, lockState, transition, serveBootLogo
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mbc3$Mbc3Memento`: ram, clockMemento, batteryMemento, selectedRamBank, selectedRomBank, ramEnabled
+- `eu.rekawek.coffeegb.core.memory.cart.type.Bbd$BbdMemento`: delegateMemento, dataSwapMode, bankSwapMode
+- `eu.rekawek.coffeegb.core.memory.cart.type.SlMulticart$SlMulticartMemento`: ram, configCommand, baseRomBank, selectedRomBank, romBankMask, zeroRemap, configurationMode, mbc5Mode, ramAllowed, ramEnabled, baseRamBank, selectedRamBank, ramBankMask
+- `eu.rekawek.coffeegb.core.memory.cart.type.Mmm01$Mmm01Memento`: batteryMemento, ram, ramEnabled, romBankLow, romBankMid, romBankHigh, romBankMask, ramBankLow, ramBankHigh, ramBankMask, locked, mbc1Mode, mbc1ModeDisable, multiplexMode, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Tama5$Tama5Memento`: batteryMemento, ram, selectedReg, registers, rtcTimerPage, rtcAlarmPage, rtcFreePage0, rtcFreePage1, rtcDisabled, lastRtcSecond, ramUpdated
+- `eu.rekawek.coffeegb.core.memory.cart.type.Datel$DatelMemento`: ram, regs, ramWritten, regsB, flash, flashCycle, flashErasePending, flashIdMode, launched, slotMemento
+- `eu.rekawek.coffeegb.core.memory.cart.Cartridge$CartridgeMemento`: memoryControllerMemento, batteryMemento
+- `eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock$RealTimeClockMemento`: seconds, minutes, hours, days, halt, counterOverflow, subSecondTicks, latched, latchedSeconds, latchedMinutes, latchedHours, latchedDays, latchedHalt, latchedCounterOverflow
+- `eu.rekawek.coffeegb.core.memory.UndocumentedGbcRegisters$UndocumentedGbcRegistersMemento`: ramMemento, xff6c
+- `eu.rekawek.coffeegb.core.memory.Dma$DmaMemento`: transferInProgress, restarted, from, ticks, transferClocks, oamOwnedForPpuBeforeTick, oamOwnedForPpu, ppuOamOwnedThroughRestart, cpuClockPaused, pauseEntryClocks, currentByte, regValue, pendingInterruptWriteByte, pendingInterruptWriteValue, vramDmaBusCollisionObserved
+- `eu.rekawek.coffeegb.core.memory.OamEchoRam$OamEchoRamMemento`: ram
+- `eu.rekawek.coffeegb.core.Gameboy$GameboyMemento`: biosShadowMemento, cartridgeMemento, gpuMemento, statRegisterMemento, mmuMemento, oamRamMemento, cpuMemento, interruptManagerMemento, timerMemento, dmaMemento, hdmaMemento, displayMemento, soundMemento, serialPortMemento, infraredPortMemento, codeBreakerRumbleMemento, joypadMemento, speedModeMemento, superGameboyMemento, backgroundMemento, vRamTransferMemento, sgbDisplayMemento, genieMemento, requestScreenRefresh, lcdDisabled, lcdOffTicks, speedSwitchTailTicks, speedSwitchClockPhaseShifted, blankCgbBootTilePending, clearBootTilemapPending, clearCgbBootOamShadowPending
+- `eu.rekawek.coffeegb.core.gpu.IntQueue$IntQueueMemento`: array, size, offset
+- `eu.rekawek.coffeegb.core.gpu.GpuRegisterValues$GpuRegisterValuesMemento`: values, mixValues, pendingMixValues, wxJustChangedTicks, scxOldValue, pendingScxOldValue
+- `eu.rekawek.coffeegb.core.gpu.Lcdc$LcdcMemento`: value, mixValue, pendingMixValue, dmgBlobBackgroundEnable, pendingDmgBlobBackgroundEnable, tileSelectGlitchTicks, pendingTileSelectGlitchTicks, tileSelectGlitchHistory, oamSizeHistory
+- `eu.rekawek.coffeegb.core.gpu.Display$DisplayMemento`: buffer, i, enabled, lastFrame, firstFrameAfterLcdEnable
+- `eu.rekawek.coffeegb.core.gpu.Gpu$GpuMemento`: videoRam0Memento, videoRam1Memento, displayMemento, lcdcMemento, bgPaletteMemento, oamPaletteMemento, oamSearchPhaseMemento, pixelTransferPhaseMemento, pixelMachineMemento, rMemento, lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, firstFrameAfterLcdEnable, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, lyReadLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, doubleSpeedMode2DispatchCrossedLineEdge, earlyScxStatTailThisLine, wyWrittenThisLine, lateDoubleSpeedLineZeroWindowEnable, lastCpuVramWriteTick, mode, pendingPpuWrites, cpuVisiblePpuRegisters
+- `eu.rekawek.coffeegb.core.gpu.StatRegister$StatRegisterMemento`: enableBits, registeredLy, coincidence, intCoincidence, intLine, lycWriteSuppressed, suppressedLycIrqLine, modeBlockedLycIrqLine, lycIrqStatSource, lycIrqValueSource, lycIrqStatLatch, lycIrqValueLatch, lycIrqClock, nextLycIrqEvent, pendingLycWriteIrq, pendingLycComparatorIrq, lastLycIrqRegisterChangeClock, lastLcdcInterruptAcknowledgeClock, lastVBlankInterruptAcknowledgeClock, releaseTailLycCpuAcceptance, lycComparatorSignal, modeIrqStatLatch, modeIrqLycLatch, pendingModeIrqStat, pendingModeIrqLyc, pendingModeIrqStatClock, pendingModeIrqLycClock, mode0IrqStatLatch, mode0IrqLycLatch, pendingMode0IrqStat, pendingMode0IrqLyc, pendingMode0IrqStatClock, pendingMode0IrqLycClock, lastModeIrqStatWriteClock, lastModeIrqStatWriteLineTick, lastModeIrqStatWriteOld, cgbMode1IfClearAtCapture, pendingCgbMode1Interrupt, dmgLyc143Mode1CaptureClock, mode0EventArmed, previousMode0Window, previousMode1Window, previousMode2Window, pendingCgbMode0Interrupt, pendingCgbMode2Interrupt, pendingCgbMode2IfHighAtCapture, pendingCgbMode2LateReplay, pendingCgbMode2PublicationClock, cgbMode2CapturedAtLineEdge, pendingCgbFrameMode2Interrupt, retractableCgbMode2Interrupt, ordinaryHaltWakeStatClock, previousOrdinaryHaltWakePhase, scxChangedSinceMode0Event
+- `eu.rekawek.coffeegb.core.gpu.VRamTransfer$VRamTransferMemento`: buffer, i
+- `eu.rekawek.coffeegb.core.gpu.SpriteFifo$SpriteFifoMemento`: pixel, palette, priority, bgPriority, head, size, underflow
+- `eu.rekawek.coffeegb.core.gpu.ColorPalette$ColorPaletteMemento`: palettes, index, autoIncrement
+- `eu.rekawek.coffeegb.core.gpu.DmgPixelFifo$DmgPixelFifoMemento`: pixels, spriteFifo, delayEntry, delayStamp, delayHead, delaySize, outputTicks
+- `eu.rekawek.coffeegb.core.gpu.phase.HBlankPhase$HBlankPhaseMemento`: ticks
+- `eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer$PixelTransferMemento`: fetcherMemento, fifoMemento, entryTicks, lcdEnableFirstLine, position, window, windowBeingFetched, windowLineCounter, spriteOrder, spriteCount, spriteHead, objStep, objTileId, objAttributesValue, objData0, objTileLine, objData1Pending, objRefreshAge, objRefreshPops, objRefreshD0, objRefreshTileId, objRefreshLine, objRefreshAttrsValue, objRefreshZip, objWaiting, objectTimingPenalty, previousScx, fineScxRephasedThisLine, machineActive, windowPendingTicks, windowPendingWx, windowPendingPos, windowActivatedThisLine, previousWindowDisplay, cgbWindowStartTicks, cgbTerminalWindowStartedThisLine, insertBgPixel, machineStall, windowYTriggered, windowWy, pendingWindowWy, windowWyDelay, windowWyOldOnWriteTick, windowDisplayOverride, pendingWindowDisplayWrites, windowXOverride, pendingWindowXWrites
+- `eu.rekawek.coffeegb.core.gpu.phase.OamSearch$SpritePosition$SpritePositionMemento`: x, y, address, enabled
+- `eu.rekawek.coffeegb.core.gpu.phase.VBlankPhase$VBlankPhaseMemento`: ticks
+- `eu.rekawek.coffeegb.core.gpu.phase.OamSearch$OamSearchMemento`: sprites, oamReaderY, oamReaderX, oamReaderInitialized, oamReaderBusY, oamReaderBusX, oamReaderDmaSource, oamReaderSourceChangeTicks, spritePosIndex, state, spriteY, spriteHeight, previousOamSpriteHeight, spriteHeightTransitionThisLine, spriteX, dmaBlockedThisLine, i, selectSprites, spriteCandidateSeen
+- `eu.rekawek.coffeegb.core.gpu.ColorPixelFifo$ColorPixelFifoMemento`: pixels, palettes, priorities, spriteFifo, delayEntry, delayStamp, delayHead, delaySize, outputTicks, linePixels, clearedPixels, clearedPalettes, clearedPriorities
+- `eu.rekawek.coffeegb.core.gpu.Fetcher$FetcherMemento`: pixelLine, state, windowTileX, fetcherY, tileMapAddress, tileId, tileAttributesValue, tileData1, tileData2, insertionGlitchDisabled, data2Pending, data2Delay, data2TileSelectGlitch
+- `eu.rekawek.coffeegb.core.ir.FullChanger$FullChangerMemento`: schedule, armed, running, index, remaining
+- `eu.rekawek.coffeegb.core.ir.InfraredPort$InfraredPortMemento`: rp, fullChangerMemento
+- `eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint$Peer2PeerSerialEndpointMemento`: sb, bitsReceived, bitIndex
+- `eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint$PrinterMemento`: state, commandId, compression, lengthLeft, commandData, commandLength, checksum, status, byteToSend, image, imageOffset, compressionRunLength, compressionRunIsCompressed, printCountdown, currentReply, sendBits, sb
+- `eu.rekawek.coffeegb.core.serial.SerialPort$SerialPortMemento`: sb, sc, serialClocks, serialClockSignal, receivedBits, haltWakeDelay
+- `eu.rekawek.coffeegb.core.serial.GpsReceiverSerialEndpoint$GpsReceiverMemento`: ticks, nextStartupBeacon, startupBeacons, outputBytes, outputByte, outputBit, outputTicksRemaining, outputDelayTicks, serialInputHigh, sb, receiveBit, receiveByte, receiveOnes, receiveParityValid, capturingTaip, taipCommand
+- `eu.rekawek.coffeegb.core.serial.ByteReceivingSerialEndpoint$ByteReceivingSerialEndpointMemento`: sb, bits
+- `eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint$BarcodeBoyMemento`: state, handshakeByte, sendBitIndex, data, dataByte, recvBitIndex, clockDivider
+- `eu.rekawek.coffeegb.core.serial.FourPlayerAdapter$AdapterMemento`: sb, transferArmed, pendingBits, connected, consecutiveFf, replies, transmissionBuffer, packetByte, bit, ticksUntilBit, rate, size, phase, transmissionRequested, restartPingRequested
+- `eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble$CodeBreakerRumbleMemento`: motorOn
+- `eu.rekawek.coffeegb.core.genie.GameGeniePatch`: newData, address, oldData
+- `eu.rekawek.coffeegb.core.genie.GameSharkPatch`: mode, bank, address, data
+- `eu.rekawek.coffeegb.core.gpu.Gpu$PendingPpuWrite`: address, value, mask, remainingDots
+- `eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer$DelayedWindowWrite`: value, remainingDots

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -15,6 +15,12 @@ The 11 explicit behavior tags are `Cpu.State`, `InterruptManager.InterruptType`,
 `FourPlayerAdapter.Phase`, and `Commands.MaskEnCmd.GameboyScreenMask`. Their portable form is the
 audited enum type ID plus ordinal; a missing type or out-of-range ordinal is rejected.
 
+`DmgPixelFifo$DmgPixelFifoMemento` deliberately retains its pinned seven-component Java
+serialization descriptor. The immutable Phase-1 `MachineState` carries `linePixels`, `outCount`,
+`firstEntry`, `firstBgp`, `firstObp0`, and `firstObp1` for both DMG dot machines in the separate
+primitive-only `DmgFifoRuntimeState` supplement. This closes current state ownership without
+altering the 1.7.13/1.7.14 migration schema listed below.
+
 - `eu.rekawek.coffeegb.core.genie.Genie$GenieMemento`: patches
 - `eu.rekawek.coffeegb.core.sound.FrameSequencer$FrameSequencerMemento`: step, previousBit, skipNextEdge
 - `eu.rekawek.coffeegb.core.sound.FrequencySweep$FrequencySweepMemento`: period, negate, shift, timer, shadowFreq, nr13, nr14, overflow, counterEnabled, negging, calculationDelay, unshiftedCalculation, restartHold, frequencyUpdatePending

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -6,7 +6,9 @@ exact path match, so a new capture owner or call site cannot be omitted from rev
 
 `OWNER` means that the file owns behavior fields in the record(s) named in
 [`state-memento-schema.md`](state-memento-schema.md); those record-component lists are the exact
-captured fields. Arrays and collections become deep-owned at the detached boundary. `COMPOSITE`
+legacy-memento fields. `DmgPixelFifo` additionally exposes the six primitive fields listed there
+through the detached runtime supplement, preserving its pinned record descriptor. Arrays and
+collections become deep-owned at the detached boundary. `COMPOSITE`
 means that the owner captures child mementos and any root fields listed in that schema. `WORKFLOW`
 is a controller call site which retains no additional machine field. `CONTRACT` is an interface and
 owns no instance state. Derived caches and external services omitted by each owner are documented

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -1,0 +1,112 @@
+# Production capture-site audit
+
+This manifest accounts for every production source file that declares an `Originator` contract or
+contains a `saveToMemento` site. `StateInventoryTest` scans the production trees and requires an
+exact path match, so a new capture owner or call site cannot be omitted from review.
+
+`OWNER` means that the file owns behavior fields in the record(s) named in
+[`state-memento-schema.md`](state-memento-schema.md); those record-component lists are the exact
+captured fields. Arrays and collections become deep-owned at the detached boundary. `COMPOSITE`
+means that the owner captures child mementos and any root fields listed in that schema. `WORKFLOW`
+is a controller call site which retains no additional machine field. `CONTRACT` is an interface and
+owns no instance state. Derived caches and external services omitted by each owner are documented
+by subsystem in [`state-machine-inventory.md`](state-machine-inventory.md); none of those services
+is admitted to the detached graph.
+
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt`
+- COMPOSITE `controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/SnapshotManager.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/Registers.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/genie/Genie.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPalette.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuRegisterValues.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/IntQueue.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/SpriteFifo.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/VRamTransfer.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/HBlankPhase.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/VBlankPhase.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java`
+- CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/OamEchoRam.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/Ram.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegisters.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java`
+- CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MemoryController.java`
+- CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/Battery.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBattery.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/rtc/RealTimeClock.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BasicRom.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mani32kMulticart.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc6.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7Eeprom.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mmm01.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SachenMmc.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/WisdomTree.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumble.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/BarcodeBoySerialEndpoint.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/ByteReceivingSerialEndpoint.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/GameboyPrinterSerialEndpoint.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/GpsReceiverSerialEndpoint.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java`
+- CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/AbstractSoundMode.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/FrameSequencer.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/FrequencySweep.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/LengthCounter.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/Lfsr.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/PolynomialCounter.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode2.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/sound/VolumeEnvelope.java`
+- OWNER `core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java`


### PR DESCRIPTION
## Summary

Phase 1 establishes a real immutable machine/session capture seam. `MachineState`,
`SessionState`, and `LinkedSessionState` contain only fixed-width values, explicit audited type
IDs/tags, and deeply owned immutable containers. Capture is detached from the live graph. Apply
first validates target compatibility, exact audited nullability, graph/value bounds, and the
semantic policy registered for every admitted record; rollback remains a safety net for unexpected
legacy restore failures.

The committed ownership audit inventories CPU, memory/DMA, PPU/display, APU, mapper/RTC, SGB, IR,
serial/peripheral, session, and linked-topology state. Its generated field appendix tracks all 91
admitted production record types and 11 enum tags. Executable inventory tests independently scan
production capture sites and require an explicit semantic-policy rationale for every admitted
record.

## Key invariants

- New root captures contain one GPU-owned display snapshot, not the former duplicate root copy.
  Legacy fixtures with the nullable root display remain loadable.
- The pinned seven-component `DmgPixelFifoMemento` descriptor is unchanged. The Phase 1 machine
  state instead carries `linePixels`, `outCount`, `firstEntry`, `firstBgp`, `firstObp0`, and
  `firstObp1` for both timing and output dot machines in a primitive-only
  `DmgFifoRuntimeState` supplement. Preflight now enforces the lifecycle-derived 0..160 line
  position, nonnegative output count, packed first-entry and byte-palette ranges, and the rule that
  a pending first entry exists only at output count 1. It deliberately does not impose an unsound
  output-count upper bound or converse rule after the latch clears. DMG/SGB require the supplement,
  native CGB rejects it, and every failure occurs before live mutation. Real DMG/SGB PPU samples,
  exact line boundaries, maximum packed/palette values, pending emission, and the valid cleared
  latch at output count 1 are covered.
- MBC3, HuC3, and TAMA5 receive their `TimeSource` through every `Cartridge` path, including Datel
  pass-through slots. The service is excluded while primitive RTC, latch, subsecond, pause, alarm,
  and battery-reference state remains captured per cartridge location.
- Null/non-null mismatches are rejected by default. Only exact audited owner/field positions and
  historical nullable `systemPalettes` rows are admitted. BasicRom battery and Datel slot presence
  are target identity; same-absence states round-trip while cross-presence states reject.
- Reconstructed candidates pass an exact 91-record semantic registry before live mutation. It
  checks array/queue cursors, counts/capacities, GPU/PPU/DMA phases, audio counters,
  serial/SGB/IR parser state, RTC ranges, and mapper EEPROM/flash command phases. HDMA
  `sourceBytesTransferred` is explicitly a signed wrapping emulated counter, not an allocation or
  array cursor; real block-two and synthetic signed-wrap continuations are covered.
- Barcode active and queued scans are coherent exact 30-byte frames. Runtime length is checked
  before cloning or inspecting the payload. SGB palette and attribute IDs are 0..3, noise reload
  alignment is 0..3, and Genie maps contain only non-null registered Game Genie/GameShark patch
  records. Malformed candidates fail before the live-mutation probe and leave the session
  unchanged.
- Both PPU dot machines advance their owned LCD delay ring. The timing-only skeleton retains its
  throwaway display but no longer accumulates an impossible unbounded captured occupancy.
- Context-aware machine/session and linked-session preflight rejects mapper, endpoint,
  invariant-dimension, held-input, topology, and shared-adapter mismatches before mutation. Normal
  and four-player linked restore is atomic across participating sessions.
- Every supported mutable mapper and stateful serial peripheral has executable continuation
  coverage. Dedicated non-default nested-mode tests capture MBC6 during JEDEC unlock/ID/program,
  MBC7 halfway through EEPROM write, MBC5 with active rumble, and outer Datel flash during
  program/erase/ID while a real slot cartridge is present.
- Unknown stateful endpoints fail with a typed capture error instead of being silently omitted.

## Compatibility and scope

The pinned legacy memento record manifest is unchanged. `LegacyMementoCodecTest` verifies the
current descriptor manifest, and `SnapshotManagerTest` loads both committed Coffee GB 1.7.13 and
1.7.14 snapshot fixtures. Existing ROM execution, battery persistence, save-state import/export,
rewind, boot reuse, and netplay paths continue using the bounded Phase 0 codecs and limits. No
payload, graph, queue, frame, work, or transport limit is weakened.

This PR does not add the portable file envelope, section codec, disk/protocol integration, atomic
writer, or copy-on-write paging. Issue #322 is the next gate and owns the Phase 2 byte codec.

## Validation

- `mvn -B -pl controller -am -Dtest=PixelFifoTest,DetachedStateTest,StateCoverageMatrixTest,StateInventoryTest,LegacyMementoCodecTest,SnapshotManagerTest -Dsurefire.failIfNoSpecifiedTests=false test` — 4 core + 53 controller = 57 passed, 0 failed/errors/skipped
- `mvn -B -pl core,controller -am test` — 702 core + 149 controller = 851 passed, 0 failed/errors/skipped
- `mvn -B -pl swing -am -DskipTests compile` — successful four-module compile
- `git diff --check 6576cef83919389a0ab210068b5a14187bdca98e --`, `git diff --check e92e0a3fe944ba5ede40a49b3ef1e62fdea04abe --`, and `git diff --cached --check` — clean

Closes #321
Part of #314
