### PR TITLE
[Netplay] Add bounded diagnostics and trusted-LAN discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ verified receivers deliver only complete detached candidates. Callers without th
 their earlier boundary. Own-ROM exact match remains the default and performs no transfer.
 An additional #349 developer plan enables direct StateFile-v2 checkpoints, atomic frame-safe
 restore, START/READY, and bounded ACTIVE input/reset/stop. It remains opt-in and is not wired to the
-default UI; discovery also remains unavailable. Current user netplay remains v8. V9 deliberately
+default UI. Explicit v9 callers may enable bounded PING/rollback metrics and an EDT-safe sanitized
+diagnostics panel. A separate trusted-LAN discovery service is off by default and advertises only
+an untrusted numeric endpoint/public session ID while a listener has an open slot; confirmation
+and the existing one-use authenticated invitation are still mandatory. It provides no automatic
+connection, tokenless flow, matchmaking, NAT traversal, or encryption. Current user netplay
+remains v8. V9 deliberately
 does not interoperate or
 downgrade to v8. Its TCP transport is plaintext—not confidential or secure against an on-path
 attacker. See

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -52,6 +52,10 @@ import eu.rekawek.coffeegb.controller.network.ConnectionController.ServerPlayerD
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopClientEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopServerEvent
 import eu.rekawek.coffeegb.controller.network.PeerFrameWindow
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackMetrics
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackReason
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
 import eu.rekawek.coffeegb.controller.network.v9.V9CheckpointCommitCompletion
 import eu.rekawek.coffeegb.controller.network.v9.V9CapturedCheckpoint
 import eu.rekawek.coffeegb.controller.network.v9.V9CheckpointKind
