### PR TITLE
Use immutable structurally shared snapshots for rewind

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -32,6 +32,7 @@ class BasicController private constructor(
     private val sessionPreparer: SessionPreparer,
     private val loadExecutor: ExecutorService,
     private val snapshotManagerFactory: SnapshotManagerFactory,
+    private val rewindManager: RewindManager,
 ) : Controller, SnapshotSupport {
 
   constructor(
@@ -45,6 +46,7 @@ class BasicController private constructor(
       RomSessionPreparer(),
       createLoadExecutor(),
       SnapshotManagerFactory.DEFAULT,
+      RewindManager(),
   )
 
   internal constructor(
@@ -59,6 +61,7 @@ class BasicController private constructor(
       sessionPreparer,
       createLoadExecutor(),
       SnapshotManagerFactory.DEFAULT,
+      RewindManager(),
   )
 
   internal constructor(
@@ -74,6 +77,24 @@ class BasicController private constructor(
       sessionPreparer,
       createLoadExecutor(),
       snapshotManagerFactory,
+      RewindManager(),
+  )
+
+  internal constructor(
+      parentEventBus: EventBus,
+      properties: EmulatorProperties,
+      console: Console?,
+      sessionPreparer: SessionPreparer,
+      snapshotManagerFactory: SnapshotManagerFactory,
+      rewindManager: RewindManager,
+  ) : this(
+      parentEventBus,
+      properties,
+      console,
+      sessionPreparer,
+      createLoadExecutor(),
+      snapshotManagerFactory,
+      rewindManager,
   )
 
   private val timingTicker = TimingTicker()
@@ -91,8 +112,6 @@ class BasicController private constructor(
   private var isPaused = false
 
   private var isRewinding = false
-
-  private val rewindManager = RewindManager()
 
   private val patches = mutableListOf<Patch>()
 
@@ -138,7 +157,11 @@ class BasicController private constructor(
         setPaused(false)
       }
     }
-    eventQueue.register<Controller.RewindEvent> { isRewinding = it.active }
+    eventQueue.register<Controller.RewindEvent> {
+      // Disabled rewind is a real no-work mode: the key cannot freeze forward emulation and
+      // runFrame never reaches a machine capture.
+      isRewinding = rewindManager.enabled && it.active
+    }
     eventQueue.register<Controller.ResetEmulationEvent> {
       session?.config?.rom?.file?.let {
         requestLoad(properties, Controller.LoadRomEvent(it), clearPatches = false)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
@@ -1,7 +1,7 @@
 package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.core.Gameboy
-import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.controller.state.MachineSnapshot
 
 /**
  * Rolling history of emulation states for the rewind feature. A state is recorded every
@@ -9,26 +9,36 @@ import eu.rekawek.coffeegb.core.memento.Memento
  * CAPACITY * RECORD_INTERVAL / 60 seconds of history. Rewinding restores one recorded
  * state per rendered frame, so it plays backwards at RECORD_INTERVAL times the game speed.
  */
-class RewindManager {
+internal class RewindManager(
+    val enabled: Boolean = true,
+) {
 
-  private val states = ArrayDeque<Memento<Gameboy>>()
+  private val states = ArrayDeque<MachineSnapshot>()
 
   private var frameCounter = 0
 
+  internal var captureCount = 0
+    private set
+
   fun record(gameboy: Gameboy) {
+    // This is intentionally the first operation. A disabled manager does not advance cadence,
+    // inspect the live machine, allocate a capture DTO, or create a snapshot.
+    if (!enabled) return
     if (frameCounter++ % RECORD_INTERVAL != 0) {
       return
     }
     if (states.size == CAPACITY) {
       states.removeFirst()
     }
-    states.addLast(gameboy.saveToMemento())
+    states.addLast(MachineSnapshot.capture(gameboy, states.lastOrNull()))
+    captureCount++
   }
 
   /** Restores the most recent recorded state; returns false when the history is empty. */
   fun rewindOneStep(gameboy: Gameboy): Boolean {
+    if (!enabled) return false
     val state = states.removeLastOrNull() ?: return false
-    gameboy.restoreFromMemento(state)
+    state.restore(gameboy)
     return true
   }
 
@@ -36,6 +46,11 @@ class RewindManager {
     states.clear()
     frameCounter = 0
   }
+
+  internal val historySize: Int
+    get() = states.size
+
+  internal fun snapshotsForTesting(): List<MachineSnapshot> = states.toList()
 
   companion object {
     const val RECORD_INTERVAL = 6

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.gpu.DmgPixelFifo
 import eu.rekawek.coffeegb.core.gpu.Gpu
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock
 import java.lang.reflect.Array as ReflectArray
@@ -27,9 +28,10 @@ import kotlin.math.min
  * copies only changed pages; equal pages retain the same immutable page identity. No array owned
  * by a page is exposed.
  *
- * The transitional capture source remains the complete audited memento graph so Phase 6 can
- * retire that plumbing independently. The memento is discarded after this immutable graph is
- * built and never enters rewind history, disk, or network state.
+ * Capture consumes an audited transient record view whose primitive payloads are borrowed directly
+ * from the stopped machine. It never calls the legacy deep-cloning capture. The view and its
+ * borrow token are invalid after the synchronous graph comparison and never enter rewind history,
+ * disk, or network state. The ordinary legacy memento path remains separate for Phase 6.
  */
 internal class MachineSnapshot private constructor(
     private val root: SnapshotRecord,
@@ -126,6 +128,10 @@ internal class MachineSnapshot private constructor(
       val copiedPageBytes: Long,
       val reusedPages: Int,
       val newValueNodes: Int,
+      val sourcePayloadArraysRead: Int,
+      val sourcePayloadBytesRead: Long,
+      val sourcePayloadClones: Int,
+      val sourcePayloadCloneBytes: Long,
   )
 
   internal data class RetainedStats(
@@ -141,10 +147,13 @@ internal class MachineSnapshot private constructor(
 
     fun capture(
         gameboy: Gameboy,
-        previous: MachineSnapshot? = null,
+      previous: MachineSnapshot? = null,
     ): MachineSnapshot {
       val compatiblePrevious = previous?.takeIf { it.hardware == gameboy.gameboyType }
-      val graph = SnapshotGraph.capture(gameboy.saveToMemento(), compatiblePrevious?.root)
+      val graph =
+          gameboy.withMachineStateCapture { view, source ->
+            SnapshotGraph.capture(view, compatiblePrevious?.root, source)
+          }
       val rtc = gameboy.captureRtcRuntimeState()
       val fifo = gameboy.captureDmgFifoRuntimeState()
       return MachineSnapshot(
@@ -493,8 +502,12 @@ private object SnapshotGraph {
       val stats: MachineSnapshot.CaptureStats,
   )
 
-  fun capture(value: Any, previous: SnapshotRecord?): Result {
-    val capture = Capture(previous)
+  fun capture(
+      value: Any,
+      previous: SnapshotRecord?,
+      source: MachineStateCapture,
+  ): Result {
+    val capture = Capture(previous, source)
     val root = capture.value(value, previous, 0) as? SnapshotRecord
         ?: error("Machine snapshot root is not a record")
     if (recordClassName(root.typeId) != GAMEBOY_ROOT) {
@@ -694,7 +707,10 @@ private object SnapshotGraph {
     }
   }
 
-  private class Capture(previous: SnapshotRecord?) {
+  private class Capture(
+      previous: SnapshotRecord?,
+      private val sourceCapture: MachineStateCapture,
+  ) {
     private val pool = SnapshotPagePool(previous)
     private var references = 0L
     private var copiedPages = 0
@@ -708,6 +724,10 @@ private object SnapshotGraph {
             copiedPageBytes,
             reusedPages,
             newValueNodes,
+            sourceCapture.borrowedPayloadArrays,
+            sourceCapture.borrowedPayloadBytes,
+            sourceCapture.sourcePayloadClones,
+            sourceCapture.sourcePayloadCloneBytes,
         )
 
     fun value(
@@ -750,7 +770,7 @@ private object SnapshotGraph {
 
     private fun captureBytes(source: ByteArray, previous: SnapshotBytes?): SnapshotValue =
         capturePrimitive(
-            source.size,
+            sourceCapture.requireLength(source),
             PageKind.BYTE,
             previous,
             { offset, length -> hash(source, offset, length) },
@@ -761,7 +781,7 @@ private object SnapshotGraph {
 
     private fun captureInts(source: IntArray, previous: SnapshotInts?): SnapshotValue =
         capturePrimitive(
-            source.size,
+            sourceCapture.requireLength(source),
             PageKind.INT,
             previous,
             { offset, length -> hash(source, offset, length) },
@@ -772,7 +792,7 @@ private object SnapshotGraph {
 
     private fun captureLongs(source: LongArray, previous: SnapshotLongs?): SnapshotValue =
         capturePrimitive(
-            source.size,
+            sourceCapture.requireLength(source),
             PageKind.LONG,
             previous,
             { offset, length -> hash(source, offset, length) },
@@ -783,7 +803,7 @@ private object SnapshotGraph {
 
     private fun captureBooleans(source: BooleanArray, previous: SnapshotBooleans?): SnapshotValue =
         capturePrimitive(
-            source.size,
+            sourceCapture.requireLength(source),
             PageKind.BOOLEAN,
             previous,
             { offset, length -> hash(source, offset, length) },
@@ -922,7 +942,17 @@ private object SnapshotGraph {
                     ?.getOrNull(index)
                     ?.takeIf { it.name == component.name }
                     ?.value
-            SnapshotField(component.name, value(component.accessor.invoke(source), old, depth + 1))
+            try {
+              SnapshotField(
+                  component.name,
+                  value(component.accessor.invoke(source), old, depth + 1),
+              )
+            } catch (failure: IllegalStateException) {
+              throw IllegalStateException(
+                  "${type.name}.${component.name}: ${failure.message}",
+                  failure,
+              )
+            }
           }
       if (sameType != null &&
           sameType.fields.size == fields.size &&

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -128,10 +128,8 @@ internal class MachineSnapshot private constructor(
       val copiedPageBytes: Long,
       val reusedPages: Int,
       val newValueNodes: Int,
-      val sourcePayloadArraysRead: Int,
-      val sourcePayloadBytesRead: Long,
-      val sourcePayloadClones: Int,
-      val sourcePayloadCloneBytes: Long,
+      val identityVerifiedPayloadArrays: Int,
+      val identityVerifiedPayloadBytes: Long,
   )
 
   internal data class RetainedStats(
@@ -724,10 +722,8 @@ private object SnapshotGraph {
             copiedPageBytes,
             reusedPages,
             newValueNodes,
-            sourceCapture.borrowedPayloadArrays,
-            sourceCapture.borrowedPayloadBytes,
-            sourceCapture.sourcePayloadClones,
-            sourceCapture.sourcePayloadCloneBytes,
+            sourceCapture.verifiedPayloadArrays,
+            sourceCapture.verifiedPayloadBytes,
         )
 
     fun value(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -1,0 +1,1008 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.MementoTypeRegistry
+import eu.rekawek.coffeegb.controller.StateLimits
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.gpu.DmgPixelFifo
+import eu.rekawek.coffeegb.core.gpu.Gpu
+import eu.rekawek.coffeegb.core.memento.Memento
+import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock
+import java.lang.reflect.Array as ReflectArray
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
+import java.util.Collections
+import java.util.IdentityHashMap
+import kotlin.math.min
+
+/**
+ * Immutable, service-free, in-process machine snapshot.
+ *
+ * This type is internal by design and has no byte encoding. It is captured/restored only by the
+ * owning emulation thread at the documented frame safe point. Primitive arrays are split into
+ * fixed 4 KiB payload pages. An incremental capture compares against the preceding snapshot and
+ * copies only changed pages; equal pages retain the same immutable page identity. No array owned
+ * by a page is exposed.
+ *
+ * The transitional capture source remains the complete audited memento graph so Phase 6 can
+ * retire that plumbing independently. The memento is discarded after this immutable graph is
+ * built and never enters rewind history, disk, or network state.
+ */
+internal class MachineSnapshot private constructor(
+    private val root: SnapshotRecord,
+    private val rtcRuntime: SnapshotRtcRuntime,
+    private val hardware: GameboyType,
+    private val dmgFifoRuntime: SnapshotDmgFifoRuntime?,
+    internal val captureStats: CaptureStats,
+) {
+
+  /**
+   * Reconstructs and validates the complete trusted internal candidate before mutation, then
+   * retains the old raw machine/runtime state for unexpected live-restore rollback.
+   */
+  fun restore(
+      gameboy: Gameboy,
+      probe: ((ApplyStage) -> Unit)? = null,
+  ) {
+    if (gameboy.gameboyType != hardware) {
+      throw StateApplyException(
+          "Internal $hardware snapshot does not match ${gameboy.gameboyType} hardware")
+    }
+    val rollbackMemento = gameboy.saveToMemento()
+    if (SnapshotGraph.ownershipSignature(root) !=
+        SnapshotGraph.ownershipSignature(rollbackMemento)) {
+      throw StateApplyException("Internal snapshot mapper/battery ownership does not match target")
+    }
+    val candidate =
+        try {
+          @Suppress("UNCHECKED_CAST")
+          (SnapshotGraph.restoreRoot(root) as Memento<Gameboy>).also(StateSemantics::validate)
+        } catch (failure: StateApplyException) {
+          throw failure
+        } catch (failure: Throwable) {
+          throw StateApplyException("Internal machine snapshot could not be reconstructed", failure)
+        }
+    val candidateRtc = rtcRuntime.toCore()
+    val candidateFifo = dmgFifoRuntime?.toCore()
+    try {
+      gameboy.validateRtcRuntimeState(candidateRtc)
+      gameboy.validateDmgFifoRuntimeState(candidateFifo)
+    } catch (failure: IllegalArgumentException) {
+      throw StateApplyException("Internal machine runtime layout is incompatible", failure)
+    }
+    val rollbackRtc = gameboy.captureRtcRuntimeState()
+    val rollbackFifo = gameboy.captureDmgFifoRuntimeState()
+    try {
+      probe?.invoke(ApplyStage.BEFORE_LIVE_MUTATION)
+      gameboy.restoreFromMemento(candidate)
+      probe?.invoke(ApplyStage.AFTER_MACHINE_MUTATION)
+      gameboy.restoreDmgFifoRuntimeState(candidateFifo)
+      gameboy.restoreRtcRuntimeState(candidateRtc)
+    } catch (failure: Throwable) {
+      try {
+        gameboy.restoreFromMemento(rollbackMemento)
+        gameboy.restoreDmgFifoRuntimeState(rollbackFifo)
+        gameboy.restoreRtcRuntimeState(rollbackRtc)
+      } catch (rollbackFailure: Throwable) {
+        failure.addSuppressed(rollbackFailure)
+      }
+      throw StateApplyException("Internal machine snapshot could not be applied atomically", failure)
+    }
+  }
+
+  /**
+   * Read-only structural-sharing probe for tests and the benchmark. Tokens are page objects, never
+   * their private primitive arrays.
+   */
+  internal fun debugArrays(
+      ownerClassName: String,
+      fieldName: String,
+  ): List<ArrayDebug> {
+    val result = ArrayList<ArrayDebug>()
+    root.visitRecords { record ->
+      if (SnapshotGraph.recordClassName(record.typeId) == ownerClassName) {
+        record.fields
+            .filter { it.name == fieldName }
+            .mapNotNull { it.value as? SnapshotPrimitiveArray }
+            .forEach { array ->
+              result +=
+                  ArrayDebug(
+                      array.size,
+                      Collections.unmodifiableList(array.pages.map { it as Any }),
+                  )
+            }
+      }
+    }
+    return Collections.unmodifiableList(result)
+  }
+
+  internal data class ArrayDebug(val size: Int, val pageTokens: List<Any>)
+
+  internal data class CaptureStats(
+      val copiedPages: Int,
+      val copiedPageBytes: Long,
+      val reusedPages: Int,
+      val newValueNodes: Int,
+  )
+
+  internal data class RetainedStats(
+      val snapshots: Int,
+      val uniquePages: Int,
+      val uniqueValueNodes: Int,
+      val retainedPrimitiveBytes: Long,
+      val modeledRetainedBytes: Long,
+  )
+
+  companion object {
+    const val PAGE_BYTES = 4 * 1024
+
+    fun capture(
+        gameboy: Gameboy,
+        previous: MachineSnapshot? = null,
+    ): MachineSnapshot {
+      val compatiblePrevious = previous?.takeIf { it.hardware == gameboy.gameboyType }
+      val graph = SnapshotGraph.capture(gameboy.saveToMemento(), compatiblePrevious?.root)
+      val rtc = gameboy.captureRtcRuntimeState()
+      val fifo = gameboy.captureDmgFifoRuntimeState()
+      return MachineSnapshot(
+          graph.root,
+          SnapshotRtcRuntime(
+              rtc.primary()?.let { SnapshotMbc3Runtime(it.emulationPaused(), it.pauseStartedMillis()) },
+              rtc.slot()?.let { SnapshotMbc3Runtime(it.emulationPaused(), it.pauseStartedMillis()) },
+          ),
+          gameboy.gameboyType,
+          fifo?.let {
+            SnapshotDmgFifoRuntime(
+                it.timing().toSnapshot(),
+                it.output().toSnapshot(),
+            )
+          },
+          graph.stats,
+      )
+    }
+
+    fun retainedStats(snapshots: Collection<MachineSnapshot>): RetainedStats {
+      val pages = IdentityHashMap<SnapshotPage, Boolean>()
+      val nodes = IdentityHashMap<SnapshotValue, Boolean>()
+      var primitiveBytes = 0L
+      var modeledBytes = 0L
+      snapshots.forEach { snapshot ->
+        modeledBytes += MACHINE_SNAPSHOT_SHALLOW_BYTES
+        snapshot.root.visit { value ->
+          if (nodes.put(value, true) == null) {
+            modeledBytes += value.modeledBytes()
+          }
+          if (value is SnapshotPrimitiveArray) {
+            value.pages.forEach { page ->
+              if (pages.put(page, true) == null) {
+                val retained = page.retainedBytes()
+                primitiveBytes += retained
+                modeledBytes += retained
+              }
+            }
+          }
+        }
+      }
+      return RetainedStats(
+          snapshots.size,
+          pages.size,
+          nodes.size,
+          primitiveBytes,
+          modeledBytes,
+      )
+    }
+
+    private fun eu.rekawek.coffeegb.core.gpu.DmgPixelFifo.RuntimeState.toSnapshot() =
+        SnapshotDmgPixelRuntime(
+            linePixels(),
+            outCount(),
+            firstEntry(),
+            firstBgp(),
+            firstObp0(),
+            firstObp1(),
+        )
+
+    private const val MACHINE_SNAPSHOT_SHALLOW_BYTES = 40L
+  }
+}
+
+private data class SnapshotMbc3Runtime(
+    val emulationPaused: Boolean,
+    val pauseStartedMillis: Long,
+)
+
+private data class SnapshotRtcRuntime(
+    val primary: SnapshotMbc3Runtime?,
+    val slot: SnapshotMbc3Runtime?,
+) {
+  fun toCore() =
+      Gameboy.RtcRuntimeState(
+          primary?.let { RealTimeClock.RuntimeState(it.emulationPaused, it.pauseStartedMillis) },
+          slot?.let { RealTimeClock.RuntimeState(it.emulationPaused, it.pauseStartedMillis) },
+      )
+}
+
+private data class SnapshotDmgPixelRuntime(
+    val linePixels: Int,
+    val outCount: Int,
+    val firstEntry: Int,
+    val firstBgp: Int,
+    val firstObp0: Int,
+    val firstObp1: Int,
+) {
+  fun toCore() =
+      DmgPixelFifo.RuntimeState(
+          linePixels,
+          outCount,
+          firstEntry,
+          firstBgp,
+          firstObp0,
+          firstObp1,
+      )
+}
+
+private data class SnapshotDmgFifoRuntime(
+    val timing: SnapshotDmgPixelRuntime,
+    val output: SnapshotDmgPixelRuntime,
+) {
+  fun toCore() = Gpu.DmgFifoRuntimeState(timing.toCore(), output.toCore())
+}
+
+private sealed interface SnapshotValue {
+  fun modeledBytes(): Long
+}
+
+private data object SnapshotNull : SnapshotValue {
+  override fun modeledBytes(): Long = 0
+}
+
+private data class SnapshotInt(val value: Int) : SnapshotValue {
+  override fun modeledBytes(): Long = 16
+}
+
+private data class SnapshotLong(val value: Long) : SnapshotValue {
+  override fun modeledBytes(): Long = 24
+}
+
+private data class SnapshotBoolean(val value: Boolean) : SnapshotValue {
+  override fun modeledBytes(): Long = 16
+}
+
+private data class SnapshotDoubleBits(val bits: Long) : SnapshotValue {
+  override fun modeledBytes(): Long = 24
+}
+
+private data class SnapshotString(val value: String) : SnapshotValue {
+  override fun modeledBytes(): Long = align(24L + value.length * 2L)
+}
+
+private data class SnapshotEnum(val typeId: Int, val ordinal: Int) : SnapshotValue {
+  override fun modeledBytes(): Long = 24
+}
+
+private data class SnapshotField(val name: String, val value: SnapshotValue)
+
+private class SnapshotRecord(
+    val typeId: Int,
+    fields: Collection<SnapshotField>,
+) : SnapshotValue {
+  val fields: List<SnapshotField> = Collections.unmodifiableList(ArrayList(fields))
+
+  override fun modeledBytes(): Long = align(24L + fields.size * 24L)
+
+  fun visitRecords(visitor: (SnapshotRecord) -> Unit) {
+    visit { if (it is SnapshotRecord) visitor(it) }
+  }
+
+  fun visit(visitor: (SnapshotValue) -> Unit) {
+    val seen = IdentityHashMap<SnapshotValue, Boolean>()
+    fun traverse(value: SnapshotValue) {
+      if (seen.put(value, true) != null) return
+      visitor(value)
+      when (value) {
+        is SnapshotRecord -> value.fields.forEach { traverse(it.value) }
+        is SnapshotValues -> value.values.forEach(::traverse)
+        is SnapshotIntMap -> value.entries.forEach { traverse(it.value) }
+        else -> Unit
+      }
+    }
+    traverse(this)
+  }
+}
+
+private sealed class SnapshotValues(
+    values: Collection<SnapshotValue>,
+) : SnapshotValue {
+  val values: List<SnapshotValue> = Collections.unmodifiableList(ArrayList(values))
+  override fun modeledBytes(): Long = align(24L + values.size * 8L)
+}
+
+private class SnapshotObjectArray(values: Collection<SnapshotValue>) : SnapshotValues(values)
+
+private class SnapshotList(values: Collection<SnapshotValue>) : SnapshotValues(values)
+
+private data class SnapshotMapEntry(val key: Int, val value: SnapshotValue)
+
+private class SnapshotIntMap(
+    entries: Collection<SnapshotMapEntry>,
+) : SnapshotValue {
+  val entries: List<SnapshotMapEntry> =
+      Collections.unmodifiableList(ArrayList(entries).also { it.sortBy(SnapshotMapEntry::key) })
+
+  override fun modeledBytes(): Long = align(24L + entries.size * 24L)
+}
+
+private sealed class SnapshotPrimitiveArray(
+    val size: Int,
+    pages: Collection<SnapshotPage>,
+) : SnapshotValue {
+  val pages: List<SnapshotPage> = Collections.unmodifiableList(ArrayList(pages))
+  override fun modeledBytes(): Long = align(24L + pages.size * 8L)
+  abstract fun materialize(): Any
+}
+
+private class SnapshotBytes(size: Int, pages: Collection<SnapshotPage>) :
+    SnapshotPrimitiveArray(size, pages) {
+  override fun materialize(): ByteArray {
+    val result = ByteArray(size)
+    pages.forEachIndexed { index, page -> page.copyTo(result, index * bytePageElements(1)) }
+    return result
+  }
+}
+
+private class SnapshotInts(size: Int, pages: Collection<SnapshotPage>) :
+    SnapshotPrimitiveArray(size, pages) {
+  override fun materialize(): IntArray {
+    val result = IntArray(size)
+    pages.forEachIndexed { index, page -> page.copyTo(result, index * bytePageElements(4)) }
+    return result
+  }
+}
+
+private class SnapshotLongs(size: Int, pages: Collection<SnapshotPage>) :
+    SnapshotPrimitiveArray(size, pages) {
+  override fun materialize(): LongArray {
+    val result = LongArray(size)
+    pages.forEachIndexed { index, page -> page.copyTo(result, index * bytePageElements(8)) }
+    return result
+  }
+}
+
+private class SnapshotBooleans(size: Int, pages: Collection<SnapshotPage>) :
+    SnapshotPrimitiveArray(size, pages) {
+  override fun materialize(): BooleanArray {
+    val result = BooleanArray(size)
+    pages.forEachIndexed { index, page -> page.copyTo(result, index * bytePageElements(1)) }
+    return result
+  }
+}
+
+private enum class PageKind(val width: Int) {
+  BYTE(1),
+  INT(4),
+  LONG(8),
+  BOOLEAN(1),
+}
+
+private data class PageKey(val kind: PageKind, val length: Int, val hash: Int)
+
+private sealed class SnapshotPage(
+    val kind: PageKind,
+    val length: Int,
+    val hash: Int,
+) {
+  abstract fun matches(source: Any, offset: Int): Boolean
+  abstract fun copyTo(target: Any, offset: Int)
+  fun retainedBytes(): Long = align(16L + length.toLong() * kind.width)
+}
+
+private class BytePage(private val data: ByteArray, hash: Int) :
+    SnapshotPage(PageKind.BYTE, data.size, hash) {
+  override fun matches(source: Any, offset: Int): Boolean {
+    source as ByteArray
+    return data.indices.all { data[it] == source[offset + it] }
+  }
+
+  override fun copyTo(target: Any, offset: Int) {
+    data.copyInto(target as ByteArray, offset)
+  }
+}
+
+private class IntPage(private val data: IntArray, hash: Int) :
+    SnapshotPage(PageKind.INT, data.size, hash) {
+  override fun matches(source: Any, offset: Int): Boolean {
+    source as IntArray
+    return data.indices.all { data[it] == source[offset + it] }
+  }
+
+  override fun copyTo(target: Any, offset: Int) {
+    data.copyInto(target as IntArray, offset)
+  }
+}
+
+private class LongPage(private val data: LongArray, hash: Int) :
+    SnapshotPage(PageKind.LONG, data.size, hash) {
+  override fun matches(source: Any, offset: Int): Boolean {
+    source as LongArray
+    return data.indices.all { data[it] == source[offset + it] }
+  }
+
+  override fun copyTo(target: Any, offset: Int) {
+    data.copyInto(target as LongArray, offset)
+  }
+}
+
+private class BooleanPage(private val data: BooleanArray, hash: Int) :
+    SnapshotPage(PageKind.BOOLEAN, data.size, hash) {
+  override fun matches(source: Any, offset: Int): Boolean {
+    source as BooleanArray
+    return data.indices.all { data[it] == source[offset + it] }
+  }
+
+  override fun copyTo(target: Any, offset: Int) {
+    data.copyInto(target as BooleanArray, offset)
+  }
+}
+
+private class SnapshotPagePool(previous: SnapshotRecord?) {
+  private val pages = HashMap<PageKey, MutableList<SnapshotPage>>()
+
+  init {
+    previous?.visit { value ->
+      if (value is SnapshotPrimitiveArray) value.pages.forEach(::add)
+    }
+  }
+
+  fun reuse(
+      kind: PageKind,
+      source: Any,
+      offset: Int,
+      length: Int,
+      hash: Int,
+      preferred: SnapshotPage?,
+  ): SnapshotPage? {
+    if (preferred != null &&
+        preferred.kind == kind &&
+        preferred.length == length &&
+        preferred.hash == hash &&
+        preferred.matches(source, offset)) {
+      return preferred
+    }
+    return pages[PageKey(kind, length, hash)]?.firstOrNull { it.matches(source, offset) }
+  }
+
+  fun add(page: SnapshotPage) {
+    val bucket = pages.getOrPut(PageKey(page.kind, page.length, page.hash), ::ArrayList)
+    if (bucket.none { it === page }) bucket += page
+  }
+}
+
+private object SnapshotGraph {
+  private val recordIds by lazy {
+    MementoTypeRegistry.recordClasses.withIndex().associate { (index, type) -> type to index + 1 }
+  }
+  private val enumIds by lazy {
+    MementoTypeRegistry.enumClasses.withIndex().associate { (index, type) -> type to index + 1 }
+  }
+
+  data class Result(
+      val root: SnapshotRecord,
+      val stats: MachineSnapshot.CaptureStats,
+  )
+
+  fun capture(value: Any, previous: SnapshotRecord?): Result {
+    val capture = Capture(previous)
+    val root = capture.value(value, previous, 0) as? SnapshotRecord
+        ?: error("Machine snapshot root is not a record")
+    if (recordClassName(root.typeId) != GAMEBOY_ROOT) {
+      error("Machine snapshot has the wrong root type")
+    }
+    return Result(root, capture.stats())
+  }
+
+  fun recordClassName(typeId: Int): String =
+      MementoTypeRegistry.recordClassNames.getOrNull(typeId - 1)
+          ?: error("Unknown snapshot record type ID $typeId")
+
+  fun restoreRoot(root: SnapshotRecord): Any = Restore().value(root, null, 0)
+      ?: throw StateApplyException("Internal machine snapshot root is null")
+
+  fun ownershipSignature(root: SnapshotRecord): List<Int> {
+    val signature = ArrayList<Int>()
+    root.visitRecords { record ->
+      if (isOwnershipRecord(recordClassName(record.typeId))) signature += record.typeId
+    }
+    return signature
+  }
+
+  fun ownershipSignature(root: Any): List<Int> {
+    val signature = ArrayList<Int>()
+    fun visit(value: Any?) {
+      if (value == null) return
+      when {
+        value.javaClass.isRecord -> {
+          val typeId = recordIds[value.javaClass]
+              ?: throw StateApplyException("Unregistered internal record ${value.javaClass.name}")
+          if (isOwnershipRecord(value.javaClass.name)) signature += typeId
+          value.javaClass.recordComponents.forEach { component ->
+            component.accessor.trySetAccessible()
+            visit(component.accessor.invoke(value))
+          }
+        }
+        value.javaClass.isArray && !value.javaClass.componentType.isPrimitive ->
+            repeat(ReflectArray.getLength(value)) { visit(ReflectArray.get(value, it)) }
+        value is Iterable<*> -> value.forEach(::visit)
+        value is Map<*, *> ->
+            value.entries.sortedBy { (it.key as? Int) ?: Int.MIN_VALUE }.forEach {
+              visit(it.key)
+              visit(it.value)
+            }
+      }
+    }
+    visit(root)
+    return signature
+  }
+
+  private fun isOwnershipRecord(name: String): Boolean =
+      name.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.") ||
+          name.startsWith("eu.rekawek.coffeegb.core.memory.cart.battery.")
+
+  private class Restore {
+    private var references = 0L
+
+    fun value(
+        value: SnapshotValue,
+        expectedType: Type?,
+        depth: Int,
+    ): Any? {
+      if (depth > StateLimits.LEGACY_MAX_DEPTH) {
+        throw StateApplyException("Internal machine snapshot is too deep")
+      }
+      countValue()
+      if (value === SnapshotNull) {
+        if (expectedType.rawClass()?.isPrimitive == true) {
+          throw StateApplyException("Null primitive in internal machine snapshot")
+        }
+        return null
+      }
+      val restored =
+          when (value) {
+            is SnapshotInt -> value.value
+            is SnapshotLong -> value.value
+            is SnapshotBoolean -> value.value
+            is SnapshotDoubleBits -> Double.fromBits(value.bits)
+            is SnapshotString -> value.value
+            is SnapshotEnum -> restoreEnum(value)
+            is SnapshotRecord -> restoreRecord(value, depth)
+            is SnapshotPrimitiveArray -> value.materialize()
+            is SnapshotObjectArray -> restoreArray(value, expectedType, depth)
+            is SnapshotList -> restoreList(value, expectedType, depth)
+            is SnapshotIntMap -> restoreMap(value, expectedType, depth)
+            SnapshotNull -> null
+          }
+      requireExpected(restored, expectedType)
+      return restored
+    }
+
+    private fun restoreEnum(value: SnapshotEnum): Any {
+      val type =
+          MementoTypeRegistry.enumClasses.getOrNull(value.typeId - 1)
+              ?: throw StateApplyException("Unknown internal enum type ID ${value.typeId}")
+      return type.enumConstants.getOrNull(value.ordinal)
+          ?: throw StateApplyException("Invalid ${type.name} ordinal ${value.ordinal}")
+    }
+
+    private fun restoreRecord(
+        value: SnapshotRecord,
+        depth: Int,
+    ): Any {
+      val type =
+          MementoTypeRegistry.recordClasses.getOrNull(value.typeId - 1)
+              ?: throw StateApplyException("Unknown internal record type ID ${value.typeId}")
+      val components = type.recordComponents
+      if (components.size != value.fields.size ||
+          components.indices.any { components[it].name != value.fields[it].name }) {
+        throw StateApplyException("Invalid internal ${type.name} field inventory")
+      }
+      val arguments =
+          components.indices
+              .map { index ->
+                this.value(value.fields[index].value, components[index].genericType, depth + 1)
+              }
+              .toTypedArray()
+      val constructor = type.getDeclaredConstructor(*components.map { it.type }.toTypedArray())
+      constructor.trySetAccessible()
+      try {
+        return constructor.newInstance(*arguments)
+      } catch (failure: InvocationTargetException) {
+        throw StateApplyException("Invalid internal ${type.name} value", failure.targetException)
+      } catch (failure: ReflectiveOperationException) {
+        throw StateApplyException("Internal record ${type.name} could not be constructed", failure)
+      }
+    }
+
+    private fun restoreArray(
+        value: SnapshotObjectArray,
+        expectedType: Type?,
+        depth: Int,
+    ): Any {
+      val type = expectedType.rawClass()
+      if (type?.isArray != true || type.componentType.isPrimitive) {
+        throw StateApplyException("Unexpected internal object array")
+      }
+      return ReflectArray.newInstance(type.componentType, value.values.size).also { result ->
+        value.values.forEachIndexed { index, item ->
+          ReflectArray.set(result, index, this.value(item, type.componentType, depth + 1))
+        }
+      }
+    }
+
+    private fun restoreList(
+        value: SnapshotList,
+        expectedType: Type?,
+        depth: Int,
+    ): List<Any?> {
+      val elementType = expectedType.typeArguments()?.singleOrNull()
+      return ArrayList<Any?>(value.values.size).also { result ->
+        value.values.forEach { result += this.value(it, elementType, depth + 1) }
+      }
+    }
+
+    private fun restoreMap(
+        value: SnapshotIntMap,
+        expectedType: Type?,
+        depth: Int,
+    ): Map<Int, Any?> {
+      val types = expectedType.typeArguments()
+      val keyType = types?.getOrNull(0) ?: Int::class.javaObjectType
+      if (keyType.rawClass() != Int::class.javaObjectType) {
+        throw StateApplyException("Internal snapshot maps require integer keys")
+      }
+      val itemType = types?.getOrNull(1)
+      return LinkedHashMap<Int, Any?>(value.entries.size).also { result ->
+        value.entries.forEach { entry ->
+          result[entry.key] = this.value(entry.value, itemType, depth + 1)
+        }
+      }
+    }
+
+    private fun requireExpected(value: Any?, expectedType: Type?) {
+      if (value == null || expectedType == null) return
+      val expected = expectedType.rawClass() ?: return
+      val boxed =
+          when (expected) {
+            Int::class.javaPrimitiveType -> Int::class.javaObjectType
+            Long::class.javaPrimitiveType -> Long::class.javaObjectType
+            Boolean::class.javaPrimitiveType -> Boolean::class.javaObjectType
+            Double::class.javaPrimitiveType -> Double::class.javaObjectType
+            else -> expected
+          }
+      if (!boxed.isInstance(value)) {
+        throw StateApplyException(
+            "Expected internal ${expected.name}, received ${value.javaClass.name}")
+      }
+    }
+
+    private fun countValue() {
+      references++
+      if (references > StateLimits.LEGACY_MAX_REFERENCES) {
+        throw StateApplyException("Internal machine snapshot has too many values")
+      }
+    }
+  }
+
+  private class Capture(previous: SnapshotRecord?) {
+    private val pool = SnapshotPagePool(previous)
+    private var references = 0L
+    private var copiedPages = 0
+    private var copiedPageBytes = 0L
+    private var reusedPages = 0
+    private var newValueNodes = 0
+
+    fun stats() =
+        MachineSnapshot.CaptureStats(
+            copiedPages,
+            copiedPageBytes,
+            reusedPages,
+            newValueNodes,
+        )
+
+    fun value(
+        source: Any?,
+        previous: SnapshotValue?,
+        depth: Int,
+    ): SnapshotValue {
+      check(depth <= StateLimits.LEGACY_MAX_DEPTH) { "Machine snapshot graph is too deep" }
+      countValue()
+      if (source == null) return SnapshotNull
+      return when (source) {
+        is Int -> reuseScalar(previous, SnapshotInt(source))
+        is Long -> reuseScalar(previous, SnapshotLong(source))
+        is Boolean -> reuseScalar(previous, SnapshotBoolean(source))
+        is Double -> reuseScalar(previous, SnapshotDoubleBits(source.toBits()))
+        is String -> reuseScalar(previous, SnapshotString(source))
+        is ByteArray -> captureBytes(source, previous as? SnapshotBytes)
+        is IntArray -> captureInts(source, previous as? SnapshotInts)
+        is LongArray -> captureLongs(source, previous as? SnapshotLongs)
+        is BooleanArray -> captureBooleans(source, previous as? SnapshotBooleans)
+        is List<*> -> captureValues(source, previous as? SnapshotList, depth)
+        is Map<*, *> -> captureMap(source, previous as? SnapshotIntMap, depth)
+        is Enum<*> -> {
+          val id =
+              enumIds[source.javaClass]
+                  ?: error("Unregistered snapshot enum ${source.javaClass.name}")
+          reuseScalar(previous, SnapshotEnum(id, source.ordinal))
+        }
+        else ->
+            if (source.javaClass.isArray) {
+              captureObjectArray(source, previous as? SnapshotObjectArray, depth)
+            } else {
+              captureRecord(source, previous as? SnapshotRecord, depth)
+            }
+      }
+    }
+
+    private fun reuseScalar(previous: SnapshotValue?, candidate: SnapshotValue): SnapshotValue =
+        if (previous == candidate) previous else candidate.also { newValueNodes++ }
+
+    private fun captureBytes(source: ByteArray, previous: SnapshotBytes?): SnapshotValue =
+        capturePrimitive(
+            source.size,
+            PageKind.BYTE,
+            previous,
+            { offset, length -> hash(source, offset, length) },
+            { offset, length, hash -> BytePage(source.copyOfRange(offset, offset + length), hash) },
+            { size, pages -> SnapshotBytes(size, pages) },
+            source,
+        )
+
+    private fun captureInts(source: IntArray, previous: SnapshotInts?): SnapshotValue =
+        capturePrimitive(
+            source.size,
+            PageKind.INT,
+            previous,
+            { offset, length -> hash(source, offset, length) },
+            { offset, length, hash -> IntPage(source.copyOfRange(offset, offset + length), hash) },
+            { size, pages -> SnapshotInts(size, pages) },
+            source,
+        )
+
+    private fun captureLongs(source: LongArray, previous: SnapshotLongs?): SnapshotValue =
+        capturePrimitive(
+            source.size,
+            PageKind.LONG,
+            previous,
+            { offset, length -> hash(source, offset, length) },
+            { offset, length, hash -> LongPage(source.copyOfRange(offset, offset + length), hash) },
+            { size, pages -> SnapshotLongs(size, pages) },
+            source,
+        )
+
+    private fun captureBooleans(source: BooleanArray, previous: SnapshotBooleans?): SnapshotValue =
+        capturePrimitive(
+            source.size,
+            PageKind.BOOLEAN,
+            previous,
+            { offset, length -> hash(source, offset, length) },
+            { offset, length, hash ->
+              BooleanPage(source.copyOfRange(offset, offset + length), hash)
+            },
+            { size, pages -> SnapshotBooleans(size, pages) },
+            source,
+        )
+
+    private fun capturePrimitive(
+        size: Int,
+        kind: PageKind,
+        previous: SnapshotPrimitiveArray?,
+        pageHash: (Int, Int) -> Int,
+        create: (Int, Int, Int) -> SnapshotPage,
+        array: (Int, List<SnapshotPage>) -> SnapshotPrimitiveArray,
+        source: Any,
+    ): SnapshotValue {
+      val pageElements = bytePageElements(kind.width)
+      val pageCount = if (size == 0) 0 else (size - 1) / pageElements + 1
+      val result = ArrayList<SnapshotPage>(pageCount)
+      repeat(pageCount) { index ->
+        val offset = index * pageElements
+        val length = min(pageElements, size - offset)
+        val hash = pageHash(offset, length)
+        val reused =
+            pool.reuse(
+                kind,
+                source,
+                offset,
+                length,
+                hash,
+                previous?.takeIf { it.size == size }?.pages?.getOrNull(index),
+            )
+        val page =
+            reused
+                ?: create(offset, length, hash).also {
+                  copiedPages++
+                  copiedPageBytes += length.toLong() * kind.width
+                }
+        if (reused != null) reusedPages++
+        pool.add(page)
+        result += page
+      }
+      if (previous != null &&
+          previous.size == size &&
+          previous.pages.size == result.size &&
+          result.indices.all { result[it] === previous.pages[it] }) {
+        return previous
+      }
+      newValueNodes++
+      return array(size, result)
+    }
+
+    private fun captureObjectArray(
+        source: Any,
+        previous: SnapshotObjectArray?,
+        depth: Int,
+    ): SnapshotValue {
+      val size = ReflectArray.getLength(source)
+      val values =
+          List(size) { index ->
+            value(ReflectArray.get(source, index), previous?.values?.getOrNull(index), depth + 1)
+          }
+      if (previous != null &&
+          previous.values.size == size &&
+          values.indices.all { values[it] === previous.values[it] }) {
+        return previous
+      }
+      newValueNodes++
+      return SnapshotObjectArray(values)
+    }
+
+    private fun captureValues(
+        source: List<*>,
+        previous: SnapshotList?,
+        depth: Int,
+    ): SnapshotValue {
+      val values =
+          source.mapIndexed { index, item ->
+            value(item, previous?.values?.getOrNull(index), depth + 1)
+          }
+      if (previous != null &&
+          previous.values.size == values.size &&
+          values.indices.all { values[it] === previous.values[it] }) {
+        return previous
+      }
+      newValueNodes++
+      return SnapshotList(values)
+    }
+
+    private fun captureMap(
+        source: Map<*, *>,
+        previous: SnapshotIntMap?,
+        depth: Int,
+    ): SnapshotValue {
+      val sorted =
+          source.entries
+              .map { entry ->
+                val key = entry.key as? Int ?: error("Snapshot map key is not an Int")
+                key to entry.value
+              }
+              .sortedBy { it.first }
+      val entries =
+          sorted.mapIndexed { index, (key, item) ->
+            val old = previous?.entries?.getOrNull(index)?.takeIf { it.key == key }
+            SnapshotMapEntry(key, value(item, old?.value, depth + 1))
+          }
+      if (previous != null &&
+          previous.entries.size == entries.size &&
+          entries.indices.all {
+            entries[it].key == previous.entries[it].key &&
+                entries[it].value === previous.entries[it].value
+          }) {
+        return previous
+      }
+      newValueNodes++
+      return SnapshotIntMap(entries)
+    }
+
+    private fun captureRecord(
+        source: Any,
+        previous: SnapshotRecord?,
+        depth: Int,
+    ): SnapshotValue {
+      val type = source.javaClass
+      val typeId = recordIds[type] ?: error("Unregistered snapshot record ${type.name}")
+      val sameType = previous?.takeIf { it.typeId == typeId }
+      val fields =
+          type.recordComponents.mapIndexed { index, component ->
+            component.accessor.trySetAccessible()
+            val old =
+                sameType
+                    ?.fields
+                    ?.getOrNull(index)
+                    ?.takeIf { it.name == component.name }
+                    ?.value
+            SnapshotField(component.name, value(component.accessor.invoke(source), old, depth + 1))
+          }
+      if (sameType != null &&
+          sameType.fields.size == fields.size &&
+          fields.indices.all {
+            fields[it].name == sameType.fields[it].name &&
+                fields[it].value === sameType.fields[it].value
+          }) {
+        return sameType
+      }
+      newValueNodes++
+      return SnapshotRecord(typeId, fields)
+    }
+
+    private fun countValue() {
+      references++
+      check(references <= StateLimits.LEGACY_MAX_REFERENCES) {
+        "Machine snapshot graph has too many values"
+      }
+    }
+  }
+
+  private const val GAMEBOY_ROOT = "eu.rekawek.coffeegb.core.Gameboy\$GameboyMemento"
+}
+
+private fun hash(
+    source: ByteArray,
+    offset: Int,
+    length: Int,
+): Int {
+  var result = 1
+  repeat(length) { result = 31 * result + source[offset + it] }
+  return result
+}
+
+private fun hash(
+    source: IntArray,
+    offset: Int,
+    length: Int,
+): Int {
+  var result = 1
+  repeat(length) { result = 31 * result + source[offset + it] }
+  return result
+}
+
+private fun hash(
+    source: LongArray,
+    offset: Int,
+    length: Int,
+): Int {
+  var result = 1
+  repeat(length) {
+    val value = source[offset + it]
+    result = 31 * result + (value xor (value ushr 32)).toInt()
+  }
+  return result
+}
+
+private fun hash(
+    source: BooleanArray,
+    offset: Int,
+    length: Int,
+): Int {
+  var result = 1
+  repeat(length) { result = 31 * result + if (source[offset + it]) 1231 else 1237 }
+  return result
+}
+
+private fun bytePageElements(width: Int): Int = MachineSnapshot.PAGE_BYTES / width
+
+private fun align(value: Long): Long = (value + 7) and -8L
+
+private fun Type?.rawClass(): Class<*>? =
+    when (this) {
+      is Class<*> -> this
+      is ParameterizedType -> rawType as? Class<*>
+      is GenericArrayType ->
+          genericComponentType.rawClass()?.let { ReflectArray.newInstance(it, 0).javaClass }
+      is WildcardType -> upperBounds.singleOrNull().rawClass()
+      else -> null
+    }
+
+private fun Type?.typeArguments(): Array<Type>? =
+    (this as? ParameterizedType)?.actualTypeArguments

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -31,6 +31,45 @@ import org.junit.Test
 class BasicControllerTest {
 
   @Test
+  fun disabledRewindCreatesNoFrameCapturesAndCannotFreezeForwardEmulation() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val frames = LinkedBlockingQueue<GbcFrameReadyEvent>()
+    eventBus.register<EmulationStartedEvent> { started.add(it) }
+    eventBus.register<GbcFrameReadyEvent> { frames.add(it) }
+    val rewind = RewindManager(enabled = false)
+    val controller =
+        BasicController(
+            eventBus,
+            EmulatorProperties(),
+            null,
+            RomSessionPreparer(),
+            SnapshotManagerFactory.DEFAULT,
+            rewind,
+        )
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(ROM))
+      assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertNotNull(frames.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(0, rewind.captureCount)
+
+      frames.clear()
+      eventBus.post(Controller.RewindEvent(true))
+      assertNotNull(
+          frames.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "a disabled rewind request must not stop normal frame progress",
+      )
+      assertEquals(0, rewind.captureCount)
+      assertEquals(0, rewind.historySize)
+    } finally {
+      controller.close()
+      eventBus.close()
+    }
+  }
+
+  @Test
   fun failedSnapshotSaveEmitsOnlyFailureRetainsOldFileAndControllerLaterSaves() {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
@@ -49,11 +49,15 @@ class MachineSnapshotBenchmarkTest {
             "modeledRetainedBytes=${snapshots.modeledRetainedBytes} " +
             "uniquePages=${snapshots.uniquePages} uniqueValueNodes=${snapshots.uniqueValueNodes} " +
             "copiedPageBytes=${snapshots.copiedPageBytes} " +
+            "sourcePayloadCloneBytes=${snapshots.sourcePayloadCloneBytes} " +
             "captureAllocatedBytes=${snapshots.captureAllocatedBytes} " +
             "captureNanos=${snapshots.captureNanos} restoreNanos=${snapshots.restoreNanos}",
     )
     check(snapshots.retainedPrimitiveBytes * 2 < baseline.retainedPrimitiveBytes) {
       "MachineSnapshot retained primitive bytes must be at least 50% below the baseline"
+    }
+    check(snapshots.sourcePayloadCloneBytes == 0L) {
+      "Incremental rewind capture must not clone source primitive payloads"
     }
   }
 
@@ -66,9 +70,9 @@ class MachineSnapshotBenchmarkTest {
       var allocatedBytes = 0L
       var captureNanos = 0L
 
-      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
-        exercise(gameboy, step)
-        if (step % RewindManager.RECORD_INTERVAL == 0) {
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { frame ->
+        emulateProductionFrame(gameboy, frame)
+        if (frame % RewindManager.RECORD_INTERVAL == 0) {
           val before = allocation?.current() ?: 0L
           captureNanos += measureNanoTime { snapshots += gameboy.saveToMemento() }
           allocatedBytes += (allocation?.current() ?: before) - before
@@ -88,6 +92,7 @@ class MachineSnapshotBenchmarkTest {
           retained.arrays.toInt(),
           0,
           0,
+          0,
           allocatedBytes,
           captureNanos,
           restoreNanos,
@@ -104,15 +109,17 @@ class MachineSnapshotBenchmarkTest {
       var allocatedBytes = 0L
       var captureNanos = 0L
       var copiedPageBytes = 0L
+      var sourcePayloadCloneBytes = 0L
 
-      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
-        exercise(gameboy, step)
-        if (step % RewindManager.RECORD_INTERVAL == 0) {
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { frame ->
+        emulateProductionFrame(gameboy, frame)
+        if (frame % RewindManager.RECORD_INTERVAL == 0) {
           val before = allocation?.current() ?: 0L
           captureNanos +=
               measureNanoTime {
                 val snapshot = MachineSnapshot.capture(gameboy, snapshots.lastOrNull())
                 copiedPageBytes += snapshot.captureStats.copiedPageBytes
+                sourcePayloadCloneBytes += snapshot.captureStats.sourcePayloadCloneBytes
                 snapshots += snapshot
               }
           allocatedBytes += (allocation?.current() ?: before) - before
@@ -132,6 +139,7 @@ class MachineSnapshotBenchmarkTest {
           retained.uniquePages,
           retained.uniqueValueNodes,
           copiedPageBytes,
+          sourcePayloadCloneBytes,
           allocatedBytes,
           captureNanos,
           restoreNanos,
@@ -142,19 +150,19 @@ class MachineSnapshotBenchmarkTest {
   private fun configuration(rom: ByteArray) =
       StateCodecTestSupport.configuration(rom, GameboyType.CGB).setSupportBatterySave(false)
 
-  private fun exercise(
+  private fun emulateProductionFrame(
       gameboy: Gameboy,
-      step: Int,
+      frame: Int,
   ) {
-    repeat(TICKS_PER_STEP) { gameboy.tick() }
-    val value = step and 0xff
-    gameboy.addressSpace.setByte(0xc000 + (step * 37 and 0xfff), value)
-    gameboy.addressSpace.setByte(0xd000 + (step * 53 and 0xfff), value xor 0x5a)
-    gameboy.gpu.videoRam0.setByte(0x8000 + (step * 29 and 0x1fff), value xor 0xa5)
-    gameboy.gpu.videoRam1.setByte(0x8000 + (step * 31 and 0x1fff), value xor 0x3c)
-    gameboy.addressSpace.setByte(0xfe00 + (step % 0xa0), value)
-    gameboy.addressSpace.setByte(0x4000, step ushr 5 and 0x03)
-    gameboy.addressSpace.setByte(0xa000 + (step * 43 and 0x1fff), value xor 0xc3)
+    repeat(Gameboy.TICKS_PER_FRAME) { gameboy.tick() }
+    val value = frame and 0xff
+    gameboy.addressSpace.setByte(0xc000 + (frame * 37 and 0xfff), value)
+    gameboy.addressSpace.setByte(0xd000 + (frame * 53 and 0xfff), value xor 0x5a)
+    gameboy.gpu.videoRam0.setByte(0x8000 + (frame * 29 and 0x1fff), value xor 0xa5)
+    gameboy.gpu.videoRam1.setByte(0x8000 + (frame * 31 and 0x1fff), value xor 0x3c)
+    gameboy.addressSpace.setByte(0xfe00 + (frame % 0xa0), value)
+    gameboy.addressSpace.setByte(0x4000, frame ushr 5 and 0x03)
+    gameboy.addressSpace.setByte(0xa000 + (frame * 43 and 0x1fff), value xor 0xc3)
   }
 
   private fun threadAllocation(): AllocationCounter? {
@@ -229,6 +237,7 @@ class MachineSnapshotBenchmarkTest {
       val uniquePages: Int,
       val uniqueValueNodes: Int,
       val copiedPageBytes: Long,
+      val sourcePayloadCloneBytes: Long,
       val captureAllocatedBytes: Long,
       val captureNanos: Long,
       val restoreNanos: Long,
@@ -236,7 +245,6 @@ class MachineSnapshotBenchmarkTest {
 
   companion object {
     private const val BENCHMARK_PROPERTY = "coffeegb.rewind.benchmark"
-    private const val TICKS_PER_STEP = 2_048
     private const val ARRAY_HEADER_BYTES = 16L
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
@@ -49,15 +49,15 @@ class MachineSnapshotBenchmarkTest {
             "modeledRetainedBytes=${snapshots.modeledRetainedBytes} " +
             "uniquePages=${snapshots.uniquePages} uniqueValueNodes=${snapshots.uniqueValueNodes} " +
             "copiedPageBytes=${snapshots.copiedPageBytes} " +
-            "sourcePayloadCloneBytes=${snapshots.sourcePayloadCloneBytes} " +
+            "identityVerifiedPayloadBytes=${snapshots.identityVerifiedPayloadBytes} " +
             "captureAllocatedBytes=${snapshots.captureAllocatedBytes} " +
             "captureNanos=${snapshots.captureNanos} restoreNanos=${snapshots.restoreNanos}",
     )
     check(snapshots.retainedPrimitiveBytes * 2 < baseline.retainedPrimitiveBytes) {
       "MachineSnapshot retained primitive bytes must be at least 50% below the baseline"
     }
-    check(snapshots.sourcePayloadCloneBytes == 0L) {
-      "Incremental rewind capture must not clone source primitive payloads"
+    check(snapshots.identityVerifiedPayloadBytes > 0L) {
+      "Incremental rewind capture must identity-verify source primitive payloads"
     }
   }
 
@@ -109,7 +109,7 @@ class MachineSnapshotBenchmarkTest {
       var allocatedBytes = 0L
       var captureNanos = 0L
       var copiedPageBytes = 0L
-      var sourcePayloadCloneBytes = 0L
+      var identityVerifiedPayloadBytes = 0L
 
       repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { frame ->
         emulateProductionFrame(gameboy, frame)
@@ -119,7 +119,7 @@ class MachineSnapshotBenchmarkTest {
               measureNanoTime {
                 val snapshot = MachineSnapshot.capture(gameboy, snapshots.lastOrNull())
                 copiedPageBytes += snapshot.captureStats.copiedPageBytes
-                sourcePayloadCloneBytes += snapshot.captureStats.sourcePayloadCloneBytes
+                identityVerifiedPayloadBytes += snapshot.captureStats.identityVerifiedPayloadBytes
                 snapshots += snapshot
               }
           allocatedBytes += (allocation?.current() ?: before) - before
@@ -139,7 +139,7 @@ class MachineSnapshotBenchmarkTest {
           retained.uniquePages,
           retained.uniqueValueNodes,
           copiedPageBytes,
-          sourcePayloadCloneBytes,
+          identityVerifiedPayloadBytes,
           allocatedBytes,
           captureNanos,
           restoreNanos,
@@ -237,7 +237,7 @@ class MachineSnapshotBenchmarkTest {
       val uniquePages: Int,
       val uniqueValueNodes: Int,
       val copiedPageBytes: Long,
-      val sourcePayloadCloneBytes: Long,
+      val identityVerifiedPayloadBytes: Long,
       val captureAllocatedBytes: Long,
       val captureNanos: Long,
       val restoreNanos: Long,

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/MachineSnapshotBenchmarkTest.kt
@@ -1,0 +1,242 @@
+package eu.rekawek.coffeegb.controller
+
+import com.sun.management.ThreadMXBean
+import eu.rekawek.coffeegb.controller.state.MachineSnapshot
+import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.memento.Memento
+import java.lang.management.ManagementFactory
+import java.lang.reflect.Array as ReflectArray
+import java.util.IdentityHashMap
+import kotlin.system.measureNanoTime
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * Manual, deterministic 300-entry rewind measurement.
+ *
+ * Run with:
+ * `mvn -B -pl controller -am -Dtest=MachineSnapshotBenchmarkTest
+ * -Dcoffeegb.rewind.benchmark=true test`
+ *
+ * Wall-clock and allocated-byte figures are observations, not CI thresholds. The retained-byte
+ * model is deterministic: it counts aligned primitive arrays in the complete retained graph.
+ */
+class MachineSnapshotBenchmarkTest {
+
+  @Test
+  fun measureLegacyBaselineAndMachineSnapshots() {
+    assumeTrue(java.lang.Boolean.getBoolean(BENCHMARK_PROPERTY))
+    val rom =
+        StateCodecTestSupport.rom(cgb = true).also {
+          it[0x147] = 0x1b // MBC5 + RAM + battery
+          it[0x149] = 0x03 // 32 KiB RAM
+        }
+    val baseline = measureLegacy(rom)
+    println(
+        "REWIND_BENCHMARK mode=legacy-baseline entries=${baseline.entries} " +
+            "retainedPrimitiveBytes=${baseline.retainedPrimitiveBytes} " +
+            "retainedPrimitiveArrays=${baseline.retainedPrimitiveArrays} " +
+            "captureAllocatedBytes=${baseline.captureAllocatedBytes} " +
+            "captureNanos=${baseline.captureNanos} restoreNanos=${baseline.restoreNanos}",
+    )
+
+    val snapshots = measureSnapshots(rom)
+    println(
+        "REWIND_BENCHMARK mode=machine-snapshot entries=${snapshots.entries} " +
+            "retainedPrimitiveBytes=${snapshots.retainedPrimitiveBytes} " +
+            "modeledRetainedBytes=${snapshots.modeledRetainedBytes} " +
+            "uniquePages=${snapshots.uniquePages} uniqueValueNodes=${snapshots.uniqueValueNodes} " +
+            "copiedPageBytes=${snapshots.copiedPageBytes} " +
+            "captureAllocatedBytes=${snapshots.captureAllocatedBytes} " +
+            "captureNanos=${snapshots.captureNanos} restoreNanos=${snapshots.restoreNanos}",
+    )
+    check(snapshots.retainedPrimitiveBytes * 2 < baseline.retainedPrimitiveBytes) {
+      "MachineSnapshot retained primitive bytes must be at least 50% below the baseline"
+    }
+  }
+
+  private fun measureLegacy(rom: ByteArray): BenchmarkResult {
+    StateCodecTestSupport.session(configuration(rom)).use { session ->
+      val gameboy = session.gameboy
+      gameboy.addressSpace.setByte(0x0000, 0x0a)
+      val snapshots = ArrayList<Memento<Gameboy>>(RewindManager.CAPACITY)
+      val allocation = threadAllocation()
+      var allocatedBytes = 0L
+      var captureNanos = 0L
+
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
+        exercise(gameboy, step)
+        if (step % RewindManager.RECORD_INTERVAL == 0) {
+          val before = allocation?.current() ?: 0L
+          captureNanos += measureNanoTime { snapshots += gameboy.saveToMemento() }
+          allocatedBytes += (allocation?.current() ?: before) - before
+        }
+      }
+
+      val retained = PrimitiveArrayRetainedBytes.measure(snapshots)
+      var restoreNanos = 0L
+      snapshots.forEach { snapshot ->
+        restoreNanos += measureNanoTime { gameboy.restoreFromMemento(snapshot) }
+      }
+      return BenchmarkResult(
+          snapshots.size,
+          retained.bytes,
+          retained.arrays,
+          retained.bytes,
+          retained.arrays.toInt(),
+          0,
+          0,
+          allocatedBytes,
+          captureNanos,
+          restoreNanos,
+      )
+    }
+  }
+
+  private fun measureSnapshots(rom: ByteArray): BenchmarkResult {
+    StateCodecTestSupport.session(configuration(rom)).use { session ->
+      val gameboy = session.gameboy
+      gameboy.addressSpace.setByte(0x0000, 0x0a)
+      val snapshots = ArrayList<MachineSnapshot>(RewindManager.CAPACITY)
+      val allocation = threadAllocation()
+      var allocatedBytes = 0L
+      var captureNanos = 0L
+      var copiedPageBytes = 0L
+
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
+        exercise(gameboy, step)
+        if (step % RewindManager.RECORD_INTERVAL == 0) {
+          val before = allocation?.current() ?: 0L
+          captureNanos +=
+              measureNanoTime {
+                val snapshot = MachineSnapshot.capture(gameboy, snapshots.lastOrNull())
+                copiedPageBytes += snapshot.captureStats.copiedPageBytes
+                snapshots += snapshot
+              }
+          allocatedBytes += (allocation?.current() ?: before) - before
+        }
+      }
+
+      val retained = MachineSnapshot.retainedStats(snapshots)
+      var restoreNanos = 0L
+      snapshots.forEach { snapshot ->
+        restoreNanos += measureNanoTime { snapshot.restore(gameboy) }
+      }
+      return BenchmarkResult(
+          snapshots.size,
+          retained.retainedPrimitiveBytes,
+          retained.uniquePages.toLong(),
+          retained.modeledRetainedBytes,
+          retained.uniquePages,
+          retained.uniqueValueNodes,
+          copiedPageBytes,
+          allocatedBytes,
+          captureNanos,
+          restoreNanos,
+      )
+    }
+  }
+
+  private fun configuration(rom: ByteArray) =
+      StateCodecTestSupport.configuration(rom, GameboyType.CGB).setSupportBatterySave(false)
+
+  private fun exercise(
+      gameboy: Gameboy,
+      step: Int,
+  ) {
+    repeat(TICKS_PER_STEP) { gameboy.tick() }
+    val value = step and 0xff
+    gameboy.addressSpace.setByte(0xc000 + (step * 37 and 0xfff), value)
+    gameboy.addressSpace.setByte(0xd000 + (step * 53 and 0xfff), value xor 0x5a)
+    gameboy.gpu.videoRam0.setByte(0x8000 + (step * 29 and 0x1fff), value xor 0xa5)
+    gameboy.gpu.videoRam1.setByte(0x8000 + (step * 31 and 0x1fff), value xor 0x3c)
+    gameboy.addressSpace.setByte(0xfe00 + (step % 0xa0), value)
+    gameboy.addressSpace.setByte(0x4000, step ushr 5 and 0x03)
+    gameboy.addressSpace.setByte(0xa000 + (step * 43 and 0x1fff), value xor 0xc3)
+  }
+
+  private fun threadAllocation(): AllocationCounter? {
+    val bean = ManagementFactory.getThreadMXBean() as? ThreadMXBean ?: return null
+    if (!bean.isThreadAllocatedMemorySupported) return null
+    if (!bean.isThreadAllocatedMemoryEnabled) bean.isThreadAllocatedMemoryEnabled = true
+    return AllocationCounter(bean, Thread.currentThread().threadId())
+  }
+
+  private data class AllocationCounter(
+      val bean: ThreadMXBean,
+      val threadId: Long,
+  ) {
+    fun current(): Long = bean.getThreadAllocatedBytes(threadId)
+  }
+
+  private object PrimitiveArrayRetainedBytes {
+    fun measure(root: Any): Retained {
+      val seen = IdentityHashMap<Any, Boolean>()
+      var bytes = 0L
+      var arrays = 0L
+
+      fun visit(value: Any?) {
+        if (value == null || value.javaClass.isEnum || value is String || value is Number || value is Boolean) {
+          return
+        }
+        if (seen.put(value, true) != null) return
+        val type = value.javaClass
+        when {
+          type.isArray -> {
+            val component = type.componentType
+            val length = ReflectArray.getLength(value)
+            if (component.isPrimitive) {
+              val width =
+                  when (component) {
+                    java.lang.Byte.TYPE, java.lang.Boolean.TYPE -> 1
+                    java.lang.Short.TYPE, java.lang.Character.TYPE -> 2
+                    java.lang.Integer.TYPE, java.lang.Float.TYPE -> 4
+                    java.lang.Long.TYPE, java.lang.Double.TYPE -> 8
+                    else -> error("Unknown primitive $component")
+                  }
+              bytes += align(ARRAY_HEADER_BYTES + length.toLong() * width)
+              arrays++
+            } else {
+              repeat(length) { visit(ReflectArray.get(value, it)) }
+            }
+          }
+          value is Iterable<*> -> value.forEach(::visit)
+          value is Map<*, *> -> value.forEach { (key, item) -> visit(key); visit(item) }
+          type.isRecord ->
+              type.recordComponents.forEach { component ->
+                component.accessor.trySetAccessible()
+                visit(component.accessor.invoke(value))
+              }
+        }
+      }
+
+      visit(root)
+      return Retained(bytes, arrays)
+    }
+
+    private fun align(value: Long): Long = (value + 7) and -8L
+  }
+
+  private data class Retained(val bytes: Long, val arrays: Long)
+
+  private data class BenchmarkResult(
+      val entries: Int,
+      val retainedPrimitiveBytes: Long,
+      val retainedPrimitiveArrays: Long,
+      val modeledRetainedBytes: Long,
+      val uniquePages: Int,
+      val uniqueValueNodes: Int,
+      val copiedPageBytes: Long,
+      val captureAllocatedBytes: Long,
+      val captureNanos: Long,
+      val restoreNanos: Long,
+  )
+
+  companion object {
+    private const val BENCHMARK_PROPERTY = "coffeegb.rewind.benchmark"
+    private const val TICKS_PER_STEP = 2_048
+    private const val ARRAY_HEADER_BYTES = 16L
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
@@ -70,11 +70,18 @@ class RewindManagerTest {
     StateCodecTestSupport.session(configuration()).use { session ->
       val manager = RewindManager()
       session.gameboy.addressSpace.setByte(0x0000, 0x0a)
-      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
-        exercise(session.gameboy, step)
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { frame ->
+        emulateProductionFrame(session.gameboy, frame)
         manager.record(session.gameboy)
       }
       assertEquals(RewindManager.CAPACITY, manager.historySize)
+      assertTrue(
+          manager.snapshotsForTesting().all {
+            it.captureStats.sourcePayloadClones == 0 &&
+                it.captureStats.sourcePayloadCloneBytes == 0L
+          },
+          "production-cadence captures must borrow source payloads without cloning",
+      )
       val retained = MachineSnapshot.retainedStats(manager.snapshotsForTesting())
       assertTrue(
           retained.retainedPrimitiveBytes * 2 < MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES,
@@ -84,19 +91,19 @@ class RewindManagerTest {
     }
   }
 
-  private fun exercise(
+  private fun emulateProductionFrame(
       gameboy: Gameboy,
-      step: Int,
+      frame: Int,
   ) {
-    repeat(TICKS_PER_STEP) { gameboy.tick() }
-    val value = step and 0xff
-    gameboy.addressSpace.setByte(0xc000 + (step * 37 and 0xfff), value)
-    gameboy.addressSpace.setByte(0xd000 + (step * 53 and 0xfff), value xor 0x5a)
-    gameboy.gpu.videoRam0.setByte(0x8000 + (step * 29 and 0x1fff), value xor 0xa5)
-    gameboy.gpu.videoRam1.setByte(0x8000 + (step * 31 and 0x1fff), value xor 0x3c)
-    gameboy.addressSpace.setByte(0xfe00 + (step % 0xa0), value)
-    gameboy.addressSpace.setByte(0x4000, step ushr 5 and 0x03)
-    gameboy.addressSpace.setByte(0xa000 + (step * 43 and 0x1fff), value xor 0xc3)
+    repeat(Gameboy.TICKS_PER_FRAME) { gameboy.tick() }
+    val value = frame and 0xff
+    gameboy.addressSpace.setByte(0xc000 + (frame * 37 and 0xfff), value)
+    gameboy.addressSpace.setByte(0xd000 + (frame * 53 and 0xfff), value xor 0x5a)
+    gameboy.gpu.videoRam0.setByte(0x8000 + (frame * 29 and 0x1fff), value xor 0xa5)
+    gameboy.gpu.videoRam1.setByte(0x8000 + (frame * 31 and 0x1fff), value xor 0x3c)
+    gameboy.addressSpace.setByte(0xfe00 + (frame % 0xa0), value)
+    gameboy.addressSpace.setByte(0x4000, frame ushr 5 and 0x03)
+    gameboy.addressSpace.setByte(0xa000 + (frame * 43 and 0x1fff), value xor 0xc3)
   }
 
   private fun configuration() =
@@ -110,10 +117,9 @@ class RewindManagerTest {
           .setSupportBatterySave(false)
 
   companion object {
-    /** Exact primitive-array retained baseline measured on master 195d9172. */
-    private const val MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES = 420_760_640L
+    /** Exact production-cadence primitive-array baseline measured on master 195d9172. */
+    private const val MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES = 337_665_600L
     private const val EXTRA_CAPTURES = 2
     private const val TEST_ADDRESS = 0xc100
-    private const val TICKS_PER_STEP = 2_048
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
@@ -77,10 +77,10 @@ class RewindManagerTest {
       assertEquals(RewindManager.CAPACITY, manager.historySize)
       assertTrue(
           manager.snapshotsForTesting().all {
-            it.captureStats.sourcePayloadClones == 0 &&
-                it.captureStats.sourcePayloadCloneBytes == 0L
+            it.captureStats.identityVerifiedPayloadArrays > 0 &&
+                it.captureStats.identityVerifiedPayloadBytes > 0L
           },
-          "production-cadence captures must borrow source payloads without cloning",
+          "production-cadence captures must identity-verify their live source payloads",
       )
       val retained = MachineSnapshot.retainedStats(manager.snapshotsForTesting())
       assertTrue(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
@@ -1,0 +1,119 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.state.MachineSnapshot
+import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class RewindManagerTest {
+
+  @Test
+  fun capacityCadenceEvictionRewindAndClearRemainExact() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+      var capturedIndex = 0
+      var evictedSnapshot: MachineSnapshot? = null
+      repeat((RewindManager.CAPACITY + EXTRA_CAPTURES) * RewindManager.RECORD_INTERVAL) { step ->
+        if (step % RewindManager.RECORD_INTERVAL == 0) {
+          session.gameboy.addressSpace.setByte(TEST_ADDRESS, capturedIndex and 0xff)
+          capturedIndex++
+        }
+        manager.record(session.gameboy)
+        if (manager.captureCount == 1) {
+          evictedSnapshot = manager.snapshotsForTesting().single()
+        }
+      }
+
+      assertEquals(RewindManager.CAPACITY, manager.historySize)
+      assertEquals(RewindManager.CAPACITY + EXTRA_CAPTURES, manager.captureCount)
+      assertTrue(manager.snapshotsForTesting().none { it === evictedSnapshot })
+      for (index in capturedIndex - 1 downTo EXTRA_CAPTURES) {
+        assertTrue(manager.rewindOneStep(session.gameboy))
+        assertEquals(index and 0xff, session.gameboy.addressSpace.getByte(TEST_ADDRESS))
+      }
+      assertFalse(manager.rewindOneStep(session.gameboy))
+      assertEquals(0, manager.historySize)
+      val heldEvictedSnapshot = requireNotNull(evictedSnapshot)
+      heldEvictedSnapshot.restore(session.gameboy)
+      assertEquals(0, session.gameboy.addressSpace.getByte(TEST_ADDRESS))
+
+      repeat(RewindManager.RECORD_INTERVAL * 3) { manager.record(session.gameboy) }
+      assertTrue(manager.historySize > 0)
+      manager.clear()
+      assertEquals(0, manager.historySize)
+      heldEvictedSnapshot.restore(session.gameboy)
+      assertEquals(0, session.gameboy.addressSpace.getByte(TEST_ADDRESS))
+      manager.record(session.gameboy)
+      assertEquals(1, manager.historySize, "clear resets the six-frame cadence")
+    }
+  }
+
+  @Test
+  fun disabledManagerPerformsZeroCaptureOrCadenceWork() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager(enabled = false)
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL * 2) {
+        manager.record(session.gameboy)
+      }
+      assertEquals(0, manager.captureCount)
+      assertEquals(0, manager.historySize)
+      assertFalse(manager.rewindOneStep(session.gameboy))
+    }
+  }
+
+  @Test
+  fun deterministicThreeHundredEntryWorkloadBeatsMeasuredMasterBaselineByHalf() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+      session.gameboy.addressSpace.setByte(0x0000, 0x0a)
+      repeat(RewindManager.CAPACITY * RewindManager.RECORD_INTERVAL) { step ->
+        exercise(session.gameboy, step)
+        manager.record(session.gameboy)
+      }
+      assertEquals(RewindManager.CAPACITY, manager.historySize)
+      val retained = MachineSnapshot.retainedStats(manager.snapshotsForTesting())
+      assertTrue(
+          retained.retainedPrimitiveBytes * 2 < MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES,
+          "retained=${retained.retainedPrimitiveBytes}, " +
+              "baseline=$MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES",
+      )
+    }
+  }
+
+  private fun exercise(
+      gameboy: Gameboy,
+      step: Int,
+  ) {
+    repeat(TICKS_PER_STEP) { gameboy.tick() }
+    val value = step and 0xff
+    gameboy.addressSpace.setByte(0xc000 + (step * 37 and 0xfff), value)
+    gameboy.addressSpace.setByte(0xd000 + (step * 53 and 0xfff), value xor 0x5a)
+    gameboy.gpu.videoRam0.setByte(0x8000 + (step * 29 and 0x1fff), value xor 0xa5)
+    gameboy.gpu.videoRam1.setByte(0x8000 + (step * 31 and 0x1fff), value xor 0x3c)
+    gameboy.addressSpace.setByte(0xfe00 + (step % 0xa0), value)
+    gameboy.addressSpace.setByte(0x4000, step ushr 5 and 0x03)
+    gameboy.addressSpace.setByte(0xa000 + (step * 43 and 0x1fff), value xor 0xc3)
+  }
+
+  private fun configuration() =
+      StateCodecTestSupport.configuration(
+              StateCodecTestSupport.rom(cgb = true).also {
+                it[0x147] = 0x1b
+                it[0x149] = 0x03
+              },
+              GameboyType.CGB,
+          )
+          .setSupportBatterySave(false)
+
+  companion object {
+    /** Exact primitive-array retained baseline measured on master 195d9172. */
+    private const val MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES = 420_760_640L
+    private const val EXTRA_CAPTURES = 2
+    private const val TEST_ADDRESS = 0xc100
+    private const val TICKS_PER_STEP = 2_048
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -33,6 +33,11 @@ class MachineSnapshotTest {
       val unchanged = MachineSnapshot.capture(gameboy, first)
 
       assertEquals(0, unchanged.captureStats.copiedPages)
+      assertEquals(0, unchanged.captureStats.copiedPageBytes)
+      assertEquals(0, unchanged.captureStats.sourcePayloadClones)
+      assertEquals(0, unchanged.captureStats.sourcePayloadCloneBytes)
+      assertTrue(unchanged.captureStats.sourcePayloadArraysRead > 0)
+      assertTrue(unchanged.captureStats.sourcePayloadBytesRead > 0)
       assertTrue(unchanged.captureStats.reusedPages > 0)
       assertSamePages(
           first.debugArrays(RAM_MEMENTO, "space"),
@@ -52,9 +57,39 @@ class MachineSnapshotTest {
       assertEquals(1, changedPageCount)
       assertEquals(1, changed.captureStats.copiedPages)
       assertEquals(MachineSnapshot.PAGE_BYTES.toLong(), changed.captureStats.copiedPageBytes)
+      assertEquals(0, changed.captureStats.sourcePayloadClones)
+      assertEquals(0, changed.captureStats.sourcePayloadCloneBytes)
 
       // The only debug surface returns opaque immutable page tokens, never backing arrays.
       assertTrue(after.flatMap { it.pageTokens }.none { it.javaClass.isArray })
+    }
+  }
+
+  @Test
+  fun legacyGameboyMementoStillDeepOwnsPrimitivePayloads() {
+    StateCodecTestSupport.session(cgbMbc5Configuration()).use { session ->
+      val gameboy = session.gameboy
+      val bus = gameboy.addressSpace
+      bus.setByte(0x0000, 0x0a)
+      bus.setByte(0xc321, 0x11)
+      gameboy.gpu.videoRam0.setByte(0x8123, 0x22)
+      bus.setByte(0xfe23, 0x33)
+      bus.setByte(0xa123, 0x44)
+      repeat(8_765) { gameboy.tick() }
+      val expected = DetachedStateAdapter.capture(gameboy)
+      val legacy = gameboy.saveToMemento()
+
+      bus.setByte(0xc321, 0xaa)
+      gameboy.gpu.videoRam0.setByte(0x8123, 0xbb)
+      bus.setByte(0xfe23, 0xcc)
+      bus.setByte(0xa123, 0xdd)
+      repeat(2_048) { gameboy.tick() }
+
+      gameboy.restoreFromMemento(legacy)
+      assertEquals(expected, DetachedStateAdapter.capture(gameboy))
+      assertEquals(0x11, bus.getByte(0xc321))
+      assertEquals(0x22, gameboy.gpu.videoRam0.getByte(0x8123))
+      assertEquals(0x44, bus.getByte(0xa123))
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -22,9 +22,12 @@ class MachineSnapshotTest {
       val first = MachineSnapshot.capture(gameboy)
       assertPagedArray(first, GBC_RAM_MEMENTO, "ram", 7 * 0x1000)
       assertTrue(
-          first.debugArrays(RAM_MEMENTO, "space").map { it.size }.containsAll(
-              listOf(0x2000, 0x00a0),
-          ),
+          first.debugArrays(RAM_MEMENTO, "space").count { it.size == 0x2000 } >= 2,
+          "both VRAM banks must be represented by immutable pages",
+      )
+      assertEquals(
+          1,
+          first.debugArrays(RAM_MEMENTO, "space").count { it.size == 0x00a0 },
           "VRAM and OAM must be represented by immutable pages",
       )
       assertPagedArray(first, DISPLAY_MEMENTO, "buffer", 160 * 144)
@@ -34,10 +37,8 @@ class MachineSnapshotTest {
 
       assertEquals(0, unchanged.captureStats.copiedPages)
       assertEquals(0, unchanged.captureStats.copiedPageBytes)
-      assertEquals(0, unchanged.captureStats.sourcePayloadClones)
-      assertEquals(0, unchanged.captureStats.sourcePayloadCloneBytes)
-      assertTrue(unchanged.captureStats.sourcePayloadArraysRead > 0)
-      assertTrue(unchanged.captureStats.sourcePayloadBytesRead > 0)
+      assertTrue(unchanged.captureStats.identityVerifiedPayloadArrays > 0)
+      assertTrue(unchanged.captureStats.identityVerifiedPayloadBytes > 0)
       assertTrue(unchanged.captureStats.reusedPages > 0)
       assertSamePages(
           first.debugArrays(RAM_MEMENTO, "space"),
@@ -57,8 +58,14 @@ class MachineSnapshotTest {
       assertEquals(1, changedPageCount)
       assertEquals(1, changed.captureStats.copiedPages)
       assertEquals(MachineSnapshot.PAGE_BYTES.toLong(), changed.captureStats.copiedPageBytes)
-      assertEquals(0, changed.captureStats.sourcePayloadClones)
-      assertEquals(0, changed.captureStats.sourcePayloadCloneBytes)
+      assertEquals(
+          unchanged.captureStats.identityVerifiedPayloadArrays,
+          changed.captureStats.identityVerifiedPayloadArrays,
+      )
+      assertEquals(
+          unchanged.captureStats.identityVerifiedPayloadBytes,
+          changed.captureStats.identityVerifiedPayloadBytes,
+      )
 
       // The only debug surface returns opaque immutable page tokens, never backing arrays.
       assertTrue(after.flatMap { it.pageTokens }.none { it.javaClass.isArray })
@@ -175,6 +182,7 @@ class MachineSnapshotTest {
           bus.setByte(0xff12, 0xf3)
           bus.setByte(0xff13, 0x40)
           bus.setByte(0xff14, 0x87)
+          repeat(512) { session.gameboy.tick() }
           bus.setByte(0xff01, 0xa5)
           bus.setByte(0xff02, 0x81)
           bus.setByte(0xff51, 0xc0)
@@ -191,6 +199,10 @@ class MachineSnapshotTest {
 
           val snapshot = MachineSnapshot.capture(session.gameboy)
           val captured = DetachedStateAdapter.capture(session.gameboy)
+          assertTrue(
+              snapshot.debugArrays(SOUND_MEMENTO, "buffer").single().size > 0,
+              "active audio must identity-verify the pending output prefix",
+          )
           assertTrue(captured.record(DMA_MEMENTO).bool("transferInProgress"))
           assertTrue(captured.record(HDMA_MEMENTO).bool("transferInProgress"))
           assertTrue(captured.record(SOUND_MODE_MEMENTO).bool("channelEnabled"))
@@ -222,6 +234,8 @@ class MachineSnapshotTest {
           bus.setByte(0x4aaa, 0x55)
           bus.setByte(0x5555, 0xa0)
           val armed = MachineSnapshot.capture(session.gameboy)
+          assertPagedArray(armed, MBC6_MEMENTO, "ram", 0x8000)
+          assertPagedArray(armed, MBC6_MEMENTO, "flash", 0x100000)
           assertTrue(DetachedStateAdapter.capture(session.gameboy).record(MBC6_MEMENTO)
               .bool("flashProgramMode"))
 
@@ -333,6 +347,7 @@ class MachineSnapshotTest {
           )
           assertPagedArray(snapshot, SGB_DISPLAY_MEMENTO, "sgbBuffer", 256 * 224)
           assertPagedArray(snapshot, SGB_DISPLAY_MEMENTO, "sgbMask", 256 * 224)
+          assertPagedArray(snapshot, SGB_DISPLAY_MEMENTO, "paletteMap", 20 * 18)
 
           val secondPacket = IntArray(16)
           sendSgbPacket(session.gameboy.addressSpace, secondPacket)
@@ -536,6 +551,8 @@ class MachineSnapshotTest {
         "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento"
     private const val SOUND_MODE_MEMENTO =
         "eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento"
+    private const val SOUND_MEMENTO =
+        "eu.rekawek.coffeegb.core.sound.Sound\$SoundMemento"
     private const val SERIAL_PORT_MEMENTO =
         "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
     private const val FULL_CHANGER_MEMENTO =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -1,0 +1,521 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.ir.FullChanger
+import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class MachineSnapshotTest {
+
+  @Test
+  fun unchangedPagesReuseIdentityAndOneWramWriteCopiesOnlyItsPage() {
+    StateCodecTestSupport.session(cgbMbc5Configuration()).use { session ->
+      val gameboy = session.gameboy
+      val first = MachineSnapshot.capture(gameboy)
+      assertPagedArray(first, GBC_RAM_MEMENTO, "ram", 7 * 0x1000)
+      assertTrue(
+          first.debugArrays(RAM_MEMENTO, "space").map { it.size }.containsAll(
+              listOf(0x2000, 0x00a0),
+          ),
+          "VRAM and OAM must be represented by immutable pages",
+      )
+      assertPagedArray(first, DISPLAY_MEMENTO, "buffer", 160 * 144)
+      assertPagedArray(first, DISPLAY_MEMENTO, "lastFrame", 160 * 144)
+      assertPagedArray(first, MBC5_MEMENTO, "ram", 0x8000)
+      val unchanged = MachineSnapshot.capture(gameboy, first)
+
+      assertEquals(0, unchanged.captureStats.copiedPages)
+      assertTrue(unchanged.captureStats.reusedPages > 0)
+      assertSamePages(
+          first.debugArrays(RAM_MEMENTO, "space"),
+          unchanged.debugArrays(RAM_MEMENTO, "space"),
+      )
+
+      gameboy.addressSpace.setByte(0xc321, 0x5a)
+      val changed = MachineSnapshot.capture(gameboy, unchanged)
+      val before = unchanged.debugArrays(RAM_MEMENTO, "space")
+      val after = changed.debugArrays(RAM_MEMENTO, "space")
+      val changedPageCount =
+          before.indices.sumOf { index ->
+            before[index].pageTokens.indices.count { page ->
+              before[index].pageTokens[page] !== after[index].pageTokens[page]
+            }
+          }
+      assertEquals(1, changedPageCount)
+      assertEquals(1, changed.captureStats.copiedPages)
+      assertEquals(MachineSnapshot.PAGE_BYTES.toLong(), changed.captureStats.copiedPageBytes)
+
+      // The only debug surface returns opaque immutable page tokens, never backing arrays.
+      assertTrue(after.flatMap { it.pageTokens }.none { it.javaClass.isArray })
+    }
+  }
+
+  @Test
+  fun liveMutationRestoreBranchAndSnapshotEvictionCannotAliasPages() {
+    StateCodecTestSupport.session(cgbMbc5Configuration()).use { session ->
+      val gameboy = session.gameboy
+      val bus = gameboy.addressSpace
+      bus.setByte(0xc100, 0x11)
+      val old = MachineSnapshot.capture(gameboy)
+      bus.setByte(0xc100, 0x22)
+      val newer = MachineSnapshot.capture(gameboy, old)
+      bus.setByte(0xc100, 0x33)
+
+      old.restore(gameboy)
+      assertEquals(0x11, bus.getByte(0xc100))
+      bus.setByte(0xc100, 0x44)
+      val branch = MachineSnapshot.capture(gameboy, old)
+
+      newer.restore(gameboy)
+      assertEquals(0x22, bus.getByte(0xc100))
+      old.restore(gameboy)
+      assertEquals(0x11, bus.getByte(0xc100))
+      branch.restore(gameboy)
+      assertEquals(0x44, bus.getByte(0xc100))
+
+      val oldPages = old.debugArrays(RAM_MEMENTO, "space")
+      val newerPages = newer.debugArrays(RAM_MEMENTO, "space")
+      val branchPages = branch.debugArrays(RAM_MEMENTO, "space")
+      assertNotEquals(oldPages, newerPages)
+      assertNotEquals(oldPages, branchPages)
+    }
+  }
+
+  @Test
+  fun displayIsRetainedOnceByPageIdentityAndRestoresVisibleContinuation() {
+    StateCodecTestSupport.session(
+            StateCodecTestSupport.configuration(hardware = GameboyType.DMG))
+        .use { session ->
+          val initial = MachineSnapshot.capture(session.gameboy)
+          val buffer = initial.debugArrays(DISPLAY_MEMENTO, "buffer").single()
+          val lastFrame = initial.debugArrays(DISPLAY_MEMENTO, "lastFrame").single()
+          assertEquals(buffer.size, lastFrame.size)
+          assertTrue(
+              buffer.pageTokens.indices.all {
+                buffer.pageTokens[it] === lastFrame.pageTokens[it]
+              },
+              "equal panel buffers must retain one immutable page payload",
+          )
+
+          repeat(31_337) { session.gameboy.tick() }
+          val captured = MachineSnapshot.capture(session.gameboy, initial)
+          val displayBefore = DetachedStateAdapter.capture(session.gameboy).record(DISPLAY_MEMENTO)
+          repeat(4_321) { session.gameboy.tick() }
+          val expected = DetachedStateAdapter.capture(session.gameboy)
+          repeat(997) { session.gameboy.tick() }
+
+          captured.restore(session.gameboy)
+          assertEquals(
+              displayBefore,
+              DetachedStateAdapter.capture(session.gameboy).record(DISPLAY_MEMENTO),
+          )
+          repeat(4_321) { session.gameboy.tick() }
+          assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+        }
+  }
+
+  @Test
+  fun doubleSpeedDmaHdmaAudioSerialInfraredAndHeldInputPolicyContinue() {
+    StateCodecTestSupport.session(
+            StateCodecTestSupport.configuration(cgbSpeedSwitchRom(), GameboyType.CGB))
+        .use { session ->
+          repeat(140_000) {
+            if (session.gameboy.speedMode.speedMode == 1 ||
+                session.gameboy.cpu.isSpeedSwitching) {
+              session.gameboy.tick()
+            }
+          }
+          assertEquals(2, session.gameboy.speedMode.speedMode)
+          val bus = session.gameboy.addressSpace
+          bus.setByte(0xff26, 0x80)
+          bus.setByte(0xff11, 0x80)
+          bus.setByte(0xff12, 0xf3)
+          bus.setByte(0xff13, 0x40)
+          bus.setByte(0xff14, 0x87)
+          bus.setByte(0xff01, 0xa5)
+          bus.setByte(0xff02, 0x81)
+          bus.setByte(0xff51, 0xc0)
+          bus.setByte(0xff52, 0x00)
+          bus.setByte(0xff53, 0x00)
+          bus.setByte(0xff54, 0x00)
+          bus.setByte(0xff55, 0x80)
+          bus.setByte(0xff46, 0xc0)
+          bus.setByte(0xff56, 0xc0)
+          session.eventBus.post(FullChanger.TransformEvent(5))
+          bus.getByte(0xff56)
+          repeat(30) { session.gameboy.tick() }
+          session.heldButtons = setOf(Button.A, Button.RIGHT)
+
+          val snapshot = MachineSnapshot.capture(session.gameboy)
+          val captured = DetachedStateAdapter.capture(session.gameboy)
+          assertTrue(captured.record(DMA_MEMENTO).bool("transferInProgress"))
+          assertTrue(captured.record(HDMA_MEMENTO).bool("transferInProgress"))
+          assertTrue(captured.record(SOUND_MODE_MEMENTO).bool("channelEnabled"))
+          assertEquals(0x81, captured.record(SERIAL_PORT_MEMENTO).int("sc"))
+          assertTrue(captured.record(FULL_CHANGER_MEMENTO).bool("running"))
+
+          // Physical input is intentionally outside rewind snapshots. Use the same held
+          // input for both continuations and prove restore keeps it.
+          session.heldButtons = setOf(Button.B)
+          repeat(192) { session.gameboy.tick() }
+          val expected = DetachedStateAdapter.capture(session.gameboy)
+          repeat(1_000) { session.gameboy.tick() }
+          snapshot.restore(session.gameboy)
+          assertEquals(setOf(Button.B), session.heldButtons, "rewind preserves physical input")
+          repeat(192) { session.gameboy.tick() }
+          assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+        }
+  }
+
+  @Test
+  fun mbc6FlashAndMbc3RamRtcPagesRestoreDeterministically() {
+    StateCodecTestSupport.session(
+            StateCodecTestSupport.configuration(mbc6Rom(), GameboyType.CGB)
+                .setBatteryData(ByteArray(0x108000) { 0xff.toByte() }))
+        .use { session ->
+          val bus = session.gameboy.addressSpace
+          enableMbc6Flash(bus)
+          bus.setByte(0x5555, 0xaa)
+          bus.setByte(0x4aaa, 0x55)
+          bus.setByte(0x5555, 0xa0)
+          val armed = MachineSnapshot.capture(session.gameboy)
+          assertTrue(DetachedStateAdapter.capture(session.gameboy).record(MBC6_MEMENTO)
+              .bool("flashProgramMode"))
+
+          bus.setByte(0x4321, 0x12)
+          val programmed = MachineSnapshot.capture(session.gameboy, armed)
+          val before = armed.debugArrays(MBC6_MEMENTO, "flash").single()
+          val after = programmed.debugArrays(MBC6_MEMENTO, "flash").single()
+          assertEquals(
+              1,
+              before.pageTokens.indices.count {
+                before.pageTokens[it] !== after.pageTokens[it]
+              },
+          )
+          val expected = DetachedStateAdapter.capture(session.gameboy)
+          bus.setByte(0x4321, 0)
+          armed.restore(session.gameboy)
+          bus.setByte(0x4321, 0x12)
+          assertEquals(0x12, bus.getByte(0x4321))
+          assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+        }
+
+    val time = VirtualTimeSource(120_000)
+    val configuration =
+        StateCodecTestSupport.configuration(mbc3Rom())
+            .setRtcTimeSource(time)
+            .setSupportBatterySave(false)
+    StateCodecTestSupport.session(configuration).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0x0000, 0x0a)
+      bus.setByte(0x4000, 0)
+      bus.setByte(0xa000, 0x4a)
+      session.gameboy.setCartridgeClockPaused(true)
+      val snapshot = MachineSnapshot.capture(session.gameboy)
+      val capturedTime = time.currentTimeMillis()
+
+      time.forward(250, TimeUnit.MILLISECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      repeat(128) { session.gameboy.tick() }
+      val expected = DetachedStateAdapter.capture(session.gameboy)
+      bus.setByte(0xa000, 0xe1)
+      time.forward(5, TimeUnit.SECONDS)
+      repeat(1_000) { session.gameboy.tick() }
+
+      snapshot.restore(session.gameboy)
+      time.setCurrentTimeMillis(capturedTime)
+      time.forward(250, TimeUnit.MILLISECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      repeat(128) { session.gameboy.tick() }
+      assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+    }
+  }
+
+  @Test
+  fun mbc7EepromMidWriteCopiesOnePageAndContinuesDeterministically() {
+    val configuration =
+        StateCodecTestSupport.configuration(mbc7Rom(), GameboyType.CGB)
+            .setBatteryData(ByteArray(256) { 0xff.toByte() })
+    StateCodecTestSupport.session(configuration).use { session ->
+      val bus = session.gameboy.addressSpace
+      bus.setByte(0x0000, 0x0a)
+      bus.setByte(0x4000, 0x40)
+      mbc7Command(bus, 0b00, 0b11000000) // EWEN
+      bus.setByte(0xa080, 0)
+      mbc7Command(bus, 0b01, 0x12) // WRITE
+      mbc7SendBits(bus, 0xbe, 8)
+
+      val midWrite = MachineSnapshot.capture(session.gameboy)
+      val eepromBefore = midWrite.debugArrays(MBC7_EEPROM_MEMENTO, "eeprom").single()
+      assertEquals(256, eepromBefore.size)
+
+      mbc7SendBits(bus, 0xef, 8)
+      val completed = MachineSnapshot.capture(session.gameboy, midWrite)
+      val eepromAfter = completed.debugArrays(MBC7_EEPROM_MEMENTO, "eeprom").single()
+      assertEquals(
+          1,
+          eepromBefore.pageTokens.indices.count {
+            eepromBefore.pageTokens[it] !== eepromAfter.pageTokens[it]
+          },
+      )
+      val expected = DetachedStateAdapter.capture(session.gameboy)
+
+      bus.setByte(0xa080, 0)
+      mbc7Command(bus, 0b01, 0x12)
+      mbc7SendBits(bus, 0, 16)
+      midWrite.restore(session.gameboy)
+      mbc7SendBits(bus, 0xef, 8)
+      assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+    }
+  }
+
+  @Test
+  fun activeSgbMultipacketAndBorderBuffersRestoreDeterministically() {
+    StateCodecTestSupport.session(
+            StateCodecTestSupport.configuration(hardware = GameboyType.SGB))
+        .use { session ->
+          val firstPacket =
+              IntArray(16).also {
+                it[0] = 2 // first half of a two-packet PAL01 command
+                it[1] = 0x34
+                it[2] = 0x12
+              }
+          sendSgbPacket(session.gameboy.addressSpace, firstPacket)
+          val snapshot = MachineSnapshot.capture(session.gameboy)
+          assertEquals(
+              1,
+              DetachedStateAdapter.capture(session.gameboy)
+                  .record(SUPER_GAMEBOY_MEMENTO)
+                  .int("multipacketIndex"),
+          )
+          assertPagedArray(snapshot, SGB_DISPLAY_MEMENTO, "sgbBuffer", 256 * 224)
+          assertPagedArray(snapshot, SGB_DISPLAY_MEMENTO, "sgbMask", 256 * 224)
+
+          val secondPacket = IntArray(16)
+          sendSgbPacket(session.gameboy.addressSpace, secondPacket)
+          repeat(512) { session.gameboy.tick() }
+          val expected = DetachedStateAdapter.capture(session.gameboy)
+
+          sendSgbPacket(session.gameboy.addressSpace, IntArray(16) { 0xff })
+          repeat(1_000) { session.gameboy.tick() }
+          snapshot.restore(session.gameboy)
+          sendSgbPacket(session.gameboy.addressSpace, secondPacket)
+          repeat(512) { session.gameboy.tick() }
+          assertEquals(expected, DetachedStateAdapter.capture(session.gameboy))
+        }
+  }
+
+  @Test
+  fun unexpectedLiveFailureRollsBackMachineRtcAndRuntime() {
+    val time = VirtualTimeSource(120_000)
+    val configuration =
+        StateCodecTestSupport.configuration(mbc3Rom())
+            .setRtcTimeSource(time)
+            .setSupportBatterySave(false)
+    StateCodecTestSupport.session(configuration).use { session ->
+      session.gameboy.addressSpace.setByte(0xc234, 0x11)
+      session.gameboy.setCartridgeClockPaused(true)
+      val target = MachineSnapshot.capture(session.gameboy)
+
+      time.forward(2, TimeUnit.SECONDS)
+      session.gameboy.setCartridgeClockPaused(false)
+      session.gameboy.addressSpace.setByte(0xc234, 0x77)
+      repeat(2_000) { session.gameboy.tick() }
+      session.heldButtons = setOf(Button.START)
+      val before = DetachedStateAdapter.capture(session.gameboy)
+
+      assertFailsWith<StateApplyException> {
+        target.restore(session.gameboy) { stage ->
+          if (stage == ApplyStage.AFTER_MACHINE_MUTATION) throw InjectedFailure()
+        }
+      }
+      assertEquals(before, DetachedStateAdapter.capture(session.gameboy))
+      assertEquals(setOf(Button.START), session.heldButtons)
+    }
+  }
+
+  private fun assertSamePages(
+      expected: List<MachineSnapshot.ArrayDebug>,
+      actual: List<MachineSnapshot.ArrayDebug>,
+  ) {
+    assertEquals(expected.map { it.size }, actual.map { it.size })
+    expected.indices.forEach { index ->
+      assertTrue(
+          expected[index].pageTokens.indices.all { page ->
+            expected[index].pageTokens[page] === actual[index].pageTokens[page]
+          })
+    }
+  }
+
+  private fun assertPagedArray(
+      snapshot: MachineSnapshot,
+      owner: String,
+      field: String,
+      size: Int,
+  ) {
+    val array = snapshot.debugArrays(owner, field).single()
+    assertEquals(size, array.size)
+    assertTrue(array.pageTokens.isNotEmpty())
+  }
+
+  private fun MachineState.record(className: String): RecordState {
+    fun find(value: StateValue): RecordState? =
+        when (value) {
+          is RecordState ->
+              if (MementoClassNames.record(value.typeId) == className) value
+              else value.fields.firstNotNullOfOrNull { find(it.value) }
+          is ObjectArrayState -> value.values.firstNotNullOfOrNull(::find)
+          is ListState -> value.values.firstNotNullOfOrNull(::find)
+          is Int32MapState -> value.entries.firstNotNullOfOrNull { find(it.value) }
+          else -> null
+        }
+    return requireNotNull(find(root)) { "No $className record" }
+  }
+
+  private fun RecordState.field(name: String): StateValue =
+      fields.single { it.name == name }.value
+
+  private fun RecordState.bool(name: String): Boolean = (field(name) as BooleanState).value
+
+  private fun RecordState.int(name: String): Int = (field(name) as Int32State).value
+
+  private fun cgbMbc5Configuration() =
+      StateCodecTestSupport.configuration(mbc5Rom(), GameboyType.CGB)
+          .setSupportBatterySave(false)
+
+  private fun mbc5Rom(): ByteArray =
+      StateCodecTestSupport.rom(cgb = true).also {
+        it[0x147] = 0x1b
+        it[0x149] = 0x03
+      }
+
+  private fun mbc3Rom(): ByteArray =
+      StateCodecTestSupport.rom().also {
+        it[0x147] = 0x10
+        it[0x149] = 0x03
+      }
+
+  private fun mbc6Rom(): ByteArray =
+      ByteArray(0x10000).also {
+        it[0x100] = 0x18
+        it[0x101] = 0xfe.toByte()
+        it[0x143] = 0x80.toByte()
+        it[0x147] = 0x20
+        it[0x148] = 0x01
+        it[0x149] = 0x03
+      }
+
+  private fun mbc7Rom(): ByteArray =
+      StateCodecTestSupport.rom(cgb = true).also {
+        it[0x147] = 0x22
+        it[0x149] = 0x00
+      }
+
+  private fun cgbSpeedSwitchRom(): ByteArray =
+      ByteArray(0x8000).also {
+        it[0x100] = 0x3e
+        it[0x101] = 0x01
+        it[0x102] = 0xe0.toByte()
+        it[0x103] = 0x4d
+        it[0x104] = 0x10
+        it[0x105] = 0x00
+        it[0x106] = 0x18
+        it[0x107] = 0xfe.toByte()
+        it[0x143] = 0x80.toByte()
+      }
+
+  private fun enableMbc6Flash(bus: eu.rekawek.coffeegb.core.AddressSpace) {
+    bus.setByte(0x1000, 1)
+    bus.setByte(0x0c00, 1)
+    bus.setByte(0x2000, 0)
+    bus.setByte(0x2800, 0x08)
+  }
+
+  private fun mbc7SendBit(
+      bus: eu.rekawek.coffeegb.core.AddressSpace,
+      bit: Boolean,
+  ) {
+    val data = if (bit) 0x02 else 0
+    bus.setByte(0xa080, 0x80 or data)
+    bus.setByte(0xa080, 0xc0 or data)
+  }
+
+  private fun mbc7SendBits(
+      bus: eu.rekawek.coffeegb.core.AddressSpace,
+      value: Int,
+      count: Int,
+  ) {
+    for (bit in count - 1 downTo 0) mbc7SendBit(bus, ((value shr bit) and 1) != 0)
+  }
+
+  private fun mbc7Command(
+      bus: eu.rekawek.coffeegb.core.AddressSpace,
+      op: Int,
+      address: Int,
+  ) {
+    mbc7SendBit(bus, true)
+    mbc7SendBits(bus, op, 2)
+    mbc7SendBits(bus, address, 8)
+  }
+
+  private fun sendSgbPacket(
+      bus: eu.rekawek.coffeegb.core.AddressSpace,
+      packet: IntArray,
+  ) {
+    require(packet.size == 16)
+    bus.setByte(0xff00, 0x30)
+    bus.setByte(0xff00, 0x00)
+    bus.setByte(0xff00, 0x30)
+    repeat(128) { bitIndex ->
+      val bit = (packet[bitIndex / 8] shr (bitIndex and 7)) and 1
+      bus.setByte(0xff00, if (bit == 0) 0x20 else 0x10)
+      bus.setByte(0xff00, 0x30)
+    }
+    bus.setByte(0xff00, 0x20)
+    bus.setByte(0xff00, 0x30)
+  }
+
+  private object MementoClassNames {
+    fun record(typeId: Int): String =
+        eu.rekawek.coffeegb.controller.MementoTypeRegistry.recordClasses[typeId - 1].name
+  }
+
+  private class InjectedFailure : RuntimeException()
+
+  companion object {
+    private const val RAM_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.Ram\$RamMemento"
+    private const val DISPLAY_MEMENTO =
+        "eu.rekawek.coffeegb.core.gpu.Display\$DisplayMemento"
+    private const val DMA_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.Dma\$DmaMemento"
+    private const val HDMA_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.Hdma\$HdmaMemento"
+    private const val SOUND_MODE_MEMENTO =
+        "eu.rekawek.coffeegb.core.sound.AbstractSoundMode\$AbstractSoundModeMemento"
+    private const val SERIAL_PORT_MEMENTO =
+        "eu.rekawek.coffeegb.core.serial.SerialPort\$SerialPortMemento"
+    private const val FULL_CHANGER_MEMENTO =
+        "eu.rekawek.coffeegb.core.ir.FullChanger\$FullChangerMemento"
+    private const val MBC6_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.cart.type.Mbc6\$Mbc6Memento"
+    private const val MBC7_EEPROM_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromMemento"
+    private const val MBC5_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5Memento"
+    private const val GBC_RAM_MEMENTO =
+        "eu.rekawek.coffeegb.core.memory.GbcRam\$GbcRamMemento"
+    private const val SUPER_GAMEBOY_MEMENTO =
+        "eu.rekawek.coffeegb.core.sgb.SuperGameboy\$SuperGameboyMemento"
+    private const val SGB_DISPLAY_MEMENTO =
+        "eu.rekawek.coffeegb.core.sgb.SgbDisplay\$SgbDisplayMemento"
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.ir.FullChanger
 import eu.rekawek.coffeegb.core.ir.InfraredPort
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture
 import eu.rekawek.coffeegb.core.memento.Memento
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController
 import eu.rekawek.coffeegb.core.memory.cart.Rom
@@ -115,6 +116,17 @@ class StateCoverageMatrixTest {
       val idle = StateGraph.capture(controller.saveToMemento())
       case.setup(controller)
       val captured = StateGraph.capture(controller.saveToMemento())
+      val direct = directState(controller)
+      assertEquals(
+          captured,
+          direct.state,
+          "${case.name} direct capture must use identity-verified live payloads",
+      )
+      assertEquals(
+          primitivePayloadCount(captured),
+          direct.identityVerifiedPayloadArrays,
+          "${case.name} must explicitly declare every mapper-owned primitive payload",
+      )
       assertNotEquals(idle, captured, "${case.name} setup did not exercise owned state")
 
       val expectedTrace = continueMapper(controller, case.probes)
@@ -138,6 +150,30 @@ class StateCoverageMatrixTest {
         }
     assertEquals(24, registeredMapperRecords.size)
   }
+
+  private fun directState(controller: MemoryController): DirectState =
+      MachineStateCapture.withVerifiedView(
+          controller::declareMachineStatePayloads,
+          { capture -> controller.saveToMemento(capture) },
+          { view, capture ->
+            DirectState(StateGraph.capture(view), capture.verifiedPayloadArrays)
+          },
+      )
+
+  private fun primitivePayloadCount(value: StateValue): Int =
+      when (value) {
+        is PrimitiveArrayState<*> -> 1
+        is RecordState -> value.fields.sumOf { primitivePayloadCount(it.value) }
+        is ObjectArrayState -> value.values.sumOf(::primitivePayloadCount)
+        is ListState -> value.values.sumOf(::primitivePayloadCount)
+        is Int32MapState -> value.entries.sumOf { primitivePayloadCount(it.value) }
+        else -> 0
+      }
+
+  private data class DirectState(
+      val state: StateValue,
+      val identityVerifiedPayloadArrays: Int,
+  )
 
   @Test
   fun everyStatefulSerialPeripheralRoundTripsWithoutCapturingCallbacks() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -57,7 +57,7 @@ class StateInventoryTest {
             }
             .sorted()
 
-    assertEquals(96, discovered.size)
+    assertEquals(97, discovered.size)
     assertEquals(discovered, documented)
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -917,6 +917,32 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
                 clearCgbBootOamShadowPending);
     }
 
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        biosShadow.declareMachineStatePayloads(capture);
+        cartridge.declareMachineStatePayloads(capture);
+        gpu.declareMachineStatePayloads(capture);
+        statRegister.declareMachineStatePayloads(capture);
+        mmu.declareMachineStatePayloads(capture);
+        oamRam.declareMachineStatePayloads(capture);
+        cpu.declareMachineStatePayloads(capture);
+        interruptManager.declareMachineStatePayloads(capture);
+        timer.declareMachineStatePayloads(capture);
+        dma.declareMachineStatePayloads(capture);
+        hdma.declareMachineStatePayloads(capture);
+        sound.declareMachineStatePayloads(capture);
+        serialPort.declareMachineStatePayloads(capture);
+        infraredPort.declareMachineStatePayloads(capture);
+        codeBreakerRumble.declareMachineStatePayloads(capture);
+        joypad.declareMachineStatePayloads(capture);
+        speedMode.declareMachineStatePayloads(capture);
+        superGameboy.declareMachineStatePayloads(capture);
+        background.declareMachineStatePayloads(capture);
+        vRamTransfer.declareMachineStatePayloads(capture);
+        sgbDisplay.declareMachineStatePayloads(capture);
+        gameGenie.declareMachineStatePayloads(capture);
+    }
+
     /**
      * Exposes a transient, service-free machine view only for the duration of {@code consumer}.
      *
@@ -928,9 +954,8 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         if (consumer == null) {
             throw new IllegalArgumentException("Machine-state consumer is required");
         }
-        try (MachineStateCapture capture = new MachineStateCapture()) {
-            return consumer.apply(saveToMemento(capture), capture);
-        }
+        return MachineStateCapture.withVerifiedView(
+                this::declareMachineStatePayloads, this::saveToMemento, consumer);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -11,6 +11,7 @@ import eu.rekawek.coffeegb.core.gpu.*;
 import eu.rekawek.coffeegb.core.ir.InfraredEndpoint;
 import eu.rekawek.coffeegb.core.ir.InfraredPort;
 import eu.rekawek.coffeegb.core.joypad.Joypad;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.*;
@@ -35,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.CancellationException;
+import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 
 public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Closeable {
@@ -877,6 +879,58 @@ public class Gameboy implements Runnable, Serializable, Originator<Gameboy>, Clo
         // record shape so Phase-0 fixtures still decode, but do not clone the two 160x144 buffers
         // a second time for new captures.
         return new GameboyMemento(biosShadow.saveToMemento(), cartridge.saveToMemento(), gpu.saveToMemento(), statRegister.saveToMemento(), mmu.saveToMemento(), oamRam.saveToMemento(), cpu.saveToMemento(), interruptManager.saveToMemento(), timer.saveToMemento(), dma.saveToMemento(), hdma.saveToMemento(), null, sound.saveToMemento(), serialPort.saveToMemento(), infraredPort.saveToMemento(), codeBreakerRumble.saveToMemento(), joypad.saveToMemento(), speedMode.saveToMemento(), superGameboy.saveToMemento(), background.saveToMemento(), vRamTransfer.saveToMemento(), sgbDisplay.saveToMemento(), gameGenie.saveToMemento(), requestedScreenRefresh, lcdDisabled, lcdOffTicks, speedSwitchTailTicks, speedSwitchClockPhaseShifted, blankCgbBootTilePending, clearBootTilemapPending, clearCgbBootOamShadowPending);
+    }
+
+    @Override
+    public Memento<Gameboy> saveToMemento(MachineStateCapture capture) {
+        return new GameboyMemento(
+                biosShadow.saveToMemento(capture),
+                cartridge.saveToMemento(capture),
+                gpu.saveToMemento(capture),
+                statRegister.saveToMemento(capture),
+                mmu.saveToMemento(capture),
+                oamRam.saveToMemento(capture),
+                cpu.saveToMemento(capture),
+                interruptManager.saveToMemento(capture),
+                timer.saveToMemento(capture),
+                dma.saveToMemento(capture),
+                hdma.saveToMemento(capture),
+                null,
+                sound.saveToMemento(capture),
+                serialPort.saveToMemento(capture),
+                infraredPort.saveToMemento(capture),
+                codeBreakerRumble.saveToMemento(capture),
+                joypad.saveToMemento(capture),
+                speedMode.saveToMemento(capture),
+                superGameboy.saveToMemento(capture),
+                background.saveToMemento(capture),
+                vRamTransfer.saveToMemento(capture),
+                sgbDisplay.saveToMemento(capture),
+                gameGenie.saveToMemento(capture),
+                requestedScreenRefresh,
+                lcdDisabled,
+                lcdOffTicks,
+                speedSwitchTailTicks,
+                speedSwitchClockPhaseShifted,
+                blankCgbBootTilePending,
+                clearBootTilemapPending,
+                clearCgbBootOamShadowPending);
+    }
+
+    /**
+     * Exposes a transient, service-free machine view only for the duration of {@code consumer}.
+     *
+     * <p>The owning emulator thread must be stopped at its documented frame boundary. The view
+     * contains borrowed live primitive arrays and must not escape the callback.
+     */
+    public <R> R withMachineStateCapture(
+            BiFunction<Memento<Gameboy>, MachineStateCapture, R> consumer) {
+        if (consumer == null) {
+            throw new IllegalArgumentException("Machine-state consumer is required");
+        }
+        try (MachineStateCapture capture = new MachineStateCapture()) {
+            return consumer.apply(saveToMemento(capture), capture);
+        }
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.op.Op;
 import eu.rekawek.coffeegb.core.cpu.opcode.Opcode;
 import eu.rekawek.coffeegb.core.gpu.*;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.timer.Timer;
@@ -977,6 +978,18 @@ public class Cpu implements Serializable, Originator<Cpu> {
         operand[0] = this.operand[0];
         operand[1] = this.operand[1];
         return new CpuMemento(registers.saveToMemento(), opcode1, opcode2, operand, operandIndex, opIndex,
+                state, opContext, interruptFlag, interruptEnabled, requestedIrq, clockCycle, haltBugMode,
+                haltEntrySampleTicks, synchronousHaltEntryStatPhase, asynchronousHaltEntryStatPhase,
+                ordinaryHaltWakeStatPhase, haltedCpuCycles,
+                hdmaOpcodePrefetched, hdmaArbitrationOpcode, hdmaArbitrationOpcodeValid,
+                haltPrefetchedOpcode, haltOpcodePrefetchValid,
+                speedSwitchPaddingOpcode, speedSwitchPaddingReplayValid,
+                speedSwitchTicks, phasedPpuInputHigh, fastPhasedPpuDispatch);
+    }
+
+    @Override
+    public Memento<Cpu> saveToMemento(MachineStateCapture capture) {
+        return new CpuMemento(registers.saveToMemento(), opcode1, opcode2, capture.ints(operand), operandIndex, opIndex,
                 state, opContext, interruptFlag, interruptEnabled, requestedIrq, clockCycle, haltBugMode,
                 haltEntrySampleTicks, synchronousHaltEntryStatPhase, asynchronousHaltEntryStatPhase,
                 ordinaryHaltWakeStatPhase, haltedCpuCycles,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPalette.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPalette.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -124,6 +125,11 @@ public class ColorPalette implements AddressSpace, Serializable, Originator<Colo
             palettesCopy[i] = palettes[i].clone();
         }
         return new ColorPaletteMemento(palettesCopy, index, autoIncrement);
+    }
+
+    @Override
+    public Memento<ColorPalette> saveToMemento(MachineStateCapture capture) {
+        return new ColorPaletteMemento(capture.ints2(palettes), index, autoIncrement);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -284,6 +285,24 @@ public class ColorPixelFifo implements PixelFifo, Serializable, Originator<Color
                 clearedPixels.saveToMemento(),
                 clearedPalettes.saveToMemento(),
                 clearedPriorities.saveToMemento());
+    }
+
+    @Override
+    public Memento<ColorPixelFifo> saveToMemento(MachineStateCapture capture) {
+        return new ColorPixelFifoMemento(
+                pixels.saveToMemento(capture),
+                palettes.saveToMemento(capture),
+                priorities.saveToMemento(capture),
+                spriteFifo.saveToMemento(capture),
+                capture.ints(delayEntry),
+                capture.longs(delayStamp),
+                delayHead,
+                delaySize,
+                outputTicks,
+                linePixels,
+                clearedPixels.saveToMemento(capture),
+                clearedPalettes.saveToMemento(capture),
+                clearedPriorities.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -134,6 +135,12 @@ public class Display implements Serializable, Originator<Display> {
     @Override
     public Memento<Display> saveToMemento() {
         return new DisplayMemento(buffer.clone(), i, enabled, lastFrame.clone(), firstFrameAfterLcdEnable);
+    }
+
+    @Override
+    public Memento<Display> saveToMemento(MachineStateCapture capture) {
+        return new DisplayMemento(
+                capture.ints(buffer), i, enabled, capture.ints(lastFrame), firstFrameAfterLcdEnable);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -144,6 +144,12 @@ public class Display implements Serializable, Originator<Display> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(buffer);
+        capture.declareInts(lastFrame);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Display> memento) {
         if (!(memento instanceof DisplayMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.gpu;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -298,6 +299,18 @@ public class DmgPixelFifo implements PixelFifo, Serializable, Originator<DmgPixe
     public Memento<DmgPixelFifo> saveToMemento() {
         return new DmgPixelFifoMemento(pixels.saveToMemento(), spriteFifo.saveToMemento(),
                 delayEntry.clone(), delayStamp.clone(), delayHead, delaySize, outputTicks);
+    }
+
+    @Override
+    public Memento<DmgPixelFifo> saveToMemento(MachineStateCapture capture) {
+        return new DmgPixelFifoMemento(
+                pixels.saveToMemento(capture),
+                spriteFifo.saveToMemento(capture),
+                capture.ints(delayEntry),
+                capture.longs(delayStamp),
+                delayHead,
+                delaySize,
+                outputTicks);
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Fetcher.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -469,6 +470,24 @@ public class Fetcher implements Serializable, Originator<Fetcher> {
     public Memento<Fetcher> saveToMemento() {
         return new FetcherMemento(
                 pixelLine.clone(),
+                state,
+                windowTileX,
+                fetcherY,
+                tileMapAddress,
+                tileId,
+                tileAttributes == null ? -1 : tileAttributes.getValue(),
+                tileData1,
+                tileData2,
+                insertionGlitchDisabled,
+                data2Pending,
+                data2Delay,
+                data2TileSelectGlitch);
+    }
+
+    @Override
+    public Memento<Fetcher> saveToMemento(MachineStateCapture capture) {
+        return new FetcherMemento(
+                capture.ints(pixelLine),
                 state,
                 windowTileX,
                 fetcherY,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.phase.*;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.Dma;
@@ -1964,6 +1965,49 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
         Memento<Ram> videoRam1Memento = videoRam1 instanceof Ram ? videoRam1.saveToMemento() : null;
 
         return new GpuMemento(videoRam0Memento, videoRam1Memento, display.saveToMemento(), lcdc.saveToMemento(), bgPalette.saveToMemento(), oamPalette.saveToMemento(), oamSearchPhase.saveToMemento(), pixelTransferPhase.saveToMemento(), pixelMachine.saveToMemento(), r.saveToMemento(), lcdEnabled, displayEnabledDelay, line, ticksInLine, firstLine, lcdEnableClockPhase, firstFrameAfterLcdEnable, pixelTransferDone, hblankIntFrom, mode0IntFrom, statModeLatchRephasedBySpeedSwitch, speedSwitchCompletedThisLine, lyReadLatchRephasedBySpeedSwitch, scxWrittenThisLine, doubleSpeedMode2DispatchStatTailThisLine, doubleSpeedMode2DispatchCrossedLineEdge, earlyScxStatTailThisLine, wyWrittenThisLine, lateDoubleSpeedLineZeroWindowEnable, lastCpuVramWriteTick, mode, new ArrayList<>(pendingPpuWrites), cpuVisiblePpuRegisters.clone());
+    }
+
+    @Override
+    public Memento<Gpu> saveToMemento(MachineStateCapture capture) {
+        Memento<Ram> videoRam0Memento =
+                videoRam0 instanceof Ram ? videoRam0.saveToMemento(capture) : null;
+        Memento<Ram> videoRam1Memento =
+                videoRam1 instanceof Ram ? videoRam1.saveToMemento(capture) : null;
+
+        return new GpuMemento(
+                videoRam0Memento,
+                videoRam1Memento,
+                display.saveToMemento(capture),
+                lcdc.saveToMemento(capture),
+                bgPalette.saveToMemento(capture),
+                oamPalette.saveToMemento(capture),
+                oamSearchPhase.saveToMemento(capture),
+                pixelTransferPhase.saveToMemento(capture),
+                pixelMachine.saveToMemento(capture),
+                r.saveToMemento(capture),
+                lcdEnabled,
+                displayEnabledDelay,
+                line,
+                ticksInLine,
+                firstLine,
+                lcdEnableClockPhase,
+                firstFrameAfterLcdEnable,
+                pixelTransferDone,
+                hblankIntFrom,
+                mode0IntFrom,
+                statModeLatchRephasedBySpeedSwitch,
+                speedSwitchCompletedThisLine,
+                lyReadLatchRephasedBySpeedSwitch,
+                scxWrittenThisLine,
+                doubleSpeedMode2DispatchStatTailThisLine,
+                doubleSpeedMode2DispatchCrossedLineEdge,
+                earlyScxStatTailThisLine,
+                wyWrittenThisLine,
+                lateDoubleSpeedLineZeroWindowEnable,
+                lastCpuVramWriteTick,
+                mode,
+                new ArrayList<>(pendingPpuWrites),
+                capture.ints(cpuVisiblePpuRegisters));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -2011,6 +2011,17 @@ public class Gpu implements AddressSpace, Serializable, Originator<Gpu> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        if (videoRam0 instanceof Ram) {
+            videoRam0.declareMachineStatePayloads(capture);
+        }
+        if (videoRam1 instanceof Ram) {
+            videoRam1.declareMachineStatePayloads(capture);
+        }
+        display.declareMachineStatePayloads(capture);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Gpu> memento) {
         if (!(memento instanceof GpuMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuRegisterValues.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuRegisterValues.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -171,6 +172,17 @@ public class GpuRegisterValues implements AddressSpace, Serializable, Originator
     public Memento<GpuRegisterValues> saveToMemento() {
         return new GpuRegisterValuesMemento(values.clone(), mixValues.clone(), pendingMixValues.clone(),
                 wxJustChangedTicks, scxOldValue, pendingScxOldValue);
+    }
+
+    @Override
+    public Memento<GpuRegisterValues> saveToMemento(MachineStateCapture capture) {
+        return new GpuRegisterValuesMemento(
+                capture.ints(values),
+                capture.ints(mixValues),
+                capture.ints(pendingMixValues),
+                wxJustChangedTicks,
+                scxOldValue,
+                pendingScxOldValue);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/IntQueue.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/IntQueue.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.gpu;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -64,6 +65,11 @@ public class IntQueue implements Serializable, Originator<IntQueue> {
     @Override
     public Memento<IntQueue> saveToMemento() {
         return new IntQueueMemento(array.clone(), size, offset);
+    }
+
+    @Override
+    public Memento<IntQueue> saveToMemento(MachineStateCapture capture) {
+        return new IntQueueMemento(capture.ints(array), size, offset);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -213,6 +214,15 @@ public class Lcdc implements AddressSpace, Serializable, Originator<Lcdc> {
                 tileSelectGlitchTicks, pendingTileSelectGlitchTicks,
                 tileSelectGlitchHistory.clone(),
                 oamSizeHistory.clone());
+    }
+
+    @Override
+    public Memento<Lcdc> saveToMemento(MachineStateCapture capture) {
+        return new LcdcMemento(value, mixValue, pendingMixValue,
+                dmgBlobBackgroundEnable, pendingDmgBlobBackgroundEnable,
+                tileSelectGlitchTicks, pendingTileSelectGlitchTicks,
+                capture.booleans(tileSelectGlitchHistory),
+                capture.ints(oamSizeHistory));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/SpriteFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/SpriteFifo.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.gpu;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -126,6 +127,18 @@ public class SpriteFifo implements Serializable, Originator<SpriteFifo> {
     public Memento<SpriteFifo> saveToMemento() {
         return new SpriteFifoMemento(
                 pixel.clone(), palette.clone(), priority.clone(), bgPriority.clone(), head, size, underflow);
+    }
+
+    @Override
+    public Memento<SpriteFifo> saveToMemento(MachineStateCapture capture) {
+        return new SpriteFifoMemento(
+                capture.ints(pixel),
+                capture.ints(palette),
+                capture.ints(priority),
+                capture.booleans(bgPriority),
+                head,
+                size,
+                underflow);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/VRamTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/VRamTransfer.java
@@ -56,6 +56,11 @@ public class VRamTransfer implements Originator<VRamTransfer> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(buffer);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<VRamTransfer> memento) {
         if (!(memento instanceof VRamTransferMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/VRamTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/VRamTransfer.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -47,6 +48,11 @@ public class VRamTransfer implements Originator<VRamTransfer> {
     @Override
     public Memento<VRamTransfer> saveToMemento() {
         return new VRamTransferMemento(buffer.clone(), i);
+    }
+
+    @Override
+    public Memento<VRamTransfer> saveToMemento(MachineStateCapture capture) {
+        return new VRamTransferMemento(capture.ints(buffer), i);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.GpuRegister;
 import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
 import eu.rekawek.coffeegb.core.gpu.Lcdc;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.Dma;
@@ -297,11 +298,17 @@ public class OamSearch implements GpuPhase, Serializable, Originator<OamSearch> 
 
     @Override
     public Memento<OamSearch> saveToMemento() {
+        return saveToMemento(null);
+    }
+
+    @Override
+    public Memento<OamSearch> saveToMemento(MachineStateCapture capture) {
         Memento<?>[] spriteMementos =
                 Arrays.stream(sprites).map(SpritePosition::saveToMemento).toArray(Memento[]::new);
         return new OamSearchMemento(
-                spriteMementos, Arrays.copyOf(oamReaderY, oamReaderY.length),
-                Arrays.copyOf(oamReaderX, oamReaderX.length),
+                spriteMementos,
+                capture == null ? Arrays.copyOf(oamReaderY, oamReaderY.length) : capture.ints(oamReaderY),
+                capture == null ? Arrays.copyOf(oamReaderX, oamReaderX.length) : capture.ints(oamReaderX),
                 oamReaderInitialized, oamReaderBusY, oamReaderBusX,
                 oamReaderDmaSource, oamReaderSourceChangeTicks,
                 spritePosIndex, state, spriteY, spriteHeight,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.gpu.*;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -1098,15 +1099,24 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
 
     @Override
     public Memento<PixelTransfer> saveToMemento() {
+        return saveToMemento(null);
+    }
+
+    @Override
+    public Memento<PixelTransfer> saveToMemento(MachineStateCapture capture) {
         Memento<?> fifoMemento = null;
         if (fifo instanceof DmgPixelFifo) {
-            fifoMemento = ((DmgPixelFifo) fifo).saveToMemento();
+            fifoMemento = capture == null
+                    ? ((DmgPixelFifo) fifo).saveToMemento()
+                    : ((DmgPixelFifo) fifo).saveToMemento(capture);
         } else if (fifo instanceof ColorPixelFifo) {
-            fifoMemento = ((ColorPixelFifo) fifo).saveToMemento();
+            fifoMemento = capture == null
+                    ? ((ColorPixelFifo) fifo).saveToMemento()
+                    : ((ColorPixelFifo) fifo).saveToMemento(capture);
         }
 
         return new PixelTransferMemento(
-                fetcher.saveToMemento(),
+                capture == null ? fetcher.saveToMemento() : fetcher.saveToMemento(capture),
                 fifoMemento,
                 entryTicks,
                 lcdEnableFirstLine,
@@ -1114,7 +1124,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
                 window,
                 windowBeingFetched,
                 windowLineCounter,
-                spriteOrder.clone(),
+                capture == null ? spriteOrder.clone() : capture.ints(spriteOrder),
                 spriteCount,
                 spriteHead,
                 objStep,
@@ -1129,7 +1139,7 @@ public class PixelTransfer implements GpuPhase, Serializable, Originator<PixelTr
                 objRefreshTileId,
                 objRefreshLine,
                 objRefreshAttrs == null ? -1 : objRefreshAttrs.getValue(),
-                objRefreshZip.clone(),
+                capture == null ? objRefreshZip.clone() : capture.ints(objRefreshZip),
                 objWaiting,
                 objectTimingPenalty,
                 previousScx,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.ir;
 
 import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -112,6 +113,12 @@ public class FullChanger implements Serializable, Originator<FullChanger> {
     @Override
     public Memento<FullChanger> saveToMemento() {
         return new FullChangerMemento(schedule.clone(), armed, running, index, remaining);
+    }
+
+    @Override
+    public Memento<FullChanger> saveToMemento(MachineStateCapture capture) {
+        return new FullChangerMemento(
+                capture.ints(schedule), armed, running, index, remaining);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.ir;
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
@@ -109,6 +110,11 @@ public class InfraredPort implements AddressSpace, Serializable, Originator<Infr
     @Override
     public Memento<InfraredPort> saveToMemento() {
         return new InfraredPortMemento(rp, fullChanger.saveToMemento());
+    }
+
+    @Override
+    public Memento<InfraredPort> saveToMemento(MachineStateCapture capture) {
+        return new InfraredPortMemento(rp, fullChanger.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.BitUtils;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.sgb.Commands;
@@ -270,6 +271,14 @@ public class Joypad implements AddressSpace, Serializable, Originator<Joypad> {
         return new JoypadMemento(p1, tick, inputHistory, filteredInputLines,
                 inputChangedSinceLastTick, players, currentPlayer, transferInProgress,
                 transferReadyForData, pendingTransferBit, currentByte, currentPacket.clone(),
+                currentByteIndex, currentPacketIndex);
+    }
+
+    @Override
+    public Memento<Joypad> saveToMemento(MachineStateCapture capture) {
+        return new JoypadMemento(p1, tick, inputHistory, filteredInputLines,
+                inputChangedSinceLastTick, players, currentPlayer, transferInProgress,
+                transferReadyForData, pendingTransferBit, currentByte, capture.ints(currentPacket),
                 currentByteIndex, currentPacketIndex);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memento/MachineStateCapture.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memento/MachineStateCapture.java
@@ -1,28 +1,94 @@
 package eu.rekawek.coffeegb.core.memento;
 
 import java.util.IdentityHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Internal safe-point token for building a transient machine-state view without cloning primitive
  * payloads.
  *
- * <p>Array-owning originators register their live arrays with this token and place those same
- * references in a short-lived memento-shaped view. The consumer must copy or compare the arrays
- * synchronously while the emulator is stopped at its frame boundary. The token is closed before
- * the capture call returns, and neither it nor the transient view may be retained.
+ * <p>Dominant array owners first declare their live backing identities and logical lengths through
+ * {@link Originator#declareMachineStatePayloads(MachineStateCapture)}. Their token-aware mementos
+ * must then register those exact identities. A helper clone such as {@code
+ * capture.ints(ram.clone())} leaves the declared live backing unmatched and therefore fails
+ * deterministically. Every primitive array in the transient view, including smaller non-dominant
+ * payloads, must still be registered by the token-aware path.
  *
- * <p>This is deliberately separate from the normal {@link Originator#saveToMemento()} contract.
- * Legacy, portable-state, boot-state and other callers continue to receive deep-owned arrays.
+ * <p>The consumer must copy or compare the verified arrays synchronously while the emulator is
+ * stopped at its frame boundary. The token is closed before the capture call returns, and neither
+ * it nor the transient view may be retained. This is deliberately separate from the normal {@link
+ * Originator#saveToMemento()} contract. Legacy, portable-state, boot-state and other callers
+ * continue to receive deep-owned arrays.
  */
 public final class MachineStateCapture implements AutoCloseable {
 
-    private final IdentityHashMap<Object, Integer> lengths = new IdentityHashMap<>();
+    private final IdentityHashMap<Object, Integer> declaredPayloads = new IdentityHashMap<>();
 
-    private long borrowedPayloadBytes;
+    private final IdentityHashMap<Object, Integer> registeredLengths = new IdentityHashMap<>();
 
-    private int borrowedPayloadArrays;
+    private long verifiedPayloadBytes;
+
+    private int verifiedPayloadArrays;
 
     private boolean active = true;
+
+    private MachineStateCapture() {}
+
+    /**
+     * Builds and consumes one verified transient machine view.
+     *
+     * <p>Declaration reads only explicit owner fields and does not build a memento graph. The
+     * source then builds exactly one short-lived record view.
+     */
+    public static <V, R> R withVerifiedView(
+            Consumer<MachineStateCapture> declaration,
+            Function<MachineStateCapture, V> source,
+            BiFunction<V, MachineStateCapture, R> consumer) {
+        if (declaration == null || source == null || consumer == null) {
+            throw new IllegalArgumentException(
+                    "Machine-state declaration, source and consumer are required");
+        }
+        try (MachineStateCapture capture = new MachineStateCapture()) {
+            declaration.accept(capture);
+            V view = source.apply(capture);
+            capture.requireAllDeclaredPayloadsVerified();
+            return consumer.apply(view, capture);
+        }
+    }
+
+    public void declareBytes(byte[] source) {
+        declare(source, source.length, 1);
+    }
+
+    public void declareInts(int[] source) {
+        declareInts(source, source.length);
+    }
+
+    public void declareInts(int[] source, int length) {
+        if (length < 0 || length > source.length) {
+            throw new IllegalArgumentException("Invalid declared int-array prefix");
+        }
+        declare(source, length, Integer.BYTES);
+    }
+
+    public void declareLongs(long[] source) {
+        declare(source, source.length, Long.BYTES);
+    }
+
+    public void declareBooleans(boolean[] source) {
+        declare(source, source.length, 1);
+    }
+
+    public void declareInts2(int[][] source) {
+        ensureActive();
+        for (int[] row : source) {
+            if (row != null) {
+                declareInts(row);
+            }
+        }
+    }
 
     public byte[] bytes(byte[] source) {
         register(source, source.length, 1);
@@ -73,7 +139,7 @@ public final class MachineStateCapture implements AutoCloseable {
      */
     public int requireLength(Object source) {
         ensureActive();
-        Integer length = lengths.get(source);
+        Integer length = registeredLengths.get(source);
         if (length == null) {
             throw new IllegalStateException(
                     "Primitive payload was not registered by the machine-state capture seam");
@@ -81,48 +147,70 @@ public final class MachineStateCapture implements AutoCloseable {
         return length;
     }
 
-    public int getBorrowedPayloadArrays() {
+    /** Number of dominant primitive backing arrays verified against explicit owner declarations. */
+    public int getVerifiedPayloadArrays() {
         ensureActive();
-        return borrowedPayloadArrays;
+        return verifiedPayloadArrays;
     }
 
-    public long getBorrowedPayloadBytes() {
+    /** Logical bytes whose dominant live backing identity and length were explicitly verified. */
+    public long getVerifiedPayloadBytes() {
         ensureActive();
-        return borrowedPayloadBytes;
-    }
-
-    /** Primitive source payloads are borrowed, never cloned, by this seam. */
-    public int getSourcePayloadClones() {
-        ensureActive();
-        return 0;
-    }
-
-    /** Primitive source payloads are borrowed, never cloned, by this seam. */
-    public long getSourcePayloadCloneBytes() {
-        ensureActive();
-        return 0;
+        return verifiedPayloadBytes;
     }
 
     @Override
     public void close() {
         active = false;
-        lengths.clear();
+        declaredPayloads.clear();
+        registeredLengths.clear();
+    }
+
+    private void declare(Object source, int length, int width) {
+        ensureActive();
+        if (source == null) {
+            throw new IllegalArgumentException("Declared primitive payload is required");
+        }
+        Integer existing = declaredPayloads.putIfAbsent(source, length);
+        if (existing != null && existing != length) {
+            throw new IllegalArgumentException(
+                    "A dominant primitive payload cannot be declared with two logical layouts");
+        }
     }
 
     private void register(Object source, int length, int width) {
         ensureActive();
-        Integer existing = lengths.putIfAbsent(source, length);
-        if (existing != null) {
-            if (existing != length) {
+        if (source == null) {
+            throw new IllegalArgumentException("Primitive payload is required");
+        }
+        Integer existingLength = registeredLengths.putIfAbsent(source, length);
+        if (existingLength != null) {
+            if (existingLength != length) {
                 throw new IllegalArgumentException(
-                        "A primitive payload cannot be borrowed with two logical lengths");
+                        "A primitive payload cannot be registered with two logical lengths");
             }
             return;
         }
-        borrowedPayloadArrays++;
-        borrowedPayloadBytes = Math.addExact(
-                borrowedPayloadBytes,
+        Integer declared = declaredPayloads.remove(source);
+        if (declared == null) {
+            return;
+        }
+        if (declared != length) {
+            throw new IllegalStateException(
+                    "Dominant primitive payload layout changed during machine-state capture");
+        }
+        verifiedPayloadArrays++;
+        verifiedPayloadBytes = Math.addExact(
+                verifiedPayloadBytes,
                 Math.multiplyExact((long) length, width));
+    }
+
+    private void requireAllDeclaredPayloadsVerified() {
+        ensureActive();
+        if (!declaredPayloads.isEmpty()) {
+            throw new IllegalStateException(
+                    "A dominant primitive payload was copied or omitted by machine-state capture");
+        }
     }
 
     private void ensureActive() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memento/MachineStateCapture.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memento/MachineStateCapture.java
@@ -1,0 +1,133 @@
+package eu.rekawek.coffeegb.core.memento;
+
+import java.util.IdentityHashMap;
+
+/**
+ * Internal safe-point token for building a transient machine-state view without cloning primitive
+ * payloads.
+ *
+ * <p>Array-owning originators register their live arrays with this token and place those same
+ * references in a short-lived memento-shaped view. The consumer must copy or compare the arrays
+ * synchronously while the emulator is stopped at its frame boundary. The token is closed before
+ * the capture call returns, and neither it nor the transient view may be retained.
+ *
+ * <p>This is deliberately separate from the normal {@link Originator#saveToMemento()} contract.
+ * Legacy, portable-state, boot-state and other callers continue to receive deep-owned arrays.
+ */
+public final class MachineStateCapture implements AutoCloseable {
+
+    private final IdentityHashMap<Object, Integer> lengths = new IdentityHashMap<>();
+
+    private long borrowedPayloadBytes;
+
+    private int borrowedPayloadArrays;
+
+    private boolean active = true;
+
+    public byte[] bytes(byte[] source) {
+        register(source, source.length, 1);
+        return source;
+    }
+
+    public int[] ints(int[] source) {
+        return ints(source, source.length);
+    }
+
+    /**
+     * Borrows a behavior-relevant prefix of a live array. The transient view still carries the
+     * source reference; the snapshot consumer observes only {@code length} elements.
+     */
+    public int[] ints(int[] source, int length) {
+        if (length < 0 || length > source.length) {
+            throw new IllegalArgumentException("Invalid borrowed int-array prefix");
+        }
+        register(source, length, Integer.BYTES);
+        return source;
+    }
+
+    public long[] longs(long[] source) {
+        register(source, source.length, Long.BYTES);
+        return source;
+    }
+
+    public boolean[] booleans(boolean[] source) {
+        register(source, source.length, 1);
+        return source;
+    }
+
+    public int[][] ints2(int[][] source) {
+        ensureActive();
+        for (int[] row : source) {
+            if (row != null) {
+                ints(row);
+            }
+        }
+        return source;
+    }
+
+    /**
+     * Returns the registered logical length for a primitive payload.
+     *
+     * <p>An unregistered array means an originator fell back to the legacy deep-copy path. The
+     * incremental consumer rejects that mistake instead of silently hiding its allocation.
+     */
+    public int requireLength(Object source) {
+        ensureActive();
+        Integer length = lengths.get(source);
+        if (length == null) {
+            throw new IllegalStateException(
+                    "Primitive payload was not registered by the machine-state capture seam");
+        }
+        return length;
+    }
+
+    public int getBorrowedPayloadArrays() {
+        ensureActive();
+        return borrowedPayloadArrays;
+    }
+
+    public long getBorrowedPayloadBytes() {
+        ensureActive();
+        return borrowedPayloadBytes;
+    }
+
+    /** Primitive source payloads are borrowed, never cloned, by this seam. */
+    public int getSourcePayloadClones() {
+        ensureActive();
+        return 0;
+    }
+
+    /** Primitive source payloads are borrowed, never cloned, by this seam. */
+    public long getSourcePayloadCloneBytes() {
+        ensureActive();
+        return 0;
+    }
+
+    @Override
+    public void close() {
+        active = false;
+        lengths.clear();
+    }
+
+    private void register(Object source, int length, int width) {
+        ensureActive();
+        Integer existing = lengths.putIfAbsent(source, length);
+        if (existing != null) {
+            if (existing != length) {
+                throw new IllegalArgumentException(
+                        "A primitive payload cannot be borrowed with two logical lengths");
+            }
+            return;
+        }
+        borrowedPayloadArrays++;
+        borrowedPayloadBytes = Math.addExact(
+                borrowedPayloadBytes,
+                Math.multiplyExact((long) length, width));
+    }
+
+    private void ensureActive() {
+        if (!active) {
+            throw new IllegalStateException("Machine-state capture token is no longer active");
+        }
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java
@@ -3,5 +3,16 @@ package eu.rekawek.coffeegb.core.memento;
 public interface Originator<T> {
     Memento<T> saveToMemento();
 
+    /**
+     * Builds the transient, safe-point-only view used by in-process machine snapshots.
+     *
+     * <p>The default is valid only for originators whose memento contains no primitive arrays.
+     * Array owners override it and register borrowed payloads through {@code capture}; the
+     * snapshot consumer rejects unregistered primitive arrays.
+     */
+    default Memento<T> saveToMemento(MachineStateCapture capture) {
+        return saveToMemento();
+    }
+
     void restoreFromMemento(Memento<T> memento);
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java
@@ -4,11 +4,20 @@ public interface Originator<T> {
     Memento<T> saveToMemento();
 
     /**
+     * Declares dominant live primitive payloads for the internal incremental machine capture.
+     *
+     * <p>Implementations recurse only through owned machine-state children and must not allocate or
+     * build a memento. Smaller payloads may rely on token registration alone, but dominant memory
+     * owners use this independent declaration so registering a helper-created copy is rejected.
+     */
+    default void declareMachineStatePayloads(MachineStateCapture capture) {}
+
+    /**
      * Builds the transient, safe-point-only view used by in-process machine snapshots.
      *
      * <p>The default is valid only for originators whose memento contains no primitive arrays.
-     * Array owners override it and register borrowed payloads through {@code capture}; the
-     * snapshot consumer rejects unregistered primitive arrays.
+     * Array owners override it and register borrowed payloads through {@code capture}; the snapshot
+     * consumer rejects unregistered primitive arrays.
      */
     default Memento<T> saveToMemento(MachineStateCapture capture) {
         return saveToMemento();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
@@ -81,6 +81,11 @@ public class GbcRam implements AddressSpace, Serializable, Originator<GbcRam> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<GbcRam> memento) {
         if (!(memento instanceof GbcRamMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -72,6 +73,11 @@ public class GbcRam implements AddressSpace, Serializable, Originator<GbcRam> {
     @Override
     public Memento<GbcRam> saveToMemento() {
         return new GbcRamMemento(ram.clone(), svbk);
+    }
+
+    @Override
+    public Memento<GbcRam> saveToMemento(MachineStateCapture capture) {
+        return new GbcRamMemento(capture.ints(ram), svbk);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.memory;
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.gpu.Mode;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -752,8 +753,14 @@ public class Hdma implements AddressSpace, Serializable, Originator<Hdma> {
 
     @Override
     public Memento<Hdma> saveToMemento() {
+        return saveToMemento(null);
+    }
+
+    @Override
+    public Memento<Hdma> saveToMemento(MachineStateCapture capture) {
         return new HdmaMemento(gpuMode, transferInProgress, hblankTransfer, lcdEnabled, length,
-                src, dst, tick, blockData.clone(), hblankRequestTicks, hblankRequestAge, nextHblankRequestTicks,
+                src, dst, tick, capture == null ? blockData.clone() : capture.ints(blockData),
+                hblankRequestTicks, hblankRequestAge, nextHblankRequestTicks,
                 nextHblankRequestAge,
                 sourceBytesTransferred, cpuBusValue,
                 stopAfterCurrentBlock, preserveLengthAfterCurrentBlock, speedSwitchInProgress,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.Gpu;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble;
@@ -220,6 +221,17 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
         return new MmuMemento(ramC000.saveToMemento(), ramD000.saveToMemento(), ramFF80.saveToMemento(),
                 gbcRam.saveToMemento(), undocumentedGbcRegisters.saveToMemento(),
                 oamEchoRam.saveToMemento());
+    }
+
+    @Override
+    public Memento<Mmu> saveToMemento(MachineStateCapture capture) {
+        return new MmuMemento(
+                ramC000.saveToMemento(capture),
+                ramD000.saveToMemento(capture),
+                ramFF80.saveToMemento(capture),
+                gbcRam.saveToMemento(capture),
+                undocumentedGbcRegisters.saveToMemento(capture),
+                oamEchoRam.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -235,6 +235,14 @@ public class Mmu implements AddressSpace, Serializable, Originator<Mmu> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        ramC000.declareMachineStatePayloads(capture);
+        ramD000.declareMachineStatePayloads(capture);
+        ramFF80.declareMachineStatePayloads(capture);
+        gbcRam.declareMachineStatePayloads(capture);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Mmu> memento) {
         if (!(memento instanceof MmuMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/OamEchoRam.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/OamEchoRam.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.Gpu;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -69,6 +70,11 @@ final class OamEchoRam implements AddressSpace, Serializable, Originator<OamEcho
     @Override
     public Memento<OamEchoRam> saveToMemento() {
         return new OamEchoRamMemento(ram.clone());
+    }
+
+    @Override
+    public Memento<OamEchoRam> saveToMemento(MachineStateCapture capture) {
+        return new OamEchoRamMemento(capture.ints(ram));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Ram.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Ram.java
@@ -55,6 +55,11 @@ public class Ram implements AddressSpace, Serializable, Originator<Ram> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(space);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Ram> memento) {
         if (!(memento instanceof RamMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Ram.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Ram.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -46,6 +47,11 @@ public class Ram implements AddressSpace, Serializable, Originator<Ram> {
     @Override
     public Memento<Ram> saveToMemento() {
         return new RamMemento(space.clone());
+    }
+
+    @Override
+    public Memento<Ram> saveToMemento(MachineStateCapture capture) {
+        return new RamMemento(capture.ints(space));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegisters.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/UndocumentedGbcRegisters.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -69,6 +70,11 @@ public class UndocumentedGbcRegisters implements AddressSpace, Serializable, Ori
     @Override
     public Memento<UndocumentedGbcRegisters> saveToMemento() {
         return new UndocumentedGbcRegistersMemento(ram.saveToMemento(), xff6c);
+    }
+
+    @Override
+    public Memento<UndocumentedGbcRegisters> saveToMemento(MachineStateCapture capture) {
+        return new UndocumentedGbcRegistersMemento(ram.saveToMemento(capture), xff6c);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory.cart;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -216,6 +217,13 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
     @Override
     public Memento<Cartridge> saveToMemento() {
         return new CartridgeMemento(addressSpace.saveToMemento(), battery.saveToMemento());
+    }
+
+    @Override
+    public Memento<Cartridge> saveToMemento(MachineStateCapture capture) {
+        return new CartridgeMemento(
+                addressSpace.saveToMemento(capture),
+                battery.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -227,6 +227,12 @@ public class Cartridge implements AddressSpace, Serializable, Originator<Cartrid
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        addressSpace.declareMachineStatePayloads(capture);
+        battery.declareMachineStatePayloads(capture);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Cartridge> memento) {
         if (!(memento instanceof CartridgeMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBattery.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBattery.java
@@ -184,6 +184,12 @@ public class FileBattery implements Battery {
     }
 
     @Override
+    public synchronized void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareBytes(clockBuffer);
+        capture.declareBytes(ramBuffer);
+    }
+
+    @Override
     public synchronized void restoreFromMemento(Memento<Battery> memento) {
         if (!(memento instanceof FileBatteryMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBattery.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBattery.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.battery;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter;
 import org.apache.commons.io.IOUtils;
@@ -171,6 +172,15 @@ public class FileBattery implements Battery {
     @Override
     public synchronized Memento<Battery> saveToMemento() {
         return new FileBatteryMemento(clockBuffer.clone(), ramBuffer.clone(), isClockPresent, isDirty);
+    }
+
+    @Override
+    public synchronized Memento<Battery> saveToMemento(MachineStateCapture capture) {
+        return new FileBatteryMemento(
+                capture.bytes(clockBuffer),
+                capture.bytes(ramBuffer),
+                isClockPresent,
+                isDirty);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.battery;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery.FileBatteryMemento;
@@ -80,6 +81,11 @@ public class MemoryBattery implements Battery, Originator<Battery> {
     @Override
     public Memento<Battery> saveToMemento() {
         return new MemoryBatteryMemento(buffer.clone());
+    }
+
+    @Override
+    public Memento<Battery> saveToMemento(MachineStateCapture capture) {
+        return new MemoryBatteryMemento(capture.bytes(buffer));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/MemoryBattery.java
@@ -89,6 +89,11 @@ public class MemoryBattery implements Battery, Originator<Battery> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareBytes(buffer);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Battery> memento) {
         if (memento instanceof MemoryBatteryMemento mem) {
             if (this.buffer.length != mem.buffer.length) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BasicRom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BasicRom.java
@@ -74,6 +74,12 @@ public class BasicRom implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         // BasicRom had no mutable state before plain ROM+RAM support was added.
         // Accept its legacy null snapshots as the initial RAM state.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BasicRom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BasicRom.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -64,6 +65,12 @@ public class BasicRom implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new BasicRomMemento(battery.saveToMemento(), ram.clone(), ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new BasicRomMemento(
+                battery.saveToMemento(capture), capture.ints(ram), ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -94,6 +95,12 @@ public class Bbd implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new BbdMemento(delegate.saveToMemento(), dataSwapMode, bankSwapMode);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new BbdMemento(
+                delegate.saveToMemento(capture), dataSwapMode, bankSwapMode);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Bbd.java
@@ -104,6 +104,11 @@ public class Bbd implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof BbdMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
@@ -110,6 +110,12 @@ public class BhgosMulticart implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof BhgosMulticartMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BhgosMulticart.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -94,6 +95,18 @@ public class BhgosMulticart implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new BhgosMulticartMemento(battery.saveToMemento(), ram.clone(), selectedRomBank,
                 selectedRamBank, baseRomBank, blockSelectWrites, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new BhgosMulticartMemento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedRomBank,
+                selectedRamBank,
+                baseRomBank,
+                blockSelectWrites,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
@@ -136,6 +136,12 @@ public class BungEms implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof BungEmsMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/BungEms.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -117,6 +118,21 @@ public class BungEms implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new BungEmsMemento(battery.saveToMemento(), ram.clone(), romBankLow, romBankHigh,
                 romBankMask, romBankLatch, selectedRamBank, configureMode, ramEnabled, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new BungEmsMemento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                romBankLow,
+                romBankHigh,
+                romBankMask,
+                romBankLatch,
+                selectedRamBank,
+                configureMode,
+                ramEnabled,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -312,6 +313,21 @@ public class Datel implements MemoryController {
         return new DatelMemento(ram.clone(), regs.clone(), ramWritten.clone(), regsB.clone(),
                 flash.clone(), flashCycle, flashErasePending, flashIdMode, launched,
                 slot == null ? null : slot.saveToMemento());
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new DatelMemento(
+                capture.ints(ram),
+                capture.ints(regs),
+                capture.booleans(ramWritten),
+                capture.ints(regsB),
+                capture.ints(flash),
+                flashCycle,
+                flashErasePending,
+                flashIdMode,
+                launched,
+                slot == null ? null : slot.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Datel.java
@@ -331,6 +331,18 @@ public class Datel implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+        capture.declareInts(regs);
+        capture.declareBooleans(ramWritten);
+        capture.declareInts(regsB);
+        capture.declareInts(flash);
+        if (slot != null) {
+            slot.declareMachineStatePayloads(capture);
+        }
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof DatelMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java
@@ -121,6 +121,12 @@ public class DuzMulticart implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+        capture.declareInts(regs);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof DuzMulticartMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -105,6 +106,18 @@ public class DuzMulticart implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new DuzMulticartMemento(ram.clone(), regs.clone(), selectedBank, selectedRamBank,
                 baseBank, regIndex, ramWriteEnabled);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new DuzMulticartMemento(
+                capture.ints(ram),
+                capture.ints(regs),
+                selectedBank,
+                selectedRamBank,
+                baseBank,
+                regIndex,
+                ramWriteEnabled);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java
@@ -121,6 +121,12 @@ public class Huc1 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Huc1Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -106,6 +107,17 @@ public class Huc1 implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new Huc1Memento(battery.saveToMemento(), ram.clone(), romBank, ramBank, irMode, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Huc1Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                romBank,
+                ramBank,
+                irMode,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -251,6 +252,26 @@ public class Huc3 implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new Huc3Memento(battery.saveToMemento(), ram.clone(), romBank, ramBank, mode, minutes, days,
                 alarmMinutes, alarmDays, alarmEnabled, accessIndex, accessFlags, readValue, lastRtcSecond,
+                ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Huc3Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                romBank,
+                ramBank,
+                mode,
+                minutes,
+                days,
+                alarmMinutes,
+                alarmDays,
+                alarmEnabled,
+                accessIndex,
+                accessFlags,
+                readValue,
+                lastRtcSecond,
                 ramUpdated);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java
@@ -276,6 +276,12 @@ public class Huc3 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Huc3Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
@@ -188,6 +188,12 @@ public class MakonNtOld2 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof MakonNtOld2Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -169,6 +170,21 @@ public class MakonNtOld2 implements MemoryController {
         return new MakonNtOld2Memento(battery.saveToMemento(), ram.clone(), selectedRomBank,
                 mappedRomBank, baseRomBank, gameRomBankMask, weirdMode, rumbleEnabled,
                 motorOn, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new MakonNtOld2Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedRomBank,
+                mappedRomBank,
+                baseRomBank,
+                gameRomBankMask,
+                weirdMode,
+                rumbleEnabled,
+                motorOn,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -258,6 +258,12 @@ public class Mbc1 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mbc1Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
@@ -238,6 +239,22 @@ public class Mbc1 implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new Mbc1Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, memoryModel, ramWriteEnabled, cachedRomBankFor0x0000, cachedRomBankFor0x4000, ramUpdated, wideBank, upperRegisterUsed);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc1Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedRamBank,
+                selectedRomBank,
+                memoryModel,
+                ramWriteEnabled,
+                cachedRomBankFor0x0000,
+                cachedRomBankFor0x4000,
+                ramUpdated,
+                wideBank,
+                upperRegisterUsed);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
@@ -131,6 +131,12 @@ public class Mbc2 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mbc2Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc2.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
@@ -117,6 +118,16 @@ public class Mbc2 implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new Mbc2Memento(battery.saveToMemento(), ram.clone(), selectedRomBank, ramWriteEnabled, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc2Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedRomBank,
+                ramWriteEnabled,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -209,6 +209,12 @@ public class Mbc3 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mbc3Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -194,6 +195,17 @@ public class Mbc3 implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new Mbc3Memento(ram.clone(), clock.saveToMemento(), battery.saveToMemento(), selectedRamBank,
                 selectedRomBank, ramEnabled);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc3Memento(
+                capture.ints(ram),
+                clock.saveToMemento(capture),
+                battery.saveToMemento(capture),
+                selectedRamBank,
+                selectedRomBank,
+                ramEnabled);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -156,6 +156,12 @@ public class Mbc5 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mbc5Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -140,6 +141,18 @@ public class Mbc5 implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new Mbc5Memento(battery.saveToMemento(), ram.clone(), selectedRamBank, selectedRomBank, ramWriteEnabled, ramUpdated, motorOn);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc5Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedRamBank,
+                selectedRomBank,
+                ramWriteEnabled,
+                ramUpdated,
+                motorOn);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc6.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc6.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -214,6 +215,26 @@ public class Mbc6 implements MemoryController {
         return new Mbc6Memento(
                 ram.clone(),
                 flash.clone(),
+                ramEnabled,
+                ramBankA,
+                ramBankB,
+                romBankA,
+                romBankB,
+                romBankAFlash,
+                romBankBFlash,
+                flashEnabled,
+                flashWriteEnable,
+                flashCommandState,
+                flashIdMode,
+                flashProgramMode
+        );
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc6Memento(
+                capture.ints(ram),
+                capture.ints(flash),
                 ramEnabled,
                 ramBankA,
                 ramBankB,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc6.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc6.java
@@ -251,6 +251,12 @@ public class Mbc6 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+        capture.declareInts(flash);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (memento instanceof Mbc6Memento mem) {
             System.arraycopy(mem.ram, 0, this.ram, 0, ram.length);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
@@ -168,6 +168,11 @@ public class Mbc7 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        eeprom.declareMachineStatePayloads(capture);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mbc7Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -148,6 +149,21 @@ public class Mbc7 implements MemoryController {
                 latchY,
                 latchState,
                 eeprom.saveToMemento()
+        );
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mbc7Memento(
+                selectedRomBank,
+                ramWriteEnabled1,
+                ramWriteEnabled2,
+                x,
+                y,
+                latchX,
+                latchY,
+                latchState,
+                eeprom.saveToMemento(capture)
         );
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7Eeprom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7Eeprom.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 
@@ -175,6 +176,20 @@ public class Mbc7Eeprom implements Serializable {
     public Memento<Mbc7Eeprom> saveToMemento() {
         return new EepromMemento(
                 eeprom.clone(),
+                state,
+                bitsRead,
+                command,
+                address,
+                writeValue,
+                writeEnabled,
+                sk,
+                doBit
+        );
+    }
+
+    public Memento<Mbc7Eeprom> saveToMemento(MachineStateCapture capture) {
+        return new EepromMemento(
+                capture.ints(eeprom),
                 state,
                 bitsRead,
                 command,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7Eeprom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7Eeprom.java
@@ -201,6 +201,10 @@ public class Mbc7Eeprom implements Serializable {
         );
     }
 
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(eeprom);
+    }
+
     public void restoreFromMemento(Memento<Mbc7Eeprom> memento) {
         if (memento instanceof EepromMemento mem) {
             System.arraycopy(mem.eeprom, 0, this.eeprom, 0, 256);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mmm01.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mmm01.java
@@ -228,6 +228,12 @@ public class Mmm01 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Mmm01Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mmm01.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mmm01.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -204,6 +205,26 @@ public class Mmm01 implements MemoryController {
         return new Mmm01Memento(battery.saveToMemento(), ram.clone(), ramEnabled, romBankLow, romBankMid,
                 romBankHigh, romBankMask, ramBankLow, ramBankHigh, ramBankMask, locked, mbc1Mode,
                 mbc1ModeDisable, multiplexMode, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Mmm01Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                ramEnabled,
+                romBankLow,
+                romBankMid,
+                romBankHigh,
+                romBankMask,
+                ramBankLow,
+                ramBankHigh,
+                ramBankMask,
+                locked,
+                mbc1Mode,
+                mbc1ModeDisable,
+                multiplexMode,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
@@ -229,6 +230,17 @@ public class PocketCamera implements MemoryController {
     public Memento<MemoryController> saveToMemento() {
         return new PocketCameraMemento(
                 ram.clone(), cameraRegisters.clone(), romBank, ramBank, ramEnabled, cameraMapped);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new PocketCameraMemento(
+                capture.ints(ram),
+                capture.ints(cameraRegisters),
+                romBank,
+                ramBank,
+                ramEnabled,
+                cameraMapped);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
@@ -244,6 +244,12 @@ public class PocketCamera implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+        capture.declareInts(cameraRegisters);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof PocketCameraMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -107,6 +108,16 @@ public class Sintax implements MemoryController {
     @Override
     public Memento<MemoryController> saveToMemento() {
         return new SintaxMemento(delegate.saveToMemento(), xorValues.clone(), mode, bankNo,
+                romBankXor);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new SintaxMemento(
+                delegate.saveToMemento(capture),
+                capture.ints(xorValues),
+                mode,
+                bankNo,
                 romBankXor);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java
@@ -122,6 +122,12 @@ public class Sintax implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+        capture.declareInts(xorValues);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof SintaxMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -178,6 +179,24 @@ public class SlMulticart implements MemoryController {
         return new SlMulticartMemento(ram.clone(), configCommand, baseRomBank,
                 selectedRomBank, romBankMask, zeroRemap, configurationMode, mbc5Mode,
                 ramAllowed, ramEnabled, baseRamBank, selectedRamBank, ramBankMask);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new SlMulticartMemento(
+                capture.ints(ram),
+                configCommand,
+                baseRomBank,
+                selectedRomBank,
+                romBankMask,
+                zeroRemap,
+                configurationMode,
+                mbc5Mode,
+                ramAllowed,
+                ramEnabled,
+                baseRamBank,
+                selectedRamBank,
+                ramBankMask);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java
@@ -200,6 +200,11 @@ public class SlMulticart implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(ram);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof SlMulticartMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -470,6 +471,22 @@ public class Tama5 implements MemoryController {
         return new Tama5Memento(battery.saveToMemento(), ram.clone(), selectedReg, registers.clone(),
                 rtcTimerPage.clone(), rtcAlarmPage.clone(), rtcFreePage0.clone(), rtcFreePage1.clone(),
                 rtcDisabled, lastRtcSecond, ramUpdated);
+    }
+
+    @Override
+    public Memento<MemoryController> saveToMemento(MachineStateCapture capture) {
+        return new Tama5Memento(
+                battery.saveToMemento(capture),
+                capture.ints(ram),
+                selectedReg,
+                capture.ints(registers),
+                capture.ints(rtcTimerPage),
+                capture.ints(rtcAlarmPage),
+                capture.ints(rtcFreePage0),
+                capture.ints(rtcFreePage1),
+                rtcDisabled,
+                lastRtcSecond,
+                ramUpdated);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java
@@ -490,6 +490,17 @@ public class Tama5 implements MemoryController {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+        capture.declareInts(registers);
+        capture.declareInts(rtcTimerPage);
+        capture.declareInts(rtcAlarmPage);
+        capture.declareInts(rtcFreePage0);
+        capture.declareInts(rtcFreePage1);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<MemoryController> memento) {
         if (!(memento instanceof Tama5Memento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
@@ -134,6 +134,14 @@ public class Background implements Originator<Background> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(tiles);
+        if (pendingPicture != null) {
+            pendingPicture.declareMachineStatePayloads(capture);
+        }
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Background> memento) {
         if (!(memento instanceof BackgroundMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Background.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.sgb;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 
@@ -122,6 +123,14 @@ public class Background implements Originator<Background> {
     public Memento<Background> saveToMemento() {
         return new BackgroundMemento(tiles.clone(),
                 pendingPicture == null ? null : pendingPicture.saveToMemento(), borderAnimation);
+    }
+
+    @Override
+    public Memento<Background> saveToMemento(MachineStateCapture capture) {
+        return new BackgroundMemento(
+                capture.ints(tiles),
+                pendingPicture == null ? null : pendingPicture.saveToMemento(capture),
+                borderAnimation);
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.sgb;
 
 import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 
 import java.util.Arrays;
@@ -92,6 +93,12 @@ public class Commands {
 
         public Memento<TransferCommand> saveToMemento() {
             return new TransferCommandMemento(packet.clone(), dataTransfer == null ? null : dataTransfer.clone());
+        }
+
+        public Memento<TransferCommand> saveToMemento(MachineStateCapture capture) {
+            return new TransferCommandMemento(
+                    capture.ints(packet),
+                    dataTransfer == null ? null : capture.ints(dataTransfer));
         }
 
         private record TransferCommandMemento(int[] packet, int[] dataTransfer) implements Memento<TransferCommand> {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/Commands.java
@@ -101,6 +101,13 @@ public class Commands {
                     dataTransfer == null ? null : capture.ints(dataTransfer));
         }
 
+        public void declareMachineStatePayloads(MachineStateCapture capture) {
+            capture.declareInts(packet);
+            if (dataTransfer != null) {
+                capture.declareInts(dataTransfer);
+            }
+        }
+
         private record TransferCommandMemento(int[] packet, int[] dataTransfer) implements Memento<TransferCommand> {
         }
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -264,6 +264,16 @@ public class SgbDisplay implements Originator<SgbDisplay> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(sgbBuffer);
+        capture.declareInts(sgbMask);
+        capture.declareInts2(palettes);
+        capture.declareInts2(systemPalettes);
+        capture.declareInts(paletteMap);
+        capture.declareInts2(attributeFiles);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<SgbDisplay> memento) {
         if (!(memento instanceof SgbDisplayMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.sgb;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.gpu.Display.DmgFrameReadyEvent;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
@@ -246,6 +247,19 @@ public class SgbDisplay implements Originator<SgbDisplay> {
     public Memento<SgbDisplay> saveToMemento() {
         return new SgbDisplayMemento(sgbBuffer.clone(), sgbMask.clone(), clone2(palettes),
                 clone2(systemPalettes), paletteMap.clone(), clone2(attributeFiles), screenMask,
+                borderFade);
+    }
+
+    @Override
+    public Memento<SgbDisplay> saveToMemento(MachineStateCapture capture) {
+        return new SgbDisplayMemento(
+                capture.ints(sgbBuffer),
+                capture.ints(sgbMask),
+                capture.ints2(palettes),
+                capture.ints2(systemPalettes),
+                capture.ints(paletteMap),
+                capture.ints2(attributeFiles),
+                screenMask,
                 borderFade);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.sgb;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.gpu.VRamTransfer;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.sgb.Commands.TransferCommand;
@@ -87,6 +88,18 @@ public class SuperGameboy implements Originator<SuperGameboy> {
         int[][] multipacketCopy = Arrays.stream(multipacket).map(int[]::clone).toArray(int[][]::new);
         return new SuperGameboyMemento(multipacketCopy, multipacketIndex, multipacketLength, transferCountdown,
                 waitingTransferCommand == null ? null : waitingTransferCommand.saveToMemento());
+    }
+
+    @Override
+    public Memento<SuperGameboy> saveToMemento(MachineStateCapture capture) {
+        return new SuperGameboyMemento(
+                capture.ints2(multipacket),
+                multipacketIndex,
+                multipacketLength,
+                transferCountdown,
+                waitingTransferCommand == null
+                        ? null
+                        : waitingTransferCommand.saveToMemento(capture));
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SuperGameboy.java
@@ -103,6 +103,14 @@ public class SuperGameboy implements Originator<SuperGameboy> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts2(multipacket);
+        if (waitingTransferCommand != null) {
+            waitingTransferCommand.declareMachineStatePayloads(capture);
+        }
+    }
+
+    @Override
     public void restoreFromMemento(Memento<SuperGameboy> memento) {
         if (!(memento instanceof SuperGameboyMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.Gameboy;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memento.Originator;
 import eu.rekawek.coffeegb.core.memory.Ram;
@@ -303,17 +304,29 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
 
     @Override
     public Memento<Sound> saveToMemento() {
+        return saveToMemento(null);
+    }
+
+    @Override
+    public Memento<Sound> saveToMemento(MachineStateCapture capture) {
         var allModeMementos = new Memento[allModes.length];
         for (int i = 0; i < allModes.length; i++) {
-            allModeMementos[i] = allModes[i].saveToMemento();
+            allModeMementos[i] = capture == null
+                    ? allModes[i].saveToMemento()
+                    : allModes[i].saveToMemento(capture);
         }
         // Only the prefix before i has been written. The rest is overwritten before the
         // next SoundSampleEvent can expose it, so retaining the full ~546 KiB frame buffer
         // in every rewind state wastes memory and creates a G1 humongous allocation.
-        int[] pendingSamples = Arrays.copyOf(buffer, i);
-        return new SoundMemento(allModeMementos, r.saveToMemento(),
-                frameSequencer.saveToMemento(), channels.clone(), enabled,
-                overriddenEnabled.clone(), pendingSamples, i, pendingFrameSequencerStep,
+        int[] pendingSamples = capture == null ? Arrays.copyOf(buffer, i) : capture.ints(buffer, i);
+        return new SoundMemento(
+                allModeMementos,
+                capture == null ? r.saveToMemento() : r.saveToMemento(capture),
+                frameSequencer.saveToMemento(),
+                capture == null ? channels.clone() : capture.ints(channels),
+                enabled,
+                capture == null ? overriddenEnabled.clone() : capture.booleans(overriddenEnabled),
+                pendingSamples, i, pendingFrameSequencerStep,
                 frameSequencerClockPhase, frameSequencerDivOffset);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -331,6 +331,12 @@ public class Sound implements AddressSpace, Serializable, Originator<Sound> {
     }
 
     @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        r.declareMachineStatePayloads(capture);
+        capture.declareInts(buffer, i);
+    }
+
+    @Override
     public void restoreFromMemento(Memento<Sound> memento) {
         if (!(memento instanceof SoundMemento mem)) {
             throw new IllegalArgumentException("Invalid memento type");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.sound;
 
+import eu.rekawek.coffeegb.core.memento.MachineStateCapture;
 import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import eu.rekawek.coffeegb.core.timer.Timer;
@@ -242,6 +243,21 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     public Memento<AbstractSoundMode> saveToMemento() {
         return new SoundMode3Memento(super.saveToMemento(), waveRam.saveToMemento(), freqDivider, lastOutput, i, ticksSinceRead, lastReadAddr, buffer, triggered, clock2Mhz);
+    }
+
+    @Override
+    public Memento<AbstractSoundMode> saveToMemento(MachineStateCapture capture) {
+        return new SoundMode3Memento(
+                super.saveToMemento(),
+                waveRam.saveToMemento(capture),
+                freqDivider,
+                lastOutput,
+                i,
+                ticksSinceRead,
+                lastReadAddr,
+                buffer,
+                triggered,
+                clock2Mhz);
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memento/MachineStateCaptureTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memento/MachineStateCaptureTest.java
@@ -1,0 +1,72 @@
+package eu.rekawek.coffeegb.core.memento;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+public class MachineStateCaptureTest {
+
+    @Test
+    public void verifiesTheSameLiveBackingArrayAcrossBothPasses() {
+        int[] backing = new int[4096];
+
+        Verified result = MachineStateCapture.withVerifiedView(
+                capture -> capture.declareInts(backing),
+                capture -> new ArrayView(capture.ints(backing)),
+                (view, capture) -> {
+                    assertSame(backing, view.values());
+                    assertEquals(backing.length, capture.requireLength(view.values()));
+                    return new Verified(
+                            capture.getVerifiedPayloadArrays(),
+                            capture.getVerifiedPayloadBytes());
+                });
+
+        assertEquals(1, result.arrays());
+        assertEquals((long) backing.length * Integer.BYTES, result.bytes());
+    }
+
+    @Test
+    public void rejectsACloneRegisteredByTheTokenAwarePath() {
+        int[] backing = new int[4096];
+        AtomicBoolean consumerCalled = new AtomicBoolean();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> MachineStateCapture.withVerifiedView(
+                        capture -> capture.declareInts(backing),
+                        capture -> new ArrayView(capture.ints(backing.clone())),
+                        (view, capture) -> {
+                            consumerCalled.set(true);
+                            return null;
+                        }));
+
+        assertFalse(consumerCalled.get());
+    }
+
+    @Test
+    public void rejectsAnUnregisteredPrimitiveArrayFallback() {
+        int[] backing = new int[4096];
+        AtomicBoolean consumerCalled = new AtomicBoolean();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> MachineStateCapture.withVerifiedView(
+                        capture -> {},
+                        capture -> new ArrayView(backing.clone()),
+                        (view, capture) -> {
+                            capture.requireLength(view.values());
+                            consumerCalled.set(true);
+                            return null;
+                        }));
+
+        assertFalse(consumerCalled.get());
+    }
+
+    private record ArrayView(int[] values) {}
+
+    private record Verified(int arrays, long bytes) {}
+}

--- a/docs/rewind-machine-snapshots.md
+++ b/docs/rewind-machine-snapshots.md
@@ -47,9 +47,22 @@ capture computes a deterministic content hash and then performs an exact primiti
 Equal content reuses an immutable predecessor page (or an equal page already seen in the same
 generation); only a changed retained page payload is copied. This content comparison is the dirty
 transition and cannot mistake a hash collision for equality. Unchanged scalar/container/record
-nodes are also reused by identity. The temporary Phase-1 memento used as the audited capture source
-is discarded immediately and is never stored in rewind history; eliminating that transitional
-capture allocation belongs to the broader memento retirement in #326.
+nodes are also reused by identity.
+
+Rewind does not call the ordinary `Gameboy.saveToMemento()` path. At the safe point, array-owning
+machine components build a short-lived typed record view and register their live primitive
+payloads with `MachineStateCapture`. Snapshot construction reads and compares those registered
+arrays synchronously; the token is then closed and the borrowed view cannot escape. Unchanged
+arrays therefore have no source-payload clone and no retained-page copy. A changed page produces
+one private retained payload. The capture rejects any primitive array that was not explicitly
+registered, preventing a component from silently falling back to legacy deep capture.
+
+The audited direct owners include CPU operands; WRAM, VRAM, OAM and MMU/register RAM; both display
+buffers and all PPU queues/FIFOs/fetch history/palettes; pending audio; SGB packet, border, mask,
+palette and attribute buffers; IR schedules; cartridge battery buffers; and every mutable mapper
+RAM/flash/EEPROM implementation, including nested Datel slots. The memento record descriptors are
+unchanged. Ordinary legacy, boot, portable StateFile and netplay capture still use their existing
+deep-owned paths; their retirement remains #326.
 
 A restore always materializes new live arrays from the private pages. Live mutation can therefore
 never write into a snapshot. Branching by restoring an old generation and capturing from it reuses
@@ -89,15 +102,19 @@ with:
   -Dcoffeegb.rewind.benchmark=true test
 ```
 
-Method: use one synthetic CGB MBC5+32 KiB RAM machine, run 1800 deterministic workload steps,
-capture every sixth step, and retain 300 entries. Each step advances 2048 master ticks and changes
-scattered WRAM, both VRAM banks, OAM, mapper RAM, and display state. Then restore all 300 entries.
+Method: use one synthetic CGB MBC5+32 KiB RAM machine, run 1800 complete forward frames, and retain
+the 300 states selected by `RewindManager`'s first-capture/every-sixth-frame cadence. Each frame
+executes exactly `Gameboy.TICKS_PER_FRAME` (69,905) emulator ticks before the record point, then
+applies the same deterministic scattered WRAM, both-VRAM-bank, OAM and mapper-RAM workload to the
+legacy and MachineSnapshot machines. The harness then restores all 300 entries.
 The legacy baseline counts every distinct reachable primitive array using the measured 64-bit
 HotSpot layout model (16-byte array header, element width, eight-byte alignment). The new exact
 primitive payload figure counts each immutable page identity once. `modeledRetainedBytes` also adds
 deterministic shallow estimates for snapshot/value/container nodes. Thread allocation comes from
 HotSpot's `ThreadMXBean`; capture/restore times use `System.nanoTime`. Allocation and time are
-reported for diagnosis only and have no flaky CI threshold.
+reported for diagnosis only and have no flaky CI threshold. The normal deterministic guard repeats
+the final 1800-frame MachineSnapshot workload and compares retained bytes to the recorded legacy
+baseline; it does not assert time or allocation.
 
 Environment: Coffee GB master `195d9172f27d707934f631fa64c08803b18776a4`, final Phase-5 branch,
 Oracle HotSpot 21.0.1, Maven 3.8.6, Linux 6.17.0-41 x86-64, Intel i7-1165G7 (4 cores/8 threads),
@@ -106,17 +123,20 @@ Oracle HotSpot 21.0.1, Maven 3.8.6, Linux 6.17.0-41 x86-64, Intel i7-1165G7 (4 c
 | Measurement | Legacy master | MachineSnapshot final |
 |---|---:|---:|
 | entries | 300 | 300 |
-| retained primitive bytes | 420,760,640 | 8,118,616 |
-| modeled retained bytes | not measured (object graph excluded) | 12,310,608 |
-| retained arrays/pages | 194,400 arrays | 4,090 pages |
-| unique immutable value nodes | n/a | 31,872 |
-| copied retained page bytes | n/a | 8,053,164 |
-| capture allocated bytes | 423,527,328 | 727,215,224 |
-| capture time | 125,434,035 ns | 954,542,780 ns |
-| restore time | 52,817,678 ns | 1,503,275,044 ns |
+| retained primitive bytes | 337,665,600 | 8,036,600 |
+| modeled retained bytes | not measured (object graph excluded) | 12,672,880 |
+| retained arrays/pages | 194,400 arrays | 4,331 pages |
+| unique immutable value nodes | n/a | 36,202 |
+| copied retained page bytes | n/a | 7,967,292 |
+| cloned source-payload bytes | 337,665,600 | 0 |
+| capture allocated bytes | 340,432,880 | 304,800,456 |
+| capture time | 116,675,757 ns | 771,432,075 ns |
+| restore time | 42,101,754 ns | 3,153,219,918 ns |
 
-Exact retained primitive payload fell by 98.07%; even the final modeled total is 97.07% below the
-baseline's primitive arrays alone. The normal test asserts the deterministic primitive retained
-total stays below half of the recorded master baseline. The higher transient allocation and timing
-are explicit limitations of the Phase-1 memento bridge and reflection-based reconstruction; they
-are not hidden by the retained-memory result and do not form a normal-test performance assertion.
+Exact retained primitive payload fell by 97.62%; even the final modeled total is 96.25% below the
+baseline's primitive arrays alone. Capture allocation is 10.47% below the identical legacy
+baseline and 58.09% below the rejected transitional implementation's 727,215,224 bytes. Source
+payload cloning is zero by construction and is asserted by the focused capture tests. Capture and
+restore remain slower than the legacy graph; these honest timing costs come primarily from exact
+page comparison and reflection-based immutable graph conversion/reconstruction. They are not
+hidden by copied-page accounting and do not form a normal-test performance threshold.

--- a/docs/rewind-machine-snapshots.md
+++ b/docs/rewind-machine-snapshots.md
@@ -1,0 +1,122 @@
+# In-process rewind machine snapshots
+
+## Scope and ownership
+
+`MachineSnapshot` is Coffee GB's internal rewind representation. It is immutable, service-free, and
+owned by the emulator thread. It is not a StateFile root, has no byte codec, is not serializable,
+and must never cross a disk or network boundary. Disk snapshots and netplay continue to use
+StateFile v1. The local-only legacy importer and the remaining `ControllerState`/boot-state memento
+uses are intentionally left for issue #326.
+
+`BasicController` captures only after a completed forward frame, after its queued events have been
+dispatched and before the next frame starts. Restore occurs at the same owner-thread boundary
+before the normal frame ticks that make the rewound frame visible and audible. Calling capture or
+restore concurrently with `Gameboy.tick`, cartridge flushing, or endpoint mutation is unsupported.
+Physical held buttons remain session input and are deliberately not rewound.
+
+`RewindManager` keeps the existing 300 entries and records every sixth emulated frame. A successful
+ROM load/reset or disk-state load clears the history and resets capture cadence. The default
+constructor enables rewind. Its explicit disabled mode returns before cadence bookkeeping or
+machine inspection, so it creates no per-frame snapshot allocation and a rewind request cannot
+freeze forward emulation.
+
+## Immutable graph and page generations
+
+The snapshot graph covers the complete Phase-1 machine inventory, including the primary and Datel
+slot RTC runtime and the two compatibility DMG FIFO runtime records. It contains only immutable
+scalars, enum/type IDs, immutable record/container nodes, and private primitive-array pages. It
+never retains an event bus, callback, console, file, time source, thread, ROM byte array, or other
+host service.
+
+Primitive arrays use fixed 4096-byte payload pages:
+
+| Primitive | Elements per full page |
+|---|---:|
+| byte / boolean | 4096 |
+| int | 1024 |
+| long | 512 |
+
+Four KiB is small enough that normal scattered WRAM/VRAM/display changes do not copy an entire
+large component, while keeping a 1 MiB mapper flash to 256 page identities instead of thousands of
+tiny objects. The scheme applies uniformly to WRAM, both VRAM banks, OAM, display continuation and
+visible-frame buffers, audio and peripheral buffers, SGB buffers, mapper RAM, Datel/MBC6 flash, and
+MBC7 EEPROM.
+
+Each capture is a generation whose predecessor is the previous retained snapshot. For every page,
+capture computes a deterministic content hash and then performs an exact primitive comparison.
+Equal content reuses an immutable predecessor page (or an equal page already seen in the same
+generation); only a changed retained page payload is copied. This content comparison is the dirty
+transition and cannot mistake a hash collision for equality. Unchanged scalar/container/record
+nodes are also reused by identity. The temporary Phase-1 memento used as the audited capture source
+is discarded immediately and is never stored in rewind history; eliminating that transitional
+capture allocation belongs to the broader memento retirement in #326.
+
+A restore always materializes new live arrays from the private pages. Live mutation can therefore
+never write into a snapshot. Branching by restoring an old generation and capturing from it reuses
+only content that is still equal. Removing an entry, clearing the queue, or evicting the oldest
+entry merely drops references; it does not modify pages shared by surviving or externally held
+snapshots.
+
+Before live mutation, restore reconstructs the complete registered machine record, checks hardware
+and mapper/battery ownership, runs the Phase-1 semantic validation, and validates both primitive
+runtime supplements. It retains a rollback capture for unexpected failures while applying the
+machine, FIFO runtime, and RTC runtime. Snapshot pages are private and the test/benchmark probe
+returns only opaque page-identity tokens.
+
+## Presentation state
+
+Presentation data is retained only where it affects current output or deterministic continuation:
+
+- `Display.buffer`, its write index, LCD/repeat flags, and `lastFrame` restore a partially rendered
+  frame and the complete visible panel. Equal `buffer`/`lastFrame` pages share one identity.
+- PPU FIFO/fetcher/OAM/palette state and VRAM-transfer buffers determine subsequent pixels.
+- The APU output buffer/index and channel phases determine the post-restore audio stream.
+- SGB border, mask, palette, and animation buffers determine the presented SGB frame.
+
+Host render listeners, audio sinks, and UI buffers are services and are not retained. Phase 1's
+single display-owner rule remains intact; the historical duplicate root display record stays null
+for new captures.
+
+## Reproducible 300-entry measurement
+
+The manual harness is `MachineSnapshotBenchmarkTest`. It is skipped during normal tests and runs
+with:
+
+```text
+/opt/maven/bin/mvn -B -pl controller -am \
+  -Dtest=MachineSnapshotBenchmarkTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dcoffeegb.rewind.benchmark=true test
+```
+
+Method: use one synthetic CGB MBC5+32 KiB RAM machine, run 1800 deterministic workload steps,
+capture every sixth step, and retain 300 entries. Each step advances 2048 master ticks and changes
+scattered WRAM, both VRAM banks, OAM, mapper RAM, and display state. Then restore all 300 entries.
+The legacy baseline counts every distinct reachable primitive array using the measured 64-bit
+HotSpot layout model (16-byte array header, element width, eight-byte alignment). The new exact
+primitive payload figure counts each immutable page identity once. `modeledRetainedBytes` also adds
+deterministic shallow estimates for snapshot/value/container nodes. Thread allocation comes from
+HotSpot's `ThreadMXBean`; capture/restore times use `System.nanoTime`. Allocation and time are
+reported for diagnosis only and have no flaky CI threshold.
+
+Environment: Coffee GB master `195d9172f27d707934f631fa64c08803b18776a4`, final Phase-5 branch,
+Oracle HotSpot 21.0.1, Maven 3.8.6, Linux 6.17.0-41 x86-64, Intel i7-1165G7 (4 cores/8 threads),
+38 GiB RAM. The exact pre-change master run and final run produced:
+
+| Measurement | Legacy master | MachineSnapshot final |
+|---|---:|---:|
+| entries | 300 | 300 |
+| retained primitive bytes | 420,760,640 | 8,118,616 |
+| modeled retained bytes | not measured (object graph excluded) | 12,310,608 |
+| retained arrays/pages | 194,400 arrays | 4,090 pages |
+| unique immutable value nodes | n/a | 31,872 |
+| copied retained page bytes | n/a | 8,053,164 |
+| capture allocated bytes | 423,527,328 | 727,215,224 |
+| capture time | 125,434,035 ns | 954,542,780 ns |
+| restore time | 52,817,678 ns | 1,503,275,044 ns |
+
+Exact retained primitive payload fell by 98.07%; even the final modeled total is 97.07% below the
+baseline's primitive arrays alone. The normal test asserts the deterministic primitive retained
+total stays below half of the recorded master baseline. The higher transient allocation and timing
+are explicit limitations of the Phase-1 memento bridge and reflection-based reconstruction; they
+are not hidden by the retained-memory result and do not form a normal-test performance assertion.

--- a/docs/rewind-machine-snapshots.md
+++ b/docs/rewind-machine-snapshots.md
@@ -50,19 +50,27 @@ transition and cannot mistake a hash collision for equality. Unchanged scalar/co
 nodes are also reused by identity.
 
 Rewind does not call the ordinary `Gameboy.saveToMemento()` path. At the safe point, array-owning
-machine components build a short-lived typed record view and register their live primitive
-payloads with `MachineStateCapture`. Snapshot construction reads and compares those registered
-arrays synchronously; the token is then closed and the borrowed view cannot escape. Unchanged
-arrays therefore have no source-payload clone and no retained-page copy. A changed page produces
-one private retained payload. The capture rejects any primitive array that was not explicitly
-registered, preventing a component from silently falling back to legacy deep capture.
+machine components first declare the identities and logical lengths of their dominant live
+primitive payloads without constructing a memento. They then build exactly one short-lived typed
+record view and register its live primitive payloads with `MachineStateCapture`. Every dominant
+declaration must be matched by the same array identity and length; registering
+`capture.ints(ram.clone())` leaves the real backing unmatched and rejects the capture. Snapshot
+construction reads and compares the registered arrays synchronously; the token is then closed and
+the borrowed view cannot escape. Unchanged arrays therefore require neither a full source-payload
+copy nor a retained-page copy. A changed page produces one private retained payload. Snapshot graph
+construction also rejects every unregistered primitive array, preventing an owner from silently
+falling back to legacy deep capture.
 
-The audited direct owners include CPU operands; WRAM, VRAM, OAM and MMU/register RAM; both display
-buffers and all PPU queues/FIFOs/fetch history/palettes; pending audio; SGB packet, border, mask,
-palette and attribute buffers; IR schedules; cartridge battery buffers; and every mutable mapper
-RAM/flash/EEPROM implementation, including nested Datel slots. The memento record descriptors are
-unchanged. Ordinary legacy, boot, portable StateFile and netplay capture still use their existing
-deep-owned paths; their retirement remains #326.
+The independently declared dominant owners include WRAM, both VRAM banks, OAM, both display
+buffers, the behavior-relevant pending-audio prefix, SGB packet/border/mask/palette/attribute
+buffers, cartridge battery buffers, and every mutable mapper RAM/flash/EEPROM implementation,
+including MBC6 flash, MBC7 EEPROM, wrapper delegates and nested Datel slots. Smaller CPU, PPU,
+serial, IR and register arrays still use the mandatory token registration and immutable paging
+path. The 24-family mapper matrix asserts that every mapper primitive payload is independently
+declared, and focused tests reject both a copied dominant registration and an unregistered
+primitive fallback. The memento record descriptors are unchanged. Ordinary legacy, boot, portable
+StateFile and netplay capture still use their existing deep-owned paths; their retirement remains
+#326.
 
 A restore always materializes new live arrays from the private pages. Live mutation can therefore
 never write into a snapshot. Branching by restoring an old generation and capturing from it reuses
@@ -128,15 +136,16 @@ Oracle HotSpot 21.0.1, Maven 3.8.6, Linux 6.17.0-41 x86-64, Intel i7-1165G7 (4 c
 | retained arrays/pages | 194,400 arrays | 4,331 pages |
 | unique immutable value nodes | n/a | 36,202 |
 | copied retained page bytes | n/a | 7,967,292 |
-| cloned source-payload bytes | 337,665,600 | 0 |
-| capture allocated bytes | 340,432,880 | 304,800,456 |
-| capture time | 116,675,757 ns | 771,432,075 ns |
-| restore time | 42,101,754 ns | 3,153,219,918 ns |
+| identity-verified dominant source bytes (cumulative) | n/a | 333,717,600 |
+| capture allocated bytes | 340,432,880 | 318,594,760 |
+| capture time | 90,746,351 ns | 777,744,061 ns |
+| restore time | 43,962,026 ns | 1,525,814,700 ns |
 
 Exact retained primitive payload fell by 97.62%; even the final modeled total is 96.25% below the
-baseline's primitive arrays alone. Capture allocation is 10.47% below the identical legacy
-baseline and 58.09% below the rejected transitional implementation's 727,215,224 bytes. Source
-payload cloning is zero by construction and is asserted by the focused capture tests. Capture and
-restore remain slower than the legacy graph; these honest timing costs come primarily from exact
-page comparison and reflection-based immutable graph conversion/reconstruction. They are not
-hidden by copied-page accounting and do not form a normal-test performance threshold.
+baseline's primitive arrays alone. Capture allocation is 6.41% below the identical legacy
+baseline and 56.19% below the rejected transitional implementation's 727,215,224 bytes. The
+deterministic ownership tests prove the no-full-clone property by making a copied dominant
+registration fail; no synthetic "zero clone" counter is reported. Capture and restore remain
+slower than the legacy graph; these honest timing costs come primarily from exact page comparison
+and reflection-based immutable graph conversion/reconstruction. They are not hidden by copied-page
+accounting and do not form a normal-test performance threshold.

--- a/docs/snapshot-migration.md
+++ b/docs/snapshot-migration.md
@@ -11,8 +11,9 @@ runs when `BasicController` dispatches the save event at its emulation-thread fr
 normalized primary-ROM SHA-256, optional Datel slot-ROM SHA-256, and complete stable hardware
 profile. ROM bytes and host services are not written.
 
-Rewind states and `ControllerState` remain in memory on their existing memento path. Netplay
-protocol v8 independently uses StateFile v1 and cannot invoke this local legacy importer; see
+Rewind states remain in memory as internal, structurally shared `MachineSnapshot` values;
+`ControllerState` remains on its existing memento path. Netplay protocol v8 independently uses
+StateFile v1 and cannot invoke this local legacy importer; see
 [netplay-protocol-v8.md](netplay-protocol-v8.md).
 
 ## Bounded format detection

--- a/docs/state-file-v1.md
+++ b/docs/state-file-v1.md
@@ -5,8 +5,9 @@ independent of Coffee GB's Maven/application version and of Java serialization. 
 integers are big-endian, all lengths are nonnegative, and all strings are strict UTF-8.
 
 The codec and explicit decode-then-apply seam are used by local slot snapshots and protocol-v8
-netplay. Rewind and `ControllerState` retain their existing in-memory mementos until their assigned
-phases. Network state has no Java-memento compatibility path.
+netplay. Rewind uses its separate internal, structurally shared `MachineSnapshot` representation;
+`ControllerState` retains its existing in-memory memento until #326. Network state has no
+Java-memento compatibility path.
 
 ## Envelope
 

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -140,9 +140,12 @@ restore. New captures set that nullable compatibility component to null, so only
 `GpuMemento.displayMemento` owns the two 160x144 panel arrays. Visible frame, partial scanout/index,
 LCD enable and repeat behavior therefore remain restorable without duplicate payload.
 
-Rewind, `ControllerState`, and boot-state reuse continue to use their existing in-process mementos.
-Local slot snapshots and netplay protocol v8 use the bounded StateFile codec; their distinct disk
-and network limits do not weaken the graph, queue, frame, or work limits.
+Rewind now retains internal immutable, structurally shared `MachineSnapshot` generations described
+in [rewind-machine-snapshots.md](rewind-machine-snapshots.md). Its transitional capture source is
+the audited memento graph, but no memento is retained in rewind history. `ControllerState` and
+boot-state reuse continue to use their existing in-process mementos until #326. Local slot
+snapshots and netplay protocol v8 use the bounded StateFile codec; their distinct disk and network
+limits do not weaken the graph, queue, frame, or work limits.
 
 ## Failure and extension policy
 

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -141,11 +141,12 @@ restore. New captures set that nullable compatibility component to null, so only
 LCD enable and repeat behavior therefore remain restorable without duplicate payload.
 
 Rewind now retains internal immutable, structurally shared `MachineSnapshot` generations described
-in [rewind-machine-snapshots.md](rewind-machine-snapshots.md). Its transitional capture source is
-the audited memento graph, but no memento is retained in rewind history. `ControllerState` and
-boot-state reuse continue to use their existing in-process mementos until #326. Local slot
-snapshots and netplay protocol v8 use the bounded StateFile codec; their distinct disk and network
-limits do not weaken the graph, queue, frame, or work limits.
+in [rewind-machine-snapshots.md](rewind-machine-snapshots.md). Its safe-point capture consumes an
+audited, short-lived record view that borrows registered live primitive arrays for synchronous
+comparison; it neither calls the deep-cloning legacy root capture nor retains the borrowed view.
+`ControllerState` and boot-state reuse continue to use their existing in-process mementos until
+#326. Local slot snapshots and netplay protocol v8 use the bounded StateFile codec; their distinct
+disk and network limits do not weaken the graph, queue, frame, or work limits.
 
 ## Failure and extension policy
 

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -16,11 +16,11 @@ by subsystem in [`state-machine-inventory.md`](state-machine-inventory.md); none
 is admitted to the detached graph.
 
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt`
-- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt`
 - COMPOSITE `controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt`
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt`
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt`
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt`
+- WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt`
 - COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java`

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -15,6 +15,12 @@ owns no instance state. Derived caches and external services omitted by each own
 by subsystem in [`state-machine-inventory.md`](state-machine-inventory.md); none of those services
 is admitted to the detached graph.
 
+For internal rewind only, array-owning sites additionally implement the
+`saveToMemento(MachineStateCapture)` safe-point overload. That overload constructs a transient
+record view with registered borrowed primitive arrays; `MachineSnapshot` compares/copies it
+synchronously and rejects any unregistered array. It does not alter the listed record components,
+the ordinary deep-owned `saveToMemento()` contract, or any portable/legacy byte schema.
+
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt`
 - COMPOSITE `controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt`
 - WORKFLOW `controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt`
@@ -46,6 +52,7 @@ is admitted to the detached graph.
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java`
 - COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java`
+- CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/memento/MachineStateCapture.java`
 - CONTRACT `core/src/main/java/eu/rekawek/coffeegb/core/memento/Originator.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java`


### PR DESCRIPTION
## Invariant

Rewind history owns immutable, service-free, in-process `MachineSnapshot` generations. At the emulator frame safe point, dominant owners explicitly declare their live primitive backing identities and logical lengths, then exactly one transient capture view must register those same arrays. A token-aware helper copy such as `capture.ints(ram.clone())` is rejected, as is any unregistered ordinary deep-memento fallback. Incremental capture copies only changed 4 KiB retained pages; live arrays and sibling/older/newer snapshots cannot alias.

Base: `195d9172f27d707934f631fa64c08803b18776a4`
Head: `b2035efc332ed17684bf41f9953d657d7770fc13`

## What changed

- Replaced `RewindManager`'s `ArrayDeque<Memento<Gameboy>>` with `MachineSnapshot` end to end while retaining capacity 300, first-capture/every-sixth-frame cadence, rewind behavior, held-input policy, and clear/reset behavior.
- Added the safe-point-only `MachineStateCapture` seam. It builds one transient typed record graph; every primitive array must be token-registered, while dominant arrays are independently declared from their actual owner fields before that graph exists.
- Added active deterministic ownership guards. A copied dominant registration leaves the live declaration unmatched and fails before paging; an ordinary unregistered primitive-array fallback fails while paging. The implementation no longer reports a synthetic literal-zero clone counter.
- Covered WRAM, both VRAM banks, OAM, both display buffers, pending audio, SGB packet/border/mask/palette/attribute buffers, battery buffers, and every mutable mapper RAM/flash/EEPROM implementation, including MBC6 flash, MBC7 EEPROM, wrapper delegates, and nested Datel slots. The 24-family mapper matrix asserts every mapper primitive payload is independently declared.
- Added private 4096-byte pages with exact content comparison, immutable graph-node/page reuse, hardware/mapper ownership validation, RTC and DMG FIFO runtime supplements, and atomic restore rollback.
- Preserved ordinary deep-owned `saveToMemento()`, the 91-record registry/descriptors, StateFile v1 bytes, protocol v8, legacy import, and fixture bytes. General memento/Serializable retirement remains #326.

## Production-cadence 300-entry measurement

Command:

```text
mvn -B -pl controller -am \
  -Dtest=MachineSnapshotBenchmarkTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dcoffeegb.rewind.benchmark=true test
```

Environment: Oracle HotSpot 21.0.1, Maven 3.8.6, Linux 6.17.0-41 x86-64, Intel i7-1165G7 (4C/8T), 38 GiB RAM. Both paths use identical CGB MBC5+32 KiB RAM machines and state points: 1,800 complete forward frames, exactly `Gameboy.TICKS_PER_FRAME` (69,905) ticks per frame, capture at `RewindManager`'s first/every-sixth-frame cadence, deterministic scattered WRAM/VRAM/OAM/mapper changes, then 300 restores.

| Measurement | Legacy baseline | MachineSnapshot |
|---|---:|---:|
| entries | 300 | 300 |
| retained primitive bytes | 337,665,600 | 8,036,600 |
| modeled retained bytes | not measured | 12,672,880 |
| arrays/pages | 194,400 arrays | 4,331 pages |
| unique immutable value nodes | n/a | 36,202 |
| copied retained page bytes | n/a | 7,967,292 |
| identity-verified dominant source bytes (cumulative) | n/a | 333,717,600 |
| capture allocated bytes | 340,432,880 | 318,594,760 |
| capture time | 90,746,351 ns | 777,744,061 ns |
| restore time | 43,962,026 ns | 1,525,814,700 ns |

Exact retained primitive payload is 97.62% lower; modeled retained total is 96.25% below the legacy primitive arrays alone. Capture allocation is 6.41% below the identical legacy baseline and 56.19% below the rejected transitional implementation's 727,215,224 bytes. The deterministic clone/fallback negative tests establish source ownership; wall-clock and allocation observations are reported honestly but are not flaky CI thresholds.

## Verification

- Focused ownership/MachineSnapshot/Rewind/mapper/fixture command: 59 passed (3 core + 56 controller), zero failures/errors.
- Manual production-cadence benchmark: 1 passed.
- `mvn -B -pl core,controller -am clean test`: core 718/718; controller 200 total, 198 passed and 2 intentional opt-in utilities skipped; zero failures/errors.
- `mvn -B -pl swing -am -DskipTests compile`: four-module reactor passed.
- `git diff --check`: passed.
- Ownership audit: exactly 91 admitted record policies; legacy descriptor/fixture and portable golden tests passed.

Fixture SHA-256 values are unchanged:

- legacy 1.7.13: `7a7ba6fa23538fcd2bdb734487a3b30a18452b69379e18712fc289858ba191ec`
- legacy 1.7.14: `3588e825efd91f8555d2fd941645a21af1c2ba330df6b56053f01ed81faf5573`
- StateFile v1 golden: `e5ae258c3f1a9405ca87518dbb13526def9fd3e44a4486d7a495c111958cf091`

## Compatibility and boundary

StateFile v1 bytes, netplay protocol v8, atomic persistence, local legacy fixtures/import, controller load-state plumbing, serial `Session` endpoint ownership, and public default rewind behavior are unchanged. This PR does not retire `Serializable`, the isolated legacy importer, boot/controller mementos, or other in-process memento plumbing; those remain #326.

Closes #325
Part of #314
