### PR TITLE
Add gamepad and audio preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ states, and rewind are disabled during netplay.
 <details>
 <summary>Custom keyboard and game-controller mapping</summary>
 
-Desktop settings are stored in `~/.coffeegb.properties`; the complete typed schema, validation,
-migration, and recovery rules are documented in the
+Desktop settings are stored in `~/.coffeegb.properties`. **File > Preferences…** configures
+General behavior, four-player keyboard bindings, gamepad assignment/tuning, and audio
+device/volume/mute/latency without manual editing. The complete typed schema, validation,
+migration, device fallback, and recovery rules are documented in the
 [desktop command-line and settings contract](docs/desktop-settings.md). For keyboard mappings, use
 [`KeyEvent`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/event/KeyEvent.html)
 constant names:
@@ -179,6 +181,15 @@ may use a given ID, and only one `auto` assignment is allowed. The ID hashes SDL
 path, and name. If SDL exposes no path, the current connection's instance ID disambiguates otherwise
 identical pads. IDs are stable across enumeration-order changes; an OS path change (or reconnect on
 a path-less backend) is conservatively treated as device replacement.
+
+Per-device movement and tilt dead zones plus X/Y inversion are available in Preferences. Controller
+discovery stays on the SDL polling thread; disconnects, focus loss, ROM changes, and mapping changes
+release held input to prevent stuck buttons.
+
+Audio Preferences lists outputs asynchronously and retains an unavailable configured output while
+using the system default as a safe runtime fallback, then returns to the configured output when it
+reappears. Master volume and mute are software controlled; the LOW, BALANCED, and SAFE presets trade
+latency for additional buffering without changing emulation timing.
 
 Independent SGB P2-P4 desktop input is available only in local/basic-controller mode. Netplay
 protocol v8 carries one frame-owned P1 stream per linked emulator and has no representation for

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -128,15 +128,48 @@ data class ApplicationSettings(
     }
   }
 