@@ -142,6 +146,11 @@ class LinkedController(
   private var rejectedLocalState: Controller.ControllerState? = null
 
   @VisibleForTesting internal val stateHistory: StateHistory = StateHistory(mode)
+
+  private val rollbackMetrics = NetplayRollbackMetrics(StateHistory.MAX_HISTORY_STATES)
+
+  internal fun rollbackMetricsSource(): NetplaySnapshotSource<NetplayRollbackMetricsSnapshot> =
+      rollbackMetrics
 
   @VisibleForTesting
   internal fun mainHeldButtons() = sessions[localPlayer]?.heldButtons ?: emptySet()
@@ -294,6 +303,7 @@ class LinkedController(
       currentInput = null
       lastInput = null
       rebaseHistoryToLiveState()
+      rollbackMetrics.recordCheckpoint(NetplayRollbackReason.CHECKPOINT)
     } catch (failure: Throwable) {
       try {
         rollback.forEach { (_, session, prepared) ->
@@ -363,6 +373,7 @@ class LinkedController(
       initialStateSynchronized = true
       rebaseHistoryToLiveState()
       syncV9RemoteButtons()
+      rollbackMetrics.recordCheckpoint(NetplayRollbackReason.RESYNCHRONIZATION)
     } catch (failure: Throwable) {
       try {
         links = oldLinks
@@ -661,7 +672,7 @@ class LinkedController(
       if (isFourPlayerHost()) {
         commitHostCheckpoint()
       } else {
-        commitStateBoundary()
+        commitStateBoundary(NetplayRollbackReason.RESET)
         if (mode == LinkMode.FOUR_PLAYER_ADAPTER) localCheckpointCreditPending = true
       }
       eventBus.postAsync(RequestResetEvent(frame, localPlayer))
@@ -807,7 +818,7 @@ class LinkedController(
         if (isFourPlayerHost()) {
           commitHostCheckpoint()
         } else {
-          commitStateBoundary()
+          commitStateBoundary(NetplayRollbackReason.RESET)
           if (mode == LinkMode.FOUR_PLAYER_ADAPTER) grantCheckpointCredit(e.source)
         }
         eventBus.post(ValidatedPeerResetEvent(e))
@@ -829,7 +840,7 @@ class LinkedController(
         if (isFourPlayerHost()) {
           commitHostCheckpoint()
         } else {
-          commitStateBoundary()
+          commitStateBoundary(NetplayRollbackReason.TOPOLOGY_CHANGE)
         }
         eventBus.post(ValidatedPeerStopEvent(e))
       }
@@ -969,6 +980,7 @@ class LinkedController(
         sessions.map { it?.captureDetachedState() },
         sessions.map { it?.heldButtons ?: emptySet() },
     )
+    rollbackMetrics.updateHistory(stateHistory.entryCount())
 
     sessions[localPlayer]?.let { effectiveInput.send(it.eventBus) }
 
@@ -1196,6 +1208,8 @@ class LinkedController(
         LOG.warn("Unable to close replaced linked session", failure)
       }
     }
+    rollbackMetrics.recordCheckpoint(NetplayRollbackReason.CHECKPOINT)
+    rollbackMetrics.updateHistory(stateHistory.entryCount())
     return true
   }
 
@@ -1292,7 +1306,7 @@ class LinkedController(
             "Player ${player + 1} portable state could not be prepared atomically",
             failure,
         )
-    LOG.info("Rejecting player {} state: {}", player + 1, failure.message)
+    LOG.atDebug().log("Rejecting portable state for player {}", player + 1)
     source?.let(eventQueue::discardSource)
     source?.reject(ProtocolErrorReason.INVALID_PORTABLE_STATE, error)
   }
@@ -1317,12 +1331,12 @@ class LinkedController(
   }
 
   private fun validateRuntimeFrame(peerFrame: Long, source: PeerEventSource?): Boolean {
-    if (peerFrame < runtimeFrameFloor) {
+    val historyFloor = maxOf(runtimeFrameFloor, stateHistory.oldestFrame() ?: runtimeFrameFloor)
+    if (peerFrame < historyFloor) {
+      rollbackMetrics.recordHistoryExhausted()
       LOG.atDebug().log(
-          "Discarding player {} frame {} from before checkpoint floor {}",
+          "Discarding player {} frame from before retained history",
           source?.player?.plus(1),
-          peerFrame,
-          runtimeFrameFloor,
       )
       return false
     }
@@ -1334,10 +1348,13 @@ class LinkedController(
       player: Int,
       requireActiveSession: Boolean = true,
   ): V9ErrorCode? {
+    val historyExhausted =
+        peerFrame < runtimeFrameFloor || stateHistory.oldestFrame()?.let { peerFrame < it } == true
     if (player == localPlayer || player !in sessions.indices ||
         requireActiveSession && sessions[player] == null ||
         !requireActiveSession && configs[player] == null ||
-        peerFrame < runtimeFrameFloor || stateHistory.oldestFrame()?.let { peerFrame < it } == true) {
+        historyExhausted) {
+      if (historyExhausted) rollbackMetrics.recordHistoryExhausted()
       return V9ErrorCode.SEQUENCE_ERROR
     }
     return try {
@@ -1406,7 +1423,7 @@ class LinkedController(
     v9RemoteButtons[value.player] = null
     if (isFourPlayerHost()) commitHostCheckpoint()
     else {
-      commitStateBoundary()
+      commitStateBoundary(NetplayRollbackReason.RESET)
       if (mode == LinkMode.FOUR_PLAYER_ADAPTER) localCheckpointCreditPending = true
     }
     eventBus.post(ValidatedPeerResetEvent(ReceivedRemoteResetEvent(value.frame, value.player)))
@@ -1418,7 +1435,8 @@ class LinkedController(
     sessions[value.player]?.close()
     sessions[value.player] = null
     v9RemoteButtons[value.player] = null
-    if (isFourPlayerHost()) commitHostCheckpoint() else commitStateBoundary()
+    if (isFourPlayerHost()) commitHostCheckpoint()
+    else commitStateBoundary(NetplayRollbackReason.TOPOLOGY_CHANGE)
     eventBus.post(ValidatedPeerStopEvent(ReceivedRemoteStopEvent(value.frame, value.player)))
   }
 
@@ -1513,8 +1531,8 @@ class LinkedController(
         validation()
         true
       } catch (e: IOException) {
-        LOG.info("Rejecting player {} frame at controller frame {}: {}",
-            source?.player?.plus(1), frame, e.message)
+        LOG.atDebug().log("Rejecting invalid peer frame for player {}",
+            source?.player?.plus(1))
         source?.let(eventQueue::discardSource)
         source?.reject(ProtocolErrorReason.INVALID_FRAME, e)
         false
@@ -1593,7 +1611,7 @@ class LinkedController(
 
   /** Applies every accepted old-generation patch before a topology snapshot is captured. */
   private fun reconcileHistory() {
-    if (!stateHistory.merge(configs)) return
+    val merge = stateHistory.mergeDetailed(configs) ?: return
     val head = stateHistory.getHead()
     for (player in sessions.indices) {
       val session = sessions[player]
@@ -1604,27 +1622,33 @@ class LinkedController(
       }
     }
     frame = head.frame
+    rollbackMetrics.recordRollback(merge.framesRewound, merge.framesResimulated)
+    rollbackMetrics.updateHistory(stateHistory.entryCount())
     LOG.atDebug().log("State merged to {}", frame)
   }
 
   /** Publishes and installs the same exact generation boundary used by remote clients. */
   private fun commitHostCheckpoint() {
-    commitStateBoundary()
+    commitStateBoundary(NetplayRollbackReason.TOPOLOGY_CHANGE)
     hostCheckpointPending = true
   }
 
   /** Coalesces mutations in one dispatch and captures any same-frame patches after the boundary. */
   private fun flushHostCheckpoint() {
     if (!hostCheckpointPending) return
-    commitStateBoundary()
+    commitStateBoundary(NetplayRollbackReason.TOPOLOGY_CHANGE, record = false)
     broadcastCurrentState()
     hostCheckpointPending = false
   }
 
   /** Ends the old input/history generation after a reset or topology mutation. */
-  private fun commitStateBoundary() {
+  private fun commitStateBoundary(
+      reason: NetplayRollbackReason = NetplayRollbackReason.CHECKPOINT,
+      record: Boolean = true,
+  ) {
     runtimeFrameFloor = frame
     rebaseHistoryToLiveState()
+    if (record) rollbackMetrics.recordCheckpoint(reason)
   }
 
   private fun rebaseHistoryToLiveState() {
@@ -1637,6 +1661,7 @@ class LinkedController(
         sessionStates,
         heldButtons,
     )
+    rollbackMetrics.updateHistory(stateHistory.entryCount())
   }
 
   override fun close() {}
@@ -1687,6 +1712,7 @@ class LinkedController(
 
     localSession?.eventBus?.post(Controller.EmulationStoppedEvent())
     sessions.forEach { it?.close() }
+    rollbackMetrics.close()
     eventBus.close()
 
     return state
@@ -1913,6 +1939,9 @@ internal class V9LinkedControllerTarget(
       completion.complete(V9ErrorCode.CANCELLED)
     }
   }
+
+  override fun rollbackMetricsSource(): NetplaySnapshotSource<NetplayRollbackMetricsSnapshot> =
+      controller.rollbackMetricsSource()
 
   override fun disconnected(player: Int) {
     close()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/StateHistory.kt
@@ -55,11 +55,15 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
   }
 
   @Synchronized
-  fun merge(configs: List<GameboyConfiguration?>): Boolean {
+  fun merge(configs: List<GameboyConfiguration?>): Boolean = mergeDetailed(configs) != null
+
+  @Synchronized
+  internal fun mergeDetailed(configs: List<GameboyConfiguration?>): MergeResult? {
     require(configs.size == mode.playerCount)
     if (patches.isEmpty() || states.isEmpty()) {
-      return false
+      return null
     }
+    val previousHead = states.last().frame
     val baseFrame = min(patches.minOf { it.frame }, states.last().frame)
     val toFrame = max(states.last().frame, patches.maxOf { it.frame })
     LOG.atDebug().log("Rebasing from $baseFrame to $toFrame")
@@ -147,7 +151,10 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
     sessions.forEach { it?.close() }
 
     LOG.atDebug().log("Rebase from $baseFrame to $toFrame completed.")
-    return true
+    return MergeResult(
+        framesRewound = (previousHead - baseFrame).coerceAtLeast(0),
+        framesResimulated = Math.addExact(Math.subtractExact(toFrame, baseFrame), 1),
+    )
   }
 
   fun getHead() = states.last()
@@ -202,6 +209,9 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
   @Synchronized
   internal fun oldestFrame(): Long? = states.firstOrNull()?.frame
 
+  @Synchronized
+  internal fun entryCount(): Int = states.size
+
   private fun emptyInputs() = List(mode.playerCount) { Input(emptyList(), emptyList()) }
 
   private fun trimHistory() {
@@ -224,6 +234,11 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
       val patches: List<Patch>,
   )
 
+  internal data class MergeResult(
+      val framesRewound: Long,
+      val framesResimulated: Long,
+  )
+
   @VisibleForTesting
   internal data class GameboyJoypadPressEvent(
       val button: Button,
@@ -233,7 +248,7 @@ class StateHistory(private val mode: LinkMode = LinkMode.NORMAL) {
 
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(StateHistory::class.java)
-    private val MAX_HISTORY_STATES = StateLimits.NETPLAY_ROLLBACK_FRAMES.toInt()
+    internal val MAX_HISTORY_STATES = StateLimits.NETPLAY_ROLLBACK_FRAMES.toInt()
 
     internal fun createLinks(
         mode: LinkMode,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnostics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnostics.kt
@@ -1,0 +1,339 @@
+package eu.rekawek.coffeegb.controller.network
+
+import java.io.Closeable
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/** Listener for immutable, detached netplay diagnostic snapshots. */
+fun interface NetplaySnapshotListener<T> {
+  fun onSnapshot(snapshot: T)
+}
+
+/** Platform-neutral source used by controller, v9, and Swing presentation adapters. */
+interface NetplaySnapshotSource<T> {
+  fun snapshot(): T
+
+  fun addListener(listener: NetplaySnapshotListener<T>): Closeable
+}
+
+/** Pure bounded numeric-address validation; it never performs DNS or interface lookup. */
+internal object NetplayNumericAddress {
+  fun isValid(value: String): Boolean {
+    if (value.length !in 2..64) return false
+    val address = value.substringBefore('%')
+    val scope = value.substringAfter('%', "")
+    if ('%' in value && (scope.length !in 1..16 || scope.any {
+          !it.isLetterOrDigit() && it !in "._-"
+        })) return false
+    if ('.' in address && ':' !in address) {
+      if ('%' in value) return false
+      val octets = address.split('.')
+      return octets.size == 4 && octets.all { octet ->
+        octet.isNotEmpty() && octet.all(Char::isDigit) &&
+            (octet == "0" || !octet.startsWith('0')) &&
+            octet.toIntOrNull() in 0..255
+      }
+    }
+    if (':' !in address || address.any { !it.isDigit() && it !in ":abcdefABCDEF" }) return false
+    if (address.count { it == ':' } < 2 || ":::" in address) return false
+    val compressed = "::" in address
+    if (!compressed && (address.startsWith(':') || address.endsWith(':'))) return false
+    val pieces = address.split("::")
+    if (pieces.size > 2) return false
+    var groups = 0
+    for (side in pieces) {
+      if (side.isEmpty()) continue
+      val values = side.split(':')
+      if (values.any { it.length !in 1..4 }) return false
+      groups += values.size
+    }
+    return if (compressed) groups < 8 else groups == 8
+  }
+}
+
+/** Stable local-only rollback causes. Declaration order has no persisted or wire meaning. */
+enum class NetplayRollbackReason(val stableId: String) {
+  NONE("none"),
+  REMOTE_INPUT("remote-input"),
+  HISTORY_EXHAUSTED("history-exhausted"),
+  CHECKPOINT("checkpoint"),
+  RESYNCHRONIZATION("resynchronization"),
+  RESET("reset"),
+  TOPOLOGY_CHANGE("topology-change"),
+}
+
+/**
+ * Immutable bounded rollback/history diagnostics. The rolling average is represented in
+ * thousandths of a frame and is rounded down deterministically. Zero-rewind forward replays add
+ * to re-simulated frames but are not counted as rollbacks or rolling rewind samples.
+ */
+data class NetplayRollbackMetricsSnapshot(
+    val rollbackCount: Long,
+    val lastFramesRewound: Long,
+    val maximumFramesRewound: Long,
+    val rollingAverageFramesRewoundMilli: Long,
+    val totalFramesResimulated: Long,
+    val historyEntries: Int,
+    val historyCapacity: Int,
+    val tooOldInputs: Long,
+    val checkpointResynchronizations: Long,
+    val lastReason: NetplayRollbackReason,
+)
+
+/** Bounded diagnostics tracker; no emulator state or replay decision depends on these counters. */
+class NetplayRollbackMetrics(
+    historyCapacity: Int,
+) : NetplaySnapshotSource<NetplayRollbackMetricsSnapshot>, Closeable {
+  private val lock = Any()
+  private val samples = LongArray(ROLLING_SAMPLES)
+  private var sampleIndex = 0
+  private var sampleCount = 0
+  private var sampleTotal = 0L
+  private var rollbackCount = 0L
+  private var lastFramesRewound = 0L
+  private var maximumFramesRewound = 0L
+  private var totalFramesResimulated = 0L
+  private var historyEntries = 0
+  private val historyCapacity = historyCapacity.also { require(it > 0) }
+  private var tooOldInputs = 0L
+  private var checkpointResynchronizations = 0L
+  private var lastReason = NetplayRollbackReason.NONE
+  private var closed = false
+  private val publisher =
+      BoundedSnapshotPublisher(snapshotLocked(), "netplay-rollback-diagnostics")
+
+  fun recordRollback(framesRewound: Long, framesResimulated: Long) {
+    require(framesRewound in 0..historyCapacity.toLong() && framesResimulated >= 0)
+    val value = synchronized(lock) {
+      if (closed) return
+      totalFramesResimulated = saturatingAdd(totalFramesResimulated, framesResimulated)
+      if (framesRewound > 0) {
+        rollbackCount = saturatingAdd(rollbackCount, 1)
+        lastFramesRewound = framesRewound
+        maximumFramesRewound = maxOf(maximumFramesRewound, framesRewound)
+        if (sampleCount == samples.size) {
+          sampleTotal = (sampleTotal - samples[sampleIndex]).coerceAtLeast(0)
+        } else {
+          sampleCount++
+        }
+        samples[sampleIndex] = framesRewound
+        sampleIndex = (sampleIndex + 1) % samples.size
+        sampleTotal = saturatingAdd(sampleTotal, framesRewound)
+      }
+      lastReason = NetplayRollbackReason.REMOTE_INPUT
+      snapshotLocked()
+    }
+    publisher.update(value)
+  }
+
+  fun recordHistoryExhausted() {
+    val value = synchronized(lock) {
+      if (closed) return
+      tooOldInputs = saturatingAdd(tooOldInputs, 1)
+      lastReason = NetplayRollbackReason.HISTORY_EXHAUSTED
+      snapshotLocked()
+    }
+    publisher.update(value)
+  }
+
+  fun recordCheckpoint(reason: NetplayRollbackReason = NetplayRollbackReason.CHECKPOINT) {
+    require(
+        reason in
+            setOf(
+                NetplayRollbackReason.CHECKPOINT,
+                NetplayRollbackReason.RESYNCHRONIZATION,
+                NetplayRollbackReason.RESET,
+                NetplayRollbackReason.TOPOLOGY_CHANGE,
+            ),
+    )
+    val value = synchronized(lock) {
+      if (closed) return
+      checkpointResynchronizations = saturatingAdd(checkpointResynchronizations, 1)
+      lastReason = reason
+      snapshotLocked()
+    }
+    publisher.update(value)
+  }
+
+  fun updateHistory(entries: Int) {
+    require(entries in 0..historyCapacity)
+    val value = synchronized(lock) {
+      if (closed) return
+      historyEntries = entries
+      snapshotLocked()
+    }
+    publisher.update(value)
+  }
+
+  override fun snapshot(): NetplayRollbackMetricsSnapshot = synchronized(lock) { snapshotLocked() }
+
+  override fun addListener(
+      listener: NetplaySnapshotListener<NetplayRollbackMetricsSnapshot>,
+  ): Closeable = publisher.addListener(listener)
+
+  override fun close() {
+    synchronized(lock) {
+      if (closed) return
+      closed = true
+    }
+    publisher.close()
+  }
+
+  internal fun retainedSampleCount(): Int = synchronized(lock) { sampleCount }
+
+  internal fun seedCountersForTest(
+      rollbacks: Long,
+      resimulated: Long,
+      tooOld: Long,
+      checkpoints: Long,
+  ) {
+    require(rollbacks >= 0 && resimulated >= 0 && tooOld >= 0 && checkpoints >= 0)
+    val value = synchronized(lock) {
+      if (closed) return
+      rollbackCount = rollbacks
+      totalFramesResimulated = resimulated
+      tooOldInputs = tooOld
+      checkpointResynchronizations = checkpoints
+      snapshotLocked()
+    }
+    publisher.update(value)
+  }
+
+  private fun snapshotLocked(): NetplayRollbackMetricsSnapshot {
+    val average =
+        if (sampleCount == 0) 0
+        else if (sampleTotal > Long.MAX_VALUE / 1_000L) Long.MAX_VALUE
+        else sampleTotal * 1_000L / sampleCount
+    return NetplayRollbackMetricsSnapshot(
+        rollbackCount,
+        lastFramesRewound,
+        maximumFramesRewound,
+        average,
+        totalFramesResimulated,
+        historyEntries,
+        historyCapacity,
+        tooOldInputs,
+        checkpointResynchronizations,
+        lastReason,
+    )
+  }
+
+  companion object {
+    const val ROLLING_SAMPLES = 64
+
+    internal fun saturatingAdd(left: Long, right: Long): Long {
+      require(left >= 0 && right >= 0)
+      return if (right > Long.MAX_VALUE - left) Long.MAX_VALUE else left + right
+    }
+  }
+}
+
+/**
+ * Latest-value publisher with one retained snapshot, at most 16 observers, and one lazily-created
+ * daemon. Producers only replace/offer a value and therefore never wait for presentation code.
+ */
+internal class BoundedSnapshotPublisher<T>(
+    initial: T,
+    private val threadName: String,
+) : NetplaySnapshotSource<T>, Closeable {
+  private val current = AtomicReference(initial)
+  private val queue = ArrayBlockingQueue<T>(1)
+  private val closed = AtomicBoolean(false)
+  private val listenerLock = Any()
+  private val listeners = LinkedHashSet<NetplaySnapshotListener<T>>()
+  private val terminated = CountDownLatch(1)
+  private var worker: Thread? = null
+
+  override fun snapshot(): T = current.get()
+
+  override fun addListener(listener: NetplaySnapshotListener<T>): Closeable {
+    synchronized(listenerLock) {
+      check(!closed.get()) { "netplay diagnostics source is closed" }
+      check(listeners.size < MAX_LISTENERS) { "netplay diagnostics listener limit reached" }
+      listeners += listener
+      if (worker == null) {
+        worker = thread(isDaemon = true, name = threadName, block = ::dispatchLoop)
+      }
+    }
+    offerLatest(current.get())
+    val active = AtomicBoolean(true)
+    return Closeable {
+      if (active.compareAndSet(true, false)) {
+        synchronized(listenerLock) { listeners.remove(listener) }
+      }
+    }
+  }
+
+  fun update(value: T) {
+    if (closed.get()) return
+    current.set(value)
+    val observed = synchronized(listenerLock) { listeners.isNotEmpty() }
+    if (observed) offerLatest(value)
+  }
+
+  private fun offerLatest(value: T) {
+    if (closed.get()) return
+    if (!queue.offer(value)) {
+      queue.poll()
+      queue.offer(value)
+    }
+  }
+
+  private fun dispatchLoop() {
+    try {
+      while (true) {
+        val value = queue.poll(250, java.util.concurrent.TimeUnit.MILLISECONDS)
+        if (value == null) {
+          if (closed.get()) return
+          continue
+        }
+        val snapshot = synchronized(listenerLock) { listeners.toList() }
+        snapshot.forEach { listener ->
+          try {
+            listener.onSnapshot(value)
+          } catch (_: RuntimeException) {
+            // A presentation observer cannot affect networking or emulation ownership.
+          }
+        }
+        if (closed.get() && queue.isEmpty()) return
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    } finally {
+      synchronized(listenerLock) {
+        listeners.clear()
+        worker = null
+      }
+      terminated.countDown()
+    }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    synchronized(listenerLock) {
+      if (worker == null) {
+        listeners.clear()
+        terminated.countDown()
+      } else if (!queue.offer(current.get())) {
+        queue.poll()
+        queue.offer(current.get())
+      }
+    }
+  }
+
+  internal fun activeWorkerCount(): Int =
+      synchronized(listenerLock) { if (worker?.isAlive == true) 1 else 0 }
+
+  internal fun activeListenerCount(): Int = synchronized(listenerLock) { listeners.size }
+
+  internal fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
+      terminated.await(timeout, unit)
+
+  companion object {
+    const val MAX_LISTENERS = 16
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnosticsExport.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnosticsExport.kt
@@ -1,0 +1,112 @@
+package eu.rekawek.coffeegb.controller.network
+
+import eu.rekawek.coffeegb.controller.network.v9.V9TransportMetricsSnapshot
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleState
+
+/** Whitelist-only bounded diagnostics export. It never receives peer text or payload objects. */
+object NetplayDiagnosticsExporter {
+  const val MAX_EXPORT_CHARS = 8_192
+
+  fun export(
+      transport: V9TransportMetricsSnapshot,
+      rollback: NetplayRollbackMetricsSnapshot?,
+      includeAddress: Boolean = false,
+  ): String {
+    val lines = mutableListOf<String>()
+    lines += "Coffee GB netplay diagnostics"
+    lines += "protocol=v9"
+    lines += "role=${if (transport.role.wireId == 1) "server" else "client"}"
+    lines += "mode=${if (transport.mode == eu.rekawek.coffeegb.controller.network.v9.V9LinkMode.NORMAL) "normal" else "four-player"}"
+    lines += "state=${stableLifecycleId(transport.lifecycle)}"
+    lines += "slot=${transport.authenticatedSlot?.toString() ?: "unassigned"}"
+    lines += "rtt-current-us=${number(transport.currentRttMicros)}"
+    lines += "rtt-ewma-us=${number(transport.ewmaRttMicros)}"
+    lines += "rtt-recent-min-us=${number(transport.recentMinimumRttMicros)}"
+    lines += "rtt-recent-max-us=${number(transport.recentMaximumRttMicros)}"
+    lines += "jitter-us=${number(transport.jitterMicros)}"
+    lines += "unanswered-pings=${transport.unansweredPings}"
+    lines += "timed-out-pings=${transport.timedOutPings}"
+    lines += "bytes-sent=${transport.bytesSent}"
+    lines += "bytes-received=${transport.bytesReceived}"
+    lines += "duration-ms=${transport.connectionDurationMillis}"
+    lines += "local-frame=${number(transport.localFrame)}"
+    lines += "remote-frame=${number(transport.remoteFrame)}"
+    lines += "newest-remote-input-age-ms=${number(transport.newestRemoteInputAgeMillis)}"
+    if (includeAddress) {
+      val endpoint = transport.remoteEndpoint
+      lines +=
+          if (endpoint == null) "remote-address=unavailable"
+          else "remote-address=${formatEndpoint(endpoint.numericAddress, endpoint.port)}"
+    } else {
+      lines += "remote-address=redacted"
+    }
+    if (rollback != null) {
+      lines += "rollback-count=${rollback.rollbackCount}"
+      lines += "rollback-last-frames=${rollback.lastFramesRewound}"
+      lines += "rollback-max-frames=${rollback.maximumFramesRewound}"
+      lines += "rollback-average-milliframes=${rollback.rollingAverageFramesRewoundMilli}"
+      lines += "resimulated-frames=${rollback.totalFramesResimulated}"
+      lines += "history-entries=${rollback.historyEntries}"
+      lines += "history-capacity=${rollback.historyCapacity}"
+      lines += "too-old-inputs=${rollback.tooOldInputs}"
+      lines += "checkpoint-resyncs=${rollback.checkpointResynchronizations}"
+      lines += "rollback-last-reason=${rollback.lastReason.stableId}"
+    }
+    return lines.joinToString("\n").take(MAX_EXPORT_CHARS)
+  }
+
+  private fun number(value: Long?): String = value?.toString() ?: "unavailable"
+
+  private fun formatEndpoint(address: String, port: Int): String =
+      if (':' in address) "[$address]:$port" else "$address:$port"
+
+  private fun stableLifecycleId(value: V9LifecycleState): String = when (value) {
+    V9LifecycleState.SEND_SERVER_HELLO -> "send-server-hello"
+    V9LifecycleState.WAIT_SERVER_HELLO -> "wait-server-hello"
+    V9LifecycleState.SEND_CLIENT_HELLO -> "send-client-hello"
+    V9LifecycleState.WAIT_CLIENT_HELLO -> "wait-client-hello"
+    V9LifecycleState.SEND_AUTH -> "send-auth"
+    V9LifecycleState.WAIT_AUTH -> "wait-auth"
+    V9LifecycleState.SEND_AUTH_RESULT -> "send-auth-result"
+    V9LifecycleState.WAIT_AUTH_RESULT -> "wait-auth-result"
+    V9LifecycleState.SEND_SERVER_MANIFEST -> "send-server-manifest"
+    V9LifecycleState.WAIT_SERVER_MANIFEST -> "wait-server-manifest"
+    V9LifecycleState.SEND_CLIENT_MANIFEST -> "send-client-manifest"
+    V9LifecycleState.WAIT_CLIENT_MANIFEST -> "wait-client-manifest"
+    V9LifecycleState.EXCHANGE_CONSENT -> "exchange-consent"
+    V9LifecycleState.SYNCHRONIZING -> "synchronizing"
+    V9LifecycleState.SEND_READY -> "send-ready"
+    V9LifecycleState.WAIT_READY -> "wait-ready"
+    V9LifecycleState.ACTIVE -> "active"
+    V9LifecycleState.BULK_PROGRESS -> "bulk-progress"
+    V9LifecycleState.TERMINAL_CLEANUP -> "terminal-cleanup"
+    V9LifecycleState.CLOSED -> "closed"
+  }
+}
+
+/** Defense-in-depth for bounded UI status text; exports above never consume untrusted text. */
+object NetplayDiagnosticSanitizer {
+  const val MAX_INPUT_CHARS = 4_096
+  const val MAX_OUTPUT_CHARS = 1_024
+
+  private val invitation = Regex("(?i)coffeegb://[^\\s]+")
+  private val credential = Regex("(?i)[a-z][a-z0-9+.-]*://[^/\\s:@]+:[^/\\s@]+@")
+  private val windowsPath = Regex("(?i)[a-z]:\\\\[^\\s]+")
+  private val posixPath = Regex("(?<![a-zA-Z0-9])/(?:[^\\s/]+/)*[^\\s/]+")
+  private val ipv4 = Regex("(?<![0-9])(?:[0-9]{1,3}\\.){3}[0-9]{1,3}(?![0-9])")
+  private val bracketedIpv6 = Regex("\\[(?=[0-9a-zA-Z:._%-]*:)[0-9a-zA-Z:._%-]+]")
+  private val dns = Regex("(?i)(?<![a-z0-9-])(?:[a-z0-9-]+\\.)+[a-z]{2,63}(?![a-z0-9-])")
+
+  fun redact(value: String): String {
+    var bounded = value.take(MAX_INPUT_CHARS).map { if (it.code in 0x20..0x7e) it else '?' }
+        .joinToString("")
+    bounded = invitation.replace(bounded, "[redacted-invitation]")
+    bounded = credential.replace(bounded, "[redacted-credentials]")
+    bounded = windowsPath.replace(bounded, "[redacted-path]")
+    bounded = posixPath.replace(bounded, "[redacted-path]")
+    bounded = bracketedIpv6.replace(bounded, "[redacted-address]")
+    bounded = ipv4.replace(bounded, "[redacted-address]")
+    bounded = dns.replace(bounded, "[redacted-host]")
+    return bounded.take(MAX_OUTPUT_CHARS)
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscovery.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscovery.kt
@@ -1,0 +1,607 @@
+package eu.rekawek.coffeegb.controller.network.discovery
+
+import eu.rekawek.coffeegb.controller.network.BoundedSnapshotPublisher
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
+import eu.rekawek.coffeegb.controller.network.NetplayNumericAddress
+import eu.rekawek.coffeegb.controller.network.v9.V9DeadlineScheduler
+import eu.rekawek.coffeegb.controller.network.v9.V9FoundationServerStatus
+import eu.rekawek.coffeegb.controller.network.v9.V9LinkMode
+import eu.rekawek.coffeegb.controller.network.v9.V9MonotonicClock
+import eu.rekawek.coffeegb.controller.network.v9.V9SystemDeadlineScheduler
+import java.io.Closeable
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.MulticastSocket
+import java.net.NetworkInterface
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.SecureRandom
+import java.util.Collections
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+/** Public, random identifier for one discovery advertisement. It is not an invitation secret. */
+class NetplayPublicSessionId(bytes: ByteArray) {
+  private val value: ByteArray
+
+  init {
+    require(bytes.size == BYTES)
+    value = bytes.copyOf()
+  }
+
+  fun bytes(): ByteArray = value.copyOf()
+
+  override fun equals(other: Any?): Boolean =
+      other is NetplayPublicSessionId && value.contentEquals(other.value)
+
+  override fun hashCode(): Int = value.contentHashCode()
+
+  override fun toString(): String = "NetplayPublicSessionId(redacted-public-id)"
+
+  companion object { const val BYTES = 16 }
+}
+
+data class NetplayDiscoveryAdvertisement(
+    val protocolMajor: Int,
+    val sessionId: NetplayPublicSessionId,
+    val mode: V9LinkMode,
+    val openSlots: Int,
+    val pairingRequired: Boolean,
+    val port: Int,
+) {
+  init {
+    require(protocolMajor == PROTOCOL_MAJOR)
+    require(openSlots in 1..if (mode == V9LinkMode.NORMAL) 1 else 3)
+    require(pairingRequired)
+    require(port in 1..65_535)
+  }
+
+  companion object { const val PROTOCOL_MAJOR = 9 }
+}
+
+class NetplayDiscoveredHost(
+    val advertisement: NetplayDiscoveryAdvertisement,
+    numericAddresses: Collection<String>,
+    val lastSeenMillis: Long,
+) {
+  init {
+    require(numericAddresses.size in 1..TrustedLanNetplayDiscovery.MAX_ADDRESSES_PER_SERVICE)
+    require(numericAddresses.all(NetplayNumericAddress::isValid))
+  }
+
+  val numericAddresses: List<String> =
+      Collections.unmodifiableList(numericAddresses.distinct().sorted())
+}
+
+class NetplayDiscoverySnapshot internal constructor(
+    val enabled: Boolean,
+    val backendHealthy: Boolean,
+    hosts: Collection<NetplayDiscoveredHost>,
+) {
+  init { require(hosts.size <= TrustedLanNetplayDiscovery.MAX_SERVICES) }
+
+  val hosts: List<NetplayDiscoveredHost> = Collections.unmodifiableList(hosts.toList())
+}
+
+/** Selection only prefills an endpoint. There is deliberately no connect/tokenless API here. */
+class NetplayDiscoverySelection(
+    val endpoint: InetSocketAddress,
+    val requiresAuthenticatedInvitation: Boolean = true,
+) {
+  override fun toString(): String = "NetplayDiscoverySelection(redacted-endpoint)"
+}
+
+interface NetplayDiscovery : NetplaySnapshotSource<NetplayDiscoverySnapshot>, Closeable {
+  fun enable()
+  fun disable()
+  fun updateHost(status: V9FoundationServerStatus)
+  fun confirm(host: NetplayDiscoveredHost, addressIndex: Int, confirmed: Boolean):
+      NetplayDiscoverySelection
+}
+
+internal data class NetplayDiscoveryDatagram(val bytes: ByteArray, val source: InetAddress)
+
+/** Bounded backend boundary. Implementations may not invoke receiver with more than 64 bytes. */
+internal interface NetplayDiscoveryBackend : Closeable {
+  fun start(receiver: (NetplayDiscoveryDatagram) -> Unit)
+  fun advertise(bytes: ByteArray)
+  fun withdraw()
+  fun stop()
+}
+
+internal object NetplayDiscoveryCodec {
+  const val BYTES = 28
+  private val MAGIC = byteArrayOf(0x43, 0x47, 0x42, 0x44) // CGBD; not the CGB9 stream preface.
+
+  fun encode(value: NetplayDiscoveryAdvertisement): ByteArray {
+    val mode = if (value.mode == V9LinkMode.NORMAL) 0 else 1
+    return ByteBuffer.allocate(BYTES).order(ByteOrder.BIG_ENDIAN)
+        .put(MAGIC)
+        .put(1)
+        .put(value.protocolMajor.toByte())
+        .put(mode.toByte())
+        .put(value.openSlots.toByte())
+        .put(if (value.pairingRequired) 1 else 0)
+        .put(0)
+        .putShort(value.port.toShort())
+        .put(value.sessionId.bytes())
+        .array()
+  }
+
+  fun decode(bytes: ByteArray): NetplayDiscoveryAdvertisement? {
+    if (bytes.size != BYTES || !bytes.copyOfRange(0, 4).contentEquals(MAGIC)) return null
+    if (u8(bytes, 4) != 1 || u8(bytes, 5) != 9 || u8(bytes, 9) != 0) return null
+    val mode = when (u8(bytes, 6)) {
+      0 -> V9LinkMode.NORMAL
+      1 -> V9LinkMode.FOUR_PLAYER
+      else -> return null
+    }
+    if (u8(bytes, 8) != 1) return null
+    val openSlots = u8(bytes, 7)
+    val port = (u8(bytes, 10) shl 8) or u8(bytes, 11)
+    return try {
+      NetplayDiscoveryAdvertisement(
+          9,
+          NetplayPublicSessionId(bytes.copyOfRange(12, 28)),
+          mode,
+          openSlots,
+          true,
+          port,
+      )
+    } catch (_: IllegalArgumentException) {
+      null
+    }
+  }
+
+  private fun u8(bytes: ByteArray, offset: Int): Int = bytes[offset].toInt() and 0xff
+}
+
+/**
+ * Trusted-LAN discovery is off by default and strictly address-only. Cache and listener storage
+ * are constant bounded; malformed metadata is ignored without affecting direct hosting.
+ */
+class TrustedLanNetplayDiscovery internal constructor(
+    private val backend: NetplayDiscoveryBackend,
+    private val clock: V9MonotonicClock = V9MonotonicClock.SYSTEM,
+    scheduler: V9DeadlineScheduler? = null,
+    sessionId: NetplayPublicSessionId =
+        NetplayPublicSessionId(ByteArray(16).also(SecureRandom()::nextBytes)),
+) : NetplayDiscovery {
+  constructor() : this(V9MulticastDiscoveryBackend())
+
+  private val lock = Any()
+  private val scheduler = scheduler ?: V9SystemDeadlineScheduler(clock)
+  private val ownedScheduler = if (scheduler == null) this.scheduler as Closeable else null
+  private val publicSessionId = sessionId
+  private val cache = LinkedHashMap<NetplayPublicSessionId, CachedHost>()
+  private var enabled = false
+  private var started = false
+  private var closed = false
+  private var backendHealthy = true
+  private var hostStatus: V9FoundationServerStatus? = null
+  private var refreshTask: Closeable? = null
+  private val publisher =
+      BoundedSnapshotPublisher(
+          NetplayDiscoverySnapshot(false, true, emptyList()),
+          "netplay-v9-discovery-snapshots",
+      )
+
+  override fun snapshot(): NetplayDiscoverySnapshot = synchronized(lock) { snapshotLocked() }
+
+  override fun addListener(listener: NetplaySnapshotListener<NetplayDiscoverySnapshot>): Closeable =
+      publisher.addListener(listener)
+
+  override fun enable() {
+    val shouldStart = synchronized(lock) {
+      check(!closed) { "netplay discovery is closed" }
+      if (enabled) return
+      enabled = true
+      if (!started) {
+        started = true
+        true
+      } else false
+    }
+    if (shouldStart) {
+      try {
+        backend.start(::receive)
+        synchronized(lock) { backendHealthy = true }
+      } catch (_: RuntimeException) {
+        synchronized(lock) { backendHealthy = false }
+      } catch (_: IOException) {
+        synchronized(lock) { backendHealthy = false }
+      }
+    }
+    refresh()
+    scheduleRefresh()
+  }
+
+  override fun disable() {
+    val value = synchronized(lock) {
+      if (!enabled) return
+      enabled = false
+      started = false
+      cache.clear()
+      refreshTask?.close()
+      refreshTask = null
+      snapshotLocked()
+    }
+    try {
+      backend.stop()
+    } catch (_: RuntimeException) {
+      synchronized(lock) { backendHealthy = false }
+    } catch (_: IOException) {
+      synchronized(lock) { backendHealthy = false }
+    }
+    publisher.update(value)
+  }
+
+  override fun updateHost(status: V9FoundationServerStatus) {
+    synchronized(lock) { if (!closed) hostStatus = status }
+    refresh()
+  }
+
+  override fun confirm(
+      host: NetplayDiscoveredHost,
+      addressIndex: Int,
+      confirmed: Boolean,
+  ): NetplayDiscoverySelection {
+    require(confirmed) { "discovered endpoint requires explicit local confirmation" }
+    require(addressIndex in host.numericAddresses.indices)
+    val address = synchronized(lock) {
+      check(enabled && !closed) { "netplay discovery is not active" }
+      val cached = cache[host.advertisement.sessionId]
+          ?: throw IllegalArgumentException("discovered service is no longer available")
+      require(cached.advertisement == host.advertisement) {
+        "discovered service metadata changed before confirmation"
+      }
+      cached.addresses[host.numericAddresses[addressIndex]]
+          ?: throw IllegalArgumentException("discovered address is no longer available")
+    }
+    return NetplayDiscoverySelection(InetSocketAddress(address, host.advertisement.port))
+  }
+
+  internal fun expireNow() = refresh()
+
+  internal fun cacheSize(): Int = synchronized(lock) { cache.size }
+
+  private fun receive(value: NetplayDiscoveryDatagram) {
+    if (value.bytes.size > MAX_PACKET_BYTES) return
+    val decoded = NetplayDiscoveryCodec.decode(value.bytes) ?: return
+    if (decoded.sessionId == publicSessionId) return
+    val numeric = value.source.hostAddress ?: return
+    if (!safeNumericAddress(numeric)) return
+    val now = clock.nowMillis()
+    val snapshot = synchronized(lock) {
+      if (!enabled || closed) return
+      val current = cache[decoded.sessionId]
+      if (current == null && cache.size >= MAX_SERVICES) {
+        val oldest = cache.entries.minWithOrNull(
+            compareBy<Map.Entry<NetplayPublicSessionId, CachedHost>> { it.value.lastSeen }
+                .thenBy { stableId(it.key) },
+        )
+        if (oldest != null) cache.remove(oldest.key)
+      }
+      val target = cache.getOrPut(decoded.sessionId) { CachedHost(decoded, now) }
+      target.advertisement = decoded
+      target.lastSeen = now
+      if (target.addresses.size < MAX_ADDRESSES_PER_SERVICE || numeric in target.addresses) {
+        target.addresses[numeric] = value.source
+      }
+      snapshotLocked()
+    }
+    publisher.update(snapshot)
+  }
+
+  private fun refresh() {
+    val packet: ByteArray?
+    synchronized(lock) {
+      if (closed) return
+      val now = clock.nowMillis()
+      cache.entries.removeIf { elapsedMillis(now, it.value.lastSeen) >= CACHE_EXPIRY_MILLIS }
+      val status = hostStatus
+      packet =
+          if (enabled && backendHealthy && status?.listening == true && status.openSlots > 0) {
+            NetplayDiscoveryCodec.encode(
+                NetplayDiscoveryAdvertisement(
+                    9,
+                    publicSessionId,
+                    status.mode,
+                    status.openSlots,
+                    true,
+                    status.port,
+                ),
+            )
+          } else null
+    }
+    if (packet != null) {
+      try {
+        backend.advertise(packet)
+      } catch (_: RuntimeException) {
+        synchronized(lock) { backendHealthy = false }
+      } catch (_: IOException) {
+        synchronized(lock) { backendHealthy = false }
+      } finally {
+        packet.fill(0)
+      }
+    } else {
+      try {
+        backend.withdraw()
+      } catch (_: RuntimeException) {
+        synchronized(lock) { backendHealthy = false }
+      } catch (_: IOException) {
+        synchronized(lock) { backendHealthy = false }
+      }
+    }
+    publisher.update(synchronized(lock) { snapshotLocked() })
+  }
+
+  private fun scheduleRefresh() {
+    val failureSnapshot = synchronized(lock) {
+      if (!enabled || closed || refreshTask != null) return
+      val deadline = addSaturated(clock.nowMillis(), REFRESH_MILLIS)
+      try {
+        refreshTask = scheduler.schedule(deadline) {
+          synchronized(lock) { refreshTask = null }
+          refresh()
+          scheduleRefresh()
+        }
+        null
+      } catch (_: RuntimeException) {
+        backendHealthy = false
+        refreshTask = null
+        snapshotLocked()
+      }
+    }
+    failureSnapshot?.let(publisher::update)
+  }
+
+  private fun snapshotLocked(): NetplayDiscoverySnapshot =
+      NetplayDiscoverySnapshot(
+          enabled,
+          backendHealthy,
+          Collections.unmodifiableList(
+              cache.values.mapNotNull { value ->
+                if (value.addresses.isEmpty()) null
+                else NetplayDiscoveredHost(
+                    value.advertisement,
+                    value.addresses.keys,
+                    value.lastSeen,
+                )
+              }.sortedBy { stableId(it.advertisement.sessionId) },
+          ),
+      )
+
+  override fun close() {
+    val finalSnapshot = synchronized(lock) {
+      if (closed) return
+      closed = true
+      enabled = false
+      cache.clear()
+      refreshTask?.close()
+      refreshTask = null
+      snapshotLocked()
+    }
+    try {
+      backend.close()
+    } catch (_: RuntimeException) {
+      // Discovery is ancillary and cannot affect direct hosting cleanup.
+    } catch (_: IOException) {
+      // Discovery is ancillary and cannot affect direct hosting cleanup.
+    }
+    ownedScheduler?.close()
+    publisher.update(finalSnapshot)
+    publisher.close()
+  }
+
+  private class CachedHost(
+      var advertisement: NetplayDiscoveryAdvertisement,
+      var lastSeen: Long,
+      val addresses: MutableMap<String, InetAddress> = linkedMapOf(),
+  )
+
+  companion object {
+    const val MAX_SERVICES = 64
+    const val MAX_ADDRESSES_PER_SERVICE = 8
+    const val MAX_PACKET_BYTES = 64
+    const val CACHE_EXPIRY_MILLIS = 5_000L
+    const val REFRESH_MILLIS = 1_000L
+
+    private fun safeNumericAddress(value: String): Boolean = NetplayNumericAddress.isValid(value)
+
+    private fun stableId(value: NetplayPublicSessionId): String {
+      val digits = "0123456789abcdef"
+      val bytes = value.bytes()
+      val result = StringBuilder(bytes.size * 2)
+      bytes.forEach { byte ->
+        val unsigned = byte.toInt() and 0xff
+        result.append(digits[unsigned ushr 4]).append(digits[unsigned and 0x0f])
+      }
+      return result.toString()
+    }
+
+    private fun addSaturated(left: Long, right: Long): Long =
+        try {
+          Math.addExact(left, right)
+        } catch (_: ArithmeticException) {
+          Long.MAX_VALUE
+        }
+
+    private fun elapsedMillis(now: Long, since: Long): Long =
+        try {
+          Math.subtractExact(now, since).coerceAtLeast(0)
+        } catch (_: ArithmeticException) {
+          if (now >= since) Long.MAX_VALUE else 0
+        }
+  }
+}
+
+/** Keeps advertisement gating tied to the real listener without coupling discovery to sockets. */
+class NetplayDiscoveryHostBinding(
+    source: NetplaySnapshotSource<V9FoundationServerStatus>,
+    private val discovery: NetplayDiscovery,
+) : Closeable {
+  private val mode = source.snapshot().mode
+  private val subscription = source.addListener(discovery::updateHost)
+  override fun close() {
+    subscription.close()
+    discovery.updateHost(V9FoundationServerStatus(false, 0, mode, 0))
+  }
+}
+
+/**
+ * Java-16-only multicast backend. It carries the fixed 28-byte metadata datagram, never an
+ * invitation or emulator content. All socket work is owned by two daemon threads.
+ */
+internal class V9MulticastDiscoveryBackend : NetplayDiscoveryBackend {
+  private val closed = AtomicBoolean(false)
+  private val running = AtomicBoolean(false)
+  private val outgoing = ArrayBlockingQueue<ByteArray>(1)
+  private var socket: MulticastSocket? = null
+  private var interfaces: List<NetworkInterface> = emptyList()
+  private var receiverTask: Thread? = null
+  private var senderTask: Thread? = null
+
+  override fun start(receiver: (NetplayDiscoveryDatagram) -> Unit) {
+    check(!closed.get()) { "discovery backend is closed" }
+    check(running.compareAndSet(false, true)) { "discovery backend already started" }
+    val value = MulticastSocket(null)
+    try {
+      value.reuseAddress = true
+      value.bind(InetSocketAddress(PORT))
+      value.timeToLive = 1
+      val interfaces =
+          (NetworkInterface.getNetworkInterfaces()?.let(Collections::list) ?: emptyList())
+              .filter { it.isUp }
+              .sortedBy { it.name }
+              .take(MAX_INTERFACES)
+      this.interfaces = interfaces
+      for (network in interfaces) {
+        try {
+          value.joinGroup(InetSocketAddress(IPV4_GROUP, PORT), network)
+        } catch (_: IOException) {
+          // One interface/family failure does not disable direct hosting or other interfaces.
+        }
+        try {
+          value.joinGroup(InetSocketAddress(IPV6_GROUP, PORT), network)
+        } catch (_: IOException) {
+          // IPv6 is best effort on hosts without a multicast route.
+        }
+      }
+      value.soTimeout = 250
+      socket = value
+      receiverTask = thread(isDaemon = true, name = "netplay-v9-discovery-receive") {
+        receiveLoop(value, receiver)
+      }
+      senderTask = thread(isDaemon = true, name = "netplay-v9-discovery-send") {
+        sendLoop(value)
+      }
+    } catch (failure: RuntimeException) {
+      value.close()
+      running.set(false)
+      throw failure
+    } catch (failure: IOException) {
+      value.close()
+      running.set(false)
+      throw failure
+    }
+  }
+
+  override fun advertise(bytes: ByteArray) {
+    require(bytes.size == NetplayDiscoveryCodec.BYTES)
+    if (closed.get() || !running.get()) return
+    val owned = bytes.copyOf()
+    outgoing.poll()?.fill(0)
+    if (!outgoing.offer(owned)) owned.fill(0)
+  }
+
+  override fun withdraw() {
+    outgoing.poll()?.fill(0)
+  }
+
+  private fun receiveLoop(
+      socket: MulticastSocket,
+      receiver: (NetplayDiscoveryDatagram) -> Unit,
+  ) {
+    val buffer = ByteArray(TrustedLanNetplayDiscovery.MAX_PACKET_BYTES)
+    while (running.get() && !closed.get()) {
+      val packet = DatagramPacket(buffer, buffer.size)
+      try {
+        socket.receive(packet)
+        if (packet.length <= TrustedLanNetplayDiscovery.MAX_PACKET_BYTES) {
+          receiver(
+              NetplayDiscoveryDatagram(
+                  packet.data.copyOfRange(packet.offset, packet.offset + packet.length),
+                  packet.address,
+              ),
+          )
+        }
+      } catch (_: java.net.SocketTimeoutException) {
+        // Poll close.
+      } catch (_: IOException) {
+        if (running.get() && !closed.get()) return
+      } catch (_: RuntimeException) {
+        if (running.get() && !closed.get()) continue
+      }
+    }
+  }
+
+  private fun sendLoop(socket: MulticastSocket) {
+    try {
+      while (running.get() && !closed.get()) {
+        val bytes = outgoing.poll(250, java.util.concurrent.TimeUnit.MILLISECONDS) ?: continue
+        try {
+          val targets: List<NetworkInterface?> =
+              if (interfaces.isEmpty()) listOf(null) else interfaces
+          for (network in targets) {
+            if (network != null) socket.networkInterface = network
+            try {
+              socket.send(DatagramPacket(bytes, bytes.size, IPV4_GROUP, PORT))
+            } catch (_: IOException) {
+              // Continue with other interfaces/families.
+            }
+            try {
+              socket.send(DatagramPacket(bytes, bytes.size, IPV6_GROUP, PORT))
+            } catch (_: IOException) {
+              // IPv4 discovery remains available when IPv6 multicast is unavailable.
+            }
+          }
+        } finally {
+          bytes.fill(0)
+        }
+      }
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    } catch (_: IOException) {
+      // Discovery failure is isolated from direct hosting.
+    }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    stop()
+  }
+
+  override fun stop() {
+    if (!running.compareAndSet(true, false)) return
+    socket?.close()
+    socket = null
+    interfaces = emptyList()
+    outgoing.forEach { it.fill(0) }
+    outgoing.clear()
+    receiverTask?.takeUnless { it === Thread.currentThread() }?.interrupt()
+    senderTask?.takeUnless { it === Thread.currentThread() }?.interrupt()
+    receiverTask = null
+    senderTask = null
+  }
+
+  companion object {
+    private const val PORT = 37_619
+    private const val MAX_INTERFACES = 8
+    private val IPV4_GROUP = InetAddress.getByName("239.255.67.66")
+    private val IPV6_GROUP = InetAddress.getByName("ff02::4347:4244")
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscovery.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscovery.kt
@@ -21,6 +21,8 @@ import java.nio.ByteOrder
 import java.security.SecureRandom
 import java.util.Collections
 import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
@@ -179,11 +181,23 @@ class TrustedLanNetplayDiscovery internal constructor(
   private val publicSessionId = sessionId
   private val cache = LinkedHashMap<NetplayPublicSessionId, CachedHost>()
   private var enabled = false
-  private var started = false
   private var closed = false
+  private var backendRunning = false
   private var backendHealthy = true
+  private var lifecycleGeneration = 0L
+  private var lifecycleSettled = CountDownLatch(0)
   private var hostStatus: V9FoundationServerStatus? = null
   private var refreshTask: Closeable? = null
+  private val lifecycleSignals = ArrayBlockingQueue<Unit>(1)
+  private val lifecycleWorkerTerminated = CountDownLatch(1)
+  private val lifecycleWorker =
+      thread(isDaemon = true, name = "netplay-v9-discovery-lifecycle") {
+        try {
+          lifecycleLoop()
+        } finally {
+          lifecycleWorkerTerminated.countDown()
+        }
+      }
   private val publisher =
       BoundedSnapshotPublisher(
           NetplayDiscoverySnapshot(false, true, emptyList()),
@@ -196,46 +210,27 @@ class TrustedLanNetplayDiscovery internal constructor(
       publisher.addListener(listener)
 
   override fun enable() {
-    val shouldStart = synchronized(lock) {
+    synchronized(lock) {
       check(!closed) { "netplay discovery is closed" }
       if (enabled) return
       enabled = true
-      if (!started) {
-        started = true
-        true
-      } else false
+      advanceLifecycleLocked()
     }
-    if (shouldStart) {
-      try {
-        backend.start(::receive)
-        synchronized(lock) { backendHealthy = true }
-      } catch (_: RuntimeException) {
-        synchronized(lock) { backendHealthy = false }
-      } catch (_: IOException) {
-        synchronized(lock) { backendHealthy = false }
-      }
-    }
-    refresh()
-    scheduleRefresh()
+    signalLifecycle()
+    publisher.update(synchronized(lock) { snapshotLocked() })
   }
 
   override fun disable() {
     val value = synchronized(lock) {
       if (!enabled) return
       enabled = false
-      started = false
       cache.clear()
       refreshTask?.close()
       refreshTask = null
+      advanceLifecycleLocked()
       snapshotLocked()
     }
-    try {
-      backend.stop()
-    } catch (_: RuntimeException) {
-      synchronized(lock) { backendHealthy = false }
-    } catch (_: IOException) {
-      synchronized(lock) { backendHealthy = false }
-    }
+    signalLifecycle()
     publisher.update(value)
   }
 
@@ -268,6 +263,18 @@ class TrustedLanNetplayDiscovery internal constructor(
 
   internal fun cacheSize(): Int = synchronized(lock) { cache.size }
 
+  internal fun awaitBackendLifecycle(timeout: Long, unit: TimeUnit): Boolean {
+    val settled = synchronized(lock) { lifecycleSettled }
+    return settled.await(timeout, unit)
+  }
+
+  internal fun backendRunningForTest(): Boolean = synchronized(lock) { backendRunning }
+
+  internal fun lifecycleWorkerAliveForTest(): Boolean = lifecycleWorker.isAlive
+
+  internal fun awaitLifecycleWorkerStoppedForTest(timeout: Long, unit: TimeUnit): Boolean =
+      lifecycleWorkerTerminated.await(timeout, unit)
+
   private fun receive(value: NetplayDiscoveryDatagram) {
     if (value.bytes.size > MAX_PACKET_BYTES) return
     val decoded = NetplayDiscoveryCodec.decode(value.bytes) ?: return
@@ -298,13 +305,16 @@ class TrustedLanNetplayDiscovery internal constructor(
 
   private fun refresh() {
     val packet: ByteArray?
+    val mayUseBackend: Boolean
     synchronized(lock) {
       if (closed) return
       val now = clock.nowMillis()
       cache.entries.removeIf { elapsedMillis(now, it.value.lastSeen) >= CACHE_EXPIRY_MILLIS }
       val status = hostStatus
+      mayUseBackend = backendRunning
       packet =
-          if (enabled && backendHealthy && status?.listening == true && status.openSlots > 0) {
+          if (mayUseBackend && enabled && backendHealthy &&
+              status?.listening == true && status.openSlots > 0) {
             NetplayDiscoveryCodec.encode(
                 NetplayDiscoveryAdvertisement(
                     9,
@@ -316,6 +326,10 @@ class TrustedLanNetplayDiscovery internal constructor(
                 ),
             )
           } else null
+    }
+    if (!mayUseBackend) {
+      publisher.update(synchronized(lock) { snapshotLocked() })
+      return
     }
     if (packet != null) {
       try {
@@ -383,8 +397,91 @@ class TrustedLanNetplayDiscovery internal constructor(
       cache.clear()
       refreshTask?.close()
       refreshTask = null
+      advanceLifecycleLocked()
       snapshotLocked()
     }
+    signalLifecycle()
+    ownedScheduler?.close()
+    publisher.update(finalSnapshot)
+    publisher.close()
+  }
+
+  private fun lifecycleLoop() {
+    while (true) {
+      try {
+        lifecycleSignals.take()
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return
+      }
+      while (true) {
+        val target = synchronized(lock) {
+          LifecycleTarget(lifecycleGeneration, enabled, closed, backendRunning)
+        }
+        if (target.closed) {
+          closeBackend()
+          synchronized(lock) {
+            backendRunning = false
+            settleLifecycleLocked(target.generation)
+          }
+          return
+        }
+        if (target.enabled && !target.running) {
+          val startedSuccessfully = startBackend()
+          val accepted = synchronized(lock) {
+            if (startedSuccessfully) backendRunning = true
+            startedSuccessfully && !closed && enabled &&
+                lifecycleGeneration == target.generation
+          }
+          if (!accepted && startedSuccessfully) {
+            stopBackend()
+            synchronized(lock) { backendRunning = false }
+          }
+          if (accepted) {
+            refresh()
+            scheduleRefresh()
+          }
+        } else if (!target.enabled && target.running) {
+          stopBackend()
+          synchronized(lock) { backendRunning = false }
+        }
+        val reconciled = synchronized(lock) {
+          if (lifecycleGeneration == target.generation) {
+            settleLifecycleLocked(target.generation)
+            true
+          } else {
+            false
+          }
+        }
+        if (reconciled) break
+      }
+    }
+  }
+
+  private fun startBackend(): Boolean =
+      try {
+        backend.start(::receive)
+        synchronized(lock) { backendHealthy = true }
+        true
+      } catch (_: RuntimeException) {
+        synchronized(lock) { backendHealthy = false }
+        false
+      } catch (_: IOException) {
+        synchronized(lock) { backendHealthy = false }
+        false
+      }
+
+  private fun stopBackend() {
+    try {
+      backend.stop()
+    } catch (_: RuntimeException) {
+      synchronized(lock) { backendHealthy = false }
+    } catch (_: IOException) {
+      synchronized(lock) { backendHealthy = false }
+    }
+  }
+
+  private fun closeBackend() {
     try {
       backend.close()
     } catch (_: RuntimeException) {
@@ -392,10 +489,28 @@ class TrustedLanNetplayDiscovery internal constructor(
     } catch (_: IOException) {
       // Discovery is ancillary and cannot affect direct hosting cleanup.
     }
-    ownedScheduler?.close()
-    publisher.update(finalSnapshot)
-    publisher.close()
   }
+
+  private fun advanceLifecycleLocked() {
+    lifecycleSettled.countDown()
+    lifecycleGeneration = addSaturated(lifecycleGeneration, 1)
+    lifecycleSettled = CountDownLatch(1)
+  }
+
+  private fun settleLifecycleLocked(generation: Long) {
+    if (generation == lifecycleGeneration) lifecycleSettled.countDown()
+  }
+
+  private fun signalLifecycle() {
+    lifecycleSignals.offer(Unit)
+  }
+
+  private data class LifecycleTarget(
+      val generation: Long,
+      val enabled: Boolean,
+      val closed: Boolean,
+      val running: Boolean,
+  )
 
   private class CachedHost(
       var advertisement: NetplayDiscoveryAdvertisement,
@@ -457,6 +572,7 @@ class NetplayDiscoveryHostBinding(
  * invitation or emulator content. All socket work is owned by two daemon threads.
  */
 internal class V9MulticastDiscoveryBackend : NetplayDiscoveryBackend {
+  private val lifecycleLock = Any()
   private val closed = AtomicBoolean(false)
   private val running = AtomicBoolean(false)
   private val outgoing = ArrayBlockingQueue<ByteArray>(1)
@@ -464,62 +580,95 @@ internal class V9MulticastDiscoveryBackend : NetplayDiscoveryBackend {
   private var interfaces: List<NetworkInterface> = emptyList()
   private var receiverTask: Thread? = null
   private var senderTask: Thread? = null
+  private var receiverTerminated = CountDownLatch(0)
+  private var senderTerminated = CountDownLatch(0)
 
   override fun start(receiver: (NetplayDiscoveryDatagram) -> Unit) {
-    check(!closed.get()) { "discovery backend is closed" }
-    check(running.compareAndSet(false, true)) { "discovery backend already started" }
-    val value = MulticastSocket(null)
-    try {
-      value.reuseAddress = true
-      value.bind(InetSocketAddress(PORT))
-      value.timeToLive = 1
-      val interfaces =
-          (NetworkInterface.getNetworkInterfaces()?.let(Collections::list) ?: emptyList())
-              .filter { it.isUp }
-              .sortedBy { it.name }
-              .take(MAX_INTERFACES)
-      this.interfaces = interfaces
-      for (network in interfaces) {
-        try {
-          value.joinGroup(InetSocketAddress(IPV4_GROUP, PORT), network)
-        } catch (_: IOException) {
-          // One interface/family failure does not disable direct hosting or other interfaces.
+    synchronized(lifecycleLock) {
+      check(!closed.get()) { "discovery backend is closed" }
+      check(receiverTask?.isAlive != true && senderTask?.isAlive != true) {
+        "discovery backend workers have not terminated"
+      }
+      check(running.compareAndSet(false, true)) { "discovery backend already started" }
+      val value = MulticastSocket(null)
+      try {
+        value.reuseAddress = true
+        value.bind(InetSocketAddress(PORT))
+        value.timeToLive = 1
+        val interfaces =
+            (NetworkInterface.getNetworkInterfaces()?.let(Collections::list) ?: emptyList())
+                .filter { it.isUp }
+                .sortedBy { it.name }
+                .take(MAX_INTERFACES)
+        this.interfaces = interfaces
+        for (network in interfaces) {
+          try {
+            value.joinGroup(InetSocketAddress(IPV4_GROUP, PORT), network)
+          } catch (_: IOException) {
+            // One interface/family failure does not disable direct hosting or other interfaces.
+          }
+          try {
+            value.joinGroup(InetSocketAddress(IPV6_GROUP, PORT), network)
+          } catch (_: IOException) {
+            // IPv6 is best effort on hosts without a multicast route.
+          }
         }
-        try {
-          value.joinGroup(InetSocketAddress(IPV6_GROUP, PORT), network)
-        } catch (_: IOException) {
-          // IPv6 is best effort on hosts without a multicast route.
+        value.soTimeout = 250
+        socket = value
+        receiverTerminated = CountDownLatch(1)
+        senderTerminated = CountDownLatch(1)
+        val receiverDone = receiverTerminated
+        val senderDone = senderTerminated
+        receiverTask = thread(isDaemon = true, name = "netplay-v9-discovery-receive") {
+          try {
+            receiveLoop(value, receiver)
+          } finally {
+            receiverDone.countDown()
+          }
         }
+        senderTask = thread(isDaemon = true, name = "netplay-v9-discovery-send") {
+          try {
+            sendLoop(value)
+          } finally {
+            senderDone.countDown()
+          }
+        }
+      } catch (failure: RuntimeException) {
+        value.close()
+        running.set(false)
+        receiverTask?.interrupt()
+        senderTask?.interrupt()
+        awaitTermination(receiverTask, receiverTerminated)
+        awaitTermination(senderTask, senderTerminated)
+        receiverTask = null
+        senderTask = null
+        throw failure
+      } catch (failure: IOException) {
+        value.close()
+        running.set(false)
+        receiverTask?.interrupt()
+        senderTask?.interrupt()
+        awaitTermination(receiverTask, receiverTerminated)
+        awaitTermination(senderTask, senderTerminated)
+        receiverTask = null
+        senderTask = null
+        throw failure
       }
-      value.soTimeout = 250
-      socket = value
-      receiverTask = thread(isDaemon = true, name = "netplay-v9-discovery-receive") {
-        receiveLoop(value, receiver)
-      }
-      senderTask = thread(isDaemon = true, name = "netplay-v9-discovery-send") {
-        sendLoop(value)
-      }
-    } catch (failure: RuntimeException) {
-      value.close()
-      running.set(false)
-      throw failure
-    } catch (failure: IOException) {
-      value.close()
-      running.set(false)
-      throw failure
     }
   }
 
   override fun advertise(bytes: ByteArray) {
     require(bytes.size == NetplayDiscoveryCodec.BYTES)
-    if (closed.get() || !running.get()) return
-    val owned = bytes.copyOf()
-    outgoing.poll()?.fill(0)
-    if (!outgoing.offer(owned)) owned.fill(0)
+    synchronized(lifecycleLock) {
+      if (closed.get() || !running.get()) return
+      val owned = bytes.copyOf()
+      outgoing.poll()?.fill(0)
+      if (!outgoing.offer(owned)) owned.fill(0)
+    }
   }
 
   override fun withdraw() {
-    outgoing.poll()?.fill(0)
+    synchronized(lifecycleLock) { outgoing.poll()?.fill(0) }
   }
 
   private fun receiveLoop(
@@ -586,21 +735,77 @@ internal class V9MulticastDiscoveryBackend : NetplayDiscoveryBackend {
   }
 
   override fun stop() {
-    if (!running.compareAndSet(true, false)) return
-    socket?.close()
-    socket = null
-    interfaces = emptyList()
+    val stopped = synchronized(lifecycleLock) {
+      if (!running.compareAndSet(true, false)) {
+        wipeOutgoing()
+        return
+      }
+      val value = StopState(
+          socket,
+          receiverTask,
+          senderTask,
+          receiverTerminated,
+          senderTerminated,
+      )
+      socket = null
+      interfaces = emptyList()
+      value.socket?.close()
+      value.receiver?.takeUnless { it === Thread.currentThread() }?.interrupt()
+      value.sender?.takeUnless { it === Thread.currentThread() }?.interrupt()
+      wipeOutgoing()
+      value
+    }
+    val receiverStopped = awaitTermination(stopped.receiver, stopped.receiverDone)
+    val senderStopped = awaitTermination(stopped.sender, stopped.senderDone)
+    synchronized(lifecycleLock) {
+      if (receiverStopped && receiverTask === stopped.receiver) receiverTask = null
+      if (senderStopped && senderTask === stopped.sender) senderTask = null
+    }
+  }
+
+  internal fun liveWorkerCount(): Int = synchronized(lifecycleLock) {
+    listOfNotNull(receiverTask, senderTask).count(Thread::isAlive)
+  }
+
+  internal fun queuedAdvertisementCount(): Int = outgoing.size
+
+  internal fun awaitWorkersStopped(timeout: Long, unit: TimeUnit): Boolean {
+    val deadlines = synchronized(lifecycleLock) { receiverTerminated to senderTerminated }
+    val started = System.nanoTime()
+    if (!deadlines.first.await(timeout, unit)) return false
+    val budgetNanos = unit.toNanos(timeout)
+    val remaining = (budgetNanos - (System.nanoTime() - started)).coerceAtLeast(0)
+    return deadlines.second.await(remaining, TimeUnit.NANOSECONDS)
+  }
+
+  private fun awaitTermination(task: Thread?, terminated: CountDownLatch): Boolean {
+    if (task == null) return true
+    if (task === Thread.currentThread()) return false
+    return try {
+      terminated.await(STOP_WAIT_MILLIS, TimeUnit.MILLISECONDS)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      false
+    }
+  }
+
+  private fun wipeOutgoing() {
     outgoing.forEach { it.fill(0) }
     outgoing.clear()
-    receiverTask?.takeUnless { it === Thread.currentThread() }?.interrupt()
-    senderTask?.takeUnless { it === Thread.currentThread() }?.interrupt()
-    receiverTask = null
-    senderTask = null
   }
+
+  private data class StopState(
+      val socket: MulticastSocket?,
+      val receiver: Thread?,
+      val sender: Thread?,
+      val receiverDone: CountDownLatch,
+      val senderDone: CountDownLatch,
+  )
 
   companion object {
     private const val PORT = 37_619
     private const val MAX_INTERFACES = 8
+    private const val STOP_WAIT_MILLIS = 1_000L
     private val IPV4_GROUP = InetAddress.getByName("239.255.67.66")
     private val IPV6_GROUP = InetAddress.getByName("ff02::4347:4244")
   }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ActiveSession.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9ActiveSession.kt
@@ -62,6 +62,11 @@ internal class V9PlaySession(
   private var lastCheckpointOutcome: V9ErrorCode? = null
   private var checkpointCompletionCount = 0
   private val lastInputOrder = mutableMapOf<Pair<Long, Int>, Int>()
+  @Volatile private var transportMetrics: V9TransportMetrics? = null
+
+  internal fun attachTransportMetrics(value: V9TransportMetrics?) {
+    transportMetrics = value
+  }
 
   init {
     val proposal = authorization.proposal
@@ -307,6 +312,11 @@ internal class V9PlaySession(
   private fun sendRuntime(type: V9MessageType, player: Int, payload: ByteArray) {
     try {
       ensureActive()
+      if (payload.size >= java.lang.Long.BYTES) {
+        transportMetrics?.recordLocalFrame(
+            ByteBuffer.wrap(payload, 0, java.lang.Long.BYTES).order(ByteOrder.BIG_ENDIAN).long,
+        )
+      }
       val sequence =
           send.send(type, 0, 0, player.toLong() + 1, payload, { Closeable {} }) {
             if (!isClosed()) lifecycle.activeProgress()
@@ -569,16 +579,18 @@ internal class V9PlaySession(
       failure: V9ErrorCode?,
   ) {
     if (!committing.completed.compareAndSet(false, true)) return
-    synchronized(lock) {
+    val completedFrame = synchronized(lock) {
       if (committingIncoming === committing) committingIncoming = null
       checkpointInFlight = false
       lastCheckpointOutcome = failure
       checkpointCompletionCount++
+      checkpointFrame
     }
     committing.prepared.close()
     if (failure == null) {
       // The safe-point winner is one complete atomic outcome even if transport close races later.
       committing.ticket.commit()
+      completedFrame?.let { transportMetrics?.recordRemoteFrame(it) }
       if (!isClosed()) committing.onSuccess()
     } else {
       committing.ticket.close()
@@ -602,6 +614,7 @@ internal class V9PlaySession(
       if (pending != null && initialCheckpointReady) pendingStart = null
     }
     if (active) {
+      transportMetrics?.recordLocalFrame(frame)
       lifecycle.activeProgress()
       return
     }
@@ -751,6 +764,8 @@ internal class V9PlaySession(
         return
       }
     }
+    transportMetrics?.recordLocalFrame(frame)
+    transportMetrics?.recordRemoteFrame(frame)
     onActive(value)
   }
 
@@ -773,6 +788,7 @@ internal class V9PlaySession(
     }
     plan.gameplayTarget.input(value) { failure ->
       if (failure == null && !isClosed()) {
+        transportMetrics?.recordRemoteInput(value.frame)
         lifecycle.activeProgress()
         if (mode == V9LinkMode.FOUR_PLAYER && role == V9Role.SERVER) {
           try {
@@ -793,6 +809,7 @@ internal class V9PlaySession(
     }
     plan.gameplayTarget.control(value) { failure ->
       if (failure == null && !isClosed()) {
+        transportMetrics?.recordRemoteFrame(value.frame)
         lifecycle.activeProgress()
         if (mode == V9LinkMode.FOUR_PLAYER && role == V9Role.SERVER) {
           try {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Diagnostics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Diagnostics.kt
@@ -1,0 +1,318 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import eu.rekawek.coffeegb.controller.network.BoundedSnapshotPublisher
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackMetrics
+import eu.rekawek.coffeegb.controller.network.NetplayNumericAddress
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
+import java.io.Closeable
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.SecureRandom
+
+/** Explicit opt-in for #350 diagnostics. Older v9 callers do not negotiate or emit PING. */
+data class V9DiagnosticsOptions(
+    val enabled: Boolean = false,
+    val pingCadenceMillis: Long = DEFAULT_PING_CADENCE_MILLIS,
+    val pingTimeoutMillis: Long = DEFAULT_PING_TIMEOUT_MILLIS,
+) {
+  init {
+    require(pingCadenceMillis in 1_000..30_000)
+    require(pingTimeoutMillis in pingCadenceMillis..30_000)
+  }
+
+  companion object {
+    val DISABLED = V9DiagnosticsOptions()
+    val ENABLED = V9DiagnosticsOptions(enabled = true)
+    const val DEFAULT_PING_CADENCE_MILLIS = 10_000L
+    const val DEFAULT_PING_TIMEOUT_MILLIS = 20_000L
+  }
+}
+
+data class V9PingPayload(val nonce: Long, val peerDiagnosticMicros: Long)
+
+/** Exact frozen 16-byte PING/PONG payload. Both fields are unsigned bit patterns on the wire. */
+object V9PingCodec {
+  const val PAYLOAD_BYTES = 16
+
+  fun encode(value: V9PingPayload): ByteArray =
+      ByteBuffer.allocate(PAYLOAD_BYTES).order(ByteOrder.BIG_ENDIAN)
+          .putLong(value.nonce)
+          .putLong(value.peerDiagnosticMicros)
+          .array()
+
+  fun decode(bytes: ByteArray): V9PingPayload {
+    if (bytes.size != PAYLOAD_BYTES) {
+      throw V9ProtocolException(V9ErrorCode.LIMIT_EXCEEDED, 0)
+    }
+    val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+    return V9PingPayload(buffer.long, buffer.long)
+  }
+}
+
+/** Address is retained locally for the explicit export opt-in; it is never included by default. */
+class V9DiagnosticEndpoint(val numericAddress: String, val port: Int) {
+  init {
+    require(NetplayNumericAddress.isValid(numericAddress))
+    require(port in 1..65_535)
+  }
+
+  override fun equals(other: Any?): Boolean =
+      other is V9DiagnosticEndpoint &&
+          numericAddress == other.numericAddress && port == other.port
+
+  override fun hashCode(): Int = 31 * numericAddress.hashCode() + port
+
+  override fun toString(): String = "V9DiagnosticEndpoint(redacted)"
+}
+
+data class V9TransportMetricsSnapshot(
+    val currentRttMicros: Long?,
+    val ewmaRttMicros: Long?,
+    val recentMinimumRttMicros: Long?,
+    val recentMaximumRttMicros: Long?,
+    val jitterMicros: Long?,
+    val unansweredPings: Int,
+    val timedOutPings: Long,
+    val bytesSent: Long,
+    val bytesReceived: Long,
+    val connectionDurationMillis: Long,
+    val localFrame: Long?,
+    val remoteFrame: Long?,
+    val newestRemoteInputAgeMillis: Long?,
+    val lifecycle: V9LifecycleState,
+    val mode: V9LinkMode,
+    val role: V9Role,
+    val authenticatedSlot: Int?,
+    val remoteEndpoint: V9DiagnosticEndpoint?,
+)
+
+/**
+ * Bounded local metrics. It retains one pending ping and the newest 32 RTT samples. Peer stamps
+ * are echoed for diagnostics only; all RTT/liveness math uses [clock].
+ */
+internal class V9TransportMetrics(
+    private val clock: V9MonotonicClock,
+    private val role: V9Role,
+    private val mode: V9LinkMode,
+    private val endpoint: V9DiagnosticEndpoint?,
+) : NetplaySnapshotSource<V9TransportMetricsSnapshot>, Closeable {
+  private val lock = Any()
+  private val startedAt = clock.nowMillis()
+  private val pending = LinkedHashMap<Long, PendingPing>()
+  private val rttSamples = LongArray(RTT_SAMPLES)
+  private var rttIndex = 0
+  private var rttCount = 0
+  private var currentRtt: Long? = null
+  private var ewmaRtt: Long? = null
+  private var jitter: Long? = null
+  private var timedOut = 0L
+  private var bytesSent = 0L
+  private var bytesReceived = 0L
+  private var localFrame: Long? = null
+  private var remoteFrame: Long? = null
+  private var lastRemoteInputAt: Long? = null
+  private var lifecycle =
+      if (role == V9Role.SERVER) V9LifecycleState.SEND_SERVER_HELLO
+      else V9LifecycleState.WAIT_SERVER_HELLO
+  private var slot: Int? = null
+  private var closed = false
+  private val publisher =
+      BoundedSnapshotPublisher(snapshotLocked(startedAt), "netplay-v9-transport-diagnostics")
+
+  override fun snapshot(): V9TransportMetricsSnapshot = synchronized(lock) {
+    snapshotLocked(clock.nowMillis())
+  }
+
+  override fun addListener(
+      listener: NetplaySnapshotListener<V9TransportMetricsSnapshot>,
+  ): Closeable = publisher.addListener(listener)
+
+  fun recordLifecycle(value: V9LifecycleSnapshot, authenticatedSlot: Int?) {
+    publish {
+      lifecycle = value.state
+      slot = authenticatedSlot
+    }
+  }
+
+  fun recordRead(count: Int) {
+    require(count >= 0)
+    publish { bytesReceived = saturatingAdd(bytesReceived, count.toLong()) }
+  }
+
+  fun recordWrite(count: Int) {
+    require(count >= 0)
+    publish { bytesSent = saturatingAdd(bytesSent, count.toLong()) }
+  }
+
+  fun recordLocalFrame(frame: Long) {
+    if (frame < 0) return
+    publish { localFrame = maxOf(localFrame ?: frame, frame) }
+  }
+
+  fun recordRemoteInput(frame: Long) {
+    if (frame < 0) return
+    publish {
+      remoteFrame = maxOf(remoteFrame ?: frame, frame)
+      lastRemoteInputAt = clock.nowMillis()
+    }
+  }
+
+  fun recordRemoteFrame(frame: Long) {
+    if (frame < 0) return
+    publish { remoteFrame = maxOf(remoteFrame ?: frame, frame) }
+  }
+
+  fun registerPing(sequence: Long, value: V9PingPayload): Boolean = synchronized(lock) {
+    if (closed || pending.size >= MAX_PENDING_PINGS || pending.containsKey(sequence)) return false
+    pending[sequence] = PendingPing(value, clock.nowMillis())
+    publisher.update(snapshotLocked(clock.nowMillis()))
+    true
+  }
+
+  fun cancelPing(sequence: Long) {
+    publish { pending.remove(sequence) }
+  }
+
+  fun acceptPong(correlation: Long, value: V9PingPayload): V9ErrorCode? {
+    val now = clock.nowMillis()
+    val outcome = synchronized(lock) {
+      if (closed) return V9ErrorCode.CORRELATION_ERROR
+      val original = pending[correlation] ?: return V9ErrorCode.CORRELATION_ERROR
+      if (original.payload != value) return V9ErrorCode.CORRELATION_ERROR
+      pending.remove(correlation)
+      val elapsedMillis = elapsedMillis(now, original.sentAtMillis)
+      val sample = saturatingMultiply(elapsedMillis, 1_000)
+      val previous = currentRtt
+      currentRtt = sample
+      ewmaRtt = ewmaRtt?.let { it + (sample - it) / 8 } ?: sample
+      if (previous != null) {
+        val difference = unsignedAbsDifference(sample, previous)
+        jitter = jitter?.let { it + (difference - it) / 16 } ?: difference
+      } else {
+        jitter = 0
+      }
+      rttSamples[rttIndex] = sample
+      rttIndex = (rttIndex + 1) % rttSamples.size
+      if (rttCount < rttSamples.size) rttCount++
+      snapshotLocked(now)
+    }
+    publisher.update(outcome)
+    return null
+  }
+
+  fun expirePings(timeoutMillis: Long): List<Long> {
+    require(timeoutMillis > 0)
+    val now = clock.nowMillis()
+    val expired = ArrayList<Long>(MAX_PENDING_PINGS)
+    val snapshot = synchronized(lock) {
+      if (closed) return emptyList()
+      val iterator = pending.entries.iterator()
+      while (iterator.hasNext()) {
+        val entry = iterator.next()
+        if (elapsedMillis(now, entry.value.sentAtMillis) >= timeoutMillis) {
+          expired += entry.key
+          iterator.remove()
+        }
+      }
+      timedOut = saturatingAdd(timedOut, expired.size.toLong())
+      snapshotLocked(now)
+    }
+    if (expired.isNotEmpty()) publisher.update(snapshot)
+    return expired.toList()
+  }
+
+  internal fun pendingCount(): Int = synchronized(lock) { pending.size }
+  internal fun nextExpiryDeadline(timeoutMillis: Long): Long? = synchronized(lock) {
+    require(timeoutMillis > 0)
+    pending.values.minOfOrNull { addSaturated(it.sentAtMillis, timeoutMillis) }
+  }
+  internal fun retainedRttSampleCount(): Int = synchronized(lock) { rttCount }
+  internal fun listenerCountForTest(): Int = publisher.activeListenerCount()
+  internal fun seedCountersForTest(sent: Long, received: Long, timeoutCount: Long) {
+    require(sent >= 0 && received >= 0 && timeoutCount >= 0)
+    publish {
+      bytesSent = sent
+      bytesReceived = received
+      timedOut = timeoutCount
+    }
+  }
+
+  override fun close() {
+    synchronized(lock) {
+      if (closed) return
+      closed = true
+      pending.clear()
+    }
+    publisher.close()
+  }
+
+  private fun publish(update: () -> Unit) {
+    val value = synchronized(lock) {
+      if (closed) return
+      update()
+      snapshotLocked(clock.nowMillis())
+    }
+    publisher.update(value)
+  }
+
+  private fun snapshotLocked(now: Long): V9TransportMetricsSnapshot {
+    var minimum: Long? = null
+    var maximum: Long? = null
+    for (index in 0 until rttCount) {
+      val value = rttSamples[index]
+      minimum = minimum?.let { minOf(it, value) } ?: value
+      maximum = maximum?.let { maxOf(it, value) } ?: value
+    }
+    return V9TransportMetricsSnapshot(
+        currentRtt,
+        ewmaRtt,
+        minimum,
+        maximum,
+        jitter,
+        pending.size,
+        timedOut,
+        bytesSent,
+        bytesReceived,
+        elapsedMillis(now, startedAt),
+        localFrame,
+        remoteFrame,
+        lastRemoteInputAt?.let { elapsedMillis(now, it) },
+        lifecycle,
+        mode,
+        role,
+        slot,
+        endpoint,
+    )
+  }
+
+  private data class PendingPing(val payload: V9PingPayload, val sentAtMillis: Long)
+
+  companion object {
+    const val MAX_PENDING_PINGS = 1
+    const val RTT_SAMPLES = 32
+
+    private fun saturatingAdd(left: Long, right: Long): Long =
+        NetplayRollbackMetrics.saturatingAdd(left, right)
+
+    private fun saturatingMultiply(value: Long, multiplier: Long): Long =
+        if (value > Long.MAX_VALUE / multiplier) Long.MAX_VALUE else value * multiplier
+
+    private fun addSaturated(left: Long, right: Long): Long =
+        try {
+          Math.addExact(left, right)
+        } catch (_: ArithmeticException) {
+          Long.MAX_VALUE
+        }
+
+    private fun unsignedAbsDifference(left: Long, right: Long): Long =
+        if (left >= right) left - right else right - left
+
+    private fun elapsedMillis(now: Long, since: Long): Long =
+        try {
+          Math.subtractExact(now, since).coerceAtLeast(0)
+        } catch (_: ArithmeticException) {
+          if (now >= since) Long.MAX_VALUE else 0
+        }
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
@@ -1,5 +1,8 @@
 package eu.rekawek.coffeegb.controller.network.v9
 
+import eu.rekawek.coffeegb.controller.network.BoundedSnapshotPublisher
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
 import java.io.Closeable
 import java.io.IOException
 import java.net.InetSocketAddress
@@ -27,6 +30,9 @@ interface V9TransportChannel : Closeable {
 
   @Throws(IOException::class)
   fun shutdownOutput()
+
+  /** Local diagnostics only. Implementations must return a numeric address, never peer text. */
+  fun remoteEndpoint(): V9DiagnosticEndpoint? = null
 }
 
 interface V9ConnectableChannel : V9TransportChannel {
@@ -58,6 +64,16 @@ class V9SocketChannel(private val socket: Socket) : V9ConnectableChannel {
 
   override fun shutdownOutput() {
     if (!socket.isOutputShutdown) socket.shutdownOutput()
+  }
+
+  override fun remoteEndpoint(): V9DiagnosticEndpoint? {
+    val address = socket.remoteSocketAddress as? InetSocketAddress ?: return null
+    val numeric = address.address?.hostAddress ?: return null
+    return try {
+      V9DiagnosticEndpoint(numeric, address.port)
+    } catch (_: IllegalArgumentException) {
+      null
+    }
   }
 
   override fun close() {
@@ -177,6 +193,13 @@ data class V9PostAuthBoundary(
     val state: V9LifecycleState,
 )
 
+data class V9FoundationServerStatus(
+    val listening: Boolean,
+    val port: Int,
+    val mode: V9LinkMode,
+    val openSlots: Int,
+)
+
 /**
  * Opt-in protocol-v9 transport foundation.
  *
@@ -202,11 +225,19 @@ class V9FoundationConnection(
     private val manifestPlan: V9ManifestPlan? = null,
     private val part3Plan: V9Part3Plan? = null,
     private val playPlan: V9PlayPlan? = null,
+    private val diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
 ) : Closeable, V9LifecycleSource {
   private val scheduler = scheduler ?: V9SystemDeadlineScheduler(clock)
   private val ownedScheduler = if (scheduler == null) this.scheduler as Closeable else null
   private val lifecycle = V9Lifecycle(role, clock)
-  private val localHello = V9HelloCodec.create(role, nonce, optionalCapabilities)
+  private val effectiveOptionalCapabilities =
+      (optionalCapabilities - V9Capability.PING_V1) +
+          if (diagnosticsOptions.enabled) setOf(V9Capability.PING_V1) else emptySet()
+  private val localHello = V9HelloCodec.create(role, nonce, effectiveOptionalCapabilities)
+  private val transportMetrics =
+      diagnosticsOptions.takeIf { it.enabled }?.let {
+        V9TransportMetrics(clock, role, mode, channel.remoteEndpoint())
+      }
   private val decoderPolicy =
       V9DecoderPolicy(
           allowedMessages =
@@ -250,6 +281,7 @@ class V9FoundationConnection(
   private val part3Registrations = mutableSetOf<Part3ListenerRegistration>()
   private val wireStateLock = Any()
   private var timeoutTask: Closeable? = null
+  private var pingTask: Closeable? = null
   private var writerTask: Thread? = null
   private var negotiated: V9NegotiatedCapabilities? = null
   private var remoteHello: V9Hello? = null
@@ -262,6 +294,11 @@ class V9FoundationConnection(
   @Volatile private var playSession: V9PlaySession? = null
   @Volatile private var activatingPlayTarget: V9CheckpointTarget? = null
   private var nextOutgoingSequence = 0L
+  private var nextPingNonce = SecureRandom().nextLong()
+  private var consecutivePingTimeouts = 0
+  @Volatile private var activeRollbackMetrics:
+      eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource<
+          eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot>? = null
 
   init {
     require(invitationHost == null || role == V9Role.SERVER && invitationHost.mode == mode)
@@ -280,6 +317,8 @@ class V9FoundationConnection(
     require(playPlan == null || playPlan.role == role && playPlan.mode == mode)
     lifecycle.addListener { state ->
       scheduleDeadline(state)
+      transportMetrics?.recordLifecycle(state, authenticatedBoundary?.slot)
+      if (state.state == V9LifecycleState.ACTIVE) schedulePingIfNeeded()
       if (state.phase == V9LifecyclePhase.AWAITING_PAIRING) {
         pairingBoundary = state
         boundary.countDown()
@@ -379,6 +418,15 @@ class V9FoundationConnection(
 
   fun negotiatedCapabilities(): Set<V9Capability> =
       negotiated?.capabilities?.toSet() ?: emptySet()
+
+  fun transportMetricsSource():
+      eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource<V9TransportMetricsSnapshot>? =
+      transportMetrics
+
+  fun rollbackMetricsSource():
+      eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource<
+          eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot>? =
+      activeRollbackMetrics
 
   fun writerQueueSnapshot(): V9QueueSnapshot = writer.snapshot()
 
@@ -504,6 +552,7 @@ class V9FoundationConnection(
           return
         }
         if (count == 0) continue
+        transportMetrics?.recordRead(count)
         if (snapshot().state == V9LifecycleState.TERMINAL_CLEANUP) {
           // Output is half-closed. Peer bytes are drained only to observe EOF; no frame is admitted.
           continue
@@ -622,6 +671,8 @@ class V9FoundationConnection(
         V9MessageType.STOP ->
           playSession?.handle(frame)
               ?: reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.TRANSFER_REJECTED)
+        V9MessageType.PING -> handlePing(frame)
+        V9MessageType.PONG -> handlePong(frame)
         V9MessageType.CANCEL -> fail(V9ErrorCode.CANCELLED, V9Diagnostic.CANCELLED)
         V9MessageType.GOODBYE -> {
           lifecycle.closeNormally()
@@ -639,7 +690,6 @@ class V9FoundationConnection(
           }
           fail(remote.error, diagnosticFor(remote.error))
         }
-        else -> reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
       }
     }
   }
@@ -1041,6 +1091,7 @@ class V9FoundationConnection(
                 completedActiveBoundary = active
                 activeComplete.countDown()
               }
+          session.attachTransportMetrics(transportMetrics)
           val discard = synchronized(wireStateLock) {
             synchronized(playOwnershipLock) {
               if (closed.get() || playSession != null) {
@@ -1057,6 +1108,7 @@ class V9FoundationConnection(
             session.close()
             return@startTask
           }
+          activeRollbackMetrics = plan.gameplayTarget.rollbackMetricsSource()
           session.start()
         } catch (failure: V9ProtocolException) {
           reject(failure.reason, diagnosticFor(failure.reason))
@@ -1168,9 +1220,11 @@ class V9FoundationConnection(
             }
         var requestRecorded = false
         var admissionRollback: Closeable? = null
-        if (type == V9MessageType.START) {
+        val requestType =
+            type.takeIf { it == V9MessageType.START || it == V9MessageType.PING }
+        if (requestType != null) {
           try {
-            responseLedger.recordPeerRequest(sequence, V9MessageType.START)
+            responseLedger.recordPeerRequest(sequence, requestType)
             requestRecorded = true
           } catch (_: RuntimeException) {
             encoded.fill(0)
@@ -1190,7 +1244,7 @@ class V9FoundationConnection(
         if (offered) sequence else {
           admissionRollback?.close()
           if (requestRecorded) {
-            responseLedger.cancelPeerRequest(sequence, V9MessageType.START)
+            responseLedger.cancelPeerRequest(sequence, requireNotNull(requestType))
           }
           reject(V9ErrorCode.QUEUE_OVERFLOW, V9Diagnostic.QUEUE_FULL)
           null
@@ -1206,6 +1260,15 @@ class V9FoundationConnection(
   ): V9ErrorCode? {
     if (type !in PART3_MESSAGES && type !in PLAY_MESSAGES) return null
     return synchronized(wireStateLock) {
+      if (type == V9MessageType.PING || type == V9MessageType.PONG) {
+        if (negotiated?.capabilities?.contains(V9Capability.PING_V1) != true) {
+          return@synchronized V9ErrorCode.CAPABILITY_MISMATCH
+        }
+        if (snapshot().state != V9LifecycleState.ACTIVE || playSession == null) {
+          return@synchronized V9ErrorCode.UNEXPECTED_MESSAGE
+        }
+        return@synchronized null
+      }
       if (type in PART3_MESSAGES) {
         val session = part3Session ?: return@synchronized V9ErrorCode.UNEXPECTED_MESSAGE
         session.headerAdmission(type, flags, channel, encodedLength, decodedLength)
@@ -1340,6 +1403,7 @@ class V9FoundationConnection(
       val count = channel.write(bytes, offset, bytes.size - offset)
       if (count <= 0) throw IOException("v9 writer made no progress")
       offset = Math.addExact(offset, count)
+      transportMetrics?.recordWrite(count)
     }
     if (offset != bytes.size) throw IOException("v9 writer closed")
   }
@@ -1424,6 +1488,120 @@ class V9FoundationConnection(
     }
   }
 
+  private fun schedulePingIfNeeded() {
+    if (!diagnosticsOptions.enabled ||
+        negotiated?.capabilities?.contains(V9Capability.PING_V1) != true ||
+        snapshot().state != V9LifecycleState.ACTIVE) return
+    synchronized(taskLock) {
+      if (closed.get() || pingTask != null) return
+      val cadenceDeadline =
+          addSaturated(clock.nowMillis(), diagnosticsOptions.pingCadenceMillis)
+      val deadline =
+          transportMetrics?.nextExpiryDeadline(diagnosticsOptions.pingTimeoutMillis)
+              ?.let { minOf(cadenceDeadline, it) }
+              ?: cadenceDeadline
+      pingTask = scheduler.schedule(deadline) {
+        synchronized(taskLock) {
+          pingTask?.close()
+          pingTask = null
+        }
+        if (closed.get() || snapshot().state != V9LifecycleState.ACTIVE) return@schedule
+        val metrics = transportMetrics ?: return@schedule
+        val livenessFailed = synchronized(wireStateLock) {
+          val expired = metrics.expirePings(diagnosticsOptions.pingTimeoutMillis)
+          expired.forEach { responseLedger.cancelPeerRequest(it, V9MessageType.PING) }
+          consecutivePingTimeouts =
+              (consecutivePingTimeouts + expired.size).coerceAtMost(MAX_TIMED_OUT_PINGS)
+          consecutivePingTimeouts >= MAX_TIMED_OUT_PINGS
+        }
+        if (livenessFailed) {
+          fail(V9ErrorCode.TIMEOUT, V9Diagnostic.TIMEOUT)
+          return@schedule
+        }
+        sendPing()
+        schedulePingIfNeeded()
+      }
+    }
+  }
+
+  private fun sendPing() {
+    val metrics = transportMetrics ?: return
+    if (metrics.pendingCount() >= V9TransportMetrics.MAX_PENDING_PINGS) {
+      // The configured timeout may span several cadence intervals. Retain the existing probe and
+      // try again at the next cadence instead of allocating or failing early.
+      return
+    }
+    val nonce = nextPingNonce++
+    val micros = multiplySaturated(clock.nowMillis().coerceAtLeast(0), 1_000)
+    val value = V9PingPayload(nonce, micros)
+    val payload = V9PingCodec.encode(value)
+    try {
+      enqueuePlay(
+          V9MessageType.PING,
+          0,
+          0,
+          ProtocolV9.CONTROL_CHANNEL,
+          payload,
+          { sequence ->
+            if (!metrics.registerPing(sequence, value)) {
+              throw IllegalStateException("v9 pending ping bound reached")
+            }
+            Closeable { metrics.cancelPing(sequence) }
+          },
+          {},
+      )
+    } finally {
+      payload.fill(0)
+    }
+  }
+
+  private fun handlePing(frame: V9Frame) {
+    if (negotiated?.capabilities?.contains(V9Capability.PING_V1) != true) {
+      reject(V9ErrorCode.CAPABILITY_MISMATCH, V9Diagnostic.HELLO_REJECTED)
+      return
+    }
+    if (snapshot().state != V9LifecycleState.ACTIVE) {
+      reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+      return
+    }
+    val payload = V9PingCodec.encode(V9PingCodec.decode(frame.payloadView()))
+    val admitted =
+        enqueuePlay(
+            V9MessageType.PONG,
+            V9Flag.RESPONSE.wireMask,
+            frame.header.sequence,
+            ProtocolV9.CONTROL_CHANNEL,
+            payload,
+            { Closeable {} },
+            { if (!closed.get()) lifecycle.activeProgress() },
+        )
+    payload.fill(0)
+    if (admitted == null) reject(V9ErrorCode.QUEUE_OVERFLOW, V9Diagnostic.QUEUE_FULL)
+  }
+
+  private fun handlePong(frame: V9Frame) {
+    if (negotiated?.capabilities?.contains(V9Capability.PING_V1) != true) {
+      reject(V9ErrorCode.CAPABILITY_MISMATCH, V9Diagnostic.HELLO_REJECTED)
+      return
+    }
+    if (snapshot().state != V9LifecycleState.ACTIVE) {
+      reject(V9ErrorCode.UNEXPECTED_MESSAGE, V9Diagnostic.HELLO_REJECTED)
+      return
+    }
+    val metrics = transportMetrics
+        ?: return reject(V9ErrorCode.CORRELATION_ERROR, V9Diagnostic.HELLO_REJECTED)
+    val failure =
+        metrics.acceptPong(
+            frame.header.correlation,
+            V9PingCodec.decode(frame.payloadView()),
+        )
+    if (failure != null) reject(failure, V9Diagnostic.HELLO_REJECTED)
+    else {
+      consecutivePingTimeouts = 0
+      lifecycle.activeProgress()
+    }
+  }
+
   private fun fail(reason: V9ErrorCode, diagnostic: V9Diagnostic) {
     if (!closed.get()) lifecycle.fail(reason, diagnostic)
     closeResources()
@@ -1438,6 +1616,8 @@ class V9FoundationConnection(
     synchronized(taskLock) {
       timeoutTask?.close()
       timeoutTask = null
+      pingTask?.close()
+      pingTask = null
     }
     writer.close()
     slotReservation?.close()
@@ -1466,6 +1646,7 @@ class V9FoundationConnection(
       currentSession to currentTarget
     }
     activePlaySession?.close()
+    activeRollbackMetrics = null
     activatingTarget?.close()
     clientInvitation?.close()
     try {
@@ -1477,6 +1658,7 @@ class V9FoundationConnection(
       tasks.filter { it !== Thread.currentThread() }.forEach(Thread::interrupt)
     }
     ownedScheduler?.close()
+    transportMetrics?.close()
     boundary.countDown()
     postAuth.countDown()
     manifestComplete.countDown()
@@ -1572,7 +1754,21 @@ class V9FoundationConnection(
             V9MessageType.INPUT,
             V9MessageType.RESET,
             V9MessageType.STOP,
+            V9MessageType.PING,
+            V9MessageType.PONG,
         )
+
+    private const val MAX_TIMED_OUT_PINGS = 2
+
+    private fun addSaturated(left: Long, right: Long): Long =
+        try {
+          Math.addExact(left, right)
+        } catch (_: ArithmeticException) {
+          Long.MAX_VALUE
+        }
+
+    private fun multiplySaturated(value: Long, multiplier: Long): Long =
+        if (value > Long.MAX_VALUE / multiplier) Long.MAX_VALUE else value * multiplier
 
     private fun randomNonce(): ByteArray = ByteArray(32).also(SecureRandom()::nextBytes)
   }
@@ -1591,6 +1787,7 @@ class V9FoundationServer(
     private val manifestPlan: V9ManifestPlan? = null,
     private val part3Plan: V9Part3Plan? = null,
     private val playPlan: V9PlayPlan? = null,
+    private val diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
     private val onAwaitingPairing: (V9FoundationConnection) -> Unit,
 ) : Closeable {
   init {
@@ -1628,6 +1825,11 @@ class V9FoundationServer(
       )
   private var listener: ServerSocket? = null
   private var acceptThread: Thread? = null
+  private val statusPublisher =
+      BoundedSnapshotPublisher(
+          V9FoundationServerStatus(false, 0, mode, 0),
+          "netplay-v9-server-status",
+      )
 
   internal var connectionFactory:
       (V9TransportChannel, V9Role, V9LinkMode, Set<V9Capability>) ->
@@ -1642,12 +1844,15 @@ class V9FoundationServer(
             manifestPlan = manifestPlan,
             part3Plan = part3Plan,
             playPlan = playPlan,
+            diagnosticsOptions = diagnosticsOptions,
         )
       }
 
   internal var candidateHooks = V9ServerCandidateHooks()
 
   val localPort: Int get() = listener?.localPort ?: 0
+
+  fun statusSource(): NetplaySnapshotSource<V9FoundationServerStatus> = statusPublisher
 
   internal fun activeConnectionCount(): Int = connections.size
 
@@ -1666,6 +1871,7 @@ class V9FoundationServer(
           thread(isDaemon = true, name = "netplay-v9-accept") {
             acceptLoop(requireNotNull(listener))
           }
+      publishStatus()
     }
   }
 
@@ -1689,6 +1895,8 @@ class V9FoundationServer(
     playPlan?.close()
     invitationHost?.close()
     acceptThread?.interrupt()
+    statusPublisher.update(V9FoundationServerStatus(false, 0, mode, 0))
+    statusPublisher.close()
   }
 
   private fun acceptLoop(server: ServerSocket) {
@@ -1745,7 +1953,13 @@ class V9FoundationServer(
               optionalCapabilities,
           )
       connections += connection
-      connection.addCloseListener { connections.remove(connection) }
+      lateinit var statusSubscription: Closeable
+      statusSubscription = connection.addListener { publishStatus() }
+      connection.addCloseListener {
+        statusSubscription.close()
+        connections.remove(connection)
+        publishStatus()
+      }
       connection.start()
       val state =
           connection.awaitPairingBoundary(
@@ -1790,6 +2004,20 @@ class V9FoundationServer(
         // Candidate construction/start/callback failures remain isolated to this socket.
       }
     }
+  }
+
+  private fun publishStatus() {
+    val listening = !stopped.get() && listener?.isClosed == false
+    val capacity = if (mode == V9LinkMode.NORMAL) 1 else 3
+    val occupied = invitationHost?.occupiedSlots()?.size ?: capacity
+    statusPublisher.update(
+        V9FoundationServerStatus(
+            listening,
+            if (listening) localPort else 0,
+            mode,
+            (capacity - occupied).coerceIn(0, capacity),
+        ),
+    )
   }
 
   private inner class V9PendingCandidate(
@@ -1842,6 +2070,7 @@ object V9FoundationClient {
       manifestPlan: V9ManifestPlan? = null,
       part3Plan: V9Part3Plan? = null,
       playPlan: V9PlayPlan? = null,
+      diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
   ): V9FoundationConnection {
     require(invitation == null || invitation.mode == mode)
     require(manifestPlan == null || manifestPlan.role == V9Role.CLIENT && manifestPlan.mode == mode)
@@ -1860,6 +2089,7 @@ object V9FoundationClient {
         manifestPlan,
         part3Plan,
         playPlan,
+        diagnosticsOptions,
         ::newV9SocketChannel,
     )
   }
@@ -1873,6 +2103,7 @@ object V9FoundationClient {
       manifestPlan: V9ManifestPlan? = null,
       part3Plan: V9Part3Plan? = null,
       playPlan: V9PlayPlan? = null,
+      diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
       channelFactory: () -> V9ConnectableChannel,
   ): V9FoundationConnection {
     require(invitation == null || invitation.mode == mode)
@@ -1892,6 +2123,7 @@ object V9FoundationClient {
         manifestPlan,
         part3Plan,
         playPlan,
+        diagnosticsOptions,
         channelFactory,
     )
   }
@@ -1905,6 +2137,7 @@ object V9FoundationClient {
       manifestPlan: V9ManifestPlan?,
       part3Plan: V9Part3Plan?,
       playPlan: V9PlayPlan?,
+      diagnosticsOptions: V9DiagnosticsOptions,
       channelFactory: () -> V9ConnectableChannel,
   ): V9FoundationConnection {
     var channel: V9ConnectableChannel? = null
@@ -1922,6 +2155,7 @@ object V9FoundationClient {
           manifestPlan = manifestPlan,
           part3Plan = part3Plan,
           playPlan = playPlan,
+          diagnosticsOptions = diagnosticsOptions,
       )
       connection = acceptedConnection
       acceptedConnection.start()
@@ -1979,6 +2213,7 @@ class V9FoundationConnectAttempt(
       manifestPlan: V9ManifestPlan? = null,
       part3Plan: V9Part3Plan? = null,
       playPlan: V9PlayPlan? = null,
+      diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
       onComplete: (V9FoundationConnection?, V9ErrorCode?) -> Unit,
   ) {
     require(invitation == null || invitation.mode == mode)
@@ -2038,6 +2273,7 @@ class V9FoundationConnectAttempt(
               manifestPlan,
               part3Plan,
               playPlan,
+              diagnosticsOptions,
           )
         }
     val startWorker =
@@ -2079,6 +2315,7 @@ class V9FoundationConnectAttempt(
       manifestPlan: V9ManifestPlan?,
       part3Plan: V9Part3Plan? = null,
       playPlan: V9PlayPlan? = null,
+      diagnosticsOptions: V9DiagnosticsOptions = V9DiagnosticsOptions.DISABLED,
   ) {
     var createdChannel: V9ConnectableChannel? = null
     try {
@@ -2107,6 +2344,7 @@ class V9FoundationConnectAttempt(
               manifestPlan = manifestPlan,
               part3Plan = part3Plan,
               playPlan = playPlan,
+              diagnosticsOptions = diagnosticsOptions,
           )
       if (!adoptConnection(value)) {
         value.close()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9Foundation.kt
@@ -209,8 +209,9 @@ data class V9FoundationServerStatus(
  * it exchanges and validates MANIFEST and stops at the immutable pre-consent boundary. With an
  * explicit [part3Plan], item-scoped CONSENT and bounded ROM/battery preparation are enabled and
  * stop at an immutable pre-START boundary. An explicit [playPlan] additionally enables direct
- * StateFile-v2 CHECKPOINT, START/READY, and bounded ACTIVE traffic. Diagnostics and discovery
- * remain unavailable.
+ * StateFile-v2 CHECKPOINT, START/READY, and bounded ACTIVE traffic. Explicit diagnostics options
+ * additionally negotiate bounded PING/PONG transport metrics. Trusted-LAN discovery is a separate,
+ * off-by-default address-only service and never changes this connection's authentication flow.
  */
 class V9FoundationConnection(
     private val channel: V9TransportChannel,
@@ -439,6 +440,11 @@ class V9FoundationConnection(
   internal fun isClosed(): Boolean = closed.get()
 
   internal fun activeTaskCount(): Int = synchronized(taskLock) { tasks.count(Thread::isAlive) }
+
+  internal fun seedConsecutivePingTimeoutsForTest(value: Int) {
+    require(value in 0 until MAX_TIMED_OUT_PINGS)
+    synchronized(wireStateLock) { consecutivePingTimeouts = value }
+  }
 
   internal fun runtimeRelayQueueSizeForTest(): Int = synchronized(playOwnershipLock) {
     playSession?.runtimeRelayQueueSize() ?: 0
@@ -1775,8 +1781,7 @@ class V9FoundationConnection(
 }
 
 /**
- * Opt-in listener used only by foundation/Part-1/Part-2 diagnostics and tests until later pairing
- * phases.
+ * Opt-in listener for the complete authenticated v9 foundation and its optional diagnostics.
  * It is intentionally not reachable from [eu.rekawek.coffeegb.controller.network.ConnectionController].
  */
 class V9FoundationServer(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransport.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransport.kt
@@ -360,6 +360,11 @@ interface V9GameplayTarget {
   fun input(value: V9InputState, completion: V9GameplayCompletion)
   fun control(value: V9RuntimeControl, completion: V9GameplayCompletion)
   fun disconnected(player: Int) {}
+
+  /** Optional local-only diagnostics. It never participates in wire or deterministic state. */
+  fun rollbackMetricsSource():
+      eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource<
+          eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot>? = null
 }
 
 object V9GameplayCodec {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -78,6 +78,44 @@ import kotlin.test.assertTrue
 class LinkedControllerTest {
 
   @Test
+  fun v9RollbackDiagnosticsObserveSafePointReplayWithoutChangingState() {
+    val (_, controller) = configuredController(LinkMode.NORMAL, 2)
+    val target = controller.createV9Target()
+    try {
+      repeat(6) { controller.runFrame() }
+      val accepted = AtomicReference<V9ErrorCode?>()
+      val lateFrame = controller.currentFrame() - 3
+      target.input(
+          eu.rekawek.coffeegb.controller.network.v9.V9InputState(lateFrame, 1, 0x10, 1),
+      ) { accepted.set(it) }
+      dispatchOnly(controller)
+      assertNull(accepted.get())
+      controller.runFrame()
+      val metrics = controller.rollbackMetricsSource().snapshot()
+      assertEquals(1, metrics.rollbackCount)
+      assertTrue(metrics.lastFramesRewound >= 2)
+      assertTrue(metrics.totalFramesResimulated >= 1)
+      assertEquals(eu.rekawek.coffeegb.controller.network.NetplayRollbackReason.REMOTE_INPUT,
+          metrics.lastReason)
+      assertTrue(metrics.historyEntries in 1..metrics.historyCapacity)
+      val stateAfterReplay = controller.encodedSessionStates()
+      repeat(100) { controller.rollbackMetricsSource().snapshot() }
+      assertEncodedStatesEqual(stateAfterReplay, controller.encodedSessionStates())
+
+      val rejected = AtomicReference<V9ErrorCode?>()
+      target.input(
+          eu.rekawek.coffeegb.controller.network.v9.V9InputState(-1, 1, 0, 2),
+      ) { rejected.set(it) }
+      dispatchOnly(controller)
+      assertEquals(V9ErrorCode.SEQUENCE_ERROR, rejected.get())
+      assertEquals(1, controller.rollbackMetricsSource().snapshot().tooOldInputs)
+    } finally {
+      target.close()
+      controller.closeWithState()
+    }
+  }
+
+  @Test
   fun v9ProviderCapturesAtFrameSafePointAndCancellationReleasesWaiter() {
     val (eventBus, controller) = configuredController(LinkMode.NORMAL, 2)
     val executor = Executors.newSingleThreadExecutor()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnosticsTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/NetplayDiagnosticsTest.kt
@@ -1,0 +1,195 @@
+package eu.rekawek.coffeegb.controller.network
+
+import eu.rekawek.coffeegb.controller.network.v9.V9DiagnosticEndpoint
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleState
+import eu.rekawek.coffeegb.controller.network.v9.V9LinkMode
+import eu.rekawek.coffeegb.controller.network.v9.V9Role
+import eu.rekawek.coffeegb.controller.network.v9.V9TransportMetricsSnapshot
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class NetplayDiagnosticsTest {
+
+  @Test
+  fun longRollbackSequenceHasExactBoundedAggregatesAndSaturates() {
+    val metrics = NetplayRollbackMetrics(300)
+    var expectedTotal = 0L
+    var expectedRollbacks = 0L
+    val lastWindow = ArrayDeque<Long>()
+    repeat(10_000) { index ->
+      val rewound = (index % 47).toLong()
+      val resimulated = rewound + 1
+      expectedTotal += resimulated
+      metrics.recordRollback(rewound, resimulated)
+      if (rewound > 0) {
+        expectedRollbacks++
+        lastWindow += rewound
+        if (lastWindow.size > NetplayRollbackMetrics.ROLLING_SAMPLES) lastWindow.removeFirst()
+      }
+      metrics.updateHistory((index % 301))
+    }
+    repeat(17) { metrics.recordHistoryExhausted() }
+    repeat(9) { metrics.recordCheckpoint(NetplayRollbackReason.RESYNCHRONIZATION) }
+    val snapshot = metrics.snapshot()
+    assertEquals(expectedRollbacks, snapshot.rollbackCount)
+    assertEquals(46, snapshot.maximumFramesRewound)
+    assertEquals(expectedTotal, snapshot.totalFramesResimulated)
+    assertEquals(lastWindow.sum() * 1_000 / lastWindow.size, snapshot.rollingAverageFramesRewoundMilli)
+    assertEquals(17, snapshot.tooOldInputs)
+    assertEquals(9, snapshot.checkpointResynchronizations)
+    assertEquals(NetplayRollbackReason.RESYNCHRONIZATION, snapshot.lastReason)
+    assertEquals(NetplayRollbackMetrics.ROLLING_SAMPLES, metrics.retainedSampleCount())
+
+    metrics.seedCountersForTest(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE)
+    metrics.recordRollback(1, 1)
+    metrics.recordHistoryExhausted()
+    metrics.recordCheckpoint()
+    val saturated = metrics.snapshot()
+    assertEquals(Long.MAX_VALUE, saturated.rollbackCount)
+    assertEquals(Long.MAX_VALUE, saturated.totalFramesResimulated)
+    assertEquals(Long.MAX_VALUE, saturated.tooOldInputs)
+    assertEquals(Long.MAX_VALUE, saturated.checkpointResynchronizations)
+    metrics.close()
+  }
+
+  @Test
+  fun exportIsWhitelistedBoundedAndAddressOptInIsExplicit() {
+    val transport = transport()
+    val rollback =
+        NetplayRollbackMetricsSnapshot(3, 2, 4, 1_500, 8, 42, 300, 1, 2,
+            NetplayRollbackReason.REMOTE_INPUT)
+    val safe = NetplayDiagnosticsExporter.export(transport, rollback)
+    assertTrue(safe.contains("remote-address=redacted"))
+    assertFalse(safe.contains("192.0.2.44"))
+    assertFalse(safe.contains("token", ignoreCase = true))
+    assertTrue(safe.length <= NetplayDiagnosticsExporter.MAX_EXPORT_CHARS)
+
+    val explicit = NetplayDiagnosticsExporter.export(transport, rollback, includeAddress = true)
+    assertTrue(explicit.contains("remote-address=192.0.2.44:8765"))
+    assertFalse(explicit.contains("coffeegb://"))
+    val scoped = V9DiagnosticEndpoint("fe80::1%en0", 8765)
+    assertFalse(scoped.toString().contains("fe80"))
+    val ipv6 =
+        NetplayDiagnosticsExporter.export(
+            transport().copy(remoteEndpoint = scoped),
+            rollback,
+            includeAddress = true,
+        )
+    assertTrue(ipv6.contains("remote-address=[fe80::1%en0]:8765"))
+    assertFailsWith<IllegalArgumentException> { V9DiagnosticEndpoint("dead.beef", 8765) }
+    assertFailsWith<IllegalArgumentException> { V9DiagnosticEndpoint("192.168.001.1", 8765) }
+    assertFailsWith<IllegalArgumentException> { V9DiagnosticEndpoint("2001:::1", 8765) }
+  }
+
+  @Test
+  fun adversarialTextRedactionCoversSecretsPathsAddressesControlsAndBounds() {
+    val hostile =
+        "coffeegb://example.test:8765/join?v=9&token=AAAAAAAAAAAAAAAAAAAAAA " +
+            "https://alice:password@example.test/x C:\\Users\\alice\\save.sav " +
+            "/home/alice/rom.gb 192.0.2.42 [2001:db8::42] [fe80::1%en0] " +
+            "peer.example.test\u0000" +
+            "x".repeat(20_000)
+    val value = NetplayDiagnosticSanitizer.redact(hostile)
+    assertTrue(value.contains("[redacted-invitation]"))
+    assertTrue(value.contains("[redacted-credentials]"))
+    assertTrue(value.contains("[redacted-path]"))
+    assertTrue(value.contains("[redacted-address]"))
+    assertTrue(value.contains("[redacted-host]"))
+    assertFalse(value.contains("AAAAAAAAAAAAAAAAAAAAAA"))
+    assertFalse(value.contains("alice"))
+    assertTrue(value.length <= NetplayDiagnosticSanitizer.MAX_OUTPUT_CHARS)
+    assertFalse(value.any { it.code < 0x20 })
+  }
+
+  @Test
+  fun runtimeInputAndPeerFailuresHaveNoInfoLogPath() {
+    val root = repositoryRoot()
+    val linked = Files.readString(
+        root.resolve("controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt"),
+    )
+    val v9 =
+        Files.walk(
+            root.resolve("controller/src/main/java/eu/rekawek/coffeegb/controller/network/v9"),
+        ).use { paths ->
+          paths.filter { Files.isRegularFile(it) && it.toString().endsWith(".kt") }
+              .sorted()
+              .map(Files::readString)
+              .toList()
+              .joinToString("\n")
+        }
+    assertFalse("LOG.info(" in linked || "LOG.atInfo(" in linked)
+    assertFalse("LOG.info(" in v9 || "LOG.atInfo(" in v9)
+  }
+
+  @Test
+  fun finalBoundedSnapshotIsDeliveredWithoutBlockingItsProducer() {
+    val publisher = BoundedSnapshotPublisher(0, "netplay-diagnostics-close-test")
+    val delivered = CountDownLatch(1)
+    publisher.addListener { if (it == 2) delivered.countDown() }
+    publisher.update(1)
+    publisher.update(2)
+    publisher.close()
+    assertTrue(delivered.await(1, TimeUnit.SECONDS))
+    assertTrue(publisher.awaitTermination(1, TimeUnit.SECONDS))
+    assertEquals(0, publisher.activeWorkerCount())
+    assertEquals(0, publisher.activeListenerCount())
+  }
+
+  @Test
+  fun snapshotListenerBoundaryAndBoundaryPlusOneAreEnforced() {
+    val publisher = BoundedSnapshotPublisher(0, "netplay-diagnostics-listener-bound")
+    val subscriptions =
+        List(BoundedSnapshotPublisher.MAX_LISTENERS) { index ->
+          publisher.addListener { _ -> check(index >= 0) }
+        }
+    assertEquals(BoundedSnapshotPublisher.MAX_LISTENERS, publisher.activeListenerCount())
+    assertFailsWith<IllegalStateException> { publisher.addListener { _ -> } }
+    subscriptions.forEach(Closeable::close)
+    publisher.close()
+    assertTrue(publisher.awaitTermination(1, TimeUnit.SECONDS))
+    assertEquals(0, publisher.activeListenerCount())
+  }
+
+  private fun transport() =
+      V9TransportMetricsSnapshot(
+          1_000,
+          1_100,
+          900,
+          1_300,
+          50,
+          1,
+          0,
+          123,
+          456,
+          7_000,
+          80,
+          79,
+          4,
+          V9LifecycleState.ACTIVE,
+          V9LinkMode.NORMAL,
+          V9Role.CLIENT,
+          1,
+          V9DiagnosticEndpoint("192.0.2.44", 8765),
+      )
+
+  private fun repositoryRoot(): Path {
+    System.getProperty("maven.multiModuleProjectDirectory")?.let { candidate ->
+      val root = Path.of(candidate).toAbsolutePath().normalize()
+      if (Files.isRegularFile(root.resolve("controller/pom.xml"))) return root
+    }
+    var candidate = Path.of("").toAbsolutePath().normalize()
+    while (candidate.parent != null) {
+      if (Files.isRegularFile(candidate.resolve("controller/pom.xml"))) return candidate
+      candidate = candidate.parent
+    }
+    throw AssertionError("Cannot locate repository root")
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscoveryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscoveryTest.kt
@@ -10,6 +10,7 @@ import eu.rekawek.coffeegb.controller.network.v9.V9LinkMode
 import eu.rekawek.coffeegb.controller.network.v9.V9MonotonicClock
 import java.io.Closeable
 import java.net.InetAddress
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
@@ -52,6 +53,7 @@ class NetplayDiscoveryTest {
     val localId = id(1)
     val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, localId)
     discovery.enable()
+    settle(discovery)
     assertTrue(backend.advertisements.isEmpty())
 
     discovery.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 0))
@@ -89,12 +91,16 @@ class NetplayDiscoveryTest {
     val badReserved = packet.copyOf().also { it[9] = 1 }
     assertEquals(null, NetplayDiscoveryCodec.decode(badReserved))
     discovery.disable()
+    settle(discovery)
     assertEquals(1, backend.stopCount)
     assertFalse(discovery.snapshot().enabled)
     discovery.enable()
+    settle(discovery)
     assertEquals(2, backend.startCount)
     discovery.disable()
+    settle(discovery)
     discovery.close()
+    settle(discovery)
   }
 
   @Test
@@ -104,6 +110,7 @@ class NetplayDiscoveryTest {
     val backend = FakeBackend()
     val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, id(0))
     discovery.enable()
+    settle(discovery)
     val advertisement =
         NetplayDiscoveryAdvertisement(9, id(2), V9LinkMode.FOUR_PLAYER, 3, true, 9000)
     val bytes = NetplayDiscoveryCodec.encode(advertisement)
@@ -159,6 +166,7 @@ class NetplayDiscoveryTest {
       it.advertisement.sessionId == mostRecent.advertisement.sessionId
     })
     discovery.close()
+    settle(discovery)
     assertFalse(discovery.snapshot().enabled)
     assertTrue(discovery.snapshot().hosts.isEmpty())
   }
@@ -170,18 +178,22 @@ class NetplayDiscoveryTest {
     val failing = FakeBackend(failStart = true)
     val isolated = TrustedLanNetplayDiscovery(failing, clock, scheduler, id(0))
     isolated.enable()
+    settle(isolated)
     assertFalse(isolated.snapshot().backendHealthy)
     // Discovery failure never changes or throws from the direct-listener status update.
     isolated.updateHost(V9FoundationServerStatus(true, 7777, V9LinkMode.NORMAL, 1))
     isolated.close()
+    settle(isolated)
 
     val advertiseFailure = FakeBackend(failAdvertise = true)
     val advertiseIsolated =
         TrustedLanNetplayDiscovery(advertiseFailure, clock, scheduler, id(8))
     advertiseIsolated.enable()
+    settle(advertiseIsolated)
     advertiseIsolated.updateHost(V9FoundationServerStatus(true, 7777, V9LinkMode.NORMAL, 1))
     assertFalse(advertiseIsolated.snapshot().backendHealthy)
     advertiseIsolated.close()
+    settle(advertiseIsolated)
 
     val schedulingBackend = FakeBackend()
     val schedulingIsolated =
@@ -192,12 +204,15 @@ class NetplayDiscoveryTest {
             id(10),
         )
     schedulingIsolated.enable()
+    settle(schedulingIsolated)
     assertFalse(schedulingIsolated.snapshot().backendHealthy)
     schedulingIsolated.close()
+    settle(schedulingIsolated)
 
     val backend = FakeBackend()
     val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, id(0))
     discovery.enable()
+    settle(discovery)
     val bytes =
         NetplayDiscoveryCodec.encode(
             NetplayDiscoveryAdvertisement(9, id(7), V9LinkMode.NORMAL, 1, true, 7777),
@@ -228,7 +243,48 @@ class NetplayDiscoveryTest {
     scheduler.runDue()
     assertEquals(count, backend.advertisements.size)
     discovery.close()
+    settle(discovery)
     assertEquals(1, backend.closeCount)
+  }
+
+  @Test
+  fun disableAndCloseFenceAStartThatCompletesAfterTheLifecycleChanges() {
+    val clock = MutableClock()
+    val disabledBackend = FakeBackend(blockStart = true)
+    val disabled =
+        TrustedLanNetplayDiscovery(disabledBackend, clock, ManualScheduler(clock), id(40))
+    disabled.enable()
+    assertTrue(disabledBackend.startEntered.await(1, TimeUnit.SECONDS))
+    disabled.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 1))
+    disabled.disable()
+    assertFalse(disabled.snapshot().enabled)
+    assertTrue(disabled.snapshot().hosts.isEmpty())
+    assertTrue(disabledBackend.advertisements.isEmpty())
+    disabledBackend.releaseStart.countDown()
+    settle(disabled)
+    assertFalse(disabled.backendRunningForTest())
+    assertFalse(disabledBackend.running)
+    assertEquals(1, disabledBackend.stopCount)
+    assertTrue(disabledBackend.advertisements.isEmpty())
+    disabled.close()
+    settle(disabled)
+    assertTrue(disabled.awaitLifecycleWorkerStoppedForTest(1, TimeUnit.SECONDS))
+    assertFalse(disabled.lifecycleWorkerAliveForTest())
+
+    val closedBackend = FakeBackend(blockStart = true)
+    val closed = TrustedLanNetplayDiscovery(closedBackend, clock, ManualScheduler(clock), id(41))
+    closed.enable()
+    assertTrue(closedBackend.startEntered.await(1, TimeUnit.SECONDS))
+    closed.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 1))
+    closed.close()
+    closedBackend.releaseStart.countDown()
+    settle(closed)
+    assertFalse(closed.backendRunningForTest())
+    assertFalse(closedBackend.running)
+    assertEquals(1, closedBackend.closeCount)
+    assertTrue(closedBackend.advertisements.isEmpty())
+    assertTrue(closed.awaitLifecycleWorkerStoppedForTest(1, TimeUnit.SECONDS))
+    assertFalse(closed.lifecycleWorkerAliveForTest())
   }
 
   @Test
@@ -272,6 +328,24 @@ class NetplayDiscoveryTest {
         assumeTrue("multicast is unavailable on this host", false)
       }
       assumeTrue("multicast loopback is unavailable on this host", observed.await(2, TimeUnit.SECONDS))
+      sender.advertise(expected)
+      receiver.stop()
+      sender.stop()
+      assertTrue(receiver.awaitWorkersStopped(2, TimeUnit.SECONDS))
+      assertTrue(sender.awaitWorkersStopped(2, TimeUnit.SECONDS))
+      assertEquals(0, receiver.liveWorkerCount())
+      assertEquals(0, sender.liveWorkerCount())
+      assertEquals(0, receiver.queuedAdvertisementCount())
+      assertEquals(0, sender.queuedAdvertisementCount())
+
+      receiver.start {}
+      sender.start {}
+      receiver.stop()
+      sender.stop()
+      assertTrue(receiver.awaitWorkersStopped(2, TimeUnit.SECONDS))
+      assertTrue(sender.awaitWorkersStopped(2, TimeUnit.SECONDS))
+      assertEquals(0, receiver.liveWorkerCount())
+      assertEquals(0, sender.liveWorkerCount())
     } finally {
       receiver.close()
       sender.close()
@@ -283,6 +357,10 @@ class NetplayDiscoveryTest {
       NetplayPublicSessionId(ByteArray(16).also { it[12] = (number ushr 24).toByte();
         it[13] = (number ushr 16).toByte(); it[14] = (number ushr 8).toByte();
         it[15] = number.toByte() })
+
+  private fun settle(discovery: TrustedLanNetplayDiscovery) {
+    assertTrue(discovery.awaitBackendLifecycle(2, TimeUnit.SECONDS))
+  }
 
   private class MutableClock(var now: Long = 0) : V9MonotonicClock {
     override fun nowMillis(): Long = now
@@ -311,25 +389,32 @@ class NetplayDiscoveryTest {
   private class FakeBackend(
       private val failStart: Boolean = false,
       private val failAdvertise: Boolean = false,
+      private val blockStart: Boolean = false,
   ) : NetplayDiscoveryBackend {
-    var receiver: ((NetplayDiscoveryDatagram) -> Unit)? = null
-    val advertisements = mutableListOf<ByteArray>()
+    @Volatile var receiver: ((NetplayDiscoveryDatagram) -> Unit)? = null
+    val advertisements = Collections.synchronizedList(mutableListOf<ByteArray>())
+    val startEntered = CountDownLatch(1)
+    val releaseStart = CountDownLatch(if (blockStart) 1 else 0)
+    @Volatile var running = false
     var stopCount = 0
     var closeCount = 0
     var startCount = 0
     var withdrawCount = 0
     override fun start(receiver: (NetplayDiscoveryDatagram) -> Unit) {
       startCount++
+      startEntered.countDown()
+      releaseStart.await()
       if (failStart) throw IllegalStateException("synthetic backend failure")
       this.receiver = receiver
+      running = true
     }
     override fun advertise(bytes: ByteArray) {
       if (failAdvertise) throw IllegalStateException("synthetic advertise failure")
       advertisements += bytes.copyOf()
     }
     override fun withdraw() { withdrawCount++ }
-    override fun stop() { stopCount++; receiver = null }
-    override fun close() { closeCount++; receiver = null }
+    override fun stop() { stopCount++; running = false; receiver = null }
+    override fun close() { closeCount++; running = false; receiver = null }
     fun emit(bytes: ByteArray, address: String) {
       receiver?.invoke(NetplayDiscoveryDatagram(bytes.copyOf(), InetAddress.getByName(address)))
     }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscoveryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/discovery/NetplayDiscoveryTest.kt
@@ -1,0 +1,353 @@
+package eu.rekawek.coffeegb.controller.network.discovery
+
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
+import eu.rekawek.coffeegb.controller.network.v9.V9DeadlineScheduler
+import eu.rekawek.coffeegb.controller.network.v9.V9FoundationServerStatus
+import eu.rekawek.coffeegb.controller.network.v9.V9FoundationServer
+import eu.rekawek.coffeegb.controller.network.v9.V9InvitationHost
+import eu.rekawek.coffeegb.controller.network.v9.V9LinkMode
+import eu.rekawek.coffeegb.controller.network.v9.V9MonotonicClock
+import java.io.Closeable
+import java.net.InetAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.assertContentEquals
+import org.junit.Test
+import org.junit.Assume.assumeTrue
+
+class NetplayDiscoveryTest {
+
+  @Test
+  fun productionFoundationStatusTracksListenerAndPairableCapacity() {
+    val host = V9InvitationHost(V9LinkMode.NORMAL)
+    val server = V9FoundationServer(invitationHost = host) { it.close() }
+    try {
+      assertFalse(server.statusSource().snapshot().listening)
+      server.start()
+      val listening = server.statusSource().snapshot()
+      assertTrue(listening.listening)
+      assertEquals(server.localPort, listening.port)
+      assertEquals(V9LinkMode.NORMAL, listening.mode)
+      assertEquals(1, listening.openSlots)
+    } finally {
+      server.close()
+      host.close()
+    }
+    val stopped = server.statusSource().snapshot()
+    assertFalse(stopped.listening)
+    assertEquals(0, stopped.openSlots)
+    assertEquals(0, stopped.port)
+  }
+
+  @Test
+  fun codecAndHostGatingExposeOnlyFrozenPublicFields() {
+    val clock = MutableClock()
+    val scheduler = ManualScheduler(clock)
+    val backend = FakeBackend()
+    val localId = id(1)
+    val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, localId)
+    discovery.enable()
+    assertTrue(backend.advertisements.isEmpty())
+
+    discovery.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 0))
+    assertTrue(backend.advertisements.isEmpty())
+    discovery.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 1))
+    val packet = backend.advertisements.single()
+    assertEquals(NetplayDiscoveryCodec.BYTES, packet.size)
+    assertContentEquals(
+        byteArrayOf(
+            0x43, 0x47, 0x42, 0x44, 0x01, 0x09, 0x00, 0x01,
+            0x01, 0x00, 0x22, 0x3d,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ),
+        packet,
+    )
+    val decoded = requireNotNull(NetplayDiscoveryCodec.decode(packet))
+    assertEquals(9, decoded.protocolMajor)
+    assertEquals(localId, decoded.sessionId)
+    assertEquals(V9LinkMode.NORMAL, decoded.mode)
+    assertEquals(1, decoded.openSlots)
+    assertTrue(decoded.pairingRequired)
+    assertEquals(8765, decoded.port)
+    val firstRefreshCount = backend.advertisements.size
+    clock.now = TrustedLanNetplayDiscovery.REFRESH_MILLIS - 1
+    scheduler.runDue()
+    assertEquals(firstRefreshCount, backend.advertisements.size)
+    clock.now++
+    scheduler.runDue()
+    assertEquals(firstRefreshCount + 1, backend.advertisements.size)
+    discovery.updateHost(V9FoundationServerStatus(true, 8765, V9LinkMode.NORMAL, 0))
+    assertTrue(backend.withdrawCount > 0)
+
+    assertEquals(null, NetplayDiscoveryCodec.decode(packet.copyOf(27)))
+    assertEquals(null, NetplayDiscoveryCodec.decode(packet + 0))
+    val badReserved = packet.copyOf().also { it[9] = 1 }
+    assertEquals(null, NetplayDiscoveryCodec.decode(badReserved))
+    discovery.disable()
+    assertEquals(1, backend.stopCount)
+    assertFalse(discovery.snapshot().enabled)
+    discovery.enable()
+    assertEquals(2, backend.startCount)
+    discovery.disable()
+    discovery.close()
+  }
+
+  @Test
+  fun ipv4Ipv6DedupCacheEvictionRefreshAndExactExpiryAreBounded() {
+    val clock = MutableClock()
+    val scheduler = ManualScheduler(clock)
+    val backend = FakeBackend()
+    val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, id(0))
+    discovery.enable()
+    val advertisement =
+        NetplayDiscoveryAdvertisement(9, id(2), V9LinkMode.FOUR_PLAYER, 3, true, 9000)
+    val bytes = NetplayDiscoveryCodec.encode(advertisement)
+    backend.emit(bytes, "192.0.2.10")
+    backend.emit(bytes, "192.0.2.10")
+    backend.emit(bytes, "2001:db8::10")
+    var snapshot = discovery.snapshot()
+    assertEquals(1, snapshot.hosts.size)
+    assertEquals(2, snapshot.hosts.single().numericAddresses.size)
+    @Suppress("UNCHECKED_CAST")
+    assertFailsWith<UnsupportedOperationException> {
+      (snapshot.hosts as MutableList<NetplayDiscoveredHost>).clear()
+    }
+    @Suppress("UNCHECKED_CAST")
+    assertFailsWith<UnsupportedOperationException> {
+      (snapshot.hosts.single().numericAddresses as MutableList<String>).add("192.0.2.99")
+    }
+    assertContentEquals(
+        listOf("192.0.2.10", InetAddress.getByName("2001:db8::10").hostAddress).sorted(),
+        snapshot.hosts.single().numericAddresses,
+    )
+    val addressBound =
+        NetplayDiscoveryAdvertisement(9, id(68), V9LinkMode.NORMAL, 1, true, 9002)
+    repeat(TrustedLanNetplayDiscovery.MAX_ADDRESSES_PER_SERVICE + 1) { index ->
+      backend.emit(NetplayDiscoveryCodec.encode(addressBound), "203.0.113.${index + 1}")
+    }
+    assertEquals(
+        TrustedLanNetplayDiscovery.MAX_ADDRESSES_PER_SERVICE,
+        discovery.snapshot().hosts.single {
+          it.advertisement.sessionId == addressBound.sessionId
+        }.numericAddresses.size,
+    )
+
+    for (index in 3..67) {
+      clock.now++
+      val value =
+          NetplayDiscoveryAdvertisement(9, id(index), V9LinkMode.NORMAL, 1, true, 9001)
+      backend.emit(NetplayDiscoveryCodec.encode(value), "198.51.100.${index % 200 + 1}")
+    }
+    assertEquals(TrustedLanNetplayDiscovery.MAX_SERVICES, discovery.cacheSize())
+    assertEquals(TrustedLanNetplayDiscovery.MAX_SERVICES, discovery.snapshot().hosts.size)
+
+    val mostRecent = discovery.snapshot().hosts.last()
+    val beforeExpiry = mostRecent.lastSeenMillis
+    clock.now = beforeExpiry + TrustedLanNetplayDiscovery.CACHE_EXPIRY_MILLIS - 1
+    discovery.expireNow()
+    assertTrue(discovery.snapshot().hosts.any {
+      it.advertisement.sessionId == mostRecent.advertisement.sessionId
+    })
+    clock.now++
+    discovery.expireNow()
+    assertFalse(discovery.snapshot().hosts.any {
+      it.advertisement.sessionId == mostRecent.advertisement.sessionId
+    })
+    discovery.close()
+    assertFalse(discovery.snapshot().enabled)
+    assertTrue(discovery.snapshot().hosts.isEmpty())
+  }
+
+  @Test
+  fun hostileMetadataFailureIsolationConfirmationAndCleanupStayExplicit() {
+    val clock = MutableClock()
+    val scheduler = ManualScheduler(clock)
+    val failing = FakeBackend(failStart = true)
+    val isolated = TrustedLanNetplayDiscovery(failing, clock, scheduler, id(0))
+    isolated.enable()
+    assertFalse(isolated.snapshot().backendHealthy)
+    // Discovery failure never changes or throws from the direct-listener status update.
+    isolated.updateHost(V9FoundationServerStatus(true, 7777, V9LinkMode.NORMAL, 1))
+    isolated.close()
+
+    val advertiseFailure = FakeBackend(failAdvertise = true)
+    val advertiseIsolated =
+        TrustedLanNetplayDiscovery(advertiseFailure, clock, scheduler, id(8))
+    advertiseIsolated.enable()
+    advertiseIsolated.updateHost(V9FoundationServerStatus(true, 7777, V9LinkMode.NORMAL, 1))
+    assertFalse(advertiseIsolated.snapshot().backendHealthy)
+    advertiseIsolated.close()
+
+    val schedulingBackend = FakeBackend()
+    val schedulingIsolated =
+        TrustedLanNetplayDiscovery(
+            schedulingBackend,
+            clock,
+            FailingScheduler,
+            id(10),
+        )
+    schedulingIsolated.enable()
+    assertFalse(schedulingIsolated.snapshot().backendHealthy)
+    schedulingIsolated.close()
+
+    val backend = FakeBackend()
+    val discovery = TrustedLanNetplayDiscovery(backend, clock, scheduler, id(0))
+    discovery.enable()
+    val bytes =
+        NetplayDiscoveryCodec.encode(
+            NetplayDiscoveryAdvertisement(9, id(7), V9LinkMode.NORMAL, 1, true, 7777),
+        )
+    backend.emit(bytes, "203.0.113.9")
+    val host = discovery.snapshot().hosts.single()
+    assertFailsWith<IllegalArgumentException> { discovery.confirm(host, 0, false) }
+    val selected = discovery.confirm(host, 0, true)
+    assertTrue(selected.requiresAuthenticatedInvitation)
+    assertEquals("203.0.113.9", selected.endpoint.address.hostAddress)
+    assertEquals(7777, selected.endpoint.port)
+    assertFalse(selected.toString().contains("203.0.113.9"))
+    assertFailsWith<IllegalArgumentException> {
+      NetplayDiscoveredHost(host.advertisement, listOf("dead.beef"), host.lastSeenMillis)
+    }
+    val forged =
+        NetplayDiscoveredHost(host.advertisement, listOf("203.0.113.10"), host.lastSeenMillis)
+    assertFailsWith<IllegalArgumentException> { discovery.confirm(forged, 0, true) }
+
+    val source = MutableStatusSource(V9FoundationServerStatus(false, 0, V9LinkMode.NORMAL, 0))
+    val binding = NetplayDiscoveryHostBinding(source, discovery)
+    source.publish(V9FoundationServerStatus(true, 7777, V9LinkMode.NORMAL, 1))
+    assertTrue(backend.advertisements.isNotEmpty())
+    binding.close()
+    val count = backend.advertisements.size
+    source.publish(V9FoundationServerStatus(true, 8888, V9LinkMode.NORMAL, 1))
+    clock.now += TrustedLanNetplayDiscovery.REFRESH_MILLIS
+    scheduler.runDue()
+    assertEquals(count, backend.advertisements.size)
+    discovery.close()
+    assertEquals(1, backend.closeCount)
+  }
+
+  @Test
+  fun malformedMetadataFailsClosedAtEveryDecisiveField() {
+    val valid =
+        NetplayDiscoveryCodec.encode(
+            NetplayDiscoveryAdvertisement(9, id(9), V9LinkMode.NORMAL, 1, true, 8765),
+        )
+    val hostile =
+        listOf(
+            valid.copyOf().also { it[0] = 0 },
+            valid.copyOf().also { it[4] = 2 },
+            valid.copyOf().also { it[5] = 8 },
+            valid.copyOf().also { it[6] = 2 },
+            valid.copyOf().also { it[7] = 0 },
+            valid.copyOf().also { it[7] = 4 },
+            valid.copyOf().also { it[8] = 0 },
+            valid.copyOf().also { it[9] = 1 },
+            valid.copyOf().also { it[10] = 0; it[11] = 0 },
+            valid.copyOf(TrustedLanNetplayDiscovery.MAX_PACKET_BYTES),
+        )
+    hostile.forEach { assertEquals(null, NetplayDiscoveryCodec.decode(it)) }
+    assertEquals(null, NetplayDiscoveryCodec.decode(ByteArray(1_000)))
+  }
+
+  @Test
+  fun realBackendLoopbackSmokeIsBoundedWhereMulticastIsAvailable() {
+    val receiver = V9MulticastDiscoveryBackend()
+    val sender = V9MulticastDiscoveryBackend()
+    val observed = CountDownLatch(1)
+    val expected =
+        NetplayDiscoveryCodec.encode(
+            NetplayDiscoveryAdvertisement(9, id(31), V9LinkMode.NORMAL, 1, true, 8765),
+        )
+    try {
+      try {
+        receiver.start { if (it.bytes.contentEquals(expected)) observed.countDown() }
+        sender.start {}
+        sender.advertise(expected)
+      } catch (_: Exception) {
+        assumeTrue("multicast is unavailable on this host", false)
+      }
+      assumeTrue("multicast loopback is unavailable on this host", observed.await(2, TimeUnit.SECONDS))
+    } finally {
+      receiver.close()
+      sender.close()
+      expected.fill(0)
+    }
+  }
+
+  private fun id(number: Int): NetplayPublicSessionId =
+      NetplayPublicSessionId(ByteArray(16).also { it[12] = (number ushr 24).toByte();
+        it[13] = (number ushr 16).toByte(); it[14] = (number ushr 8).toByte();
+        it[15] = number.toByte() })
+
+  private class MutableClock(var now: Long = 0) : V9MonotonicClock {
+    override fun nowMillis(): Long = now
+  }
+
+  private class ManualScheduler(private val clock: MutableClock) : V9DeadlineScheduler {
+    private val tasks = mutableListOf<Task>()
+    override fun schedule(deadlineMillis: Long, action: Runnable): Closeable {
+      val task = Task(deadlineMillis, action)
+      tasks += task
+      return Closeable { task.cancelled = true }
+    }
+    fun runDue() {
+      val due = tasks.filter { !it.cancelled && it.deadline <= clock.now }.toList()
+      tasks.removeAll(due)
+      due.forEach { it.action.run() }
+    }
+    private data class Task(val deadline: Long, val action: Runnable, var cancelled: Boolean = false)
+  }
+
+  private object FailingScheduler : V9DeadlineScheduler {
+    override fun schedule(deadlineMillis: Long, action: Runnable): Closeable =
+        throw IllegalStateException("synthetic scheduler failure")
+  }
+
+  private class FakeBackend(
+      private val failStart: Boolean = false,
+      private val failAdvertise: Boolean = false,
+  ) : NetplayDiscoveryBackend {
+    var receiver: ((NetplayDiscoveryDatagram) -> Unit)? = null
+    val advertisements = mutableListOf<ByteArray>()
+    var stopCount = 0
+    var closeCount = 0
+    var startCount = 0
+    var withdrawCount = 0
+    override fun start(receiver: (NetplayDiscoveryDatagram) -> Unit) {
+      startCount++
+      if (failStart) throw IllegalStateException("synthetic backend failure")
+      this.receiver = receiver
+    }
+    override fun advertise(bytes: ByteArray) {
+      if (failAdvertise) throw IllegalStateException("synthetic advertise failure")
+      advertisements += bytes.copyOf()
+    }
+    override fun withdraw() { withdrawCount++ }
+    override fun stop() { stopCount++; receiver = null }
+    override fun close() { closeCount++; receiver = null }
+    fun emit(bytes: ByteArray, address: String) {
+      receiver?.invoke(NetplayDiscoveryDatagram(bytes.copyOf(), InetAddress.getByName(address)))
+    }
+  }
+
+  private class MutableStatusSource(initial: V9FoundationServerStatus) :
+      NetplaySnapshotSource<V9FoundationServerStatus> {
+    private var value = initial
+    private val listeners = mutableListOf<NetplaySnapshotListener<V9FoundationServerStatus>>()
+    override fun snapshot(): V9FoundationServerStatus = value
+    override fun addListener(listener: NetplaySnapshotListener<V9FoundationServerStatus>): Closeable {
+      listeners += listener
+      listener.onSnapshot(value)
+      return Closeable { listeners.remove(listener) }
+    }
+    fun publish(next: V9FoundationServerStatus) {
+      value = next
+      listeners.toList().forEach { it.onSnapshot(next) }
+    }
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9DiagnosticsTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9DiagnosticsTest.kt
@@ -1,0 +1,217 @@
+package eu.rekawek.coffeegb.controller.network.v9
+
+import java.net.InetSocketAddress
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ProtocolV9DiagnosticsTest {
+
+  @Test
+  fun diagnosticsOptionIsTheOnlyWayFoundationAdvertisesPing() {
+    val accepted = ArrayBlockingQueue<V9FoundationConnection>(1)
+    val server =
+        V9FoundationServer(optionalCapabilities = setOf(V9Capability.PING_V1)) {
+          accepted.offer(it)
+        }
+    var client: V9FoundationConnection? = null
+    try {
+      server.start()
+      client =
+          V9FoundationClient.connect(
+              InetSocketAddress("127.0.0.1", server.localPort),
+              optionalCapabilities = setOf(V9Capability.PING_V1),
+          )
+      client.awaitPairingBoundary(3, TimeUnit.SECONDS)
+      val serverConnection = assertNotNull(accepted.poll(3, TimeUnit.SECONDS))
+      assertFalse(V9Capability.PING_V1 in client.negotiatedCapabilities())
+      assertFalse(V9Capability.PING_V1 in serverConnection.negotiatedCapabilities())
+      assertNull(client.transportMetricsSource())
+      assertNull(serverConnection.transportMetricsSource())
+    } finally {
+      client?.close()
+      server.close()
+    }
+  }
+
+  @Test
+  fun pingCodecAndIncrementalFrameHonorFrozenWireContract() {
+    val value = V9PingPayload(0x0102030405060708L, Long.MIN_VALUE)
+    val payload = V9PingCodec.encode(value)
+    assertEquals(16, payload.size)
+    assertEquals(value, V9PingCodec.decode(payload))
+    for (length in 0 until V9PingCodec.PAYLOAD_BYTES) {
+      val failure = runCatching { V9PingCodec.decode(payload.copyOf(length)) }.exceptionOrNull()
+      assertTrue(failure is V9ProtocolException)
+      assertEquals(V9ErrorCode.LIMIT_EXCEEDED, failure.reason)
+    }
+    val oversized = runCatching { V9PingCodec.decode(payload + 0) }.exceptionOrNull()
+    assertTrue(oversized is V9ProtocolException)
+    assertEquals(V9ErrorCode.LIMIT_EXCEEDED, oversized.reason)
+
+    val policy =
+        V9DecoderPolicy(
+            allowedMessages = setOf(V9MessageType.PING, V9MessageType.PONG),
+            negotiatedCapabilities = setOf(V9Capability.PING_V1),
+        )
+    val frame =
+        V9FrameEncoder.encode(
+            V9OutboundFrame(V9MessageType.PING, 0, 0, 0, 0, payload),
+            policy,
+        )
+    val decoder = V9IncrementalDecoder(policy = policy)
+    for (index in frame.indices) {
+      val result = decoder.feedOne(frame, index, 1)
+      if (index < frame.lastIndex) {
+        assertTrue(result.frames.isEmpty())
+        assertNull(result.failure)
+      } else {
+        assertEquals(V9MessageType.PING, result.frames.single().header.type)
+        result.frames.single().use { assertEquals(value, V9PingCodec.decode(it.payloadView())) }
+      }
+    }
+
+    val malformedPong = frame.copyOf()
+    malformedPong[8] = 0
+    malformedPong[9] = V9MessageType.PONG.wireId.toByte()
+    // PONG without RESPONSE is rejected at the decisive flags field before payload allocation.
+    val rejected = V9IncrementalDecoder(policy = policy).feed(malformedPong)
+    assertEquals(V9ErrorCode.UNKNOWN_REQUIRED_FLAG, rejected.failure?.reason)
+  }
+
+  @Test
+  fun rttMathPendingBoundsExpiryAndPeerStampIsolationAreExact() {
+    val clock = MutableClock()
+    val metrics = V9TransportMetrics(clock, V9Role.CLIENT, V9LinkMode.NORMAL, null)
+    val first = V9PingPayload(11, Long.MAX_VALUE)
+    assertTrue(metrics.registerPing(1, first))
+    clock.now = 10
+    assertNull(metrics.acceptPong(1, first))
+    assertEquals(10_000, metrics.snapshot().currentRttMicros)
+    assertEquals(V9ErrorCode.CORRELATION_ERROR, metrics.acceptPong(1, first))
+
+    val second = V9PingPayload(12, Long.MIN_VALUE)
+    assertTrue(metrics.registerPing(2, second))
+    clock.now = 30
+    assertNull(metrics.acceptPong(2, second))
+    val snapshot = metrics.snapshot()
+    assertEquals(20_000, snapshot.currentRttMicros)
+    assertEquals(11_250, snapshot.ewmaRttMicros)
+    assertEquals(10_000, snapshot.recentMinimumRttMicros)
+    assertEquals(20_000, snapshot.recentMaximumRttMicros)
+    assertEquals(625, snapshot.jitterMicros)
+    assertEquals(2, metrics.retainedRttSampleCount())
+
+    assertTrue(metrics.registerPing(3, V9PingPayload(3, 3)))
+    assertEquals(50, metrics.nextExpiryDeadline(20))
+    assertEquals(V9ErrorCode.CORRELATION_ERROR, metrics.acceptPong(99, V9PingPayload(3, 3)))
+    assertEquals(V9ErrorCode.CORRELATION_ERROR, metrics.acceptPong(3, V9PingPayload(4, 3)))
+    assertEquals(1, metrics.pendingCount())
+    assertFalse(metrics.registerPing(4, V9PingPayload(4, 0)))
+    clock.now = 49
+    assertTrue(metrics.expirePings(20).isEmpty())
+    clock.now = 50
+    assertEquals(listOf(3L), metrics.expirePings(20))
+    assertEquals(V9ErrorCode.CORRELATION_ERROR,
+        metrics.acceptPong(3, V9PingPayload(3, 3)))
+    assertEquals(0, metrics.pendingCount())
+    assertEquals(1, metrics.snapshot().timedOutPings)
+    metrics.close()
+    assertFalse(metrics.registerPing(9, V9PingPayload(9, 0)))
+    assertEquals(V9ErrorCode.CORRELATION_ERROR,
+        metrics.acceptPong(9, V9PingPayload(9, 0)))
+  }
+
+  @Test
+  fun transportCountersFramesListenersAndOverflowRemainBounded() {
+    val clock = MutableClock(100)
+    val metrics =
+        V9TransportMetrics(
+            clock,
+            V9Role.SERVER,
+            V9LinkMode.FOUR_PLAYER,
+            V9DiagnosticEndpoint("2001:db8::1", 8765),
+        )
+    val callbacks = AtomicInteger()
+    val subscription = metrics.addListener { callbacks.incrementAndGet() }
+    assertEquals(1, metrics.listenerCountForTest())
+    metrics.recordRead(17)
+    metrics.recordWrite(19)
+    metrics.recordLocalFrame(40)
+    metrics.recordLocalFrame(39)
+    metrics.recordRemoteInput(37)
+    clock.now = 106
+    metrics.recordRemoteFrame(38)
+    var value = metrics.snapshot()
+    assertEquals(17, value.bytesReceived)
+    assertEquals(19, value.bytesSent)
+    assertEquals(40, value.localFrame)
+    assertEquals(38, value.remoteFrame)
+    assertEquals(6, value.newestRemoteInputAgeMillis)
+    assertEquals(6, value.connectionDurationMillis)
+
+    metrics.seedCountersForTest(Long.MAX_VALUE - 1, Long.MAX_VALUE - 2, Long.MAX_VALUE - 1)
+    metrics.recordWrite(Int.MAX_VALUE)
+    metrics.recordRead(Int.MAX_VALUE)
+    clock.now = 20_106
+    assertTrue(metrics.registerPing(1, V9PingPayload(1, 0)))
+    clock.now = 20_107
+    metrics.expirePings(1)
+    value = metrics.snapshot()
+    assertEquals(Long.MAX_VALUE, value.bytesSent)
+    assertEquals(Long.MAX_VALUE, value.bytesReceived)
+    assertEquals(Long.MAX_VALUE, value.timedOutPings)
+    subscription.close()
+    assertEquals(0, metrics.listenerCountForTest())
+    metrics.close()
+    assertEquals(0, metrics.pendingCount())
+
+    val wrappingClock = MutableClock(Long.MIN_VALUE)
+    val wrapping = V9TransportMetrics(
+        wrappingClock, V9Role.CLIENT, V9LinkMode.NORMAL, null,
+    )
+    wrapping.recordRemoteInput(1)
+    wrappingClock.now = Long.MAX_VALUE
+    assertEquals(Long.MAX_VALUE, wrapping.snapshot().connectionDurationMillis)
+    assertEquals(Long.MAX_VALUE, wrapping.snapshot().newestRemoteInputAgeMillis)
+    wrapping.close()
+  }
+
+  @Test
+  fun slowObserverCannotBlockMetricProducer() {
+    val metrics = V9TransportMetrics(MutableClock(), V9Role.CLIENT, V9LinkMode.NORMAL, null)
+    val observerEntered = CountDownLatch(1)
+    val releaseObserver = CountDownLatch(1)
+    val subscription = metrics.addListener {
+      observerEntered.countDown()
+      releaseObserver.await()
+    }
+    assertTrue(observerEntered.await(1, TimeUnit.SECONDS))
+    val producerReturned = CountDownLatch(1)
+    val producer = Thread {
+      metrics.recordWrite(1)
+      producerReturned.countDown()
+    }
+    producer.start()
+    try {
+      assertTrue(producerReturned.await(1, TimeUnit.SECONDS))
+    } finally {
+      releaseObserver.countDown()
+      producer.join(1_000)
+      subscription.close()
+      metrics.close()
+    }
+    assertFalse(producer.isAlive)
+  }
+
+  private class MutableClock(var now: Long = 0) : V9MonotonicClock {
+    override fun nowMillis(): Long = now
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransportTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransportTest.kt
@@ -32,6 +32,7 @@ import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.memory.cart.Rom
+import java.io.Closeable
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -40,6 +41,7 @@ import java.nio.ByteOrder
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -683,6 +685,162 @@ class ProtocolV9StateTransportTest {
     } finally {
       grant.close()
       fixture.close()
+    }
+  }
+
+  @Test
+  fun foundationPingSchedulerNegotiationCadencePendingBoundAndLivenessAreExact() {
+    diagnosticPair(serverDiagnostics = true, clientDiagnostics = false).use { disabled ->
+      assertFalse(V9Capability.PING_V1 in disabled.server.negotiatedCapabilities())
+      assertFalse(V9Capability.PING_V1 in disabled.client.negotiatedCapabilities())
+      assertNotNull(disabled.server.transportMetricsSource())
+      assertNull(disabled.client.transportMetricsSource())
+      assertEquals(listOf(30_000L), disabled.serverScheduler.activeDeadlines())
+      assertEquals(listOf(30_000L), disabled.clientScheduler.activeDeadlines())
+      disabled.serverScheduler.runAt(1_000)
+      assertEquals(0, disabled.serverChannel.messageCount(V9MessageType.PING))
+      assertEquals(0, disabled.clientChannel.messageCount(V9MessageType.PING))
+      assertEquals(V9LifecycleState.ACTIVE, disabled.server.snapshot().state)
+    }
+
+    val timed = diagnosticPair(serverDiagnostics = true, clientDiagnostics = true)
+    val metrics = assertNotNull(timed.server.transportMetricsSource()) as V9TransportMetrics
+    val callbacks = AtomicInteger()
+    val subscription = metrics.addListener { callbacks.incrementAndGet() }
+    try {
+      assertTrue(V9Capability.PING_V1 in timed.server.negotiatedCapabilities())
+      assertTrue(V9Capability.PING_V1 in timed.client.negotiatedCapabilities())
+      assertTrue(timed.serverScheduler.activeDeadlines().contains(1_000L))
+      timed.clientChannel.blockWrites()
+      timed.serverScheduler.runAt(1_000)
+      assertTrue(timed.clientChannel.awaitBlockedWrite(1, TimeUnit.SECONDS))
+      waitUntil { timed.serverChannel.messageCount(V9MessageType.PING) == 1 }
+      val firstPing = timed.serverChannel.lastMessage(V9MessageType.PING)
+      assertEquals(ProtocolV9.HEADER_BYTES + V9PingCodec.PAYLOAD_BYTES, firstPing.size)
+      val firstHeader = ByteBuffer.wrap(firstPing).order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0, firstHeader.getShort(10).toInt())
+      assertEquals(V9PingCodec.PAYLOAD_BYTES, firstHeader.getInt(20))
+      assertEquals(V9PingCodec.PAYLOAD_BYTES, firstHeader.getInt(24))
+      assertEquals(ProtocolV9.CONTROL_CHANNEL.toInt(), firstHeader.getInt(28))
+      firstPing.fill(0)
+      assertEquals(1, metrics.pendingCount())
+      assertEquals(1, metrics.snapshot().unansweredPings)
+
+      timed.serverScheduler.runAt(2_000)
+      timed.serverScheduler.runAt(3_000)
+      timed.serverScheduler.runAt(3_999)
+      assertEquals(1, timed.serverChannel.messageCount(V9MessageType.PING))
+      assertEquals(0, metrics.snapshot().timedOutPings)
+      assertEquals(V9LifecycleState.ACTIVE, timed.server.snapshot().state)
+
+      timed.serverScheduler.runAt(4_000)
+      waitUntil { timed.serverChannel.messageCount(V9MessageType.PING) == 2 }
+      assertEquals(1, metrics.snapshot().timedOutPings)
+      assertEquals(1, metrics.pendingCount())
+      timed.serverScheduler.runAt(5_000)
+      timed.serverScheduler.runAt(6_000)
+      timed.serverScheduler.runAt(6_999)
+      assertEquals(V9LifecycleState.ACTIVE, timed.server.snapshot().state)
+      timed.serverScheduler.runAt(7_000)
+      assertEquals(V9LifecycleState.CLOSED, timed.server.snapshot().state)
+      assertEquals(V9ErrorCode.TIMEOUT, timed.server.snapshot().failure?.reason)
+      assertEquals(2, metrics.snapshot().timedOutPings)
+      assertEquals(0, metrics.pendingCount())
+    } finally {
+      timed.close()
+    }
+    assertEquals(0, timed.serverScheduler.activeTaskCount())
+    assertEquals(0, timed.clientScheduler.activeTaskCount())
+    assertEquals(0, metrics.pendingCount())
+    assertEquals(0, metrics.listenerCountForTest())
+    subscription.close()
+  }
+
+  @Test
+  fun validPongResetsFoundationTimeoutProgressionAndCloseCancelsPingOwnership() {
+    val pair = diagnosticPair(serverDiagnostics = true, clientDiagnostics = true)
+    val metrics = assertNotNull(pair.server.transportMetricsSource()) as V9TransportMetrics
+    try {
+      pair.server.seedConsecutivePingTimeoutsForTest(1)
+      pair.serverScheduler.runAt(1_000)
+      waitUntil { metrics.pendingCount() == 0 && metrics.snapshot().currentRttMicros != null }
+      assertEquals(V9LifecycleState.ACTIVE, pair.server.snapshot().state)
+
+      pair.clientChannel.blockWrites()
+      pair.serverScheduler.runAt(2_000)
+      assertTrue(pair.clientChannel.awaitBlockedWrite(1, TimeUnit.SECONDS))
+      pair.serverScheduler.runAt(3_000)
+      pair.serverScheduler.runAt(4_000)
+      pair.serverScheduler.runAt(4_999)
+      assertEquals(V9LifecycleState.ACTIVE, pair.server.snapshot().state)
+      pair.serverScheduler.runAt(5_000)
+      // The valid PONG reset the consecutive counter: this is the first new missed probe.
+      assertEquals(V9LifecycleState.ACTIVE, pair.server.snapshot().state)
+      assertEquals(1, metrics.snapshot().timedOutPings)
+      assertEquals(1, metrics.pendingCount())
+    } finally {
+      pair.close()
+    }
+    assertEquals(0, pair.serverScheduler.activeTaskCount())
+    assertEquals(0, pair.clientScheduler.activeTaskCount())
+    assertEquals(0, metrics.pendingCount())
+  }
+
+  @Test
+  fun liveFoundationRejectsLateDuplicateWrongCorrelationAndWrongNoncePongs() {
+    fun rejected(
+        expected: V9ErrorCode,
+        prepare: (DiagnosticConnectionPair) -> ByteArray,
+    ) {
+      diagnosticPair(serverDiagnostics = true, clientDiagnostics = true).use { pair ->
+        val hostile = prepare(pair)
+        pair.clientChannel.injectToPeer(hostile)
+        hostile.fill(0)
+        waitUntil { pair.server.snapshot().failure != null }
+        assertEquals(expected, pair.server.snapshot().failure?.reason)
+      }
+    }
+
+    rejected(V9ErrorCode.CORRELATION_ERROR) { pair ->
+      pair.clientChannel.blockWrites()
+      pair.serverScheduler.runAt(1_000)
+      assertTrue(pair.clientChannel.awaitBlockedWrite(1, TimeUnit.SECONDS))
+      val pong = pair.clientChannel.lastMessage(V9MessageType.PONG)
+      pair.clientChannel.discardBlockedWrite(keepBlocking = false)
+      ByteBuffer.wrap(pong).order(ByteOrder.BIG_ENDIAN).putInt(16, 0x7fffffff)
+      pong
+    }
+
+    rejected(V9ErrorCode.CORRELATION_ERROR) { pair ->
+      pair.clientChannel.blockWrites()
+      pair.serverScheduler.runAt(1_000)
+      assertTrue(pair.clientChannel.awaitBlockedWrite(1, TimeUnit.SECONDS))
+      val pong = pair.clientChannel.lastMessage(V9MessageType.PONG)
+      pair.clientChannel.discardBlockedWrite(keepBlocking = false)
+      pong[ProtocolV9.HEADER_BYTES] = (pong[ProtocolV9.HEADER_BYTES].toInt() xor 1).toByte()
+      val digest = MessageDigest.getInstance("SHA-256")
+          .digest(pong.copyOfRange(ProtocolV9.HEADER_BYTES, pong.size))
+      System.arraycopy(digest, 0, pong, 32, digest.size)
+      digest.fill(0)
+      pong
+    }
+
+    rejected(V9ErrorCode.CORRELATION_ERROR) { pair ->
+      pair.clientChannel.blockWrites()
+      pair.serverScheduler.runAt(1_000)
+      assertTrue(pair.clientChannel.awaitBlockedWrite(1, TimeUnit.SECONDS))
+      val late = pair.clientChannel.lastMessage(V9MessageType.PONG)
+      pair.serverScheduler.runAt(2_000)
+      pair.serverScheduler.runAt(3_000)
+      pair.serverScheduler.runAt(4_000)
+      late
+    }
+
+    rejected(V9ErrorCode.SEQUENCE_ERROR) { pair ->
+      pair.serverScheduler.runAt(1_000)
+      val metrics = assertNotNull(pair.server.transportMetricsSource())
+      waitUntil { metrics.snapshot().currentRttMicros != null }
+      pair.clientChannel.lastMessage(V9MessageType.PONG)
     }
   }
 
@@ -2699,6 +2857,263 @@ class ProtocolV9StateTransportTest {
     override fun close() {
       controller.closeWithState()
       Files.deleteIfExists(romPath)
+    }
+  }
+
+  private fun diagnosticPair(
+      serverDiagnostics: Boolean,
+      clientDiagnostics: Boolean,
+  ): DiagnosticConnectionPair {
+    val fixture = stateFixture()
+    val manifests = manifestPair(fixture.identity)
+    val host = V9InvitationHost(V9LinkMode.NORMAL)
+    val channels = DiagnosticMemoryChannel.pair()
+    val clock = MutableClock()
+    val serverScheduler = DiagnosticManualScheduler(clock)
+    val clientScheduler = DiagnosticManualScheduler(clock)
+    val serverTarget = target(fixture.identities, AtomicReference(), LinkedBlockingQueue())
+    val clientTarget = target(fixture.identities, AtomicReference(), LinkedBlockingQueue())
+    val serverGeneration = serverTarget.captureGeneration()
+    val serverPlan =
+        V9GuestPlayPlan(
+            serverTarget,
+            serverTarget,
+            provider(serverGeneration) { fixture.v2.copyOf() },
+            V9CheckpointKind.MACHINE,
+            0,
+            V9SessionIdSource { 0x0102030405060708L },
+        )
+    val clientPlan =
+        V9GuestPlayPlan(
+            clientTarget,
+            clientTarget,
+            initialKind = V9CheckpointKind.MACHINE,
+            initialOwnerPlayer = 0,
+        )
+    val invitation =
+        host.createInvitation("127.0.0.1", 8765, 1).forClientAuthentication()
+    val options = { enabled: Boolean ->
+      V9DiagnosticsOptions(enabled = enabled, pingCadenceMillis = 1_000,
+          pingTimeoutMillis = 3_000)
+    }
+    val server =
+        V9FoundationConnection(
+            channels.first,
+            V9Role.SERVER,
+            V9LinkMode.NORMAL,
+            clock = clock,
+            scheduler = serverScheduler,
+            invitationHost = host,
+            manifestPlan = V9ManifestPlan.server(V9LinkMode.NORMAL, mapOf(1 to manifests.server)),
+            part3Plan = V9Part3Plan.server(V9LinkMode.NORMAL, mapOf(1 to part3Guest())),
+            playPlan = V9PlayPlan.server(V9LinkMode.NORMAL, mapOf(1 to serverPlan)),
+            diagnosticsOptions = options(serverDiagnostics),
+        )
+    val client =
+        V9FoundationConnection(
+            channels.second,
+            V9Role.CLIENT,
+            V9LinkMode.NORMAL,
+            clock = clock,
+            scheduler = clientScheduler,
+            clientInvitation = invitation,
+            manifestPlan = V9ManifestPlan.client(V9LinkMode.NORMAL, 1, manifests.client),
+            part3Plan = V9Part3Plan.client(V9LinkMode.NORMAL, 1, part3Guest()),
+            playPlan = V9PlayPlan.client(V9LinkMode.NORMAL, 1, clientPlan),
+            diagnosticsOptions = options(clientDiagnostics),
+        )
+    val result =
+        DiagnosticConnectionPair(
+            fixture,
+            host,
+            channels.first,
+            channels.second,
+            clock,
+            serverScheduler,
+            clientScheduler,
+            server,
+            client,
+        )
+    try {
+      server.start()
+      client.start()
+      assertNotNull(server.awaitManifestBoundary(5, TimeUnit.SECONDS))
+      assertNotNull(client.awaitManifestBoundary(5, TimeUnit.SECONDS))
+      server.submitConsent(41, V9ConsentDecision.APPROVE)
+      client.submitConsent(41, V9ConsentDecision.APPROVE)
+      assertNotNull(server.awaitActiveBoundary(5, TimeUnit.SECONDS))
+      assertNotNull(client.awaitActiveBoundary(5, TimeUnit.SECONDS))
+      assertEquals(V9LifecycleState.ACTIVE, server.snapshot().state)
+      assertEquals(V9LifecycleState.ACTIVE, client.snapshot().state)
+      return result
+    } catch (failure: Throwable) {
+      result.close()
+      throw failure
+    }
+  }
+
+  private data class DiagnosticConnectionPair(
+      val fixture: StateFixture,
+      val host: V9InvitationHost,
+      val serverChannel: DiagnosticMemoryChannel,
+      val clientChannel: DiagnosticMemoryChannel,
+      val clock: MutableClock,
+      val serverScheduler: DiagnosticManualScheduler,
+      val clientScheduler: DiagnosticManualScheduler,
+      val server: V9FoundationConnection,
+      val client: V9FoundationConnection,
+  ) : Closeable {
+    override fun close() {
+      server.close()
+      client.close()
+      host.close()
+      fixture.close()
+    }
+  }
+
+  private class DiagnosticManualScheduler(private val clock: MutableClock) :
+      V9DeadlineScheduler {
+    private val tasks = mutableListOf<Task>()
+
+    @Synchronized
+    override fun schedule(deadlineMillis: Long, action: Runnable): Closeable {
+      val task = Task(deadlineMillis, action)
+      tasks += task
+      return Closeable { task.active.set(false) }
+    }
+
+    fun runAt(now: Long) {
+      require(now >= clock.now)
+      clock.now = now
+      while (true) {
+        val task = synchronized(this) {
+          tasks.firstOrNull { it.active.get() && it.deadline <= clock.now }
+        } ?: return
+        if (task.active.compareAndSet(true, false)) task.action.run()
+      }
+    }
+
+    @Synchronized
+    fun activeDeadlines(): List<Long> =
+        tasks.filter { it.active.get() }.map(Task::deadline).sorted()
+
+    @Synchronized
+    fun activeTaskCount(): Int = tasks.count { it.active.get() }
+
+    private data class Task(
+        val deadline: Long,
+        val action: Runnable,
+        val active: AtomicBoolean = AtomicBoolean(true),
+    )
+  }
+
+  private class DiagnosticMemoryChannel : V9TransportChannel {
+    private val incoming = LinkedBlockingQueue<Int>()
+    private val writes = Collections.synchronizedList(mutableListOf<ByteArray>())
+    private val gateDecisions = LinkedBlockingQueue<Boolean>()
+    private val closed = AtomicBoolean(false)
+    private val blockedWrites = AtomicInteger()
+    private val completedBlocked = AtomicInteger()
+    @Volatile private var blocking = false
+    @Volatile private var blocked = CountDownLatch(0)
+    private lateinit var peer: DiagnosticMemoryChannel
+
+    fun blockWrites() {
+      blocked = CountDownLatch(1)
+      blocking = true
+    }
+
+    fun awaitBlockedWrite(timeout: Long, unit: TimeUnit): Boolean = blocked.await(timeout, unit)
+
+    fun blockedWriteCount(): Int = blockedWrites.get()
+
+    fun completedBlockedWrites(): Int = completedBlocked.get()
+
+    fun discardBlockedWrite(keepBlocking: Boolean) {
+      blocking = keepBlocking
+      gateDecisions.offer(false)
+    }
+
+    fun injectToPeer(bytes: ByteArray) {
+      bytes.forEach { peer.incoming.put(it.toInt() and 0xff) }
+    }
+
+    fun messageCount(type: V9MessageType): Int = synchronized(writes) {
+      writes.count { messageType(it) == type }
+    }
+
+    fun lastMessage(type: V9MessageType): ByteArray = synchronized(writes) {
+      requireNotNull(writes.lastOrNull { messageType(it) == type }).copyOf()
+    }
+
+    override fun read(bytes: ByteArray, offset: Int, length: Int): Int {
+      val first = incoming.take()
+      if (first < 0) return -1
+      bytes[offset] = first.toByte()
+      var count = 1
+      while (count < length) {
+        val next = incoming.poll() ?: break
+        if (next < 0) {
+          incoming.offer(next)
+          break
+        }
+        bytes[offset + count++] = next.toByte()
+      }
+      return count
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int): Int {
+      if (closed.get()) throw IOException("closed")
+      val owned = bytes.copyOfRange(offset, offset + length)
+      writes += owned
+      if (blocking) {
+        blockedWrites.incrementAndGet()
+        blocked.countDown()
+        val deliver = try {
+          gateDecisions.take()
+        } catch (interrupted: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw IOException("diagnostic write gate was cancelled", interrupted)
+        } finally {
+          completedBlocked.incrementAndGet()
+        }
+        if (!deliver) return length
+      }
+      injectToPeer(owned)
+      return length
+    }
+
+    override fun shutdownOutput() {
+      peer.incoming.offer(-1)
+    }
+
+    override fun close() {
+      if (!closed.compareAndSet(false, true)) return
+      blocking = false
+      repeat(4) { gateDecisions.offer(false) }
+      incoming.offer(-1)
+      if (::peer.isInitialized) peer.incoming.offer(-1)
+      synchronized(writes) {
+        writes.forEach { it.fill(0) }
+        writes.clear()
+      }
+    }
+
+    private fun messageType(bytes: ByteArray): V9MessageType? {
+      if (bytes.size < ProtocolV9.HEADER_BYTES ||
+          !bytes.copyOfRange(0, 4).contentEquals(ProtocolV9.MAGIC)) return null
+      val id = ((bytes[8].toInt() and 0xff) shl 8) or (bytes[9].toInt() and 0xff)
+      return V9MessageType.fromWireId(id)
+    }
+
+    companion object {
+      fun pair(): Pair<DiagnosticMemoryChannel, DiagnosticMemoryChannel> {
+        val first = DiagnosticMemoryChannel()
+        val second = DiagnosticMemoryChannel()
+        first.peer = second
+        second.peer = first
+        return first to second
+      }
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransportTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/v9/ProtocolV9StateTransportTest.kt
@@ -724,6 +724,9 @@ class ProtocolV9StateTransportTest {
             manifestPlan = V9ManifestPlan.server(V9LinkMode.NORMAL, mapOf(1 to pair.server)),
             part3Plan = V9Part3Plan.server(V9LinkMode.NORMAL, mapOf(1 to part3Guest())),
             playPlan = V9PlayPlan.server(V9LinkMode.NORMAL, mapOf(1 to serverPlay)),
+            diagnosticsOptions =
+                V9DiagnosticsOptions(enabled = true, pingCadenceMillis = 1_000,
+                    pingTimeoutMillis = 2_000),
         ) { accepted.put(it) }
     var client: V9FoundationConnection? = null
     try {
@@ -738,6 +741,9 @@ class ProtocolV9StateTransportTest {
               manifestPlan = V9ManifestPlan.client(V9LinkMode.NORMAL, 1, pair.client),
               part3Plan = V9Part3Plan.client(V9LinkMode.NORMAL, 1, part3Guest()),
               playPlan = V9PlayPlan.client(V9LinkMode.NORMAL, 1, clientPlay),
+              diagnosticsOptions =
+                  V9DiagnosticsOptions(enabled = true, pingCadenceMillis = 1_000,
+                      pingTimeoutMillis = 2_000),
           )
       val serverConnection = assertNotNull(accepted.poll(5, TimeUnit.SECONDS))
       assertNotNull(serverConnection.awaitManifestBoundary(5, TimeUnit.SECONDS))
@@ -751,6 +757,30 @@ class ProtocolV9StateTransportTest {
       assertEquals(serverActive.sessionId, clientActive.sessionId)
       assertEquals(V9LifecycleState.ACTIVE, serverConnection.snapshot().state)
       assertEquals(V9LifecycleState.ACTIVE, client.snapshot().state)
+      assertTrue(V9Capability.PING_V1 in serverConnection.negotiatedCapabilities())
+      assertTrue(V9Capability.PING_V1 in client.negotiatedCapabilities())
+      val serverPingObserved = CountDownLatch(1)
+      val clientPingObserved = CountDownLatch(1)
+      val serverMetrics = assertNotNull(serverConnection.transportMetricsSource())
+      val clientMetrics = assertNotNull(client.transportMetricsSource())
+      val serverSubscription = serverMetrics.addListener {
+        if (it.currentRttMicros != null) serverPingObserved.countDown()
+      }
+      val clientSubscription = clientMetrics.addListener {
+        if (it.currentRttMicros != null) clientPingObserved.countDown()
+      }
+      assertTrue(serverPingObserved.await(5, TimeUnit.SECONDS))
+      assertTrue(clientPingObserved.await(5, TimeUnit.SECONDS))
+      serverSubscription.close()
+      clientSubscription.close()
+      assertEquals(0, serverMetrics.snapshot().unansweredPings)
+      assertEquals(0, clientMetrics.snapshot().unansweredPings)
+      assertEquals(9, serverMetrics.snapshot().localFrame)
+      assertEquals(9, serverMetrics.snapshot().remoteFrame)
+      assertEquals(9, clientMetrics.snapshot().localFrame)
+      assertEquals(9, clientMetrics.snapshot().remoteFrame)
+      assertTrue(requireNotNull(serverMetrics.snapshot().currentRttMicros) >= 0)
+      assertTrue(requireNotNull(clientMetrics.snapshot().currentRttMicros) >= 0)
       val applied = assertNotNull(clientApplied.get())
       assertContentEquals(
           MessageDigest.getInstance("SHA-256").digest(fixture.v2),

--- a/docs/netplay-protocol-v9.md
+++ b/docs/netplay-protocol-v9.md
@@ -293,8 +293,13 @@ most 256 runtime values and one worker. The controller safe-point callback perfo
 non-blocking offer; sequence assignment, writer-queue admission, and socket writes happen on that
 worker. A full handoff fails only that destination with `QUEUE_OVERFLOW`, and connection close
 clears the handoff and interrupts its worker.
-PING/PONG are opaque nonce u64 and diagnostic monotonic-microsecond
-stamp u64; the stamp never drives emulation.
+PING/PONG are opaque nonce u64 and diagnostic monotonic-microsecond stamp u64; the stamp never
+drives emulation. Production PING is opt-in, requires negotiated capability 12, and is legal only
+in ACTIVE. Default local cadence is 10,000 ms, unanswered timeout is 20,000 ms, pending requests
+are capped at one per direction, and RTT history is capped at 32. PONG echoes the complete PING
+payload and correlates exactly once to its request. RTT/EWMA/jitter and all liveness decisions use
+only the receiver's injected monotonic clock; late, duplicate, unsolicited, wrong-nonce, or
+wrong-correlation PONG fails closed. A full pending set skips another probe rather than allocating.
 
 CHECKPOINT is checkpoint kind u8 (`0` initial MACHINE, `1` normal SESSION, `2` four-player
 LINKED_SESSION), player mask u8, owner player u8, zero u8, frame u64, StateFile byte length u32,
@@ -514,9 +519,22 @@ coffeegb://HOST:PORT/join?v=9&mode=MODE&slot=SLOT&exp=EXP&token=TOKEN
 - Parsing is strict: a noncanonical spelling is rejected, never normalized. Rendering always emits
   this form. `invitation-vectors.tsv` freezes success and typed failure behavior.
 
-V9 has no tokenless/manual-address authentication path. Adding nonce comparison, discovery, or a
-different invitation mechanism requires a separately reviewed capability and threat-model change;
-it cannot bypass AUTH/MANIFEST/CONSENT in this wire generation.
+V9 has no tokenless/manual-address authentication path. #350's separately reviewed trusted-LAN
+discovery advertises only an untrusted numeric endpoint and the fixed public fields below; it
+cannot bypass AUTH/MANIFEST/CONSENT. Adding nonce comparison or a different invitation mechanism
+still requires a separately reviewed capability and threat-model change.
+
+### Trusted-LAN address advertisement (not a CGB9 session frame)
+
+The optional discovery datagram is exactly 28 bytes, big-endian, and is parsed as untrusted input
+before cache mutation: `0..3="CGBD"`, `4=schema 1`, `5=protocol major 9`, `6=mode` (`0` normal,
+`1` four-player), `7=open slots` (`1` normal or `1..3` four-player), `8=pairing-required 1`,
+`9=zero`, `10..11=listener port u16 (1..65535)`, and `12..27=random public session ID`. A receive
+buffer is capped at 64 bytes and any non-exact length/value is discarded. The TTL-1 implementation
+uses UDP 37619 and both `239.255.67.66` and `ff02::4347:4244`; the cache holds 64 services and eight
+numeric addresses per service, refreshes every 1,000 monotonic ms, and expires at `now >= last +
+5,000 ms`. The session ID is public deduplication data, not a token or identity proof. Selection is
+an explicit local endpoint confirmation and still requires the canonical authenticated invitation.
 
 Invitation parsing is local and uses stable reason names (not wire ERROR numbers): `INV_TOO_LONG`,
 `INV_CONTROL`, `INV_ENCODING`, `INV_FRAGMENT`, `INV_SCHEME`, `INV_PATH`, `INV_AUTHORITY`,
@@ -538,7 +556,7 @@ does not provide TLS, matchmaking, rendezvous, NAT traversal, relay, or public i
 | #348 Part 2 | MANIFEST ordering, exact roster/identity comparison, and item proposals | implemented through an immutable pre-consent boundary; manifests are caller-prepared metadata and no private content is opened or hashed on transport threads |
 | #348 Part 3 | CONSENT ordering and ROM/battery transactions | implemented through immutable preparation completion; lazy sources open only after two exact approvals and verified receivers deliver only whole detached candidates; callers without a play plan remain blocked before START |
 | #349 | CHECKPOINT schema, StateFile-v2 identity, atomic group/history rules | implemented behind an explicit play plan: initial MACHINE or full-roster LINKED_SESSION, normal ACTIVE SESSION resync, START/READY, bounded INPUT/RESET/STOP, and two-stage frame-safe atomic commit; default v8/UI remain isolated |
-| #350 | cancellation/cleanup/diagnostic contracts, hostile lifecycle cases, and any separately reviewed discovery mechanism | no hardening rollout or v8 retirement occurs after #347; no nonce/manual-address bypass exists |
+| #350 | PING/PONG transport metrics, rollback/history snapshots, sanitized Swing diagnostics, and separately reviewed trusted-LAN endpoint discovery | implemented as bounded opt-ins; no hardening rollout, v8 retirement, central service, or nonce/manual-address bypass exists |
 | #351 | Mobile clean-room ADR/source inventory/transcripts | no production Mobile engine exists in #346 |
 | #352 | bounded async backend/status/cancellation contract | no DNS/socket/backend work exists in #346 |
 | #353 | desktop adapter/configuration/privacy documentation | no Mobile UI or external-service preset exists in #346 |

--- a/docs/netplay-v9-foundation.md
+++ b/docs/netplay-v9-foundation.md
@@ -23,6 +23,9 @@ The platform-neutral controller package `controller.network.v9` owns:
   boundary;
 - an additional opt-in #349 play plan with direct StateFile-v2 checkpoints, two-stage target
   prepare/commit, START/READY, bounded ACTIVE input/control, and normal/four-player barriers;
+- optional #350 PING/PONG transport diagnostics, bounded rollback/history snapshots, a
+  whitelist-only export, an EDT-owned Swing diagnostics panel, and separately opt-in trusted-LAN
+  address discovery;
 - injected monotonic deadlines, bounded reader/writer retention, cancellation, idempotent close,
   socket/task ownership, and an accept loop that isolates malformed or stalled candidates; and
 - an EDT-marshalling Swing adapter whose controller-facing source has no Swing or AWT dependency.
@@ -169,8 +172,46 @@ authenticated generation.
 
 Callers that omit a play plan retain the Part-3 pre-START boundary; callers that omit Part 3 retain
 the Part-2 boundary; callers that also omit a manifest plan retain the Part-1 post-AUTH boundary.
-Diagnostics/discovery and Mobile Adapter behavior remain unavailable. The default
-`ConnectionController` still has no v9 reference; shipped netplay remains protocol v8.
+Diagnostics are also explicit: `V9DiagnosticsOptions.DISABLED` neither advertises `PING_V1` nor
+creates a probe task. Trusted-LAN discovery is a separate off-by-default controller service and
+does not make a v9 session or authentication path. Mobile Adapter behavior remains unavailable.
+The default `ConnectionController` still has no v9 reference; shipped netplay remains protocol v8.
+
+## Bounded diagnostics and trusted-LAN discovery
+
+When both explicit v9 endpoints enable diagnostics, capability 12 admits exact 16-byte PING/PONG
+frames only in ACTIVE. The default cadence is 10,000 ms and the local unanswered-probe timeout is
+20,000 ms. At most one request per direction and the newest 32 RTT samples are retained. A full
+pending set skips a new probe without allocating; two consecutive expired probes close with typed
+`TIMEOUT` if the frozen 30,000 ms ACTIVE-idle deadline has not already closed the connection.
+Expired correlations are removed, so late/duplicate PONG is rejected rather than growing request
+history. RTT, EWMA (1/8), and jitter (1/16) use only the injected local monotonic clock. The peer
+stamp is echoed and never controls a deadline, host clock, pacing, emulation, or RTT result.
+Byte/frame/age counters saturate at signed 64-bit maximum.
+
+`LinkedController` publishes a separate immutable rollback snapshot without entering StateFile or
+deterministic state. It retains 64 rewind samples and reports rollback count, last/maximum/rolling
+rewind, re-simulated frames, current 300-entry history occupancy, too-old inputs, checkpoint or
+resynchronization count, and one stable local reason. Counters saturate; publication retains one
+latest value, at most 16 listeners, and at most one lazily created daemon until the source closes.
+Producers use only bounded constant work and never wait for Swing.
+
+The Swing `V9SwingDiagnosticsPanel` consumes these detached sources, marshals rendering and
+clipboard access to the EDT, and detaches listeners on close. Its copy action is built from a
+field whitelist and is capped at 8,192 characters. Numeric peer address is redacted unless the
+user explicitly selects the local include-address checkbox. This component remains available to
+explicit v9 integrations; it does not add v9 to the shipped v8 menu.
+
+`TrustedLanNetplayDiscovery` is likewise explicit and disabled by default. Its Java-16 multicast
+backend sends a fixed 28-byte `CGBD` advertisement with TTL 1 over UDP port 37619, IPv4 group
+`239.255.67.66`, and IPv6 link-local group `ff02::4347:4244`. It advertises only while enabled,
+the bound v9 listener is running, and a guest slot is open. The controller retains at most 64
+public session IDs, eight numeric addresses per service, eight network interfaces, one outgoing
+packet, and one latest snapshot; entries expire after 5,000 monotonic ms and refresh every 1,000
+ms. Disable stops backend I/O and clears cache/tasks, and discovery failure never changes direct
+hosting.
+Selecting a result returns only a confirmed numeric endpoint marked as still requiring an
+authenticated invitation. It cannot connect, mint a token, or bypass AUTH, MANIFEST, or consent.
 
 ## Ownership, errors, and privacy
 

--- a/docs/netplay-v9-privacy.md
+++ b/docs/netplay-v9-privacy.md
@@ -30,7 +30,7 @@ copy are explicit disclosure operations and fail after invalidation. A URI `Stri
 returned to caller or clipboard code is immutable and cannot be zeroized; from that disclosure
 point the caller owns its lifetime and must not log or persist it.
 
-V9's planned TCP transport is plaintext. It does not encrypt ROM, battery, state, input, or
+V9's opt-in TCP transport is plaintext. It does not encrypt ROM, battery, state, input, or
 metadata and cannot authenticate a server against an on-path attacker. It is not safe merely
 because the URI contains a random token. V9 does not provide TLS, matchmaking, NAT traversal,
 relay, or public Internet hardening. Prefer a trusted local network or a separately secured tunnel
@@ -82,6 +82,39 @@ wired into the normal netplay menu.
 The exact grammar, limits, timeouts, errors, and state transitions are normative in
 [netplay-protocol-v9.md](netplay-protocol-v9.md).
 
+## In-session diagnostics and copied reports
+
+Transport and rollback diagnostics are opt-in local measurements. A snapshot contains stable
+role/mode/lifecycle/slot values, local-clock RTT aggregates, bounded ping counts, saturated byte
+counts, connection duration, frame/remote-input age, and bounded rollback/history aggregates. It
+does not contain invitation material, content payloads, peer diagnostic strings, ROM title or
+digest, input masks, save/state bytes, or paths. Peer PING timestamps are never trusted for RTT,
+timeouts, emulation, or host clock state.
+
+Copied diagnostics are constructed from that whitelist and capped at 8,192 characters; they are
+not exception or object dumps. Address is `redacted` by default. The Swing panel offers a separate
+explicit local checkbox to include only the numeric peer address and port; tokens remain
+impossible to include. Defense-in-depth text sanitization bounds input to 4,096 and output to
+1,024 characters and replaces invitation URIs, credentials, POSIX/Windows paths, DNS names,
+IPv4/bracketed IPv6 addresses, and controls. Runtime INPUT/RESET/STOP values and raw peer failures
+are not logged at INFO.
+
+## Trusted-LAN discovery
+
+Discovery is off by default and is address discovery only. While explicitly enabled and a v9 host
+is listening with an open slot, the local multicast advertisement contains protocol major 9, a
+random 128-bit **public** session ID, normal/four-player mode, open-slot count, pairing-required
+`true`, and the listener port. It contains no invitation token, ROM title/identity/hash, build,
+user, path, credential, content, or state. Results are untrusted, bounded, deduplicated by public
+session/address, and expire after five seconds. A forged LAN advertisement may mislabel or redirect
+an endpoint; possession of the separate invitation and explicit local confirmation are still
+required, and the existing AUTH/MANIFEST/two-sided-consent checks remain unchanged.
+
+The implementation uses TTL-1 multicast only; there is no central/Nintendo service, broadcast
+Internet scan, matchmaking, NAT traversal, UPnP, relay, automatic connection, or tokenless nonce
+flow. Discovery failure is isolated from direct invitation hosting. Plaintext TCP remains visible
+and mutable to an on-path attacker even when a host was discovered locally.
+
 ## Explicit #349 play boundary
 
 After successful AUTH, explicitly prepared peers exchange bounded MANIFEST metadata. An exact pair
@@ -125,6 +158,7 @@ retained rollback history instead terminates with a typed sequence failure befor
 that terminal boundary a fresh authenticated generation is required rather than an implicit
 checkpoint retry.
 
-Diagnostics and discovery remain for #350. The stale nonce-comparison roadmap checkbox is not a
-tokenless/manual-address bypass: v9 has no such flow. Discovery or a different invitation
-mechanism requires a separately reviewed capability and threat-model change.
+#350 implements only the bounded diagnostics and address-only trusted-LAN discovery described
+above. The stale nonce-comparison roadmap checkbox is not a tokenless/manual-address bypass: v9
+has no such flow. A different invitation or authentication mechanism still requires a separately
+reviewed capability and threat-model change.

--- a/docs/test-fixture-provenance.md
+++ b/docs/test-fixture-provenance.md
@@ -80,6 +80,14 @@ GB. They contain no third-party ROM, BIOS, palette, screenshot, or game asset:
   transport-foundation tests. It adds no binary fixture, invitation secret, remote capture, ROM,
   save, StateFile, credential, endpoint, or downloaded artifact; all resource bytes and manifest
   hashes from Phase #346 remain unchanged.
+- Phase #350 adds no fixture or downloaded artifact. PING/PONG, rollback, diagnostics-redaction,
+  discovery-cache, and Swing publication cases are generated in test code from synthetic numeric
+  values and documentation-reserved example addresses. The optional multicast smoke sends only
+  the fixed synthetic 28-byte public advertisement on the local host and skips when multicast
+  loopback is unavailable. The inline schema-1 normal-mode vector (port 8765, public session ID 1)
+  has SHA-256 `869a2044ee029f2876988a809864f4a0a220d0f8701b92ad8aa2248091958b36`.
+  Existing `netplay-v9` contract resources and released StateFile/legacy fixtures are not
+  rewritten.
 
 The canonical hash format and every expected hash are specified in
 [sgb-conformance-baselines.md](sgb-conformance-baselines.md). These values lock current Coffee GB

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/V9SwingDiagnosticsPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/V9SwingDiagnosticsPanel.kt
@@ -1,0 +1,129 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.network.NetplayDiagnosticsExporter
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
+import eu.rekawek.coffeegb.controller.network.v9.V9TransportMetricsSnapshot
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTextArea
+import javax.swing.SwingUtilities
+
+fun interface V9DiagnosticsClipboard {
+  fun copy(value: String)
+}
+
+/**
+ * Real opt-in in-session diagnostics surface. Its model is immutable, publication is EDT-only,
+ * and clipboard text is built exclusively by the bounded whitelist exporter.
+ */
+class V9SwingDiagnosticsPanel private constructor(
+    transportSource: NetplaySnapshotSource<V9TransportMetricsSnapshot>,
+    rollbackSource: NetplaySnapshotSource<NetplayRollbackMetricsSnapshot>?,
+    private val clipboard: V9DiagnosticsClipboard,
+    @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
+) : JPanel(BorderLayout()), Closeable {
+  constructor(
+      transportSource: NetplaySnapshotSource<V9TransportMetricsSnapshot>,
+      rollbackSource: NetplaySnapshotSource<NetplayRollbackMetricsSnapshot>? = null,
+      clipboard: V9DiagnosticsClipboard = SYSTEM_CLIPBOARD,
+  ) : this(transportSource, rollbackSource, clipboard, requireEdt())
+
+  private val closed = AtomicBoolean(false)
+  private val generation = AtomicLong(1)
+  @Volatile private var transport = transportSource.snapshot()
+  @Volatile private var rollback = rollbackSource?.snapshot()
+  internal val includeAddress = JCheckBox("Include numeric peer address")
+  internal val copyButton = JButton("Copy sanitized diagnostics")
+  internal val text = JTextArea(18, 52)
+  internal val status = JLabel("Diagnostics are local and sanitized")
+  private val subscriptions = mutableListOf<Closeable>()
+
+  init {
+    text.isEditable = false
+    text.lineWrap = false
+    val actions = JPanel(FlowLayout(FlowLayout.LEADING))
+    actions.add(includeAddress)
+    actions.add(copyButton)
+    actions.add(status)
+    add(JScrollPane(text), BorderLayout.CENTER)
+    add(actions, BorderLayout.SOUTH)
+
+    val current = generation.get()
+    subscriptions +=
+        transportSource.addListener(
+            NetplaySnapshotListener { value ->
+              publish(current) {
+                transport = value
+                render()
+              }
+            },
+        )
+    if (rollbackSource != null) {
+      subscriptions +=
+          rollbackSource.addListener(
+              NetplaySnapshotListener { value ->
+                publish(current) {
+                  rollback = value
+                  render()
+                }
+              },
+          )
+    }
+    includeAddress.addActionListener { render() }
+    copyButton.addActionListener {
+      check(SwingUtilities.isEventDispatchThread())
+      val value =
+          NetplayDiagnosticsExporter.export(transport, rollback, includeAddress.isSelected)
+      try {
+        clipboard.copy(value)
+        status.text = "Sanitized diagnostics copied"
+      } catch (_: RuntimeException) {
+        status.text = "Clipboard unavailable"
+      }
+    }
+    render()
+  }
+
+  private fun render() {
+    check(SwingUtilities.isEventDispatchThread())
+    text.text = NetplayDiagnosticsExporter.export(transport, rollback, includeAddress.isSelected)
+  }
+
+  private fun publish(expected: Long, update: () -> Unit) {
+    SwingUtilities.invokeLater {
+      if (!closed.get() && generation.get() == expected) update()
+    }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    generation.incrementAndGet()
+    subscriptions.toList().forEach(Closeable::close)
+    subscriptions.clear()
+  }
+
+  companion object {
+    private fun requireEdt() {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "v9 diagnostics panel must be constructed on the EDT"
+      }
+    }
+
+    private val SYSTEM_CLIPBOARD = V9DiagnosticsClipboard { value ->
+      check(SwingUtilities.isEventDispatchThread())
+      Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(value), null)
+    }
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/V9SwingDiagnosticsPanelTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/V9SwingDiagnosticsPanelTest.kt
@@ -1,0 +1,155 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackMetricsSnapshot
+import eu.rekawek.coffeegb.controller.network.NetplayRollbackReason
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotListener
+import eu.rekawek.coffeegb.controller.network.NetplaySnapshotSource
+import eu.rekawek.coffeegb.controller.network.v9.V9DiagnosticEndpoint
+import eu.rekawek.coffeegb.controller.network.v9.V9LifecycleState
+import eu.rekawek.coffeegb.controller.network.v9.V9LinkMode
+import eu.rekawek.coffeegb.controller.network.v9.V9Role
+import eu.rekawek.coffeegb.controller.network.v9.V9TransportMetricsSnapshot
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class V9SwingDiagnosticsPanelTest {
+
+  @Test
+  fun modelRenderingClipboardAndCloseAreEdtOwnedAndSanitized() {
+    val transport = MutableSource(transport(10))
+    val rollback = MutableSource(rollback(1))
+    val copied = AtomicReference<String>()
+    val clipboardOnEdt = AtomicBoolean()
+    lateinit var panel: V9SwingDiagnosticsPanel
+    SwingUtilities.invokeAndWait {
+      panel =
+          V9SwingDiagnosticsPanel(transport, rollback) { value ->
+            clipboardOnEdt.set(SwingUtilities.isEventDispatchThread())
+            copied.set(value)
+          }
+      assertTrue(panel.text.text.contains("rtt-current-us=10"))
+      assertTrue(panel.text.text.contains("remote-address=redacted"))
+      panel.copyButton.doClick()
+    }
+    assertTrue(clipboardOnEdt.get())
+    assertFalse(requireNotNull(copied.get()).contains("192.0.2.8"))
+
+    transport.publish(transport(22))
+    rollback.publish(rollback(4))
+    SwingUtilities.invokeAndWait {
+      assertTrue(panel.text.text.contains("rtt-current-us=22"))
+      assertTrue(panel.text.text.contains("rollback-count=4"))
+      panel.includeAddress.isSelected = true
+      panel.includeAddress.doClick()
+      panel.includeAddress.doClick()
+      assertTrue(panel.text.text.contains("remote-address=192.0.2.8:8765"))
+      panel.copyButton.doClick()
+    }
+    assertTrue(requireNotNull(copied.get()).contains("192.0.2.8:8765"))
+
+    val edtBlocked = CountDownLatch(1)
+    val releaseEdt = CountDownLatch(1)
+    SwingUtilities.invokeLater {
+      edtBlocked.countDown()
+      releaseEdt.await()
+    }
+    assertTrue(edtBlocked.await(1, TimeUnit.SECONDS))
+    try {
+      transport.publish(transport(777))
+      panel.close()
+      panel.close()
+      assertEquals(0, transport.listenerCount())
+      assertEquals(0, rollback.listenerCount())
+      transport.publish(transport(999))
+    } finally {
+      releaseEdt.countDown()
+    }
+    SwingUtilities.invokeAndWait {
+      assertFalse(panel.text.text.contains("rtt-current-us=777"))
+      assertFalse(panel.text.text.contains("rtt-current-us=999"))
+    }
+  }
+
+  @Test
+  fun constructionOutsideEdtIsRejected() {
+    val failure = runCatching { V9SwingDiagnosticsPanel(MutableSource(transport(1))) }
+        .exceptionOrNull()
+    assertTrue(failure is IllegalStateException)
+  }
+
+  @Test
+  fun clipboardFailureIsSanitizedOnTheEdt() {
+    lateinit var panel: V9SwingDiagnosticsPanel
+    SwingUtilities.invokeAndWait {
+      panel =
+          V9SwingDiagnosticsPanel(MutableSource(transport(1))) {
+            check(SwingUtilities.isEventDispatchThread())
+            throw IllegalStateException("C:\\Users\\peer\\private-state.bin")
+          }
+      panel.copyButton.doClick()
+      assertEquals("Clipboard unavailable", panel.status.text)
+      assertFalse(panel.status.text.contains("peer"))
+      panel.close()
+    }
+  }
+
+  private fun transport(rtt: Long) =
+      V9TransportMetricsSnapshot(
+          rtt,
+          rtt,
+          rtt,
+          rtt,
+          0,
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          4,
+          0,
+          V9LifecycleState.ACTIVE,
+          V9LinkMode.NORMAL,
+          V9Role.SERVER,
+          1,
+          V9DiagnosticEndpoint("192.0.2.8", 8765),
+      )
+
+  private fun rollback(count: Long) =
+      NetplayRollbackMetricsSnapshot(
+          count,
+          1,
+          2,
+          1_000,
+          count,
+          10,
+          300,
+          0,
+          0,
+          NetplayRollbackReason.REMOTE_INPUT,
+      )
+
+  private class MutableSource<T>(initial: T) : NetplaySnapshotSource<T> {
+    private var value = initial
+    private val listeners = mutableListOf<NetplaySnapshotListener<T>>()
+    override fun snapshot(): T = value
+    override fun addListener(listener: NetplaySnapshotListener<T>): Closeable {
+      synchronized(listeners) { listeners += listener }
+      listener.onSnapshot(value)
+      return Closeable { synchronized(listeners) { listeners.remove(listener) } }
+    }
+    fun publish(next: T) {
+      value = next
+      synchronized(listeners) { listeners.toList() }.forEach { it.onSnapshot(next) }
+    }
+    fun listenerCount(): Int = synchronized(listeners) { listeners.size }
+  }
+}


### PR DESCRIPTION
Closes #350

Part of #318. Related to #314 and #311.

## Outcome

Completes the bounded diagnostics/discovery phase without changing the shipped/default protocol-v8 path or making protocol v9 a default/playable UI flow.

- Adds explicit opt-in `PING_V1` transport diagnostics. Disabled sessions cannot advertise PING even through the raw optional-capability set.
- Implements exact 16-byte PING/PONG in ACTIVE only, exact response-ledger correlation, receiver-local monotonic RTT/EWMA/jitter/liveness math, and bounded immutable snapshots.
- Instruments `LinkedController`/`StateHistory` with detached rollback/history aggregates without entering deterministic state or changing StateFile bytes.
- Adds a whitelist-only sanitized diagnostics export and an EDT-owned Swing panel with explicit numeric-address opt-in.
- Adds an off-by-default trusted-LAN discovery abstraction and Java-16 multicast backend. Discovery only prefills a confirmed numeric endpoint; the existing authenticated invitation, manifest, and two-sided consent remain mandatory.
- Updates wire/foundation/privacy/troubleshooting and fixture-provenance documentation.

## Review revision: lifecycle and liveness ownership

- `TrustedLanNetplayDiscovery` now reconciles enable/disable/close through one bounded daemon lifecycle worker and a monotonic generation fence. A backend start that returns after disable/close is stopped/closed before it can advertise; socket startup never runs on the caller or Swing EDT.
- Deterministic latch tests force both disable-during-start and close-during-start, asserting an empty disabled cache/snapshot, no advertisement, no running backend, and terminated lifecycle ownership.
- `V9MulticastDiscoveryBackend` now retains per-start receiver/sender termination latches, uses bounded termination waits, refuses restart while an older worker is alive, and wipes its one-cell advertisement queue. Stop/restart tests prove zero live workers and zero queued advertisements.
- Production `V9FoundationConnection` fake-clock/manual-scheduler tests now execute disabled/unnegotiated behavior, exact cadence, the one-pending bound, exact timeout expiry, two-expiry typed closure, valid-PONG reset, close cleanup, and hostile PONG correlation/nonce cases at the live connection layer.
- Foundation KDoc now accurately describes negotiated diagnostics and the separate off-by-default discovery service.

## Frozen bounds and ownership

- PING cadence 10,000 ms; unanswered timeout 20,000 ms; one outstanding request/direction; 32 RTT samples; two expired probes produce typed `TIMEOUT` unless the frozen 30,000 ms ACTIVE-idle deadline closes first.
- Peer timestamps are echoed but never drive RTT, deadlines, pacing, emulation, or clock state. Byte/frame/counter arithmetic saturates.
- Rollback metrics retain 64 rewind samples; history capacity remains 300. Snapshot publication retains one latest value, one queue cell, at most 16 listeners, and one lazy daemon.
- Export is whitelist-built and capped at 8,192 characters; defense-in-depth sanitizer input/output caps are 4,096/1,024 characters. Address is redacted unless explicitly selected locally.
- Discovery datagrams are exact 28-byte `CGBD` schema-1 records in a 64-byte receive buffer. Cache: 64 services, 8 numeric addresses/service, 8 interfaces, one outgoing datagram; refresh 1,000 ms; exact expiry 5,000 ms; TTL 1.
- Discovery advertises only protocol major, random public 128-bit session ID, mode, open-slot count, pairing-required, and the listener routing port while enabled/listening/open. No token, ROM/title/hash, build, user, path, credential, state, or content enters discovery.
- All network, multicast lifecycle, and discovery work remains off emulator and Swing EDT ownership. Swing callbacks/clipboard are EDT-only and subscriptions detach on close.

The transport is still plaintext and provides no confidentiality or protection from an on-path attacker. Discovery is untrusted address discovery—not authentication, automatic connection, matchmaking, NAT traversal, UPnP, relay, Internet scanning, or a tokenless bypass.

## Compatibility and fixtures

- Base: `11b1bb44623a281048af399c7a652333d9f9088a`
- Head: `e178c4deeb3f24c9c2b5e3e7142a9351ddb9df90`
- Existing protocol-v9 resource tree unchanged: `020088bd391fa04bf11fcfaaf4fd0e65d4e4e1368686f6e9568e26bb047d96e3`
- Released legacy/StateFile resource tree unchanged: `28912f211227cfdaaf8f74354160f422a2d961b93ded6f6fa3a48a8170a08c73`
- 1.7.13: `7a7ba6fa23538fcd2bdb734487a3b30a18452b69379e18712fc289858ba191ec`
- 1.7.14: `3588e825efd91f8555d2fd941645a21af1c2ba330df6b56053f01ed81faf5573`
- StateFile v1: `e5ae258c3f1a9405ca87518dbb13526def9fd3e44a4486d7a495c111958cf091`
- StateFile v2: `2d2178e6eba26a8debdacf84be144cccd1b42e50bf0dbce5c41612bcb16aa226`

No native/legacy/CGBN/Memento/StateFile-v1 peer path, enum-ordinal identity, `HexFormat`, Mobile Adapter change, frozen-row rewrite, commercial fixture, credential, or user artifact was added. The exact-head diff has no test-resource changes.

## Java 16 verification

Runtime: Temurin `16.0.2+7`.

- Focused:
  `mvn -B -pl swing -am '-Dtest=ProtocolV9*Test,NetplayDiscoveryTest,NetplayDiagnosticsTest,LinkedControllerTest,StateHistoryTest,V9Swing*Test' -Dsurefire.failIfNoSpecifiedTests=false test`
  - controller: 194 tests; Swing: 13 tests; total 207; 0 failures/errors/skips.
- Historical TCP regression, 10 independent invocations:
  `TcpConnectionTest#linkedControllersExchangePortableRunningStateOverTcp` — 10/10.
- Historical four-player TCP regression, 10 independent invocations:
  `TcpConnectionTest#linkedFourPlayerClientStartsFromPortableCheckpointOverTcp` — 10/10.
- Full clean reactor: `mvn -B clean test`
  - core 791/0/0/0; controller 429/0/0/2; Swing 44/0/0/0.
  - aggregate 1,264 tests, 0 failures, 0 errors, 2 expected skips; `BUILD SUCCESS` in 4:13.
- `git diff --check` and static Java-16/ordinal/legacy/Mobile/frozen-resource audits pass.

Durable exact-head logs are under `/tmp/coffee-gb-issue350-logs/e178c4deeb3f24c9c2b5e3e7142a9351ddb9df90/`. Every historical invocation contains its command/test name, one-test Maven summary, exit code 0, and explicit `PASS` marker. The exact-head full reactor log is `full-clean-test.log`; focused coverage is `focused-v9-discovery-diagnostics-link-swing.log`.

## Residual risk

Multicast availability and IPv6 routing vary by OS/network policy; the bounded real-backend smoke passed locally and is allowed to skip where multicast loopback is unavailable. Backend failure remains isolated, and direct authenticated invitation hosting remains usable. Worker termination is bounded; an uncooperative platform multicast call is retained as live ownership and blocks restart instead of being silently forgotten.

## Exact-head hosted CI

[Workflow run 30266690315](https://github.com/trekawek/coffee-gb/actions/runs/30266690315) completed successfully on `e178c4deeb3f24c9c2b5e3e7142a9351ddb9df90`: build plus all 13 integration jobs passed—Acid2, both Blargg jobs, CGB-ACID-HELL, CasualPokePlayer, Compatibility ROMs, GBMicrotest, Gambatte HWTests, Mealybug Tearoom, Misc.-GB-Tests, Mooneye, Strikethrough, and gbc-hw-tests. Totals: 14 successful, 0 failing/cancelled/skipped/pending.
