### PR TITLE
Implement protocol v9 transport foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ also requires SDL2 (`brew install sdl2`); keyboard input works without it.
 For netplay, one player chooses **Link > Start server** and the other chooses
 **Link > Connect to server**.
 
-The next-generation pairing and consent design is frozen as **protocol v9** but is not implemented
-yet. It deliberately does not interoperate or downgrade to current protocol v8. Its short-lived
-invitation proves possession only: planned TCP remains plaintext and is not confidential or secure
-against an on-path attacker. Own-ROM use is the default and ROM, battery, and checkpoint transfer
-classes require compatible manifests plus explicit consent on both sides. See
+The next-generation pairing and consent design is frozen as **protocol v9**. An opt-in developer
+foundation now validates CGB9 framing and HELLO capabilities, but it stops before pairing and is
+not a playable user flow; current user netplay remains v8. V9 deliberately does not interoperate
+or downgrade to v8. Invitation authentication is not implemented yet, and planned TCP remains
+plaintext—not confidential or secure against an on-path attacker. Own-ROM use is the default and
+ROM, battery, and checkpoint transfer classes will require compatible manifests plus explicit
+consent on both sides. See
 [the v9 privacy/troubleshooting guide](docs/netplay-v9-privacy.md) and the
-[normative v9 contract](docs/netplay-protocol-v9.md).
+[normative v9 contract](docs/netplay-protocol-v9.md). The implemented foundation boundary is
+documented in [netplay-v9-foundation.md](docs/netplay-v9-foundation.md).
 
 Mobile Adapter GB support is likewise specification-only. The clean-room design treats it as a
 bounded serial peripheral, never a rollback link mode, and neither connects to historical Nintendo

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Codec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Codec.kt
@@ -1,0 +1,638 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.util.Collections
+import java.util.zip.DataFormatException
+import java.util.zip.Deflater
+import java.util.zip.Inflater
+
+class V9ProtocolException(
+    val reason: V9ErrorCode,
+    val decisiveBytes: Int,
+    message: String = reason.wireName,
+) : Exception(message)
+
+data class V9QueueSnapshot(
+    val frames: Long,
+    val wireBytes: Long,
+    val decodedBytes: Long,
+)
+
+/** Session-wide retained-frame budget. A reservation must be closed exactly once. */
+class V9QueueBudget(
+    private val maximumFrames: Long = V9Limit.QUEUED_FRAMES.value,
+    private val maximumWireBytes: Long = V9Limit.QUEUED_WIRE_BYTES.value,
+    private val maximumDecodedBytes: Long = V9Limit.SESSION_DECODED_AGGREGATE_BYTES.value,
+    initialFrames: Long = 0,
+    initialWireBytes: Long = 0,
+    initialDecodedBytes: Long = 0,
+) {
+  private var frames = initialFrames
+  private var wireBytes = initialWireBytes
+  private var decodedBytes = initialDecodedBytes
+
+  init {
+    require(initialFrames >= 0 && initialWireBytes >= 0 && initialDecodedBytes >= 0)
+    require(initialFrames <= maximumFrames)
+    require(initialWireBytes <= maximumWireBytes)
+    require(initialDecodedBytes <= maximumDecodedBytes)
+  }
+
+  @Synchronized
+  fun canReserve(additionalWireBytes: Long, additionalDecodedBytes: Long): Boolean =
+      admissionError(additionalWireBytes, additionalDecodedBytes) == null
+
+  @Synchronized
+  fun admissionError(
+      additionalWireBytes: Long,
+      additionalDecodedBytes: Long,
+  ): V9ErrorCode? =
+      evaluateAdmission(
+          V9QueueSnapshot(frames, wireBytes, decodedBytes),
+          V9QueueSnapshot(1, additionalWireBytes, additionalDecodedBytes),
+          maximumFrames,
+          maximumWireBytes,
+          maximumDecodedBytes,
+      )
+
+  @Synchronized
+  fun reserve(additionalWireBytes: Long, additionalDecodedBytes: Long): Reservation? {
+    if (admissionError(additionalWireBytes, additionalDecodedBytes) != null) return null
+    frames = Math.addExact(frames, 1)
+    wireBytes = Math.addExact(wireBytes, additionalWireBytes)
+    decodedBytes = Math.addExact(decodedBytes, additionalDecodedBytes)
+    return Reservation(this, additionalWireBytes, additionalDecodedBytes)
+  }
+
+  @Synchronized
+  fun snapshot(): V9QueueSnapshot = V9QueueSnapshot(frames, wireBytes, decodedBytes)
+
+  @Synchronized
+  private fun release(wire: Long, decoded: Long) {
+    frames = Math.subtractExact(frames, 1)
+    wireBytes = Math.subtractExact(wireBytes, wire)
+    decodedBytes = Math.subtractExact(decodedBytes, decoded)
+  }
+
+  class Reservation internal constructor(
+      private val owner: V9QueueBudget,
+      val wireBytes: Long,
+      val decodedBytes: Long,
+  ) : Closeable {
+    private var closed = false
+
+    @Synchronized
+    override fun close() {
+      if (!closed) {
+        closed = true
+        owner.release(wireBytes, decodedBytes)
+      }
+    }
+  }
+
+  companion object {
+    fun evaluateAdmission(
+        current: V9QueueSnapshot,
+        additional: V9QueueSnapshot,
+        maximumFrames: Long = V9Limit.QUEUED_FRAMES.value,
+        maximumWireBytes: Long = V9Limit.QUEUED_WIRE_BYTES.value,
+        maximumDecodedBytes: Long = V9Limit.SESSION_DECODED_AGGREGATE_BYTES.value,
+    ): V9ErrorCode? {
+      if (listOf(
+              current.frames,
+              current.wireBytes,
+              current.decodedBytes,
+              additional.frames,
+              additional.wireBytes,
+              additional.decodedBytes,
+          ).any { it < 0 }) {
+        return V9ErrorCode.MALFORMED_HEADER
+      }
+      val nextFrames: Long
+      val nextWire: Long
+      val nextDecoded: Long
+      try {
+        nextFrames = Math.addExact(current.frames, additional.frames)
+        nextWire = Math.addExact(current.wireBytes, additional.wireBytes)
+        nextDecoded = Math.addExact(current.decodedBytes, additional.decodedBytes)
+      } catch (_: ArithmeticException) {
+        return V9ErrorCode.LIMIT_EXCEEDED
+      }
+      if (nextFrames > maximumFrames || nextWire > maximumWireBytes) {
+        return V9ErrorCode.QUEUE_OVERFLOW
+      }
+      if (nextDecoded > maximumDecodedBytes) return V9ErrorCode.LIMIT_EXCEEDED
+      return null
+    }
+  }
+}
+
+class V9FrameHeader(
+    val typeId: Int,
+    val type: V9MessageType?,
+    val flags: Int,
+    val sequence: Long,
+    val correlation: Long,
+    val encodedLength: Long,
+    val decodedLength: Long,
+    val channel: Long,
+    digest: ByteArray,
+) {
+  private val ownedDigest = digest.copyOf()
+
+  fun digest(): ByteArray = ownedDigest.copyOf()
+}
+
+class V9Frame internal constructor(
+    val header: V9FrameHeader,
+    payload: ByteArray,
+    private val reservation: V9QueueBudget.Reservation? = null,
+) : Closeable {
+  // The incremental decoder transfers sole ownership of this already-bounded array.
+  private val ownedPayload = payload
+
+  fun payload(): ByteArray = ownedPayload.copyOf()
+
+  internal fun payloadView(): ByteArray = ownedPayload
+
+  override fun close() {
+    reservation?.close()
+  }
+}
+
+data class V9DecodeBatch(
+    val frames: List<V9Frame>,
+    val needsMore: Boolean,
+    val failure: V9ProtocolException?,
+    val consumedBytes: Long,
+    val retainedBytes: Int,
+    val payloadAllocations: Int,
+    val payloadReservations: Int,
+    val directionExhausted: Boolean,
+)
+
+class V9DecoderPolicy(
+    allowedMessages: Set<V9MessageType> =
+        setOf(V9MessageType.HELLO, V9MessageType.ERROR),
+    negotiatedCapabilities: Set<V9Capability> = V9Capability.entries.toSet(),
+    val linkMode: V9LinkMode = V9LinkMode.NORMAL,
+    val allowUnknownOptional: Boolean = false,
+) {
+  val allowedMessages: Set<V9MessageType> =
+      Collections.unmodifiableSet(allowedMessages.toSet())
+  val negotiatedCapabilities: Set<V9Capability> =
+      Collections.unmodifiableSet(negotiatedCapabilities.toSet())
+}
+
+/**
+ * Incremental one-frame-at-a-time decoder.
+ *
+ * It retains one fixed header and at most one declared payload. Header precedence is evaluated at
+ * the frozen decisive byte and the queue budget is checked before the payload allocation.
+ */
+class V9IncrementalDecoder(
+    initialSequence: Long = 0,
+    private val budget: V9QueueBudget = V9QueueBudget(),
+    private val policy: V9DecoderPolicy = V9DecoderPolicy(),
+) {
+  private val headerBytes = ByteArray(ProtocolV9.HEADER_BYTES)
+  private var headerCount = 0
+  private var header: V9FrameHeader? = null
+  private var encodedPayload: ByteArray? = null
+  private var payloadCount = 0
+  private var expectedSequence = validateInitialSequence(initialSequence)
+  private var terminal = false
+  private var failure: V9ProtocolException? = null
+  private var consumed = 0L
+  private var allocations = 0
+  private var reservations = 0
+  private var completedFrames = 0
+  private var currentReservation: V9QueueBudget.Reservation? = null
+
+  fun feed(bytes: ByteArray): V9DecodeBatch = feed(bytes, 0, bytes.size)
+
+  fun feed(bytes: ByteArray, offset: Int, length: Int): V9DecodeBatch {
+    require(offset >= 0 && length >= 0 && offset <= bytes.size - length)
+    val completed = mutableListOf<V9Frame>()
+    var input = offset
+    val end = offset + length
+    while (input < end && failure == null) {
+      if (terminal) {
+        consumed = Math.addExact(consumed, 1)
+        fail(V9ErrorCode.TRAILING_DATA, consumed.toIntBounded())
+        break
+      }
+      if (headerCount < ProtocolV9.HEADER_BYTES) {
+        headerBytes[headerCount++] = bytes[input++]
+        consumed = Math.addExact(consumed, 1)
+        val early = headerFailure(headerBytes, headerCount)
+        if (early != null) {
+          fail(early, consumed.toIntBounded())
+          break
+        }
+        if (headerCount == ProtocolV9.HEADER_BYTES) {
+          val parsed = parseHeader(headerBytes)
+          val wireBytes = checkedWireBytes(parsed.encodedLength)
+              ?: return failed(completed, V9ErrorCode.LIMIT_EXCEEDED, 32)
+          val reservation = budget.reserve(wireBytes, parsed.decodedLength)
+              ?: return failed(completed, V9ErrorCode.QUEUE_OVERFLOW, 32)
+          currentReservation = reservation
+          reservations++
+          header = parsed
+          encodedPayload = ByteArray(parsed.encodedLength.toInt())
+          allocations++
+          payloadCount = 0
+          if (parsed.encodedLength == 0L) {
+            completeFrame(completed)
+          }
+        }
+        continue
+      }
+
+      val payload = checkNotNull(encodedPayload)
+      val copy = minOf(end - input, payload.size - payloadCount)
+      System.arraycopy(bytes, input, payload, payloadCount, copy)
+      input += copy
+      payloadCount += copy
+      consumed = Math.addExact(consumed, copy.toLong())
+      if (payloadCount == payload.size) {
+        completeFrame(completed)
+      }
+    }
+    return snapshot(completed)
+  }
+
+  fun finish(): V9DecodeBatch {
+    if (failure == null && (headerCount != 0 || header != null)) {
+      fail(V9ErrorCode.TRUNCATED, consumed.toIntBounded())
+    } else if (failure == null && completedFrames == 0) {
+      fail(V9ErrorCode.TRUNCATED, consumed.toIntBounded())
+    } else if (failure == null && !terminal) {
+      fail(V9ErrorCode.UNEXPECTED_EOF, consumed.toIntBounded())
+    }
+    return snapshot(emptyList())
+  }
+
+  fun snapshot(): V9DecodeBatch = snapshot(emptyList())
+
+  fun queueSnapshot(): V9QueueSnapshot = budget.snapshot()
+
+  private fun completeFrame(completed: MutableList<V9Frame>) {
+    val currentHeader = checkNotNull(header)
+    val encoded = checkNotNull(encodedPayload)
+    val decoded = if (currentHeader.flags has V9Flag.DEFLATE) {
+      inflateExact(encoded, currentHeader.decodedLength.toInt())
+          ?: return fail(V9ErrorCode.DECOMPRESSION_FAILED, consumed.toIntBounded())
+    } else {
+      encoded
+    }
+    if (!MessageDigest.isEqual(currentHeader.digest(), sha256(decoded))) {
+      return fail(V9ErrorCode.CHECKSUM_MISMATCH, consumed.toIntBounded())
+    }
+
+    val payloadFailure = validateFoundationPayload(currentHeader, decoded)
+    if (payloadFailure != null) {
+      return fail(payloadFailure, consumed.toIntBounded())
+    }
+    if (currentHeader.type == null) {
+      currentReservation?.close()
+    } else {
+      completed += V9Frame(currentHeader, decoded, currentReservation)
+    }
+    completedFrames++
+    currentReservation = null
+    if (expectedSequence == ProtocolV9.LAST_SEQUENCE) {
+      expectedSequence = ProtocolV9.EXHAUSTED_SEQUENCE
+    } else {
+      expectedSequence = Math.addExact(expectedSequence, 1)
+    }
+    terminal = currentHeader.flags has V9Flag.TERMINAL
+    resetFrame()
+  }
+
+  private fun validateFoundationPayload(
+      header: V9FrameHeader,
+      payload: ByteArray,
+  ): V9ErrorCode? = when (header.type) {
+    V9MessageType.HELLO -> V9HelloCodec.validate(payload)
+    V9MessageType.ERROR -> V9ErrorPayloadCodec.validate(header.flags, payload)
+    else -> null
+  }
+
+  private fun headerFailure(bytes: ByteArray, count: Int): V9ErrorCode? {
+    if (count >= 4 && !bytes.copyOfRange(0, 4).contentEquals(ProtocolV9.MAGIC)) {
+      return V9ErrorCode.UNSUPPORTED_PROTOCOL
+    }
+    if (count >= 6 &&
+        ((bytes[4].toInt() and 0xff) != ProtocolV9.MAJOR ||
+            (bytes[5].toInt() and 0xff) != ProtocolV9.MINOR)) {
+      return V9ErrorCode.UNSUPPORTED_PROTOCOL
+    }
+    if (count >= 8 && u16(bytes, 6) != ProtocolV9.HEADER_BYTES) {
+      return V9ErrorCode.MALFORMED_HEADER
+    }
+    if (count < 12) return null
+
+    val type = V9MessageType.fromWireId(u16(bytes, 8))
+    val flags = u16(bytes, 10)
+    if (type == null && flags != V9Flag.OPTIONAL.wireMask) {
+      return V9ErrorCode.UNKNOWN_REQUIRED_TYPE
+    }
+    if (type != null) {
+      val spec = type.spec
+      if (flags and V9Flag.KNOWN_MASK.inv() != 0 ||
+          flags and spec.allowedFlags.inv() != 0 ||
+          flags and spec.requiredFlags != spec.requiredFlags ||
+          flags has V9Flag.DEFLATE && spec.compression != V9Compression.RAW_DEFLATE) {
+        return V9ErrorCode.UNKNOWN_REQUIRED_FLAG
+      }
+    }
+    if (count < 32) return null
+
+    val sequence = u32(bytes, 12)
+    val correlation = u32(bytes, 16)
+    val encodedLength = u32(bytes, 20)
+    val decodedLength = u32(bytes, 24)
+    val channel = u32(bytes, 28)
+    if (type == null) {
+      if (encodedLength != decodedLength ||
+          encodedLength > V9Limit.UNKNOWN_OPTIONAL_BYTES.value ||
+          channel != ProtocolV9.CONTROL_CHANNEL ||
+          correlation != 0L) {
+        return V9ErrorCode.UNKNOWN_REQUIRED_TYPE
+      }
+    } else if (!validChannel(type.spec.channelKind, channel)) {
+      return V9ErrorCode.MALFORMED_HEADER
+    }
+    if (expectedSequence == ProtocolV9.EXHAUSTED_SEQUENCE || sequence != expectedSequence) {
+      return V9ErrorCode.SEQUENCE_ERROR
+    }
+    if (flags has V9Flag.RESPONSE && correlation == 0L ||
+        !(flags has V9Flag.RESPONSE) && correlation != 0L) {
+      return V9ErrorCode.CORRELATION_ERROR
+    }
+    if (!(flags has V9Flag.DEFLATE) && encodedLength != decodedLength) {
+      return V9ErrorCode.MALFORMED_HEADER
+    }
+    if (type != null &&
+        (encodedLength > type.spec.maximumEncodedBytes ||
+            decodedLength > type.spec.maximumDecodedBytes ||
+            decodedLength < type.spec.minimumDecodedBytes)) {
+      return V9ErrorCode.LIMIT_EXCEEDED
+    }
+    if (encodedLength > Int.MAX_VALUE || decodedLength > Int.MAX_VALUE) {
+      return V9ErrorCode.LIMIT_EXCEEDED
+    }
+    val wireBytes = checkedWireBytes(encodedLength) ?: return V9ErrorCode.LIMIT_EXCEEDED
+    budget.admissionError(wireBytes, decodedLength)?.let { return it }
+    if (type != null) {
+      capabilityFailure(type, flags, policy)?.let { return it }
+      if (type !in policy.allowedMessages) return V9ErrorCode.UNEXPECTED_MESSAGE
+    } else if (!policy.allowUnknownOptional) {
+      return V9ErrorCode.UNEXPECTED_MESSAGE
+    }
+    return null
+  }
+
+  private fun failed(
+      completed: List<V9Frame>,
+      reason: V9ErrorCode,
+      decisiveBytes: Int,
+  ): V9DecodeBatch {
+    fail(reason, decisiveBytes)
+    return snapshot(completed)
+  }
+
+  private fun fail(reason: V9ErrorCode, decisiveBytes: Int) {
+    currentReservation?.close()
+    currentReservation = null
+    failure = V9ProtocolException(reason, decisiveBytes)
+    terminal = true
+    resetFrame()
+  }
+
+  private fun resetFrame() {
+    headerCount = 0
+    header = null
+    encodedPayload = null
+    payloadCount = 0
+  }
+
+  private fun snapshot(completed: List<V9Frame>): V9DecodeBatch =
+      V9DecodeBatch(
+          completed.toList(),
+          failure == null && !terminal,
+          failure,
+          consumed,
+          headerCount + payloadCount,
+          allocations,
+          reservations,
+          expectedSequence == ProtocolV9.EXHAUSTED_SEQUENCE,
+      )
+
+  private fun validateInitialSequence(sequence: Long): Long {
+    require(sequence in 0..ProtocolV9.EXHAUSTED_SEQUENCE)
+    return sequence
+  }
+}
+
+data class V9OutboundFrame(
+    val type: V9MessageType,
+    val flags: Int,
+    val sequence: Long,
+    val correlation: Long,
+    val channel: Long,
+    val payload: ByteArray,
+)
+
+object V9FrameEncoder {
+  fun encode(
+      frame: V9OutboundFrame,
+      policy: V9DecoderPolicy = V9DecoderPolicy(),
+  ): ByteArray {
+    require(frame.sequence in 0..ProtocolV9.LAST_SEQUENCE) { "v9 sequence is exhausted" }
+    require(frame.correlation in 0..ProtocolV9.U32_MAX)
+    require(frame.channel in 0..ProtocolV9.U32_MAX)
+    validateFlags(frame.type, frame.flags)?.let { throw V9ProtocolException(it, 12) }
+    if (!validChannel(frame.type.spec.channelKind, frame.channel)) {
+      throw V9ProtocolException(V9ErrorCode.MALFORMED_HEADER, 32)
+    }
+    if (frame.flags has V9Flag.RESPONSE && frame.correlation == 0L ||
+        !(frame.flags has V9Flag.RESPONSE) && frame.correlation != 0L) {
+      throw V9ProtocolException(V9ErrorCode.CORRELATION_ERROR, 32)
+    }
+    capabilityFailure(frame.type, frame.flags, policy)?.let {
+      throw V9ProtocolException(it, 32)
+    }
+    if (frame.type !in policy.allowedMessages) {
+      throw V9ProtocolException(V9ErrorCode.UNEXPECTED_MESSAGE, 32)
+    }
+
+    val decodedBytes = frame.payload.size.toLong()
+    if (decodedBytes !in
+        frame.type.spec.minimumDecodedBytes..frame.type.spec.maximumDecodedBytes) {
+      throw V9ProtocolException(V9ErrorCode.LIMIT_EXCEEDED, 32)
+    }
+    val decoded = frame.payload.copyOf()
+    val encoded =
+        if (frame.flags has V9Flag.DEFLATE) deflateRaw(decoded) else decoded
+    if (encoded.size.toLong() > frame.type.spec.maximumEncodedBytes) {
+      throw V9ProtocolException(V9ErrorCode.LIMIT_EXCEEDED, 32)
+    }
+    val size = try {
+      Math.addExact(ProtocolV9.HEADER_BYTES, encoded.size)
+    } catch (_: ArithmeticException) {
+      throw V9ProtocolException(V9ErrorCode.LIMIT_EXCEEDED, 32)
+    }
+    val result = ByteBuffer.allocate(size).order(ByteOrder.BIG_ENDIAN)
+    result.put(ProtocolV9.MAGIC)
+    result.put(ProtocolV9.MAJOR.toByte())
+    result.put(ProtocolV9.MINOR.toByte())
+    result.putShort(ProtocolV9.HEADER_BYTES.toShort())
+    result.putShort(frame.type.wireId.toShort())
+    result.putShort(frame.flags.toShort())
+    result.putInt(frame.sequence.toInt())
+    result.putInt(frame.correlation.toInt())
+    result.putInt(encoded.size)
+    result.putInt(decoded.size)
+    result.putInt(frame.channel.toInt())
+    result.put(sha256(decoded))
+    result.put(encoded)
+    return result.array()
+  }
+}
+
+private fun validateFlags(type: V9MessageType, flags: Int): V9ErrorCode? {
+  val spec = type.spec
+  return if (flags and V9Flag.KNOWN_MASK.inv() != 0 ||
+      flags and spec.allowedFlags.inv() != 0 ||
+      flags and spec.requiredFlags != spec.requiredFlags ||
+      flags has V9Flag.DEFLATE && spec.compression != V9Compression.RAW_DEFLATE) {
+    V9ErrorCode.UNKNOWN_REQUIRED_FLAG
+  } else {
+    null
+  }
+}
+
+internal fun capabilityFailure(
+    type: V9MessageType,
+    flags: Int,
+    policy: V9DecoderPolicy,
+): V9ErrorCode? {
+  val capabilities = policy.negotiatedCapabilities
+  if (policy.linkMode == V9LinkMode.FOUR_PLAYER &&
+      V9Capability.FOUR_PLAYER_V1 !in capabilities) {
+    return V9ErrorCode.CAPABILITY_MISMATCH
+  }
+  val requiredClass = when (type) {
+    V9MessageType.ROM_BEGIN, V9MessageType.ROM_CHUNK, V9MessageType.ROM_END ->
+      V9Capability.ROM_TRANSFER_V1
+    V9MessageType.BATTERY_BEGIN, V9MessageType.BATTERY_CHUNK, V9MessageType.BATTERY_END ->
+      V9Capability.BATTERY_TRANSFER_V1
+    V9MessageType.PING, V9MessageType.PONG -> V9Capability.PING_V1
+    else -> null
+  }
+  if (requiredClass != null && requiredClass !in capabilities) {
+    return V9ErrorCode.CAPABILITY_MISMATCH
+  }
+  if (flags has V9Flag.DEFLATE && V9Capability.RAW_DEFLATE_V1 !in capabilities) {
+    return V9ErrorCode.CAPABILITY_MISMATCH
+  }
+  return null
+}
+
+internal fun validChannel(kind: V9ChannelKind, channel: Long): Boolean = when (kind) {
+  V9ChannelKind.CONTROL -> channel == ProtocolV9.CONTROL_CHANNEL
+  V9ChannelKind.PLAYER -> channel in 1L..4L
+  V9ChannelKind.GROUP_OR_PLAYER ->
+    channel == ProtocolV9.GROUP_CHANNEL || channel in 1L..4L
+}
+
+private fun parseHeader(bytes: ByteArray): V9FrameHeader =
+    V9FrameHeader(
+        u16(bytes, 8),
+        V9MessageType.fromWireId(u16(bytes, 8)),
+        u16(bytes, 10),
+        u32(bytes, 12),
+        u32(bytes, 16),
+        u32(bytes, 20),
+        u32(bytes, 24),
+        u32(bytes, 28),
+        bytes.copyOfRange(32, 64),
+    )
+
+internal fun u16(bytes: ByteArray, offset: Int): Int =
+    ((bytes[offset].toInt() and 0xff) shl 8) or
+        (bytes[offset + 1].toInt() and 0xff)
+
+internal fun u32(bytes: ByteArray, offset: Int): Long =
+    ((bytes[offset].toLong() and 0xff) shl 24) or
+        ((bytes[offset + 1].toLong() and 0xff) shl 16) or
+        ((bytes[offset + 2].toLong() and 0xff) shl 8) or
+        (bytes[offset + 3].toLong() and 0xff)
+
+private fun checkedWireBytes(encoded: Long): Long? = try {
+  Math.addExact(ProtocolV9.HEADER_BYTES.toLong(), encoded)
+} catch (_: ArithmeticException) {
+  null
+}
+
+private fun sha256(bytes: ByteArray): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(bytes)
+
+private fun deflateRaw(decoded: ByteArray): ByteArray {
+  val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true)
+  return try {
+    deflater.setInput(decoded)
+    deflater.finish()
+    val output = ByteArrayOutputStream()
+    val chunk = ByteArray(8_192)
+    while (!deflater.finished()) {
+      val count = deflater.deflate(chunk)
+      if (count <= 0) throw V9ProtocolException(V9ErrorCode.DECOMPRESSION_FAILED, 32)
+      output.write(chunk, 0, count)
+    }
+    output.toByteArray()
+  } finally {
+    deflater.end()
+  }
+}
+
+private fun inflateExact(encoded: ByteArray, decodedLength: Int): ByteArray? {
+  val inflater = Inflater(true)
+  return try {
+    inflater.setInput(encoded)
+    val output = ByteArray(decodedLength)
+    var offset = 0
+    while (offset < output.size) {
+      val count = inflater.inflate(output, offset, output.size - offset)
+      if (count > 0) {
+        offset += count
+      } else if (inflater.needsDictionary() || inflater.needsInput() || inflater.finished()) {
+        break
+      } else {
+        return null
+      }
+    }
+    if (offset != output.size) return null
+    if (!inflater.finished()) {
+      val overflow = ByteArray(1)
+      if (inflater.inflate(overflow) != 0) return null
+    }
+    if (!inflater.finished() || inflater.needsDictionary() || inflater.remaining != 0) null
+    else output
+  } catch (_: DataFormatException) {
+    null
+  } finally {
+    inflater.end()
+  }
+}
+
+private infix fun Int.has(flag: V9Flag): Boolean = this and flag.wireMask != 0
+
+private fun Long.toIntBounded(): Int =
+    if (this > Int.MAX_VALUE) Int.MAX_VALUE else toInt()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
@@ -1,0 +1,716 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.security.SecureRandom
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+interface V9TransportChannel : Closeable {
+  @Throws(IOException::class)
+  fun read(bytes: ByteArray, offset: Int, length: Int): Int
+
+  @Throws(IOException::class)
+  fun write(bytes: ByteArray, offset: Int, length: Int): Int
+
+  @Throws(IOException::class)
+  fun shutdownOutput()
+}
+
+interface V9ConnectableChannel : V9TransportChannel {
+  @Throws(IOException::class)
+  fun connect(address: InetSocketAddress, timeoutMillis: Int)
+}
+
+class V9SocketChannel(private val socket: Socket) : V9ConnectableChannel {
+  override fun connect(address: InetSocketAddress, timeoutMillis: Int) {
+    socket.connect(address, timeoutMillis)
+    socket.tcpNoDelay = true
+    socket.keepAlive = true
+    socket.soTimeout = V9Timeout.WAIT_SERVER_HELLO.milliseconds.toInt()
+  }
+
+  override fun read(bytes: ByteArray, offset: Int, length: Int): Int =
+      socket.getInputStream().read(bytes, offset, length)
+
+  override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+    socket.getOutputStream().write(bytes, offset, length)
+    return length
+  }
+
+  override fun shutdownOutput() {
+    if (!socket.isOutputShutdown) socket.shutdownOutput()
+  }
+
+  override fun close() {
+    socket.close()
+  }
+}
+
+fun interface V9DeadlineScheduler {
+  fun schedule(deadlineMillis: Long, action: Runnable): Closeable
+}
+
+class V9SystemDeadlineScheduler(
+    private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
+) : V9DeadlineScheduler, Closeable {
+  private val executor =
+      ScheduledThreadPoolExecutor(1) { task ->
+        Thread(task, "netplay-v9-deadline").also { it.isDaemon = true }
+      }.also { it.removeOnCancelPolicy = true }
+
+  override fun schedule(deadlineMillis: Long, action: Runnable): Closeable {
+    val now = clock.nowMillis()
+    val delay =
+        if (deadlineMillis <= now) {
+          0
+        } else {
+          try {
+            Math.subtractExact(deadlineMillis, now)
+          } catch (_: ArithmeticException) {
+            Long.MAX_VALUE
+          }
+        }
+    val future = executor.schedule(action, delay, TimeUnit.MILLISECONDS)
+    return Closeable { future.cancel(false) }
+  }
+
+  override fun close() {
+    executor.shutdownNow()
+  }
+}
+
+internal class V9WriterQueue {
+  private val queue =
+      ArrayBlockingQueue<QueuedWrite>(V9Limit.QUEUED_FRAMES.value.toInt())
+  private var wireBytes = 0L
+  private var closed = false
+
+  @Synchronized
+  fun offer(value: ByteArray, onWritten: () -> Unit): Boolean {
+    if (closed) return false
+    if (queue.remainingCapacity() == 0) return false
+    val next = try {
+      Math.addExact(wireBytes, value.size.toLong())
+    } catch (_: ArithmeticException) {
+      return false
+    }
+    if (next > V9Limit.QUEUED_WIRE_BYTES.value) return false
+    val owned = value.copyOf()
+    if (!queue.offer(QueuedWrite(owned, onWritten))) return false
+    wireBytes = next
+    return true
+  }
+
+  fun poll(timeoutMillis: Long): QueuedWrite? =
+      queue.poll(timeoutMillis, TimeUnit.MILLISECONDS)
+
+  @Synchronized
+  fun completed(value: QueuedWrite) {
+    if (closed) return
+    wireBytes = Math.subtractExact(wireBytes, value.bytes.size.toLong())
+  }
+
+  @Synchronized
+  fun close() {
+    closed = true
+    queue.clear()
+    wireBytes = 0
+  }
+
+  @Synchronized
+  fun snapshot(): V9QueueSnapshot = V9QueueSnapshot(queue.size.toLong(), wireBytes, 0)
+
+  data class QueuedWrite(val bytes: ByteArray, val onWritten: () -> Unit)
+}
+
+/**
+ * Opt-in protocol-v9 transport foundation.
+ *
+ * This owner performs only the server-first HELLO exchange. It stops at the role-specific
+ * `WAIT_AUTH`/`SEND_AUTH` state (public phase `AWAITING_PAIRING`); no invitation, manifest,
+ * consent, private payload, checkpoint, or gameplay message can be queued or delivered.
+ */
+class V9FoundationConnection(
+    private val channel: V9TransportChannel,
+    val role: V9Role,
+    private val mode: V9LinkMode = V9LinkMode.NORMAL,
+    nonce: ByteArray = randomNonce(),
+    optionalCapabilities: Set<V9Capability> = emptySet(),
+    private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
+    private val scheduler: V9DeadlineScheduler = V9SystemDeadlineScheduler(clock),
+) : Closeable, V9LifecycleSource {
+  private val ownedScheduler = scheduler as? V9SystemDeadlineScheduler
+  private val lifecycle = V9Lifecycle(role, clock)
+  private val localHello = V9HelloCodec.create(role, nonce, optionalCapabilities)
+  private val decoder =
+      V9IncrementalDecoder(
+          policy =
+              V9DecoderPolicy(
+                  allowedMessages = setOf(V9MessageType.HELLO, V9MessageType.ERROR),
+                  negotiatedCapabilities = V9Capability.entries.toSet(),
+                  linkMode = mode,
+              ),
+      )
+  private val writer = V9WriterQueue()
+  private val closed = AtomicBoolean(false)
+  private val started = AtomicBoolean(false)
+  private val boundary = CountDownLatch(1)
+  private val tasks = mutableListOf<Thread>()
+  private val taskLock = Any()
+  private val wireStateLock = Any()
+  private var timeoutTask: Closeable? = null
+  private var negotiated: V9NegotiatedCapabilities? = null
+  private var nextOutgoingSequence = 0L
+
+  init {
+    lifecycle.addListener { state ->
+      scheduleDeadline(state)
+      if (state.phase == V9LifecyclePhase.AWAITING_PAIRING ||
+          state.phase == V9LifecyclePhase.CLOSED) {
+        boundary.countDown()
+      }
+    }
+  }
+
+  override fun snapshot(): V9LifecycleSnapshot = lifecycle.snapshot()
+
+  override fun addListener(listener: V9LifecycleListener): Closeable =
+      lifecycle.addListener(listener)
+
+  fun start() {
+    check(started.compareAndSet(false, true)) { "v9 foundation already started" }
+    startTask("netplay-v9-writer", ::writeLoop)
+    if (role == V9Role.SERVER) {
+      // The server-first contract does not admit a peer byte until the complete HELLO is written.
+      enqueueHello {
+        lifecycle.serverHelloSent()
+        startTask("netplay-v9-reader", ::readLoop)
+      }
+    } else {
+      startTask("netplay-v9-reader", ::readLoop)
+    }
+  }
+
+  fun awaitPairingBoundary(timeout: Long, unit: TimeUnit): V9LifecycleSnapshot {
+    boundary.await(timeout, unit)
+    return snapshot()
+  }
+
+  fun negotiatedCapabilities(): Set<V9Capability> =
+      negotiated?.capabilities?.toSet() ?: emptySet()
+
+  fun writerQueueSnapshot(): V9QueueSnapshot = writer.snapshot()
+
+  /** Phase #347 deliberately refuses all post-HELLO traffic. */
+  fun sendUnavailable(type: V9MessageType): Nothing {
+    require(type != V9MessageType.HELLO && type != V9MessageType.ERROR)
+    throw V9ProtocolException(V9ErrorCode.UNEXPECTED_MESSAGE, 0)
+  }
+
+  fun cancel() {
+    if (!closed.get()) lifecycle.cancel()
+    closeResources()
+  }
+
+  override fun close() {
+    if (!closed.get()) lifecycle.closeNormally()
+    closeResources()
+  }
+
+  private fun enqueueHello(onWritten: () -> Unit) {
+    val payload = V9HelloCodec.encode(localHello)
+    val sequence = synchronized(wireStateLock) { nextOutgoingSequence }
+    val encoded =
+        try {
+          V9FrameEncoder.encode(
+              V9OutboundFrame(
+                  V9MessageType.HELLO,
+                  0,
+                  sequence,
+                  0,
+                  ProtocolV9.CONTROL_CHANNEL,
+                  payload,
+              ),
+              V9DecoderPolicy(
+                  allowedMessages = setOf(V9MessageType.HELLO),
+                  negotiatedCapabilities = V9Capability.entries.toSet(),
+                  linkMode = mode,
+              ),
+          )
+        } catch (e: V9ProtocolException) {
+          fail(e.reason, V9Diagnostic.HELLO_REJECTED)
+          return
+        }
+    if (!writer.offer(encoded) {
+          advanceOutgoingSequence()
+          onWritten()
+        }) {
+      fail(V9ErrorCode.QUEUE_OVERFLOW, V9Diagnostic.QUEUE_FULL)
+    }
+  }
+
+  private fun readLoop() {
+    val bytes = ByteArray(8_192)
+    try {
+      while (!closed.get()) {
+        val count = channel.read(bytes, 0, bytes.size)
+        if (count < 0) {
+          val result = decoder.finish()
+          val reason = result.failure?.reason ?: V9ErrorCode.UNEXPECTED_EOF
+          fail(reason, V9Diagnostic.IO_FAILURE)
+          return
+        }
+        if (count == 0) continue
+        val result = decoder.feed(bytes, 0, count)
+        result.frames.forEach { frame ->
+          frame.use(::handleFrame)
+        }
+        result.failure?.let {
+          reject(it.reason, diagnosticFor(it.reason))
+          return
+        }
+      }
+    } catch (e: V9ProtocolException) {
+      reject(e.reason, diagnosticFor(e.reason))
+    } catch (_: SocketTimeoutException) {
+      fail(V9ErrorCode.TIMEOUT, V9Diagnostic.TIMEOUT)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      if (!closed.get()) fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+    } catch (_: IOException) {
+      if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
+    } catch (_: RuntimeException) {
+      if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
+    }
+  }
+
+  private fun writeLoop() {
+    try {
+      while (!closed.get()) {
+        val value = writer.poll(50) ?: continue
+        synchronized(wireStateLock) {
+          writeFully(value.bytes)
+          writer.completed(value)
+          if (!closed.get()) value.onWritten()
+        }
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      if (!closed.get()) fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+    } catch (_: IOException) {
+      if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
+    } catch (_: RuntimeException) {
+      if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
+    }
+  }
+
+  private fun handleFrame(frame: V9Frame) {
+    synchronized(wireStateLock) {
+      when (frame.header.type) {
+        V9MessageType.HELLO -> handleHello(V9HelloCodec.decode(frame.payloadView()))
+        V9MessageType.ERROR -> {
+          val remote = V9ErrorPayloadCodec.decode(frame.payloadView())
+          fail(remote.error, diagnosticFor(remote.error))
+        }
+        else -> reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+      }
+    }
+  }
+
+  private fun handleHello(remote: V9Hello) {
+    try {
+      when (role) {
+        V9Role.CLIENT -> {
+          if (snapshot().state != V9LifecycleState.WAIT_SERVER_HELLO) {
+            return fail(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+          }
+          val result = V9HelloCodec.negotiate(localHello, remote, V9Role.SERVER, mode)
+          negotiated = result
+          lifecycle.serverHelloReceived()
+          enqueueHello { lifecycle.clientHelloSent(result) }
+        }
+        V9Role.SERVER -> {
+          if (snapshot().state != V9LifecycleState.WAIT_CLIENT_HELLO) {
+            return fail(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+          }
+          val result = V9HelloCodec.negotiate(localHello, remote, V9Role.CLIENT, mode)
+          negotiated = result
+          lifecycle.clientHelloReceived(result)
+        }
+      }
+    } catch (e: V9ProtocolException) {
+      reject(e.reason, V9Diagnostic.CAPABILITY_MISMATCH)
+    }
+  }
+
+  private fun reject(reason: V9ErrorCode, diagnostic: V9Diagnostic) {
+    if (reason.peerVisible &&
+        reason != V9ErrorCode.UNSUPPORTED_PROTOCOL &&
+        !closed.get()) {
+      try {
+        sendProtocolError(reason)
+      } catch (_: IOException) {
+        // Local state remains a typed rejection; raw I/O details are never exposed.
+      } catch (_: V9ProtocolException) {
+        // An exhausted direction cannot emit another frame and closes below.
+      }
+    }
+    fail(reason, diagnostic)
+  }
+
+  @Throws(IOException::class, V9ProtocolException::class)
+  private fun sendProtocolError(reason: V9ErrorCode) {
+    synchronized(wireStateLock) {
+      if (closed.get() || nextOutgoingSequence > ProtocolV9.LAST_SEQUENCE) return
+      val bytes =
+          V9FrameEncoder.encode(
+              V9OutboundFrame(
+                  V9MessageType.ERROR,
+                  V9Flag.TERMINAL.wireMask,
+                  nextOutgoingSequence,
+                  0,
+                  ProtocolV9.CONTROL_CHANNEL,
+                  V9ErrorPayloadCodec.encode(reason),
+              ),
+          )
+      writeFully(bytes)
+      advanceOutgoingSequence()
+      channel.shutdownOutput()
+    }
+  }
+
+  @Throws(IOException::class)
+  private fun writeFully(bytes: ByteArray) {
+    var offset = 0
+    while (offset < bytes.size && !closed.get()) {
+      val count = channel.write(bytes, offset, bytes.size - offset)
+      if (count <= 0) throw IOException("v9 writer made no progress")
+      offset = Math.addExact(offset, count)
+    }
+    if (offset != bytes.size) throw IOException("v9 writer closed")
+  }
+
+  private fun advanceOutgoingSequence() {
+    nextOutgoingSequence =
+        if (nextOutgoingSequence == ProtocolV9.LAST_SEQUENCE) {
+          ProtocolV9.EXHAUSTED_SEQUENCE
+        } else {
+          Math.addExact(nextOutgoingSequence, 1)
+        }
+  }
+
+  private fun startTask(name: String, block: () -> Unit) {
+    val task = thread(start = false, isDaemon = true, name = name, block = block)
+    synchronized(taskLock) { tasks += task }
+    task.start()
+  }
+
+  private fun scheduleDeadline(state: V9LifecycleSnapshot) {
+    synchronized(taskLock) {
+      timeoutTask?.close()
+      timeoutTask = null
+      val deadline = state.deadlineMillis ?: return
+      timeoutTask =
+          scheduler.schedule(deadline) {
+            val current = lifecycle.snapshot()
+            if (!closed.get() &&
+                current.state == state.state &&
+                current.deadlineMillis == deadline &&
+                clock.nowMillis() >= deadline) {
+              lifecycle.checkDeadline()
+              closeResources()
+            }
+          }
+    }
+  }
+
+  private fun fail(reason: V9ErrorCode, diagnostic: V9Diagnostic) {
+    if (!closed.get()) lifecycle.fail(reason, diagnostic)
+    closeResources()
+  }
+
+  private fun closeResources() {
+    if (!closed.compareAndSet(false, true)) return
+    synchronized(taskLock) {
+      timeoutTask?.close()
+      timeoutTask = null
+    }
+    writer.close()
+    try {
+      channel.close()
+    } catch (_: IOException) {
+      // The typed lifecycle state already reports the local failure without leaking I/O text.
+    }
+    synchronized(taskLock) {
+      tasks.filter { it !== Thread.currentThread() }.forEach(Thread::interrupt)
+    }
+    ownedScheduler?.close()
+    boundary.countDown()
+  }
+
+  private fun diagnosticFor(reason: V9ErrorCode): V9Diagnostic = when (reason) {
+    V9ErrorCode.UNSUPPORTED_PROTOCOL -> V9Diagnostic.PROTOCOL_MISMATCH
+    V9ErrorCode.CAPABILITY_MISMATCH,
+    V9ErrorCode.UNKNOWN_REQUIRED_CAPABILITY -> V9Diagnostic.CAPABILITY_MISMATCH
+    V9ErrorCode.TIMEOUT -> V9Diagnostic.TIMEOUT
+    V9ErrorCode.CANCELLED -> V9Diagnostic.CANCELLED
+    V9ErrorCode.QUEUE_OVERFLOW -> V9Diagnostic.QUEUE_FULL
+    else -> V9Diagnostic.HELLO_REJECTED
+  }
+
+  companion object {
+    private fun randomNonce(): ByteArray = ByteArray(32).also(SecureRandom()::nextBytes)
+  }
+}
+
+/**
+ * Opt-in listener used only by foundation diagnostics/tests until #348 supplies pairing.
+ * It is intentionally not reachable from [eu.rekawek.coffeegb.controller.network.ConnectionController].
+ */
+class V9FoundationServer(
+    private val port: Int = 0,
+    private val mode: V9LinkMode = V9LinkMode.NORMAL,
+    private val optionalCapabilities: Set<V9Capability> = emptySet(),
+    private val onAwaitingPairing: (V9FoundationConnection) -> Unit,
+) : Closeable {
+  private val stopped = AtomicBoolean(false)
+  private val connections = ConcurrentHashMap.newKeySet<V9FoundationConnection>()
+  private val pending = ConcurrentHashMap.newKeySet<Socket>()
+  private val workers =
+      ThreadPoolExecutor(
+          V9Limit.HANDSHAKE_WORKERS.value.toInt(),
+          V9Limit.HANDSHAKE_WORKERS.value.toInt(),
+          0,
+          TimeUnit.MILLISECONDS,
+          ArrayBlockingQueue(V9Limit.PENDING_HANDSHAKES.value.toInt()),
+          { task -> Thread(task, "netplay-v9-handshake").also { it.isDaemon = true } },
+      )
+  private var listener: ServerSocket? = null
+  private var acceptThread: Thread? = null
+
+  val localPort: Int get() = listener?.localPort ?: 0
+
+  fun start() {
+    check(listener == null) { "v9 foundation listener already started" }
+    listener = ServerSocket(port).also { it.soTimeout = 100 }
+    acceptThread =
+        thread(isDaemon = true, name = "netplay-v9-accept") {
+          acceptLoop(requireNotNull(listener))
+        }
+  }
+
+  override fun close() {
+    if (!stopped.compareAndSet(false, true)) return
+    try {
+      listener?.close()
+    } catch (_: IOException) {
+      // Best-effort listener shutdown.
+    }
+    pending.forEach {
+      try {
+        it.close()
+      } catch (_: IOException) {
+        // Best-effort candidate shutdown.
+      }
+    }
+    connections.forEach(V9FoundationConnection::close)
+    workers.shutdownNow()
+    acceptThread?.interrupt()
+  }
+
+  private fun acceptLoop(server: ServerSocket) {
+    while (!stopped.get()) {
+      try {
+        val socket = server.accept()
+        if (pending.size >= V9Limit.PENDING_HANDSHAKES.value) {
+          socket.close()
+          continue
+        }
+        pending += socket
+        try {
+          workers.execute { negotiate(socket) }
+        } catch (_: RejectedExecutionException) {
+          pending.remove(socket)
+          socket.close()
+        }
+      } catch (_: SocketTimeoutException) {
+        // Poll stop.
+      } catch (_: SocketException) {
+        if (!stopped.get()) continue
+      } catch (_: IOException) {
+        if (!stopped.get()) continue
+      }
+    }
+  }
+
+  private fun negotiate(socket: Socket) {
+    var connection: V9FoundationConnection? = null
+    try {
+      socket.tcpNoDelay = true
+      socket.keepAlive = true
+      socket.soTimeout = V9Timeout.WAIT_CLIENT_HELLO.milliseconds.toInt()
+      connection =
+          V9FoundationConnection(
+              V9SocketChannel(socket),
+              V9Role.SERVER,
+              mode,
+              optionalCapabilities = optionalCapabilities,
+          )
+      connections += connection
+      connection.start()
+      val state =
+          connection.awaitPairingBoundary(
+              V9Timeout.WAIT_CLIENT_HELLO.milliseconds + 1_000,
+              TimeUnit.MILLISECONDS,
+          )
+      if (state.phase == V9LifecyclePhase.AWAITING_PAIRING) {
+        onAwaitingPairing(connection)
+      } else {
+        connection.close()
+        connections.remove(connection)
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      connection?.close()
+      connection?.let(connections::remove)
+      try {
+        socket.close()
+      } catch (_: IOException) {
+        // Server shutdown owns this candidate and remains best effort.
+      }
+    } catch (_: IOException) {
+      connection?.close()
+      connection?.let(connections::remove)
+      try {
+        socket.close()
+      } catch (_: IOException) {
+        // Candidate isolation is more important than reporting remote details.
+      }
+    } finally {
+      pending.remove(socket)
+    }
+  }
+}
+
+object V9FoundationClient {
+  fun connect(
+      address: InetSocketAddress,
+      mode: V9LinkMode = V9LinkMode.NORMAL,
+      optionalCapabilities: Set<V9Capability> = emptySet(),
+      connectTimeoutMillis: Int = V9Timeout.WAIT_SERVER_HELLO.milliseconds.toInt(),
+  ): V9FoundationConnection {
+    val channel = V9SocketChannel(Socket())
+    try {
+      channel.connect(address, connectTimeoutMillis)
+      return V9FoundationConnection(
+          channel,
+          V9Role.CLIENT,
+          mode,
+          optionalCapabilities = optionalCapabilities,
+      ).also(V9FoundationConnection::start)
+    } catch (e: IOException) {
+      try {
+        channel.close()
+      } catch (_: IOException) {
+        // Keep the original connect failure.
+      }
+      throw e
+    }
+  }
+}
+
+/**
+ * Cancellable connect owner for callers that must never block the emulator thread or EDT.
+ * The attempt owns the pending channel until it hands a started connection to the callback.
+ */
+class V9FoundationConnectAttempt(
+    private val channelFactory: () -> V9ConnectableChannel =
+        { V9SocketChannel(Socket()) },
+) : Closeable {
+  private val cancelled = AtomicBoolean(false)
+  private val completed = AtomicBoolean(false)
+  @Volatile private var pending: V9ConnectableChannel? = null
+  @Volatile private var connection: V9FoundationConnection? = null
+  @Volatile private var task: Thread? = null
+
+  fun start(
+      address: InetSocketAddress,
+      mode: V9LinkMode = V9LinkMode.NORMAL,
+      optionalCapabilities: Set<V9Capability> = emptySet(),
+      onComplete: (V9FoundationConnection?, V9ErrorCode?) -> Unit,
+  ) {
+    check(task == null) { "v9 connect attempt already started" }
+    task =
+        thread(isDaemon = true, name = "netplay-v9-connect") {
+          val channel = channelFactory()
+          pending = channel
+          try {
+            if (cancelled.get()) throw IOException("cancelled")
+            channel.connect(address, V9Timeout.WAIT_SERVER_HELLO.milliseconds.toInt())
+            if (cancelled.get()) throw IOException("cancelled")
+            val value =
+                V9FoundationConnection(
+                    channel,
+                    V9Role.CLIENT,
+                    mode,
+                    optionalCapabilities = optionalCapabilities,
+                )
+            connection = value
+            pending = null
+            value.start()
+            completed.set(true)
+            onComplete(value, null)
+          } catch (_: IOException) {
+            try {
+              channel.close()
+            } catch (_: IOException) {
+              // The stable result below deliberately does not expose raw socket text.
+            }
+            completed.set(true)
+            onComplete(
+                null,
+                if (cancelled.get()) V9ErrorCode.CANCELLED else V9ErrorCode.INTERNAL_ERROR,
+            )
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            try {
+              channel.close()
+            } catch (_: IOException) {
+              // Cancellation remains typed and sanitized.
+            }
+            completed.set(true)
+            onComplete(null, V9ErrorCode.CANCELLED)
+          }
+        }
+  }
+
+  fun isComplete(): Boolean = completed.get()
+
+  fun cancel() {
+    cancelled.set(true)
+    try {
+      pending?.close()
+    } catch (_: IOException) {
+      // Cancellation remains typed and sanitized.
+    }
+    connection?.cancel()
+    task?.interrupt()
+  }
+
+  override fun close() {
+    cancel()
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
@@ -583,8 +583,9 @@ class V9FoundationServer(
   private val stopped = AtomicBoolean(false)
   private val startStopLock = Any()
   private val callbackLock = Any()
+  private val candidateLock = Any()
   private val connections = ConcurrentHashMap.newKeySet<V9FoundationConnection>()
-  private val pending = ConcurrentHashMap.newKeySet<Socket>()
+  private val pending = ConcurrentHashMap.newKeySet<V9PendingCandidate>()
   private val workers =
       ThreadPoolExecutor(
           V9Limit.HANDSHAKE_WORKERS.value.toInt(),
@@ -609,11 +610,17 @@ class V9FoundationServer(
         )
       }
 
+  internal var candidateHooks = V9ServerCandidateHooks()
+
   val localPort: Int get() = listener?.localPort ?: 0
 
   internal fun activeConnectionCount(): Int = connections.size
 
   internal fun pendingCandidateCount(): Int = pending.size
+
+  internal fun acceptThreadAlive(): Boolean = acceptThread?.isAlive == true
+
+  internal fun workerPoolTerminated(): Boolean = workers.isTerminated
 
   fun start() {
     synchronized(startStopLock) {
@@ -630,7 +637,9 @@ class V9FoundationServer(
   override fun close() {
     synchronized(callbackLock) {
       synchronized(startStopLock) {
-        if (!stopped.compareAndSet(false, true)) return
+        synchronized(candidateLock) {
+          if (!stopped.compareAndSet(false, true)) return
+        }
       }
     }
     try {
@@ -638,15 +647,10 @@ class V9FoundationServer(
     } catch (_: IOException) {
       // Best-effort listener shutdown.
     }
-    pending.forEach {
-      try {
-        it.close()
-      } catch (_: IOException) {
-        // Best-effort candidate shutdown.
-      }
-    }
-    connections.forEach(V9FoundationConnection::close)
-    workers.shutdownNow()
+    val neverStarted = workers.shutdownNow()
+    neverStarted.filterIsInstance<V9PendingCandidate>().forEach(V9PendingCandidate::close)
+    pending.toList().forEach(V9PendingCandidate::close)
+    connections.toList().forEach(V9FoundationConnection::close)
     acceptThread?.interrupt()
   }
 
@@ -654,16 +658,15 @@ class V9FoundationServer(
     while (!stopped.get()) {
       try {
         val socket = server.accept()
-        if (pending.size >= V9Limit.PENDING_HANDSHAKES.value) {
-          socket.close()
-          continue
-        }
-        pending += socket
+        val candidate = V9PendingCandidate(socket)
         try {
-          workers.execute { negotiate(socket) }
-        } catch (_: RejectedExecutionException) {
-          pending.remove(socket)
-          socket.close()
+          candidateHooks.afterAcceptBeforeAdmission(socket)
+          admit(candidate)
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          candidate.close()
+        } catch (_: RuntimeException) {
+          candidate.close()
         }
       } catch (_: SocketTimeoutException) {
         // Poll stop.
@@ -671,6 +674,22 @@ class V9FoundationServer(
         if (!stopped.get()) continue
       } catch (_: IOException) {
         if (!stopped.get()) continue
+      }
+    }
+  }
+
+  private fun admit(candidate: V9PendingCandidate) {
+    synchronized(candidateLock) {
+      if (stopped.get() ||
+          pending.size >= V9Limit.PENDING_HANDSHAKES.value) {
+        candidate.close()
+        return
+      }
+      pending += candidate
+      try {
+        workers.execute(candidate)
+      } catch (_: RejectedExecutionException) {
+        candidate.close()
       }
     }
   }
@@ -733,11 +752,48 @@ class V9FoundationServer(
       } catch (_: IOException) {
         // Candidate construction/start/callback failures remain isolated to this socket.
       }
-    } finally {
-      pending.remove(socket)
+    }
+  }
+
+  private inner class V9PendingCandidate(
+      private val socket: Socket,
+  ) : Runnable, Closeable {
+    private val candidateClosed = AtomicBoolean(false)
+
+    override fun run() {
+      try {
+        candidateHooks.beforeWorkerNegotiation(socket)
+        if (stopped.get()) {
+          close()
+          return
+        }
+        negotiate(socket)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        close()
+      } catch (_: RuntimeException) {
+        close()
+      } finally {
+        pending.remove(this)
+      }
+    }
+
+    override fun close() {
+      pending.remove(this)
+      if (!candidateClosed.compareAndSet(false, true)) return
+      try {
+        socket.close()
+      } catch (_: IOException) {
+        // Candidate cleanup remains best effort and never affects another accept.
+      }
     }
   }
 }
+
+internal class V9ServerCandidateHooks(
+    var afterAcceptBeforeAdmission: (Socket) -> Unit = {},
+    var beforeWorkerNegotiation: (Socket) -> Unit = {},
+)
 
 object V9FoundationClient {
   fun connect(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
@@ -150,9 +150,10 @@ class V9FoundationConnection(
     nonce: ByteArray = randomNonce(),
     optionalCapabilities: Set<V9Capability> = emptySet(),
     private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
-    private val scheduler: V9DeadlineScheduler = V9SystemDeadlineScheduler(clock),
+    scheduler: V9DeadlineScheduler? = null,
 ) : Closeable, V9LifecycleSource {
-  private val ownedScheduler = scheduler as? V9SystemDeadlineScheduler
+  private val scheduler = scheduler ?: V9SystemDeadlineScheduler(clock)
+  private val ownedScheduler = if (scheduler == null) this.scheduler as Closeable else null
   private val lifecycle = V9Lifecycle(role, clock)
   private val localHello = V9HelloCodec.create(role, nonce, optionalCapabilities)
   private val decoder =
@@ -165,13 +166,18 @@ class V9FoundationConnection(
               ),
       )
   private val writer = V9WriterQueue()
+  private val responseLedger = V9ResponseLedger()
   private val closed = AtomicBoolean(false)
   private val started = AtomicBoolean(false)
   private val boundary = CountDownLatch(1)
   private val tasks = mutableListOf<Thread>()
   private val taskLock = Any()
+  private val ownershipLock = Any()
+  private val closeListenerLock = Any()
+  private val closeListeners = mutableListOf<() -> Unit>()
   private val wireStateLock = Any()
   private var timeoutTask: Closeable? = null
+  private var writerTask: Thread? = null
   private var negotiated: V9NegotiatedCapabilities? = null
   private var nextOutgoingSequence = 0L
 
@@ -191,16 +197,19 @@ class V9FoundationConnection(
       lifecycle.addListener(listener)
 
   fun start() {
-    check(started.compareAndSet(false, true)) { "v9 foundation already started" }
-    startTask("netplay-v9-writer", ::writeLoop)
-    if (role == V9Role.SERVER) {
-      // The server-first contract does not admit a peer byte until the complete HELLO is written.
-      enqueueHello {
-        lifecycle.serverHelloSent()
+    synchronized(ownershipLock) {
+      check(!closed.get()) { "v9 foundation is closed" }
+      check(started.compareAndSet(false, true)) { "v9 foundation already started" }
+      writerTask = startTask("netplay-v9-writer", ::writeLoop)
+      if (role == V9Role.SERVER) {
+        // The server-first contract does not admit a peer byte until the complete HELLO is written.
+        enqueueHello {
+          lifecycle.serverHelloSent()
+          startTask("netplay-v9-reader", ::readLoop)
+        }
+      } else {
         startTask("netplay-v9-reader", ::readLoop)
       }
-    } else {
-      startTask("netplay-v9-reader", ::readLoop)
     }
   }
 
@@ -214,6 +223,21 @@ class V9FoundationConnection(
 
   fun writerQueueSnapshot(): V9QueueSnapshot = writer.snapshot()
 
+  internal fun isClosed(): Boolean = closed.get()
+
+  internal fun activeTaskCount(): Int = synchronized(taskLock) { tasks.count(Thread::isAlive) }
+
+  internal fun addCloseListener(listener: () -> Unit): Closeable {
+    var invokeNow = false
+    synchronized(closeListenerLock) {
+      if (closed.get()) invokeNow = true else closeListeners += listener
+    }
+    if (invokeNow) listener()
+    return Closeable {
+      synchronized(closeListenerLock) { closeListeners.remove(listener) }
+    }
+  }
+
   /** Phase #347 deliberately refuses all post-HELLO traffic. */
   fun sendUnavailable(type: V9MessageType): Nothing {
     require(type != V9MessageType.HELLO && type != V9MessageType.ERROR)
@@ -221,13 +245,17 @@ class V9FoundationConnection(
   }
 
   fun cancel() {
-    if (!closed.get()) lifecycle.cancel()
-    closeResources()
+    synchronized(ownershipLock) {
+      if (!closed.get()) lifecycle.cancel()
+      closeResourcesLocked()
+    }
   }
 
   override fun close() {
-    if (!closed.get()) lifecycle.closeNormally()
-    closeResources()
+    synchronized(ownershipLock) {
+      if (!closed.get()) lifecycle.closeNormally()
+      closeResourcesLocked()
+    }
   }
 
   private fun enqueueHello(onWritten: () -> Unit) {
@@ -268,19 +296,32 @@ class V9FoundationConnection(
       while (!closed.get()) {
         val count = channel.read(bytes, 0, bytes.size)
         if (count < 0) {
+          if (snapshot().state == V9LifecycleState.TERMINAL_CLEANUP) {
+            lifecycle.completeTerminalCleanup()
+            closeResources()
+            return
+          }
           val result = decoder.finish()
           val reason = result.failure?.reason ?: V9ErrorCode.UNEXPECTED_EOF
           fail(reason, V9Diagnostic.IO_FAILURE)
           return
         }
         if (count == 0) continue
+        if (snapshot().state == V9LifecycleState.TERMINAL_CLEANUP) {
+          // Output is half-closed. Peer bytes are drained only to observe EOF; no frame is admitted.
+          continue
+        }
         val result = decoder.feed(bytes, 0, count)
         result.frames.forEach { frame ->
-          frame.use(::handleFrame)
+          frame.use {
+            if (!closed.get() &&
+                snapshot().state != V9LifecycleState.TERMINAL_CLEANUP) {
+              handleFrame(frame)
+            }
+          }
         }
         result.failure?.let {
           reject(it.reason, diagnosticFor(it.reason))
-          return
         }
       }
     } catch (e: V9ProtocolException) {
@@ -289,7 +330,10 @@ class V9FoundationConnection(
       fail(V9ErrorCode.TIMEOUT, V9Diagnostic.TIMEOUT)
     } catch (_: InterruptedException) {
       Thread.currentThread().interrupt()
-      if (!closed.get()) fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+      if (!closed.get() &&
+          snapshot().state != V9LifecycleState.TERMINAL_CLEANUP) {
+        fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+      }
     } catch (_: IOException) {
       if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
     } catch (_: RuntimeException) {
@@ -309,7 +353,10 @@ class V9FoundationConnection(
       }
     } catch (_: InterruptedException) {
       Thread.currentThread().interrupt()
-      if (!closed.get()) fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+      if (!closed.get() &&
+          snapshot().state != V9LifecycleState.TERMINAL_CLEANUP) {
+        fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+      }
     } catch (_: IOException) {
       if (!closed.get()) fail(V9ErrorCode.INTERNAL_ERROR, V9Diagnostic.IO_FAILURE)
     } catch (_: RuntimeException) {
@@ -319,10 +366,30 @@ class V9FoundationConnection(
 
   private fun handleFrame(frame: V9Frame) {
     synchronized(wireStateLock) {
-      when (frame.header.type) {
+      val type = frame.header.type
+          ?: return reject(V9ErrorCode.UNKNOWN_REQUIRED_TYPE, V9Diagnostic.HELLO_REJECTED)
+      responseLedger.accept(
+              frame.header.sequence,
+              type,
+              frame.header.flags,
+              frame.header.correlation,
+          )
+          ?.let {
+            reject(it, V9Diagnostic.HELLO_REJECTED)
+            return
+          }
+      when (type) {
         V9MessageType.HELLO -> handleHello(V9HelloCodec.decode(frame.payloadView()))
         V9MessageType.ERROR -> {
           val remote = V9ErrorPayloadCodec.decode(frame.payloadView())
+          if (role == V9Role.CLIENT &&
+              snapshot().state == V9LifecycleState.WAIT_SERVER_HELLO &&
+              (frame.header.flags != V9Flag.TERMINAL.wireMask ||
+                  frame.header.sequence != 0L ||
+                  remote.error !in setOf(V9ErrorCode.SERVER_BUSY, V9ErrorCode.SERVER_FULL))) {
+            reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+            return
+          }
           fail(remote.error, diagnosticFor(remote.error))
         }
         else -> reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
@@ -357,6 +424,10 @@ class V9FoundationConnection(
   }
 
   private fun reject(reason: V9ErrorCode, diagnostic: V9Diagnostic) {
+    if (closed.get() || snapshot().state == V9LifecycleState.TERMINAL_CLEANUP) return
+    writer.close()
+    writerTask?.takeUnless { it === Thread.currentThread() }?.interrupt()
+    lifecycle.beginTerminalCleanup(reason, diagnostic)
     if (reason.peerVisible &&
         reason != V9ErrorCode.UNSUPPORTED_PROTOCOL &&
         !closed.get()) {
@@ -364,11 +435,17 @@ class V9FoundationConnection(
         sendProtocolError(reason)
       } catch (_: IOException) {
         // Local state remains a typed rejection; raw I/O details are never exposed.
+        lifecycle.completeTerminalCleanup()
+        closeResources()
       } catch (_: V9ProtocolException) {
         // An exhausted direction cannot emit another frame and closes below.
+        lifecycle.completeTerminalCleanup()
+        closeResources()
       }
+    } else {
+      lifecycle.completeTerminalCleanup()
+      closeResources()
     }
-    fail(reason, diagnostic)
   }
 
   @Throws(IOException::class, V9ProtocolException::class)
@@ -412,10 +489,12 @@ class V9FoundationConnection(
         }
   }
 
-  private fun startTask(name: String, block: () -> Unit) {
+  private fun startTask(name: String, block: () -> Unit): Thread {
+    check(!closed.get()) { "v9 foundation is closed" }
     val task = thread(start = false, isDaemon = true, name = name, block = block)
     synchronized(taskLock) { tasks += task }
     task.start()
+    return task
   }
 
   private fun scheduleDeadline(state: V9LifecycleSnapshot) {
@@ -443,6 +522,10 @@ class V9FoundationConnection(
   }
 
   private fun closeResources() {
+    synchronized(ownershipLock) { closeResourcesLocked() }
+  }
+
+  private fun closeResourcesLocked() {
     if (!closed.compareAndSet(false, true)) return
     synchronized(taskLock) {
       timeoutTask?.close()
@@ -459,6 +542,17 @@ class V9FoundationConnection(
     }
     ownedScheduler?.close()
     boundary.countDown()
+    val listeners =
+        synchronized(closeListenerLock) {
+          closeListeners.toList().also { closeListeners.clear() }
+        }
+    listeners.forEach {
+      try {
+        it()
+      } catch (_: RuntimeException) {
+        // Resource release is final even when an observer is faulty.
+      }
+    }
   }
 
   private fun diagnosticFor(reason: V9ErrorCode): V9Diagnostic = when (reason) {
@@ -487,6 +581,8 @@ class V9FoundationServer(
     private val onAwaitingPairing: (V9FoundationConnection) -> Unit,
 ) : Closeable {
   private val stopped = AtomicBoolean(false)
+  private val startStopLock = Any()
+  private val callbackLock = Any()
   private val connections = ConcurrentHashMap.newKeySet<V9FoundationConnection>()
   private val pending = ConcurrentHashMap.newKeySet<Socket>()
   private val workers =
@@ -501,19 +597,42 @@ class V9FoundationServer(
   private var listener: ServerSocket? = null
   private var acceptThread: Thread? = null
 
+  internal var connectionFactory:
+      (V9TransportChannel, V9Role, V9LinkMode, Set<V9Capability>) ->
+          V9FoundationConnection =
+      { channel, role, linkMode, capabilities ->
+        V9FoundationConnection(
+            channel,
+            role,
+            linkMode,
+            optionalCapabilities = capabilities,
+        )
+      }
+
   val localPort: Int get() = listener?.localPort ?: 0
 
+  internal fun activeConnectionCount(): Int = connections.size
+
+  internal fun pendingCandidateCount(): Int = pending.size
+
   fun start() {
-    check(listener == null) { "v9 foundation listener already started" }
-    listener = ServerSocket(port).also { it.soTimeout = 100 }
-    acceptThread =
-        thread(isDaemon = true, name = "netplay-v9-accept") {
-          acceptLoop(requireNotNull(listener))
-        }
+    synchronized(startStopLock) {
+      check(!stopped.get()) { "v9 foundation listener is closed" }
+      check(listener == null) { "v9 foundation listener already started" }
+      listener = ServerSocket(port).also { it.soTimeout = 100 }
+      acceptThread =
+          thread(isDaemon = true, name = "netplay-v9-accept") {
+            acceptLoop(requireNotNull(listener))
+          }
+    }
   }
 
   override fun close() {
-    if (!stopped.compareAndSet(false, true)) return
+    synchronized(callbackLock) {
+      synchronized(startStopLock) {
+        if (!stopped.compareAndSet(false, true)) return
+      }
+    }
     try {
       listener?.close()
     } catch (_: IOException) {
@@ -563,13 +682,14 @@ class V9FoundationServer(
       socket.keepAlive = true
       socket.soTimeout = V9Timeout.WAIT_CLIENT_HELLO.milliseconds.toInt()
       connection =
-          V9FoundationConnection(
+          connectionFactory(
               V9SocketChannel(socket),
               V9Role.SERVER,
               mode,
-              optionalCapabilities = optionalCapabilities,
+              optionalCapabilities,
           )
       connections += connection
+      connection.addCloseListener { connections.remove(connection) }
       connection.start()
       val state =
           connection.awaitPairingBoundary(
@@ -577,7 +697,13 @@ class V9FoundationServer(
               TimeUnit.MILLISECONDS,
           )
       if (state.phase == V9LifecyclePhase.AWAITING_PAIRING) {
-        onAwaitingPairing(connection)
+        synchronized(callbackLock) {
+          if (stopped.get()) {
+            connection.close()
+          } else {
+            onAwaitingPairing(connection)
+          }
+        }
       } else {
         connection.close()
         connections.remove(connection)
@@ -598,6 +724,14 @@ class V9FoundationServer(
         socket.close()
       } catch (_: IOException) {
         // Candidate isolation is more important than reporting remote details.
+      }
+    } catch (_: RuntimeException) {
+      connection?.close()
+      connection?.let(connections::remove)
+      try {
+        socket.close()
+      } catch (_: IOException) {
+        // Candidate construction/start/callback failures remain isolated to this socket.
       }
     } finally {
       pending.remove(socket)
@@ -637,14 +771,24 @@ object V9FoundationClient {
  * The attempt owns the pending channel until it hands a started connection to the callback.
  */
 class V9FoundationConnectAttempt(
+    private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
+    scheduler: V9DeadlineScheduler? = null,
     private val channelFactory: () -> V9ConnectableChannel =
         { V9SocketChannel(Socket()) },
 ) : Closeable {
-  private val cancelled = AtomicBoolean(false)
-  private val completed = AtomicBoolean(false)
-  @Volatile private var pending: V9ConnectableChannel? = null
-  @Volatile private var connection: V9FoundationConnection? = null
-  @Volatile private var task: Thread? = null
+  private val lock = Any()
+  private val scheduler = scheduler ?: V9SystemDeadlineScheduler(clock)
+  private val ownedScheduler = if (scheduler == null) this.scheduler as Closeable else null
+  private var state = V9ConnectAttemptState.NEW
+  private var pendingChannel: V9ConnectableChannel? = null
+  private var pendingConnection: V9FoundationConnection? = null
+  private var task: Thread? = null
+  private var timeoutTask: Closeable? = null
+  private var callback:
+      ((V9FoundationConnection?, V9ErrorCode?) -> Unit)? = null
+  private var callbackDelivered = false
+
+  internal var hooks = V9ConnectAttemptHooks()
 
   fun start(
       address: InetSocketAddress,
@@ -652,65 +796,250 @@ class V9FoundationConnectAttempt(
       optionalCapabilities: Set<V9Capability> = emptySet(),
       onComplete: (V9FoundationConnection?, V9ErrorCode?) -> Unit,
   ) {
-    check(task == null) { "v9 connect attempt already started" }
-    task =
-        thread(isDaemon = true, name = "netplay-v9-connect") {
-          val channel = channelFactory()
-          pending = channel
-          try {
-            if (cancelled.get()) throw IOException("cancelled")
-            channel.connect(address, V9Timeout.WAIT_SERVER_HELLO.milliseconds.toInt())
-            if (cancelled.get()) throw IOException("cancelled")
-            val value =
-                V9FoundationConnection(
-                    channel,
-                    V9Role.CLIENT,
-                    mode,
-                    optionalCapabilities = optionalCapabilities,
-                )
-            connection = value
-            pending = null
-            value.start()
-            completed.set(true)
-            onComplete(value, null)
-          } catch (_: IOException) {
-            try {
-              channel.close()
-            } catch (_: IOException) {
-              // The stable result below deliberately does not expose raw socket text.
-            }
-            completed.set(true)
-            onComplete(
-                null,
-                if (cancelled.get()) V9ErrorCode.CANCELLED else V9ErrorCode.INTERNAL_ERROR,
-            )
-          } catch (_: InterruptedException) {
-            Thread.currentThread().interrupt()
-            try {
-              channel.close()
-            } catch (_: IOException) {
-              // Cancellation remains typed and sanitized.
-            }
-            completed.set(true)
-            onComplete(null, V9ErrorCode.CANCELLED)
+    var cancelledBeforeStart = false
+    synchronized(lock) {
+      check(callback == null) { "v9 connect attempt already started" }
+      callback = onComplete
+      if (state == V9ConnectAttemptState.CANCELLED) {
+        callbackDelivered = true
+        cancelledBeforeStart = true
+      } else {
+        check(state == V9ConnectAttemptState.NEW) { "v9 connect attempt is closed" }
+        state = V9ConnectAttemptState.CONNECTING
+      }
+    }
+    if (cancelledBeforeStart) {
+      onComplete(null, V9ErrorCode.CANCELLED)
+      return
+    }
+
+    val deadline =
+        try {
+          Math.addExact(clock.nowMillis(), V9Timeout.WAIT_SERVER_HELLO.milliseconds)
+        } catch (_: ArithmeticException) {
+          Long.MAX_VALUE
+        }
+    val scheduled =
+        scheduler.schedule(deadline) {
+          if (clock.nowMillis() >= deadline) completeFailure(V9ErrorCode.TIMEOUT)
+        }
+    synchronized(lock) {
+      if (state == V9ConnectAttemptState.CONNECTING) timeoutTask = scheduled
+      else scheduled.close()
+    }
+
+    val worker =
+        thread(start = false, isDaemon = true, name = "netplay-v9-connect") {
+          runAttempt(address, mode, optionalCapabilities)
+        }
+    val startWorker =
+        synchronized(lock) {
+          if (state == V9ConnectAttemptState.CONNECTING) {
+            task = worker
+            true
+          } else {
+            false
           }
         }
+    if (startWorker) worker.start()
   }
 
-  fun isComplete(): Boolean = completed.get()
+  fun isComplete(): Boolean =
+      synchronized(lock) {
+        state in
+            setOf(
+                V9ConnectAttemptState.HANDED_OFF,
+                V9ConnectAttemptState.CANCELLED,
+                V9ConnectAttemptState.TIMED_OUT,
+                V9ConnectAttemptState.FAILED,
+            )
+      }
 
   fun cancel() {
-    cancelled.set(true)
-    try {
-      pending?.close()
-    } catch (_: IOException) {
-      // Cancellation remains typed and sanitized.
-    }
-    connection?.cancel()
-    task?.interrupt()
+    completeFailure(V9ErrorCode.CANCELLED)
   }
 
   override fun close() {
     cancel()
   }
+
+  private fun runAttempt(
+      address: InetSocketAddress,
+      mode: V9LinkMode,
+      optionalCapabilities: Set<V9Capability>,
+  ) {
+    var createdChannel: V9ConnectableChannel? = null
+    try {
+      createdChannel = channelFactory()
+      if (!adoptChannel(createdChannel)) {
+        closeQuietly(createdChannel)
+        return
+      }
+      hooks.beforeConnect()
+      if (!isState(V9ConnectAttemptState.CONNECTING)) return
+      createdChannel.connect(
+          address,
+          V9Timeout.WAIT_SERVER_HELLO.milliseconds.toInt(),
+      )
+      if (!advance(V9ConnectAttemptState.CONNECTING, V9ConnectAttemptState.CONNECTED)) return
+      hooks.afterConnect()
+      if (!isState(V9ConnectAttemptState.CONNECTED)) return
+
+      val value =
+          V9FoundationConnection(
+              createdChannel,
+              V9Role.CLIENT,
+              mode,
+              optionalCapabilities = optionalCapabilities,
+          )
+      if (!adoptConnection(value)) {
+        value.close()
+        return
+      }
+      createdChannel = null
+      hooks.afterConnectionCreated()
+      if (!isState(V9ConnectAttemptState.CONSTRUCTED)) return
+      value.start()
+      if (!advance(V9ConnectAttemptState.CONSTRUCTED, V9ConnectAttemptState.STARTED)) return
+      hooks.afterConnectionStarted()
+      handOff(value)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      completeFailure(V9ErrorCode.CANCELLED)
+    } catch (_: IOException) {
+      completeFailure(V9ErrorCode.INTERNAL_ERROR)
+    } catch (_: RuntimeException) {
+      completeFailure(V9ErrorCode.INTERNAL_ERROR)
+    } finally {
+      createdChannel?.let(::closeQuietly)
+    }
+  }
+
+  private fun adoptChannel(channel: V9ConnectableChannel): Boolean =
+      synchronized(lock) {
+        if (state != V9ConnectAttemptState.CONNECTING) {
+          false
+        } else {
+          pendingChannel = channel
+          true
+        }
+      }
+
+  private fun adoptConnection(connection: V9FoundationConnection): Boolean =
+      synchronized(lock) {
+        if (state != V9ConnectAttemptState.CONNECTED) {
+          false
+        } else {
+          pendingConnection = connection
+          pendingChannel = null
+          state = V9ConnectAttemptState.CONSTRUCTED
+          true
+        }
+      }
+
+  private fun advance(
+      expected: V9ConnectAttemptState,
+      next: V9ConnectAttemptState,
+  ): Boolean =
+      synchronized(lock) {
+        if (state != expected) false
+        else {
+          state = next
+          true
+        }
+      }
+
+  private fun isState(expected: V9ConnectAttemptState): Boolean =
+      synchronized(lock) { state == expected }
+
+  private fun handOff(connection: V9FoundationConnection) {
+    val completion: ((V9FoundationConnection?, V9ErrorCode?) -> Unit)?
+    val deadline: Closeable?
+    synchronized(lock) {
+      if (state != V9ConnectAttemptState.STARTED) return
+      state = V9ConnectAttemptState.HANDED_OFF
+      pendingConnection = null
+      pendingChannel = null
+      deadline = timeoutTask
+      timeoutTask = null
+      completion = callback.takeUnless { callbackDelivered }
+      callbackDelivered = true
+    }
+    deadline?.close()
+    ownedScheduler?.close()
+    try {
+      completion?.invoke(connection, null)
+    } catch (_: RuntimeException) {
+      // A callback that refuses ownership cannot leave the started connection orphaned.
+      connection.close()
+    }
+  }
+
+  private fun completeFailure(error: V9ErrorCode) {
+    val channel: V9ConnectableChannel?
+    val connection: V9FoundationConnection?
+    val worker: Thread?
+    val deadline: Closeable?
+    val completion: ((V9FoundationConnection?, V9ErrorCode?) -> Unit)?
+    synchronized(lock) {
+      if (state == V9ConnectAttemptState.HANDED_OFF ||
+          state == V9ConnectAttemptState.CANCELLED ||
+          state == V9ConnectAttemptState.TIMED_OUT ||
+          state == V9ConnectAttemptState.FAILED) {
+        return
+      }
+      state =
+          when (error) {
+            V9ErrorCode.CANCELLED -> V9ConnectAttemptState.CANCELLED
+            V9ErrorCode.TIMEOUT -> V9ConnectAttemptState.TIMED_OUT
+            else -> V9ConnectAttemptState.FAILED
+          }
+      channel = pendingChannel
+      connection = pendingConnection
+      pendingChannel = null
+      pendingConnection = null
+      worker = task
+      deadline = timeoutTask
+      timeoutTask = null
+      completion = callback.takeUnless { callbackDelivered }
+      if (completion != null) callbackDelivered = true
+    }
+    deadline?.close()
+    closeQuietly(channel)
+    connection?.cancel()
+    if (worker !== Thread.currentThread()) worker?.interrupt()
+    ownedScheduler?.close()
+    try {
+      completion?.invoke(null, error)
+    } catch (_: RuntimeException) {
+      // A faulty observer cannot reopen or change an already-completed attempt.
+    }
+  }
+
+  private fun closeQuietly(channel: V9TransportChannel?) {
+    try {
+      channel?.close()
+    } catch (_: IOException) {
+      // Completion remains typed and sanitized.
+    }
+  }
 }
+
+internal enum class V9ConnectAttemptState {
+  NEW,
+  CONNECTING,
+  CONNECTED,
+  CONSTRUCTED,
+  STARTED,
+  HANDED_OFF,
+  CANCELLED,
+  TIMED_OUT,
+  FAILED,
+}
+
+internal class V9ConnectAttemptHooks(
+    var beforeConnect: () -> Unit = {},
+    var afterConnect: () -> Unit = {},
+    var afterConnectionCreated: () -> Unit = {},
+    var afterConnectionStarted: () -> Unit = {},
+)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Handshake.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Handshake.kt
@@ -1,0 +1,280 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.util.Collections
+
+data class V9CapabilityDeclaration(
+    val wireId: Int,
+    val schemaVersion: Int,
+    val required: Boolean,
+    val capability: V9Capability?,
+)
+
+class V9Hello(
+    val role: V9Role,
+    nonce: ByteArray,
+    capabilities: List<V9CapabilityDeclaration>,
+) {
+  private val ownedNonce = nonce.copyOf()
+  val capabilities: List<V9CapabilityDeclaration> =
+      Collections.unmodifiableList(capabilities.toList())
+
+  init {
+    require(ownedNonce.size == 32)
+    require(this.capabilities.size <= V9Limit.CAPABILITY_COUNT.value)
+  }
+
+  fun nonce(): ByteArray = ownedNonce.copyOf()
+}
+
+class V9NegotiatedCapabilities(capabilities: Set<V9Capability>) {
+  val capabilities: Set<V9Capability> =
+      Collections.unmodifiableSet(capabilities.toSet())
+
+  init {
+    require(capabilities.containsAll(V9Capability.requiredCapabilities))
+  }
+
+  fun decoderPolicy(
+      mode: V9LinkMode,
+      allowedMessages: Set<V9MessageType>,
+      allowUnknownOptional: Boolean = false,
+  ): V9DecoderPolicy =
+      V9DecoderPolicy(allowedMessages, capabilities, mode, allowUnknownOptional)
+}
+
+object V9HelloCodec {
+  fun create(
+      role: V9Role,
+      nonce: ByteArray,
+      optionalCapabilities: Set<V9Capability> = emptySet(),
+  ): V9Hello {
+    require(optionalCapabilities.none { it.required })
+    val declarations =
+        (V9Capability.requiredCapabilities + optionalCapabilities)
+            .sortedBy { it.wireId }
+            .map {
+              V9CapabilityDeclaration(it.wireId, it.schemaVersion, it.required, it)
+            }
+    return V9Hello(role, nonce, declarations)
+  }
+
+  fun encode(hello: V9Hello): ByteArray {
+    val structural = validateHello(hello)
+    if (structural != null) throw V9ProtocolException(structural, 0)
+    val result =
+        ByteBuffer.allocate(38 + hello.capabilities.size * 8).order(ByteOrder.BIG_ENDIAN)
+    result.put(hello.role.wireId.toByte())
+    result.put(ProtocolV9.MAJOR.toByte())
+    result.put(ProtocolV9.MAJOR.toByte())
+    result.put(0)
+    result.put(hello.nonce())
+    result.putShort(hello.capabilities.size.toShort())
+    hello.capabilities.forEach {
+      result.putShort(it.wireId.toShort())
+      result.putShort(it.schemaVersion.toShort())
+      result.putInt(if (it.required) 1 else 0)
+    }
+    return result.array()
+  }
+
+  fun decode(payload: ByteArray): V9Hello {
+    validate(payload)?.let { throw V9ProtocolException(it, payload.size) }
+    val count = u16(payload, 36)
+    val declarations = ArrayList<V9CapabilityDeclaration>(count)
+    repeat(count) { index ->
+      val offset = 38 + index * 8
+      val id = u16(payload, offset)
+      val capability = V9Capability.fromWireId(id)
+      declarations +=
+          V9CapabilityDeclaration(
+              id,
+              u16(payload, offset + 2),
+              u32(payload, offset + 4) == 1L,
+              capability,
+          )
+    }
+    return V9Hello(
+        requireNotNull(V9Role.fromWireId(payload[0].toInt() and 0xff)),
+        payload.copyOfRange(4, 36),
+        declarations,
+    )
+  }
+
+  fun negotiate(
+      local: V9Hello,
+      remote: V9Hello,
+      expectedRemoteRole: V9Role,
+      mode: V9LinkMode,
+  ): V9NegotiatedCapabilities {
+    validateHello(local)?.let { throw V9ProtocolException(it, 0) }
+    validateHello(remote)?.let { throw V9ProtocolException(it, 0) }
+    if (local.role == remote.role || remote.role != expectedRemoteRole) {
+      throw V9ProtocolException(V9ErrorCode.CAPABILITY_MISMATCH, 0)
+    }
+    val localKnown = local.capabilities.mapNotNull { it.capability }.toSet()
+    val remoteKnown = remote.capabilities.mapNotNull { it.capability }.toSet()
+    val negotiated = localKnown intersect remoteKnown
+    if (!negotiated.containsAll(V9Capability.requiredCapabilities) ||
+        mode == V9LinkMode.FOUR_PLAYER && V9Capability.FOUR_PLAYER_V1 !in negotiated) {
+      throw V9ProtocolException(V9ErrorCode.CAPABILITY_MISMATCH, 0)
+    }
+    return V9NegotiatedCapabilities(negotiated)
+  }
+
+  internal fun validate(payload: ByteArray): V9ErrorCode? {
+    if (payload.size < 38) return V9ErrorCode.CAPABILITY_MISMATCH
+    if (V9Role.fromWireId(payload[0].toInt() and 0xff) == null ||
+        (payload[1].toInt() and 0xff) != ProtocolV9.MAJOR ||
+        (payload[2].toInt() and 0xff) != ProtocolV9.MAJOR ||
+        payload[3].toInt() != 0) {
+      return V9ErrorCode.CAPABILITY_MISMATCH
+    }
+    val count = u16(payload, 36)
+    if (count > V9Limit.CAPABILITY_COUNT.value ||
+        payload.size.toLong() != 38L + count.toLong() * 8L) {
+      return V9ErrorCode.CAPABILITY_MISMATCH
+    }
+    var previous = 0
+    val seenRequired = mutableSetOf<V9Capability>()
+    repeat(count) { index ->
+      val offset = 38 + index * 8
+      val id = u16(payload, offset)
+      val version = u16(payload, offset + 2)
+      val flags = u32(payload, offset + 4)
+      if (id <= previous || flags !in 0L..1L) return V9ErrorCode.CAPABILITY_MISMATCH
+      previous = id
+      val known = V9Capability.fromWireId(id)
+      if (known == null) {
+        if (flags == 1L) return V9ErrorCode.UNKNOWN_REQUIRED_CAPABILITY
+      } else {
+        if (version != known.schemaVersion ||
+            (flags == 1L) != known.required) {
+          return V9ErrorCode.CAPABILITY_MISMATCH
+        }
+        if (known.required) seenRequired += known
+      }
+    }
+    if (seenRequired != V9Capability.requiredCapabilities) {
+      return V9ErrorCode.CAPABILITY_MISMATCH
+    }
+    return null
+  }
+
+  private fun validateHello(hello: V9Hello): V9ErrorCode? =
+      try {
+        validate(encodeUnchecked(hello))
+      } catch (_: IllegalArgumentException) {
+        V9ErrorCode.CAPABILITY_MISMATCH
+      }
+
+  private fun encodeUnchecked(hello: V9Hello): ByteArray {
+    if (hello.capabilities.size > V9Limit.CAPABILITY_COUNT.value) {
+      throw IllegalArgumentException("too many capabilities")
+    }
+    val result =
+        ByteBuffer.allocate(38 + hello.capabilities.size * 8).order(ByteOrder.BIG_ENDIAN)
+            .put(hello.role.wireId.toByte())
+            .put(ProtocolV9.MAJOR.toByte())
+            .put(ProtocolV9.MAJOR.toByte())
+            .put(0)
+            .put(hello.nonce())
+            .putShort(hello.capabilities.size.toShort())
+    hello.capabilities.forEach {
+      result.putShort(it.wireId.toShort())
+          .putShort(it.schemaVersion.toShort())
+          .putInt(if (it.required) 1 else 0)
+    }
+    return result.array()
+  }
+}
+
+enum class V9Diagnostic {
+  PROTOCOL_MISMATCH,
+  HELLO_REJECTED,
+  CAPABILITY_MISMATCH,
+  TIMEOUT,
+  CANCELLED,
+  IO_FAILURE,
+  QUEUE_FULL,
+  CLOSED,
+}
+
+data class V9Failure(
+    val reason: V9ErrorCode,
+    val stage: V9LifecycleState,
+    val diagnostic: V9Diagnostic,
+)
+
+data class V9ErrorPayload(
+    val error: V9ErrorCode,
+    val offendingType: Int,
+    val offendingSequence: Long,
+)
+
+object V9ErrorPayloadCodec {
+  fun encode(
+      error: V9ErrorCode,
+      offendingType: Int = 0,
+      offendingSequence: Long = 0,
+      diagnostic: String = "",
+  ): ByteArray {
+    require(offendingType in 0..0xffff)
+    require(offendingSequence in 0..ProtocolV9.U32_MAX)
+    val text = diagnostic.toByteArray(StandardCharsets.UTF_8)
+    if (!isSafeDiagnostic(text, 512)) {
+      throw IllegalArgumentException("diagnostic must be sanitized strict UTF-8")
+    }
+    return ByteBuffer.allocate(12 + text.size).order(ByteOrder.BIG_ENDIAN)
+        .putShort(error.wireId.toShort())
+        .putShort(offendingType.toShort())
+        .putInt(offendingSequence.toInt())
+        .putShort(text.size.toShort())
+        .putShort(0)
+        .put(text)
+        .array()
+  }
+
+  fun decode(payload: ByteArray): V9ErrorPayload {
+    validate(V9Flag.TERMINAL.wireMask, payload)?.let {
+      throw V9ProtocolException(it, payload.size)
+    }
+    return V9ErrorPayload(
+        requireNotNull(V9ErrorCode.fromWireId(u16(payload, 0))),
+        u16(payload, 2),
+        u32(payload, 4),
+    )
+  }
+
+  internal fun validate(flags: Int, payload: ByteArray): V9ErrorCode? {
+    if (flags and V9Flag.TERMINAL.wireMask == 0 || payload.size < 12) {
+      return V9ErrorCode.MALFORMED_HEADER
+    }
+    val length = u16(payload, 8)
+    if (V9ErrorCode.fromWireId(u16(payload, 0)) == null ||
+        u16(payload, 10) != 0 ||
+        payload.size != 12 + length) {
+      return V9ErrorCode.MALFORMED_HEADER
+    }
+    return if (isSafeDiagnostic(payload.copyOfRange(12, payload.size), 512)) null
+    else V9ErrorCode.STRICT_UTF8
+  }
+}
+
+private fun isSafeDiagnostic(bytes: ByteArray, maximum: Int): Boolean {
+  if (bytes.size > maximum) return false
+  val text = try {
+    StandardCharsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+        .decode(ByteBuffer.wrap(bytes))
+        .toString()
+  } catch (_: CharacterCodingException) {
+    return false
+  }
+  return text.none { it == '\u0000' || it.code < 0x20 || it.code == 0x7f }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Lifecycle.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Lifecycle.kt
@@ -1,0 +1,320 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.io.Closeable
+import java.util.Collections
+import java.util.concurrent.CopyOnWriteArrayList
+
+fun interface V9MonotonicClock {
+  fun nowMillis(): Long
+
+  companion object {
+    val SYSTEM = V9MonotonicClock { System.nanoTime() / 1_000_000L }
+  }
+}
+
+enum class V9LifecycleState {
+  SEND_SERVER_HELLO,
+  WAIT_SERVER_HELLO,
+  SEND_CLIENT_HELLO,
+  WAIT_CLIENT_HELLO,
+  SEND_AUTH,
+  WAIT_AUTH,
+  SEND_AUTH_RESULT,
+  WAIT_AUTH_RESULT,
+  SEND_SERVER_MANIFEST,
+  WAIT_SERVER_MANIFEST,
+  SEND_CLIENT_MANIFEST,
+  WAIT_CLIENT_MANIFEST,
+  EXCHANGE_CONSENT,
+  SYNCHRONIZING,
+  SEND_READY,
+  WAIT_READY,
+  ACTIVE,
+  BULK_PROGRESS,
+  TERMINAL_CLEANUP,
+  CLOSED;
+
+  fun timeout(): V9Timeout? = when (this) {
+    SEND_SERVER_HELLO -> V9Timeout.SEND_SERVER_HELLO
+    WAIT_SERVER_HELLO -> V9Timeout.WAIT_SERVER_HELLO
+    SEND_CLIENT_HELLO -> V9Timeout.SEND_CLIENT_HELLO
+    WAIT_CLIENT_HELLO -> V9Timeout.WAIT_CLIENT_HELLO
+    SEND_AUTH -> V9Timeout.SEND_AUTH
+    WAIT_AUTH -> V9Timeout.WAIT_AUTH
+    SEND_AUTH_RESULT -> V9Timeout.SEND_AUTH_RESULT
+    WAIT_AUTH_RESULT -> V9Timeout.WAIT_AUTH_RESULT
+    SEND_SERVER_MANIFEST -> V9Timeout.SEND_SERVER_MANIFEST
+    WAIT_SERVER_MANIFEST -> V9Timeout.WAIT_SERVER_MANIFEST
+    SEND_CLIENT_MANIFEST -> V9Timeout.SEND_CLIENT_MANIFEST
+    WAIT_CLIENT_MANIFEST -> V9Timeout.WAIT_CLIENT_MANIFEST
+    EXCHANGE_CONSENT -> V9Timeout.EXCHANGE_CONSENT
+    SYNCHRONIZING -> V9Timeout.SYNCHRONIZING
+    SEND_READY -> V9Timeout.SEND_READY
+    WAIT_READY -> V9Timeout.WAIT_READY
+    ACTIVE -> V9Timeout.ACTIVE_IDLE
+    BULK_PROGRESS -> V9Timeout.BULK_PROGRESS
+    TERMINAL_CLEANUP -> V9Timeout.TERMINAL_CLEANUP
+    CLOSED -> null
+  }
+}
+
+enum class V9LifecyclePhase {
+  NEGOTIATING,
+  AWAITING_PAIRING,
+  PAIRING,
+  SYNCHRONIZING,
+  ACTIVE,
+  TERMINAL,
+  CLOSED,
+}
+
+data class V9LifecycleSnapshot(
+    val role: V9Role,
+    val state: V9LifecycleState,
+    val phase: V9LifecyclePhase,
+    val deadlineMillis: Long?,
+    val negotiatedCapabilities: Set<V9Capability>,
+    val failure: V9Failure?,
+)
+
+fun interface V9LifecycleListener {
+  fun onStateChanged(snapshot: V9LifecycleSnapshot)
+}
+
+interface V9LifecycleSource {
+  fun snapshot(): V9LifecycleSnapshot
+
+  fun addListener(listener: V9LifecycleListener): Closeable
+}
+
+/**
+ * Controller-owned immutable lifecycle stream.
+ *
+ * Phase #347 advances only HELLO states. All later frozen states are explicit values, rather than
+ * being inferred from unrelated emulator events, but their transitions remain unavailable until
+ * their owning phases implement them.
+ */
+class V9Lifecycle(
+    private val role: V9Role,
+    private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
+) : V9LifecycleSource {
+  private val listeners = CopyOnWriteArrayList<V9LifecycleListener>()
+  private var state =
+      if (role == V9Role.SERVER) V9LifecycleState.SEND_SERVER_HELLO
+      else V9LifecycleState.WAIT_SERVER_HELLO
+  private var deadline = deadlineFor(state)
+  private var capabilities: Set<V9Capability> = emptySet()
+  private var failure: V9Failure? = null
+
+  @Synchronized
+  override fun snapshot(): V9LifecycleSnapshot =
+      V9LifecycleSnapshot(
+          role,
+          state,
+          phase(state),
+          deadline,
+          Collections.unmodifiableSet(capabilities.toSet()),
+          failure,
+      )
+
+  override fun addListener(listener: V9LifecycleListener): Closeable {
+    listeners += listener
+    listener.onStateChanged(snapshot())
+    return Closeable { listeners.remove(listener) }
+  }
+
+  @Synchronized
+  fun serverHelloSent() {
+    requireRoleState(V9Role.SERVER, V9LifecycleState.SEND_SERVER_HELLO)
+    transition(V9LifecycleState.WAIT_CLIENT_HELLO)
+  }
+
+  @Synchronized
+  fun serverHelloReceived() {
+    requireRoleState(V9Role.CLIENT, V9LifecycleState.WAIT_SERVER_HELLO)
+    transition(V9LifecycleState.SEND_CLIENT_HELLO)
+  }
+
+  @Synchronized
+  fun clientHelloSent(negotiated: V9NegotiatedCapabilities) {
+    requireRoleState(V9Role.CLIENT, V9LifecycleState.SEND_CLIENT_HELLO)
+    capabilities = negotiated.capabilities.toSet()
+    transition(V9LifecycleState.SEND_AUTH)
+  }
+
+  @Synchronized
+  fun clientHelloReceived(negotiated: V9NegotiatedCapabilities) {
+    requireRoleState(V9Role.SERVER, V9LifecycleState.WAIT_CLIENT_HELLO)
+    capabilities = negotiated.capabilities.toSet()
+    transition(V9LifecycleState.WAIT_AUTH)
+  }
+
+  @Synchronized
+  fun checkDeadline(): V9Failure? {
+    val currentDeadline = deadline ?: return failure
+    if (clock.nowMillis() >= currentDeadline && state != V9LifecycleState.CLOSED) {
+      val error = state.timeout()?.expiryError ?: V9ErrorCode.TIMEOUT
+      fail(error, V9Diagnostic.TIMEOUT)
+    }
+    return failure
+  }
+
+  @Synchronized
+  fun cancel(): V9Failure {
+    if (state != V9LifecycleState.CLOSED) {
+      fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+    }
+    return requireNotNull(failure)
+  }
+
+  @Synchronized
+  fun fail(reason: V9ErrorCode, diagnostic: V9Diagnostic): V9Failure {
+    if (state == V9LifecycleState.CLOSED && failure != null) return requireNotNull(failure)
+    val result = V9Failure(reason, state, diagnostic)
+    failure = result
+    state = V9LifecycleState.CLOSED
+    deadline = null
+    publish()
+    return result
+  }
+
+  @Synchronized
+  fun closeNormally() {
+    if (state != V9LifecycleState.CLOSED) {
+      state = V9LifecycleState.CLOSED
+      deadline = null
+      publish()
+    }
+  }
+
+  private fun transition(next: V9LifecycleState) {
+    state = next
+    deadline = deadlineFor(next)
+    publish()
+  }
+
+  private fun publish() {
+    val value = snapshot()
+    listeners.forEach { it.onStateChanged(value) }
+  }
+
+  private fun deadlineFor(value: V9LifecycleState): Long? {
+    val timeout = value.timeout() ?: return null
+    return try {
+      Math.addExact(clock.nowMillis(), timeout.milliseconds)
+    } catch (_: ArithmeticException) {
+      Long.MAX_VALUE
+    }
+  }
+
+  private fun requireRoleState(expectedRole: V9Role, expectedState: V9LifecycleState) {
+    check(role == expectedRole && state == expectedState) {
+      "Illegal v9 lifecycle transition"
+    }
+  }
+
+  private fun phase(value: V9LifecycleState): V9LifecyclePhase = when (value) {
+    V9LifecycleState.SEND_SERVER_HELLO,
+    V9LifecycleState.WAIT_SERVER_HELLO,
+    V9LifecycleState.SEND_CLIENT_HELLO,
+    V9LifecycleState.WAIT_CLIENT_HELLO -> V9LifecyclePhase.NEGOTIATING
+    V9LifecycleState.SEND_AUTH,
+    V9LifecycleState.WAIT_AUTH -> V9LifecyclePhase.AWAITING_PAIRING
+    V9LifecycleState.SEND_AUTH_RESULT,
+    V9LifecycleState.WAIT_AUTH_RESULT,
+    V9LifecycleState.SEND_SERVER_MANIFEST,
+    V9LifecycleState.WAIT_SERVER_MANIFEST,
+    V9LifecycleState.SEND_CLIENT_MANIFEST,
+    V9LifecycleState.WAIT_CLIENT_MANIFEST,
+    V9LifecycleState.EXCHANGE_CONSENT -> V9LifecyclePhase.PAIRING
+    V9LifecycleState.SYNCHRONIZING,
+    V9LifecycleState.SEND_READY,
+    V9LifecycleState.WAIT_READY,
+    V9LifecycleState.BULK_PROGRESS -> V9LifecyclePhase.SYNCHRONIZING
+    V9LifecycleState.ACTIVE -> V9LifecyclePhase.ACTIVE
+    V9LifecycleState.TERMINAL_CLEANUP -> V9LifecyclePhase.TERMINAL
+    V9LifecycleState.CLOSED -> V9LifecyclePhase.CLOSED
+  }
+}
+
+/**
+ * Exact per-direction response ledger. It is independent of the lifecycle so later phases can
+ * reuse it without assigning wire meaning to enum ordering.
+ */
+class V9ResponseLedger(initialIncomingSequence: Long = 0) {
+  private var expected = validateSequence(initialIncomingSequence, allowExhausted = true)
+  private val outstanding = mutableMapOf<Long, V9MessageType>()
+  private val completed = mutableSetOf<Long>()
+
+  val nextIncomingSequence: Long?
+    @Synchronized get() = expected.takeUnless { it == ProtocolV9.EXHAUSTED_SEQUENCE }
+
+  @Synchronized
+  fun recordPeerRequest(sequence: Long, type: V9MessageType) {
+    require(sequence in 1..ProtocolV9.LAST_SEQUENCE)
+    require(type in setOf(V9MessageType.AUTH, V9MessageType.START, V9MessageType.PING))
+    require(sequence !in outstanding && sequence !in completed)
+    outstanding[sequence] = type
+  }
+
+  @Synchronized
+  fun accept(
+      incomingSequence: Long,
+      type: V9MessageType,
+      flags: Int,
+      correlation: Long,
+  ): V9ErrorCode? {
+    if (expected == ProtocolV9.EXHAUSTED_SEQUENCE || incomingSequence != expected) {
+      return V9ErrorCode.SEQUENCE_ERROR
+    }
+    val response = flags and V9Flag.RESPONSE.wireMask != 0
+    if (!response) {
+      if (correlation != 0L) return V9ErrorCode.CORRELATION_ERROR
+    } else {
+      if (correlation == 0L || correlation in completed) return V9ErrorCode.CORRELATION_ERROR
+      val request = outstanding[correlation] ?: return V9ErrorCode.CORRELATION_ERROR
+      val allowed = when (type) {
+        V9MessageType.AUTH_RESULT -> request == V9MessageType.AUTH
+        V9MessageType.READY -> request == V9MessageType.START
+        V9MessageType.PONG -> request == V9MessageType.PING
+        V9MessageType.ERROR -> true
+        else -> false
+      }
+      if (!allowed) return V9ErrorCode.CORRELATION_ERROR
+      outstanding.remove(correlation)
+      completed += correlation
+    }
+    expected =
+        if (expected == ProtocolV9.LAST_SEQUENCE) ProtocolV9.EXHAUSTED_SEQUENCE
+        else Math.addExact(expected, 1)
+    return null
+  }
+
+  private fun validateSequence(value: Long, allowExhausted: Boolean): Long {
+    val maximum =
+        if (allowExhausted) ProtocolV9.EXHAUSTED_SEQUENCE else ProtocolV9.LAST_SEQUENCE
+    require(value in 0..maximum)
+    return value
+  }
+}
+
+enum class V9PrefaceKind {
+  V9,
+  LEGACY_V8_OR_EARLIER,
+  UNSUPPORTED,
+  NEED_MORE,
+  TRUNCATED,
+}
+
+object V9Preface {
+  fun detect(bytes: ByteArray, eof: Boolean = false): V9PrefaceKind {
+    val count = minOf(bytes.size, 4)
+    if (count < 4) return if (eof) V9PrefaceKind.TRUNCATED else V9PrefaceKind.NEED_MORE
+    val prefix = bytes.copyOfRange(0, 4)
+    if (prefix.contentEquals(ProtocolV9.MAGIC)) return V9PrefaceKind.V9
+    if (prefix.contentEquals(byteArrayOf(0x43, 0x6f, 0x66, 0x66))) {
+      return V9PrefaceKind.LEGACY_V8_OR_EARLIER
+    }
+    return V9PrefaceKind.UNSUPPORTED
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Lifecycle.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Lifecycle.kt
@@ -153,23 +153,54 @@ class V9Lifecycle(
   fun checkDeadline(): V9Failure? {
     val currentDeadline = deadline ?: return failure
     if (clock.nowMillis() >= currentDeadline && state != V9LifecycleState.CLOSED) {
-      val error = state.timeout()?.expiryError ?: V9ErrorCode.TIMEOUT
-      fail(error, V9Diagnostic.TIMEOUT)
+      val error = state.timeout()?.expiryError
+      if (error == null) {
+        closeNormally()
+      } else {
+        fail(error, V9Diagnostic.TIMEOUT)
+      }
     }
     return failure
   }
 
   @Synchronized
-  fun cancel(): V9Failure {
+  fun cancel(): V9Failure? {
     if (state != V9LifecycleState.CLOSED) {
       fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
     }
-    return requireNotNull(failure)
+    return failure
+  }
+
+  /**
+   * Records the original local rejection and begins the frozen best-effort terminal drain.
+   *
+   * The failure stage is the state that rejected the peer, not `TERMINAL_CLEANUP`. Subsequent
+   * cancellation, delivery failure, peer EOF, or cleanup expiry cannot replace that outcome.
+   */
+  @Synchronized
+  fun beginTerminalCleanup(reason: V9ErrorCode, diagnostic: V9Diagnostic): V9Failure? {
+    if (state == V9LifecycleState.CLOSED || state == V9LifecycleState.TERMINAL_CLEANUP) {
+      return failure
+    }
+    val result = V9Failure(reason, state, diagnostic)
+    failure = result
+    transition(V9LifecycleState.TERMINAL_CLEANUP)
+    return result
+  }
+
+  /** Completes terminal cleanup after peer EOF or a failed best-effort terminal write. */
+  @Synchronized
+  fun completeTerminalCleanup() {
+    if (state == V9LifecycleState.TERMINAL_CLEANUP) closeNormally()
   }
 
   @Synchronized
-  fun fail(reason: V9ErrorCode, diagnostic: V9Diagnostic): V9Failure {
-    if (state == V9LifecycleState.CLOSED && failure != null) return requireNotNull(failure)
+  fun fail(reason: V9ErrorCode, diagnostic: V9Diagnostic): V9Failure? {
+    if (state == V9LifecycleState.CLOSED) return failure
+    if (state == V9LifecycleState.TERMINAL_CLEANUP && failure != null) {
+      closeNormally()
+      return failure
+    }
     val result = V9Failure(reason, state, diagnostic)
     failure = result
     state = V9LifecycleState.CLOSED
@@ -244,17 +275,22 @@ class V9Lifecycle(
 class V9ResponseLedger(initialIncomingSequence: Long = 0) {
   private var expected = validateSequence(initialIncomingSequence, allowExhausted = true)
   private val outstanding = mutableMapOf<Long, V9MessageType>()
-  private val completed = mutableSetOf<Long>()
+  private var lastRecordedRequestSequence = 0L
 
   val nextIncomingSequence: Long?
     @Synchronized get() = expected.takeUnless { it == ProtocolV9.EXHAUSTED_SEQUENCE }
+
+  val outstandingRequests: Int
+    @Synchronized get() = outstanding.size
 
   @Synchronized
   fun recordPeerRequest(sequence: Long, type: V9MessageType) {
     require(sequence in 1..ProtocolV9.LAST_SEQUENCE)
     require(type in setOf(V9MessageType.AUTH, V9MessageType.START, V9MessageType.PING))
-    require(sequence !in outstanding && sequence !in completed)
+    require(sequence > lastRecordedRequestSequence)
+    require(outstanding.size < V9Limit.QUEUED_FRAMES.value)
     outstanding[sequence] = type
+    lastRecordedRequestSequence = sequence
   }
 
   @Synchronized
@@ -271,7 +307,7 @@ class V9ResponseLedger(initialIncomingSequence: Long = 0) {
     if (!response) {
       if (correlation != 0L) return V9ErrorCode.CORRELATION_ERROR
     } else {
-      if (correlation == 0L || correlation in completed) return V9ErrorCode.CORRELATION_ERROR
+      if (correlation == 0L) return V9ErrorCode.CORRELATION_ERROR
       val request = outstanding[correlation] ?: return V9ErrorCode.CORRELATION_ERROR
       val allowed = when (type) {
         V9MessageType.AUTH_RESULT -> request == V9MessageType.AUTH
@@ -282,7 +318,6 @@ class V9ResponseLedger(initialIncomingSequence: Long = 0) {
       }
       if (!allowed) return V9ErrorCode.CORRELATION_ERROR
       outstanding.remove(correlation)
-      completed += correlation
     }
     expected =
         if (expected == ProtocolV9.LAST_SEQUENCE) ProtocolV9.EXHAUSTED_SEQUENCE

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Registry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Registry.kt
@@ -1,0 +1,269 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+/**
+ * Stable protocol-v9 wire constants.
+ *
+ * The numeric values in this package are the production mirror of the frozen registries under
+ * `controller/src/test/resources/netplay-v9`. Enum declaration order is never used on the wire.
+ */
+object ProtocolV9 {
+  val MAGIC: ByteArray = byteArrayOf(0x43, 0x47, 0x42, 0x39)
+    get() = field.copyOf()
+
+  const val MAJOR = 9
+  const val MINOR = 0
+  const val HEADER_BYTES = 64
+  const val CONTROL_CHANNEL = 0L
+  const val GROUP_CHANNEL = 0xffff_ffffL
+  const val LAST_SEQUENCE = 0xffff_fffeL
+  const val EXHAUSTED_SEQUENCE = 0xffff_ffffL
+  const val U32_MAX = 0xffff_ffffL
+}
+
+enum class V9Flag(val wireMask: Int) {
+  OPTIONAL(0x0001),
+  DEFLATE(0x0002),
+  RESPONSE(0x0004),
+  TERMINAL(0x0008);
+
+  companion object {
+    const val KNOWN_MASK = 0x000f
+  }
+}
+
+enum class V9ChannelKind {
+  CONTROL,
+  PLAYER,
+  GROUP_OR_PLAYER,
+}
+
+enum class V9Compression {
+  NONE,
+  RAW_DEFLATE,
+}
+
+data class V9MessageSpec(
+    val wireId: Int,
+    val wireName: String,
+    val minimumDecodedBytes: Long,
+    val maximumDecodedBytes: Long,
+    val maximumEncodedBytes: Long,
+    val allowedFlags: Int,
+    val requiredFlags: Int,
+    val channelKind: V9ChannelKind,
+    val compression: V9Compression,
+    val payloadSchema: String,
+)
+
+enum class V9MessageType(val spec: V9MessageSpec) {
+  HELLO(spec(0x0001, "HELLO", 38, 294, 294, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "hello-v1")),
+  AUTH(spec(0x0002, "AUTH", 36, 36, 36, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "auth-v1")),
+  AUTH_RESULT(spec(0x0003, "AUTH_RESULT", 4, 4, 4, 0x000c, 0x0004, V9ChannelKind.CONTROL, V9Compression.NONE, "auth-result-v1")),
+  MANIFEST(spec(0x0004, "MANIFEST", 342, 1_396, 1_396, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "manifest-v1")),
+  CONSENT(spec(0x0005, "CONSENT", 116, 116, 116, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "consent-v1")),
+  START(spec(0x0006, "START", 16, 16, 16, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "start-v1")),
+  READY(spec(0x0007, "READY", 8, 8, 8, 0x0004, 0x0004, V9ChannelKind.CONTROL, V9Compression.NONE, "ready-v1")),
+  INPUT(spec(0x0008, "INPUT", 16, 16, 16, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "input-v1")),
+  CHECKPOINT(spec(0x0009, "CHECKPOINT", 88, 33_554_452, 33_554_452, 0, 0, V9ChannelKind.GROUP_OR_PLAYER, V9Compression.NONE, "statefile-v2-group-v1")),
+  ROM_BEGIN(spec(0x000a, "ROM_BEGIN", 52, 52, 52, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "bulk-begin-v1")),
+  ROM_CHUNK(spec(0x000b, "ROM_CHUNK", 9, 65_544, 65_600, 0x0002, 0, V9ChannelKind.PLAYER, V9Compression.RAW_DEFLATE, "bulk-chunk-v1")),
+  ROM_END(spec(0x000c, "ROM_END", 36, 36, 36, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "bulk-end-v1")),
+  BATTERY_BEGIN(spec(0x000d, "BATTERY_BEGIN", 52, 52, 52, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "bulk-begin-v1")),
+  BATTERY_CHUNK(spec(0x000e, "BATTERY_CHUNK", 9, 65_544, 65_600, 0x0002, 0, V9ChannelKind.PLAYER, V9Compression.RAW_DEFLATE, "bulk-chunk-v1")),
+  BATTERY_END(spec(0x000f, "BATTERY_END", 36, 36, 36, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "bulk-end-v1")),
+  RESET(spec(0x0010, "RESET", 16, 16, 16, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "reset-v1")),
+  STOP(spec(0x0011, "STOP", 16, 16, 16, 0, 0, V9ChannelKind.PLAYER, V9Compression.NONE, "stop-v1")),
+  PING(spec(0x0012, "PING", 16, 16, 16, 0, 0, V9ChannelKind.CONTROL, V9Compression.NONE, "ping-v1")),
+  PONG(spec(0x0013, "PONG", 16, 16, 16, 0x0004, 0x0004, V9ChannelKind.CONTROL, V9Compression.NONE, "pong-v1")),
+  CANCEL(spec(0x0014, "CANCEL", 4, 260, 260, 0x0008, 0x0008, V9ChannelKind.CONTROL, V9Compression.NONE, "terminal-text-v1")),
+  GOODBYE(spec(0x0015, "GOODBYE", 4, 260, 260, 0x0008, 0x0008, V9ChannelKind.CONTROL, V9Compression.NONE, "terminal-text-v1")),
+  ERROR(spec(0x0016, "ERROR", 12, 524, 524, 0x000c, 0x0008, V9ChannelKind.CONTROL, V9Compression.NONE, "error-v1"));
+
+  val wireId: Int get() = spec.wireId
+  val wireName: String get() = spec.wireName
+
+  companion object {
+    private val BY_ID = entries.associateBy { it.wireId }
+    private val BY_NAME = entries.associateBy { it.wireName }
+
+    fun fromWireId(wireId: Int): V9MessageType? = BY_ID[wireId]
+
+    fun fromWireName(wireName: String): V9MessageType? = BY_NAME[wireName]
+  }
+}
+
+private fun spec(
+    id: Int,
+    name: String,
+    minimumDecoded: Long,
+    maximumDecoded: Long,
+    maximumEncoded: Long,
+    allowedFlags: Int,
+    requiredFlags: Int,
+    channelKind: V9ChannelKind,
+    compression: V9Compression,
+    payloadSchema: String,
+) = V9MessageSpec(
+    id,
+    name,
+    minimumDecoded,
+    maximumDecoded,
+    maximumEncoded,
+    allowedFlags,
+    requiredFlags,
+    channelKind,
+    compression,
+    payloadSchema,
+)
+
+enum class V9Capability(
+    val wireId: Int,
+    val wireName: String,
+    val schemaVersion: Int,
+    val required: Boolean,
+    val phaseOwner: Int,
+    val meaning: String,
+) {
+  FRAME_V1(0x0001, "FRAME_V1", 1, true, 347, "64-byte-CGB9-header-and-SHA256"),
+  INVITATION_PROOF_V1(0x0002, "INVITATION_PROOF_V1", 1, true, 347, "HMAC-SHA256-invitation-possession-proof"),
+  MANIFEST_V1(0x0003, "MANIFEST_V1", 1, true, 348, "bounded-ROM-slot-profile-manifest"),
+  CONSENT_V1(0x0004, "CONSENT_V1", 1, true, 348, "two-sided-item-scoped-directional-consent"),
+  STATEFILE_V2(0x0005, "STATEFILE_V2", 1, true, 349, "exact-profile-portable-checkpoints"),
+  PROFILE_ID_ASCII_V1(0x0006, "PROFILE_ID_ASCII_V1", 1, true, 349, "canonical-lowercase-profile-identities"),
+  ATOMIC_GROUP_CHECKPOINT_V1(0x0007, "ATOMIC_GROUP_CHECKPOINT_V1", 1, true, 349, "one-logical-linked-session-transaction"),
+  ROM_TRANSFER_V1(0x0008, "ROM_TRANSFER_V1", 1, false, 348, "consent-gated-ROM-transfer"),
+  BATTERY_TRANSFER_V1(0x0009, "BATTERY_TRANSFER_V1", 1, false, 348, "consent-gated-battery-transfer"),
+  RAW_DEFLATE_V1(0x000a, "RAW_DEFLATE_V1", 1, false, 348, "bounded-RFC1951-bulk-chunks-only"),
+  FOUR_PLAYER_V1(0x000b, "FOUR_PLAYER_V1", 1, false, 349, "four-player-mode-and-topology"),
+  PING_V1(0x000c, "PING_V1", 1, false, 350, "active-idle-liveness-probe");
+
+  companion object {
+    private val BY_ID = entries.associateBy { it.wireId }
+
+    val requiredCapabilities: Set<V9Capability> =
+        entries.filter { it.required }.toSet()
+
+    fun fromWireId(wireId: Int): V9Capability? = BY_ID[wireId]
+  }
+}
+
+enum class V9ErrorCode(
+    val wireId: Int,
+    val wireName: String,
+    val peerVisible: Boolean = true,
+    val retrySameConnection: Boolean = false,
+    val mutationAllowed: Boolean = false,
+) {
+  MALFORMED_HEADER(0x0001, "MALFORMED_HEADER"),
+  UNSUPPORTED_PROTOCOL(0x0002, "UNSUPPORTED_PROTOCOL"),
+  UNKNOWN_REQUIRED_TYPE(0x0003, "UNKNOWN_REQUIRED_TYPE"),
+  UNKNOWN_REQUIRED_CAPABILITY(0x0004, "UNKNOWN_REQUIRED_CAPABILITY"),
+  UNKNOWN_REQUIRED_FLAG(0x0005, "UNKNOWN_REQUIRED_FLAG"),
+  LIMIT_EXCEEDED(0x0006, "LIMIT_EXCEEDED"),
+  TRUNCATED(0x0007, "TRUNCATED"),
+  CHECKSUM_MISMATCH(0x0008, "CHECKSUM_MISMATCH"),
+  DECOMPRESSION_FAILED(0x0009, "DECOMPRESSION_FAILED"),
+  UNEXPECTED_MESSAGE(0x000a, "UNEXPECTED_MESSAGE"),
+  SEQUENCE_ERROR(0x000b, "SEQUENCE_ERROR"),
+  CORRELATION_ERROR(0x000c, "CORRELATION_ERROR"),
+  TIMEOUT(0x000d, "TIMEOUT"),
+  CANCELLED(0x000e, "CANCELLED"),
+  AUTH_FAILED(0x000f, "AUTH_FAILED"),
+  SERVER_FULL(0x0010, "SERVER_FULL"),
+  SERVER_BUSY(0x0011, "SERVER_BUSY"),
+  CAPABILITY_MISMATCH(0x0012, "CAPABILITY_MISMATCH"),
+  MANIFEST_MISMATCH(0x0013, "MANIFEST_MISMATCH"),
+  CONSENT_REJECTED(0x0014, "CONSENT_REJECTED"),
+  ROM_MISMATCH(0x0015, "ROM_MISMATCH"),
+  PROFILE_MISMATCH(0x0016, "PROFILE_MISMATCH"),
+  STATEFILE_VERSION(0x0017, "STATEFILE_VERSION"),
+  ROOT_KIND_MISMATCH(0x0018, "ROOT_KIND_MISMATCH"),
+  TOPOLOGY_MISMATCH(0x0019, "TOPOLOGY_MISMATCH"),
+  QUEUE_OVERFLOW(0x001a, "QUEUE_OVERFLOW"),
+  UNEXPECTED_EOF(0x001b, "UNEXPECTED_EOF", false),
+  TRAILING_DATA(0x001c, "TRAILING_DATA", false),
+  STRICT_UTF8(0x001d, "STRICT_UTF8"),
+  INTERNAL_ERROR(0x001e, "INTERNAL_ERROR"),
+  STATEFILE_MALFORMED(0x001f, "STATEFILE_MALFORMED");
+
+  companion object {
+    private val BY_ID = entries.associateBy { it.wireId }
+
+    fun fromWireId(wireId: Int): V9ErrorCode? = BY_ID[wireId]
+  }
+}
+
+enum class V9Limit(
+    val value: Long,
+    val unit: String,
+    val validationBoundary: String,
+    val rationale: String,
+) {
+  HEADER_BYTES(64, "bytes", "before-payload", "fixed-framing"),
+  UNKNOWN_OPTIONAL_BYTES(4_096, "bytes", "before-payload-read", "bounded-forward-skip"),
+  CAPABILITY_COUNT(32, "entries", "before-capability-loop", "finite-negotiation"),
+  PROFILE_ID_BYTES(32, "bytes", "before-string-decode", "StateFile-v2-compatible"),
+  MANIFEST_ENTRIES(4, "entries", "before-entry-allocation", "one-per-logical-slot"),
+  MANIFEST_PROPOSALS(8, "entries", "before-proposal-allocation", "item-scoped-private-transfer-proposals"),
+  MANIFEST_DIFFS(16, "entries", "before-diff-allocation", "bounded-compatibility-report"),
+  INVITATION_URI_BYTES(512, "bytes", "before-URI-parse", "clipboard-and-log-bound"),
+  INVITATION_TOKEN_BYTES(16, "bytes", "before-auth", "128-bit-minimum"),
+  INVITATION_EXPIRY_MIN_SECONDS(60, "seconds", "before-invitation-create", "bounded-lifetime-lower-bound"),
+  INVITATION_EXPIRY_DEFAULT_SECONDS(300, "seconds", "before-invitation-create", "canonical-default"),
+  INVITATION_EXPIRY_MAX_SECONDS(600, "seconds", "before-invitation-create", "bounded-lifetime-upper-bound"),
+  AUTH_FAILURES_PER_WINDOW(8, "attempts", "before-proof-admission", "bounded-listener-work"),
+  AUTH_FAILURE_WINDOW_MILLIS(60_000, "milliseconds", "monotonic-before-proof-admission", "generic-rate-limit-window"),
+  STATEFILE_ENCODED_BYTES(33_554_432, "bytes", "before-StateFile-read", "tighter-network-bound"),
+  STATEFILE_DECODED_BYTES(33_554_432, "bytes", "before-StateFile-inflate", "tighter-network-bound"),
+  ROM_BYTES(67_108_864, "bytes", "before-ROM-transaction", "current-ROM-policy"),
+  BATTERY_BYTES(2_097_152, "bytes", "before-battery-transaction", "current-battery-policy"),
+  BULK_CHUNK_DECODED_BYTES(65_536, "bytes", "before-chunk-read", "bounded-stream-window"),
+  BULK_CHUNK_ENCODED_BYTES(65_600, "bytes", "before-chunk-read", "bounded-deflate-overhead"),
+  BULK_WINDOW_CHUNKS(4, "chunks", "before-queue-admission", "bounded-backpressure"),
+  SESSION_DECODED_AGGREGATE_BYTES(134_217_728, "bytes", "checked-before-admission", "portable-aggregate-ceiling"),
+  QUEUED_FRAMES(256, "frames", "before-queue-admission", "bounded-session-work"),
+  QUEUED_WIRE_BYTES(33_817_172, "bytes", "checked-before-copy", "one-complete-checkpoint-frame-plus-four-complete-maximum-chunk-frames"),
+  PENDING_HANDSHAKES(8, "sessions", "before-accept-admission", "listener-isolation"),
+  HANDSHAKE_WORKERS(4, "workers", "before-task-start", "listener-isolation"),
+  OPEN_BULK_TRANSACTIONS(1, "transaction", "before-BEGIN", "bounded-ownership"),
+  CHECKPOINTS_PER_DIRECTIONAL_GRANT(32, "transactions", "before-checkpoint-admission", "bounded-session-scoped-checkpoint-resynchronization"),
+}
+
+enum class V9Timeout(
+    val milliseconds: Long,
+    val expiryError: V9ErrorCode?,
+) {
+  SEND_SERVER_HELLO(5_000, V9ErrorCode.TIMEOUT),
+  WAIT_SERVER_HELLO(5_000, V9ErrorCode.TIMEOUT),
+  SEND_CLIENT_HELLO(5_000, V9ErrorCode.TIMEOUT),
+  WAIT_CLIENT_HELLO(5_000, V9ErrorCode.TIMEOUT),
+  SEND_AUTH(5_000, V9ErrorCode.TIMEOUT),
+  WAIT_AUTH(5_000, V9ErrorCode.TIMEOUT),
+  SEND_AUTH_RESULT(5_000, V9ErrorCode.TIMEOUT),
+  WAIT_AUTH_RESULT(5_000, V9ErrorCode.TIMEOUT),
+  SEND_SERVER_MANIFEST(10_000, V9ErrorCode.TIMEOUT),
+  WAIT_SERVER_MANIFEST(10_000, V9ErrorCode.TIMEOUT),
+  SEND_CLIENT_MANIFEST(10_000, V9ErrorCode.TIMEOUT),
+  WAIT_CLIENT_MANIFEST(10_000, V9ErrorCode.TIMEOUT),
+  EXCHANGE_CONSENT(120_000, V9ErrorCode.CONSENT_REJECTED),
+  SEND_READY(15_000, V9ErrorCode.TIMEOUT),
+  WAIT_READY(15_000, V9ErrorCode.TIMEOUT),
+  SYNCHRONIZING(120_000, V9ErrorCode.TIMEOUT),
+  ACTIVE_IDLE(30_000, V9ErrorCode.TIMEOUT),
+  BULK_PROGRESS(15_000, V9ErrorCode.TIMEOUT),
+  TERMINAL_CLEANUP(2_000, null),
+}
+
+enum class V9Role(val wireId: Int) {
+  SERVER(1),
+  CLIENT(2);
+
+  companion object {
+    fun fromWireId(wireId: Int): V9Role? = entries.firstOrNull { it.wireId == wireId }
+  }
+}
+
+enum class V9LinkMode {
+  NORMAL,
+  FOUR_PLAYER,
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ContractTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ContractTest.kt
@@ -688,17 +688,8 @@ class ProtocolV9ContractTest {
   }
 
   @Test
-  fun productionRemainsV8OnlyAndTheContractCannotReachLegacyOrNativeState() {
+  fun productionV9FoundationMirrorsTheContractWithoutReachingLegacyOrReplacingV8() {
     val root = repositoryRoot()
-    val productionRoots = listOf(root.resolve("core/src/main"), root.resolve("controller/src/main"), root.resolve("swing/src/main"))
-    val production = productionRoots.flatMap { sourceRoot ->
-      Files.walk(sourceRoot).use { paths ->
-        paths.filter { Files.isRegularFile(it) && (it.toString().endsWith(".kt") || it.toString().endsWith(".java")) }
-            .toList()
-      }
-    }.associateWith { it.readUtf8() }
-    assertFalse(production.values.any { "CGB9" in it || "PROTOCOL_VERSION: Byte = 0x09" in it })
-
     val v8 = root.resolve("controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt").readUtf8()
     listOf(
         "private const val PROTOCOL_NAME = \"CoffeeGB NETPLAY\"",
@@ -708,6 +699,33 @@ class ProtocolV9ContractTest {
         "private const val PROTOCOL_ERROR: Byte = 0x0a",
         "internal const val ROM_HEADER_SIZE = 44",
     ).forEach { assertTrue(v8.contains(it), "v8 production contract drift: $it") }
+    val defaultController =
+        root.resolve(
+            "controller/src/main/java/eu/rekawek/coffeegb/controller/network/ConnectionController.kt")
+            .readUtf8()
+    assertFalse(defaultController.contains(".network.v9"))
+    assertFalse(defaultController.contains("V9Foundation"))
+
+    val v9Root =
+        root.resolve("controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9")
+    val v9Production =
+        Files.walk(v9Root).use { paths ->
+          paths.filter {
+            Files.isRegularFile(it) &&
+                (it.toString().endsWith(".kt") || it.toString().endsWith(".java"))
+          }.sorted().map { it.readUtf8() }.toList().joinToString("\n")
+        }
+    assertTrue(v9Production.contains("CGB9"))
+    listOf(
+        "ObjectInputStream",
+        "ObjectOutputStream",
+        "LegacySnapshotImporter",
+        "NetplayMementoCodec",
+        "CGBN",
+        "Memento<",
+    ).forEach { assertFalse(v9Production.contains(it)) }
+    assertFalse(v9Production.contains("java.util." + "Hex" + "Format"))
+    assertFalse(Regex("(?:Enum\\.)?ordinal(?:\\(\\))?|\\.ordinal").containsMatchIn(v9Production))
 
     val contractRoot = root.resolve("controller/src/test/resources/netplay-v9")
     val contractResources = Files.list(contractRoot).use { paths ->

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9OwnershipTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9OwnershipTest.kt
@@ -1,0 +1,691 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ProtocolV9OwnershipTest {
+
+  @Test
+  fun localTerminalErrorDrainsUntilPeerEofOrExactCleanupDeadline() {
+    val clock = FakeClock()
+    val scheduler = ManualScheduler(clock)
+    val channel = ScriptedChannel()
+    val connection =
+        V9FoundationConnection(
+            channel,
+            V9Role.CLIENT,
+            clock = clock,
+            scheduler = scheduler,
+        )
+    connection.start()
+    channel.enqueue(malformedServerHello())
+    assertTrue(channel.outputShutdown.await(2, TimeUnit.SECONDS))
+    assertEquals(V9LifecycleState.TERMINAL_CLEANUP, connection.snapshot().state)
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, connection.snapshot().failure?.reason)
+    assertEquals(V9QueueSnapshot(0, 0, 0), connection.writerQueueSnapshot())
+
+    // Reader admission is stopped: even a complete valid HELLO cannot replace the rejection.
+    channel.enqueue(serverHello())
+    clock.now = 1_999
+    scheduler.runDue()
+    assertFalse(channel.closed.get())
+    assertEquals(V9LifecycleState.TERMINAL_CLEANUP, connection.snapshot().state)
+    clock.now = 2_000
+    scheduler.runDue()
+    assertTrue(channel.closed.get())
+    awaitCondition { connection.activeTaskCount() == 0 }
+    assertEquals(V9LifecycleState.CLOSED, connection.snapshot().state)
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, connection.snapshot().failure?.reason)
+    connection.cancel()
+    connection.close()
+    assertEquals(1, channel.closeCount.get())
+
+    val eofClock = FakeClock()
+    val eofScheduler = ManualScheduler(eofClock)
+    val eofChannel = ScriptedChannel()
+    val peerEof =
+        V9FoundationConnection(
+            eofChannel,
+            V9Role.CLIENT,
+            clock = eofClock,
+            scheduler = eofScheduler,
+        )
+    peerEof.start()
+    eofChannel.enqueue(malformedServerHello())
+    assertTrue(eofChannel.outputShutdown.await(2, TimeUnit.SECONDS))
+    eofChannel.enqueueEof()
+    awaitCondition { peerEof.isClosed() }
+    awaitCondition { peerEof.activeTaskCount() == 0 }
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, peerEof.snapshot().failure?.reason)
+    assertEquals(0, eofScheduler.activeTasks())
+  }
+
+  @Test
+  fun blockedTerminalWriteStillClosesAtDeadlineWithoutReplacingOriginalFailure() {
+    val clock = FakeClock()
+    val scheduler = ManualScheduler(clock)
+    val channel = ScriptedChannel(blockWrites = true)
+    val connection =
+        V9FoundationConnection(
+            channel,
+            V9Role.CLIENT,
+            clock = clock,
+            scheduler = scheduler,
+        )
+    connection.start()
+    channel.enqueue(malformedServerHello())
+    assertTrue(channel.writeEntered.await(2, TimeUnit.SECONDS))
+    assertEquals(V9LifecycleState.TERMINAL_CLEANUP, connection.snapshot().state)
+    clock.now = 1_999
+    scheduler.runDue()
+    assertFalse(connection.isClosed())
+    clock.now = 2_000
+    scheduler.runDue()
+    awaitCondition { connection.isClosed() }
+    awaitCondition { connection.activeTaskCount() == 0 }
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, connection.snapshot().failure?.reason)
+    assertEquals(1, channel.closeCount.get())
+
+    val failedWrite = ScriptedChannel(failWrites = true)
+    val isolated = V9FoundationConnection(failedWrite, V9Role.CLIENT)
+    isolated.start()
+    failedWrite.enqueue(malformedServerHello())
+    awaitCondition { isolated.isClosed() }
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, isolated.snapshot().failure?.reason)
+    assertEquals(1, failedWrite.closeCount.get())
+  }
+
+  @Test
+  fun everyHelloStageUsesItsExactInjectedDeadlineAndStartAfterCloseStartsNoTask() {
+    assertStageTimeout(
+        V9LifecycleState.SEND_SERVER_HELLO,
+        V9Role.SERVER,
+        ScriptedChannel(blockWrites = true),
+    )
+    assertStageTimeout(
+        V9LifecycleState.WAIT_SERVER_HELLO,
+        V9Role.CLIENT,
+        ScriptedChannel(),
+    )
+    assertStageTimeout(
+        V9LifecycleState.SEND_CLIENT_HELLO,
+        V9Role.CLIENT,
+        ScriptedChannel(blockWrites = true).also { it.enqueue(serverHello()) },
+    )
+    assertStageTimeout(
+        V9LifecycleState.WAIT_CLIENT_HELLO,
+        V9Role.SERVER,
+        ScriptedChannel(),
+    )
+
+    val closed = V9FoundationConnection(ScriptedChannel(), V9Role.CLIENT)
+    closed.close()
+    assertFailsWith<IllegalStateException> { closed.start() }
+    assertEquals(0, closed.activeTaskCount())
+    closed.cancel()
+    assertEquals(V9LifecycleState.CLOSED, closed.snapshot().state)
+    assertNull(closed.snapshot().failure)
+  }
+
+  @Test
+  fun liveFoundationAppliesResponseLedgerAndOnlyAllowsFrozenPreHelloRejections() {
+    val responseChannel = ScriptedChannel()
+    val response =
+        V9FoundationConnection(responseChannel, V9Role.CLIENT)
+    response.start()
+    responseChannel.enqueue(
+        rawFrame(
+            V9MessageType.ERROR,
+            V9Flag.RESPONSE.wireMask or V9Flag.TERMINAL.wireMask,
+            0,
+            7,
+            V9ErrorPayloadCodec.encode(V9ErrorCode.SERVER_BUSY),
+        ),
+    )
+    assertTrue(responseChannel.outputShutdown.await(2, TimeUnit.SECONDS))
+    assertEquals(V9ErrorCode.CORRELATION_ERROR, response.snapshot().failure?.reason)
+    responseChannel.enqueueEof()
+    awaitCondition { response.isClosed() }
+
+    val rejectedChannel = ScriptedChannel()
+    val rejected = V9FoundationConnection(rejectedChannel, V9Role.CLIENT)
+    rejected.start()
+    rejectedChannel.enqueue(
+        rawFrame(
+            V9MessageType.ERROR,
+            V9Flag.TERMINAL.wireMask,
+            0,
+            0,
+            V9ErrorPayloadCodec.encode(V9ErrorCode.SERVER_FULL),
+        ),
+    )
+    awaitCondition { rejected.isClosed() }
+    assertEquals(V9ErrorCode.SERVER_FULL, rejected.snapshot().failure?.reason)
+    assertEquals(0, rejectedChannel.outputBytes().size)
+
+    val illegalChannel = ScriptedChannel()
+    val illegal = V9FoundationConnection(illegalChannel, V9Role.CLIENT)
+    illegal.start()
+    illegalChannel.enqueue(
+        rawFrame(
+            V9MessageType.ERROR,
+            V9Flag.TERMINAL.wireMask,
+            0,
+            0,
+            V9ErrorPayloadCodec.encode(V9ErrorCode.CAPABILITY_MISMATCH),
+        ),
+    )
+    assertTrue(illegalChannel.outputShutdown.await(2, TimeUnit.SECONDS))
+    assertEquals(V9ErrorCode.UNEXPECTED_MESSAGE, illegal.snapshot().failure?.reason)
+    illegalChannel.enqueueEof()
+    awaitCondition { illegal.isClosed() }
+  }
+
+  @Test
+  fun injectedSystemSchedulerRemainsCallerOwned() {
+    val scheduler = V9SystemDeadlineScheduler()
+    try {
+      val connection =
+          V9FoundationConnection(
+              ScriptedChannel(),
+              V9Role.CLIENT,
+              scheduler = scheduler,
+          )
+      connection.close()
+      val invoked = CountDownLatch(1)
+      scheduler.schedule(V9MonotonicClock.SYSTEM.nowMillis()) { invoked.countDown() }
+      assertTrue(invoked.await(2, TimeUnit.SECONDS))
+
+      val attempt =
+          V9FoundationConnectAttempt(
+              scheduler = scheduler,
+              channelFactory = { ImmediateConnectableChannel() },
+          )
+      attempt.cancel()
+      attempt.start(InetSocketAddress("127.0.0.1", 1)) { _, error ->
+        assertEquals(V9ErrorCode.CANCELLED, error)
+      }
+      val invokedAfterAttempt = CountDownLatch(1)
+      scheduler.schedule(V9MonotonicClock.SYSTEM.nowMillis()) {
+        invokedAfterAttempt.countDown()
+      }
+      assertTrue(invokedAfterAttempt.await(2, TimeUnit.SECONDS))
+    } finally {
+      scheduler.close()
+    }
+  }
+
+  @Test
+  fun connectAttemptCancellationWinsEveryPreHandoffBoundaryExactlyOnce() {
+    V9ConnectHook.entries.forEach { selected ->
+      val channel = ImmediateConnectableChannel()
+      val entered = CountDownLatch(1)
+      val release = CountDownLatch(1)
+      val callback = CountDownLatch(1)
+      val callbackCount = AtomicInteger()
+      var result: V9ErrorCode? = null
+      val attempt = V9FoundationConnectAttempt(channelFactory = { channel })
+      val blocker = {
+        entered.countDown()
+        release.await()
+        Unit
+      }
+      attempt.hooks =
+          V9ConnectAttemptHooks(
+              beforeConnect = if (selected == V9ConnectHook.BEFORE_CONNECT) blocker else ({}),
+              afterConnect = if (selected == V9ConnectHook.AFTER_CONNECT) blocker else ({}),
+              afterConnectionCreated =
+                  if (selected == V9ConnectHook.AFTER_CONSTRUCTION) blocker else ({}),
+              afterConnectionStarted =
+                  if (selected == V9ConnectHook.AFTER_START) blocker else ({}),
+          )
+      attempt.start(InetSocketAddress("127.0.0.1", 1)) { connection, error ->
+        assertNull(connection)
+        result = error
+        callbackCount.incrementAndGet()
+        callback.countDown()
+      }
+      assertTrue(entered.await(2, TimeUnit.SECONDS), selected.name)
+      attempt.cancel()
+      attempt.cancel()
+      attempt.close()
+      release.countDown()
+      assertTrue(callback.await(2, TimeUnit.SECONDS), selected.name)
+      assertEquals(V9ErrorCode.CANCELLED, result, selected.name)
+      assertEquals(1, callbackCount.get(), selected.name)
+      assertEquals(1, channel.closeCount.get(), selected.name)
+    }
+
+    val cancelled = V9FoundationConnectAttempt { ImmediateConnectableChannel() }
+    cancelled.cancel()
+    val callback = AtomicInteger()
+    cancelled.start(InetSocketAddress("127.0.0.1", 1)) { connection, error ->
+      assertNull(connection)
+      assertEquals(V9ErrorCode.CANCELLED, error)
+      callback.incrementAndGet()
+    }
+    cancelled.close()
+    assertEquals(1, callback.get())
+  }
+
+  @Test
+  fun connectAttemptTimesOutExactlyAndRelinquishesAHandedOffConnection() {
+    val clock = FakeClock()
+    val scheduler = ManualScheduler(clock)
+    val blocked = BlockingConnectableChannel()
+    val timeoutResult = CountDownLatch(1)
+    var timeoutError: V9ErrorCode? = null
+    val timeout =
+        V9FoundationConnectAttempt(
+            clock = clock,
+            scheduler = scheduler,
+            channelFactory = { blocked },
+        )
+    timeout.start(InetSocketAddress("127.0.0.1", 1)) { connection, error ->
+      assertNull(connection)
+      timeoutError = error
+      timeoutResult.countDown()
+    }
+    assertTrue(blocked.connectEntered.await(2, TimeUnit.SECONDS))
+    clock.now = 4_999
+    scheduler.runDue()
+    assertFalse(timeout.isComplete())
+    assertEquals(0, blocked.closeCount.get())
+    clock.now = 5_000
+    scheduler.runDue()
+    assertTrue(timeoutResult.await(2, TimeUnit.SECONDS))
+    assertEquals(V9ErrorCode.TIMEOUT, timeoutError)
+    assertEquals(1, blocked.closeCount.get())
+
+    val handedChannel = ImmediateConnectableChannel()
+    val handedResult = CountDownLatch(1)
+    var handed: V9FoundationConnection? = null
+    val attempt = V9FoundationConnectAttempt { handedChannel }
+    attempt.start(InetSocketAddress("127.0.0.1", 1)) { connection, error ->
+      assertNull(error)
+      handed = assertNotNull(connection)
+      handedResult.countDown()
+    }
+    assertTrue(handedResult.await(2, TimeUnit.SECONDS))
+    attempt.close()
+    assertEquals(0, handedChannel.closeCount.get())
+    assertFalse(assertNotNull(handed).isClosed())
+    assertNotNull(handed).close()
+    assertEquals(1, handedChannel.closeCount.get())
+  }
+
+  @Test
+  fun serverRemovesClosedCandidatesAndIsolatesConstructionStartAndCallbackFailures() {
+    val callbacks = AtomicInteger()
+    val accepted = CountDownLatch(3)
+    V9FoundationServer(onAwaitingPairing = {
+      callbacks.incrementAndGet()
+      it.close()
+      accepted.countDown()
+    }).use { server ->
+      server.start()
+      val candidates = List(3) { completeClientHello(server.localPort) }
+      assertTrue(accepted.await(5, TimeUnit.SECONDS))
+      candidates.forEach(Socket::close)
+      awaitCondition {
+        server.activeConnectionCount() == 0 && server.pendingCandidateCount() == 0
+      }
+      assertEquals(3, callbacks.get())
+    }
+
+    val valid = CountDownLatch(1)
+    val factoryCalls = AtomicInteger()
+    V9FoundationServer(onAwaitingPairing = {
+      it.close()
+      valid.countDown()
+    }).use { server ->
+      server.connectionFactory = { channel, role, mode, capabilities ->
+        when (factoryCalls.incrementAndGet()) {
+          1 -> throw IllegalStateException("synthetic constructor failure")
+          2 ->
+            V9FoundationConnection(
+                    channel,
+                    role,
+                    mode,
+                    optionalCapabilities = capabilities,
+                )
+                .also(V9FoundationConnection::close)
+          else ->
+            V9FoundationConnection(
+                channel,
+                role,
+                mode,
+                optionalCapabilities = capabilities,
+            )
+        }
+      }
+      server.start()
+      Socket("127.0.0.1", server.localPort).use { it.getInputStream().read() }
+      Socket("127.0.0.1", server.localPort).use { it.getInputStream().read() }
+      val candidate = completeClientHello(server.localPort)
+      assertTrue(valid.await(5, TimeUnit.SECONDS))
+      candidate.close()
+      awaitCondition {
+        server.activeConnectionCount() == 0 && server.pendingCandidateCount() == 0
+      }
+      assertEquals(3, factoryCalls.get())
+    }
+
+    val callbackCalls = AtomicInteger()
+    val laterValid = CountDownLatch(1)
+    V9FoundationServer(onAwaitingPairing = {
+      if (callbackCalls.incrementAndGet() == 1) {
+        throw IllegalStateException("synthetic callback failure")
+      }
+      it.close()
+      laterValid.countDown()
+    }).use { server ->
+      server.start()
+      val first = completeClientHello(server.localPort)
+      val second = completeClientHello(server.localPort)
+      assertTrue(laterValid.await(5, TimeUnit.SECONDS))
+      first.close()
+      second.close()
+      awaitCondition {
+        server.activeConnectionCount() == 0 && server.pendingCandidateCount() == 0
+      }
+      assertEquals(2, callbackCalls.get())
+    }
+
+    val callbackEntered = CountDownLatch(1)
+    val releaseCallback = CountDownLatch(1)
+    val closeReturned = CountDownLatch(1)
+    val callbackAfterClose = AtomicInteger()
+    val racing =
+        V9FoundationServer(onAwaitingPairing = {
+          callbackEntered.countDown()
+          releaseCallback.await()
+          if (closeReturned.count == 0L) callbackAfterClose.incrementAndGet()
+          it.close()
+        })
+    racing.start()
+    val candidate = completeClientHello(racing.localPort)
+    assertTrue(callbackEntered.await(5, TimeUnit.SECONDS))
+    val closer =
+        Thread {
+          racing.close()
+          closeReturned.countDown()
+        }.also(Thread::start)
+    assertFalse(closeReturned.await(50, TimeUnit.MILLISECONDS))
+    releaseCallback.countDown()
+    assertTrue(closeReturned.await(5, TimeUnit.SECONDS))
+    closer.join()
+    candidate.close()
+    assertEquals(0, callbackAfterClose.get())
+    assertEquals(0, racing.activeConnectionCount())
+    assertEquals(0, racing.pendingCandidateCount())
+
+    val neverStarted = V9FoundationServer(onAwaitingPairing = {})
+    neverStarted.close()
+    assertFailsWith<IllegalStateException> { neverStarted.start() }
+    assertEquals(0, neverStarted.activeConnectionCount())
+    assertEquals(0, neverStarted.pendingCandidateCount())
+  }
+
+  private fun assertStageTimeout(
+      expected: V9LifecycleState,
+      role: V9Role,
+      channel: ScriptedChannel,
+  ) {
+    val clock = FakeClock()
+    val scheduler = ManualScheduler(clock)
+    val connection =
+        V9FoundationConnection(
+            channel,
+            role,
+            clock = clock,
+            scheduler = scheduler,
+        )
+    connection.start()
+    awaitCondition { connection.snapshot().state == expected }
+    clock.now = 4_999
+    scheduler.runDue()
+    assertEquals(expected, connection.snapshot().state)
+    clock.now = 5_000
+    scheduler.runDue()
+    awaitCondition { connection.isClosed() }
+    assertEquals(V9ErrorCode.TIMEOUT, connection.snapshot().failure?.reason)
+    assertEquals(1, channel.closeCount.get())
+  }
+
+  private fun completeClientHello(port: Int): Socket {
+    val socket = Socket("127.0.0.1", port)
+    socket.soTimeout = 3_000
+    readExactly(socket, ProtocolV9.HEADER_BYTES + 94)
+    socket.getOutputStream().write(clientHello())
+    socket.getOutputStream().flush()
+    return socket
+  }
+
+  private fun readExactly(socket: Socket, size: Int) {
+    val bytes = ByteArray(size)
+    var offset = 0
+    while (offset < bytes.size) {
+      val count = socket.getInputStream().read(bytes, offset, bytes.size - offset)
+      if (count < 0) throw IOException("unexpected test EOF")
+      offset += count
+    }
+  }
+
+  private fun serverHello(): ByteArray =
+      helloFrame(V9Role.SERVER, ByteArray(32) { 1 })
+
+  private fun clientHello(): ByteArray =
+      helloFrame(V9Role.CLIENT, ByteArray(32) { 2 })
+
+  private fun helloFrame(role: V9Role, nonce: ByteArray): ByteArray =
+      V9FrameEncoder.encode(
+          V9OutboundFrame(
+              V9MessageType.HELLO,
+              0,
+              0,
+              0,
+              ProtocolV9.CONTROL_CHANNEL,
+              V9HelloCodec.encode(V9HelloCodec.create(role, nonce)),
+          ),
+      )
+
+  private fun malformedServerHello(): ByteArray {
+    val valid = V9HelloCodec.encode(V9HelloCodec.create(V9Role.SERVER, ByteArray(32) { 3 }))
+    val malformed =
+        valid.copyOf(valid.size - 8).also {
+          ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putShort(36, 6)
+        }
+    return rawFrame(V9MessageType.HELLO, 0, 0, 0, malformed)
+  }
+
+  private fun rawFrame(
+      type: V9MessageType,
+      flags: Int,
+      sequence: Long,
+      correlation: Long,
+      payload: ByteArray,
+  ): ByteArray =
+      ByteBuffer.allocate(ProtocolV9.HEADER_BYTES + payload.size).order(ByteOrder.BIG_ENDIAN)
+          .put(ProtocolV9.MAGIC)
+          .put(ProtocolV9.MAJOR.toByte())
+          .put(ProtocolV9.MINOR.toByte())
+          .putShort(ProtocolV9.HEADER_BYTES.toShort())
+          .putShort(type.wireId.toShort())
+          .putShort(flags.toShort())
+          .putInt(sequence.toInt())
+          .putInt(correlation.toInt())
+          .putInt(payload.size)
+          .putInt(payload.size)
+          .putInt(ProtocolV9.CONTROL_CHANNEL.toInt())
+          .put(MessageDigest.getInstance("SHA-256").digest(payload))
+          .put(payload)
+          .array()
+
+  private fun awaitCondition(condition: () -> Boolean) {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (!condition()) {
+      check(System.nanoTime() < deadline) { "condition did not become true" }
+      Thread.yield()
+    }
+  }
+
+  private enum class V9ConnectHook {
+    BEFORE_CONNECT,
+    AFTER_CONNECT,
+    AFTER_CONSTRUCTION,
+    AFTER_START,
+  }
+
+  private class FakeClock(var now: Long = 0) : V9MonotonicClock {
+    override fun nowMillis(): Long = now
+  }
+
+  private class ManualScheduler(private val clock: FakeClock) : V9DeadlineScheduler {
+    private val tasks = mutableListOf<Task>()
+
+    @Synchronized
+    override fun schedule(deadlineMillis: Long, action: Runnable): Closeable {
+      val task = Task(deadlineMillis, action)
+      tasks += task
+      return Closeable { task.active.set(false) }
+    }
+
+    @Synchronized
+    fun runDue() {
+      tasks.filter { it.active.get() && it.deadline <= clock.now }.forEach {
+        if (it.active.compareAndSet(true, false)) it.action.run()
+      }
+    }
+
+    @Synchronized
+    fun activeTasks(): Int = tasks.count { it.active.get() }
+
+    private data class Task(
+        val deadline: Long,
+        val action: Runnable,
+        val active: AtomicBoolean = AtomicBoolean(true),
+    )
+  }
+
+  private class ScriptedChannel(
+      private val blockWrites: Boolean = false,
+      private val failWrites: Boolean = false,
+  ) : V9TransportChannel {
+    private val incoming = LinkedBlockingQueue<Int>()
+    private val output = ByteArrayOutputStream()
+    private val writeRelease = CountDownLatch(if (blockWrites) 1 else 0)
+    val writeEntered = CountDownLatch(1)
+    val outputShutdown = CountDownLatch(1)
+    val closed = AtomicBoolean()
+    val closeCount = AtomicInteger()
+
+    fun enqueue(bytes: ByteArray) {
+      bytes.forEach { incoming.put(it.toInt() and 0xff) }
+    }
+
+    fun enqueueEof() {
+      incoming.put(-1)
+    }
+
+    @Synchronized
+    fun outputBytes(): ByteArray = output.toByteArray()
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+      val first = incoming.take()
+      if (first < 0) return -1
+      bytes[offset] = first.toByte()
+      var count = 1
+      while (count < length) {
+        val next = incoming.poll() ?: break
+        if (next < 0) {
+          incoming.offer(next)
+          break
+        }
+        bytes[offset + count++] = next.toByte()
+      }
+      return count
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+      writeEntered.countDown()
+      writeRelease.await()
+      if (closed.get()) throw IOException("closed")
+      if (failWrites) throw IOException("synthetic write failure")
+      synchronized(this) { output.write(bytes, offset, length) }
+      return length
+    }
+
+    override fun shutdownOutput() {
+      outputShutdown.countDown()
+    }
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        closeCount.incrementAndGet()
+        writeRelease.countDown()
+        incoming.offer(-1)
+      }
+    }
+  }
+
+  private open class ImmediateConnectableChannel : V9ConnectableChannel {
+    private val closeLatch = CountDownLatch(1)
+    val closeCount = AtomicInteger()
+    private val closed = AtomicBoolean()
+
+    override fun connect(address: InetSocketAddress, timeoutMillis: Int) = Unit
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+      closeLatch.await()
+      return -1
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+      if (closed.get()) throw IOException("closed")
+      return length
+    }
+
+    override fun shutdownOutput() = Unit
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        closeCount.incrementAndGet()
+        closeLatch.countDown()
+      }
+    }
+  }
+
+  private class BlockingConnectableChannel : ImmediateConnectableChannel() {
+    val connectEntered = CountDownLatch(1)
+    private val connectRelease = CountDownLatch(1)
+
+    override fun connect(address: InetSocketAddress, timeoutMillis: Int) {
+      connectEntered.countDown()
+      connectRelease.await()
+    }
+
+    override fun close() {
+      connectRelease.countDown()
+      super.close()
+    }
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9OwnershipTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9OwnershipTest.kt
@@ -8,11 +8,13 @@ import java.net.Socket
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -443,6 +445,104 @@ class ProtocolV9OwnershipTest {
     assertFailsWith<IllegalStateException> { neverStarted.start() }
     assertEquals(0, neverStarted.activeConnectionCount())
     assertEquals(0, neverStarted.pendingCandidateCount())
+  }
+
+  @Test
+  fun serverShutdownClosesSocketAcceptedBeforeCandidateAdmission() {
+    val accepted = CountDownLatch(1)
+    val releaseAdmission = CountDownLatch(1)
+    val serverSocket = AtomicReference<Socket>()
+    val callbacks = AtomicInteger()
+    val server =
+        V9FoundationServer(onAwaitingPairing = {
+          callbacks.incrementAndGet()
+          it.close()
+        })
+    server.candidateHooks =
+        V9ServerCandidateHooks(
+            afterAcceptBeforeAdmission = {
+              serverSocket.set(it)
+              accepted.countDown()
+              releaseAdmission.await()
+            },
+        )
+    server.start()
+    val client = Socket("127.0.0.1", server.localPort)
+    try {
+      assertTrue(accepted.await(2, TimeUnit.SECONDS))
+      assertEquals(0, server.pendingCandidateCount())
+
+      server.close()
+      releaseAdmission.countDown()
+
+      awaitCondition { assertNotNull(serverSocket.get()).isClosed }
+      awaitServerShutdown(server)
+      assertEquals(0, callbacks.get())
+    } finally {
+      releaseAdmission.countDown()
+      client.close()
+      server.close()
+    }
+  }
+
+  @Test
+  fun serverShutdownClosesCandidateQueuedBeforeAnyWorkerCanRunIt() {
+    val workerCount = V9Limit.HANDSHAKE_WORKERS.value.toInt()
+    val candidateCount = workerCount + 1
+    val accepted = CountDownLatch(candidateCount)
+    val workersEntered = CountDownLatch(workerCount)
+    val workerStarts = AtomicInteger()
+    val releaseWorkers = CountDownLatch(1)
+    val serverSockets = ConcurrentLinkedQueue<Socket>()
+    val callbacks = AtomicInteger()
+    val server =
+        V9FoundationServer(onAwaitingPairing = {
+          callbacks.incrementAndGet()
+          it.close()
+        })
+    server.candidateHooks =
+        V9ServerCandidateHooks(
+            afterAcceptBeforeAdmission = {
+              serverSockets += it
+              accepted.countDown()
+            },
+            beforeWorkerNegotiation = {
+              workerStarts.incrementAndGet()
+              workersEntered.countDown()
+              releaseWorkers.await()
+            },
+        )
+    server.start()
+    val clients = List(candidateCount) { Socket("127.0.0.1", server.localPort) }
+    try {
+      assertTrue(accepted.await(2, TimeUnit.SECONDS))
+      assertTrue(workersEntered.await(2, TimeUnit.SECONDS))
+      awaitCondition { server.pendingCandidateCount() == candidateCount }
+      // All workers are held above; the extra accepted candidate is still queued.
+      assertEquals(workerCount, workerStarts.get())
+
+      server.close()
+      releaseWorkers.countDown()
+
+      awaitCondition {
+        serverSockets.size == candidateCount && serverSockets.all(Socket::isClosed)
+      }
+      awaitServerShutdown(server)
+      assertEquals(0, callbacks.get())
+    } finally {
+      releaseWorkers.countDown()
+      clients.forEach(Socket::close)
+      server.close()
+    }
+  }
+
+  private fun awaitServerShutdown(server: V9FoundationServer) {
+    awaitCondition {
+      server.pendingCandidateCount() == 0 &&
+          server.activeConnectionCount() == 0 &&
+          !server.acceptThreadAlive() &&
+          server.workerPoolTerminated()
+    }
   }
 
   private fun assertStageTimeout(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ProductionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ProductionTest.kt
@@ -613,22 +613,63 @@ class ProtocolV9ProductionTest {
 
   @Test
   fun sequenceAndResponseLedgerNeverUsesOrdinalsOrWraps() {
-    val ledger = V9ResponseLedger(1)
-    ledger.recordPeerRequest(7, V9MessageType.AUTH)
-    assertNull(ledger.accept(1, V9MessageType.AUTH_RESULT, V9Flag.RESPONSE.wireMask, 7))
-    assertEquals(2, ledger.nextIncomingSequence)
-    assertEquals(
-        V9ErrorCode.CORRELATION_ERROR,
-        ledger.accept(2, V9MessageType.AUTH_RESULT, V9Flag.RESPONSE.wireMask, 7),
+    rows("/netplay-v9/response-vectors.tsv").forEach { row ->
+      val exhausted = row.getValue("expected_sequence") == "4294967295"
+      val expected =
+          if (exhausted) ProtocolV9.EXHAUSTED_SEQUENCE
+          else row.long("expected_sequence")
+      val alreadyResponded = row.boolean("already_responded")
+      val ledger =
+          V9ResponseLedger(
+              if (alreadyResponded) Math.subtractExact(expected, 1) else expected,
+          )
+      if (row.getValue("outstanding_sequence") != "-") {
+        val requestSequence = row.long("outstanding_sequence")
+        val requestType =
+            assertNotNull(V9MessageType.fromWireName(row.getValue("outstanding_message")))
+        ledger.recordPeerRequest(requestSequence, requestType)
+        if (alreadyResponded) {
+          assertNull(
+              ledger.accept(
+                  Math.subtractExact(expected, 1),
+                  V9MessageType.AUTH_RESULT,
+                  V9Flag.RESPONSE.wireMask,
+                  requestSequence,
+              ),
+          )
+          assertEquals(0, ledger.outstandingRequests)
+        }
+      }
+      val result =
+          ledger.accept(
+              row.long("incoming_sequence"),
+              assertNotNull(V9MessageType.fromWireName(row.getValue("message"))),
+              row.hexInt("flags"),
+              row.long("correlation"),
+          )
+      assertEquals(
+          row.getValue("expected"),
+          result?.wireName ?: "SUCCESS",
+          row.getValue("id"),
+      )
+      val next = row.getValue("next_sequence")
+      if (next == "EXHAUSTED") assertNull(ledger.nextIncomingSequence, row.getValue("id"))
+      else assertEquals(next.toLong(), ledger.nextIncomingSequence, row.getValue("id"))
+    }
+    val bounded = V9ResponseLedger(1)
+    bounded.recordPeerRequest(7, V9MessageType.AUTH)
+    assertNull(
+        bounded.accept(
+            1,
+            V9MessageType.AUTH_RESULT,
+            V9Flag.RESPONSE.wireMask,
+            7,
+        ),
     )
-
-    val wrong = V9ResponseLedger(1)
-    wrong.recordPeerRequest(9, V9MessageType.START)
-    assertEquals(
-        V9ErrorCode.CORRELATION_ERROR,
-        wrong.accept(1, V9MessageType.PONG, V9Flag.RESPONSE.wireMask, 9),
-    )
-    assertEquals(1, wrong.nextIncomingSequence)
+    assertEquals(0, bounded.outstandingRequests)
+    assertFailsWith<IllegalArgumentException> {
+      bounded.recordPeerRequest(7, V9MessageType.AUTH)
+    }
 
     val exhausted = V9ResponseLedger(ProtocolV9.LAST_SEQUENCE)
     assertNull(exhausted.accept(ProtocolV9.LAST_SEQUENCE, V9MessageType.INPUT, 0, 0))
@@ -686,6 +727,31 @@ class ProtocolV9ProductionTest {
     assertFailsWith<UnsupportedOperationException> {
       mutable.add(V9Capability.PING_V1)
     }
+
+    val terminalClock = FakeClock()
+    val terminal = V9Lifecycle(V9Role.CLIENT, terminalClock)
+    val original =
+        assertNotNull(
+            terminal.beginTerminalCleanup(
+                V9ErrorCode.CAPABILITY_MISMATCH,
+                V9Diagnostic.CAPABILITY_MISMATCH,
+            ),
+        )
+    assertEquals(V9LifecycleState.WAIT_SERVER_HELLO, original.stage)
+    assertEquals(2_000, terminal.snapshot().deadlineMillis)
+    terminalClock.now = 1_999
+    assertEquals(original, terminal.checkDeadline())
+    assertEquals(V9LifecycleState.TERMINAL_CLEANUP, terminal.snapshot().state)
+    terminalClock.now = 2_000
+    assertEquals(original, terminal.checkDeadline())
+    assertEquals(V9LifecycleState.CLOSED, terminal.snapshot().state)
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, terminal.snapshot().failure?.reason)
+    assertEquals(original, terminal.cancel())
+
+    val normal = V9Lifecycle(V9Role.CLIENT)
+    normal.closeNormally()
+    assertNull(normal.cancel())
+    assertEquals(V9LifecycleState.CLOSED, normal.snapshot().state)
   }
 
   @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ProductionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ProductionTest.kt
@@ -1,0 +1,1061 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ProtocolV9ProductionTest {
+
+  @Test
+  fun productionRegistriesExactlyMirrorEveryFrozenRow() {
+    val messages = rows("/netplay-v9/messages.tsv")
+    assertEquals(messages.size, V9MessageType.entries.size)
+    messages.forEach { row ->
+      val type = assertNotNull(V9MessageType.fromWireId(row.hexInt("id")))
+      val spec = type.spec
+      assertEquals(row.getValue("name"), spec.wireName)
+      assertEquals(row.long("min_decoded"), spec.minimumDecodedBytes)
+      assertEquals(row.long("max_decoded"), spec.maximumDecodedBytes)
+      assertEquals(row.long("max_encoded"), spec.maximumEncodedBytes)
+      assertEquals(row.hexInt("allowed_flags"), spec.allowedFlags)
+      assertEquals(row.hexInt("required_flags"), spec.requiredFlags)
+      assertEquals(
+          when (row.getValue("channels")) {
+            "control" -> V9ChannelKind.CONTROL
+            "player" -> V9ChannelKind.PLAYER
+            "group-or-player" -> V9ChannelKind.GROUP_OR_PLAYER
+            else -> error("unknown channel registry value")
+          },
+          spec.channelKind,
+      )
+      assertEquals(
+          if (row.getValue("compression") == "raw-deflate") V9Compression.RAW_DEFLATE
+          else V9Compression.NONE,
+          spec.compression,
+      )
+      assertEquals(row.getValue("payload_schema"), spec.payloadSchema)
+    }
+
+    val capabilities = rows("/netplay-v9/capabilities.tsv")
+    assertEquals(capabilities.size, V9Capability.entries.size)
+    capabilities.zip(V9Capability.entries).forEach { (row, capability) ->
+      assertEquals(row.hexInt("id"), capability.wireId)
+      assertEquals(row.getValue("name"), capability.wireName)
+      assertEquals(row.int("version"), capability.schemaVersion)
+      assertEquals(row.boolean("required"), capability.required)
+      assertEquals(row.int("phase_owner"), capability.phaseOwner)
+      assertEquals(row.getValue("meaning"), capability.meaning)
+    }
+
+    val errors = rows("/netplay-v9/errors.tsv")
+    assertEquals(errors.size, V9ErrorCode.entries.size)
+    errors.zip(V9ErrorCode.entries).forEach { (row, error) ->
+      assertEquals(row.hexInt("code"), error.wireId)
+      assertEquals(row.getValue("name"), error.wireName)
+      assertEquals(row.boolean("peer_visible"), error.peerVisible)
+      assertEquals(row.boolean("retry_same_connection"), error.retrySameConnection)
+      assertEquals(row.boolean("mutation_allowed"), error.mutationAllowed)
+    }
+
+    val limits = rows("/netplay-v9/limits.tsv")
+    assertEquals(limits.size, V9Limit.entries.size)
+    limits.zip(V9Limit.entries).forEach { (row, limit) ->
+      assertEquals(row.getValue("name"), limit.name)
+      assertEquals(row.long("value"), limit.value)
+      assertEquals(row.getValue("unit"), limit.unit)
+      assertEquals(row.getValue("validation_boundary"), limit.validationBoundary)
+      assertEquals(row.getValue("rationale"), limit.rationale)
+    }
+
+    val timeouts = rows("/netplay-v9/timeouts.tsv")
+    assertEquals(timeouts.size, V9Timeout.entries.size)
+    timeouts.zip(V9Timeout.entries).forEach { (row, timeout) ->
+      assertEquals(row.getValue("state"), timeout.name)
+      assertEquals(row.long("milliseconds"), timeout.milliseconds)
+      assertEquals("monotonic", row.getValue("clock"))
+      val expected = row.getValue("on_expiry")
+      if (expected == "CLOSED") assertNull(timeout.expiryError)
+      else assertEquals(expected, timeout.expiryError?.wireName)
+    }
+    val transitionStates =
+        rows("/netplay-v9/transitions.tsv")
+            .flatMap { listOf(it.getValue("state"), it.getValue("next_state")) }
+            .filter { it !in setOf("ANY_NONTERMINAL") }
+            .toSet()
+    val concreteStates =
+        transitionStates +
+            rows("/netplay-v9/timeouts.tsv").map {
+              it.getValue("state").let { state ->
+                if (state == "ACTIVE_IDLE") "ACTIVE" else state
+              }
+            } +
+            "CLOSED"
+    assertEquals(
+        concreteStates,
+        V9LifecycleState.entries.map { it.name }.toSet(),
+    )
+  }
+
+  @Test
+  fun productionHeaderPreflightMatchesFrozenPrecedenceAndAllocationBoundary() {
+    rows("/netplay-v9/header-precedence-vectors.tsv").forEach { row ->
+      val budget =
+          V9QueueBudget(
+              initialFrames = row.long("current_frames"),
+              initialWireBytes = row.long("current_wire"),
+              initialDecodedBytes = row.long("current_decoded"),
+          )
+      val decoder =
+          V9IncrementalDecoder(
+              initialSequence = 1,
+              budget = budget,
+              policy =
+                  V9DecoderPolicy(
+                      allowedMessages = V9MessageType.entries.toSet(),
+                      negotiatedCapabilities = V9Capability.entries.toSet(),
+                  ),
+          )
+      val header = headerFrom(row)
+      val decisive = row.int("decisive_read")
+      val result = decoder.feed(header.copyOf(decisive))
+      if (row.getValue("expected") == "ACCEPT") {
+        assertNull(result.failure, row.getValue("id"))
+        assertEquals(1, result.payloadReservations, row.getValue("id"))
+        assertEquals(1, result.payloadAllocations, row.getValue("id"))
+      } else {
+        assertEquals(row.getValue("expected"), result.failure?.reason?.wireName, row.getValue("id"))
+        assertEquals(decisive, result.failure?.decisiveBytes, row.getValue("id"))
+        assertEquals(0, result.payloadReservations, row.getValue("id"))
+        assertEquals(0, result.payloadAllocations, row.getValue("id"))
+      }
+      result.frames.forEach(V9Frame::close)
+    }
+  }
+
+  @Test
+  fun productionDecoderHandlesBytewiseIrregularCoalescedAndExactEofBoundaries() {
+    val vectors = rows("/netplay-v9/wire-vectors.tsv").associateBy { it.getValue("id") }
+    val input = hex(vectors.getValue("valid_input").getValue("input_hex"))
+    val policy =
+        V9DecoderPolicy(
+            allowedMessages = setOf(V9MessageType.INPUT, V9MessageType.PING),
+            negotiatedCapabilities = V9Capability.entries.toSet(),
+        )
+    val bytewise = V9IncrementalDecoder(1, policy = policy)
+    input.forEachIndexed { index, byte ->
+      val result = bytewise.feed(byteArrayOf(byte))
+      if (index < input.lastIndex) {
+        assertTrue(result.needsMore, "index=$index")
+        assertEquals(0, result.frames.size, "index=$index")
+        assertTrue(result.retainedBytes in 1..79, "index=$index")
+      } else {
+        assertEquals(1, result.frames.size)
+        assertEquals(V9MessageType.INPUT, result.frames.single().header.type)
+        result.frames.single().close()
+      }
+    }
+    assertEquals(V9QueueSnapshot(0, 0, 0), bytewise.queueSnapshot())
+
+    val irregular = V9IncrementalDecoder(1, policy = policy)
+    var offset = 0
+    listOf(3, 1, 17, 2, 31, 5, 7, 14).forEach { size ->
+      val result = irregular.feed(input, offset, size)
+      offset += size
+      result.frames.forEach(V9Frame::close)
+    }
+    assertEquals(input.size, offset)
+    assertNull(irregular.snapshot().failure)
+    assertEquals(0, irregular.snapshot().retainedBytes)
+
+    val coalesced = hex(vectors.getValue("coalesced_input_ping").getValue("input_hex"))
+    val together = V9IncrementalDecoder(1, policy = policy).feed(coalesced)
+    assertEquals(listOf(V9MessageType.INPUT, V9MessageType.PING), together.frames.map { it.header.type })
+    together.frames.forEach(V9Frame::close)
+
+    val ping = hex(vectors.getValue("valid_ping").getValue("input_hex"))
+    rows("/netplay-v9/header-truncations.tsv").single()
+        .getValue("cut_offsets").split(',').map(String::toInt).forEach { cut ->
+          val decoder = V9IncrementalDecoder(2, policy = policy)
+          decoder.feed(ping.copyOf(cut))
+          val eof = decoder.finish()
+          assertEquals(V9ErrorCode.TRUNCATED, eof.failure?.reason, "cut=$cut")
+          assertEquals(0, eof.frames.size, "cut=$cut")
+          assertEquals(0, eof.payloadAllocations, "cut=$cut")
+      }
+
+    val complete = V9IncrementalDecoder(2, policy = policy)
+    val completeFrame = complete.feed(ping)
+    completeFrame.frames.single().close()
+    assertEquals(V9ErrorCode.UNEXPECTED_EOF, complete.finish().failure?.reason)
+  }
+
+  @Test
+  fun compressedFramesAreExactBoundedAndCannotCarryBombsOrTrailingStreams() {
+    val capabilities = V9Capability.entries.toSet()
+    val policy =
+        V9DecoderPolicy(
+            allowedMessages = setOf(V9MessageType.ROM_CHUNK),
+            negotiatedCapabilities = capabilities,
+        )
+    val payload = ByteBuffer.allocate(9).putInt(1).putInt(0).put(0x5a).array()
+    val compressed =
+        V9FrameEncoder.encode(
+            V9OutboundFrame(
+                V9MessageType.ROM_CHUNK,
+                V9Flag.DEFLATE.wireMask,
+                0,
+                0,
+                1,
+                payload,
+            ),
+            policy,
+        )
+    val decoded = V9IncrementalDecoder(policy = policy).feed(compressed)
+    assertContentEquals(payload, decoded.frames.single().payload())
+    decoded.frames.single().close()
+
+    val corrupt =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "corrupt_deflate" }
+                .getValue("input_hex"),
+        )
+    assertEquals(
+        V9ErrorCode.DECOMPRESSION_FAILED,
+        V9IncrementalDecoder(1, policy = policy).feed(corrupt).failure?.reason,
+    )
+
+    val trailing = compressed.copyOf(compressed.size + 1).also {
+      ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putInt(20, compressed.size - 64 + 1)
+      it[it.lastIndex] = 0
+    }
+    assertEquals(
+        V9ErrorCode.DECOMPRESSION_FAILED,
+        V9IncrementalDecoder(policy = policy).feed(trailing).failure?.reason,
+    )
+
+    val maximum = ByteArray(V9MessageType.ROM_CHUNK.spec.maximumDecodedBytes.toInt()).also {
+      ByteBuffer.wrap(it).putInt(1).putInt(0)
+    }
+    val maximumCompressed =
+        V9FrameEncoder.encode(
+            V9OutboundFrame(
+                V9MessageType.ROM_CHUNK,
+                V9Flag.DEFLATE.wireMask,
+                0,
+                0,
+                1,
+                maximum,
+            ),
+            policy,
+        )
+    val bomb = maximumCompressed.copyOf().also {
+      ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putInt(24, 9)
+    }
+    assertEquals(
+        V9ErrorCode.DECOMPRESSION_FAILED,
+        V9IncrementalDecoder(policy = policy).feed(bomb).failure?.reason,
+    )
+    val over = ByteArray(maximum.size + 1)
+    val exception =
+        assertFailsWith<V9ProtocolException> {
+          V9FrameEncoder.encode(
+              V9OutboundFrame(
+                  V9MessageType.ROM_CHUNK,
+                  V9Flag.DEFLATE.wireMask,
+                  0,
+                  0,
+                  1,
+                  over,
+              ),
+              policy,
+          )
+        }
+    assertEquals(V9ErrorCode.LIMIT_EXCEEDED, exception.reason)
+
+    val missingCodec =
+        V9DecoderPolicy(
+            allowedMessages = setOf(V9MessageType.ROM_CHUNK),
+            negotiatedCapabilities =
+                capabilities - V9Capability.RAW_DEFLATE_V1,
+        )
+    val gate = V9IncrementalDecoder(policy = missingCodec).feed(compressed.copyOf(32))
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, gate.failure?.reason)
+    assertEquals(0, gate.payloadAllocations)
+  }
+
+  @Test
+  fun aggregateQueueArithmeticMatchesEveryFrozenBoundary() {
+    rows("/netplay-v9/aggregate-vectors.tsv").forEach { row ->
+      val result =
+          V9QueueBudget.evaluateAdmission(
+              V9QueueSnapshot(
+                  row.long("current_frames"),
+                  row.long("current_wire"),
+                  row.long("current_decoded"),
+              ),
+              V9QueueSnapshot(
+                  row.long("add_frames"),
+                  row.long("add_wire"),
+                  row.long("add_decoded"),
+              ),
+          )
+      val actual = result?.wireName ?: "SUCCESS"
+      assertEquals(row.getValue("expected"), actual, row.getValue("id"))
+    }
+  }
+
+  @Test
+  fun capabilityExecutionGatesExactlyMirrorEveryFrozenVector() {
+    rows("/netplay-v9/capability-gate-vectors.tsv").forEach { row ->
+      val capabilities =
+          row.getValue("negotiated").split(',').map {
+            assertNotNull(V9Capability.fromWireId(it.toInt()), row.getValue("id"))
+          }.toSet()
+      val policy =
+          V9DecoderPolicy(
+              allowedMessages = V9MessageType.entries.toSet(),
+              negotiatedCapabilities = capabilities,
+              linkMode =
+                  when (row.getValue("mode")) {
+                    "normal" -> V9LinkMode.NORMAL
+                    "four" -> V9LinkMode.FOUR_PLAYER
+                    else -> error("unknown mode")
+                  },
+          )
+      val message = assertNotNull(V9MessageType.fromWireName(row.getValue("message")))
+      val actual = capabilityFailure(message, row.hexInt("flags"), policy)?.wireName ?: "SUCCESS"
+      assertEquals(row.getValue("expected"), actual, row.getValue("id"))
+    }
+  }
+
+  @Test
+  fun hostileFrozenHeadersAndPrefacesFailWithTheProductionTypedReason() {
+    rows("/netplay-v9/preface-vectors.tsv").forEach { row ->
+      val actual =
+          V9Preface.detect(
+              hex(row.getValue("input_hex")),
+              row.boolean("eof"),
+          )
+      val expected = when (row.getValue("expected")) {
+        "V9" -> V9PrefaceKind.V9
+        "NEED_MORE" -> V9PrefaceKind.NEED_MORE
+        "TRUNCATED" -> V9PrefaceKind.TRUNCATED
+        else -> if (row.getValue("id") == "v8_or_earlier") {
+          V9PrefaceKind.LEGACY_V8_OR_EARLIER
+        } else {
+          V9PrefaceKind.UNSUPPORTED
+        }
+      }
+      assertEquals(expected, actual, row.getValue("id"))
+    }
+
+    val selected =
+        setOf(
+            "bad_magic",
+            "bad_major",
+            "bad_minor",
+            "bad_header_length",
+            "unknown_required",
+            "reserved_flag",
+            "input_zero",
+            "input_plus_one",
+            "raw_length_mismatch",
+            "sequence_gap",
+            "invalid_input_channel",
+            "checksum_mismatch",
+            "terminal_trailing",
+        )
+    rows("/netplay-v9/wire-vectors.tsv").filter { it.getValue("id") in selected }.forEach { row ->
+      val policy =
+          V9DecoderPolicy(
+              allowedMessages = V9MessageType.entries.toSet(),
+              negotiatedCapabilities = V9Capability.entries.toSet(),
+          )
+      val result =
+          V9IncrementalDecoder(row.long("next_sequence"), policy = policy)
+              .feed(hex(row.getValue("input_hex")))
+      assertEquals(row.getValue("expected"), result.failure?.reason?.wireName, row.getValue("id"))
+      assertEquals(row.int("decisive_read"), result.failure?.decisiveBytes, row.getValue("id"))
+      result.frames.forEach(V9Frame::close)
+    }
+
+    val checkpointHeader =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "checkpoint_exact_declaration" }
+                .getValue("input_hex"),
+        )
+    val unavailable = V9IncrementalDecoder(1).feed(checkpointHeader)
+    assertEquals(V9ErrorCode.UNEXPECTED_MESSAGE, unavailable.failure?.reason)
+    assertEquals(0, unavailable.payloadAllocations)
+    assertEquals(0, unavailable.payloadReservations)
+
+    val unknownOptionalBytes =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "unknown_optional" }
+                .getValue("input_hex"),
+        )
+    val skipped =
+        V9IncrementalDecoder(
+                3,
+                policy =
+                    V9DecoderPolicy(
+                        allowedMessages = V9MessageType.entries.toSet(),
+                        allowUnknownOptional = true,
+                    ),
+            )
+            .feed(unknownOptionalBytes)
+    assertNull(skipped.failure)
+    assertEquals(0, skipped.frames.size)
+    assertEquals(1, skipped.payloadAllocations)
+    assertEquals(0, skipped.retainedBytes)
+
+    val declaredTruncated =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "declared_actual_truncated" }
+                .getValue("input_hex"),
+        )
+    val payloadDecoder =
+        V9IncrementalDecoder(
+            policy =
+                V9DecoderPolicy(
+                    allowedMessages = setOf(V9MessageType.PING),
+                    negotiatedCapabilities = V9Capability.entries.toSet(),
+                ),
+        )
+    val partial = payloadDecoder.feed(declaredTruncated)
+    assertTrue(partial.needsMore)
+    assertEquals(1, partial.payloadAllocations)
+    assertEquals(V9ErrorCode.TRUNCATED, payloadDecoder.finish().failure?.reason)
+    assertEquals(V9QueueSnapshot(0, 0, 0), payloadDecoder.queueSnapshot())
+
+    val refused = V9IncrementalDecoder(3).feed(unknownOptionalBytes.copyOf(32))
+    assertEquals(V9ErrorCode.UNEXPECTED_MESSAGE, refused.failure?.reason)
+    assertEquals(0, refused.payloadAllocations)
+  }
+
+  @Test
+  fun smallTypedErrorDiscardsRemoteTextAndWriterQueueIsBounded() {
+    val payload =
+        V9ErrorPayloadCodec.encode(
+            V9ErrorCode.SERVER_BUSY,
+            diagnostic = "candidate unavailable",
+        )
+    val frame =
+        V9FrameEncoder.encode(
+            V9OutboundFrame(
+                V9MessageType.ERROR,
+                V9Flag.TERMINAL.wireMask,
+                0,
+                0,
+                0,
+                payload,
+            ),
+        )
+    val decoded = V9IncrementalDecoder().feed(frame)
+    val error = V9ErrorPayloadCodec.decode(decoded.frames.single().payload())
+    assertEquals(V9ErrorCode.SERVER_BUSY, error.error)
+    assertFalse(error.toString().contains("candidate unavailable"))
+    decoded.frames.single().close()
+
+    val queue = V9WriterQueue()
+    repeat(V9Limit.QUEUED_FRAMES.value.toInt()) {
+      assertTrue(queue.offer(byteArrayOf(it.toByte())) {})
+    }
+    assertFalse(queue.offer(byteArrayOf(0)) {})
+    assertEquals(V9Limit.QUEUED_FRAMES.value, queue.snapshot().frames)
+    queue.close()
+    assertEquals(V9QueueSnapshot(0, 0, 0), queue.snapshot())
+  }
+
+  @Test
+  fun helloNegotiationRejectsDowngradeMissingDuplicateAndUnknownRequiredCapabilities() {
+    val nonce = ByteArray(32) { it.toByte() }
+    val server = V9HelloCodec.create(V9Role.SERVER, nonce)
+    val client = V9HelloCodec.create(V9Role.CLIENT, nonce.reversedArray())
+    val serverBytes = V9HelloCodec.encode(server)
+    assertEquals(94, serverBytes.size)
+    assertEquals(V9Role.SERVER, V9HelloCodec.decode(serverBytes).role)
+    assertEquals(
+        V9Capability.requiredCapabilities,
+        V9HelloCodec.negotiate(client, server, V9Role.SERVER, V9LinkMode.NORMAL).capabilities,
+    )
+
+    val missing = serverBytes.copyOf(serverBytes.size - 8).also {
+      ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putShort(36, 6)
+    }
+    assertEquals(
+        V9ErrorCode.CAPABILITY_MISMATCH,
+        assertFailsWith<V9ProtocolException> { V9HelloCodec.decode(missing) }.reason,
+    )
+    val duplicate = serverBytes.copyOf().also {
+      System.arraycopy(it, 38 + 5 * 8, it, 38 + 6 * 8, 8)
+    }
+    assertEquals(
+        V9ErrorCode.CAPABILITY_MISMATCH,
+        assertFailsWith<V9ProtocolException> { V9HelloCodec.decode(duplicate) }.reason,
+    )
+    val wrongVersion = serverBytes.copyOf().also {
+      ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putShort(40, 2)
+    }
+    assertEquals(
+        V9ErrorCode.CAPABILITY_MISMATCH,
+        assertFailsWith<V9ProtocolException> { V9HelloCodec.decode(wrongVersion) }.reason,
+    )
+    val downgrade = serverBytes.copyOf().also { it[1] = 8 }
+    assertEquals(
+        V9ErrorCode.CAPABILITY_MISMATCH,
+        assertFailsWith<V9ProtocolException> { V9HelloCodec.decode(downgrade) }.reason,
+    )
+
+    val unknownRequired = helloWithUnknown(serverBytes, required = true)
+    assertEquals(
+        V9ErrorCode.UNKNOWN_REQUIRED_CAPABILITY,
+        assertFailsWith<V9ProtocolException> { V9HelloCodec.decode(unknownRequired) }.reason,
+    )
+    val unknownOptional = V9HelloCodec.decode(helloWithUnknown(serverBytes, required = false))
+    assertEquals(8, unknownOptional.capabilities.size)
+    assertNull(unknownOptional.capabilities.last().capability)
+
+    val fourFailure =
+        assertFailsWith<V9ProtocolException> {
+          V9HelloCodec.negotiate(client, server, V9Role.SERVER, V9LinkMode.FOUR_PLAYER)
+        }
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, fourFailure.reason)
+    val serverFour =
+        V9HelloCodec.create(
+            V9Role.SERVER,
+            nonce,
+            setOf(V9Capability.FOUR_PLAYER_V1),
+        )
+    val clientFour =
+        V9HelloCodec.create(
+            V9Role.CLIENT,
+            nonce.reversedArray(),
+            setOf(V9Capability.FOUR_PLAYER_V1),
+        )
+    assertTrue(
+        V9Capability.FOUR_PLAYER_V1 in
+            V9HelloCodec.negotiate(
+                clientFour,
+                serverFour,
+                V9Role.SERVER,
+                V9LinkMode.FOUR_PLAYER,
+            ).capabilities,
+    )
+  }
+
+  @Test
+  fun serverWritesHelloBeforeReadingAndReturnsOnlyASmallTypedCapabilityRejection() {
+    val (serverChannel, peerChannel) = MemoryChannel.pair(maximumWrite = 3)
+    val server =
+        V9FoundationConnection(
+            serverChannel,
+            V9Role.SERVER,
+            nonce = ByteArray(32) { 3 },
+        )
+    server.start()
+
+    val peerDecoder =
+        V9IncrementalDecoder(
+            policy =
+                V9DecoderPolicy(
+                    allowedMessages = setOf(V9MessageType.HELLO, V9MessageType.ERROR),
+                    negotiatedCapabilities = V9Capability.entries.toSet(),
+                ),
+        )
+    val hello = peerDecoder.feed(readFrame(peerChannel))
+    assertEquals(V9MessageType.HELLO, hello.frames.single().header.type)
+    hello.frames.single().close()
+
+    val malformed =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "hello_missing_required_cap" }
+                .getValue("input_hex"),
+        )
+    writeAll(peerChannel, malformed)
+    val rejection = peerDecoder.feed(readFrame(peerChannel))
+    assertEquals(V9MessageType.ERROR, rejection.frames.single().header.type)
+    assertEquals(
+        V9ErrorCode.CAPABILITY_MISMATCH,
+        V9ErrorPayloadCodec.decode(rejection.frames.single().payload()).error,
+    )
+    assertTrue(rejection.frames.single().payload().size <= V9MessageType.ERROR.spec.maximumDecodedBytes)
+    rejection.frames.single().close()
+
+    val terminal = server.awaitPairingBoundary(3, TimeUnit.SECONDS)
+    assertEquals(V9LifecycleState.CLOSED, terminal.state)
+    assertEquals(V9ErrorCode.CAPABILITY_MISMATCH, terminal.failure?.reason)
+    server.close()
+  }
+
+  @Test
+  fun sequenceAndResponseLedgerNeverUsesOrdinalsOrWraps() {
+    val ledger = V9ResponseLedger(1)
+    ledger.recordPeerRequest(7, V9MessageType.AUTH)
+    assertNull(ledger.accept(1, V9MessageType.AUTH_RESULT, V9Flag.RESPONSE.wireMask, 7))
+    assertEquals(2, ledger.nextIncomingSequence)
+    assertEquals(
+        V9ErrorCode.CORRELATION_ERROR,
+        ledger.accept(2, V9MessageType.AUTH_RESULT, V9Flag.RESPONSE.wireMask, 7),
+    )
+
+    val wrong = V9ResponseLedger(1)
+    wrong.recordPeerRequest(9, V9MessageType.START)
+    assertEquals(
+        V9ErrorCode.CORRELATION_ERROR,
+        wrong.accept(1, V9MessageType.PONG, V9Flag.RESPONSE.wireMask, 9),
+    )
+    assertEquals(1, wrong.nextIncomingSequence)
+
+    val exhausted = V9ResponseLedger(ProtocolV9.LAST_SEQUENCE)
+    assertNull(exhausted.accept(ProtocolV9.LAST_SEQUENCE, V9MessageType.INPUT, 0, 0))
+    assertNull(exhausted.nextIncomingSequence)
+    assertEquals(
+        V9ErrorCode.SEQUENCE_ERROR,
+        exhausted.accept(0, V9MessageType.INPUT, 0, 0),
+    )
+
+    val input =
+        hex(
+            rows("/netplay-v9/wire-vectors.tsv")
+                .single { it.getValue("id") == "valid_input" }
+                .getValue("input_hex"),
+        )
+    ByteBuffer.wrap(input).order(ByteOrder.BIG_ENDIAN).putInt(12, ProtocolV9.LAST_SEQUENCE.toInt())
+    val policy =
+        V9DecoderPolicy(
+            allowedMessages = setOf(V9MessageType.INPUT),
+            negotiatedCapabilities = V9Capability.entries.toSet(),
+        )
+    val decoder = V9IncrementalDecoder(ProtocolV9.LAST_SEQUENCE, policy = policy)
+    val accepted = decoder.feed(input)
+    assertTrue(accepted.directionExhausted)
+    assertEquals(V9MessageType.INPUT, accepted.frames.single().header.type)
+    accepted.frames.single().close()
+    val wrapped = input.copyOf().also {
+      ByteBuffer.wrap(it).order(ByteOrder.BIG_ENDIAN).putInt(12, 0)
+    }
+    val rejected = decoder.feed(wrapped.copyOf(32))
+    assertEquals(V9ErrorCode.SEQUENCE_ERROR, rejected.failure?.reason)
+    assertTrue(rejected.directionExhausted)
+    assertEquals(1, rejected.payloadAllocations)
+    assertEquals(V9QueueSnapshot(0, 0, 0), decoder.queueSnapshot())
+  }
+
+  @Test
+  fun lifecycleUsesInjectedMonotonicDeadlineAndPublishesImmutableSanitizedState() {
+    val clock = FakeClock()
+    val lifecycle = V9Lifecycle(V9Role.CLIENT, clock)
+    val events = mutableListOf<V9LifecycleSnapshot>()
+    lifecycle.addListener { events += it }
+    assertEquals(5_000, lifecycle.snapshot().deadlineMillis)
+    clock.now = 4_999
+    assertNull(lifecycle.checkDeadline())
+    clock.now = 5_000
+    val failure = assertNotNull(lifecycle.checkDeadline())
+    assertEquals(V9ErrorCode.TIMEOUT, failure.reason)
+    assertEquals(V9Diagnostic.TIMEOUT, failure.diagnostic)
+    assertEquals(V9LifecycleState.CLOSED, lifecycle.snapshot().state)
+    assertTrue(events.all { it.failure?.toString()?.contains("token", ignoreCase = true) != true })
+
+    val mutable =
+        lifecycle.snapshot().negotiatedCapabilities as java.util.Set<V9Capability>
+    assertFailsWith<UnsupportedOperationException> {
+      mutable.add(V9Capability.PING_V1)
+    }
+  }
+
+  @Test
+  fun partialWriteFoundationStopsExactlyAtAwaitingPairingAndRejectsLaterTraffic() {
+    val (serverChannel, clientChannel) = MemoryChannel.pair(maximumWrite = 3)
+    val server =
+        V9FoundationConnection(
+            serverChannel,
+            V9Role.SERVER,
+            nonce = ByteArray(32) { 1 },
+        )
+    val client =
+        V9FoundationConnection(
+            clientChannel,
+            V9Role.CLIENT,
+            nonce = ByteArray(32) { 2 },
+        )
+    server.start()
+    client.start()
+    val serverState = server.awaitPairingBoundary(3, TimeUnit.SECONDS)
+    val clientState = client.awaitPairingBoundary(3, TimeUnit.SECONDS)
+    assertEquals(V9LifecycleState.WAIT_AUTH, serverState.state)
+    assertEquals(V9LifecycleState.SEND_AUTH, clientState.state)
+    assertEquals(V9LifecyclePhase.AWAITING_PAIRING, serverState.phase)
+    assertEquals(V9Capability.requiredCapabilities, server.negotiatedCapabilities())
+    assertEquals(V9Capability.requiredCapabilities, client.negotiatedCapabilities())
+    assertFailsWith<V9ProtocolException> { client.sendUnavailable(V9MessageType.AUTH) }
+    client.cancel()
+    server.close()
+    client.close()
+    assertTrue(clientChannel.closed.get())
+    assertTrue(serverChannel.closed.get())
+  }
+
+  @Test
+  fun timeoutAndCancellationCloseBlockedReadAndWriteAndAreIdempotent() {
+    val readClock = FakeClock()
+    val readScheduler = ManualScheduler(readClock)
+    val readChannel = BlockingChannel(blockWrites = false)
+    val waiting =
+        V9FoundationConnection(
+            readChannel,
+            V9Role.CLIENT,
+            clock = readClock,
+            scheduler = readScheduler,
+        )
+    waiting.start()
+    readClock.now = 4_999
+    readScheduler.runDue()
+    assertEquals(V9LifecycleState.WAIT_SERVER_HELLO, waiting.snapshot().state)
+    readClock.now = 5_000
+    readScheduler.runDue()
+    assertEquals(V9ErrorCode.TIMEOUT, waiting.snapshot().failure?.reason)
+    assertEquals(1, readChannel.closeCount.get())
+    waiting.close()
+    assertEquals(1, readChannel.closeCount.get())
+
+    val writeChannel = BlockingChannel(blockWrites = true)
+    val writing = V9FoundationConnection(writeChannel, V9Role.SERVER)
+    writing.start()
+    assertTrue(writeChannel.writeEntered.await(2, TimeUnit.SECONDS))
+    writing.cancel()
+    assertEquals(V9ErrorCode.CANCELLED, writing.snapshot().failure?.reason)
+    assertEquals(1, writeChannel.closeCount.get())
+    assertEquals(V9QueueSnapshot(0, 0, 0), writing.writerQueueSnapshot())
+
+    val connectable = BlockingConnectableChannel()
+    val attempt = V9FoundationConnectAttempt { connectable }
+    val result = CountDownLatch(1)
+    var connectError: V9ErrorCode? = null
+    attempt.start(InetSocketAddress("127.0.0.1", 1)) { _, error ->
+      connectError = error
+      result.countDown()
+    }
+    assertTrue(connectable.connectEntered.await(2, TimeUnit.SECONDS))
+    attempt.cancel()
+    assertTrue(result.await(2, TimeUnit.SECONDS))
+    assertEquals(V9ErrorCode.CANCELLED, connectError)
+    assertEquals(1, connectable.closeCount.get())
+  }
+
+  @Test
+  fun optInSocketLoopbackSurvivesMalformedCandidateAndStopsBeforePairing() {
+    val serverBoundary = CountDownLatch(1)
+    var accepted: V9FoundationConnection? = null
+    V9FoundationServer(onAwaitingPairing = {
+      accepted = it
+      serverBoundary.countDown()
+    }).use { server ->
+      server.start()
+      Socket("127.0.0.1", server.localPort).use { bad ->
+        bad.getOutputStream().write(byteArrayOf(0x42, 0x41, 0x44, 0x39))
+        bad.getOutputStream().flush()
+      }
+      Socket("127.0.0.1", server.localPort).use { rejected ->
+        rejected.soTimeout = 3_000
+        readExactly(rejected, 64 + 94) // Server HELLO is complete before peer reads begin.
+        val malformedHello =
+            hex(
+                rows("/netplay-v9/wire-vectors.tsv")
+                    .single { it.getValue("id") == "hello_missing_required_cap" }
+                    .getValue("input_hex"),
+            )
+        rejected.getOutputStream().write(malformedHello)
+        rejected.getOutputStream().flush()
+        val errorBytes = readExactly(rejected, 64 + 12)
+        val errorBatch =
+            V9IncrementalDecoder(
+                    1,
+                    policy = V9DecoderPolicy(allowedMessages = setOf(V9MessageType.ERROR)),
+                )
+                .feed(errorBytes)
+        assertEquals(V9MessageType.ERROR, errorBatch.frames.single().header.type)
+        assertEquals(
+            V9ErrorCode.CAPABILITY_MISMATCH,
+            V9ErrorPayloadCodec.decode(errorBatch.frames.single().payload()).error,
+        )
+        errorBatch.frames.single().close()
+      }
+      Socket("127.0.0.1", server.localPort).use { stalled ->
+        val client =
+            V9FoundationClient.connect(InetSocketAddress("127.0.0.1", server.localPort))
+        try {
+          assertTrue(serverBoundary.await(5, TimeUnit.SECONDS))
+          assertEquals(
+              V9LifecyclePhase.AWAITING_PAIRING,
+              client.awaitPairingBoundary(5, TimeUnit.SECONDS).phase,
+          )
+          assertEquals(V9LifecycleState.WAIT_AUTH, assertNotNull(accepted).snapshot().state)
+          assertEquals(V9LifecycleState.SEND_AUTH, client.snapshot().state)
+        } finally {
+          client.close()
+          accepted?.close()
+        }
+      }
+    }
+  }
+
+  private fun readExactly(socket: Socket, size: Int): ByteArray {
+    val result = ByteArray(size)
+    var offset = 0
+    while (offset < result.size) {
+      val count = socket.getInputStream().read(result, offset, result.size - offset)
+      if (count < 0) throw IOException("unexpected test EOF")
+      offset += count
+    }
+    return result
+  }
+
+  private fun headerFrom(row: Map<String, String>): ByteArray {
+    val magic = row.getValue("magic").toByteArray(StandardCharsets.US_ASCII)
+    return ByteBuffer.allocate(64).order(ByteOrder.BIG_ENDIAN)
+        .put(magic)
+        .put(row.int("major").toByte())
+        .put(row.int("minor").toByte())
+        .putShort(row.int("header_length").toShort())
+        .putShort(row.hexInt("type").toShort())
+        .putShort(row.hexInt("flags").toShort())
+        .putInt(row.long("sequence").toInt())
+        .putInt(row.long("correlation").toInt())
+        .putInt(row.long("encoded").toInt())
+        .putInt(row.long("decoded").toInt())
+        .putInt(row.long("channel").toInt())
+        .put(ByteArray(32))
+        .array()
+  }
+
+  private fun helloWithUnknown(base: ByteArray, required: Boolean): ByteArray {
+    val result = base.copyOf(base.size + 8)
+    ByteBuffer.wrap(result).order(ByteOrder.BIG_ENDIAN)
+        .putShort(36, 8)
+        .position(base.size)
+    ByteBuffer.wrap(result, base.size, 8).order(ByteOrder.BIG_ENDIAN)
+        .putShort(0x1000.toShort())
+        .putShort(1)
+        .putInt(if (required) 1 else 0)
+    return result
+  }
+
+  private fun readFrame(channel: V9TransportChannel): ByteArray {
+    val header = ByteArray(ProtocolV9.HEADER_BYTES)
+    readFully(channel, header)
+    val length = u32(header, 20).toInt()
+    val frame = header.copyOf(header.size + length)
+    if (length > 0) {
+      val payload = ByteArray(length)
+      readFully(channel, payload)
+      System.arraycopy(payload, 0, frame, header.size, length)
+    }
+    return frame
+  }
+
+  private fun readFully(channel: V9TransportChannel, bytes: ByteArray) {
+    var offset = 0
+    while (offset < bytes.size) {
+      val count = channel.read(bytes, offset, bytes.size - offset)
+      check(count > 0) { "unexpected EOF" }
+      offset += count
+    }
+  }
+
+  private fun writeAll(channel: V9TransportChannel, bytes: ByteArray) {
+    var offset = 0
+    while (offset < bytes.size) {
+      val count = channel.write(bytes, offset, bytes.size - offset)
+      check(count > 0) { "writer made no progress" }
+      offset += count
+    }
+  }
+
+  private class FakeClock(var now: Long = 0) : V9MonotonicClock {
+    override fun nowMillis(): Long = now
+  }
+
+  private class ManualScheduler(private val clock: FakeClock) : V9DeadlineScheduler {
+    private val tasks = mutableListOf<Task>()
+
+    @Synchronized
+    override fun schedule(deadlineMillis: Long, action: Runnable): Closeable {
+      val task = Task(deadlineMillis, action)
+      tasks += task
+      return Closeable { task.active.set(false) }
+    }
+
+    @Synchronized
+    fun runDue() {
+      tasks.filter { it.active.get() && it.deadline <= clock.now }.forEach {
+        if (it.active.compareAndSet(true, false)) it.action.run()
+      }
+    }
+
+    private data class Task(
+        val deadline: Long,
+        val action: Runnable,
+        val active: AtomicBoolean = AtomicBoolean(true),
+    )
+  }
+
+  private class BlockingChannel(private val blockWrites: Boolean) : V9TransportChannel {
+    val closeCount = AtomicInteger()
+    val writeEntered = CountDownLatch(1)
+    private val closed = AtomicBoolean(false)
+    private val wake = CountDownLatch(1)
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+      wake.await()
+      return -1
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+      writeEntered.countDown()
+      if (blockWrites) wake.await()
+      if (closed.get()) throw IOException("closed")
+      return length
+    }
+
+    override fun shutdownOutput() = Unit
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        closeCount.incrementAndGet()
+        wake.countDown()
+      }
+    }
+  }
+
+  private class BlockingConnectableChannel : V9ConnectableChannel {
+    val connectEntered = CountDownLatch(1)
+    val closeCount = AtomicInteger()
+    private val wake = CountDownLatch(1)
+    private val closed = AtomicBoolean(false)
+
+    override fun connect(address: InetSocketAddress, timeoutMillis: Int) {
+      connectEntered.countDown()
+      wake.await()
+      throw IOException("closed")
+    }
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int = -1
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int = length
+
+    override fun shutdownOutput() = Unit
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        closeCount.incrementAndGet()
+        wake.countDown()
+      }
+    }
+  }
+
+  private class MemoryChannel(private val maximumWrite: Int) : V9TransportChannel {
+    private val incoming = LinkedBlockingQueue<Int>()
+    val closed = AtomicBoolean(false)
+    private lateinit var peer: MemoryChannel
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+      val first = incoming.take()
+      if (first < 0) return -1
+      bytes[offset] = first.toByte()
+      var count = 1
+      while (count < length) {
+        val next = incoming.poll() ?: break
+        if (next < 0) {
+          incoming.offer(next)
+          break
+        }
+        bytes[offset + count++] = next.toByte()
+      }
+      return count
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+      if (closed.get()) throw IOException("closed")
+      val count = minOf(length, maximumWrite)
+      repeat(count) { peer.incoming.put(bytes[offset + it].toInt() and 0xff) }
+      return count
+    }
+
+    override fun shutdownOutput() {
+      peer.incoming.offer(-1)
+    }
+
+    override fun close() {
+      if (closed.compareAndSet(false, true)) {
+        incoming.offer(-1)
+        if (::peer.isInitialized) peer.incoming.offer(-1)
+      }
+    }
+
+    companion object {
+      fun pair(maximumWrite: Int): Pair<MemoryChannel, MemoryChannel> {
+        val first = MemoryChannel(maximumWrite)
+        val second = MemoryChannel(maximumWrite)
+        first.peer = second
+        second.peer = first
+        return first to second
+      }
+    }
+  }
+
+  private fun rows(resource: String): List<Map<String, String>> {
+    val text =
+        requireNotNull(javaClass.getResourceAsStream(resource))
+            .bufferedReader(StandardCharsets.UTF_8)
+            .use { it.readText() }
+    val lines = text.lineSequence().filter { it.isNotBlank() && !it.startsWith("#") }.toList()
+    val header = lines.first().split('\t')
+    return lines.drop(1).map { line ->
+      val values = line.split('\t')
+      require(values.size == header.size) { "Malformed $resource row: $line" }
+      header.zip(values).toMap()
+    }
+  }
+
+  private fun Map<String, String>.int(name: String): Int = getValue(name).toInt()
+
+  private fun Map<String, String>.long(name: String): Long = getValue(name).toLong()
+
+  private fun Map<String, String>.hexInt(name: String): Int =
+      getValue(name).removePrefix("0x").toInt(16)
+
+  private fun Map<String, String>.boolean(name: String): Boolean =
+      getValue(name).toBooleanStrict()
+
+  private fun hex(value: String): ByteArray {
+    require(value.length % 2 == 0)
+    return ByteArray(value.length / 2) { index ->
+      value.substring(index * 2, index * 2 + 2).toInt(16).toByte()
+    }
+  }
+}

--- a/docs/adr/0001-netplay-v9-version.md
+++ b/docs/adr/0001-netplay-v9-version.md
@@ -1,6 +1,6 @@
 # ADR 0001: allocate the next netplay wire generation as v9
 
-- Status: accepted for the Phase 0 contract gate
+- Status: accepted; Phase #347 foundation implemented
 - Date: 2026-07-26
 - Issues: #346, #318; state boundary #314
 
@@ -24,9 +24,10 @@ uses a fixed 64-byte frame header. The server sends the first v9 frame. Conseque
 - a v9 server never attempts to parse a v8/v7 byte as a v9 field; and
 - there is no downgrade, compatibility probe, dual parser, or fallback on the same connection.
 
-Protocol v8 remains implemented and documented exactly as it was before this ADR. Phase #346 adds
-no production v9 parser or dormant feature flag. Phase #347 must implement the frozen v9 contract
-beside the isolated v8 implementation and choose the protocol before interpreting a frame.
+Protocol v8 remains implemented and documented exactly as it was before this ADR. Phase #346 added
+no production parser. Phase #347 implements the frozen frame/HELLO/lifecycle foundation beside the
+isolated v8 implementation, with an explicit preface decision before interpreting a frame. It is
+opt-in and not connected to the current end-user v8 controller path.
 
 ## Consequences
 

--- a/docs/netplay-protocol-v9.md
+++ b/docs/netplay-protocol-v9.md
@@ -2,8 +2,10 @@
 
 This is the authoritative normative contract for protocol v9. The machine-readable registries in
 `controller/src/test/resources/netplay-v9/` are part of this contract and are checked against this
-document. RFC 2119 words are normative. Protocol v9 is not implemented in production in Phase
-#346; #347 consumes this contract.
+document. RFC 2119 words are normative. Phase #347 implements the CGB9 frame, HELLO negotiation,
+bounded transport ownership, and lifecycle representation beside the frozen v8 implementation.
+That foundation stops at `AWAITING_PAIRING`; later messages remain unavailable until their owning
+phases implement them.
 
 Protocol v8 is frozen separately in [netplay-protocol-v8.md](netplay-protocol-v8.md). V9 never
 downgrades to, probes, or parses v8/v7 on the same connection. The version decision and the stale
@@ -471,10 +473,10 @@ does not provide TLS, matchmaking, rendezvous, NAT traversal, relay, or public i
 
 | Phase | Consumes this frozen artifact | Production behavior still blocked before it |
 |---|---|---|
-| #347 | v9 header/registries/state machines and hostile wire corpus | no v9 listener/parser/lifecycle exists in #346 |
-| #348 | invitation/auth vectors, AUTH/MANIFEST/CONSENT ordering, ROM/battery transactions, privacy limits | no pairing, transfer, or consent UI exists in #346 |
-| #349 | CHECKPOINT schema, StateFile-v2 identity, atomic group/history rules | no v9 checkpoint/rollback integration exists in #346 |
-| #350 | cancellation/cleanup/diagnostic contracts and hostile lifecycle cases | no hardening rollout or v8 retirement occurs in #346 |
+| #347 | v9 header/registries/state machines and hostile wire corpus | implemented as an opt-in transport foundation; no invitation, authentication, consent, private transfer, checkpoint, or playable flow |
+| #348 | invitation/auth vectors, AUTH/MANIFEST/CONSENT ordering, ROM/battery transactions, privacy limits | no pairing, transfer, or consent UI exists after #347 |
+| #349 | CHECKPOINT schema, StateFile-v2 identity, atomic group/history rules | no v9 checkpoint/rollback integration exists after #347 |
+| #350 | cancellation/cleanup/diagnostic contracts and hostile lifecycle cases | no hardening rollout or v8 retirement occurs after #347 |
 | #351 | Mobile clean-room ADR/source inventory/transcripts | no production Mobile engine exists in #346 |
 | #352 | bounded async backend/status/cancellation contract | no DNS/socket/backend work exists in #346 |
 | #353 | desktop adapter/configuration/privacy documentation | no Mobile UI or external-service preset exists in #346 |

--- a/docs/netplay-v9-foundation.md
+++ b/docs/netplay-v9-foundation.md
@@ -28,8 +28,13 @@ only for a registered bulk chunk after capability 10 is negotiated.
 
 Each direction starts at sequence zero, accepts `0xfffffffe` as its last frame, and then closes;
 `0xffffffff` is never emitted. The response ledger tracks exact request type, correlation, and
-one-response ownership. Input fragmentation is arbitrary, coalesced frames are accepted, EOF is
-typed as truncated or unexpected, and bytes after a terminal frame are rejected as trailing data.
+one-response ownership without retaining an ever-growing completed-response history. Every live
+inbound foundation frame passes through that ledger before its payload handler. With no Phase-1
+request outstanding, a response-form ERROR is therefore rejected as `CORRELATION_ERROR`. Before
+the server HELLO, the client accepts only a normal HELLO or a non-response, sequence-zero terminal
+`SERVER_BUSY`/`SERVER_FULL` rejection. Input fragmentation is arbitrary, coalesced frames are
+accepted, EOF is typed as truncated or unexpected, and bytes after a terminal frame are rejected
+as trailing data.
 
 ## HELLO-only lifecycle
 
@@ -48,6 +53,26 @@ The transport owns its channel, reader/writer tasks, deadline task, bounded queu
 frames. Cancellation or timeout closes each resource idempotently and cannot block an emulator
 thread or the Swing EDT. A failed candidate is closed independently; it does not terminate the
 listener or another candidate.
+
+A local peer-visible rejection first freezes queue and decoder admission and records its original
+typed failure. The implementation then makes one best-effort terminal ERROR write, half-closes
+output, and enters `TERMINAL_CLEANUP`. It drains only for peer EOF; it does not parse another
+frame. Peer EOF closes promptly. Otherwise the injected monotonic cleanup deadline closes the
+candidate at exactly 2,000 ms (it remains open at 1,999 ms) without replacing the rejection with
+`TIMEOUT`. A failed error write also closes only that candidate while preserving the original
+reason. Received terminal errors may close promptly.
+
+Server ownership includes pending candidates and every handed-off `AWAITING_PAIRING` connection.
+A close listener removes a handed-off connection from the registry when its later owner closes it.
+Candidate construction, start, and callback failures close/remove the candidate and leave the
+accept loop available. Server shutdown and callback delivery share one gate, so shutdown cannot
+leave a post-close callback or retained candidate.
+
+The cancellable client connector owns a channel/connection only until a successful started
+connection is atomically handed to its callback. Cancellation is exactly once at every earlier
+boundary; the injected monotonic connect deadline is exactly 5,000 ms. After handoff, closing the
+attempt cannot cancel the connection. Schedulers created internally are closed with their owner;
+an injected scheduler, including an injected system scheduler, remains caller-owned and reusable.
 
 Public failures contain a stable error code and a fixed local diagnostic category. Raw peer
 diagnostic text is strictly validated where required by the wire schema but is discarded rather

--- a/docs/netplay-v9-foundation.md
+++ b/docs/netplay-v9-foundation.md
@@ -1,0 +1,68 @@
+# Protocol-v9 transport foundation
+
+Issue #347 implements only the first production layer of the frozen
+[protocol-v9 contract](netplay-protocol-v9.md). It is deliberately opt-in and is not connected to
+Coffee GB's default netplay menu or `ConnectionController`; shipped user netplay remains the
+isolated protocol-v8 path.
+
+## Implemented boundary
+
+The platform-neutral controller package `controller.network.v9` owns:
+
+- explicit stable message, capability, error, limit, timeout, flag, role, mode, and lifecycle
+  values whose wire identities never use enum ordinals;
+- the fixed 64-byte big-endian `CGB9`/9.0 frame encoder and incremental decoder;
+- exact HELLO payload validation and bidirectional required-capability negotiation;
+- immutable lifecycle snapshots from connect/listen through the post-HELLO
+  `AWAITING_PAIRING` boundary;
+- injected monotonic deadlines, bounded reader/writer retention, cancellation, idempotent close,
+  socket/task ownership, and an accept loop that isolates malformed or stalled candidates; and
+- an EDT-marshalling Swing adapter whose controller-facing source has no Swing or AWT dependency.
+
+The decoder retains one fixed header and at most one declared frame payload. It validates the
+frozen decisive-byte precedence, per-message declaration, checked 64-byte frame overhead, and
+session queue/decoded aggregate before allocation. A delivered frame owns its reservation until
+closed. The queue ceilings remain 256 frames, 33,817,172 complete wire bytes, and 134,217,728
+decoded bytes. Raw RFC-1951 DEFLATE is exact-length, no-dictionary, no-concatenation, and permitted
+only for a registered bulk chunk after capability 10 is negotiated.
+
+Each direction starts at sequence zero, accepts `0xfffffffe` as its last frame, and then closes;
+`0xffffffff` is never emitted. The response ledger tracks exact request type, correlation, and
+one-response ownership. Input fragmentation is arbitrary, coalesced frames are accepted, EOF is
+typed as truncated or unexpected, and bytes after a terminal frame are rejected as trailing data.
+
+## HELLO-only lifecycle
+
+The server sends HELLO first. Both roles validate protocol 9.0, sorted unique capability records,
+all seven required version-1 capabilities, unknown-required rejection, and the optional
+four-player gate. The connection then publishes `WAIT_AUTH` (server) or `SEND_AUTH` (client), both
+classified as `AWAITING_PAIRING`, and does not continue.
+
+AUTH, invitation proof, manifest, consent, ROM/battery transfer, checkpoints, playing messages,
+diagnostics, discovery, and Mobile Adapter behavior are unavailable. Later message declarations
+are rejected before payload allocation by the lifecycle policy. Phase #348 is the next gate.
+
+## Ownership, errors, and privacy
+
+The transport owns its channel, reader/writer tasks, deadline task, bounded queue, and retained
+frames. Cancellation or timeout closes each resource idempotently and cannot block an emulator
+thread or the Swing EDT. A failed candidate is closed independently; it does not terminate the
+listener or another candidate.
+
+Public failures contain a stable error code and a fixed local diagnostic category. Raw peer
+diagnostic text is strictly validated where required by the wire schema but is discarded rather
+than surfaced. Exceptions, payload bytes, paths, ROM/save content, invitation material, and remote
+strings are never used as UI diagnostics.
+
+Invitation authentication and encryption are **not implemented**. The eventual protocol is
+plaintext TCP and does not provide confidentiality or protection against an on-path attacker.
+The foundation must not be presented as a secure or playable Internet netplay flow.
+
+## Verification
+
+`ProtocolV9ProductionTest` compares production identities and limits against every frozen registry
+row and exercises fragmentation, coalescing, truncation, header precedence, exact/+1 limits,
+checked aggregate admission, compressed corruption/bombs, sequence exhaustion, HELLO negotiation,
+deadline/cancellation cleanup, partial writes, and accept-loop survival. The independent Phase-0
+reference model and hostile vectors remain unchanged. `V9SwingLifecycleAdapterTest` proves EDT
+delivery and the controller/Swing dependency boundary.

--- a/docs/netplay-v9-foundation.md
+++ b/docs/netplay-v9-foundation.md
@@ -66,7 +66,9 @@ Server ownership includes pending candidates and every handed-off `AWAITING_PAIR
 A close listener removes a handed-off connection from the registry when its later owner closes it.
 Candidate construction, start, and callback failures close/remove the candidate and leave the
 accept loop available. Server shutdown and callback delivery share one gate, so shutdown cannot
-leave a post-close callback or retained candidate.
+leave a post-close callback. Accepted-candidate admission shares a shutdown gate: an accept that
+has not yet registered is closed immediately after shutdown begins, while `shutdownNow` return
+values and the tracked pending set are both drained so no queued candidate is retained.
 
 The cancellable client connector owns a channel/connection only until a successful started
 connection is atomically handed to its callback. Cancellation is exactly once at every earlier

--- a/docs/netplay-v9-privacy.md
+++ b/docs/netplay-v9-privacy.md
@@ -1,17 +1,19 @@
 # Protocol-v9 pairing, privacy, and troubleshooting
 
-Protocol v9 is a reviewed future contract; it is not available in the current build. Current
-netplay remains protocol v8 with the compatibility restrictions in
+Protocol v9 has an opt-in developer transport foundation that validates CGB9 frames and negotiates
+HELLO capabilities, then stops at `AWAITING_PAIRING`. It is not a playable end-user path: no
+invitation, authentication, manifest, consent, private transfer, or checkpoint is enabled. Current
+user netplay remains protocol v8 with the compatibility restrictions in
 [netplay-protocol-v8.md](netplay-protocol-v8.md). A v8/v9 mismatch is intentional and has no
-downgrade. Use matching Coffee GB builds and do not repeatedly paste an invitation into an older
-client.
+downgrade, fallback, or compatibility probe.
 
 ## What an invitation does—and does not do
 
-A v9 invitation will contain a random, one-use, short-lived 128-bit token. Possession proves only
-that the peer received that invitation. The token stays in memory, is never logged/persisted, and
-wrong, expired, reused, or wrong-slot attempts all receive the same generic failure. Revoke an
-invitation by cancelling the host dialog or stopping the session.
+A later v9 pairing phase will create random, one-use, short-lived 128-bit invitations. Invitation
+creation and validation are not implemented by the #347 foundation. When implemented, possession
+will prove only that the peer received that invitation. The token stays in memory, is never
+logged/persisted, and wrong, expired, reused, or wrong-slot attempts all receive the same generic
+failure.
 
 V9's planned TCP transport is plaintext. It does not encrypt ROM, battery, state, input, or
 metadata and cannot authenticate a server against an on-path attacker. It is not safe merely
@@ -35,6 +37,10 @@ and diagnostics. State transport is direct bounded StateFile v2 only; local hist
 import is never reachable from a peer.
 
 ## Diagnosing a failed pairing
+
+The #347 foundation exposes only typed, sanitized protocol/timeout/cancellation diagnostics for
+developer tests. Pairing diagnostics below describe the frozen later-phase behavior and are not
+yet reachable from the desktop.
 
 - **Unsupported protocol / `Coff` versus `CGB9`:** the builds use v8 and v9. Install matching
   versions; there is no fallback.

--- a/docs/state-file-v2.md
+++ b/docs/state-file-v2.md
@@ -99,9 +99,11 @@ SGB header rejects before held-input/ROM/state payload reads; a coarse incoming 
 canonical `dmg`, never MGB. Support requires a separately negotiated profile-aware protocol.
 StateFile v2 is currently for local portable snapshots and the explicit codec/apply seam.
 
-The future protocol-v9 contract in [netplay-protocol-v9.md](netplay-protocol-v9.md) allocates a new
-wire major and requires direct bounded StateFile v2 checkpoints with exact profile identities. That
-Phase #346 contract is not a production transport and changes no v8 byte or behavior.
+The protocol-v9 contract in [netplay-protocol-v9.md](netplay-protocol-v9.md) allocates a new wire
+major and requires direct bounded StateFile v2 checkpoints with exact profile identities. The
+Phase #347 production foundation implements framing and HELLO only and rejects CHECKPOINT before
+payload allocation; Phase #349 owns StateFile-v2 checkpoint admission and atomic application.
+No v8 byte or behavior changes.
 
 There is no #315 replay format yet. Any future replay must carry the exact canonical profile ID
 (including `mgb` or `sgb2`) plus its rational `ClockSpec`; a coarse enum is insufficient.

--- a/docs/test-fixture-provenance.md
+++ b/docs/test-fixture-provenance.md
@@ -76,6 +76,10 @@ GB. They contain no third-party ROM, BIOS, palette, screenshot, or game asset:
   `490595c3b8506d3f155aa6be9d7a5cd7d0fa9a5b` (GPL-3.0); libmobile commit
   `0704f56902f23b7ebf05c82c222e0e145e3140b6` (LGPL-3.0) is corroboration only and no code is
   copied. Tests make no network request and normal builds never regenerate these resources.
+- Phase #347 consumes the same checked-in protocol-v9 TSV corpus in production-parity and
+  transport-foundation tests. It adds no binary fixture, invitation secret, remote capture, ROM,
+  save, StateFile, credential, endpoint, or downloaded artifact; all resource bytes and manifest
+  hashes from Phase #346 remain unchanged.
 
 The canonical hash format and every expected hash are specified in
 [sgb-conformance-baselines.md](sgb-conformance-baselines.md). These values lock current Coffee GB

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/V9SwingLifecycleAdapter.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/V9SwingLifecycleAdapter.kt
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleListener
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleSnapshot
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleSource
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.SwingUtilities
+
+/**
+ * EDT boundary for the opt-in v9 lifecycle.
+ *
+ * The controller publishes platform-neutral immutable values. This adapter is deliberately not
+ * wired into the user-visible netplay flow until pairing and consent arrive in #348.
+ */
+class V9SwingLifecycleAdapter(
+    source: V9LifecycleSource,
+    private val consumer: (V9LifecycleSnapshot) -> Unit,
+) : Closeable {
+  private val closed = AtomicBoolean(false)
+  private val subscription =
+      source.addListener(
+          V9LifecycleListener { value ->
+            SwingUtilities.invokeLater {
+              if (!closed.get()) consumer(value)
+            }
+          },
+      )
+
+  override fun close() {
+    if (closed.compareAndSet(false, true)) subscription.close()
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/V9SwingLifecycleAdapterTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/V9SwingLifecycleAdapterTest.kt
@@ -1,0 +1,73 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.network.v9.V9Diagnostic
+import eu.rekawek.coffeegb.controller.network.v9.V9ErrorCode
+import eu.rekawek.coffeegb.controller.network.v9.V9Lifecycle
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleState
+import eu.rekawek.coffeegb.controller.network.v9.V9Role
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class V9SwingLifecycleAdapterTest {
+
+  @Test
+  fun everyLifecycleCallbackIsMarshalledToTheEdtAndCloseStopsDelivery() {
+    val lifecycle = V9Lifecycle(V9Role.CLIENT)
+    val callbackCount = AtomicInteger()
+    val allOnEdt = AtomicBoolean(true)
+    val delivered = CountDownLatch(2)
+    val adapter =
+        V9SwingLifecycleAdapter(lifecycle) { snapshot ->
+          allOnEdt.compareAndSet(true, SwingUtilities.isEventDispatchThread())
+          callbackCount.incrementAndGet()
+          if (snapshot.state in
+              setOf(V9LifecycleState.WAIT_SERVER_HELLO, V9LifecycleState.CLOSED)) {
+            delivered.countDown()
+          }
+        }
+    lifecycle.fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
+    assertTrue(delivered.await(3, TimeUnit.SECONDS))
+    assertTrue(allOnEdt.get())
+    assertEquals(2, callbackCount.get())
+
+    adapter.close()
+    lifecycle.closeNormally()
+    SwingUtilities.invokeAndWait {}
+    assertEquals(2, callbackCount.get())
+  }
+
+  @Test
+  fun controllerV9SourcesHaveNoSwingOrAwtDependency() {
+    val root = repositoryRoot()
+    val sourceRoot =
+        root.resolve("controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9")
+    val sources =
+        Files.walk(sourceRoot).use { paths ->
+          paths.filter { Files.isRegularFile(it) }
+              .map { Files.readString(it, StandardCharsets.UTF_8) }
+              .toList()
+              .joinToString("\n")
+        }
+    assertFalse(sources.contains("java.awt"))
+    assertFalse(sources.contains("javax.swing"))
+  }
+
+  private fun repositoryRoot(): Path {
+    var current = Path.of("").toAbsolutePath()
+    while (!Files.exists(current.resolve("pom.xml")) ||
+        !Files.exists(current.resolve("controller"))) {
+      current = current.parent ?: error("repository root not found")
+    }
+    return current
+  }
+}


### PR DESCRIPTION
## Invariant

Protocol v9 now has one bounded, explicit CGB9 transport foundation that implements the frozen Phase-0 registries byte-for-byte, negotiates HELLO capabilities, owns its resources and lifecycle, and stops at the post-HELLO `AWAITING_PAIRING` boundary. Current user netplay remains isolated protocol v8; there is no fallback or downgrade.

## What changed

- Added stable production message, capability, error, limit, timeout, flag, role, mode, and lifecycle values with explicit wire IDs.
- Added the 64-byte big-endian CGB9 encoder and a truly incremental one-frame decoder with frozen error precedence, checked pre-allocation limits, bounded queue reservations, strict EOF/trailing behavior, sequence exhaustion, and exact raw-DEFLATE handling.
- Added server-first HELLO negotiation with seven required v1 capabilities, unknown-required/downgrade rejection, four-player gating, and small typed sanitized ERROR responses.
- Added immutable lifecycle snapshots, injected monotonic deadlines, bounded reader/writer ownership, and idempotent closure. A locally sent terminal ERROR freezes admission, preserves the original typed failure, half-closes output, and waits for peer EOF or the exact 2,000 ms cleanup deadline.
- Added an atomic, exactly-once cancellable connect owner with an exact injected 5,000 ms deadline and ownership handoff. Only internally created schedulers are closed.
- Added race-safe accepted-candidate admission and server candidate/connection accounting. Shutdown closes sockets caught before registration, drains never-started worker tasks and the tracked pending set, releases handed-off connections on later close, and isolates construction, start, and callback failures without stopping the accept loop.
- Enforced response sequence/correlation rules in the live foundation with bounded outstanding-request state and no unbounded completed-response history. Before server HELLO, only non-response sequence-zero terminal `SERVER_BUSY`/`SERVER_FULL` rejections are accepted.
- Added an EDT-marshalling adapter without introducing Swing/AWT dependencies into controller code.
- Converted the Phase-0 production-absence guard into registry/behavior parity and v8-isolation checks.
- Documented the implementation boundary, cleanup/ownership model, privacy posture, and troubleshooting guidance.

## Limits and wire boundary

- One fixed 64-byte header plus at most one declared payload retained by the decoder.
- 256 queued frames; 33,817,172 complete queued wire bytes; 134,217,728 decoded aggregate bytes.
- Raw RFC-1951 DEFLATE is bounded, exact-length, dictionary-free, concatenation-free, and available only to registered chunk messages with capability 10.
- `0xfffffffe` is the last legal sequence; `0xffffffff` is never emitted and a further frame is rejected.
- AUTH, invitation proof, manifest, consent, ROM/battery transfer, checkpoint, playing, diagnostics, discovery, and Mobile Adapter behavior remain unavailable in this phase.

## Security and privacy

Invitation authentication and encryption are not implemented. The v9 foundation is opt-in developer infrastructure, not a playable user flow. Planned TCP remains plaintext and offers no confidentiality or protection from an on-path attacker. Raw remote diagnostics, tokens, paths, payloads, exceptions, ROM/save bytes, and credentials are never surfaced as lifecycle diagnostics.

## Verification

Temurin JDK 16.0.2+7:

- Focused v9 lifecycle/contract/EDT suite: 55 tests, 0 failures, 0 errors, 0 skips.
- Exact formerly timing-sensitive TCP synchronization methods: 2 tests, 0 failures, 0 errors, 0 skips.
- Broader v8 Connection/TCP/link/StateFile/serial suite: 102 tests, 0 failures, 0 errors, 0 skips.
- `mvn -B clean test`: core 791 + controller 311 + Swing 33 = 1,135 tests, 0 failures, 0 errors, 2 expected skips.
- Clean compilation used javac/Kotlin target `release 16`.
- `git diff --check`: clean.
- Released fixture SHA-256 values unchanged: legacy 1.7.13 `7a7ba6fa23538fcd2bdb734487a3b30a18452b69379e18712fc289858ba191ec`, legacy 1.7.14 `3588e825efd91f8555d2fd941645a21af1c2ba330df6b56053f01ed81faf5573`, StateFile v1 `e5ae258c3f1a9405ca87518dbb13526def9fd3e44a4486d7a495c111958cf091`, and StateFile v2 `2d2178e6eba26a8debdacf84be144cccd1b42e50bf0dbce5c41612bcb16aa226`.

## Compatibility and next gate

No protocol-v8 production file, StateFile format, or released fixture changed. The default `ConnectionController` cannot reach v9. Phase #348 is the next gate for invitation authentication, manifest/consent, and private-transfer policy.

Closes #347
Part of #318
Related to #314
Related to #311