-  data class Audio(val enabled: Boolean = true)
+  data class Audio(
+      /** Historical sound.enabled value; false is the persisted master-mute compatibility path. */
+      val enabled: Boolean = true,
+      val output: AudioOutputSelection = AudioOutputSelection.Default,
+      val volume: Int = DEFAULT_AUDIO_VOLUME,
+      val latency: AudioLatency = AudioLatency.BALANCED,
+  ) {
+    init {
+      require(volume in MIN_AUDIO_VOLUME..MAX_AUDIO_VOLUME) {
+        "Audio volume must be between $MIN_AUDIO_VOLUME and $MAX_AUDIO_VOLUME"
+      }
+    }
+  }
+
+  sealed class AudioOutputSelection {
+    data object Default : AudioOutputSelection()
+
+    data class Device(val stableId: String) : AudioOutputSelection() {
+      init {
+        require(isStableAudioOutputId(stableId)) {
+          "Audio output device must be java-sound- followed by 64 lowercase hex digits"
+        }
+      }
+    }
+  }
+
+  enum class AudioLatency {
+    LOW,
+    BALANCED,
+    SAFE,
+  }
 
   class Input(
       keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey>,
       gamepads: Map<Int, GamepadSelection>,
+      gamepadTunings: Map<String, GamepadTuning> = emptyMap(),
   ) {
     val keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey> = immutableMapCopy(keyboard)
 
     val gamepads: Map<Int, GamepadSelection> = immutableMapCopy(gamepads)
+
+    val gamepadTunings: Map<String, GamepadTuning> = immutableMapCopy(gamepadTunings)
 
     init {
       require(gamepads.keys.all { it in 0..3 }) { "Logical gamepad player must be P1 through P4" }
@@ -150,6 +183,14 @@ data class ApplicationSettings(
             "Disabled P2 through P4 gamepad selections must be omitted"
           }
       keyboard.keys.forEach { require(it.player in 0..3) }
+      require(this.gamepadTunings.size <= MAX_GAMEPAD_TUNINGS) {
+        "At most $MAX_GAMEPAD_TUNINGS gamepad tuning profiles may be stored"
+      }
+      this.gamepadTunings.keys.forEach { stableId ->
+        require(ControllerProperties.isStableGamepadId(stableId)) {
+          "Gamepad tuning device must be sdl- followed by 64 lowercase hex digits"
+        }
+      }
     }
 
     fun toPlayerMapping(): ControllerProperties.PlayerMapping {
@@ -189,15 +230,21 @@ data class ApplicationSettings(
     fun copy(
         keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey> = this.keyboard,
         gamepads: Map<Int, GamepadSelection> = this.gamepads,
-    ): Input = Input(keyboard, gamepads)
+        gamepadTunings: Map<String, GamepadTuning> = this.gamepadTunings,
+    ): Input = Input(keyboard, gamepads, gamepadTunings)
 
     override fun equals(other: Any?): Boolean =
         this === other ||
-            (other is Input && keyboard == other.keyboard && gamepads == other.gamepads)
+            (other is Input &&
+                keyboard == other.keyboard &&
+                gamepads == other.gamepads &&
+                gamepadTunings == other.gamepadTunings)
 
-    override fun hashCode(): Int = 31 * keyboard.hashCode() + gamepads.hashCode()
+    override fun hashCode(): Int =
+        31 * (31 * keyboard.hashCode() + gamepads.hashCode()) + gamepadTunings.hashCode()
 
-    override fun toString(): String = "Input(keyboard=$keyboard, gamepads=$gamepads)"
+    override fun toString(): String =
+        "Input(keyboard=$keyboard, gamepads=$gamepads, gamepadTunings=$gamepadTunings)"
 
     companion object {
       fun defaults(): Input {
@@ -293,6 +340,26 @@ data class ApplicationSettings(
     }
   }
 
+  data class GamepadTuning(
+      val movementDeadZone: Int = DEFAULT_GAMEPAD_MOVEMENT_DEAD_ZONE,
+      val tiltDeadZone: Int = DEFAULT_GAMEPAD_TILT_DEAD_ZONE,
+      val invertMovementX: Boolean = false,
+      val invertMovementY: Boolean = false,
+      val invertTiltX: Boolean = false,
+      val invertTiltY: Boolean = false,
+  ) {
+    init {
+      require(movementDeadZone in MIN_GAMEPAD_DEAD_ZONE..MAX_GAMEPAD_DEAD_ZONE) {
+        "Gamepad movement dead zone must be between $MIN_GAMEPAD_DEAD_ZONE and " +
+            MAX_GAMEPAD_DEAD_ZONE
+      }
+      require(tiltDeadZone in MIN_GAMEPAD_DEAD_ZONE..MAX_GAMEPAD_DEAD_ZONE) {
+        "Gamepad tilt dead zone must be between $MIN_GAMEPAD_DEAD_ZONE and " +
+            MAX_GAMEPAD_DEAD_ZONE
+      }
+    }
+  }
+
   data class Saves(val batterySavesEnabled: Boolean = true)
 
   data class Advanced(
@@ -319,12 +386,25 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 2
+    const val CURRENT_SCHEMA_VERSION = 3
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50
+    const val MIN_AUDIO_VOLUME = 0
+    const val DEFAULT_AUDIO_VOLUME = 100
+    const val MAX_AUDIO_VOLUME = 100
+    const val MIN_GAMEPAD_DEAD_ZONE = 0
+    const val DEFAULT_GAMEPAD_MOVEMENT_DEAD_ZONE = 16_384
+    const val DEFAULT_GAMEPAD_TILT_DEAD_ZONE = 4_096
+    const val MAX_GAMEPAD_DEAD_ZONE = 32_766
+    const val MAX_GAMEPAD_TUNINGS = 32
     private val SUPPORTED_SCALES: Set<Int> =
         Collections.unmodifiableSet(linkedSetOf(1, 2, 4))
+
+    internal fun isStableAudioOutputId(value: String): Boolean =
+        value.matches(STABLE_AUDIO_OUTPUT_ID)
+
+    private val STABLE_AUDIO_OUTPUT_ID = Regex("java-sound-[0-9a-f]{64}")
   }
 }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -18,6 +18,10 @@ object ApplicationSettingsCodec {
   const val RECENT_FILE_CAPACITY_KEY = "general.recentFileCapacity"
   const val RECENT_ROM_PREFIX = "general.recent."
   const val ROM_CHANGE_CONFIRMATION_POLICY_KEY = "general.romChangeConfirmationPolicy"
+  const val AUDIO_OUTPUT_KEY = "audio.outputDevice"
+  const val AUDIO_VOLUME_KEY = "audio.masterVolume"
+  const val AUDIO_LATENCY_KEY = "audio.latencyPreset"
+  const val GAMEPAD_TUNING_PREFIX = "input.gamepad."
   internal const val PRESERVED_UNKNOWN_COLLISIONS_PREFIX =
       "settings.preservedUnknownCollisions."
 
@@ -27,6 +31,9 @@ object ApplicationSettingsCodec {
   private val versionTwoFixedKeys =
       versionOneFixedKeys +
           setOf(RECENT_FILE_CAPACITY_KEY, ROM_CHANGE_CONFIRMATION_POLICY_KEY)
+  private val versionThreeFixedKeys =
+      versionTwoFixedKeys +
+          setOf(AUDIO_OUTPUT_KEY, AUDIO_VOLUME_KEY, AUDIO_LATENCY_KEY)
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -40,7 +47,7 @@ object ApplicationSettingsCodec {
             version > SUPPORTED_SCHEMA_VERSION)) {
       throw UnsupportedApplicationSettingsVersionException(encodedVersion)
     }
-    require(version == "1" || version == SUPPORTED_SCHEMA_VERSION) {
+    require(version == "1" || version == "2" || version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
     return decodeSupportedVersion(raw, sourceVersion = version.toInt())
@@ -100,6 +107,13 @@ object ApplicationSettingsCodec {
     known[EmulatorProperties.Key.ShowSgbBorder.propertyName] =
         settings.display.showSgbBorder.toString()
     known[EmulatorProperties.Key.SoundEnabled.propertyName] = settings.audio.enabled.toString()
+    known[AUDIO_OUTPUT_KEY] =
+        when (val output = settings.audio.output) {
+          ApplicationSettings.AudioOutputSelection.Default -> DEFAULT_AUDIO_OUTPUT
+          is ApplicationSettings.AudioOutputSelection.Device -> output.stableId
+        }
+    known[AUDIO_VOLUME_KEY] = settings.audio.volume.toString()
+    known[AUDIO_LATENCY_KEY] = settings.audio.latency.name
     known[BATTERY_SAVES_KEY] = settings.saves.batterySavesEnabled.toString()
 
     encodeProfile(
@@ -129,8 +143,17 @@ object ApplicationSettingsCodec {
   ): ApplicationSettingsDocument {
     val legacyDefaults = sourceVersion == 0
     val inputProperties = Properties()
-    raw.forEach { (key, value) -> inputProperties.setProperty(key, value) }
-    val input = ControllerProperties.getInputSettings(inputProperties, legacyDefaults)
+    raw
+        .filterKeys { !isGamepadTuningKey(it) }
+        .forEach { (key, value) -> inputProperties.setProperty(key, value) }
+    val input =
+        ControllerProperties.getInputSettings(inputProperties, legacyDefaults).copy(
+            gamepadTunings =
+                if (sourceVersion >= 3) {
+                  parseGamepadTunings(raw)
+                } else {
+                  emptyMap()
+                })
 
     val recentFileCapacityValue =
         if (sourceVersion >= 2) raw[RECENT_FILE_CAPACITY_KEY] else null
@@ -213,11 +236,37 @@ object ApplicationSettingsCodec {
             display = display,
             audio =
                 ApplicationSettings.Audio(
-                    parseBoolean(
-                        raw[EmulatorProperties.Key.SoundEnabled.propertyName],
-                        true,
-                        EmulatorProperties.Key.SoundEnabled.propertyName,
-                    )),
+                    enabled =
+                        parseBoolean(
+                            raw[EmulatorProperties.Key.SoundEnabled.propertyName],
+                            true,
+                            EmulatorProperties.Key.SoundEnabled.propertyName,
+                        ),
+                    output =
+                        if (sourceVersion >= 3) {
+                          parseAudioOutput(raw[AUDIO_OUTPUT_KEY])
+                        } else {
+                          ApplicationSettings.AudioOutputSelection.Default
+                        },
+                    volume =
+                        if (sourceVersion >= 3) {
+                          parseRangedInt(
+                              raw[AUDIO_VOLUME_KEY],
+                              ApplicationSettings.DEFAULT_AUDIO_VOLUME,
+                              AUDIO_VOLUME_KEY,
+                              ApplicationSettings.MIN_AUDIO_VOLUME,
+                              ApplicationSettings.MAX_AUDIO_VOLUME,
+                          )
+                        } else {
+                          ApplicationSettings.DEFAULT_AUDIO_VOLUME
+                        },
+                    latency =
+                        if (sourceVersion >= 3) {
+                          parseAudioLatency(raw[AUDIO_LATENCY_KEY])
+                        } else {
+                          ApplicationSettings.AudioLatency.BALANCED
+                        },
+                ),
             input = input,
             saves =
                 ApplicationSettings.Saves(
@@ -251,7 +300,11 @@ object ApplicationSettingsCodec {
     val preservedCollisions =
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
-        if (sourceVersion >= 2) versionTwoFixedKeys else versionOneFixedKeys
+        when {
+          sourceVersion >= 3 -> versionThreeFixedKeys
+          sourceVersion >= 2 -> versionTwoFixedKeys
+          else -> versionOneFixedKeys
+        }
     val unknown =
         raw
             .filterKeys { key ->
@@ -263,7 +316,8 @@ object ApplicationSettingsCodec {
                       supportsCanonicalRecentKeys = sourceVersion >= 2,
                   ) &&
                   !key.startsWith("btn_") &&
-                  !key.startsWith("input.")
+                  (!key.startsWith("input.") ||
+                      (sourceVersion < 3 && isGamepadTuningKey(key)))
             }
             .toMutableMap()
             .apply { putAll(preservedCollisions) }
@@ -298,12 +352,93 @@ object ApplicationSettingsCodec {
   private fun parseInt(value: String, key: String): Int =
       value.toIntOrNull() ?: throw IllegalArgumentException("Invalid $key: $value")
 
+  private fun parseRangedInt(
+      value: String?,
+      default: Int,
+      key: String,
+      minimum: Int,
+      maximum: Int,
+  ): Int {
+    if (value == null) return default
+    val parsed = parseInt(value, key)
+    require(parsed in minimum..maximum) {
+      "Invalid $key: $parsed (expected $minimum..$maximum)"
+    }
+    return parsed
+  }
+
   private fun parseBoolean(value: String?, default: Boolean, key: String): Boolean {
     if (value == null) return default
     return when (value.lowercase(Locale.ROOT)) {
       "true" -> true
       "false" -> false
       else -> throw IllegalArgumentException("Invalid $key: $value (expected true or false)")
+    }
+  }
+
+  private fun parseAudioOutput(value: String?): ApplicationSettings.AudioOutputSelection {
+    if (value == null || value == DEFAULT_AUDIO_OUTPUT) {
+      return ApplicationSettings.AudioOutputSelection.Default
+    }
+    return try {
+      ApplicationSettings.AudioOutputSelection.Device(value)
+    } catch (failure: IllegalArgumentException) {
+      throw IllegalArgumentException(
+          "Invalid $AUDIO_OUTPUT_KEY: $value " +
+              "(expected '$DEFAULT_AUDIO_OUTPUT' or java-sound- followed by 64 lowercase hex digits)",
+          failure,
+      )
+    }
+  }
+
+  private fun parseAudioLatency(value: String?): ApplicationSettings.AudioLatency {
+    if (value == null) return ApplicationSettings.AudioLatency.BALANCED
+    return try {
+      ApplicationSettings.AudioLatency.valueOf(value)
+    } catch (_: IllegalArgumentException) {
+      throw IllegalArgumentException(
+          "Invalid $AUDIO_LATENCY_KEY: $value (expected LOW, BALANCED, or SAFE)")
+    }
+  }
+
+  private fun parseGamepadTunings(
+      raw: Map<String, String>
+  ): Map<String, ApplicationSettings.GamepadTuning> {
+    val stableIds =
+        raw.keys
+            .mapNotNull { key -> gamepadTuningKey.matchEntire(key)?.groupValues?.get(1) }
+            .toSortedSet()
+    require(stableIds.size <= ApplicationSettings.MAX_GAMEPAD_TUNINGS) {
+      "At most ${ApplicationSettings.MAX_GAMEPAD_TUNINGS} gamepad tuning profiles may be stored"
+    }
+    return stableIds.associateWith { stableId ->
+      val prefix = "$GAMEPAD_TUNING_PREFIX$stableId."
+      ApplicationSettings.GamepadTuning(
+          movementDeadZone =
+              parseRangedInt(
+                  raw["${prefix}movementDeadZone"],
+                  ApplicationSettings.DEFAULT_GAMEPAD_MOVEMENT_DEAD_ZONE,
+                  "${prefix}movementDeadZone",
+                  ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE,
+                  ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE,
+              ),
+          tiltDeadZone =
+              parseRangedInt(
+                  raw["${prefix}tiltDeadZone"],
+                  ApplicationSettings.DEFAULT_GAMEPAD_TILT_DEAD_ZONE,
+                  "${prefix}tiltDeadZone",
+                  ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE,
+                  ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE,
+              ),
+          invertMovementX =
+              parseBoolean(raw["${prefix}invertMovementX"], false, "${prefix}invertMovementX"),
+          invertMovementY =
+              parseBoolean(raw["${prefix}invertMovementY"], false, "${prefix}invertMovementY"),
+          invertTiltX =
+              parseBoolean(raw["${prefix}invertTiltX"], false, "${prefix}invertTiltX"),
+          invertTiltY =
+              parseBoolean(raw["${prefix}invertTiltY"], false, "${prefix}invertTiltY"),
+      )
     }
   }
 
@@ -466,7 +601,18 @@ object ApplicationSettingsCodec {
           }
       target["input.p${player + 1}.gamepad"] = value
     }
+    input.gamepadTunings.toSortedMap().forEach { (stableId, tuning) ->
+      val prefix = "$GAMEPAD_TUNING_PREFIX$stableId."
+      target["${prefix}movementDeadZone"] = tuning.movementDeadZone.toString()
+      target["${prefix}tiltDeadZone"] = tuning.tiltDeadZone.toString()
+      target["${prefix}invertMovementX"] = tuning.invertMovementX.toString()
+      target["${prefix}invertMovementY"] = tuning.invertMovementY.toString()
+      target["${prefix}invertTiltX"] = tuning.invertTiltX.toString()
+      target["${prefix}invertTiltY"] = tuning.invertTiltY.toString()
+    }
   }
+
+  private fun isGamepadTuningKey(key: String): Boolean = gamepadTuningKey.matches(key)
 
   private fun isKnownRecentKey(
       key: String,
@@ -488,14 +634,20 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionTwoFixedKeys ||
+      key in versionThreeFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           key.startsWith("btn_") ||
           key.startsWith("input.")
 
+  private const val DEFAULT_AUDIO_OUTPUT = "default"
   private const val COLLISION_CHUNK_SIZE = 60_000
   private const val MAX_COLLISION_CHUNKS = 32
   private const val MAX_SETTINGS_PROPERTIES = 2_048
+  private val gamepadTuningKey =
+      Regex(
+          "input\\.gamepad\\.(sdl-[0-9a-f]{64})\\." +
+              "(movementDeadZone|tiltDeadZone|invertMovementX|invertMovementY|" +
+              "invertTiltX|invertTiltY)")
   private val SUPPORTED_SCHEMA_VERSION = ApplicationSettings.CURRENT_SCHEMA_VERSION.toString()
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
@@ -95,6 +95,16 @@ internal constructor(
   val playerInputMapping: ControllerProperties.PlayerMapping
     get() = applicationSettings.input.toPlayerMapping()
 
+  val gamepadTunings: Map<String, ApplicationSettings.GamepadTuning>
+    get() = applicationSettings.input.gamepadTunings
+
+  fun gamepadTuning(stableId: String): ApplicationSettings.GamepadTuning {
+    require(ControllerProperties.isStableGamepadId(stableId)) {
+      "Gamepad tuning device must be sdl- followed by 64 lowercase hex digits"
+    }
+    return gamepadTunings[stableId] ?: ApplicationSettings.GamepadTuning()
+  }
+
   /** Shared live-input service copied into each active machine configuration. */
   val playerInputSource = PlayerInputHub()
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/SoundProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/SoundProperties.kt
@@ -3,4 +3,13 @@ package eu.rekawek.coffeegb.controller.properties
 class SoundProperties(private val properties: EmulatorProperties) {
   val soundEnabled
     get() = properties.applicationSettings.audio.enabled
+
+  val output
+    get() = properties.applicationSettings.audio.output
+
+  val volume
+    get() = properties.applicationSettings.audio.volume
+
+  val latency
+    get() = properties.applicationSettings.audio.latency
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
@@ -1,0 +1,324 @@
+package eu.rekawek.coffeegb.controller.properties
+
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ApplicationSettingsDevicesTest {
+
+  @Test
+  fun `audio and gamepad tuning models enforce explicit defaults and bounds`() {
+    assertEquals(
+        ApplicationSettings.AudioOutputSelection.Default,
+        ApplicationSettings.Audio().output,
+    )
+    assertEquals(ApplicationSettings.DEFAULT_AUDIO_VOLUME, ApplicationSettings.Audio().volume)
+    assertEquals(ApplicationSettings.AudioLatency.BALANCED, ApplicationSettings.Audio().latency)
+    ApplicationSettings.Audio(volume = ApplicationSettings.MIN_AUDIO_VOLUME)
+    ApplicationSettings.Audio(volume = ApplicationSettings.MAX_AUDIO_VOLUME)
+    ApplicationSettings.AudioOutputSelection.Device(audioId('a'))
+
+    listOf(-1, 101).forEach { volume ->
+      assertFailsWith<IllegalArgumentException> { ApplicationSettings.Audio(volume = volume) }
+    }
+    listOf(
+            "default",
+            "java-sound-" + "A".repeat(64),
+            "java-sound-" + "a".repeat(63),
+            "sdl-" + "a".repeat(64),
+        )
+        .forEach { invalid ->
+          assertFailsWith<IllegalArgumentException> {
+            ApplicationSettings.AudioOutputSelection.Device(invalid)
+          }
+        }
+
+    ApplicationSettings.GamepadTuning(
+        movementDeadZone = ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE,
+        tiltDeadZone = ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE,
+    )
+    listOf(-1, 32_767).forEach { invalid ->
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.GamepadTuning(movementDeadZone = invalid)
+      }
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.GamepadTuning(tiltDeadZone = invalid)
+      }
+    }
+
+    val maximumProfiles =
+        (0 until ApplicationSettings.MAX_GAMEPAD_TUNINGS).associate { index ->
+          gamepadId(index) to ApplicationSettings.GamepadTuning()
+        }
+    ApplicationSettings.Input.defaults().copy(gamepadTunings = maximumProfiles)
+    assertFailsWith<IllegalArgumentException> {
+      ApplicationSettings.Input.defaults().copy(
+          gamepadTunings =
+              maximumProfiles + (gamepadId(ApplicationSettings.MAX_GAMEPAD_TUNINGS) to
+                  ApplicationSettings.GamepadTuning()))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      ApplicationSettings.Input.defaults().copy(
+          gamepadTunings = mapOf("controller-0" to ApplicationSettings.GamepadTuning()))
+    }
+  }
+
+  @Test
+  fun `schema three audio and per-device tuning round trip canonically and deterministically`() {
+    val firstId = gamepadId('a')
+    val secondId = gamepadId('b')
+    val firstTuning =
+        ApplicationSettings.GamepadTuning(
+            movementDeadZone = 0,
+            tiltDeadZone = 32_766,
+            invertMovementX = true,
+            invertTiltY = true,
+        )
+    val secondTuning =
+        ApplicationSettings.GamepadTuning(
+            movementDeadZone = 12_345,
+            tiltDeadZone = 2_345,
+            invertMovementY = true,
+            invertTiltX = true,
+        )
+    val mutableTunings = linkedMapOf(secondId to secondTuning, firstId to firstTuning)
+    val document =
+        ApplicationSettingsDocument(
+            ApplicationSettings(
+                audio =
+                    ApplicationSettings.Audio(
+                        enabled = false,
+                        output = ApplicationSettings.AudioOutputSelection.Device(audioId('c')),
+                        volume = 37,
+                        latency = ApplicationSettings.AudioLatency.LOW,
+                    ),
+                input =
+                    ApplicationSettings.Input.defaults().copy(
+                        gamepadTunings = mutableTunings)),
+            mapOf("plugin.device-setting" to "preserved"),
+        )
+    mutableTunings.clear()
+
+    val encoded = ApplicationSettingsCodec.encode(document)
+    assertEquals("3", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals(audioId('c'), encoded[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
+    assertEquals("37", encoded[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
+    assertEquals("LOW", encoded[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
+    assertEquals("0", encoded[tuningKey(firstId, "movementDeadZone")])
+    assertEquals("32766", encoded[tuningKey(firstId, "tiltDeadZone")])
+    assertEquals("true", encoded[tuningKey(firstId, "invertMovementX")])
+    assertEquals("false", encoded[tuningKey(firstId, "invertMovementY")])
+    assertEquals("false", encoded[tuningKey(firstId, "invertTiltX")])
+    assertEquals("true", encoded[tuningKey(firstId, "invertTiltY")])
+    assertEquals("12345", encoded[tuningKey(secondId, "movementDeadZone")])
+    assertEquals("2345", encoded[tuningKey(secondId, "tiltDeadZone")])
+    assertEquals("false", encoded[tuningKey(secondId, "invertMovementX")])
+    assertEquals("true", encoded[tuningKey(secondId, "invertMovementY")])
+    assertEquals("true", encoded[tuningKey(secondId, "invertTiltX")])
+    assertEquals("false", encoded[tuningKey(secondId, "invertTiltY")])
+    assertEquals(encoded.keys.sorted(), encoded.keys.toList())
+
+    val decoded = ApplicationSettingsCodec.decode(encoded)
+    assertEquals(document, decoded)
+    assertEquals(encoded, ApplicationSettingsCodec.encode(decoded))
+    assertFailsWith<UnsupportedOperationException> {
+      (decoded.settings.input.gamepadTunings as MutableMap<String, *>).clear()
+    }
+  }
+
+  @Test
+  fun `schemas zero through two preserve future device fields without interpreting them`() {
+    val stableId = gamepadId('d')
+    val futureValues =
+        mapOf(
+            ApplicationSettingsCodec.AUDIO_OUTPUT_KEY to "plugin-output",
+            ApplicationSettingsCodec.AUDIO_VOLUME_KEY to "999",
+            ApplicationSettingsCodec.AUDIO_LATENCY_KEY to "TURBO",
+            tuningKey(stableId, "movementDeadZone") to "32767",
+            tuningKey(stableId, "invertMovementX") to "plugin-boolean",
+        )
+
+    listOf(null, "1", "2").forEach { sourceVersion ->
+      val raw =
+          buildMap {
+            sourceVersion?.let {
+              put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, it)
+            }
+            put("sound.enabled", "false")
+            putAll(futureValues)
+          }
+      val migrated = ApplicationSettingsCodec.decode(raw)
+
+      assertFalse(migrated.settings.audio.enabled)
+      assertEquals(
+          ApplicationSettings.AudioOutputSelection.Default,
+          migrated.settings.audio.output,
+      )
+      assertEquals(ApplicationSettings.DEFAULT_AUDIO_VOLUME, migrated.settings.audio.volume)
+      assertEquals(ApplicationSettings.AudioLatency.BALANCED, migrated.settings.audio.latency)
+      assertTrue(migrated.settings.input.gamepadTunings.isEmpty())
+      assertEquals(futureValues, migrated.unknownProperties)
+
+      val canonical = ApplicationSettingsCodec.encode(migrated)
+      assertEquals("3", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("default", canonical[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
+      assertEquals("100", canonical[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
+      assertEquals("BALANCED", canonical[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
+      assertFalse(tuningKey(stableId, "movementDeadZone") in canonical)
+      assertTrue(
+          canonical.keys.any {
+            it.startsWith(ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX)
+          })
+
+      val decodedAgain = ApplicationSettingsCodec.decode(canonical)
+      assertEquals(migrated, decodedAgain)
+      assertEquals(canonical, ApplicationSettingsCodec.encode(decodedAgain))
+    }
+  }
+
+  @Test
+  fun `schema two collision envelope retains future device values through schema three`() {
+    val stableId = gamepadId('e')
+    val collisions =
+        mapOf(
+            ApplicationSettingsCodec.AUDIO_OUTPUT_KEY to audioId('e'),
+            ApplicationSettingsCodec.AUDIO_VOLUME_KEY to "0",
+            ApplicationSettingsCodec.AUDIO_LATENCY_KEY to "SAFE",
+            tuningKey(stableId, "movementDeadZone") to "0",
+            tuningKey(stableId, "invertTiltY") to "true",
+        )
+    val raw =
+        mapOf(
+            ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "2",
+            "${ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX}0" to
+                serializeCollisions(collisions),
+        )
+
+    val migrated = ApplicationSettingsCodec.decode(raw)
+    assertEquals(ApplicationSettings.Audio(), migrated.settings.audio)
+    assertTrue(migrated.settings.input.gamepadTunings.isEmpty())
+    assertEquals(collisions, migrated.unknownProperties)
+
+    val canonical = ApplicationSettingsCodec.encode(migrated)
+    assertEquals("default", canonical[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
+    assertFalse(tuningKey(stableId, "movementDeadZone") in canonical)
+    val decodedAgain = ApplicationSettingsCodec.decode(canonical)
+    assertEquals(migrated, decodedAgain)
+    assertEquals(canonical, ApplicationSettingsCodec.encode(decodedAgain))
+  }
+
+  @Test
+  fun `schema three strictly validates audio tuning fields and profile count`() {
+    val stableId = gamepadId('f')
+    val partial =
+        ApplicationSettingsCodec.decode(
+            mapOf(
+                ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "3",
+                tuningKey(stableId, "invertTiltX") to "true",
+            ))
+    assertEquals(
+        ApplicationSettings.GamepadTuning(invertTiltX = true),
+        partial.settings.input.gamepadTunings[stableId],
+    )
+    assertEquals(
+        ApplicationSettings.DEFAULT_AUDIO_VOLUME,
+        partial.settings.audio.volume,
+    )
+
+    val invalid =
+        listOf(
+            mapOf(ApplicationSettingsCodec.AUDIO_OUTPUT_KEY to "java-sound-" + "F".repeat(64)),
+            mapOf(ApplicationSettingsCodec.AUDIO_OUTPUT_KEY to "speaker"),
+            mapOf(ApplicationSettingsCodec.AUDIO_VOLUME_KEY to "-1"),
+            mapOf(ApplicationSettingsCodec.AUDIO_VOLUME_KEY to "101"),
+            mapOf(ApplicationSettingsCodec.AUDIO_VOLUME_KEY to "loud"),
+            mapOf(ApplicationSettingsCodec.AUDIO_LATENCY_KEY to "FAST"),
+            mapOf(tuningKey(stableId, "movementDeadZone") to "-1"),
+            mapOf(tuningKey(stableId, "movementDeadZone") to "32767"),
+            mapOf(tuningKey(stableId, "tiltDeadZone") to "wide"),
+            mapOf(tuningKey(stableId, "invertMovementY") to "yes"),
+        )
+
+    invalid.forEach { fields ->
+      assertFailsWith<IllegalArgumentException>("Expected rejection for $fields") {
+        ApplicationSettingsCodec.decode(
+            fields + (ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "3"))
+      }
+    }
+
+    val tooManyProfiles =
+        buildMap {
+          put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, "3")
+          repeat(ApplicationSettings.MAX_GAMEPAD_TUNINGS + 1) { index ->
+            put(tuningKey(gamepadId(index), "movementDeadZone"), "1")
+          }
+        }
+    assertFailsWith<IllegalArgumentException> {
+      ApplicationSettingsCodec.decode(tooManyProfiles)
+    }
+  }
+
+  @Test
+  fun `controller facades expose applied audio and gamepad tuning snapshots`() {
+    val path = Files.createTempDirectory("coffee-gb-devices").resolve("settings.properties")
+    val stableId = gamepadId('1')
+    val audio =
+        ApplicationSettings.Audio(
+            enabled = false,
+            output = ApplicationSettings.AudioOutputSelection.Device(audioId('1')),
+            volume = 65,
+            latency = ApplicationSettings.AudioLatency.SAFE,
+        )
+    val tuning =
+        ApplicationSettings.GamepadTuning(
+            movementDeadZone = 1_024,
+            tiltDeadZone = 512,
+            invertMovementX = true,
+        )
+
+    EmulatorProperties(path, debounceMillis = 0).use { properties ->
+      properties.updateApplicationSettings { current ->
+        current.copy(
+            audio = audio,
+            input = current.input.copy(gamepadTunings = mapOf(stableId to tuning)),
+        )
+      }
+
+      assertFalse(properties.sound.soundEnabled)
+      assertEquals(audio.output, properties.sound.output)
+      assertEquals(65, properties.sound.volume)
+      assertEquals(ApplicationSettings.AudioLatency.SAFE, properties.sound.latency)
+      assertEquals(mapOf(stableId to tuning), properties.gamepadTunings)
+      assertEquals(tuning, properties.gamepadTuning(stableId))
+      assertEquals(ApplicationSettings.GamepadTuning(), properties.gamepadTuning(gamepadId('2')))
+      properties.flush()
+    }
+
+    val persisted =
+        ApplicationSettingsCodec.decode(
+            ApplicationSettingsStore.decodeProperties(Files.readAllBytes(path)))
+    assertEquals(audio, persisted.settings.audio)
+    assertEquals(mapOf(stableId to tuning), persisted.settings.input.gamepadTunings)
+  }
+
+  private fun gamepadId(fill: Char): String = "sdl-" + fill.toString().repeat(64)
+
+  private fun gamepadId(index: Int): String =
+      "sdl-" + index.toString(16).padStart(64, '0')
+
+  private fun audioId(fill: Char): String = "java-sound-" + fill.toString().repeat(64)
+
+  private fun tuningKey(stableId: String, field: String): String =
+      "${ApplicationSettingsCodec.GAMEPAD_TUNING_PREFIX}$stableId.$field"
+
+  private fun serializeCollisions(collisions: Map<String, String>): String =
+      buildString {
+        collisions.toSortedMap().forEach { (key, value) ->
+          append(key.length).append(':').append(key)
+          append(value.length).append(':').append(value)
+        }
+      }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
@@ -402,7 +402,7 @@ class ApplicationSettingsGeneralTest {
     val raw =
         buildMap {
           put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, "2")
-          repeat(2_034) { index -> put("plugin.$index", "value") }
+          repeat(2_031) { index -> put("plugin.$index", "value") }
           serialized.chunked(60_000).forEachIndexed { index, chunk ->
             put(
                 "${ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX}$index",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
@@ -395,7 +395,7 @@ class ApplicationSettingsStoreTest {
   }
 
   @Test
-  fun `schema one file is rewritten once as canonical schema two`() {
+  fun `schema one file is rewritten once as canonical current schema`() {
     val directory = Files.createTempDirectory("coffee-gb-settings-schema-one")
     val path = directory.resolve("settings.properties")
     val schemaOne =
@@ -427,14 +427,14 @@ class ApplicationSettingsStoreTest {
 
           Files.readAllBytes(path).also { bytes ->
             val canonical = ApplicationSettingsStore.decodeProperties(bytes)
-            assertEquals("2", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+            assertEquals("3", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
             assertEquals(store.current(), ApplicationSettingsCodec.decode(canonical))
             assertEquals(canonical, ApplicationSettingsCodec.encode(store.current()))
           }
         }
 
     ApplicationSettingsStore(path, debounceMillis = 60_000).use { store ->
-      assertEquals("2", store.current().settings.schemaVersion.toString())
+      assertEquals("3", store.current().settings.schemaVersion.toString())
     }
     assertTrue(canonicalBytes.contentEquals(Files.readAllBytes(path)))
   }
@@ -786,6 +786,9 @@ class ApplicationSettingsStoreTest {
 
   private fun expectedCanonicalFixture(): Map<String, String> =
       mapOf(
+              "audio.latencyPreset" to "BALANCED",
+              "audio.masterVolume" to "100",
+              "audio.outputDevice" to "default",
               "datel.slot.rom" to "/legacy/roms/action-replay.gbc",
               "display.blending" to "false",
               "display.colorCorrection" to "false",
@@ -813,7 +816,7 @@ class ApplicationSettingsStoreTest {
               "general.recent.1" to "/legacy/roms/second.gbc",
               "rom.recent.future" to "preserve future recent metadata",
               "saves.batteryEnabled" to "false",
-              "settings.schemaVersion" to "2",
+              "settings.schemaVersion" to "3",
               "sound.enabled" to "false",
               "system.bootstrapMode" to "FAST_FORWARD",
               "system.cgbGames" to "cgb0",

--- a/controller/src/test/resources/sgb-baselines/model-decision-fingerprints.tsv
+++ b/controller/src/test/resources/sgb-baselines/model-decision-fingerprints.tsv
@@ -78,5 +78,5 @@ core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java	1d69e05ce5a3bf
 core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java	d992464a2fa04f084a23ca2feb4c8da10b4b3308c4aad6709beb55de79c52612
 swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt	cf143068cfee5f7ea424dce97994ea9b1c083faf9b5f89a8a8469618f86aa655
 swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt	3af830c526ec5806c11691fc51a6d149cc9d0fafb9e2374ae3b27ea342f8c8c7
-swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java	ba039f021a8562b599babb14869bfa4a73fcfcdfd9df18d2714a8c1dd3c7ab37
+swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java	7203ded3e0288eab371d5fa925e1569c269ca30ed03289752e251512ca71d678
 swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java	48366395d4336f2f168ce86e1dd1bcb73d97c87f3953998c88f94eeb68e5fa32

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -45,12 +45,12 @@ The application owns one immutable `ApplicationSettings` value with typed `gener
 `audio`, `input`, `saves`, and `advanced` sections. The controller-facing `EmulatorProperties`
 class is a compatibility facade over that model while older menu code is migrated.
 
-Schema 2 continues to use `${user.home}/.coffeegb.properties`; schema 0 and schema 1 are migrated
-in place so the portable JAR remains compatible during the migration window.
+Schema 3 continues to use `${user.home}/.coffeegb.properties`; schemas 0–2 are migrated in place
+so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `2` |
+| `settings.schemaVersion` | exact supported schema version | `3` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
@@ -61,6 +61,9 @@ in place so the portable JAR remains compatible during the migration window.
 | `display.colorCorrection` | boolean | `true` |
 | `display.showSgbBorder` | boolean | `false` |
 | `sound.enabled` | boolean | `true` |
+| `audio.outputDevice` | `default` or stable Java Sound device ID | `default` |
+| `audio.masterVolume` | integer percentage in `0..100` | `100` |
+| `audio.latencyPreset` | `LOW`, `BALANCED`, or `SAFE` | `BALANCED` |
 | `saves.batteryEnabled` | boolean | `true` |
 | `rom.directory` | optional local path | absent |
 | `general.recentFileCapacity` | integer in `0..50` | `10` |
@@ -72,6 +75,10 @@ in place so the portable JAR remains compatible during the migration window.
 | `fullchanger.character` | optional stable menu value | absent |
 | `btn_*`, `input.pN.btn_*` | validated keyboard binding | documented P1 defaults |
 | `input.pN.gamepad` | disabled, automatic, or stable SDL device ID | P1 automatic |
+| `input.gamepad.<stable-id>.movementDeadZone` | raw SDL threshold in `0..32766` | `16384` |
+| `input.gamepad.<stable-id>.tiltDeadZone` | raw SDL threshold in `0..32766` | `4096` |
+| `input.gamepad.<stable-id>.invertMovementX/Y` | boolean | `false` |
+| `input.gamepad.<stable-id>.invertTiltX/Y` | boolean | `false` |
 
 Recognized values are validated before becoming live settings. Boolean values are exactly `true`
 or `false` (case-insensitive); numeric settings have explicit ranges; hardware profiles,
@@ -82,17 +89,18 @@ does not partially update the active settings.
 application may close without a redundant prompt. `ALWAYS` also confirms an idle application
 close, and `NEVER` suppresses this ordinary confirmation. A battery/autosave flush failure remains
 actionable regardless of this preference. Setting recent-file capacity to zero disables history;
-reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 2
+reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 3
 does not invent or persist an update-check preference.
 
-Unrecognized legacy keys are retained losslessly when schema 2 is saved. Keys in a reserved grammar,
+Unrecognized legacy keys are retained losslessly when schema 3 is saved. Keys in a reserved grammar,
 such as an unknown `input.*` key, remain errors so a misspelled control binding is not silently
-ignored. Schema 2 stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
+ignored. Schema 3 stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
 key beyond Coffee GB's old ten-entry history remains untouched even if capacity later grows. Schema
-2 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
+3 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
 binding is therefore unbound rather than silently restored to a default. If an older unknown key
-occupies a newly reserved schema-2 name, Coffee GB keeps its original key/value in bounded internal
-migration metadata rather than overwriting or reinterpreting it.
+occupies a name reserved by a later schema, Coffee GB keeps its original key/value in bounded
+internal migration metadata rather than overwriting or reinterpreting it. At most 32 per-device
+gamepad tuning profiles are retained.
 
 ## Preferences
 
@@ -102,7 +110,19 @@ without editing the properties file. The Input tab shows all eight current bindi
 1–4. Choose **Capture** and press a key, or use the explicit **Dialog key…** action for Enter or
 Escape. Tab remains reserved for focus navigation and Backspace remains reserved for Rewind.
 Conflicting bindings identify the existing assignment and are not applied; each row also supports
-Clear and Reset.
+Clear and Reset. The Gamepads tab lists up to four logical assignments without calling SDL on the
+EDT. It keeps an unavailable configured controller visible, prevents duplicate explicit or
+automatic assignments, and exposes independent movement/tilt dead zones and X/Y inversion for each
+stable device. A mapping change releases all held input and waits for a neutral physical sample
+before accepting new presses.
+
+The Audio tab enumerates Java Sound outputs on a cancellable background worker. It supports system
+default or an explicit descriptor-hashed output, software master volume, mute, and LOW/BALANCED/SAFE
+bounded-latency presets. If an explicit output disappears, playback retains the configured ID,
+falls back to System Default, records a diagnostic, and stays silent without blocking emulation if
+no output can be opened. While fallback remains active, Coffee GB periodically returns to the
+configured output after it reappears. Device, volume, mute, and latency changes do not reset emulated
+audio clock or DC-filter phase.
 
 **Apply** validates the complete draft, writes one settings update, and switches the live keyboard
 mapping only after persistence accepts it. **Cancel**, the window close button, and Escape discard
@@ -110,8 +130,8 @@ unapplied edits. **Restore Defaults** only changes the visible draft until Apply
 
 ## Migration and recovery
 
-A file without `settings.schemaVersion` is legacy schema 0. Schema 0 and schema 1 migration is a
-pure conversion into schema 2, preserves unknown keys, retains absent profile mappings as Auto, and
+A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 2 migration is a
+pure conversion into schema 3, preserves unknown keys, retains absent profile mappings as Auto, and
 canonicalizes the finite historical uppercase profile aliases. Repeating load/migrate/save produces
 the same normalized settings. Legacy text is decoded with the platform-default charset used by the
 former `FileReader`; versioned files use strict UTF-8 with deterministic ASCII escapes.
@@ -139,7 +159,9 @@ Each save uses the repository's crash-safe same-directory writer: write a unique
 flush it, force it to stable storage, then atomically replace the destination where the file system
 supports that operation. The existing recovery fallback preserves the last complete file.
 
-Normal window shutdown waits up to a bounded timeout for the latest pending settings and reports an
-actionable failure if the writer cannot be stopped safely.
+Normal window shutdown leaves the EDT immediately. Controller, gamepad, audio, and final settings
+teardown run on a dedicated worker; audio and settings waits are bounded, and a final watchdog
+prevents a stalled host provider from leaving a hung desktop process. A settings failure preserves
+the previous complete file and reports an actionable error.
 CLI parsing and settings file I/O occur before or outside Swing component mutation; Swing component
 creation and mutation remain owned by the Event Dispatch Thread.

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/AudioPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/AudioPreferencesEditor.kt
@@ -1,0 +1,355 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
+import java.awt.Component
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.text.ParseException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import javax.swing.BorderFactory
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JSpinner
+import javax.swing.SpinnerNumberModel
+import javax.swing.SwingUtilities
+import javax.swing.SwingWorker
+
+internal fun interface AudioDeviceProvider {
+  fun load(): List<AudioDeviceSnapshot>
+}
+
+/** Draft-only audio editor. Host audio discovery is delegated to a cancellable background worker. */
+internal class AudioPreferencesEditor private constructor(
+    initial: ApplicationSettings.Audio,
+    private val defaults: ApplicationSettings.Audio,
+    private val devices: AudioDeviceProvider,
+    @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
+) : JPanel(GridBagLayout()) {
+  constructor(
+      initial: ApplicationSettings.Audio,
+      defaults: ApplicationSettings.Audio = ApplicationSettings.Audio(),
+      devices: AudioDeviceProvider,
+  ) : this(initial, defaults, devices, requireEdt())
+
+  internal data class OutputOption(
+      val stableId: String,
+      val label: String,
+      val available: Boolean,
+  ) {
+    override fun toString(): String = label
+  }
+
+  private var selectedOutputId = initial.output.stableId()
+  private var knownDevices: List<AudioDeviceSnapshot> = emptyList()
+  private var updatingControls = false
+  private var generation = 0L
+  private var worker: SwingWorker<List<AudioDeviceSnapshot>, Unit>? = null
+
+  internal val output =
+      JComboBox<OutputOption>().apply {
+        accessibleContext.accessibleName = "Audio output device"
+        accessibleContext.accessibleDescription =
+            "Choose the system default or one explicit Java Sound output."
+        addActionListener {
+          if (!updatingControls) {
+            selectedOutputId = (selectedItem as? OutputOption)?.stableId
+                ?: AudioDeviceSnapshot.SYSTEM_DEFAULT_ID
+            updateUnavailableStatus()
+          }
+        }
+      }
+  internal val muted =
+      JCheckBox("Mute audio", !initial.enabled).apply {
+        accessibleContext.accessibleName = "Mute audio"
+      }
+  internal val volume =
+      JSpinner(
+          SpinnerNumberModel(
+              initial.volume,
+              ApplicationSettings.MIN_AUDIO_VOLUME,
+              ApplicationSettings.MAX_AUDIO_VOLUME,
+              1,
+          ))
+  internal val latency =
+      JComboBox(ApplicationSettings.AudioLatency.entries.toTypedArray()).apply {
+        selectedItem = initial.latency
+        accessibleContext.accessibleName = "Audio latency preset"
+      }
+  internal val status =
+      JLabel("Audio outputs have not been checked yet.").apply {
+        accessibleContext.accessibleName = "Audio output discovery status"
+      }
+  internal val volumeError =
+      JLabel(" ").apply {
+        foreground = ERROR_COLOR
+        accessibleContext.accessibleName = "Master volume error"
+      }
+
+  init {
+    getAccessibleContext().accessibleName = "Audio preferences"
+    getAccessibleContext().accessibleDescription =
+        "Choose an output, mute state, master volume, and latency preset."
+    border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+    volume.accessibleContext.accessibleName = "Master volume"
+    volume.toolTipText =
+        "Choose between ${ApplicationSettings.MIN_AUDIO_VOLUME} and " +
+            "${ApplicationSettings.MAX_AUDIO_VOLUME} percent."
+    refreshOutputOptions()
+    createRows()
+  }
+
+  internal fun validatedAudio(): ApplicationSettings.Audio {
+    requireEdt()
+    volumeError.text = " "
+    try {
+      volume.commitEdit()
+    } catch (_: ParseException) {
+      volumeError.text =
+          "Enter a whole-number volume from ${ApplicationSettings.MIN_AUDIO_VOLUME} to " +
+              "${ApplicationSettings.MAX_AUDIO_VOLUME}."
+      throw PreferenceEditorValidationException(
+          volumeError.text,
+          (volume.editor as JSpinner.DefaultEditor).textField,
+      )
+    }
+    val outputSelection =
+        if (selectedOutputId == AudioDeviceSnapshot.SYSTEM_DEFAULT_ID) {
+          ApplicationSettings.AudioOutputSelection.Default
+        } else {
+          ApplicationSettings.AudioOutputSelection.Device(selectedOutputId)
+        }
+    return ApplicationSettings.Audio(
+        enabled = !muted.isSelected,
+        output = outputSelection,
+        volume = (volume.value as Number).toInt(),
+        latency = latency.selectedItem as ApplicationSettings.AudioLatency,
+    )
+  }
+
+  internal fun restoreDefaults() {
+    requireEdt()
+    selectedOutputId = defaults.output.stableId()
+    muted.isSelected = !defaults.enabled
+    volume.value = defaults.volume
+    latency.selectedItem = defaults.latency
+    volumeError.text = " "
+    refreshOutputOptions()
+  }
+
+  internal fun startDeviceLoading() {
+    requireEdt()
+    cancelDeviceLoading()
+    val requestGeneration = ++generation
+    status.text = "Checking audio outputs…"
+    status.accessibleContext.accessibleDescription = status.text
+    val nextWorker =
+        object : SwingWorker<List<AudioDeviceSnapshot>, Unit>() {
+          override fun doInBackground(): List<AudioDeviceSnapshot> = devices.load()
+
+          override fun done() {
+            if (
+                worker !== this ||
+                    requestGeneration != generation ||
+                    isCancelled) {
+              return
+            }
+            worker = null
+            try {
+              knownDevices = get().distinctBy(AudioDeviceSnapshot::stableId)
+              refreshOutputOptions()
+              updateUnavailableStatus()
+            } catch (_: CancellationException) {
+              // Cancellation is normal when the dialog is disposed.
+            } catch (failure: InterruptedException) {
+              Thread.currentThread().interrupt()
+              showEnumerationFailure()
+            } catch (_: ExecutionException) {
+              showEnumerationFailure()
+            } catch (_: RuntimeException) {
+              showEnumerationFailure()
+            }
+          }
+        }
+    worker = nextWorker
+    nextWorker.execute()
+  }
+
+  internal fun cancelDeviceLoading() {
+    requireEdt()
+    generation++
+    worker?.cancel(true)
+    worker = null
+  }
+
+  internal fun isDeviceLoading(): Boolean = worker != null
+
+  override fun addNotify() {
+    super.addNotify()
+    startDeviceLoading()
+  }
+
+  override fun removeNotify() {
+    cancelDeviceLoading()
+    super.removeNotify()
+  }
+
+  private fun createRows() {
+    val constraints =
+        GridBagConstraints().apply {
+          anchor = GridBagConstraints.LINE_START
+          fill = GridBagConstraints.HORIZONTAL
+          insets = Insets(4, 4, 4, 4)
+        }
+
+    val outputLabel = JLabel("Output device:")
+    outputLabel.labelFor = output
+    outputLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_O
+    addRow(constraints, 0, outputLabel, output)
+
+    constraints.gridx = 1
+    constraints.gridy = 1
+    constraints.weightx = 1.0
+    add(status, constraints)
+
+    constraints.gridx = 1
+    constraints.gridy = 2
+    add(muted, constraints)
+
+    val volumeLabel = JLabel("Master volume:")
+    volumeLabel.labelFor = volume
+    volumeLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_V
+    addRow(constraints, 3, volumeLabel, volume)
+
+    constraints.gridx = 1
+    constraints.gridy = 4
+    add(volumeError, constraints)
+
+    val latencyLabel = JLabel("Latency preset:")
+    latencyLabel.labelFor = latency
+    latencyLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_L
+    addRow(constraints, 5, latencyLabel, latency)
+
+    constraints.gridx = 0
+    constraints.gridy = 6
+    constraints.gridwidth = 2
+    constraints.weightx = 1.0
+    constraints.weighty = 1.0
+    constraints.fill = GridBagConstraints.BOTH
+    add(JPanel(), constraints)
+  }
+
+  private fun refreshOutputOptions() {
+    val byId =
+        knownDevices.associateBy(AudioDeviceSnapshot::stableId).toMutableMap().apply {
+          putIfAbsent(
+              AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+              AudioDeviceSnapshot.systemDefaultDevice(),
+          )
+        }
+    val options =
+        buildList {
+          val systemDefault = byId.remove(AudioDeviceSnapshot.SYSTEM_DEFAULT_ID)
+          add(
+              OutputOption(
+                  AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                  systemDefault?.displayName() ?: "System Default",
+                  true,
+              ))
+          byId.values.sortedWith(
+                  compareBy(
+                      { it.displayName().lowercase() },
+                      AudioDeviceSnapshot::stableId,
+                  ))
+              .forEach { device ->
+                add(OutputOption(device.stableId(), device.displayName(), true))
+              }
+          if (
+              selectedOutputId != AudioDeviceSnapshot.SYSTEM_DEFAULT_ID &&
+                  none { it.stableId == selectedOutputId }) {
+            add(
+                OutputOption(
+                    selectedOutputId,
+                    "Unavailable configured output (${abbreviate(selectedOutputId)})",
+                    false,
+                ))
+          }
+        }
+
+    updatingControls = true
+    try {
+      output.model = DefaultComboBoxModel(options.toTypedArray())
+      output.selectedItem = options.first { it.stableId == selectedOutputId }
+    } finally {
+      updatingControls = false
+    }
+  }
+
+  private fun updateUnavailableStatus() {
+    val selected = output.selectedItem as? OutputOption
+    status.text =
+        when {
+          selected != null && !selected.available ->
+              "The configured output is unavailable; runtime playback will fall back safely."
+          knownDevices.isEmpty() ->
+              "No explicit audio outputs were found. System Default remains available."
+          else ->
+              "${knownDevices.count { !it.systemDefault() }} explicit audio outputs are available."
+        }
+    status.accessibleContext.accessibleDescription = status.text
+  }
+
+  private fun showEnumerationFailure() {
+    knownDevices = emptyList()
+    refreshOutputOptions()
+    status.text = "Audio outputs could not be listed. System Default remains available."
+    status.accessibleContext.accessibleDescription = status.text
+  }
+
+  private fun addRow(
+      constraints: GridBagConstraints,
+      row: Int,
+      label: JLabel,
+      field: Component,
+  ) {
+    constraints.gridx = 0
+    constraints.gridy = row
+    constraints.gridwidth = 1
+    constraints.weightx = 0.0
+    constraints.weighty = 0.0
+    constraints.fill = GridBagConstraints.NONE
+    add(label, constraints)
+
+    constraints.gridx = 1
+    constraints.weightx = 1.0
+    constraints.fill = GridBagConstraints.HORIZONTAL
+    add(field, constraints)
+  }
+
+  private fun abbreviate(stableId: String): String =
+      stableId.take(STABLE_ID_LABEL_PREFIX) + "…" + stableId.takeLast(STABLE_ID_LABEL_SUFFIX)
+
+  private fun ApplicationSettings.AudioOutputSelection.stableId(): String =
+      when (this) {
+        ApplicationSettings.AudioOutputSelection.Default ->
+            AudioDeviceSnapshot.SYSTEM_DEFAULT_ID
+        is ApplicationSettings.AudioOutputSelection.Device -> stableId
+      }
+
+  private companion object {
+    const val STABLE_ID_LABEL_PREFIX = 18
+    const val STABLE_ID_LABEL_SUFFIX = 6
+    val ERROR_COLOR = java.awt.Color(0xB0, 0x00, 0x20)
+
+    fun requireEdt() {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "Audio preferences must be constructed and accessed on the EDT"
+      }
+    }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/GamepadPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/GamepadPreferencesEditor.kt
@@ -1,0 +1,564 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.swing.io.GamepadCatalog
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.text.ParseException
+import javax.swing.BorderFactory
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JSpinner
+import javax.swing.JSeparator
+import javax.swing.SpinnerNumberModel
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+internal fun interface GamepadSnapshotProvider {
+  fun snapshot(): GamepadCatalog.Snapshot
+}
+
+internal data class GamepadPreferencesDraft(
+    val selections: Map<Int, ApplicationSettings.GamepadSelection>,
+    val tunings: Map<String, ApplicationSettings.GamepadTuning>,
+)
+
+/** Draft-only gamepad assignment and tuning editor. It never calls SDL or mutates the runtime. */
+internal class GamepadPreferencesEditor private constructor(
+    initial: ApplicationSettings.Input,
+    private val defaults: ApplicationSettings.Input,
+    private val snapshots: GamepadSnapshotProvider,
+    @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
+) : JPanel(BorderLayout(0, 8)) {
+  constructor(
+      initial: ApplicationSettings.Input,
+      defaults: ApplicationSettings.Input = ApplicationSettings.Input.defaults(),
+      snapshots: GamepadSnapshotProvider,
+  ) : this(initial, defaults, snapshots, requireEdt())
+
+  internal data class SelectionOption(
+      val selection: ApplicationSettings.GamepadSelection,
+      val label: String,
+  ) {
+    override fun toString(): String = label
+  }
+
+  internal data class DeviceOption(
+      val stableId: String,
+      val label: String,
+  ) {
+    override fun toString(): String = label
+  }
+
+  private val selections =
+      MutableList(PLAYER_COUNT) { player ->
+        initial.gamepads[player] ?: ApplicationSettings.GamepadSelection.Disabled
+      }
+  private val tunings = initial.gamepadTunings.toMutableMap()
+  private val explicitlyStoredProfiles = initial.gamepadTunings.keys.toMutableSet()
+  private var snapshot =
+      GamepadCatalog.Snapshot(GamepadCatalog.Status.STARTING, emptyList(), "")
+  private var optionsInitialized = false
+  private var updatingControls = false
+  private var selectedTuningId: String? =
+      initial.gamepadTunings.keys.sorted().firstOrNull()
+
+  internal val playerSelectors: List<JComboBox<SelectionOption>> =
+      List(PLAYER_COUNT) { player ->
+        JComboBox<SelectionOption>().apply {
+          accessibleContext.accessibleName = "Player ${player + 1} gamepad"
+          accessibleContext.accessibleDescription =
+              "Choose Disabled, automatic assignment, or one specific game controller."
+          addActionListener {
+            if (!updatingControls) {
+              selectedItem?.let {
+                selections[player] = (it as SelectionOption).selection
+                clearAssignmentErrors()
+                refreshOptions()
+              }
+            }
+          }
+        }
+      }
+  internal val playerErrors: List<JLabel> =
+      List(PLAYER_COUNT) { player ->
+        JLabel(" ").apply {
+          foreground = ERROR_COLOR
+          accessibleContext.accessibleName = "Player ${player + 1} gamepad error"
+        }
+      }
+  internal val catalogStatus =
+      JLabel("Detecting game controllers…").apply {
+        accessibleContext.accessibleName = "Gamepad discovery status"
+      }
+  internal val tuningDevice =
+      JComboBox<DeviceOption>().apply {
+        accessibleContext.accessibleName = "Gamepad tuning device"
+        accessibleContext.accessibleDescription =
+            "Choose a stable game controller whose dead zones and axes should be adjusted."
+        addActionListener {
+          if (!updatingControls) {
+            selectedTuningId = (selectedItem as? DeviceOption)?.stableId
+            loadTuningControls()
+          }
+        }
+      }
+  internal val movementDeadZone =
+      JSpinner(
+          SpinnerNumberModel(
+              ApplicationSettings.DEFAULT_GAMEPAD_MOVEMENT_DEAD_ZONE,
+              ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE,
+              ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE,
+              256,
+          ))
+  internal val tiltDeadZone =
+      JSpinner(
+          SpinnerNumberModel(
+              ApplicationSettings.DEFAULT_GAMEPAD_TILT_DEAD_ZONE,
+              ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE,
+              ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE,
+              256,
+          ))
+  internal val invertMovementX = JCheckBox("Invert movement X axis")
+  internal val invertMovementY = JCheckBox("Invert movement Y axis")
+  internal val invertTiltX = JCheckBox("Invert tilt X axis")
+  internal val invertTiltY = JCheckBox("Invert tilt Y axis")
+  internal val tuningError =
+      JLabel(" ").apply {
+        foreground = ERROR_COLOR
+        accessibleContext.accessibleName = "Gamepad tuning error"
+      }
+
+  private val catalogTimer =
+      Timer(CATALOG_REFRESH_MILLIS) { refreshCatalog() }.apply {
+        isRepeats = true
+        isCoalesce = true
+      }
+
+  init {
+    getAccessibleContext().accessibleName = "Gamepad preferences"
+    getAccessibleContext().accessibleDescription =
+        "Assign up to four players and configure per-device dead zones and axis inversion."
+    border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+    add(createContent(), BorderLayout.CENTER)
+    add(catalogStatus, BorderLayout.SOUTH)
+    refreshCatalog()
+  }
+
+  internal fun validatedDraft(): GamepadPreferencesDraft {
+    requireEdt()
+    clearAssignmentErrors()
+    commitTuningEditors()
+
+    val assignments =
+        selections.withIndex().filter {
+          it.value != ApplicationSettings.GamepadSelection.Disabled
+        }
+    val duplicates =
+        assignments
+            .groupBy { it.value }
+            .values
+            .filter { matching -> matching.size > 1 }
+    if (duplicates.isNotEmpty()) {
+      duplicates.forEach { duplicate ->
+        val players = duplicate.map { it.index }
+        players.forEach { player ->
+          val other = players.first { it != player }
+          playerErrors[player].text =
+              "${selectionLabel(duplicate.first().value)} is already selected for Player ${other + 1}."
+        }
+      }
+      val firstDuplicate = duplicates.first()
+      val message =
+          "${selectionLabel(firstDuplicate.first().value)} cannot be assigned to multiple players."
+      throw PreferenceEditorValidationException(
+          message,
+          playerSelectors[firstDuplicate.first().index],
+      )
+    }
+
+    val encodedSelections =
+        buildMap {
+          selections.forEachIndexed { player, selection ->
+            if (player == 0 || selection != ApplicationSettings.GamepadSelection.Disabled) {
+              put(player, selection)
+            }
+          }
+        }
+    try {
+      ApplicationSettings.Input(emptyMap(), encodedSelections, tunings).toPlayerMapping()
+    } catch (failure: IllegalArgumentException) {
+      tuningError.text = failure.message ?: "The gamepad tuning settings are invalid."
+      throw PreferenceEditorValidationException(tuningError.text, tuningDevice)
+    }
+    return GamepadPreferencesDraft(encodedSelections, tunings.toSortedMap())
+  }
+
+  internal fun restoreDefaults() {
+    requireEdt()
+    selections.indices.forEach { player ->
+      selections[player] =
+          defaults.gamepads[player] ?: ApplicationSettings.GamepadSelection.Disabled
+    }
+    tunings.clear()
+    tunings.putAll(defaults.gamepadTunings)
+    explicitlyStoredProfiles.clear()
+    explicitlyStoredProfiles.addAll(defaults.gamepadTunings.keys)
+    selectedTuningId = defaults.gamepadTunings.keys.sorted().firstOrNull()
+    clearAssignmentErrors()
+    tuningError.text = " "
+    refreshOptions()
+  }
+
+  internal fun refreshCatalog() {
+    requireEdt()
+    val nextSnapshot = snapshots.snapshot()
+    val deviceOptionsChanged =
+        !optionsInitialized ||
+            snapshot.devices().map { it.stableId() to it.name() } !=
+                nextSnapshot.devices().map { it.stableId() to it.name() }
+    snapshot = nextSnapshot
+    catalogStatus.text =
+        when (snapshot.status()) {
+          GamepadCatalog.Status.STARTING -> "Detecting game controllers…"
+          GamepadCatalog.Status.AVAILABLE ->
+              when (snapshot.devices().size) {
+                0 -> "No game controllers are currently connected."
+                1 -> "1 game controller is connected."
+                else -> "${snapshot.devices().size} game controllers are connected."
+              }
+          GamepadCatalog.Status.UNAVAILABLE ->
+              snapshot.message().ifBlank {
+                "Game controllers are unavailable. Keyboard input remains available."
+              }
+          GamepadCatalog.Status.STOPPED -> "Game controller discovery has stopped."
+        }
+    catalogStatus.accessibleContext.accessibleDescription = catalogStatus.text
+    if (deviceOptionsChanged) {
+      refreshOptions()
+      optionsInitialized = true
+    }
+  }
+
+  internal fun stopCatalogUpdates() {
+    requireEdt()
+    catalogTimer.stop()
+  }
+
+  internal fun isCatalogTimerRunning(): Boolean = catalogTimer.isRunning
+
+  override fun addNotify() {
+    super.addNotify()
+    refreshCatalog()
+    catalogTimer.start()
+  }
+
+  override fun removeNotify() {
+    catalogTimer.stop()
+    super.removeNotify()
+  }
+
+  private fun createContent(): JPanel {
+    val panel = JPanel(GridBagLayout())
+    val constraints =
+        GridBagConstraints().apply {
+          anchor = GridBagConstraints.LINE_START
+          fill = GridBagConstraints.HORIZONTAL
+          insets = Insets(4, 4, 4, 4)
+        }
+
+    playerSelectors.forEachIndexed { player, selector ->
+      val label = JLabel("Player ${player + 1}:")
+      label.labelFor = selector
+      label.displayedMnemonic = KeyEventForPlayer[player]
+      addRow(panel, constraints, player * 2, label, selector)
+      constraints.gridx = 1
+      constraints.gridy = player * 2 + 1
+      constraints.weightx = 1.0
+      panel.add(playerErrors[player], constraints)
+    }
+
+    constraints.gridx = 0
+    constraints.gridy = PLAYER_COUNT * 2
+    constraints.gridwidth = 2
+    constraints.weightx = 1.0
+    panel.add(JSeparator(), constraints)
+
+    val tuningLabel = JLabel("Tune controller:")
+    tuningLabel.labelFor = tuningDevice
+    tuningLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_T
+    addRow(panel, constraints, PLAYER_COUNT * 2 + 1, tuningLabel, tuningDevice)
+
+    movementDeadZone.accessibleContext.accessibleName = "Movement dead zone"
+    movementDeadZone.toolTipText =
+        "Raw SDL threshold from ${ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE} to " +
+            "${ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE}."
+    val movementLabel = JLabel("Movement dead zone:")
+    movementLabel.labelFor = movementDeadZone
+    movementLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_M
+    addRow(panel, constraints, PLAYER_COUNT * 2 + 2, movementLabel, movementDeadZone)
+
+    tiltDeadZone.accessibleContext.accessibleName = "Tilt dead zone"
+    tiltDeadZone.toolTipText =
+        "Raw SDL threshold from ${ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE} to " +
+            "${ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE}."
+    val tiltLabel = JLabel("Tilt dead zone:")
+    tiltLabel.labelFor = tiltDeadZone
+    tiltLabel.displayedMnemonic = java.awt.event.KeyEvent.VK_D
+    addRow(panel, constraints, PLAYER_COUNT * 2 + 3, tiltLabel, tiltDeadZone)
+
+    listOf(invertMovementX, invertMovementY, invertTiltX, invertTiltY).forEach {
+      it.accessibleContext.accessibleName = it.text
+      it.addActionListener { storeTuningFromControls() }
+    }
+    movementDeadZone.addChangeListener { storeTuningFromControls() }
+    tiltDeadZone.addChangeListener { storeTuningFromControls() }
+
+    val inversionPanel =
+        JPanel(GridBagLayout()).apply {
+          val checkboxConstraints =
+              GridBagConstraints().apply {
+                anchor = GridBagConstraints.LINE_START
+                fill = GridBagConstraints.HORIZONTAL
+                weightx = 1.0
+              }
+          listOf(invertMovementX, invertMovementY, invertTiltX, invertTiltY)
+              .forEachIndexed { index, checkbox ->
+                checkboxConstraints.gridx = index % 2
+                checkboxConstraints.gridy = index / 2
+                add(checkbox, checkboxConstraints)
+              }
+        }
+    val inversionLabel = JLabel("Axis inversion:")
+    inversionLabel.labelFor = invertMovementX
+    addRow(panel, constraints, PLAYER_COUNT * 2 + 4, inversionLabel, inversionPanel)
+
+    constraints.gridx = 1
+    constraints.gridy = PLAYER_COUNT * 2 + 5
+    constraints.gridwidth = 1
+    constraints.weightx = 1.0
+    panel.add(tuningError, constraints)
+
+    constraints.gridx = 0
+    constraints.gridy = PLAYER_COUNT * 2 + 6
+    constraints.gridwidth = 2
+    constraints.weighty = 1.0
+    constraints.fill = GridBagConstraints.BOTH
+    panel.add(JPanel(), constraints)
+    return panel
+  }
+
+  private fun refreshOptions() {
+    val available =
+        snapshot.devices().associateBy(GamepadCatalog.Device::stableId)
+    val stableIds =
+        buildSet {
+          addAll(available.keys)
+          selections.forEach { selection ->
+            if (selection is ApplicationSettings.GamepadSelection.Device) {
+              add(selection.stableId)
+            }
+          }
+          addAll(tunings.keys)
+          selectedTuningId?.let(::add)
+        }.sorted()
+
+    updatingControls = true
+    try {
+      playerSelectors.forEachIndexed { player, selector ->
+        val options =
+            buildList {
+              add(
+                  SelectionOption(
+                      ApplicationSettings.GamepadSelection.Disabled,
+                      "Disabled",
+                  ))
+              add(
+                  SelectionOption(
+                      ApplicationSettings.GamepadSelection.Auto,
+                      "Automatic",
+                  ))
+              stableIds.forEach { stableId ->
+                add(
+                    SelectionOption(
+                        ApplicationSettings.GamepadSelection.Device(stableId),
+                        deviceLabel(stableId, available[stableId]),
+                    ))
+              }
+            }
+        selector.model = DefaultComboBoxModel(options.toTypedArray())
+        selector.selectedItem = options.first { it.selection == selections[player] }
+      }
+
+      val deviceOptions =
+          stableIds.map { stableId ->
+            DeviceOption(stableId, deviceLabel(stableId, available[stableId]))
+          }
+      tuningDevice.model = DefaultComboBoxModel(deviceOptions.toTypedArray())
+      val selected =
+          deviceOptions.firstOrNull { it.stableId == selectedTuningId }
+              ?: deviceOptions.firstOrNull()
+      selectedTuningId = selected?.stableId
+      tuningDevice.selectedItem = selected
+    } finally {
+      updatingControls = false
+    }
+    loadTuningControls()
+  }
+
+  private fun loadTuningControls() {
+    val stableId = selectedTuningId
+    val enabled = stableId != null
+    val tuning =
+        stableId?.let(tunings::get) ?: ApplicationSettings.GamepadTuning()
+    updatingControls = true
+    try {
+      movementDeadZone.value = tuning.movementDeadZone
+      tiltDeadZone.value = tuning.tiltDeadZone
+      invertMovementX.isSelected = tuning.invertMovementX
+      invertMovementY.isSelected = tuning.invertMovementY
+      invertTiltX.isSelected = tuning.invertTiltX
+      invertTiltY.isSelected = tuning.invertTiltY
+      listOf(
+              movementDeadZone,
+              tiltDeadZone,
+              invertMovementX,
+              invertMovementY,
+              invertTiltX,
+              invertTiltY,
+          )
+          .forEach { it.isEnabled = enabled }
+      tuningDevice.isEnabled = tuningDevice.itemCount > 0
+    } finally {
+      updatingControls = false
+    }
+  }
+
+  private fun storeTuningFromControls() {
+    if (updatingControls) return
+    val stableId = selectedTuningId ?: return
+    tuningError.text = " "
+    val tuning =
+        ApplicationSettings.GamepadTuning(
+            movementDeadZone = (movementDeadZone.value as Number).toInt(),
+            tiltDeadZone = (tiltDeadZone.value as Number).toInt(),
+            invertMovementX = invertMovementX.isSelected,
+            invertMovementY = invertMovementY.isSelected,
+            invertTiltX = invertTiltX.isSelected,
+            invertTiltY = invertTiltY.isSelected,
+        )
+    if (stableId in explicitlyStoredProfiles || tuning != ApplicationSettings.GamepadTuning()) {
+      tunings[stableId] = tuning
+    } else {
+      tunings.remove(stableId)
+    }
+  }
+
+  private fun commitTuningEditors() {
+    try {
+      movementDeadZone.commitEdit()
+    } catch (_: ParseException) {
+      tuningError.text =
+          "Enter dead zones from ${ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE} to " +
+              "${ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE}."
+      throw PreferenceEditorValidationException(
+          tuningError.text,
+          (movementDeadZone.editor as JSpinner.DefaultEditor).textField,
+      )
+    }
+    try {
+      tiltDeadZone.commitEdit()
+    } catch (_: ParseException) {
+      tuningError.text =
+          "Enter dead zones from ${ApplicationSettings.MIN_GAMEPAD_DEAD_ZONE} to " +
+              "${ApplicationSettings.MAX_GAMEPAD_DEAD_ZONE}."
+      throw PreferenceEditorValidationException(
+          tuningError.text,
+          (tiltDeadZone.editor as JSpinner.DefaultEditor).textField,
+      )
+    }
+    storeTuningFromControls()
+  }
+
+  private fun clearAssignmentErrors() {
+    playerErrors.forEach { it.text = " " }
+  }
+
+  private fun selectionLabel(selection: ApplicationSettings.GamepadSelection): String =
+      when (selection) {
+        ApplicationSettings.GamepadSelection.Disabled -> "Disabled"
+        ApplicationSettings.GamepadSelection.Auto -> "Automatic assignment"
+        is ApplicationSettings.GamepadSelection.Device ->
+            snapshot
+                .devices()
+                .firstOrNull { it.stableId() == selection.stableId }
+                ?.name()
+                ?: "The configured controller"
+      }
+
+  private fun deviceLabel(
+      stableId: String,
+      device: GamepadCatalog.Device?,
+  ): String =
+      if (device == null) {
+        "Unavailable configured controller (${abbreviate(stableId)})"
+      } else {
+        "${device.name()} (${abbreviate(stableId)})"
+      }
+
+  private fun abbreviate(stableId: String): String =
+      stableId.take(STABLE_ID_LABEL_PREFIX) + "…" + stableId.takeLast(STABLE_ID_LABEL_SUFFIX)
+
+  private fun addRow(
+      panel: JPanel,
+      constraints: GridBagConstraints,
+      row: Int,
+      label: JLabel,
+      field: Component,
+  ) {
+    constraints.gridx = 0
+    constraints.gridy = row
+    constraints.gridwidth = 1
+    constraints.weightx = 0.0
+    constraints.weighty = 0.0
+    constraints.fill = GridBagConstraints.NONE
+    panel.add(label, constraints)
+
+    constraints.gridx = 1
+    constraints.weightx = 1.0
+    constraints.fill = GridBagConstraints.HORIZONTAL
+    panel.add(field, constraints)
+  }
+
+  private companion object {
+    const val PLAYER_COUNT = 4
+    const val CATALOG_REFRESH_MILLIS = 1_000
+    const val STABLE_ID_LABEL_PREFIX = 12
+    const val STABLE_ID_LABEL_SUFFIX = 6
+    val ERROR_COLOR = java.awt.Color(0xB0, 0x00, 0x20)
+    val KeyEventForPlayer =
+        listOf(
+            java.awt.event.KeyEvent.VK_1,
+            java.awt.event.KeyEvent.VK_2,
+            java.awt.event.KeyEvent.VK_3,
+            java.awt.event.KeyEvent.VK_4,
+        )
+
+    fun requireEdt() {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "Gamepad preferences must be constructed and accessed on the EDT"
+      }
+    }
+  }
+}
+
+internal class PreferenceEditorValidationException(
+    message: String,
+    val invalidComponent: Component,
+) : IllegalArgumentException(message)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
@@ -83,6 +83,7 @@ class KeyboardMappingEditor private constructor(
   private val keyboard =
       initialInput.keyboard.toMutableMap().also { initialInput.toPlayerMapping() }
   private val gamepads = initialInput.gamepads.toMap()
+  private val gamepadTunings = initialInput.gamepadTunings.toMap()
   private val defaultKeyboard =
       defaultInput.keyboard.toMap().also { defaultInput.toPlayerMapping() }
   private val rows = linkedMapOf<Binding, Row>()
@@ -167,7 +168,9 @@ class KeyboardMappingEditor private constructor(
    */
   fun validatedDraft(): ApplicationSettings.Input {
     requireEventDispatchThread()
-    return ApplicationSettings.Input(keyboard.toMap(), gamepads).also { it.toPlayerMapping() }
+    return ApplicationSettings.Input(keyboard.toMap(), gamepads, gamepadTunings).also {
+      it.toPlayerMapping()
+    }
   }
 
   fun currentBinding(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
@@ -3,6 +3,8 @@ package eu.rekawek.coffeegb.swing
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings.RomChangeConfirmationPolicy
 import eu.rekawek.coffeegb.controller.properties.ControllerProperties
+import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
+import eu.rekawek.coffeegb.swing.io.GamepadCatalog
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
@@ -44,7 +46,7 @@ import javax.swing.event.DocumentListener
  * The validated portion of Preferences currently exposed by the desktop UI.
  *
  * Applying this object to the latest settings, instead of replacing the document captured when the
- * dialog opened, preserves every hidden section and any gamepad changes made by another owner.
+ * dialog opened, preserves every hidden section.
  */
 internal data class PreferencesEdit(
     val romDirectory: Path?,
@@ -55,12 +57,16 @@ internal data class PreferencesEdit(
             ControllerProperties.PlayerButton,
             ApplicationSettings.KeyboardKey,
         >,
+    val gamepads: Map<Int, ApplicationSettings.GamepadSelection>,
+    val gamepadTunings: Map<String, ApplicationSettings.GamepadTuning>,
+    val audio: ApplicationSettings.Audio,
 ) {
   init {
     require(
         recentFileCapacity in
             ApplicationSettings.MIN_RECENT_FILE_CAPACITY..
                 ApplicationSettings.MAX_RECENT_FILE_CAPACITY)
+    ApplicationSettings.Input(keyboard, gamepads, gamepadTunings).toPlayerMapping()
   }
 
   fun applyTo(current: ApplicationSettings): ApplicationSettings =
@@ -72,7 +78,13 @@ internal data class PreferencesEdit(
                   recentFileCapacity = recentFileCapacity,
                   romChangeConfirmationPolicy = confirmationPolicy,
               ),
-          input = current.input.copy(keyboard = keyboard),
+          audio = audio,
+          input =
+              current.input.copy(
+                  keyboard = keyboard,
+                  gamepads = gamepads,
+                  gamepadTunings = gamepadTunings,
+              ),
       )
 }
 
@@ -88,13 +100,24 @@ internal class PreferencesPanel private constructor(
     initial: ApplicationSettings,
     private val defaults: ApplicationSettings = ApplicationSettings(),
     private val directoryChooser: RomDirectoryChooser = SYSTEM_DIRECTORY_CHOOSER,
+    gamepadSnapshots: GamepadSnapshotProvider = EMPTY_GAMEPAD_SNAPSHOTS,
+    audioDevices: AudioDeviceProvider = SYSTEM_AUDIO_DEVICES,
     @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
 ) : JPanel(BorderLayout(0, 8)) {
   constructor(
       initial: ApplicationSettings,
       defaults: ApplicationSettings = ApplicationSettings(),
       directoryChooser: RomDirectoryChooser = SYSTEM_DIRECTORY_CHOOSER,
-  ) : this(initial, defaults, directoryChooser, requireEdt())
+      gamepadSnapshots: GamepadSnapshotProvider = EMPTY_GAMEPAD_SNAPSHOTS,
+      audioDevices: AudioDeviceProvider = SYSTEM_AUDIO_DEVICES,
+  ) : this(
+      initial,
+      defaults,
+      directoryChooser,
+      gamepadSnapshots,
+      audioDevices,
+      requireEdt(),
+  )
 
   internal val directoryField = JTextField(initial.general.romDirectory?.toString().orEmpty(), 32)
   internal val directoryError = JLabel(" ")
@@ -115,6 +138,10 @@ internal class PreferencesPanel private constructor(
             }
       }
   internal val keyboardEditor = KeyboardMappingEditor(initial.input, defaults.input)
+  internal val gamepadEditor =
+      GamepadPreferencesEditor(initial.input, defaults.input, gamepadSnapshots)
+  internal val audioEditor =
+      AudioPreferencesEditor(initial.audio, defaults.audio, audioDevices)
   internal val validationSummary = JLabel(" ")
   internal val tabs = JTabbedPane()
 
@@ -125,6 +152,8 @@ internal class PreferencesPanel private constructor(
     tabs.accessibleContext.accessibleName = "Preference categories"
     tabs.addTab("General", createGeneralPanel())
     tabs.addTab("Input", JScrollPane(keyboardEditor).apply { border = null })
+    tabs.addTab("Gamepads", JScrollPane(gamepadEditor).apply { border = null })
+    tabs.addTab("Audio", JScrollPane(audioEditor).apply { border = null })
     tabs.addChangeListener {
       if (tabs.selectedIndex != INPUT_TAB) {
         keyboardEditor.cancelCapture()
@@ -146,6 +175,8 @@ internal class PreferencesPanel private constructor(
           it.policy == defaults.general.romChangeConfirmationPolicy
         }
     keyboardEditor.resetToDefaults()
+    gamepadEditor.restoreDefaults()
+    audioEditor.restoreDefaults()
     clearErrors()
   }
 
@@ -162,12 +193,49 @@ internal class PreferencesPanel private constructor(
           tabs.selectedIndex = INPUT_TAB
           throw PreferencesValidationException(validationSummary.text, keyboardEditor)
         }
+    val gamepad =
+        try {
+          gamepadEditor.validatedDraft()
+        } catch (failure: PreferenceEditorValidationException) {
+          validationSummary.text = failure.message ?: "Resolve the gamepad settings error."
+          tabs.selectedIndex = GAMEPADS_TAB
+          throw PreferencesValidationException(
+              validationSummary.text,
+              failure.invalidComponent,
+          )
+        }
+    val audio =
+        try {
+          audioEditor.validatedAudio()
+        } catch (failure: PreferenceEditorValidationException) {
+          validationSummary.text = failure.message ?: "Resolve the audio settings error."
+          tabs.selectedIndex = AUDIO_TAB
+          throw PreferencesValidationException(
+              validationSummary.text,
+              failure.invalidComponent,
+          )
+        }
     return PreferencesEdit(
         romDirectory = directory,
         recentFileCapacity = capacity,
         confirmationPolicy = (confirmationPolicy.selectedItem as ConfirmationOption).policy,
         keyboard = input.keyboard,
+        gamepads = gamepad.selections,
+        gamepadTunings = gamepad.tunings,
+        audio = audio,
     )
+  }
+
+  internal fun stopBackgroundWork() {
+    requireEdt()
+    keyboardEditor.cancelCapture()
+    gamepadEditor.stopCatalogUpdates()
+    audioEditor.cancelDeviceLoading()
+  }
+
+  override fun removeNotify() {
+    stopBackgroundWork()
+    super.removeNotify()
   }
 
   internal fun showApplyFailure(failure: RuntimeException) {
@@ -367,6 +435,8 @@ internal class PreferencesPanel private constructor(
   private companion object {
     const val GENERAL_TAB = 0
     const val INPUT_TAB = 1
+    const val GAMEPADS_TAB = 2
+    const val AUDIO_TAB = 3
     val ERROR_COLOR = Color(0xB0, 0x00, 0x20)
     val CONFIRMATION_OPTIONS =
         listOf(
@@ -394,6 +464,18 @@ internal class PreferencesPanel private constructor(
           }
         }
 
+    val EMPTY_GAMEPAD_SNAPSHOTS =
+        GamepadSnapshotProvider {
+          GamepadCatalog.Snapshot(
+              GamepadCatalog.Status.UNAVAILABLE,
+              emptyList(),
+              "Game controllers are unavailable. Keyboard input remains available.",
+          )
+        }
+
+    val SYSTEM_AUDIO_DEVICES =
+        AudioDeviceProvider { listOf(AudioDeviceSnapshot.systemDefaultDevice()) }
+
     fun parseDirectory(value: String): Path? =
         value.trim().takeIf(String::isNotEmpty)?.let(Paths::get)
 
@@ -416,6 +498,9 @@ internal object PreferencesDialog {
       owner: Window,
       initial: ApplicationSettings,
       defaults: ApplicationSettings = ApplicationSettings(),
+      gamepadCatalog: GamepadCatalog = GamepadCatalog(),
+      audioDevices: AudioDeviceProvider =
+          AudioDeviceProvider { listOf(AudioDeviceSnapshot.systemDefaultDevice()) },
       applyEdit: (PreferencesEdit) -> Unit,
   ) {
     check(SwingUtilities.isEventDispatchThread()) {
@@ -423,7 +508,13 @@ internal object PreferencesDialog {
     }
 
     val dialog = JDialog(owner, "Preferences", Dialog.ModalityType.APPLICATION_MODAL)
-    val panel = PreferencesPanel(initial, defaults)
+    val panel =
+        PreferencesPanel(
+            initial,
+            defaults,
+            gamepadSnapshots = GamepadSnapshotProvider(gamepadCatalog::snapshot),
+            audioDevices = audioDevices,
+        )
     val applyButton = JButton("Apply")
     val cancelButton = JButton("Cancel")
     val restoreButton = JButton("Restore Defaults")
@@ -479,10 +570,14 @@ internal class PreferencesDialogActions(
       panel.showApplyFailure(failure)
       return
     }
+    panel.stopBackgroundWork()
     close()
   }
 
-  fun cancel() = close()
+  fun cancel() {
+    panel.stopBackgroundWork()
+    close()
+  }
 
   fun restoreDefaults() = panel.restoreDefaults()
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -6,18 +6,25 @@ import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.link.LinkedController
 import eu.rekawek.coffeegb.controller.network.ConnectionController
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.ControllerProperties
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
+import eu.rekawek.coffeegb.swing.io.AudioDeviceCatalog
+import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
+import eu.rekawek.coffeegb.swing.io.AudioOutputStatus
+import eu.rekawek.coffeegb.swing.io.AudioRuntimeConfiguration
 import eu.rekawek.coffeegb.swing.io.AudioSystemSound
-import eu.rekawek.coffeegb.swing.io.SwingAccelerometer
-import eu.rekawek.coffeegb.swing.io.SwingTiltKeys
-import eu.rekawek.coffeegb.swing.io.SwingDisplay
-import eu.rekawek.coffeegb.swing.io.SwingJoypad
-import eu.rekawek.coffeegb.swing.io.SwingGamepad
 import eu.rekawek.coffeegb.swing.io.DesktopPlayerInput
 import eu.rekawek.coffeegb.swing.io.DesktopTiltInput
+import eu.rekawek.coffeegb.swing.io.GamepadCatalog
+import eu.rekawek.coffeegb.swing.io.GamepadConfiguration
+import eu.rekawek.coffeegb.swing.io.SwingAccelerometer
+import eu.rekawek.coffeegb.swing.io.SwingDisplay
+import eu.rekawek.coffeegb.swing.io.SwingGamepad
+import eu.rekawek.coffeegb.swing.io.SwingJoypad
+import eu.rekawek.coffeegb.swing.io.SwingTiltKeys
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -32,6 +39,7 @@ class SwingEmulator(
   private val gamepad: SwingGamepad
   private val gamepadThread: Thread
   private val sound: AudioSystemSound
+  private val audioDeviceCatalog = AudioDeviceCatalog()
   private val accelerometer: SwingAccelerometer
 
   private val tiltInput: DesktopTiltInput
@@ -46,18 +54,24 @@ class SwingEmulator(
 
   init {
     display = SwingDisplay(properties.display, eventBus, "main")
-    sound = AudioSystemSound(properties.sound, eventBus, "main")
+    sound =
+        AudioSystemSound(
+            properties.applicationSettings.audio.toRuntimeConfiguration(),
+            eventBus,
+            "main",
+        ) {}
     val playerInput = DesktopPlayerInput(properties.playerInputSource, eventBus)
     tiltInput = DesktopTiltInput(eventBus)
     joypad = SwingJoypad(properties.playerInputMapping, eventBus, playerInput)
     gamepad = SwingGamepad(properties.playerInputMapping, playerInput, tiltInput, eventBus)
+    gamepad.updateConfiguration(properties.applicationSettings.toGamepadConfiguration())
     accelerometer = SwingAccelerometer(eventBus, tiltInput, display.preferredSize)
     tiltKeys = SwingTiltKeys(tiltInput)
     printer = SwingPrinter(eventBus)
     connectionController = ConnectionController(eventBus)
 
     Thread(display).start()
-    Thread(sound).start()
+    sound.start()
     gamepadThread = Thread(gamepad, "gamepad").apply { isDaemon = true; start() }
 
     controller = BasicController(eventBus, properties, console).also { it.startController() }
@@ -111,9 +125,21 @@ class SwingEmulator(
     joypad.updateMapping(mapping)
   }
 
+  fun applyDeviceSettings(settings: ApplicationSettings) {
+    gamepad.updateConfiguration(settings.toGamepadConfiguration())
+    sound.applyConfiguration(settings.audio.toRuntimeConfiguration())
+  }
+
+  fun gamepadCatalog(): GamepadCatalog = gamepad.catalog()
+
+  fun audioDevices(): List<AudioDeviceSnapshot> = audioDeviceCatalog.snapshot()
+
+  fun audioStatus(): AudioOutputStatus = sound.currentStatus()
+
   private fun releaseForLifecycleChange() {
     joypad.releaseForLifecycleChange()
     tiltInput.releaseForLifecycleChange()
+    gamepad.releaseForLifecycleChange()
   }
 
   fun bind(jFrame: JFrame) {
@@ -141,3 +167,29 @@ class SwingEmulator(
     }
   }
 }
+
+internal fun ApplicationSettings.toGamepadConfiguration(): GamepadConfiguration =
+    GamepadConfiguration(
+        input.toPlayerMapping().gamepads,
+        input.gamepadTunings.mapValues { (_, tuning) ->
+          GamepadConfiguration.Tuning(
+              tuning.movementDeadZone,
+              tuning.tiltDeadZone,
+              tuning.invertMovementX,
+              tuning.invertMovementY,
+              tuning.invertTiltX,
+              tuning.invertTiltY,
+          )
+        },
+    )
+
+internal fun ApplicationSettings.Audio.toRuntimeConfiguration(): AudioRuntimeConfiguration =
+    AudioRuntimeConfiguration(
+        when (val selection = output) {
+          ApplicationSettings.AudioOutputSelection.Default -> AudioDeviceSnapshot.SYSTEM_DEFAULT_ID
+          is ApplicationSettings.AudioOutputSelection.Device -> selection.stableId
+        },
+        volume,
+        !enabled,
+        AudioRuntimeConfiguration.LatencyPreset.valueOf(latency.name),
+    )

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -15,10 +15,12 @@ import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.sound.Sound
 import java.awt.Cursor
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JFrame
 import javax.swing.JOptionPane
 import javax.swing.SwingUtilities
@@ -44,6 +46,8 @@ class SwingGui private constructor(
   private var romLoading = false
 
   private val romSessionState = RomSessionState()
+
+  private val shutdownStarted = AtomicBoolean()
 
   init {
     eventBus = EventBusImpl()
@@ -123,38 +127,50 @@ class SwingGui private constructor(
   }
 
   private fun stopGui() {
-    eventBus.post(StopEmulationEvent())
-    eventBus.post(StopServerEvent())
-    eventBus.post(StopClientEvent())
-    console?.stop()
-    emulator.stop()
-    // The final settings force/move can block briefly. The window is already disposed, so finish
-    // persistence off the EDT and keep this non-daemon thread alive until the bounded close ends.
-    Thread(
-            {
-              try {
-                properties.close()
-              } catch (failure: IllegalStateException) {
-                runCatching {
-                  SwingUtilities.invokeAndWait {
-                    JOptionPane.showMessageDialog(
-                        null,
-                        "Coffee GB could not save the latest settings. " +
-                            "The previous complete settings file was preserved.\n\n" +
-                            (failure.cause?.message
-                                ?: failure.message
-                                ?: failure.javaClass.simpleName),
-                        "Settings save failed",
-                        JOptionPane.ERROR_MESSAGE,
-                    )
-                  }
-                }
+    if (!shutdownStarted.compareAndSet(false, true)) {
+      return
+    }
+    // A controller close waits for its emulation and ROM-loader workers, and audio teardown may
+    // wait for a platform mixer. The window is already disposed, so none of that work belongs on
+    // Swing's Event Dispatch Thread.
+    val shutdown =
+        launchDesktopShutdown {
+          try {
+            eventBus.post(StopEmulationEvent())
+            eventBus.post(StopServerEvent())
+            eventBus.post(StopClientEvent())
+            console?.stop()
+            emulator.stop()
+          } catch (failure: RuntimeException) {
+            LOG.error("Desktop runtime did not shut down cleanly", failure)
+          }
+          try {
+            properties.close()
+          } catch (failure: IllegalStateException) {
+            runCatching {
+              SwingUtilities.invokeAndWait {
+                JOptionPane.showMessageDialog(
+                    null,
+                    "Coffee GB could not save the latest settings. " +
+                        "The previous complete settings file was preserved.\n\n" +
+                        (failure.cause?.message
+                            ?: failure.message
+                            ?: failure.javaClass.simpleName),
+                    "Settings save failed",
+                    JOptionPane.ERROR_MESSAGE,
+                )
               }
-              exitProcess(0)
-            },
-            "coffee-gb-settings-shutdown",
-        )
-        .start()
+            }
+          }
+          exitProcess(0)
+        }
+    launchDesktopShutdownWatchdog(shutdown, DESKTOP_SHUTDOWN_TIMEOUT_MILLIS) {
+      LOG.error(
+          "Desktop shutdown exceeded {} ms; terminating rather than leaving a hung process",
+          DESKTOP_SHUTDOWN_TIMEOUT_MILLIS,
+      )
+      exitProcess(1)
+    }
   }
 
   private fun requestClose() {
@@ -186,9 +202,17 @@ class SwingGui private constructor(
     check(SwingUtilities.isEventDispatchThread()) {
       "Preferences must be opened from the Event Dispatch Thread"
     }
-    PreferencesDialog.show(mainWindow, properties.applicationSettings) { edit ->
+    PreferencesDialog.show(
+        owner = mainWindow,
+        initial = properties.applicationSettings,
+        gamepadCatalog = emulator.gamepadCatalog(),
+        audioDevices = AudioDeviceProvider(emulator::audioDevices),
+    ) { edit ->
       properties.updateApplicationSettings(edit::applyTo)
-      emulator.applyKeyboardMapping(properties.playerInputMapping)
+      val applied = properties.applicationSettings
+      emulator.applyKeyboardMapping(applied.input.toPlayerMapping())
+      emulator.applyDeviceSettings(applied)
+      eventBus.post(Sound.SoundEnabledEvent(applied.audio.enabled))
     }
   }
 
@@ -210,6 +234,7 @@ class SwingGui private constructor(
 
   companion object {
     private val LOG = LoggerFactory.getLogger(SwingGui::class.java)
+    private const val DESKTOP_SHUTDOWN_TIMEOUT_MILLIS = 15_000L
 
     fun run(
         debug: Boolean,
@@ -242,3 +267,35 @@ internal fun createSettingsShutdownHook(
         },
         "coffee-gb-settings-shutdown-hook",
     )
+
+internal fun launchDesktopShutdown(shutdown: () -> Unit): Thread =
+    Thread(shutdown, "coffee-gb-desktop-shutdown").apply {
+      isDaemon = false
+      start()
+    }
+
+internal fun launchDesktopShutdownWatchdog(
+    shutdown: Thread,
+    timeoutMillis: Long,
+    onTimeout: () -> Unit,
+): Thread {
+  require(timeoutMillis > 0) { "Desktop shutdown timeout must be positive" }
+  return Thread(
+          {
+            try {
+              shutdown.join(timeoutMillis)
+              if (shutdown.isAlive) {
+                shutdown.interrupt()
+                onTimeout()
+              }
+            } catch (_: InterruptedException) {
+              Thread.currentThread().interrupt()
+            }
+          },
+          "coffee-gb-desktop-shutdown-watchdog",
+      )
+      .apply {
+        isDaemon = true
+        start()
+      }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -849,13 +849,18 @@ internal class SwingMenu(
   private fun createAudioMenu(): JMenu {
     val audioMenu = JMenu("Audio")
 
-    val enableSound = JCheckBoxMenuItem("Enable", properties.sound.soundEnabled)
-    enableSound.accelerator = KeyStroke.getKeyStroke(KeyEvent.VK_M, KEY_MODIFIER)
-    audioMenu.add(enableSound)
+    val mute = JCheckBoxMenuItem("Mute", !properties.sound.soundEnabled)
+    mute.accelerator = KeyStroke.getKeyStroke(KeyEvent.VK_M, KEY_MODIFIER)
+    mute.accessibleContext.accessibleName = "Mute audio"
+    audioMenu.add(mute)
 
-    enableSound.addActionListener {
-      eventBus.post(Sound.SoundEnabledEvent(enableSound.state))
-      properties.setProperty(EmulatorProperties.Key.SoundEnabled, enableSound.state.toString())
+    mute.addActionListener {
+      val enabled = !mute.state
+      eventBus.post(Sound.SoundEnabledEvent(enabled))
+      properties.setProperty(EmulatorProperties.Key.SoundEnabled, enabled.toString())
+    }
+    eventBus.register<Sound.SoundEnabledEvent> {
+      SwingUtilities.invokeLater { mute.state = !it.enabled() }
     }
     return audioMenu
   }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioBackend.java
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.LineUnavailableException;
+import java.util.List;
+
+/** Java-Sound-free seam for deterministic device, fallback, and lifecycle tests. */
+interface AudioBackend {
+
+    List<AudioDeviceSnapshot> devices();
+
+    AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+            throws LineUnavailableException;
+
+    interface AudioLine extends AutoCloseable {
+        void start();
+
+        int write(byte[] bytes, int offset, int length);
+
+        int available();
+
+        int bufferSize();
+
+        boolean isOpen();
+
+        void flush();
+
+        void stop();
+
+        @Override
+        void close();
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioDeviceCatalog.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioDeviceCatalog.java
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Synchronous device catalog intended to be called by a cancellable background worker.
+ *
+ * <p>No Swing component is touched here. Each call returns an immutable snapshot and reflects
+ * devices available at that moment.
+ */
+public final class AudioDeviceCatalog {
+
+    private final AudioBackend backend;
+
+    public AudioDeviceCatalog() {
+        this(new JavaSoundAudioBackend());
+    }
+
+    AudioDeviceCatalog(AudioBackend backend) {
+        this.backend = Objects.requireNonNull(backend, "backend");
+    }
+
+    public List<AudioDeviceSnapshot> snapshot() {
+        return List.copyOf(backend.devices());
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioDeviceSnapshot.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioDeviceSnapshot.java
@@ -1,0 +1,36 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.Objects;
+
+/**
+ * Immutable, persistence-safe description of a host audio output.
+ *
+ * <p>The system default is intentionally represented by a symbolic ID instead of the mixer that
+ * happens to be default while enumeration runs. Explicit Java Sound devices use a digest of their
+ * stable descriptor fields; no platform path or device name needs to be persisted.
+ */
+public record AudioDeviceSnapshot(String stableId, String displayName, boolean systemDefault) {
+
+    public static final String SYSTEM_DEFAULT_ID = "default";
+
+    public AudioDeviceSnapshot {
+        Objects.requireNonNull(stableId, "stableId");
+        Objects.requireNonNull(displayName, "displayName");
+        if (systemDefault) {
+            if (!SYSTEM_DEFAULT_ID.equals(stableId)) {
+                throw new IllegalArgumentException(
+                        "The system-default audio device must use ID " + SYSTEM_DEFAULT_ID);
+            }
+        } else if (!AudioRuntimeConfiguration.isExplicitDeviceId(stableId)) {
+            throw new IllegalArgumentException(
+                    "Explicit audio device IDs must be java-sound- followed by 64 lowercase hex digits");
+        }
+        if (displayName.isBlank()) {
+            throw new IllegalArgumentException("Audio device display name must not be blank");
+        }
+    }
+
+    public static AudioDeviceSnapshot systemDefaultDevice() {
+        return new AudioDeviceSnapshot(SYSTEM_DEFAULT_ID, "System Default", true);
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioOutputStatus.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioOutputStatus.java
@@ -1,0 +1,25 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.Objects;
+
+/** Immutable host-audio state suitable for logging or delivery to the Swing EDT. */
+public record AudioOutputStatus(
+        State state,
+        String requestedDeviceId,
+        String activeDeviceId,
+        String detail) {
+
+    public AudioOutputStatus {
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(requestedDeviceId, "requestedDeviceId");
+        Objects.requireNonNull(detail, "detail");
+    }
+
+    public enum State {
+        STARTING,
+        ACTIVE,
+        FALLBACK,
+        UNAVAILABLE,
+        STOPPED
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
@@ -1,0 +1,84 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Validated host-audio settings applied without mutating emulation state.
+ *
+ * <p>The balanced preset deliberately retains Coffee GB's historical 8192-byte line and
+ * three-frame producer queue. Every line buffer is stereo-frame aligned and every queue stays
+ * bounded so a slow host cannot create ever-growing latency.
+ */
+public record AudioRuntimeConfiguration(
+        String outputDeviceId,
+        int masterVolume,
+        boolean muted,
+        LatencyPreset latencyPreset) {
+
+    private static final Pattern EXPLICIT_DEVICE_ID =
+            Pattern.compile("java-sound-[0-9a-f]{64}");
+
+    public AudioRuntimeConfiguration {
+        Objects.requireNonNull(outputDeviceId, "outputDeviceId");
+        Objects.requireNonNull(latencyPreset, "latencyPreset");
+        if (!AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(outputDeviceId)
+                && !isExplicitDeviceId(outputDeviceId)) {
+            throw new IllegalArgumentException(
+                    "Audio output must be default or java-sound- followed by 64 lowercase hex digits");
+        }
+        if (masterVolume < 0 || masterVolume > 100) {
+            throw new IllegalArgumentException("Master volume must be between 0 and 100");
+        }
+    }
+
+    public static AudioRuntimeConfiguration defaults() {
+        return defaults(true);
+    }
+
+    public static AudioRuntimeConfiguration defaults(boolean enabled) {
+        return new AudioRuntimeConfiguration(
+                AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                100,
+                !enabled,
+                LatencyPreset.BALANCED);
+    }
+
+    public AudioRuntimeConfiguration withMuted(boolean nextMuted) {
+        return new AudioRuntimeConfiguration(
+                outputDeviceId, masterVolume, nextMuted, latencyPreset);
+    }
+
+    static boolean isExplicitDeviceId(String value) {
+        return value != null && EXPLICIT_DEVICE_ID.matcher(value).matches();
+    }
+
+    public enum LatencyPreset {
+        LOW(2048, 1),
+        BALANCED(8192, 3),
+        SAFE(16384, 6);
+
+        private final int lineBufferBytes;
+        private final int queuedFrames;
+
+        LatencyPreset(int lineBufferBytes, int queuedFrames) {
+            if (lineBufferBytes <= 0 || lineBufferBytes % 4 != 0) {
+                throw new IllegalArgumentException(
+                        "Audio line buffers must contain complete stereo frames");
+            }
+            if (queuedFrames <= 0) {
+                throw new IllegalArgumentException("Audio queue capacity must be positive");
+            }
+            this.lineBufferBytes = lineBufferBytes;
+            this.queuedFrames = queuedFrames;
+        }
+
+        public int lineBufferBytes() {
+            return lineBufferBytes;
+        }
+
+        public int queuedFrames() {
+            return queuedFrames;
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -1,35 +1,52 @@
 package eu.rekawek.coffeegb.swing.io;
 
+import eu.rekawek.coffeegb.controller.properties.SoundProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.sound.Sound;
-import eu.rekawek.coffeegb.controller.properties.SoundProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.LineUnavailableException;
-import javax.sound.sampled.SourceDataLine;
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
- * Plays the emulator audio through javax.sound. The per-tick sample buffer posted by the
- * core once per frame is decimated to the output rate directly in the event handler (the
- * event bus dispatches synchronously on the emulator thread, so the shared buffer can be
- * read without copying it). A fractional resampling step keeps the produced rate exactly
- * at the line's sample rate - an integer divider would run 0.1% fast and slowly fill any
- * queue, ending in a rising latency followed by periodic overflow glitches.
+ * Plays emulator audio through a bounded, reconfigurable host-output worker.
+ *
+ * <p>The per-tick sample buffer posted by the core is decimated directly in the event handler (the
+ * event bus dispatches synchronously on the emulation thread, so its shared buffer can be read
+ * without copying it). Device discovery, line open/reconfiguration, fallback, writes, and ordinary
+ * close operations belong exclusively to the audio worker. Applying settings only publishes an
+ * immutable configuration and never blocks the Swing EDT on a host device.
+ *
+ * <p>A fractional resampling step keeps the produced rate exactly at the line's sample rate. Host
+ * device, gain, mute, and latency changes deliberately leave that phase and the DC blockers intact:
+ * presentation changes must not alter emulation timing or same-profile pause/restore continuity.
  */
 public class AudioSystemSound implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(AudioSystemSound.class);
 
     private static final int SAMPLE_RATE = 44100;
+    private static final int BYTES_PER_STEREO_FRAME = 4;
 
     private static final AudioFormat FORMAT =
-            new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, SAMPLE_RATE, 16, 2, 4, SAMPLE_RATE, false);
+            new AudioFormat(
+                    AudioFormat.Encoding.PCM_SIGNED,
+                    SAMPLE_RATE,
+                    16,
+                    2,
+                    BYTES_PER_STEREO_FRAME,
+                    SAMPLE_RATE,
+                    false);
 
     /**
      * The mixer outputs signed DAC-modelled samples of at most 4 channels * ±15 * volume 8
@@ -38,106 +55,543 @@ public class AudioSystemSound implements Runnable {
     private static final int VOLUME_SCALE = 62;
 
     /**
-     * The console's output capacitor has a cutoff of about 28 Hz. It removes the
-     * baseline steps caused by channel routing while preserving master-volume PCM.
+     * The console's output capacitor has a cutoff of about 28 Hz. It removes baseline steps caused
+     * by channel routing while preserving master-volume PCM.
      */
     private static final double HIGHPASS_CUTOFF = 28.0;
 
-    /**
-     * Line buffer of about 45 ms; the frame queue adds at most three frames (50 ms).
+    private static final long RETRY_UNAVAILABLE_MILLIS = 1000;
+    private static final long STOP_TIMEOUT_MILLIS = 2000;
+    private static final long FORCED_CLOSE_TIMEOUT_MILLIS = 250;
+    private static final int MAX_QUEUED_FRAMES =
+            AudioRuntimeConfiguration.LatencyPreset.SAFE.queuedFrames();
+
+    private final AudioBackend backend;
+    private final AtomicReference<AudioRuntimeConfiguration> desiredConfiguration;
+    private final BlockingQueue<AudioRuntimeConfiguration> configurationQueue =
+            new ArrayBlockingQueue<>(1);
+    private final AtomicLong configurationGeneration = new AtomicLong();
+
+    /*
+     * Keep this field name and BlockingQueue type source-compatible with the deterministic clock
+     * probes. The physical capacity is the largest preset; enqueuePcm enforces the active preset.
      */
-    private static final int LINE_BUFFER_BYTES = 8192;
+    private final BlockingQueue<byte[]> queue =
+            new ArrayBlockingQueue<>(MAX_QUEUED_FRAMES);
 
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean emergencyCloseStarted = new AtomicBoolean();
+    private final CountDownLatch stopped = new CountDownLatch(1);
+    private volatile Consumer<AudioOutputStatus> statusObserver;
+    private volatile AudioOutputStatus status;
     private volatile boolean doStop;
-    private volatile boolean isStopped;
-    private volatile boolean enabled;
-
-    private final BlockingQueue<byte[]> queue = new ArrayBlockingQueue<>(3);
+    private volatile Thread workerThread;
+    private volatile AudioBackend.AudioLine activeLine;
 
     private ClockSpec activeClock = ClockSpec.LEGACY;
-
     private ClockSpec.RateAccumulator sampleAccumulator =
             activeClock.newTickRateAccumulator(SAMPLE_RATE);
-
     private volatile int silenceBytes = frameOutputBytes(activeClock);
 
     private long sumL, sumR, prevSumL, prevSumR;
-
     private int cnt, prevCnt;
 
     private final DcBlocker dcBlockerL = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
-
     private final DcBlocker dcBlockerR = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
 
+    /** Existing desktop constructor; preserves the old enabled/default-device behavior. */
     public AudioSystemSound(SoundProperties properties, EventBus eventBus, String callerId) {
-        enabled = properties.getSoundEnabled();
-        eventBus.register(this::play, Sound.SoundSampleEvent.class, callerId);
-        eventBus.register(e -> this.enabled = e.enabled(), Sound.SoundEnabledEvent.class);
+        this(
+                AudioRuntimeConfiguration.defaults(properties.getSoundEnabled()),
+                eventBus,
+                callerId,
+                new JavaSoundAudioBackend(),
+                ignored -> {
+                });
     }
 
+    /**
+     * Runtime-configurable desktop constructor. The observer runs on the audio thread; Swing callers
+     * must marshal any component mutation to the EDT.
+     */
+    public AudioSystemSound(
+            AudioRuntimeConfiguration initialConfiguration,
+            EventBus eventBus,
+            String callerId,
+            Consumer<AudioOutputStatus> statusObserver) {
+        this(
+                initialConfiguration,
+                eventBus,
+                callerId,
+                new JavaSoundAudioBackend(),
+                statusObserver);
+    }
+
+    AudioSystemSound(
+            AudioRuntimeConfiguration initialConfiguration,
+            EventBus eventBus,
+            String callerId,
+            AudioBackend backend,
+            Consumer<AudioOutputStatus> statusObserver) {
+        Objects.requireNonNull(eventBus, "eventBus");
+        this.backend = Objects.requireNonNull(backend, "backend");
+        this.desiredConfiguration =
+                new AtomicReference<>(Objects.requireNonNull(
+                        initialConfiguration, "initialConfiguration"));
+        this.statusObserver = Objects.requireNonNull(statusObserver, "statusObserver");
+        this.status = new AudioOutputStatus(
+                AudioOutputStatus.State.STARTING,
+                initialConfiguration.outputDeviceId(),
+                null,
+                "Audio output has not started");
+        eventBus.register(this::play, Sound.SoundSampleEvent.class, callerId);
+        eventBus.register(
+                event -> applyConfiguration(
+                        desiredConfiguration.get().withMuted(!event.enabled())),
+                Sound.SoundEnabledEvent.class);
+    }
+
+    /**
+     * Starts the owned audio worker as a named daemon. Existing callers may still wrap this Runnable
+     * in their own thread temporarily, but new desktop integration should use this method.
+     */
+    public Thread start() {
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Audio output can only be started once");
+        }
+        if (doStop) {
+            throw new IllegalStateException("Audio output has already been stopped");
+        }
+        Thread thread = new Thread(this::runWorker, "coffee-gb-audio-output");
+        thread.setDaemon(true);
+        workerThread = thread;
+        thread.start();
+        return thread;
+    }
+
+    /**
+     * Compatibility Runnable entry point. Prefer {@link #start()} so a stalled platform provider
+     * cannot keep the JVM alive.
+     */
     @Override
     public void run() {
-        doStop = false;
-        isStopped = false;
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Audio output can only be started once");
+        }
+        runWorker();
+    }
 
-        SourceDataLine line;
-        try {
-            line = AudioSystem.getSourceDataLine(FORMAT);
-            line.open(FORMAT, LINE_BUFFER_BYTES);
-        } catch (LineUnavailableException e) {
-            LOG.error("Cannot open the audio line", e);
-            isStopped = true;
+    /**
+     * Publishes settings without opening, enumerating, or closing a host line on the caller.
+     * Superseded pending configurations are coalesced.
+     */
+    public void applyConfiguration(AudioRuntimeConfiguration configuration) {
+        Objects.requireNonNull(configuration, "configuration");
+        AudioRuntimeConfiguration previous = desiredConfiguration.getAndSet(configuration);
+        if (previous.equals(configuration)) {
             return;
         }
-        line.start();
-        byte[] silence = new byte[silenceBytes];
-        while (!doStop) {
-            byte[] buffer;
-            try {
-                buffer = queue.poll(20, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                break;
-            }
-            if (buffer != null) {
-                line.write(buffer, 0, buffer.length);
-            } else if (line.available() >= line.getBufferSize() - 4) {
-                if (silence.length != silenceBytes) {
-                    silence = new byte[silenceBytes];
-                }
-                // nothing is playing and the line has drained: keep it warm with silence
-                // instead of letting it underrun (a transiently late producer does not
-                // cause a silence gap this way)
-                line.write(silence, 0, silence.length);
-            }
+        configurationGeneration.incrementAndGet();
+        queue.clear();
+        configurationQueue.clear();
+        configurationQueue.offer(configuration);
+    }
+
+    public AudioRuntimeConfiguration currentConfiguration() {
+        return desiredConfiguration.get();
+    }
+
+    public AudioOutputStatus currentStatus() {
+        return status;
+    }
+
+    /**
+     * Replaces the status observer and immediately supplies the immutable current snapshot on the
+     * caller's thread.
+     */
+    public void setStatusObserver(Consumer<AudioOutputStatus> observer) {
+        statusObserver = Objects.requireNonNull(observer, "observer");
+        observer.accept(status);
+    }
+
+    /**
+     * Signals shutdown and waits only for a bounded interval. Ordinary line cleanup stays on the
+     * worker. A provider that remains stuck in write receives one emergency close from a daemon
+     * helper; even a provider whose close itself stalls cannot block this caller past the deadline.
+     */
+    public void stopThread() {
+        doStop = true;
+        Thread thread = workerThread;
+        if (thread == null || thread == Thread.currentThread()) {
+            return;
         }
-        line.stop();
-        line.flush();
-        isStopped = true;
-        synchronized (this) {
-            notifyAll();
+        thread.interrupt();
+
+        boolean interrupted = false;
+        long deadline = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(
+                        STOP_TIMEOUT_MILLIS + FORCED_CLOSE_TIMEOUT_MILLIS);
+        try {
+            if (!stopped.await(STOP_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                requestEmergencyClose(activeLine);
+                thread.interrupt();
+                stopped.await(remainingNanos(deadline), TimeUnit.NANOSECONDS);
+            }
+            TimeUnit.NANOSECONDS.timedJoin(thread, remainingNanos(deadline));
+        } catch (InterruptedException failure) {
+            interrupted = true;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
-    public void stopThread() {
-        doStop = true;
-        synchronized (this) {
-            while (!isStopped) {
+    private void runWorker() {
+        workerThread = Thread.currentThread();
+        AudioRuntimeConfiguration applied = null;
+        AudioBackend.AudioLine line = null;
+        boolean usingFallback = false;
+        long retryAtNanos = 0;
+        publishStatus(new AudioOutputStatus(
+                AudioOutputStatus.State.STARTING,
+                desiredConfiguration.get().outputDeviceId(),
+                null,
+                "Opening audio output"));
+
+        try {
+            while (!doStop) {
+                AudioRuntimeConfiguration pending = latestPendingConfiguration();
+                if (applied == null || pending != null) {
+                    AudioRuntimeConfiguration next =
+                            pending == null ? desiredConfiguration.get() : pending;
+                    boolean reopen =
+                            applied == null
+                                    || !applied.outputDeviceId().equals(next.outputDeviceId())
+                                    || applied.latencyPreset() != next.latencyPreset();
+                    queue.clear();
+                    if (reopen) {
+                        closeLine(line);
+                        line = null;
+                        activeLine = null;
+                        if (!doStop) {
+                            line = openWithFallback(next);
+                            activeLine = line;
+                            usingFallback =
+                                    line != null
+                                            && status.state() == AudioOutputStatus.State.FALLBACK;
+                            retryAtNanos = retryDeadline();
+                        }
+                    } else if (line != null) {
+                        /*
+                         * Gain/mute changes are producer-side. Flush the old-gain device buffer so
+                         * they become audible promptly even under the SAFE latency preset.
+                         */
+                        safelyFlush(line);
+                    }
+                    applied = next;
+                }
+
+                if (line == null) {
+                    usingFallback = false;
+                    discardOneFrameWhileUnavailable();
+                    if (System.nanoTime() >= retryAtNanos && !doStop) {
+                        line = openWithFallback(applied == null
+                                ? desiredConfiguration.get()
+                                : applied);
+                        activeLine = line;
+                        usingFallback =
+                                line != null
+                                        && status.state() == AudioOutputStatus.State.FALLBACK;
+                        retryAtNanos = retryDeadline();
+                    }
+                    continue;
+                }
+
+                if (usingFallback && System.nanoTime() >= retryAtNanos && !doStop) {
+                    FallbackRecovery recovery = tryRecoverPreferred(applied, line);
+                    retryAtNanos = retryDeadline();
+                    line = recovery.line();
+                    activeLine = line;
+                    usingFallback = recovery.usingFallback();
+                    if (line == null) continue;
+                }
+
+                if (!line.isOpen()) {
+                    closeLine(line);
+                    line = null;
+                    activeLine = null;
+                    usingFallback = false;
+                    retryAtNanos = 0;
+                    continue;
+                }
+
+                byte[] buffer = pollPcm();
+                if (doStop) {
+                    break;
+                }
                 try {
-                    wait(10);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    if (buffer != null && buffer.length > 0) {
+                        writeFully(line, buffer);
+                    } else if (line.available() >= line.bufferSize() - BYTES_PER_STEREO_FRAME) {
+                        writeFully(line, new byte[silenceBytes]);
+                    }
+                } catch (RuntimeException failure) {
+                    LOG.warn("Audio output failed; reopening with safe fallback", failure);
+                    closeLine(line);
+                    line = null;
+                    activeLine = null;
+                    usingFallback = false;
+                    retryAtNanos = 0;
                 }
             }
+        } finally {
+            closeLine(line);
+            activeLine = null;
+            publishStatus(new AudioOutputStatus(
+                    AudioOutputStatus.State.STOPPED,
+                    desiredConfiguration.get().outputDeviceId(),
+                    null,
+                    "Audio output stopped"));
+            stopped.countDown();
         }
+    }
+
+    private AudioRuntimeConfiguration latestPendingConfiguration() {
+        AudioRuntimeConfiguration latest = null;
+        AudioRuntimeConfiguration next;
+        while ((next = configurationQueue.poll()) != null) {
+            latest = next;
+        }
+        return latest;
+    }
+
+    private AudioBackend.AudioLine openWithFallback(AudioRuntimeConfiguration configuration) {
+        String requested = configuration.outputDeviceId();
+        Throwable requestedFailure;
+        try {
+            AudioBackend.AudioLine line =
+                    openAndStart(requested, configuration.latencyPreset().lineBufferBytes());
+            publishStatus(new AudioOutputStatus(
+                    AudioOutputStatus.State.ACTIVE,
+                    requested,
+                    requested,
+                    AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(requested)
+                            ? "Using system-default audio output"
+                            : "Using configured audio output"));
+            return line;
+        } catch (LineUnavailableException | RuntimeException failure) {
+            requestedFailure = failure;
+        }
+
+        if (!AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(requested)) {
+            try {
+                AudioBackend.AudioLine fallback =
+                        openAndStart(
+                                AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                                configuration.latencyPreset().lineBufferBytes());
+                publishStatus(new AudioOutputStatus(
+                        AudioOutputStatus.State.FALLBACK,
+                        requested,
+                        AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                        "Configured audio output is unavailable; using System Default ("
+                                + failureDetail(requestedFailure) + ")"));
+                return fallback;
+            } catch (LineUnavailableException | RuntimeException fallbackFailure) {
+                publishUnavailable(requested, requestedFailure, fallbackFailure);
+                return null;
+            }
+        }
+
+        publishUnavailable(requested, requestedFailure, null);
+        return null;
+    }
+
+    private FallbackRecovery tryRecoverPreferred(
+            AudioRuntimeConfiguration configuration,
+            AudioBackend.AudioLine fallback) {
+        String requested = configuration.outputDeviceId();
+        if (AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(requested)) {
+            return new FallbackRecovery(fallback, false);
+        }
+
+        boolean available;
+        try {
+            available = backend.devices().stream()
+                    .anyMatch(device -> device.stableId().equals(requested));
+        } catch (RuntimeException enumerationFailure) {
+            LOG.debug("Unable to probe the configured audio output", enumerationFailure);
+            return new FallbackRecovery(fallback, true);
+        }
+        if (!available) {
+            return new FallbackRecovery(fallback, true);
+        }
+
+        /*
+         * Some providers expose the preferred mixer again but reject an open while the fallback
+         * line owns the same physical endpoint. Catalog presence gates this disruptive retry so an
+         * actually absent device does not make healthy fallback audio reopen every second.
+         */
+        closeLine(fallback);
+        if (doStop) {
+            return new FallbackRecovery(null, false);
+        }
+        AudioBackend.AudioLine reopened = openWithFallback(configuration);
+        boolean stillUsingFallback =
+                reopened != null && status.state() == AudioOutputStatus.State.FALLBACK;
+        return new FallbackRecovery(reopened, stillUsingFallback);
+    }
+
+    private AudioBackend.AudioLine openAndStart(String deviceId, int lineBufferBytes)
+            throws LineUnavailableException {
+        AudioBackend.AudioLine line = backend.open(deviceId, FORMAT, lineBufferBytes);
+        try {
+            line.start();
+            return line;
+        } catch (RuntimeException failure) {
+            line.close();
+            throw failure;
+        }
+    }
+
+    private void publishUnavailable(
+            String requested, Throwable requestedFailure, Throwable fallbackFailure) {
+        String detail = "No audio output is currently available ("
+                + failureDetail(requestedFailure);
+        if (fallbackFailure != null) {
+            detail += "; System Default: " + failureDetail(fallbackFailure);
+        }
+        detail += ")";
+        publishStatus(new AudioOutputStatus(
+                AudioOutputStatus.State.UNAVAILABLE,
+                requested,
+                null,
+                detail));
+    }
+
+    private void publishStatus(AudioOutputStatus next) {
+        AudioOutputStatus previous = status;
+        status = next;
+        if (next.equals(previous)) {
+            return;
+        }
+        switch (next.state()) {
+            case FALLBACK -> LOG.warn(next.detail());
+            case UNAVAILABLE -> LOG.error(next.detail());
+            default -> LOG.debug(next.detail());
+        }
+        try {
+            statusObserver.accept(next);
+        } catch (RuntimeException failure) {
+            LOG.warn("Audio status observer failed", failure);
+        }
+    }
+
+    private void closeLine(AudioBackend.AudioLine line) {
+        if (line == null) {
+            return;
+        }
+        try {
+            line.stop();
+        } catch (RuntimeException failure) {
+            LOG.debug("Unable to stop audio line cleanly", failure);
+        }
+        safelyFlush(line);
+        try {
+            line.close();
+        } catch (RuntimeException failure) {
+            LOG.debug("Unable to close audio line cleanly", failure);
+        }
+    }
+
+    private void safelyFlush(AudioBackend.AudioLine line) {
+        try {
+            line.flush();
+        } catch (RuntimeException failure) {
+            LOG.debug("Unable to flush audio line cleanly", failure);
+        }
+    }
+
+    private void requestEmergencyClose(AudioBackend.AudioLine line) {
+        if (line == null || !emergencyCloseStarted.compareAndSet(false, true)) {
+            return;
+        }
+        Thread closer = new Thread(
+                () -> {
+                    try {
+                        line.close();
+                    } catch (RuntimeException failure) {
+                        LOG.debug("Emergency audio-line close failed", failure);
+                    }
+                },
+                "coffee-gb-audio-emergency-close");
+        closer.setDaemon(true);
+        closer.start();
+    }
+
+    private void discardOneFrameWhileUnavailable() {
+        try {
+            queue.poll(20, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException failure) {
+            if (!doStop) {
+                Thread.interrupted();
+            }
+        }
+    }
+
+    private byte[] pollPcm() {
+        try {
+            return queue.poll(20, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException failure) {
+            if (!doStop) {
+                Thread.interrupted();
+            }
+            return null;
+        }
+    }
+
+    private void writeFully(AudioBackend.AudioLine line, byte[] bytes) {
+        int offset = 0;
+        while (offset < bytes.length && !doStop) {
+            int written = line.write(bytes, offset, bytes.length - offset);
+            if (written <= 0) {
+                throw new IllegalStateException("Audio line made no write progress");
+            }
+            offset += written;
+        }
+    }
+
+    private long retryDeadline() {
+        return System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(RETRY_UNAVAILABLE_MILLIS);
+    }
+
+    private static long remainingNanos(long deadline) {
+        return Math.max(0, deadline - System.nanoTime());
+    }
+
+    private record FallbackRecovery(
+            AudioBackend.AudioLine line,
+            boolean usingFallback) {
+    }
+
+    private static String failureDetail(Throwable failure) {
+        String message = failure.getMessage();
+        if (message == null || message.isBlank()) {
+            return failure.getClass().getSimpleName();
+        }
+        return message;
     }
 
     private void play(Sound.SoundSampleEvent event) {
+        long generation = configurationGeneration.get();
+        AudioRuntimeConfiguration configuration = desiredConfiguration.get();
         int[] source = event.buffer();
         int ticks = source.length / 2;
         selectClock(event.clockSpec());
 
         int maximumSamples = Math.toIntExact(activeClock.maximumOutputUnits(ticks, SAMPLE_RATE));
-        byte[] out = new byte[Math.multiplyExact(maximumSamples, 4)];
+        byte[] out = new byte[Math.multiplyExact(maximumSamples, BYTES_PER_STEREO_FRAME)];
         int j = 0;
         // moving average over two output periods (a width-2 box filter): near-Nyquist
         // content is attenuated ~38 dB, so games parking a channel on an ultrasonic
@@ -157,8 +611,8 @@ public class AudioSystemSound implements Runnable {
                 double rawR = (double) (prevSumR + sumR) / total;
                 double filteredL = dcBlockerL.filter(rawL);
                 double filteredR = dcBlockerR.filter(rawR);
-                int left = enabled ? (int) (filteredL * VOLUME_SCALE) : 0;
-                int right = enabled ? (int) (filteredR * VOLUME_SCALE) : 0;
+                int left = outputSample(filteredL, configuration);
+                int right = outputSample(filteredR, configuration);
                 out[j++] = (byte) left;
                 out[j++] = (byte) (left >> 8);
                 out[j++] = (byte) right;
@@ -174,10 +628,39 @@ public class AudioSystemSound implements Runnable {
 
         byte[] trimmed = new byte[j];
         System.arraycopy(out, 0, trimmed, 0, j);
-        if (!queue.offer(trimmed)) {
-            // the writer is behind; drop the oldest frame to keep the latency bounded
-            queue.poll();
-            queue.offer(trimmed);
+        if (generation == configurationGeneration.get()) {
+            enqueuePcm(trimmed, configuration.latencyPreset().queuedFrames());
+        }
+    }
+
+    private static int outputSample(
+            double filtered, AudioRuntimeConfiguration configuration) {
+        if (configuration.muted() || configuration.masterVolume() == 0) {
+            return 0;
+        }
+        double scaled = filtered * VOLUME_SCALE;
+        if (configuration.masterVolume() != 100) {
+            scaled = scaled * configuration.masterVolume() / 100.0;
+        }
+        if (scaled >= Short.MAX_VALUE) {
+            return Short.MAX_VALUE;
+        }
+        if (scaled <= Short.MIN_VALUE) {
+            return Short.MIN_VALUE;
+        }
+        // Preserve the historical truncation at 100% volume.
+        return (int) scaled;
+    }
+
+    private void enqueuePcm(byte[] bytes, int maximumFrames) {
+        synchronized (queue) {
+            while (queue.size() >= maximumFrames) {
+                queue.poll();
+            }
+            if (!queue.offer(bytes)) {
+                queue.poll();
+                queue.offer(bytes);
+            }
         }
     }
 
@@ -197,12 +680,21 @@ public class AudioSystemSound implements Runnable {
     }
 
     private static int frameOutputBytes(ClockSpec clockSpec) {
-        long samples = clockSpec.maximumOutputUnits(clockSpec.controllerTicksPerFrame(), SAMPLE_RATE);
-        return Math.toIntExact(Math.multiplyExact(samples, 4));
+        long samples =
+                clockSpec.maximumOutputUnits(clockSpec.controllerTicksPerFrame(), SAMPLE_RATE);
+        return Math.toIntExact(Math.multiplyExact(samples, BYTES_PER_STEREO_FRAME));
+    }
+
+    static AudioFormat outputFormat() {
+        return FORMAT;
     }
 
     /** Package-private deterministic probe; exposes only the scalar conversion phase. */
     long samplePhaseForTesting() {
         return sampleAccumulator.remainder();
+    }
+
+    Thread workerThreadForTesting() {
+        return workerThread;
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadCatalog.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadCatalog.java
@@ -1,0 +1,65 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Lock-free, UI-safe view of the devices owned by the gamepad polling thread.
+ *
+ * <p>Snapshots never expose SDL handles or mutable backend collections. Swing may read this value
+ * on the EDT without performing device discovery there.
+ */
+public final class GamepadCatalog {
+
+    public enum Status {
+        STARTING,
+        AVAILABLE,
+        UNAVAILABLE,
+        STOPPED
+    }
+
+    public record Device(String stableId, String name, Integer assignedPlayer) {
+        public Device {
+            Objects.requireNonNull(stableId, "stableId");
+            name = name == null || name.isBlank() ? "Unknown game controller" : name;
+            if (assignedPlayer != null && (assignedPlayer < 0 || assignedPlayer > 3)) {
+                throw new IllegalArgumentException("Assigned player must be P1 through P4");
+            }
+        }
+    }
+
+    public record Snapshot(Status status, List<Device> devices, String message) {
+        public Snapshot {
+            Objects.requireNonNull(status, "status");
+            Objects.requireNonNull(devices, "devices");
+            Objects.requireNonNull(message, "message");
+            devices = devices.stream()
+                    .sorted(Comparator.comparing(Device::stableId))
+                    .toList();
+        }
+    }
+
+    private final AtomicReference<Snapshot> current =
+            new AtomicReference<>(new Snapshot(Status.STARTING, List.of(), ""));
+
+    public Snapshot snapshot() {
+        return current.get();
+    }
+
+    void publishAvailable(List<Device> devices) {
+        current.set(new Snapshot(Status.AVAILABLE, devices, ""));
+    }
+
+    void publishUnavailable() {
+        current.set(new Snapshot(
+                Status.UNAVAILABLE,
+                List.of(),
+                "Game controllers are unavailable. Keyboard input remains available."));
+    }
+
+    void publishStopped() {
+        current.set(new Snapshot(Status.STOPPED, List.of(), ""));
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadConfiguration.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadConfiguration.java
@@ -1,0 +1,117 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.controller.properties.ControllerProperties;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+/**
+ * Immutable runtime gamepad configuration.
+ *
+ * <p>The controller settings layer owns persistence. This SDL-free value is the hand-off to the
+ * polling thread and defensively validates assignments even when a caller bypasses Preferences.
+ */
+public record GamepadConfiguration(
+        List<ControllerProperties.GamepadAssignment> assignments,
+        Map<String, Tuning> tuningByStableId) {
+
+    private static final Pattern STABLE_ID = Pattern.compile("sdl-[0-9a-f]{64}");
+
+    public GamepadConfiguration {
+        Objects.requireNonNull(assignments, "assignments");
+        Objects.requireNonNull(tuningByStableId, "tuningByStableId");
+
+        assignments = assignments.stream()
+                .map(assignment -> Objects.requireNonNull(assignment, "assignment"))
+                .sorted(java.util.Comparator.comparingInt(
+                        ControllerProperties.GamepadAssignment::getPlayer))
+                .toList();
+        var players = new HashSet<Integer>();
+        var selectors = new HashSet<String>();
+        for (var assignment : assignments) {
+            if (!players.add(assignment.getPlayer())) {
+                throw new IllegalArgumentException(
+                        "P" + (assignment.getPlayer() + 1)
+                                + " has more than one gamepad assignment");
+            }
+            if (!selectors.add(assignment.getSelector())) {
+                throw new IllegalArgumentException(
+                        "Gamepad selector " + assignment.getSelector()
+                                + " is assigned to multiple players");
+            }
+        }
+
+        var sortedTuning = new TreeMap<String, Tuning>();
+        tuningByStableId.forEach((stableId, tuning) -> {
+            Objects.requireNonNull(stableId, "stableId");
+            Objects.requireNonNull(tuning, "tuning");
+            if (!STABLE_ID.matcher(stableId).matches()) {
+                throw new IllegalArgumentException(
+                        "Gamepad tuning key must be sdl- followed by 64 lowercase hex digits");
+            }
+            sortedTuning.put(stableId, tuning);
+        });
+        tuningByStableId =
+                Collections.unmodifiableMap(new LinkedHashMap<>(sortedTuning));
+    }
+
+    public GamepadConfiguration(
+            List<ControllerProperties.GamepadAssignment> assignments) {
+        this(assignments, Map.of());
+    }
+
+    public static GamepadConfiguration from(ControllerProperties.PlayerMapping mapping) {
+        Objects.requireNonNull(mapping, "mapping");
+        return new GamepadConfiguration(mapping.getGamepads());
+    }
+
+    public Tuning tuningFor(String stableId) {
+        return tuningByStableId.getOrDefault(stableId, Tuning.DEFAULT);
+    }
+
+    /**
+     * Raw SDL axis thresholds preserve Coffee GB's existing input behavior exactly.
+     *
+     * <p>Movement controls the left-stick digital directions. Tilt controls the P1 right stick.
+     * Values are strictly below the maximum positive SDL axis value so full deflection remains
+     * reachable.
+     */
+    public record Tuning(
+            int movementDeadZone,
+            int tiltDeadZone,
+            boolean invertMovementX,
+            boolean invertMovementY,
+            boolean invertTiltX,
+            boolean invertTiltY) {
+
+        public static final int DEFAULT_MOVEMENT_DEAD_ZONE = 16_384;
+        public static final int DEFAULT_TILT_DEAD_ZONE = 4_096;
+        public static final int MAX_DEAD_ZONE = 32_766;
+        public static final Tuning DEFAULT =
+                new Tuning(
+                        DEFAULT_MOVEMENT_DEAD_ZONE,
+                        DEFAULT_TILT_DEAD_ZONE,
+                        false,
+                        false,
+                        false,
+                        false);
+
+        public Tuning {
+            validateDeadZone(movementDeadZone, "Movement");
+            validateDeadZone(tiltDeadZone, "Tilt");
+        }
+
+        private static void validateDeadZone(int value, String label) {
+            if (value < 0 || value > MAX_DEAD_ZONE) {
+                throw new IllegalArgumentException(
+                        label + " dead zone must be between 0 and " + MAX_DEAD_ZONE);
+            }
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/JavaSoundAudioBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/JavaSoundAudioBackend.java
@@ -1,0 +1,206 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.Line;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
+import javax.sound.sampled.SourceDataLine;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Real Java Sound adapter. Mixer discovery and line ownership stay outside Swing components. */
+final class JavaSoundAudioBackend implements AudioBackend {
+
+    @Override
+    public List<AudioDeviceSnapshot> devices() {
+        DataLine.Info lineInfo =
+                new DataLine.Info(SourceDataLine.class, AudioSystemSound.outputFormat());
+        Map<String, AudioDeviceSnapshot> devices = new LinkedHashMap<>();
+        devices.put(
+                AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                AudioDeviceSnapshot.systemDefaultDevice());
+        for (Mixer.Info info : AudioSystem.getMixerInfo()) {
+            if (Thread.currentThread().isInterrupted()) {
+                break;
+            }
+            Mixer mixer;
+            try {
+                mixer = AudioSystem.getMixer(info);
+            } catch (IllegalArgumentException | SecurityException unavailable) {
+                continue;
+            }
+            if (!mixer.isLineSupported(lineInfo)) {
+                continue;
+            }
+            String stableId = stableId(
+                    info.getName(),
+                    info.getVendor(),
+                    info.getDescription(),
+                    info.getVersion());
+            devices.putIfAbsent(
+                    stableId,
+                    new AudioDeviceSnapshot(stableId, displayName(info), false));
+        }
+        return List.copyOf(devices.values());
+    }
+
+    @Override
+    public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+            throws LineUnavailableException {
+        SourceDataLine line;
+        if (AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(stableId)) {
+            line = AudioSystem.getSourceDataLine(format);
+        } else {
+            Mixer.Info selected = findMixer(stableId, format);
+            if (selected == null) {
+                throw unavailable("Configured audio output is not available: " + stableId, null);
+            }
+            Mixer mixer;
+            try {
+                mixer = AudioSystem.getMixer(selected);
+            } catch (IllegalArgumentException | SecurityException failure) {
+                throw unavailable("Configured audio output cannot be accessed: " + stableId, failure);
+            }
+            Line candidate;
+            try {
+                candidate = mixer.getLine(new DataLine.Info(SourceDataLine.class, format));
+            } catch (IllegalArgumentException failure) {
+                throw unavailable("Configured audio output does not support Coffee GB PCM", failure);
+            }
+            if (!(candidate instanceof SourceDataLine)) {
+                candidate.close();
+                throw unavailable("Configured audio output did not provide a source data line", null);
+            }
+            line = (SourceDataLine) candidate;
+        }
+
+        try {
+            line.open(format, bufferBytes);
+            return new JavaSoundLine(line);
+        } catch (LineUnavailableException | RuntimeException failure) {
+            line.close();
+            if (failure instanceof LineUnavailableException) {
+                throw (LineUnavailableException) failure;
+            }
+            throw unavailable("Audio output could not be opened", failure);
+        }
+    }
+
+    private static Mixer.Info findMixer(String stableId, AudioFormat format) {
+        DataLine.Info lineInfo = new DataLine.Info(SourceDataLine.class, format);
+        for (Mixer.Info info : AudioSystem.getMixerInfo()) {
+            if (!stableId.equals(stableId(
+                    info.getName(),
+                    info.getVendor(),
+                    info.getDescription(),
+                    info.getVersion()))) {
+                continue;
+            }
+            try {
+                if (AudioSystem.getMixer(info).isLineSupported(lineInfo)) {
+                    return info;
+                }
+            } catch (IllegalArgumentException | SecurityException ignored) {
+                // Device disappeared between enumeration and opening.
+            }
+        }
+        return null;
+    }
+
+    static String stableId(String name, String vendor, String description, String version) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            List<String> fields = new ArrayList<>();
+            fields.add(nullToEmpty(name));
+            fields.add(nullToEmpty(vendor));
+            fields.add(nullToEmpty(description));
+            fields.add(nullToEmpty(version));
+            byte[] bytes = String.join("\0", fields).getBytes(StandardCharsets.UTF_8);
+            return "java-sound-" + lowercaseHex(digest.digest(bytes));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 unavailable", impossible);
+        }
+    }
+
+    private static String displayName(Mixer.Info info) {
+        String name = nullToEmpty(info.getName()).trim();
+        String vendor = nullToEmpty(info.getVendor()).trim();
+        if (name.isEmpty()) {
+            name = "Audio Output";
+        }
+        return vendor.isEmpty() || vendor.equalsIgnoreCase(name)
+                ? name
+                : name + " — " + vendor;
+    }
+
+    private static String lowercaseHex(byte[] bytes) {
+        char[] encoded = new char[Math.multiplyExact(bytes.length, 2)];
+        for (int i = 0; i < bytes.length; i++) {
+            int value = bytes[i] & 0xff;
+            encoded[i * 2] = Character.forDigit(value >>> 4, 16);
+            encoded[i * 2 + 1] = Character.forDigit(value & 0x0f, 16);
+        }
+        return new String(encoded);
+    }
+
+    private static LineUnavailableException unavailable(String message, Throwable cause) {
+        LineUnavailableException failure = new LineUnavailableException(message);
+        if (cause != null) {
+            failure.initCause(cause);
+        }
+        return failure;
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record JavaSoundLine(SourceDataLine line) implements AudioLine {
+        @Override
+        public void start() {
+            line.start();
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            return line.write(bytes, offset, length);
+        }
+
+        @Override
+        public int available() {
+            return line.available();
+        }
+
+        @Override
+        public int bufferSize() {
+            return line.getBufferSize();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return line.isOpen();
+        }
+
+        @Override
+        public void flush() {
+            line.flush();
+        }
+
+        @Override
+        public void stop() {
+            line.stop();
+        }
+
+        @Override
+        public void close() {
+            line.close();
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -31,19 +32,24 @@ public class SwingGamepad implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwingGamepad.class);
     private static final int POLL_MS = 8;
-    private static final int AXIS_THRESHOLD = 16384;
-    static final int TILT_DEAD_ZONE = 4096;
+    static final int TILT_DEAD_ZONE =
+            GamepadConfiguration.Tuning.DEFAULT_TILT_DEAD_ZONE;
 
     private final EventBus eventBus;
     private final DesktopPlayerInput input;
     private final DesktopTiltInput tiltInput;
-    private final List<ControllerProperties.GamepadAssignment> assignments;
     private final GamepadBackend backend;
     private final Consumer<GamepadBackend.DeviceInfo> discoveryObserver;
+    private final GamepadCatalog catalog = new GamepadCatalog();
     private final Map<Integer, ActiveDevice> active = new HashMap<>();
     private final Set<String> discovered = new HashSet<>();
+    private final Set<Integer> playersRequiringNeutral = new HashSet<>();
     private final Object tiltSourceIdentity = new Object();
 
+    private GamepadConfiguration requestedConfiguration;
+    private GamepadConfiguration appliedConfiguration;
+    private boolean rearmRequested;
+    private boolean hasPolled;
     private volatile boolean doStop;
     private volatile boolean rumbleRequested;
     private boolean rumbleActive;
@@ -51,25 +57,82 @@ public class SwingGamepad implements Runnable {
 
     public SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                         DesktopTiltInput tiltInput, EventBus eventBus) {
-        this(mapping, input, tiltInput, eventBus, new SdlGamepadBackend(), ignored -> {});
+        this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
+                new SdlGamepadBackend(), ignored -> {});
+    }
+
+    public SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                        DesktopTiltInput tiltInput, EventBus eventBus) {
+        this(configuration, input, tiltInput, eventBus,
+                new SdlGamepadBackend(), ignored -> {});
     }
 
     SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                  DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend) {
-        this(mapping, input, tiltInput, eventBus, backend, ignored -> {});
+        this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
+                backend, ignored -> {});
     }
 
     SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                  DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
                  Consumer<GamepadBackend.DeviceInfo> discoveryObserver) {
-        this.assignments = List.copyOf(mapping.getGamepads());
-        this.input = input;
-        this.tiltInput = tiltInput;
-        this.eventBus = eventBus;
-        this.backend = backend;
-        this.discoveryObserver = discoveryObserver;
+        this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
+                backend, discoveryObserver);
+    }
+
+    SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                 DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend) {
+        this(configuration, input, tiltInput, eventBus, backend, ignored -> {});
+    }
+
+    SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                 DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
+                 Consumer<GamepadBackend.DeviceInfo> discoveryObserver) {
+        this.requestedConfiguration = Objects.requireNonNull(configuration, "configuration");
+        this.appliedConfiguration = configuration;
+        this.input = Objects.requireNonNull(input, "input");
+        this.tiltInput = Objects.requireNonNull(tiltInput, "tiltInput");
+        this.eventBus = Objects.requireNonNull(eventBus, "eventBus");
+        this.backend = Objects.requireNonNull(backend, "backend");
+        this.discoveryObserver =
+                Objects.requireNonNull(discoveryObserver, "discoveryObserver");
         tiltInput.registerResetter(this::releaseTiltAndRumble);
         eventBus.register(e -> rumbleRequested = e.on(), RumbleEvent.class);
+    }
+
+    /** A lock-free immutable device view that is safe to read from Swing's EDT. */
+    public GamepadCatalog catalog() {
+        return catalog;
+    }
+
+    /**
+     * Requests a complete runtime replacement without calling SDL on the caller's thread.
+     *
+     * <p>The shared input hub is released before this method returns. The polling thread performs
+     * device close/open and waits for a neutral physical sample before the new mapping can latch.
+     */
+    public synchronized void updateConfiguration(GamepadConfiguration configuration) {
+        GamepadConfiguration next = Objects.requireNonNull(configuration, "configuration");
+        if (next.equals(requestedConfiguration)) {
+            return;
+        }
+        requestedConfiguration = next;
+        rearmRequested = true;
+        rumbleRequested = false;
+        input.releaseAll();
+        tiltInput.clear(tiltSourceIdentity);
+    }
+
+    public void updateMapping(ControllerProperties.PlayerMapping mapping) {
+        updateConfiguration(GamepadConfiguration.from(mapping));
+    }
+
+    /** Releases transient input at ROM/controller replacement and rearms only from neutral. */
+    public synchronized void releaseForLifecycleChange() {
+        rearmRequested = true;
+        rumbleRequested = false;
+        input.releaseAll();
+        tiltInput.clear(tiltSourceIdentity);
     }
 
     public void stop() {
@@ -80,6 +143,7 @@ public class SwingGamepad implements Runnable {
 
     @Override
     public void run() {
+        boolean backendUnavailable = false;
         try {
             backend.initialize();
             while (!doStop) {
@@ -92,6 +156,7 @@ public class SwingGamepad implements Runnable {
                 }
             }
         } catch (UnsatisfiedLinkError unavailable) {
+            backendUnavailable = true;
             if (isMac()) {
                 LOG.warn("Game controllers need SDL2, which macOS builds don't bundle. "
                         + "Install it with 'brew install sdl2' and restart. Keyboard input still works.");
@@ -99,14 +164,21 @@ public class SwingGamepad implements Runnable {
                 LOG.info("Game controllers unavailable (no SDL2 native): {}", unavailable.getMessage());
             }
         } catch (Throwable failure) {
+            backendUnavailable = true;
             LOG.info("Game controllers unavailable: {}", failure.toString());
         } finally {
             closeAll();
             backend.close();
+            if (backendUnavailable) {
+                catalog.publishUnavailable();
+            } else {
+                catalog.publishStopped();
+            }
         }
     }
 
     synchronized void pollOnce() {
+        applyRequestedConfiguration();
         backend.update();
         Map<String, GamepadBackend.DeviceInfo> devices = new HashMap<>();
         backend.devices().stream().sorted(Comparator.comparing(GamepadBackend.DeviceInfo::stableId))
@@ -116,6 +188,7 @@ public class SwingGamepad implements Runnable {
             ActiveDevice device = entry.getValue();
             if (!device.device.attached() || !devices.containsKey(device.device.stableId())) {
                 devices.remove(device.device.stableId());
+                playersRequiringNeutral.add(entry.getKey());
                 disconnect(entry.getKey(), "disconnected");
             }
         });
@@ -129,7 +202,7 @@ public class SwingGamepad implements Runnable {
                 });
 
         Set<String> claimed = new HashSet<>();
-        assignments.stream()
+        appliedConfiguration.assignments().stream()
                 .filter(assignment -> !assignment.getSelector().equals(
                         ControllerProperties.GamepadAssignment.AUTO))
                 .forEach(assignment -> {
@@ -137,7 +210,7 @@ public class SwingGamepad implements Runnable {
                     assign(assignment.getPlayer(), desired);
                     if (desired != null) claimed.add(desired.stableId());
                 });
-        assignments.stream()
+        appliedConfiguration.assignments().stream()
                 .filter(assignment -> assignment.getSelector().equals(
                         ControllerProperties.GamepadAssignment.AUTO))
                 .forEach(assignment -> {
@@ -162,6 +235,22 @@ public class SwingGamepad implements Runnable {
             updateTilt(0, 0);
             rumbleActive = false;
         }
+        publishCatalog(devices);
+        hasPolled = true;
+    }
+
+    private void applyRequestedConfiguration() {
+        if (!appliedConfiguration.equals(requestedConfiguration)) {
+            playersRequiringNeutral.addAll(List.of(0, 1, 2, 3));
+            new ArrayList<>(active.keySet())
+                    .forEach(player -> disconnect(player, "configuration changed"));
+            appliedConfiguration = requestedConfiguration;
+        }
+        if (rearmRequested) {
+            playersRequiringNeutral.addAll(List.of(0, 1, 2, 3));
+            active.values().forEach(device -> device.waitingForNeutral = true);
+            rearmRequested = false;
+        }
     }
 
     private void assign(int player, GamepadBackend.DeviceInfo desired) {
@@ -176,7 +265,9 @@ public class SwingGamepad implements Runnable {
         if (current != null) disconnect(player, "assignment changed");
         GamepadBackend.GamepadDevice opened = backend.open(desired);
         if (opened != null && opened.attached()) {
-            ActiveDevice next = new ActiveDevice(opened);
+            boolean waitForNeutral =
+                    playersRequiringNeutral.remove(player) || hasPolled;
+            ActiveDevice next = new ActiveDevice(opened, waitForNeutral);
             active.put(player, next);
             LOG.info("Game controller {} assigned to P{} as {}",
                     opened.name(), player + 1, opened.stableId());
@@ -187,33 +278,52 @@ public class SwingGamepad implements Runnable {
 
     private void poll(int player, ActiveDevice activeDevice) {
         GamepadBackend.GamepadDevice device = activeDevice.device;
+        GamepadConfiguration.Tuning tuning =
+                appliedConfiguration.tuningFor(device.stableId());
+        PhysicalState state = PhysicalState.read(device);
         EnumSet<Button> buttons = EnumSet.noneOf(Button.class);
-        if (input.isFocused()) {
-            int x = device.axis(LEFT_X);
-            int y = device.axis(LEFT_Y);
-            add(buttons, Button.UP, device.button(UP) || y < -AXIS_THRESHOLD);
-            add(buttons, Button.DOWN, device.button(DOWN) || y > AXIS_THRESHOLD);
-            add(buttons, Button.LEFT, device.button(LEFT) || x < -AXIS_THRESHOLD);
-            add(buttons, Button.RIGHT, device.button(RIGHT) || x > AXIS_THRESHOLD);
-            add(buttons, Button.A, device.button(A));
-            add(buttons, Button.B, device.button(B) || device.button(X));
-            add(buttons, Button.START, device.button(START));
-            add(buttons, Button.SELECT, device.button(BACK));
+        if (activeDevice.waitingForNeutral) {
+            if (state.isNeutral(tuning)) {
+                activeDevice.waitingForNeutral = false;
+            }
+        } else if (input.isFocused()) {
+            int x = invertAxis(state.leftX, tuning.invertMovementX());
+            int y = invertAxis(state.leftY, tuning.invertMovementY());
+            int threshold = tuning.movementDeadZone();
+            add(buttons, Button.UP, state.buttons.contains(UP) || y < -threshold);
+            add(buttons, Button.DOWN, state.buttons.contains(DOWN) || y > threshold);
+            add(buttons, Button.LEFT, state.buttons.contains(LEFT) || x < -threshold);
+            add(buttons, Button.RIGHT, state.buttons.contains(RIGHT) || x > threshold);
+            add(buttons, Button.A, state.buttons.contains(A));
+            add(buttons, Button.B, state.buttons.contains(B) || state.buttons.contains(X));
+            add(buttons, Button.START, state.buttons.contains(START));
+            add(buttons, Button.SELECT, state.buttons.contains(BACK));
         }
         input.update(activeDevice.sourceIdentity, player, buttons);
 
         if (player == 0) {
-            if (input.isFocused()) {
-                updateTilt(device.axis(RIGHT_X), device.axis(RIGHT_Y));
+            if (input.isFocused() && !activeDevice.waitingForNeutral) {
+                updateTilt(
+                        invertAxis(state.rightX, tuning.invertTiltX()),
+                        invertAxis(state.rightY, tuning.invertTiltY()),
+                        tuning.tiltDeadZone());
             } else {
                 updateTilt(0, 0);
             }
-            boolean requested = input.isFocused() && rumbleRequested;
+            boolean requested =
+                    input.isFocused() && !activeDevice.waitingForNeutral && rumbleRequested;
             if (requested != rumbleActive) {
                 device.rumble(requested);
                 rumbleActive = requested;
             }
         }
+    }
+
+    static int invertAxis(int value, boolean invert) {
+        if (!invert) {
+            return value;
+        }
+        return value == Short.MIN_VALUE ? Short.MAX_VALUE : -value;
     }
 
     private static void add(Set<Button> buttons, Button button, boolean down) {
@@ -241,8 +351,12 @@ public class SwingGamepad implements Runnable {
     }
 
     void updateTilt(int rawX, int rawY) {
-        double x = normalizeTiltAxis(rawX);
-        double y = normalizeTiltAxis(rawY);
+        updateTilt(rawX, rawY, TILT_DEAD_ZONE);
+    }
+
+    private void updateTilt(int rawX, int rawY, int deadZone) {
+        double x = normalizeTiltAxis(rawX, deadZone);
+        double y = normalizeTiltAxis(rawY, deadZone);
         if (x != 0 || y != 0) {
             tiltInput.update(tiltSourceIdentity, x, y);
             tiltActive = true;
@@ -254,31 +368,76 @@ public class SwingGamepad implements Runnable {
 
     private synchronized void releaseTiltAndRumble() {
         rumbleRequested = false;
-        ActiveDevice primary = active.get(0);
-        if (primary != null && rumbleActive) {
-            primary.device.rumble(false);
-        }
-        rumbleActive = false;
         tiltActive = false;
     }
 
     static double normalizeTiltAxis(int raw) {
+        return normalizeTiltAxis(raw, TILT_DEAD_ZONE);
+    }
+
+    static double normalizeTiltAxis(int raw, int deadZone) {
         int magnitude = Math.abs(raw);
-        if (magnitude <= TILT_DEAD_ZONE) return 0;
-        double normalized = (double) (magnitude - TILT_DEAD_ZONE) / (32767 - TILT_DEAD_ZONE);
+        if (magnitude <= deadZone) return 0;
+        double normalized = (double) (magnitude - deadZone) / (32767 - deadZone);
         return Math.copySign(Math.min(1, normalized), raw);
+    }
+
+    private void publishCatalog(Map<String, GamepadBackend.DeviceInfo> devices) {
+        Map<String, Integer> playersByStableId = new HashMap<>();
+        active.forEach((player, activeDevice) ->
+                playersByStableId.put(activeDevice.device.stableId(), player));
+        catalog.publishAvailable(devices.values().stream()
+                .map(device -> new GamepadCatalog.Device(
+                        device.stableId(),
+                        device.name(),
+                        playersByStableId.get(device.stableId())))
+                .toList());
     }
 
     private static boolean isMac() {
         return System.getProperty("os.name", "").toLowerCase().contains("mac");
     }
 
+    private record PhysicalState(
+            int leftX,
+            int leftY,
+            int rightX,
+            int rightY,
+            EnumSet<GamepadBackend.PadButton> buttons) {
+
+        private static PhysicalState read(GamepadBackend.GamepadDevice device) {
+            EnumSet<GamepadBackend.PadButton> buttons =
+                    EnumSet.noneOf(GamepadBackend.PadButton.class);
+            for (GamepadBackend.PadButton button : GamepadBackend.PadButton.values()) {
+                if (device.button(button)) {
+                    buttons.add(button);
+                }
+            }
+            return new PhysicalState(
+                    device.axis(LEFT_X),
+                    device.axis(LEFT_Y),
+                    device.axis(RIGHT_X),
+                    device.axis(RIGHT_Y),
+                    buttons);
+        }
+
+        private boolean isNeutral(GamepadConfiguration.Tuning tuning) {
+            return buttons.isEmpty()
+                    && Math.abs(leftX) <= tuning.movementDeadZone()
+                    && Math.abs(leftY) <= tuning.movementDeadZone()
+                    && Math.abs(rightX) <= tuning.tiltDeadZone()
+                    && Math.abs(rightY) <= tuning.tiltDeadZone();
+        }
+    }
+
     private static final class ActiveDevice {
         private final GamepadBackend.GamepadDevice device;
         private final Object sourceIdentity = new Object();
+        private boolean waitingForNeutral;
 
-        private ActiveDevice(GamepadBackend.GamepadDevice device) {
+        private ActiveDevice(GamepadBackend.GamepadDevice device, boolean waitingForNeutral) {
             this.device = device;
+            this.waitingForNeutral = waitingForNeutral;
         }
     }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
@@ -1,0 +1,510 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
+import eu.rekawek.coffeegb.swing.io.GamepadCatalog
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DevicePreferencesEditorsTest {
+
+  @Test
+  fun `gamepad snapshot choices retain unavailable assignments and persist per-device tuning`() =
+      onEdt {
+        val unavailableId = gamepadId('a')
+        val availableId = gamepadId('b')
+        val snapshots =
+            AtomicReference(
+                gamepadSnapshot(
+                    GamepadCatalog.Status.AVAILABLE,
+                    emptyList(),
+                ))
+        val initial =
+            ApplicationSettings.Input.defaults().copy(
+                gamepads =
+                    mapOf(
+                        0 to ApplicationSettings.GamepadSelection.Device(unavailableId)),
+                gamepadTunings =
+                    mapOf(
+                        unavailableId to
+                            ApplicationSettings.GamepadTuning(
+                                movementDeadZone = 2_048)),
+            )
+        val editor =
+            GamepadPreferencesEditor(
+                initial,
+                snapshots = GamepadSnapshotProvider(snapshots::get),
+            )
+
+        assertEquals(
+            ApplicationSettings.GamepadSelection.Device(unavailableId),
+            selectedGamepad(editor, 0),
+        )
+        assertTrue(editor.playerSelectors[0].selectedItem.toString().contains("Unavailable"))
+
+        snapshots.set(
+            gamepadSnapshot(
+                GamepadCatalog.Status.AVAILABLE,
+                listOf(GamepadCatalog.Device(availableId, "Arcade Pad", null)),
+            ))
+        editor.refreshCatalog()
+        selectGamepad(
+            editor,
+            1,
+            ApplicationSettings.GamepadSelection.Device(availableId),
+        )
+        selectTuningDevice(editor, availableId)
+        editor.movementDeadZone.value = 12_345
+        editor.tiltDeadZone.value = 2_345
+        editor.invertMovementX.doClick()
+        editor.invertTiltY.doClick()
+
+        val draft = editor.validatedDraft()
+
+        assertEquals(
+            ApplicationSettings.GamepadSelection.Device(unavailableId),
+            draft.selections[0],
+        )
+        assertEquals(
+            ApplicationSettings.GamepadSelection.Device(availableId),
+            draft.selections[1],
+        )
+        assertEquals(
+            ApplicationSettings.GamepadTuning(
+                movementDeadZone = 12_345,
+                tiltDeadZone = 2_345,
+                invertMovementX = true,
+                invertTiltY = true,
+            ),
+            draft.tunings[availableId],
+        )
+        assertEquals(
+            ApplicationSettings.GamepadTuning(movementDeadZone = 2_048),
+            draft.tunings[unavailableId],
+        )
+        assertEquals("Player 1 gamepad", editor.playerSelectors[0].accessibleContext.accessibleName)
+        assertEquals("Movement dead zone", editor.movementDeadZone.accessibleContext.accessibleName)
+        assertEquals("Tilt dead zone", editor.tiltDeadZone.accessibleContext.accessibleName)
+      }
+
+  @Test
+  fun `duplicate gamepad assignments mark every conflicting player field`() =
+      onEdt {
+        val stableId = gamepadId('c')
+        val editor =
+            GamepadPreferencesEditor(
+                ApplicationSettings.Input.defaults(),
+                snapshots =
+                    GamepadSnapshotProvider {
+                      gamepadSnapshot(
+                          GamepadCatalog.Status.AVAILABLE,
+                          listOf(GamepadCatalog.Device(stableId, "Shared Pad", null)),
+                      )
+                    },
+            )
+        val selection = ApplicationSettings.GamepadSelection.Device(stableId)
+        selectGamepad(editor, 0, selection)
+        selectGamepad(editor, 1, selection)
+        selectGamepad(editor, 2, ApplicationSettings.GamepadSelection.Auto)
+        selectGamepad(editor, 3, ApplicationSettings.GamepadSelection.Auto)
+
+        val failure =
+            assertFailsWith<PreferenceEditorValidationException> {
+              editor.validatedDraft()
+            }
+
+        assertSame(editor.playerSelectors[0], failure.invalidComponent)
+        assertTrue(editor.playerErrors[0].text.contains("Player 2"))
+        assertTrue(editor.playerErrors[1].text.contains("Player 1"))
+        assertTrue(editor.playerErrors[2].text.contains("Player 4"))
+        assertTrue(editor.playerErrors[3].text.contains("Player 3"))
+      }
+
+  @Test
+  fun `unchanged available controller does not create a tuning profile`() =
+      onEdt {
+        val availableId = gamepadId('e')
+        val editor =
+            GamepadPreferencesEditor(
+                ApplicationSettings.Input.defaults(),
+                snapshots =
+                    GamepadSnapshotProvider {
+                      gamepadSnapshot(
+                          GamepadCatalog.Status.AVAILABLE,
+                          listOf(GamepadCatalog.Device(availableId, "Untuned Pad", null)),
+                      )
+                    },
+            )
+
+        assertTrue(editor.validatedDraft().tunings.isEmpty())
+      }
+
+  @Test
+  fun `gamepad tuning profile overflow is translated to its field error`() =
+      onEdt {
+        val existing =
+            (0 until ApplicationSettings.MAX_GAMEPAD_TUNINGS).associate { index ->
+              gamepadId(index) to ApplicationSettings.GamepadTuning()
+            }
+        val extraId = gamepadId(ApplicationSettings.MAX_GAMEPAD_TUNINGS)
+        val initial =
+            ApplicationSettings.Input.defaults().copy(gamepadTunings = existing)
+        val editor =
+            GamepadPreferencesEditor(
+                initial,
+                snapshots =
+                    GamepadSnapshotProvider {
+                      gamepadSnapshot(
+                          GamepadCatalog.Status.AVAILABLE,
+                          listOf(GamepadCatalog.Device(extraId, "Extra Pad", null)),
+                      )
+                    },
+            )
+        selectTuningDevice(editor, extraId)
+        editor.invertTiltX.doClick()
+
+        val failure =
+            assertFailsWith<PreferenceEditorValidationException> {
+              editor.validatedDraft()
+            }
+
+        assertSame(editor.tuningDevice, failure.invalidComponent)
+        assertTrue(editor.tuningError.text.contains("At most 32"))
+      }
+
+  @Test
+  fun `gamepad catalog polling stays on the EDT and its timer stops on disposal`() =
+      onEdt {
+        val calls = AtomicInteger()
+        val allCallsOnEdt = AtomicBoolean(true)
+        val editor =
+            GamepadPreferencesEditor(
+                ApplicationSettings.Input.defaults(),
+                snapshots =
+                    GamepadSnapshotProvider {
+                      calls.incrementAndGet()
+                      allCallsOnEdt.compareAndSet(
+                          true,
+                          SwingUtilities.isEventDispatchThread(),
+                      )
+                      gamepadSnapshot(GamepadCatalog.Status.AVAILABLE, emptyList())
+                    },
+            )
+
+        editor.addNotify()
+        try {
+          assertTrue(editor.isCatalogTimerRunning())
+          editor.refreshCatalog()
+          assertTrue(calls.get() >= 3)
+          assertTrue(allCallsOnEdt.get())
+        } finally {
+          editor.removeNotify()
+        }
+        assertFalse(editor.isCatalogTimerRunning())
+      }
+
+  @Test
+  fun `audio enumeration runs off EDT and retains unavailable configured output`() {
+    val configuredId = audioId('a')
+    val availableId = audioId('b')
+    val providerCalled = CountDownLatch(1)
+    val calledOffEdt = AtomicBoolean()
+    lateinit var editor: AudioPreferencesEditor
+    onEdt {
+      editor =
+          AudioPreferencesEditor(
+              ApplicationSettings.Audio(
+                  output = ApplicationSettings.AudioOutputSelection.Device(configuredId)),
+              devices =
+                  AudioDeviceProvider {
+                    calledOffEdt.set(!SwingUtilities.isEventDispatchThread())
+                    providerCalled.countDown()
+                    listOf(
+                        AudioDeviceSnapshot.systemDefaultDevice(),
+                        AudioDeviceSnapshot(availableId, "USB Headphones", false),
+                    )
+                  },
+          )
+      assertEquals(configuredId, selectedAudioOutput(editor))
+      assertTrue(editor.output.selectedItem.toString().contains("Unavailable"))
+      editor.startDeviceLoading()
+    }
+    assertTrue(providerCalled.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+    waitForAudioWorker(editor)
+
+    onEdt {
+      assertTrue(calledOffEdt.get())
+      assertTrue(
+          audioOptions(editor).any {
+            it.stableId == configuredId && !it.available
+          })
+      selectAudioOutput(editor, availableId)
+      editor.muted.doClick()
+      editor.volume.value = 41
+      editor.latency.selectedItem = ApplicationSettings.AudioLatency.SAFE
+
+      assertEquals(
+          ApplicationSettings.Audio(
+              enabled = false,
+              output = ApplicationSettings.AudioOutputSelection.Device(availableId),
+              volume = 41,
+              latency = ApplicationSettings.AudioLatency.SAFE,
+          ),
+          editor.validatedAudio(),
+      )
+      assertEquals("Audio output device", editor.output.accessibleContext.accessibleName)
+      assertEquals("Master volume", editor.volume.accessibleContext.accessibleName)
+      assertEquals("Audio latency preset", editor.latency.accessibleContext.accessibleName)
+    }
+  }
+
+  @Test
+  fun `cancelled audio worker cannot publish a stale device result`() {
+    val staleId = audioId('c')
+    val started = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val finished = CountDownLatch(1)
+    val interrupted = AtomicBoolean()
+    lateinit var editor: AudioPreferencesEditor
+    onEdt {
+      editor =
+          AudioPreferencesEditor(
+              ApplicationSettings.Audio(),
+              devices =
+                  AudioDeviceProvider {
+                    started.countDown()
+                    var released = false
+                    while (!released) {
+                      try {
+                        released = release.await(50, TimeUnit.MILLISECONDS)
+                      } catch (_: InterruptedException) {
+                        interrupted.set(true)
+                      }
+                    }
+                    finished.countDown()
+                    listOf(AudioDeviceSnapshot(staleId, "Stale Output", false))
+                  },
+          )
+      editor.startDeviceLoading()
+    }
+    assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+    onEdt {
+      editor.cancelDeviceLoading()
+      assertFalse(editor.isDeviceLoading())
+    }
+    release.countDown()
+    assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+    flushSwingWorkerEvents()
+
+    onEdt {
+      assertTrue(interrupted.get())
+      assertEquals(
+          listOf(AudioDeviceSnapshot.SYSTEM_DEFAULT_ID),
+          audioOptions(editor).map { it.stableId },
+      )
+    }
+  }
+
+  @Test
+  fun `panel defaults do not enumerate host audio and gamepad conflicts select their tab`() {
+    lateinit var panel: PreferencesPanel
+    onEdt {
+      val stableId = gamepadId('d')
+      panel =
+          PreferencesPanel(
+              ApplicationSettings(),
+              gamepadSnapshots =
+                  GamepadSnapshotProvider {
+                    gamepadSnapshot(
+                        GamepadCatalog.Status.AVAILABLE,
+                        listOf(GamepadCatalog.Device(stableId, "Conflict Pad", null)),
+                    )
+                  },
+          )
+      panel.audioEditor.startDeviceLoading()
+      selectGamepad(
+          panel.gamepadEditor,
+          0,
+          ApplicationSettings.GamepadSelection.Device(stableId),
+      )
+      selectGamepad(
+          panel.gamepadEditor,
+          1,
+          ApplicationSettings.GamepadSelection.Device(stableId),
+      )
+    }
+    waitForAudioWorker(panel.audioEditor)
+
+    onEdt {
+      assertEquals(
+          listOf(AudioDeviceSnapshot.SYSTEM_DEFAULT_ID),
+          audioOptions(panel.audioEditor).map { it.stableId },
+      )
+      var applyCount = 0
+      var closeCount = 0
+      PreferencesDialogActions(
+              panel,
+              applyEdit = { applyCount++ },
+              close = { closeCount++ },
+          )
+          .apply()
+
+      assertEquals(0, applyCount)
+      assertEquals(0, closeCount)
+      assertEquals("Gamepads", panel.tabs.getTitleAt(panel.tabs.selectedIndex))
+      assertTrue(panel.validationSummary.text.contains("multiple players"))
+      assertEquals(
+          listOf("General", "Input", "Gamepads", "Audio"),
+          (0 until panel.tabs.tabCount).map(panel.tabs::getTitleAt),
+      )
+      assertEquals("Gamepad preferences", panel.gamepadEditor.accessibleContext.accessibleName)
+      assertEquals("Audio preferences", panel.audioEditor.accessibleContext.accessibleName)
+    }
+  }
+
+  @Test
+  fun `cancel action stops active gamepad polling and audio enumeration`() {
+    val started = CountDownLatch(1)
+    val finished = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    var panel: PreferencesPanel? = null
+    var closeCount = 0
+    try {
+      onEdt {
+        val activePanel =
+            PreferencesPanel(
+                ApplicationSettings(),
+                audioDevices =
+                    AudioDeviceProvider {
+                      started.countDown()
+                      try {
+                        release.await()
+                      } catch (_: InterruptedException) {
+                        // Cancellation is the expected way out.
+                      } finally {
+                        finished.countDown()
+                      }
+                      emptyList()
+                    },
+            )
+        panel = activePanel
+        activePanel.gamepadEditor.addNotify()
+        activePanel.audioEditor.startDeviceLoading()
+        assertTrue(activePanel.gamepadEditor.isCatalogTimerRunning())
+        assertTrue(activePanel.audioEditor.isDeviceLoading())
+      }
+      assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+      onEdt {
+        val activePanel = checkNotNull(panel)
+        PreferencesDialogActions(activePanel, applyEdit = {}, close = { closeCount++ }).cancel()
+        assertFalse(activePanel.gamepadEditor.isCatalogTimerRunning())
+        assertFalse(activePanel.audioEditor.isDeviceLoading())
+        assertEquals(1, closeCount)
+      }
+      assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+    } finally {
+      release.countDown()
+      panel?.let { activePanel ->
+        onEdt {
+          activePanel.stopBackgroundWork()
+          activePanel.gamepadEditor.removeNotify()
+        }
+      }
+    }
+  }
+
+  private fun selectGamepad(
+      editor: GamepadPreferencesEditor,
+      player: Int,
+      selection: ApplicationSettings.GamepadSelection,
+  ) {
+    val selector = editor.playerSelectors[player]
+    selector.selectedItem =
+        (0 until selector.itemCount)
+            .map(selector::getItemAt)
+            .first { it.selection == selection }
+  }
+
+  private fun selectedGamepad(
+      editor: GamepadPreferencesEditor,
+      player: Int,
+  ): ApplicationSettings.GamepadSelection =
+      (editor.playerSelectors[player].selectedItem as GamepadPreferencesEditor.SelectionOption)
+          .selection
+
+  private fun selectTuningDevice(
+      editor: GamepadPreferencesEditor,
+      stableId: String,
+  ) {
+    editor.tuningDevice.selectedItem =
+        (0 until editor.tuningDevice.itemCount)
+            .map(editor.tuningDevice::getItemAt)
+            .first { it.stableId == stableId }
+  }
+
+  private fun selectAudioOutput(
+      editor: AudioPreferencesEditor,
+      stableId: String,
+  ) {
+    editor.output.selectedItem = audioOptions(editor).first { it.stableId == stableId }
+  }
+
+  private fun selectedAudioOutput(editor: AudioPreferencesEditor): String =
+      (editor.output.selectedItem as AudioPreferencesEditor.OutputOption).stableId
+
+  private fun audioOptions(
+      editor: AudioPreferencesEditor
+  ): List<AudioPreferencesEditor.OutputOption> =
+      (0 until editor.output.itemCount).map(editor.output::getItemAt)
+
+  private fun gamepadSnapshot(
+      status: GamepadCatalog.Status,
+      devices: List<GamepadCatalog.Device>,
+  ): GamepadCatalog.Snapshot =
+      GamepadCatalog.Snapshot(status, devices, "")
+
+  private fun gamepadId(fill: Char): String = "sdl-" + fill.toString().repeat(64)
+
+  private fun gamepadId(index: Int): String =
+      "sdl-" + index.toString(16).padStart(64, '0')
+
+  private fun audioId(fill: Char): String = "java-sound-" + fill.toString().repeat(64)
+
+  private fun waitForAudioWorker(editor: AudioPreferencesEditor) {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
+    while (onEdt { editor.isDeviceLoading() } && System.nanoTime() < deadline) {
+      Thread.yield()
+    }
+    assertFalse(onEdt { editor.isDeviceLoading() }, "Audio enumeration did not finish")
+  }
+
+  private fun flushSwingWorkerEvents() {
+    repeat(20) {
+      Thread.sleep(10)
+      onEdt {}
+    }
+  }
+
+  private fun <T> onEdt(action: () -> T): T {
+    if (SwingUtilities.isEventDispatchThread()) return action()
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+
+  private companion object {
+    const val TIMEOUT_SECONDS = 5L
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditorTest.kt
@@ -68,17 +68,29 @@ class KeyboardMappingEditorTest {
       }
 
   @Test
-  fun editsClearAndResetRemainADraftAndPreserveGamepads() =
+  fun editsClearAndResetRemainADraftAndPreserveGamepadSettings() =
       onEventThread {
+        val stableId = "sdl-${"a".repeat(64)}"
         val gamepads =
             mapOf(
                 0 to ApplicationSettings.GamepadSelection.Auto,
                 1 to
                     ApplicationSettings.GamepadSelection.Device(
-                        "sdl-${"a".repeat(64)}"),
+                        stableId),
             )
+        val tunings =
+            mapOf(
+                stableId to
+                    ApplicationSettings.GamepadTuning(
+                        movementDeadZone = 1_024,
+                        invertTiltY = true,
+                    ))
         val initial =
-            ApplicationSettings.Input(ApplicationSettings.Input.defaults().keyboard, gamepads)
+            ApplicationSettings.Input(
+                ApplicationSettings.Input.defaults().keyboard,
+                gamepads,
+                tunings,
+            )
         val editor = KeyboardMappingEditor(initial)
 
         assertIs<KeyboardMappingEditor.EditResult.Applied>(
@@ -86,6 +98,7 @@ class KeyboardMappingEditorTest {
         assertEquals(KeyEvent.VK_Q, editor.currentBinding(1, Button.A)?.code)
         assertEquals(KeyEvent.VK_Q, editor.validatedDraft().keyboard[playerButton(1, Button.A)]?.code)
         assertEquals(gamepads, editor.validatedDraft().gamepads)
+        assertEquals(tunings, editor.validatedDraft().gamepadTunings)
         assertNull(initial.keyboard[playerButton(1, Button.A)], "the initial value is immutable")
 
         editor.clearBinding(1, Button.A)
@@ -98,7 +111,11 @@ class KeyboardMappingEditorTest {
         editor.editBinding(1, Button.B, KeyEvent.VK_Q)
         editor.resetToDefaults()
         assertEquals(
-            ApplicationSettings.Input(ApplicationSettings.Input.defaults().keyboard, gamepads),
+            ApplicationSettings.Input(
+                ApplicationSettings.Input.defaults().keyboard,
+                gamepads,
+                tunings,
+            ),
             editor.validatedDraft(),
         )
       }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -39,7 +39,11 @@ class PreferencesDialogTest {
                 mapOf(
                     0 to GamepadSelection.Auto,
                     1 to GamepadSelection.Device("sdl-" + "a".repeat(64)),
-                ))
+                ),
+            gamepadTunings =
+                mapOf(
+                    "sdl-" + "a".repeat(64) to
+                        ApplicationSettings.GamepadTuning(invertMovementX = true)))
     val recent = (1..4).map { Paths.get("rom-$it.gb") }
     val current =
         ApplicationSettings(
@@ -61,6 +65,17 @@ class PreferencesDialogTest {
             recentFileCapacity = 2,
             confirmationPolicy = RomChangeConfirmationPolicy.NEVER,
             keyboard = emptyMap(),
+            gamepads = mapOf(0 to GamepadSelection.Disabled),
+            gamepadTunings =
+                mapOf(
+                    "sdl-" + "b".repeat(64) to
+                        ApplicationSettings.GamepadTuning(tiltDeadZone = 1_024)),
+            audio =
+                ApplicationSettings.Audio(
+                    enabled = true,
+                    volume = 25,
+                    latency = ApplicationSettings.AudioLatency.SAFE,
+                ),
         )
 
     val updated = edit.applyTo(current)
@@ -70,9 +85,10 @@ class PreferencesDialogTest {
     assertEquals(2, updated.general.recentFileCapacity)
     assertEquals(RomChangeConfirmationPolicy.NEVER, updated.general.romChangeConfirmationPolicy)
     assertTrue(updated.input.keyboard.isEmpty())
-    assertEquals(currentInput.gamepads, updated.input.gamepads)
+    assertEquals(edit.gamepads, updated.input.gamepads)
+    assertEquals(edit.gamepadTunings, updated.input.gamepadTunings)
     assertEquals(current.display, updated.display)
-    assertEquals(current.audio, updated.audio)
+    assertEquals(edit.audio, updated.audio)
     assertEquals(current.saves, updated.saves)
     assertEquals(current.advanced, updated.advanced)
   }
@@ -98,6 +114,8 @@ class PreferencesDialogTest {
         assertEquals(listOf("apply", "close"), events)
         assertEquals(ApplicationSettings.DEFAULT_RECENT_FILE_CAPACITY, received?.recentFileCapacity)
         assertEquals(ApplicationSettings.Input.defaults().keyboard, received?.keyboard)
+        assertEquals(ApplicationSettings.Input.defaults().gamepads, received?.gamepads)
+        assertEquals(ApplicationSettings.Audio(), received?.audio)
       }
 
   @Test
@@ -116,7 +134,22 @@ class PreferencesDialogTest {
                         recentFileCapacity = 3,
                         romChangeConfirmationPolicy = RomChangeConfirmationPolicy.NEVER,
                     ),
-                input = defaults.input.copy(keyboard = changedKeyboard),
+                audio =
+                    ApplicationSettings.Audio(
+                        enabled = false,
+                        volume = 13,
+                        latency = ApplicationSettings.AudioLatency.LOW,
+                    ),
+                input =
+                    defaults.input.copy(
+                        keyboard = changedKeyboard,
+                        gamepads = mapOf(0 to GamepadSelection.Disabled),
+                        gamepadTunings =
+                            mapOf(
+                                "sdl-" + "c".repeat(64) to
+                                    ApplicationSettings.GamepadTuning(
+                                        invertMovementY = true)),
+                    ),
             )
         var applyCount = 0
         var closeCount = 0
@@ -139,6 +172,9 @@ class PreferencesDialogTest {
             restored.confirmationPolicy,
         )
         assertEquals(defaults.input.keyboard, restored.keyboard)
+        assertEquals(defaults.input.gamepads, restored.gamepads)
+        assertEquals(defaults.input.gamepadTunings, restored.gamepadTunings)
+        assertEquals(defaults.audio, restored.audio)
         assertEquals(0, applyCount)
         assertEquals(1, closeCount)
       }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingEmulatorSettingsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingEmulatorSettingsTest.kt
@@ -1,0 +1,71 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
+import eu.rekawek.coffeegb.swing.io.AudioRuntimeConfiguration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SwingEmulatorSettingsTest {
+  @Test
+  fun `typed audio settings map completely to the host runtime`() {
+    val deviceId = "java-sound-" + "a".repeat(64)
+    val runtime =
+        ApplicationSettings.Audio(
+                enabled = false,
+                output = ApplicationSettings.AudioOutputSelection.Device(deviceId),
+                volume = 37,
+                latency = ApplicationSettings.AudioLatency.SAFE,
+            )
+            .toRuntimeConfiguration()
+
+    assertEquals(deviceId, runtime.outputDeviceId())
+    assertEquals(37, runtime.masterVolume())
+    assertTrue(runtime.muted())
+    assertEquals(AudioRuntimeConfiguration.LatencyPreset.SAFE, runtime.latencyPreset())
+  }
+
+  @Test
+  fun `default audio output retains the symbolic host selection`() {
+    val runtime = ApplicationSettings.Audio().toRuntimeConfiguration()
+
+    assertEquals(AudioDeviceSnapshot.SYSTEM_DEFAULT_ID, runtime.outputDeviceId())
+    assertFalse(runtime.muted())
+  }
+
+  @Test
+  fun `gamepad assignments and per-device tuning cross the runtime boundary`() {
+    val stableId = "sdl-" + "b".repeat(64)
+    val input =
+        ApplicationSettings.Input.defaults().copy(
+            gamepads =
+                mapOf(
+                    0 to ApplicationSettings.GamepadSelection.Device(stableId),
+                    1 to ApplicationSettings.GamepadSelection.Auto,
+                ),
+            gamepadTunings =
+                mapOf(
+                    stableId to
+                        ApplicationSettings.GamepadTuning(
+                            movementDeadZone = 1234,
+                            tiltDeadZone = 5678,
+                            invertMovementX = true,
+                            invertMovementY = false,
+                            invertTiltX = true,
+                            invertTiltY = true,
+                        )),
+        )
+
+    val runtime = ApplicationSettings(input = input).toGamepadConfiguration()
+
+    assertEquals(input.toPlayerMapping().gamepads, runtime.assignments())
+    assertEquals(1234, runtime.tuningFor(stableId).movementDeadZone())
+    assertEquals(5678, runtime.tuningFor(stableId).tiltDeadZone())
+    assertTrue(runtime.tuningFor(stableId).invertMovementX())
+    assertFalse(runtime.tuningFor(stableId).invertMovementY())
+    assertTrue(runtime.tuningFor(stableId).invertTiltX())
+    assertTrue(runtime.tuningFor(stableId).invertTiltY())
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
@@ -1,0 +1,57 @@
+package eu.rekawek.coffeegb.swing
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SwingGuiShutdownTest {
+  @Test
+  fun `desktop shutdown leaves the EDT and keeps the process alive until teardown completes`() {
+    val ran = CountDownLatch(1)
+    var workerWasEdt = true
+    lateinit var worker: Thread
+
+    SwingUtilities.invokeAndWait {
+      worker =
+          launchDesktopShutdown {
+            workerWasEdt = SwingUtilities.isEventDispatchThread()
+            ran.countDown()
+          }
+    }
+
+    assertTrue(ran.await(2, TimeUnit.SECONDS))
+    worker.join(2_000)
+    assertFalse(workerWasEdt)
+    assertFalse(worker.isDaemon)
+    assertFalse(worker.isAlive)
+  }
+
+  @Test
+  fun `watchdog bounds a stalled desktop shutdown`() {
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val timedOut = CountDownLatch(1)
+    val worker =
+        launchDesktopShutdown {
+          entered.countDown()
+          try {
+            release.await()
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+          }
+        }
+    assertTrue(entered.await(2, TimeUnit.SECONDS))
+
+    val watchdog = launchDesktopShutdownWatchdog(worker, 25) { timedOut.countDown() }
+
+    assertTrue(timedOut.await(2, TimeUnit.SECONDS))
+    release.countDown()
+    worker.join(2_000)
+    watchdog.join(2_000)
+    assertFalse(worker.isAlive)
+    assertFalse(watchdog.isAlive)
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioDeviceCatalogTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioDeviceCatalogTest.java
@@ -1,0 +1,98 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import org.junit.Test;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.LineUnavailableException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class AudioDeviceCatalogTest {
+
+    @Test
+    public void javaSoundIdentityIsCanonicalAndUsesEveryDescriptorField() {
+        String one = JavaSoundAudioBackend.stableId(
+                "Output", "Vendor", "Description", "1.0");
+
+        assertTrue(one.matches("java-sound-[0-9a-f]{64}"));
+        assertEquals(
+                one,
+                JavaSoundAudioBackend.stableId(
+                        "Output", "Vendor", "Description", "1.0"));
+        assertNotEquals(
+                one,
+                JavaSoundAudioBackend.stableId(
+                        "Other", "Vendor", "Description", "1.0"));
+        assertNotEquals(
+                one,
+                JavaSoundAudioBackend.stableId(
+                        "Output", "Other", "Description", "1.0"));
+        assertNotEquals(
+                one,
+                JavaSoundAudioBackend.stableId(
+                        "Output", "Vendor", "Other", "1.0"));
+        assertNotEquals(
+                one,
+                JavaSoundAudioBackend.stableId(
+                        "Output", "Vendor", "Description", "2.0"));
+    }
+
+    @Test
+    public void catalogReturnsImmutablePointInTimeSnapshot() {
+        String id = "java-sound-" + "b".repeat(64);
+        MutableCatalogBackend backend = new MutableCatalogBackend();
+        backend.devices.add(AudioDeviceSnapshot.systemDefaultDevice());
+        AudioDeviceCatalog catalog = new AudioDeviceCatalog(backend);
+
+        List<AudioDeviceSnapshot> first = catalog.snapshot();
+        backend.devices.add(new AudioDeviceSnapshot(id, "USB Audio", false));
+        List<AudioDeviceSnapshot> second = catalog.snapshot();
+
+        assertEquals(List.of(AudioDeviceSnapshot.systemDefaultDevice()), first);
+        assertEquals(2, second.size());
+        assertEquals(id, second.get(1).stableId());
+        assertFalse(second.get(1).systemDefault());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> first.add(AudioDeviceSnapshot.systemDefaultDevice()));
+    }
+
+    @Test
+    public void symbolicDefaultAndExplicitIdsAreValidated() {
+        assertEquals(
+                "default",
+                AudioDeviceSnapshot.systemDefaultDevice().stableId());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AudioDeviceSnapshot("default", "Not default", false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AudioDeviceSnapshot(
+                        "java-sound-" + "A".repeat(64), "Uppercase", false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new AudioDeviceSnapshot(
+                        "java-sound-" + "c".repeat(64), " ", false));
+    }
+
+    private static final class MutableCatalogBackend implements AudioBackend {
+        private final List<AudioDeviceSnapshot> devices = new ArrayList<>();
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return devices;
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+                throws LineUnavailableException {
+            throw new LineUnavailableException("not used");
+        }
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
@@ -1,0 +1,521 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.sound.Sound;
+import org.junit.Test;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.LineUnavailableException;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class AudioSystemSoundTest {
+
+    private static final String DEVICE_A = "java-sound-" + "a".repeat(64);
+
+    @Test
+    public void softwareGainAndMuteDoNotDependOnHostMixerControls() throws Exception {
+        byte[] full = render(new AudioRuntimeConfiguration(
+                "default", 100, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+        byte[] half = render(new AudioRuntimeConfiguration(
+                "default", 50, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+        byte[] muted = render(new AudioRuntimeConfiguration(
+                "default", 100, true,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+
+        int fullSample = firstNonZeroLeftSample(full);
+        int halfSample = firstNonZeroLeftSample(half);
+        assertNotEquals(0, fullSample);
+        assertEquals(Math.abs(fullSample) / 2, Math.abs(halfSample), 1);
+        assertTrue(Arrays.stream(toUnsigned(muted)).allMatch(value -> value == 0));
+    }
+
+    @Test
+    public void activeLatencyPresetBoundsProducerQueueWithoutBlockingEmulation() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        AudioSystemSound sound = new AudioSystemSound(
+                new AudioRuntimeConfiguration(
+                        "default", 100, false,
+                        AudioRuntimeConfiguration.LatencyPreset.LOW),
+                eventBus,
+                null,
+                new FakeBackend(),
+                ignored -> {
+                });
+
+        for (int i = 0; i < 10; i++) {
+            eventBus.post(new Sound.SoundSampleEvent(new int[400]));
+        }
+
+        assertEquals(1, queue(sound).size());
+    }
+
+    @Test
+    public void legacySoundEventUpdatesMuteWithoutDiscardingOtherRuntimeSettings() {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        AudioRuntimeConfiguration initial = new AudioRuntimeConfiguration(
+                DEVICE_A, 37, false, AudioRuntimeConfiguration.LatencyPreset.SAFE);
+        AudioSystemSound sound = new AudioSystemSound(
+                initial,
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+
+        eventBus.post(new Sound.SoundEnabledEvent(false));
+        assertEquals(
+                new AudioRuntimeConfiguration(
+                        DEVICE_A, 37, true, AudioRuntimeConfiguration.LatencyPreset.SAFE),
+                sound.currentConfiguration());
+
+        eventBus.post(new Sound.SoundEnabledEvent(true));
+        assertEquals(initial, sound.currentConfiguration());
+    }
+
+    @Test
+    public void runtimeConfigurationNeverResetsExactClockOrFilterPhase() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add(DEVICE_A, "Output A");
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        ClockSpec clock = ClockSpec.SGB2;
+
+        eventBus.post(new Sound.SoundSampleEvent(new int[86], clock));
+        queue(sound).remove();
+        long phaseBeforeChange = sound.samplePhaseForTesting();
+        sound.applyConfiguration(new AudioRuntimeConfiguration(
+                DEVICE_A, 37, true, AudioRuntimeConfiguration.LatencyPreset.SAFE));
+        eventBus.post(new Sound.SoundSampleEvent(new int[134], ClockSpec.SGB2));
+        long samples = queue(sound).remove().length / 4L;
+
+        BigInteger numerator =
+                BigInteger.valueOf(110L).multiply(BigInteger.valueOf(44_100));
+        BigInteger[] expected = numerator.divideAndRemainder(
+                BigInteger.valueOf(clock.ticksPerSecondNumerator()));
+        assertNotEquals(0L, phaseBeforeChange);
+        assertEquals(expected[0].longValueExact(), samples);
+        assertEquals(expected[1].longValueExact(), sound.samplePhaseForTesting());
+    }
+
+    @Test
+    public void workerOwnsOpenReconfigureFallbackRecoveryAndOrdinaryClose() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add("default", "System Default");
+        backend.add(DEVICE_A, "Output A");
+        List<AudioOutputStatus> statuses = new CopyOnWriteArrayList<>();
+        AudioSystemSound sound = new AudioSystemSound(
+                new AudioRuntimeConfiguration(
+                        DEVICE_A, 100, false,
+                        AudioRuntimeConfiguration.LatencyPreset.BALANCED),
+                eventBus,
+                null,
+                backend,
+                statuses::add);
+
+        Thread worker = sound.start();
+        assertTrue(worker.isDaemon());
+        await("configured device to open",
+                () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+        assertEquals(DEVICE_A, sound.currentStatus().activeDeviceId());
+        FakeLine first = backend.lastLine(DEVICE_A);
+        assertEquals(8192, first.requestedBufferBytes);
+
+        int opensBeforeGain = backend.openedIds.size();
+        sound.applyConfiguration(new AudioRuntimeConfiguration(
+                DEVICE_A, 25, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+        await("gain change to flush old PCM", () -> first.flushCount > 0);
+        assertEquals(opensBeforeGain, backend.openedIds.size());
+
+        sound.applyConfiguration(new AudioRuntimeConfiguration(
+                DEVICE_A, 25, false,
+                AudioRuntimeConfiguration.LatencyPreset.SAFE));
+        await("latency change to reopen line",
+                () -> backend.openedIds.size() > opensBeforeGain);
+        FakeLine safe = backend.lastLine(DEVICE_A);
+        assertEquals(16384, safe.requestedBufferBytes);
+        assertTrue(first.closed);
+
+        backend.remove(DEVICE_A);
+        safe.failWrites = true;
+        eventBus.post(new Sound.SoundSampleEvent(constantSamples(400, 480)));
+        await("missing configured device to fall back",
+                () -> sound.currentStatus().state() == AudioOutputStatus.State.FALLBACK);
+        assertEquals("default", sound.currentStatus().activeDeviceId());
+        assertEquals(DEVICE_A, sound.currentStatus().requestedDeviceId());
+        assertTrue(sound.currentStatus().detail().contains("System Default"));
+
+        FakeLine fallback = backend.lastLine("default");
+        backend.exclusivePreferredDevice = DEVICE_A;
+        backend.add(DEVICE_A, "Output A reconnected");
+        await("configured device to recover from fallback",
+                () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE
+                        && DEVICE_A.equals(sound.currentStatus().activeDeviceId()));
+        assertTrue("exclusive fallback line must close before preferred reopen", fallback.closed);
+        assertEquals(0, backend.exclusiveOpenConflicts);
+
+        long started = System.nanoTime();
+        sound.stopThread();
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - started).toMillis();
+        assertTrue("shutdown exceeded its bounded normal path: " + elapsedMillis,
+                elapsedMillis < 2500);
+        assertFalse(worker.isAlive());
+        assertEquals(AudioOutputStatus.State.STOPPED, sound.currentStatus().state());
+
+        assertFalse(backend.operationThreads.isEmpty());
+        assertTrue(backend.operationThreads.stream()
+                .allMatch(name -> name.equals(worker.getName())));
+        assertTrue(statuses.stream()
+                .anyMatch(status -> status.state() == AudioOutputStatus.State.FALLBACK));
+    }
+
+    @Test
+    public void permanentlyBlockingProviderCloseCannotBreakStopDeadline() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        BlockingCloseBackend backend = new BlockingCloseBackend();
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+
+        Thread worker = sound.start();
+        await("blocking-close line to open",
+                () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+
+        long started = System.nanoTime();
+        sound.stopThread();
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - started).toMillis();
+
+        assertTrue("shutdown exceeded its strict deadline: " + elapsedMillis,
+                elapsedMillis < 2_750);
+        assertTrue("the deliberately stuck worker should remain isolated as a daemon",
+                worker.isAlive() && worker.isDaemon());
+        assertTrue("worker and emergency helper did not both reach blocking close",
+                backend.closeAttempts.await(1, TimeUnit.SECONDS));
+        assertTrue(backend.closeThreads.stream().allMatch(Thread::isDaemon));
+        assertTrue(backend.closeThreads.stream()
+                .anyMatch(thread -> thread.getName().equals(
+                        "coffee-gb-audio-emergency-close")));
+    }
+
+    @Test
+    public void unavailableDefaultStaysSilentAndStopsCleanly() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+
+        Thread worker = sound.start();
+        await("unavailable status",
+                () -> sound.currentStatus().state() == AudioOutputStatus.State.UNAVAILABLE);
+        assertNull(sound.currentStatus().activeDeviceId());
+        eventBus.post(new Sound.SoundSampleEvent(constantSamples(400, 480)));
+
+        sound.stopThread();
+        assertFalse(worker.isAlive());
+    }
+
+    @Test
+    public void runtimeConfigurationHasExplicitBoundsAndSafeDefaults() {
+        AudioRuntimeConfiguration defaults = AudioRuntimeConfiguration.defaults();
+        assertEquals("default", defaults.outputDeviceId());
+        assertEquals(100, defaults.masterVolume());
+        assertFalse(defaults.muted());
+        assertEquals(
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED,
+                defaults.latencyPreset());
+        assertEquals(8192, defaults.latencyPreset().lineBufferBytes());
+        assertEquals(3, defaults.latencyPreset().queuedFrames());
+
+        assertInvalid(() -> new AudioRuntimeConfiguration(
+                "array-index-0", 100, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+        assertInvalid(() -> new AudioRuntimeConfiguration(
+                "default", -1, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+        assertInvalid(() -> new AudioRuntimeConfiguration(
+                "default", 101, false,
+                AudioRuntimeConfiguration.LatencyPreset.BALANCED));
+    }
+
+    private static byte[] render(AudioRuntimeConfiguration configuration) throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        AudioSystemSound sound = new AudioSystemSound(
+                configuration,
+                eventBus,
+                null,
+                new FakeBackend(),
+                ignored -> {
+                });
+        eventBus.post(new Sound.SoundSampleEvent(constantSamples(2000, 480)));
+        return queue(sound).remove();
+    }
+
+    private static int[] constantSamples(int ticks, int value) {
+        int[] samples = new int[ticks * 2];
+        Arrays.fill(samples, value);
+        return samples;
+    }
+
+    private static int firstNonZeroLeftSample(byte[] bytes) {
+        for (int offset = 0; offset + 3 < bytes.length; offset += 4) {
+            int sample = (short) ((bytes[offset] & 0xff) | (bytes[offset + 1] << 8));
+            if (sample != 0) {
+                return sample;
+            }
+        }
+        return 0;
+    }
+
+    private static int[] toUnsigned(byte[] bytes) {
+        int[] values = new int[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            values[i] = bytes[i] & 0xff;
+        }
+        return values;
+    }
+
+    private static EventBusImpl synchronousBus() {
+        return new EventBusImpl(null, null, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BlockingQueue<byte[]> queue(AudioSystemSound sound) throws Exception {
+        Field field = AudioSystemSound.class.getDeclaredField("queue");
+        field.setAccessible(true);
+        return (BlockingQueue<byte[]>) field.get(sound);
+    }
+
+    private static void await(String description, BooleanSupplier condition)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(4).toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertTrue("Timed out waiting for " + description, condition.getAsBoolean());
+    }
+
+    private static void assertInvalid(Runnable construction) {
+        try {
+            construction.run();
+            fail("Expected invalid audio configuration");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static final class FakeBackend implements AudioBackend {
+        private final Map<String, AudioDeviceSnapshot> available = new ConcurrentHashMap<>();
+        private final Map<String, FakeLine> lines = new ConcurrentHashMap<>();
+        private final List<String> openedIds = new CopyOnWriteArrayList<>();
+        private final List<String> operationThreads = new CopyOnWriteArrayList<>();
+        private volatile String exclusivePreferredDevice;
+        private volatile int exclusiveOpenConflicts;
+
+        void add(String id, String name) {
+            available.put(
+                    id,
+                    "default".equals(id)
+                            ? AudioDeviceSnapshot.systemDefaultDevice()
+                            : new AudioDeviceSnapshot(id, name, false));
+        }
+
+        void remove(String id) {
+            available.remove(id);
+        }
+
+        FakeLine lastLine(String id) {
+            return lines.get(id);
+        }
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return List.copyOf(available.values());
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+                throws LineUnavailableException {
+            operationThreads.add(Thread.currentThread().getName());
+            if (!available.containsKey(stableId)) {
+                throw new LineUnavailableException("missing " + stableId);
+            }
+            FakeLine fallback = lines.get(AudioDeviceSnapshot.SYSTEM_DEFAULT_ID);
+            if (stableId.equals(exclusivePreferredDevice)
+                    && fallback != null
+                    && fallback.isOpen()) {
+                exclusiveOpenConflicts++;
+                throw new LineUnavailableException(
+                        "preferred output is exclusive while fallback remains open");
+            }
+            FakeLine line = new FakeLine(bufferBytes, operationThreads);
+            lines.put(stableId, line);
+            openedIds.add(stableId);
+            return line;
+        }
+    }
+
+    private static final class FakeLine implements AudioBackend.AudioLine {
+        private final int requestedBufferBytes;
+        private final List<String> operationThreads;
+        private volatile boolean open = true;
+        private volatile boolean closed;
+        private volatile boolean failWrites;
+        private volatile int flushCount;
+
+        private FakeLine(int requestedBufferBytes, List<String> operationThreads) {
+            this.requestedBufferBytes = requestedBufferBytes;
+            this.operationThreads = operationThreads;
+        }
+
+        private void record() {
+            operationThreads.add(Thread.currentThread().getName());
+        }
+
+        @Override
+        public void start() {
+            record();
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            record();
+            if (failWrites) {
+                throw new IllegalStateException("device disconnected");
+            }
+            return length;
+        }
+
+        @Override
+        public int available() {
+            return requestedBufferBytes;
+        }
+
+        @Override
+        public int bufferSize() {
+            return requestedBufferBytes;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void flush() {
+            record();
+            flushCount++;
+        }
+
+        @Override
+        public void stop() {
+            record();
+        }
+
+        @Override
+        public void close() {
+            record();
+            open = false;
+            closed = true;
+        }
+    }
+
+    private static final class BlockingCloseBackend implements AudioBackend {
+        private final CountDownLatch closeAttempts = new CountDownLatch(2);
+        private final CountDownLatch neverRelease = new CountDownLatch(1);
+        private final List<Thread> closeThreads = new CopyOnWriteArrayList<>();
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return List.of(AudioDeviceSnapshot.systemDefaultDevice());
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes) {
+            return new AudioLine() {
+                @Override
+                public void start() {
+                }
+
+                @Override
+                public int write(byte[] bytes, int offset, int length) {
+                    return length;
+                }
+
+                @Override
+                public int available() {
+                    return bufferBytes;
+                }
+
+                @Override
+                public int bufferSize() {
+                    return bufferBytes;
+                }
+
+                @Override
+                public boolean isOpen() {
+                    return true;
+                }
+
+                @Override
+                public void flush() {
+                }
+
+                @Override
+                public void stop() {
+                }
+
+                @Override
+                public void close() {
+                    closeThreads.add(Thread.currentThread());
+                    closeAttempts.countDown();
+                    while (true) {
+                        try {
+                            neverRelease.await();
+                        } catch (InterruptedException ignored) {
+                            // Simulate a permanently stuck provider that ignores cancellation.
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
@@ -9,15 +9,20 @@ import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SwingGamepadTest {
@@ -36,6 +41,8 @@ public class SwingGamepadTest {
         assertEquals(0.5,
                 SwingGamepad.normalizeTiltAxis((32767 + SwingGamepad.TILT_DEAD_ZONE) / 2),
                 0.0001);
+        assertEquals(Short.MAX_VALUE, SwingGamepad.invertAxis(Short.MIN_VALUE, true));
+        assertEquals(Short.MIN_VALUE, SwingGamepad.invertAxis(Short.MIN_VALUE, false));
     }
 
     @Test
@@ -93,8 +100,14 @@ public class SwingGamepadTest {
         FakeDevice reconnected = rig.backend.add(ID_A, "replacement-with-assigned-identity");
         reconnected.buttons.add(GamepadBackend.PadButton.START);
         rig.gamepad.pollOnce();
-        assertEquals(Set.of(Button.START), rig.hub.sample().buttons(0));
+        assertTrue("a reconnect must not inherit a held control",
+                rig.hub.sample().buttons(0).isEmpty());
         assertEquals(1, reconnected.openCount);
+        reconnected.buttons.clear();
+        rig.gamepad.pollOnce();
+        reconnected.buttons.add(GamepadBackend.PadButton.START);
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.START), rig.hub.sample().buttons(0));
     }
 
     @Test
@@ -137,6 +150,150 @@ public class SwingGamepadTest {
         assertEquals(List.of(ID_A, ID_B, ID_C, ID_B),
                 discovered.stream().map(GamepadBackend.DeviceInfo::stableId).toList());
         assertEquals("reconnected-two", discovered.get(3).name());
+    }
+
+    @Test
+    public void catalogPublishesSortedImmutableSnapshotsWithoutExposingBackendDevices() {
+        Rig rig = new Rig(mapping(new ControllerProperties.GamepadAssignment(0, "auto")));
+        assertEquals(GamepadCatalog.Status.STARTING,
+                rig.gamepad.catalog().snapshot().status());
+
+        rig.backend.add(ID_B, "Same name");
+        rig.backend.add(ID_A, "Same name");
+        rig.gamepad.pollOnce();
+
+        GamepadCatalog.Snapshot first = rig.gamepad.catalog().snapshot();
+        assertEquals(GamepadCatalog.Status.AVAILABLE, first.status());
+        assertEquals(List.of(ID_A, ID_B),
+                first.devices().stream().map(GamepadCatalog.Device::stableId).toList());
+        assertEquals(Integer.valueOf(0), first.devices().get(0).assignedPlayer());
+        assertEquals(null, first.devices().get(1).assignedPlayer());
+        assertThrows(UnsupportedOperationException.class,
+                () -> first.devices().add(new GamepadCatalog.Device(ID_C, "third", null)));
+
+        rig.backend.remove(ID_B);
+        rig.gamepad.pollOnce();
+        GamepadCatalog.Snapshot second = rig.gamepad.catalog().snapshot();
+        assertNotSame(first, second);
+        assertEquals(2, first.devices().size());
+        assertEquals(List.of(ID_A),
+                second.devices().stream().map(GamepadCatalog.Device::stableId).toList());
+    }
+
+    @Test
+    public void runtimeRemapReleasesImmediatelyAndRequiresNeutralBeforeRelatching() {
+        Rig rig = new Rig(configuration(
+                List.of(new ControllerProperties.GamepadAssignment(0, ID_A)),
+                Map.of()));
+        FakeDevice device = rig.backend.add(ID_A, "primary");
+        device.buttons.add(GamepadBackend.PadButton.A);
+        rig.bus.post(new RumbleEvent(true));
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.A), rig.hub.sample().buttons(0));
+        assertTrue(device.rumbling);
+
+        int backendCallsBeforeUpdate = rig.backend.callingThreads.size();
+        rig.gamepad.updateConfiguration(configuration(
+                List.of(new ControllerProperties.GamepadAssignment(3, ID_A)),
+                Map.of()));
+
+        assertTrue(rig.hub.sample().players().stream().allMatch(Set::isEmpty));
+        assertEquals("configuration hand-off must not call SDL",
+                backendCallsBeforeUpdate, rig.backend.callingThreads.size());
+        assertEquals(0, device.closeCount);
+
+        rig.gamepad.pollOnce();
+        assertTrue("held input must not jump from P1 to P4",
+                rig.hub.sample().players().stream().allMatch(Set::isEmpty));
+        assertEquals(1, device.closeCount);
+        assertEquals(2, device.openCount);
+
+        device.buttons.clear();
+        rig.gamepad.pollOnce();
+        device.buttons.add(GamepadBackend.PadButton.B);
+        rig.gamepad.pollOnce();
+        assertTrue(rig.hub.sample().buttons(0).isEmpty());
+        assertEquals(Set.of(Button.B), rig.hub.sample().buttons(3));
+    }
+
+    @Test
+    public void lifecycleReleaseRequiresNeutralBeforeTheSameMappingRelatches() {
+        Rig rig = new Rig(mapping(new ControllerProperties.GamepadAssignment(0, ID_A)));
+        FakeDevice device = rig.backend.add(ID_A, "primary");
+        device.buttons.add(GamepadBackend.PadButton.A);
+        rig.bus.post(new RumbleEvent(true));
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.A), rig.hub.sample().buttons(0));
+        assertTrue(device.rumbling);
+
+        int backendCallsBeforeRelease = rig.backend.callingThreads.size();
+        rig.gamepad.releaseForLifecycleChange();
+        assertTrue(rig.hub.sample().buttons(0).isEmpty());
+        assertEquals(backendCallsBeforeRelease, rig.backend.callingThreads.size());
+        assertTrue("lifecycle caller must not touch the SDL rumble handle", device.rumbling);
+
+        rig.gamepad.pollOnce();
+        assertTrue(rig.hub.sample().buttons(0).isEmpty());
+        assertFalse("the polling thread must force active rumble off", device.rumbling);
+        device.buttons.clear();
+        rig.gamepad.pollOnce();
+        device.buttons.add(GamepadBackend.PadButton.A);
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.A), rig.hub.sample().buttons(0));
+    }
+
+    @Test
+    public void perDeviceDeadZonesAndAxisInversionAreAppliedWithoutChangingDefaults() {
+        GamepadConfiguration.Tuning tuning =
+                new GamepadConfiguration.Tuning(1_000, 2_000,
+                        true, true, true, false);
+        Rig rig = new Rig(configuration(
+                List.of(new ControllerProperties.GamepadAssignment(0, ID_A)),
+                Map.of(ID_A, tuning)));
+        FakeDevice device = rig.backend.add(ID_A, "primary");
+        device.axes.put(GamepadBackend.Axis.LEFT_X, 1_001);
+        device.axes.put(GamepadBackend.Axis.LEFT_Y, -1_001);
+        device.axes.put(GamepadBackend.Axis.RIGHT_X, 32_767);
+        device.axes.put(GamepadBackend.Axis.RIGHT_Y, -32_768);
+        List<AccelerometerEvent> tilt = new ArrayList<>();
+        rig.bus.register(tilt::add, AccelerometerEvent.class);
+
+        rig.gamepad.pollOnce();
+
+        assertEquals(Set.of(Button.LEFT, Button.DOWN), rig.hub.sample().buttons(0));
+        assertEquals(new AccelerometerEvent(-1, -1), tilt.get(0));
+        assertEquals(GamepadConfiguration.Tuning.DEFAULT_MOVEMENT_DEAD_ZONE,
+                GamepadConfiguration.Tuning.DEFAULT.movementDeadZone());
+        assertEquals(SwingGamepad.TILT_DEAD_ZONE,
+                GamepadConfiguration.Tuning.DEFAULT.tiltDeadZone());
+
+        device.axes.put(GamepadBackend.Axis.LEFT_X, 1_000);
+        device.axes.put(GamepadBackend.Axis.LEFT_Y, -1_000);
+        device.axes.put(GamepadBackend.Axis.RIGHT_X, 2_000);
+        device.axes.put(GamepadBackend.Axis.RIGHT_Y, -2_000);
+        rig.gamepad.pollOnce();
+        assertTrue(rig.hub.sample().buttons(0).isEmpty());
+        assertEquals(new AccelerometerEvent(0, 0), tilt.get(tilt.size() - 1));
+    }
+
+    @Test
+    public void malformedRuntimeAssignmentsAreRejectedBeforeTheyCanReplaceLiveState() {
+        assertThrows(IllegalArgumentException.class,
+                () -> configuration(
+                        List.of(
+                                new ControllerProperties.GamepadAssignment(0, ID_A),
+                                new ControllerProperties.GamepadAssignment(1, ID_A)),
+                        Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> configuration(
+                        List.of(
+                                new ControllerProperties.GamepadAssignment(0, "auto"),
+                                new ControllerProperties.GamepadAssignment(1, "auto")),
+                        Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new GamepadConfiguration.Tuning(
+                        GamepadConfiguration.Tuning.MAX_DEAD_ZONE + 1,
+                        0, false, false, false, false));
     }
 
     @Test
@@ -211,11 +368,59 @@ public class SwingGamepadTest {
         assertTrue(device.closeCount > 0);
         assertFalse(device.rumbling);
         assertEquals(new AccelerometerEvent(0, 0), tilt.get(tilt.size() - 1));
+        assertEquals(GamepadCatalog.Status.STOPPED,
+                rig.gamepad.catalog().snapshot().status());
+    }
+
+    @Test
+    public void productionRunKeepsEveryBackendAndDeviceCallOnItsPollingThread()
+            throws Exception {
+        Rig rig = new Rig(mapping(new ControllerProperties.GamepadAssignment(0, ID_A)));
+        rig.backend.add(ID_A, "primary");
+        rig.gamepad.updateConfiguration(configuration(
+                List.of(new ControllerProperties.GamepadAssignment(1, ID_A)),
+                Map.of()));
+        assertTrue(rig.backend.callingThreads.isEmpty());
+
+        Thread poller = new Thread(rig.gamepad, "owned-gamepad-poller");
+        poller.start();
+        assertTrue("poller did not reach the backend",
+                rig.backend.firstUpdate.await(2, TimeUnit.SECONDS));
+        rig.gamepad.stop();
+        poller.interrupt();
+        poller.join(2_000);
+
+        assertFalse(poller.isAlive());
+        assertFalse(rig.backend.callingThreads.isEmpty());
+        assertTrue(rig.backend.callingThreads.stream().allMatch(thread -> thread == poller));
+    }
+
+    @Test
+    public void unavailableBackendPublishesSanitizedFallbackSnapshot() {
+        Rig rig = new Rig(mapping());
+        rig.backend.initializationFailure = new UnsatisfiedLinkError("private/native/detail");
+
+        rig.gamepad.run();
+
+        GamepadCatalog.Snapshot snapshot = rig.gamepad.catalog().snapshot();
+        assertEquals(GamepadCatalog.Status.UNAVAILABLE, snapshot.status());
+        assertTrue(snapshot.devices().isEmpty());
+        assertEquals(
+                "Game controllers are unavailable. Keyboard input remains available.",
+                snapshot.message());
+        assertFalse(snapshot.message().contains("private/native/detail"));
+        assertTrue(rig.backend.closed);
     }
 
     private static ControllerProperties.PlayerMapping mapping(
             ControllerProperties.GamepadAssignment... assignments) {
         return new ControllerProperties.PlayerMapping(Map.of(), List.of(assignments));
+    }
+
+    private static GamepadConfiguration configuration(
+            List<ControllerProperties.GamepadAssignment> assignments,
+            Map<String, GamepadConfiguration.Tuning> tuning) {
+        return new GamepadConfiguration(assignments, tuning);
     }
 
     private static final class Rig {
@@ -234,15 +439,23 @@ public class SwingGamepadTest {
             List<GamepadBackend.DeviceInfo> discovered) {
             gamepad = new SwingGamepad(mapping, input, tiltInput, bus, backend, discovered::add);
         }
+
+        Rig(GamepadConfiguration configuration) {
+            gamepad = new SwingGamepad(configuration, input, tiltInput, bus, backend);
+        }
     }
 
     private static final class FakeBackend implements GamepadBackend {
         private final LinkedHashMap<String, FakeDevice> devices = new LinkedHashMap<>();
+        private final List<Thread> callingThreads =
+                Collections.synchronizedList(new ArrayList<>());
+        private final CountDownLatch firstUpdate = new CountDownLatch(1);
         private boolean reversed;
         private boolean closed;
+        private Error initializationFailure;
 
         FakeDevice add(String id, String name) {
-            FakeDevice device = new FakeDevice(id, name);
+            FakeDevice device = new FakeDevice(this, id, name);
             devices.put(id, device);
             return device;
         }
@@ -255,12 +468,29 @@ public class SwingGamepadTest {
             reversed = !reversed;
         }
 
-        @Override public void initialize() {}
-        @Override public void update() {}
-        @Override public void close() { closed = true; }
+        @Override
+        public void initialize() {
+            recordCall();
+            if (initializationFailure != null) {
+                throw initializationFailure;
+            }
+        }
+
+        @Override
+        public void update() {
+            recordCall();
+            firstUpdate.countDown();
+        }
+
+        @Override
+        public void close() {
+            recordCall();
+            closed = true;
+        }
 
         @Override
         public List<DeviceInfo> devices() {
+            recordCall();
             List<FakeDevice> values = new ArrayList<>(devices.values());
             if (reversed) java.util.Collections.reverse(values);
             List<DeviceInfo> result = new ArrayList<>();
@@ -273,13 +503,19 @@ public class SwingGamepadTest {
 
         @Override
         public GamepadDevice open(DeviceInfo info) {
+            recordCall();
             FakeDevice device = devices.get(info.stableId());
             if (device != null) device.openCount++;
             return device;
         }
+
+        private void recordCall() {
+            callingThreads.add(Thread.currentThread());
+        }
     }
 
     private static final class FakeDevice implements GamepadBackend.GamepadDevice {
+        final FakeBackend backend;
         final String id;
         final String name;
         final EnumSet<GamepadBackend.PadButton> buttons =
@@ -291,17 +527,43 @@ public class SwingGamepadTest {
         int openCount;
         int closeCount;
 
-        FakeDevice(String id, String name) {
+        FakeDevice(FakeBackend backend, String id, String name) {
+            this.backend = backend;
             this.id = id;
             this.name = name;
         }
 
         @Override public String stableId() { return id; }
         @Override public String name() { return name; }
-        @Override public boolean attached() { return attached; }
-        @Override public int axis(GamepadBackend.Axis axis) { return axes.getOrDefault(axis, 0); }
-        @Override public boolean button(GamepadBackend.PadButton button) { return buttons.contains(button); }
-        @Override public void rumble(boolean enabled) { rumbling = enabled; }
-        @Override public void close() { closeCount++; }
+
+        @Override
+        public boolean attached() {
+            backend.recordCall();
+            return attached;
+        }
+
+        @Override
+        public int axis(GamepadBackend.Axis axis) {
+            backend.recordCall();
+            return axes.getOrDefault(axis, 0);
+        }
+
+        @Override
+        public boolean button(GamepadBackend.PadButton button) {
+            backend.recordCall();
+            return buttons.contains(button);
+        }
+
+        @Override
+        public void rumble(boolean enabled) {
+            backend.recordCall();
+            rumbling = enabled;
+        }
+
+        @Override
+        public void close() {
+            backend.recordCall();
+            closeCount++;
+        }
     }
 }


### PR DESCRIPTION
Part of #334 and #316.

## Summary

- add live four-player gamepad discovery, stable per-device assignments, dead zones, axis inversion, hot-plug recovery, and neutral re-arming
- add off-EDT Java Sound device discovery, output selection, master volume, mute, latency presets, safe fallback, and automatic preferred-device recovery
- extend Preferences with validated Gamepads and Audio tabs while preserving Apply/Cancel/Restore Defaults semantics
- migrate desktop settings to schema 3 with strict bounded validation and lossless preservation of older unknown-key collisions
- make desktop shutdown asynchronous and bounded, including hostile audio providers

## Invariants

SDL access remains owned by the gamepad poller. Audio discovery/open/write/reconfiguration normally remains owned by a named daemon worker; emergency close is isolated on a daemon and `stopThread()` has a 2.25-second deadline. Swing component mutation remains on the EDT. Runtime mapping changes release held inputs and require a neutral sample before re-arming. Missing configured devices remain persisted and fall back without silently changing the user selection.

Schemas 0–2 migrate idempotently to schema 3. Future schemas are still rejected without overwrite, numeric/device/profile limits are explicit, and schema-2 keys that collide with new schema-3 namespaces remain in the existing collision envelope.

## Verification

- `mvn -B clean package --file pom.xml`
- 112 Swing tests passed in the clean reactor, including 8 audio lifecycle tests and 15 gamepad tests
- `SgbInventoryGuardTest`: 2/2
- packaged JAR: `--help` exit 0, `--version` exit 0, invalid option exit 2
- Xvfb Preferences render smoke inspected for Gamepads and Audio tabs
- independent runtime audit completed; preferred-output reconnect and indefinitely blocking provider-close findings were fixed and regression-tested

## Follow-up

#334 remains open for its Display and Saves Preferences sections. #335 consumes these settings/runtime contracts next.