### PR TITLE
Fix v8 transferred CGB checkpoint ownership

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -863,6 +863,7 @@ class LinkedController(
               event.mealybugDmgBlob,
               event.codeBreakerRumble,
               event.displaySgbBorder,
+              event.portableState != null,
           )
           .setPlayerInputSource(PlayerInputSource.RELEASED)
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -632,6 +632,7 @@ class Connection(
             gameboyType,
             bootstrapMode,
             profileFlags,
+            decodedState != null,
         )
     decodedState?.let {
       validatePeerState(configuration, it.file, expectedStateRoot, eventPlayer)
@@ -811,6 +812,7 @@ class Connection(
       gameboyType: GameboyType,
       bootstrapMode: BootstrapMode,
       profileFlags: Int,
+      portableStatePresent: Boolean,
   ): Gameboy.GameboyConfiguration =
       try {
         peerConfiguration(
@@ -823,6 +825,7 @@ class Connection(
             profileFlags and PROFILE_MEALYBUG_DMG_BLOB != 0,
             profileFlags and PROFILE_CODEBREAKER_RUMBLE != 0,
             profileFlags and PROFILE_SGB_BORDER != 0,
+            portableStatePresent,
         )
       } catch (e: Exception) {
         failProtocol(
@@ -1535,13 +1538,15 @@ class Connection(
         mealybugDmgBlob: Boolean,
         codeBreakerRumble: Boolean,
         displaySgbBorder: Boolean,
+        portableStatePresent: Boolean = false,
     ): Gameboy.GameboyConfiguration {
       val primary = Rom(rom)
       if (slotRom != null &&
           primary.cartridgeProperties.mapper != CartridgeProperties.Mapper.DATEL) {
         throw IOException("A slot ROM is valid only for a Datel pass-through cartridge")
       }
-      return Gameboy.GameboyConfiguration(primary)
+      val configuration =
+          Gameboy.GameboyConfiguration(primary)
           .setGameboyType(gameboyType)
           .setBootstrapMode(bootstrapMode)
           .setCgb0Revision(cgb0Revision)
@@ -1549,8 +1554,16 @@ class Connection(
           .setCodeBreakerRumble(codeBreakerRumble)
           .setDisplaySgbBorder(displaySgbBorder)
           .setSlotRom(slotRom?.let(::Rom))
-          .setBatteryData(battery?.clone())
           .setSupportBatterySave(false)
+      // A portable checkpoint already owns the mapper RAM and RTC data, but its detached graph
+      // also retains the sender's file-backed battery bookkeeping. Give a battery cartridge a
+      // service-free in-memory target even when no save file was transferred so the audited
+      // FileBattery -> MemoryBattery adapter can preflight that graph. A state-less ROM load keeps
+      // the old absent-save behavior (default cartridge RAM, no synthetic save contents).
+      if (battery != null || portableStatePresent && primary.type.isBattery) {
+        configuration.setBatteryData(battery?.clone() ?: byteArrayOf())
+      }
+      return configuration
     }
 
     internal fun validateStateFileDeclaration(size: Int): StateFileDeclaration? {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -1039,6 +1039,10 @@ internal object StateGraph {
       }
       when {
         candidate is RecordState && target is RecordState -> {
+          if (isFileToMemoryBattery(candidate, target, owner, field)) {
+            validateFileToMemoryBattery(candidate, target, path)
+            return
+          }
           if (candidate.typeId != target.typeId) {
             throw StateApplyException(
                 "$path has ${recordClass(candidate).name}, expected ${recordClass(target).name}")
@@ -1071,6 +1075,48 @@ internal object StateGraph {
             value(candidate.values[index], target.values[index], "$path[$index]", owner, field, true)
           }
         }
+      }
+    }
+
+    /**
+     * File-backed local sessions and service-free transferred sessions deliberately use different
+     * battery owners. MemoryBattery.restoreState explicitly accepts FileBatteryState; mirror that
+     * production contract here so target preflight remains complete before mutation.
+     */
+    private fun isFileToMemoryBattery(
+        candidate: RecordState,
+        target: RecordState,
+        owner: String?,
+        field: String?,
+    ): Boolean =
+        owner != null &&
+            field == "batteryMemento" &&
+            recordClass(candidate).name == FILE_BATTERY_STATE &&
+            recordClass(target).name == MEMORY_BATTERY_STATE
+
+    private fun validateFileToMemoryBattery(
+        candidate: RecordState,
+        target: RecordState,
+        path: String,
+    ) {
+      fun RecordState.field(name: String): StateValue =
+          fields.singleOrNull { it.name == name }?.value
+              ?: throw StateApplyException("$path is missing $name")
+
+      val clock = candidate.field("clockBuffer") as? BytesState
+          ?: throw StateApplyException("$path.clockBuffer is not a byte array")
+      val ram = candidate.field("ramBuffer") as? BytesState
+          ?: throw StateApplyException("$path.ramBuffer is not a byte array")
+      val clockPresent = (candidate.field("isClockPresent") as? BooleanState)?.value
+          ?: throw StateApplyException("$path.isClockPresent is not boolean")
+      candidate.field("isDirty") as? BooleanState
+          ?: throw StateApplyException("$path.isDirty is not boolean")
+      val buffer = target.field("buffer") as? BytesState
+          ?: throw StateApplyException("$path target buffer is not a byte array")
+      val required = ram.size.toLong() + if (clockPresent) clock.size.toLong() else 0L
+      if (required > buffer.size.toLong()) {
+        throw StateApplyException(
+            "$path requires $required battery bytes, target capacity is ${buffer.size}")
       }
     }
   }
@@ -1144,6 +1190,12 @@ internal object StateGraph {
           "eu.rekawek.coffeegb.core.sgb.Commands\$TransferCommand\$TransferCommandState" to
               "dataTransfer",
       )
+
+  private const val MEMORY_BATTERY_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"
+
+  private const val FILE_BATTERY_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
 
   /**
    * Exact nullable locations in the pinned legacy graph. Nullability is a field contract, not a

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
@@ -1030,6 +1030,21 @@ class ConnectionTest {
               .run()
         }
     assertEquals(Connection.ProtocolErrorReason.INVALID_PORTABLE_STATE, wrongProfileError.reason)
+
+    val cgbMachine = portableStates(gameboyType = GameboyType.CGB).first
+    val wrongHardwareFamilyError =
+        assertFailsWith<Connection.ProtocolException> {
+          clientConnection(
+                  networkRomMessage(
+                      cgbMachine,
+                      gameboyType = GameboyType.DMG,
+                  ))
+              .run()
+        }
+    assertEquals(
+        Connection.ProtocolErrorReason.INVALID_PORTABLE_STATE,
+        wrongHardwareFamilyError.reason,
+    )
     assertEquals(null, received.poll())
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -11,9 +11,12 @@ import eu.rekawek.coffeegb.controller.link.LinkedController
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.MachineState
+import eu.rekawek.coffeegb.controller.state.MachineStateRoot
 import eu.rekawek.coffeegb.controller.state.StateCodec
 import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
 import eu.rekawek.coffeegb.controller.state.StateCompression
+import eu.rekawek.coffeegb.controller.state.StateIdentity
+import eu.rekawek.coffeegb.controller.state.StateIdentityEntry
 import eu.rekawek.coffeegb.controller.state.StateRootKind
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
@@ -810,6 +813,56 @@ class TcpConnectionTest {
   }
 
   @Test
+  fun linkedControllersExchangeTransferred512KiBCgbRomAndMachineCheckpoint() {
+    val port = ServerSocket(0).use { it.localPort }
+    val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
+    val serverReady = LinkedBlockingQueue<ConnectionController.ServerGotConnectionEvent>()
+    val clientReady = LinkedBlockingQueue<ConnectionController.ClientConnectedToServerEvent>()
+    serverBus.register<ConnectionController.ServerStartedEvent> { serverStarted.add(it) }
+    serverBus.register<ConnectionController.ServerGotConnectionEvent> { serverReady.add(it) }
+    clientBus.register<ConnectionController.ClientConnectedToServerEvent> { clientReady.add(it) }
+    val rom = synthetic512KiBCgbRom(47)
+    val properties = borderEnabledProperties(HardwareProfileRegistry.CGB)
+    assertMachineCheckpointMatchesTransferredRom(rom, properties)
+    val hostController = linkedController(serverBus, LinkMode.NORMAL, 0, properties)
+    val clientController =
+        linkedController(
+            clientBus,
+            LinkMode.NORMAL,
+            1,
+            borderEnabledProperties(HardwareProfileRegistry.CGB),
+        )
+
+    val server = TcpServer(serverBus, port)
+    this.server = server
+    threads += Thread(server).also { it.start() }
+    assertNotNull(serverStarted.poll(5, TimeUnit.SECONDS))
+    val client = TcpClient("localhost:$port", clientBus)
+    this.client = client
+    threads += Thread(client).also { it.start() }
+    assertNotNull(serverReady.poll(5, TimeUnit.SECONDS))
+    assertNotNull(clientReady.poll(5, TimeUnit.SECONDS))
+
+    serverBus.post(LoadRomEvent(rom, runningMemento(1_000, properties, rom)))
+    clientBus.post(
+        LoadRomEvent(
+            rom,
+            runningMemento(
+                2_000,
+                borderEnabledProperties(HardwareProfileRegistry.CGB),
+                rom,
+            ),
+        ))
+    driveControllers(hostController, clientController) {
+      hostController.activeSessionCount() == 2 && clientController.activeSessionCount() == 2
+    }
+
+    assertEquals(2, hostController.activeSessionCount())
+    assertEquals(2, clientController.activeSessionCount())
+    assertTrue(synchronizationFailures.isEmpty(), synchronizationFailures.peek())
+  }
+
+  @Test
   fun linkedFourPlayerClientStartsFromPortableCheckpointOverTcp() {
     val port = ServerSocket(0).use { it.localPort }
     val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
@@ -1067,6 +1120,78 @@ class TcpConnectionTest {
     }
   }
 
+  private fun assertMachineCheckpointMatchesTransferredRom(
+      romFile: java.io.File,
+      properties: EmulatorProperties,
+  ) {
+    val wireRom = romFile.readBytes()
+    assertEquals(512 * 1024, wireRom.size)
+    assertContentEquals(
+        wireRom,
+        Rom(wireRom).rom.map(Int::toByte).toByteArray(),
+        "the valid synthetic header must not require loader correction",
+    )
+    val sourceBus = EventBusImpl()
+    val sourceConfig = Controller.createGameboyConfig(properties, Rom(romFile))
+    val source = sourceConfig.build()
+    source.init(sourceBus, SerialEndpoint.NULL_ENDPOINT, InfraredEndpoint.NULL_ENDPOINT, null)
+    val file =
+        try {
+          repeat(1_000) { source.tick() }
+          StateCodec.capture(sourceConfig, source)
+        } finally {
+          source.stop()
+          source.close()
+          sourceBus.close()
+        }
+    val sourceIdentity = StateIdentity.from(sourceConfig)
+    assertEquals(sourceIdentity, file.identities.single().identity)
+    assertEquals(SYNTHETIC_CGB_SHA256, sourceIdentity.primaryRom.hex())
+    assertEquals("cgb", sourceIdentity.profile.canonicalProfileId)
+    assertFalse(sourceIdentity.profile.displaySgbBorder)
+    assertEquals(
+        2,
+        (file.root as MachineStateRoot)
+            .machine
+            .recordCount(FILE_BATTERY_STATE),
+        "the local checkpoint captures both file-backed battery ownership records",
+    )
+    val target =
+        Connection.peerConfiguration(
+            wireRom,
+            null,
+            null,
+            GameboyType.CGB,
+            Gameboy.BootstrapMode.SKIP,
+            false,
+            false,
+            false,
+            false,
+            true,
+        )
+    assertEquals(sourceIdentity, StateIdentity.from(target))
+    StateCodec.validateForTarget(
+        file,
+        StateRootKind.MACHINE,
+        listOf(StateIdentityEntry(0, StateIdentity.from(target))),
+    )
+    val targetBus = EventBusImpl()
+    val probe = target.forRestore().build()
+    probe.init(targetBus, SerialEndpoint.NULL_ENDPOINT, InfraredEndpoint.NULL_ENDPOINT, null)
+    try {
+      assertEquals(
+          2,
+          DetachedStateAdapter.capture(probe).recordCount(MEMORY_BATTERY_STATE),
+          "the peer checkpoint target must be service-free and memory-backed",
+      )
+      DetachedStateAdapter.validateTarget(probe, (file.root as MachineStateRoot).machine)
+    } finally {
+      probe.stop()
+      probe.close()
+      targetBus.close()
+    }
+  }
+
   private fun borderEnabledProperties(profile: HardwareProfile): EmulatorProperties =
       EmulatorProperties(profile).also {
         it.properties[EmulatorProperties.Key.ShowSgbBorder.propertyName] = "true"
@@ -1077,6 +1202,43 @@ class TcpConnectionTest {
           .also {
             it.writeBytes(StateCodecTestSupport.rom(seed = seed, cgb = true))
             temporaryRoms += it
+          }
+
+  private fun synthetic512KiBCgbRom(seed: Int): java.io.File =
+      java.io.File.createTempFile("coffee-gb-netplay-cgb-512k-$seed-", ".gbc")
+          .also { file ->
+            val bytes = ByteArray(512 * 1024) { index -> ((index * 17 + seed) and 0xff).toByte() }
+            bytes[0x100] = 0x18
+            bytes[0x101] = 0xfe.toByte()
+            ByteArray(16).copyInto(bytes, 0x134)
+            "CGBSYNTH512".forEachIndexed { index, character ->
+              bytes[0x134 + index] = character.code.toByte()
+            }
+            bytes[0x143] = 0x80.toByte()
+            bytes[0x144] = 0
+            bytes[0x145] = 0
+            bytes[0x146] = 0
+            bytes[0x147] = 0x1b
+            bytes[0x148] = 0x04
+            bytes[0x149] = 0x03
+            bytes[0x14a] = 0
+            bytes[0x14b] = 0
+            bytes[0x14c] = 0
+            var headerChecksum = 0
+            for (index in 0x134..0x14c) {
+              headerChecksum = (headerChecksum - (bytes[index].toInt() and 0xff) - 1) and 0xff
+            }
+            bytes[0x14d] = headerChecksum.toByte()
+            bytes[0x14e] = 0
+            bytes[0x14f] = 0
+            val globalChecksum =
+                bytes.indices
+                    .filter { it != 0x14e && it != 0x14f }
+                    .fold(0) { sum, index -> (sum + (bytes[index].toInt() and 0xff)) and 0xffff }
+            bytes[0x14e] = (globalChecksum ushr 8).toByte()
+            bytes[0x14f] = globalChecksum.toByte()
+            file.writeBytes(bytes)
+            temporaryRoms += file
           }
 
   private fun portableSession(rom: ByteArray, player: Int): ByteArray {
@@ -1096,5 +1258,11 @@ class TcpConnectionTest {
 
   private companion object {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
+    const val FILE_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
+    const val MEMORY_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"
+    const val SYNTHETIC_CGB_SHA256 =
+        "4eebdc6a6e2d47d711054a73419b06f4c8675ef1838a9cc364d32f27552e1b5c"
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/DetachedStateTest.kt
@@ -20,6 +20,7 @@ import eu.rekawek.coffeegb.core.sgb.Background
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay
 import eu.rekawek.coffeegb.core.sgb.SuperGameboy
 import eu.rekawek.coffeegb.core.state.ComponentState
+import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertContentEquals
@@ -30,6 +31,58 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class DetachedStateTest {
+
+  @Test
+  fun fileBatteryCheckpointTargetsMemoryBatteryAndRejectsOverflowBeforeMutation() {
+    val romBytes = slotRom(0x1b, 0x03)
+    val path = Files.createTempFile("coffee-gb-file-memory-battery-", ".gbc")
+    Files.write(path, romBytes)
+    try {
+      val sourceConfig =
+          Gameboy.GameboyConfiguration(Rom(path.toFile()))
+              .setBootstrapMode(BootstrapMode.SKIP)
+      val targetConfig =
+          Gameboy.GameboyConfiguration(Rom(romBytes))
+              .setBootstrapMode(BootstrapMode.SKIP)
+              .setBatteryData(byteArrayOf())
+              .setSupportBatterySave(false)
+      session(sourceConfig).use { source ->
+        session(targetConfig).use { target ->
+          val state = source.captureDetachedState().machine
+          assertEquals(2, state.recordCount(FILE_BATTERY_STATE))
+          assertEquals(
+              2,
+              target.captureDetachedState().machine.recordCount(MEMORY_BATTERY_STATE),
+          )
+          DetachedStateAdapter.validateTarget(target.gameboy, state)
+
+          val malformed =
+              MachineState(
+                  state.root.replaceRecordField(
+                      FILE_BATTERY_STATE,
+                      "ramBuffer",
+                      BytesState(ByteArray(0x8001)),
+                  ),
+                  state.rtcRuntime,
+                  state.hardware,
+                  state.dmgFifoRuntime,
+              )
+          val before = target.captureDetachedState().machine
+          val stages = mutableListOf<ApplyStage>()
+          val failure =
+              assertFailsWith<StateApplyException> {
+                DetachedStateAdapter.apply(target.gameboy, malformed, stages::add)
+              }
+          assertTrue(failure.message.orEmpty().contains("target capacity"))
+          assertTrue(stages.isEmpty())
+          assertEquals(before, target.captureDetachedState().machine)
+        }
+      }
+    } finally {
+      Files.deleteIfExists(path)
+      Files.deleteIfExists(path.resolveSibling(path.fileName.toString().substringBeforeLast('.') + ".sav"))
+    }
+  }
 
   @Test
   fun nontrivialPpuAndDisplayStateRoundTripsAndContinuesDeterministically() {
@@ -1589,6 +1642,10 @@ class DetachedStateTest {
     const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelState"
     const val BASIC_ROM_MEMENTO =
         "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomState"
+    const val FILE_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
+    const val MEMORY_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"
     const val GENIE_MEMENTO = "eu.rekawek.coffeegb.core.genie.Genie\$GenieState"
     const val RTC_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock\$RealTimeClockState"
     const val HUC3_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Huc3\$Huc3State"


### PR DESCRIPTION
## Invariant

A protocol-v8 transferred ROM with a portable MACHINE checkpoint now constructs a service-free battery target that is structurally compatible with the sender's detached battery state before apply. ROM SHA-256, canonical hardware profile, root kind, schema, checksum, and endpoint validation remain strict and unchanged.

## Root cause

For battery-backed cartridges, a file-loaded sender owns `FileBatteryState` records even when no `.sav` exists. The transferred-ROM receiver disabled filesystem persistence and, when no battery payload was sent, built a null battery owner. The ROM hash (`4eebdc6a6e2d47d711054a73419b06f4c8675ef1838a9cc364d32f27552e1b5c` in the synthetic regression), canonical `cgb` profile, SGB-border=false metadata, endpoint, and MACHINE root all matched; detached target preflight correctly rejected the battery-owner presence mismatch before mutation.

## Changes

- Construct an empty service-free `MemoryBattery` only when a portable checkpoint accompanies a battery-backed transferred ROM. State-less transfers preserve the prior absent-save/default-RAM behavior.
- Audit and preflight the existing production-supported `FileBatteryState -> MemoryBatteryState` restore path, including checked target-capacity validation before the first mutation.
- Use the same checkpoint-aware target construction for decode preflight and LinkedController replacement.
- Add a legal deterministic 512 KiB CGB/MBC5+RAM+battery ROM generator with valid header/global checksums and real loopback coverage in both transfer directions.
- Add strict negative profile-family and malformed capacity/no-mutation coverage. Existing wrong ROM, root, schema, checksum, CGB0, and SGB mismatch tests remain green.

No protocol-v9 files or behavior changed. No commercial ROM/save/state artifact is included.

## Verification

Temurin 16.0.2+7:

- Focused connection/link/state/profile suite: 131 tests, 0 failures/errors/skips.
- Historical TCP stress: 10 independent Maven invocations of both `linkedControllersExchangePortableRunningStateOverTcp` and `linkedFourPlayerClientStartsFromPortableCheckpointOverTcp` (20 executions), all passed.
- Full `mvn -B clean test`: core 791; controller 378 (2 skipped); swing 41; aggregate 1,210 tests, 0 failures, 0 errors, 2 skips.
- `git diff --check` passes.
- Java release-16 compilation passes; no `java.util.HexFormat` or added ordinal wire identity.
- Frozen netplay-v9 and released fixture resources have no diff. Legacy 1.7.13/1.7.14 and StateFile v1/v2 hashes remain unchanged.

Closes #400

Part of #318
Related to #314
