### PR TITLE
Add resizable high-DPI fullscreen display

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ ambiguous or aliased identity.
 | Pause | <kbd>Space</kbd> |
 | Save / load state | <kbd>F5</kbd> / <kbd>F7</kbd> |
 | Rewind | Hold <kbd>Backspace</kbd> |
+| Toggle fullscreen | <kbd>F11</kbd> (disabled if assigned to an emulated button) |
 
 In single-player mode, there are ten save-state slots. Battery saves (`.sav`)
 and save states (`.sn0`&ndash;`.sn9`) are stored next to the ROM. Pause, save
@@ -135,9 +136,12 @@ states, and rewind are disabled during netplay.
 <summary>Custom keyboard and game-controller mapping</summary>
 
 Desktop settings are stored in `~/.coffeegb.properties`. **File > Preferences…** configures
-General behavior, four-player keyboard bindings, gamepad assignment/tuning, and audio
-device/volume/mute/latency without manual editing. The complete typed schema, validation,
-migration, device fallback, and recovery rules are documented in the
+General behavior, aspect-correct integer/fit/1×–4× display scaling, letterboxing, fullscreen,
+four-player keyboard bindings, gamepad assignment/tuning, and audio device/volume/mute/latency
+without manual editing. The resizable display preserves DMG/CGB and SGB-border geometry; fullscreen
+restores and clamps prior window placement across monitor and DPI changes. The complete typed
+schema, validation, rendering fallback, migration, device fallback, and recovery rules are
+documented in the
 [desktop command-line and settings contract](docs/desktop-settings.md). For keyboard mappings, use
 [`KeyEvent`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/event/KeyEvent.html)
 constant names:

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -24,9 +24,6 @@ data class ApplicationSettings(
     require(schemaVersion == CURRENT_SCHEMA_VERSION) {
       "Application settings schema must be $CURRENT_SCHEMA_VERSION"
     }
-    require(display.scale in SUPPORTED_SCALES) {
-      "Display scale must be one of ${SUPPORTED_SCALES.sorted()}"
-    }
     input.toPlayerMapping()
     advanced.dmgGamesProfile.explicitProfileOrNull()?.let(HardwareProfileRegistry::requireRegistered)
     advanced.cgbGamesProfile.explicitProfileOrNull()?.let(HardwareProfileRegistry::requireRegistered)
@@ -107,13 +104,39 @@ data class ApplicationSettings(
   }
 
   data class Display(
-      val scale: Int = 2,
+      val scalingMode: DisplayScalingMode = DisplayScalingMode.EXPLICIT,
+      val explicitScale: Int = DEFAULT_EXPLICIT_DISPLAY_SCALE,
+      val letterboxColor: Int = DEFAULT_LETTERBOX_COLOR,
+      val fullscreen: Boolean = false,
       val grayscale: Boolean = false,
       val blending: Boolean = true,
       val colorCorrection: Boolean = true,
       val rotation: Rotation = Rotation.DEG_0,
       val showSgbBorder: Boolean = false,
-  )
+  ) {
+    init {
+      require(explicitScale in MIN_EXPLICIT_DISPLAY_SCALE..MAX_EXPLICIT_DISPLAY_SCALE) {
+        "Explicit display scale must be between $MIN_EXPLICIT_DISPLAY_SCALE and " +
+            MAX_EXPLICIT_DISPLAY_SCALE
+      }
+      require(letterboxColor in MIN_LETTERBOX_COLOR..MAX_LETTERBOX_COLOR) {
+        "Letterbox color must be an RGB value between 0x000000 and 0xFFFFFF"
+      }
+    }
+
+    /**
+     * Compatibility view for callers that have not yet adopted fit modes. New code should use
+     * [scalingMode] and [explicitScale].
+     */
+    val scale: Int
+      get() = explicitScale
+  }
+
+  enum class DisplayScalingMode {
+    INTEGER_FIT,
+    ASPECT_FIT,
+    EXPLICIT,
+  }
 
   enum class Rotation(val degrees: Int) {
     DEG_0(0),
@@ -386,7 +409,7 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 3
+    const val CURRENT_SCHEMA_VERSION = 4
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50
@@ -398,8 +421,12 @@ data class ApplicationSettings(
     const val DEFAULT_GAMEPAD_TILT_DEAD_ZONE = 4_096
     const val MAX_GAMEPAD_DEAD_ZONE = 32_766
     const val MAX_GAMEPAD_TUNINGS = 32
-    private val SUPPORTED_SCALES: Set<Int> =
-        Collections.unmodifiableSet(linkedSetOf(1, 2, 4))
+    const val MIN_EXPLICIT_DISPLAY_SCALE = 1
+    const val DEFAULT_EXPLICIT_DISPLAY_SCALE = 2
+    const val MAX_EXPLICIT_DISPLAY_SCALE = 4
+    const val MIN_LETTERBOX_COLOR = 0x000000
+    const val DEFAULT_LETTERBOX_COLOR = 0x000000
+    const val MAX_LETTERBOX_COLOR = 0xFFFFFF
 
     internal fun isStableAudioOutputId(value: String): Boolean =
         value.matches(STABLE_AUDIO_OUTPUT_ID)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -22,6 +22,9 @@ object ApplicationSettingsCodec {
   const val AUDIO_VOLUME_KEY = "audio.masterVolume"
   const val AUDIO_LATENCY_KEY = "audio.latencyPreset"
   const val GAMEPAD_TUNING_PREFIX = "input.gamepad."
+  const val DISPLAY_SCALING_MODE_KEY = "display.scalingMode"
+  const val DISPLAY_LETTERBOX_COLOR_KEY = "display.letterboxColor"
+  const val DISPLAY_FULLSCREEN_KEY = "display.fullscreen"
   internal const val PRESERVED_UNKNOWN_COLLISIONS_PREFIX =
       "settings.preservedUnknownCollisions."
 
@@ -34,6 +37,9 @@ object ApplicationSettingsCodec {
   private val versionThreeFixedKeys =
       versionTwoFixedKeys +
           setOf(AUDIO_OUTPUT_KEY, AUDIO_VOLUME_KEY, AUDIO_LATENCY_KEY)
+  private val versionFourFixedKeys =
+      versionThreeFixedKeys +
+          setOf(DISPLAY_SCALING_MODE_KEY, DISPLAY_LETTERBOX_COLOR_KEY, DISPLAY_FULLSCREEN_KEY)
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -47,7 +53,11 @@ object ApplicationSettingsCodec {
             version > SUPPORTED_SCHEMA_VERSION)) {
       throw UnsupportedApplicationSettingsVersionException(encodedVersion)
     }
-    require(version == "1" || version == "2" || version == SUPPORTED_SCHEMA_VERSION) {
+    require(
+        version == "1" ||
+            version == "2" ||
+            version == "3" ||
+            version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
     return decodeSupportedVersion(raw, sourceVersion = version.toInt())
@@ -97,7 +107,12 @@ object ApplicationSettingsCodec {
       known["$RECENT_ROM_PREFIX$index"] = path.toString()
     }
 
-    known[EmulatorProperties.Key.DisplayScale.propertyName] = settings.display.scale.toString()
+    known[DISPLAY_SCALING_MODE_KEY] = settings.display.scalingMode.name
+    known[EmulatorProperties.Key.DisplayScale.propertyName] =
+        settings.display.explicitScale.toString()
+    known[DISPLAY_LETTERBOX_COLOR_KEY] =
+        "%06X".format(Locale.ROOT, settings.display.letterboxColor)
+    known[DISPLAY_FULLSCREEN_KEY] = settings.display.fullscreen.toString()
     known[EmulatorProperties.Key.DisplayGrayscale.propertyName] = settings.display.grayscale.toString()
     known[EmulatorProperties.Key.DisplayBlending.propertyName] = settings.display.blending.toString()
     known[EmulatorProperties.Key.DisplayColorCorrection.propertyName] =
@@ -182,10 +197,29 @@ object ApplicationSettingsCodec {
         }
     val display =
         ApplicationSettings.Display(
-            scale =
-                raw[EmulatorProperties.Key.DisplayScale.propertyName]?.let {
-                  parseInt(it, EmulatorProperties.Key.DisplayScale.propertyName)
-                } ?: 2,
+            scalingMode =
+                if (sourceVersion >= 4) {
+                  parseDisplayScalingMode(raw[DISPLAY_SCALING_MODE_KEY])
+                } else {
+                  ApplicationSettings.DisplayScalingMode.EXPLICIT
+                },
+            explicitScale =
+                parseDisplayScale(
+                    raw[EmulatorProperties.Key.DisplayScale.propertyName],
+                    sourceVersion,
+                ),
+            letterboxColor =
+                if (sourceVersion >= 4) {
+                  parseLetterboxColor(raw[DISPLAY_LETTERBOX_COLOR_KEY])
+                } else {
+                  ApplicationSettings.DEFAULT_LETTERBOX_COLOR
+                },
+            fullscreen =
+                if (sourceVersion >= 4) {
+                  parseBoolean(raw[DISPLAY_FULLSCREEN_KEY], false, DISPLAY_FULLSCREEN_KEY)
+                } else {
+                  false
+                },
             grayscale =
                 parseBoolean(
                     raw[EmulatorProperties.Key.DisplayGrayscale.propertyName],
@@ -301,6 +335,7 @@ object ApplicationSettingsCodec {
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
         when {
+          sourceVersion >= 4 -> versionFourFixedKeys
           sourceVersion >= 3 -> versionThreeFixedKeys
           sourceVersion >= 2 -> versionTwoFixedKeys
           else -> versionOneFixedKeys
@@ -399,6 +434,49 @@ object ApplicationSettingsCodec {
       throw IllegalArgumentException(
           "Invalid $AUDIO_LATENCY_KEY: $value (expected LOW, BALANCED, or SAFE)")
     }
+  }
+
+  private fun parseDisplayScalingMode(value: String?): ApplicationSettings.DisplayScalingMode {
+    if (value == null) return ApplicationSettings.DisplayScalingMode.EXPLICIT
+    return try {
+      ApplicationSettings.DisplayScalingMode.valueOf(value)
+    } catch (_: IllegalArgumentException) {
+      throw IllegalArgumentException(
+          "Invalid $DISPLAY_SCALING_MODE_KEY: $value " +
+              "(expected INTEGER_FIT, ASPECT_FIT, or EXPLICIT)")
+    }
+  }
+
+  private fun parseDisplayScale(value: String?, sourceVersion: Int): Int {
+    if (value == null) return ApplicationSettings.DEFAULT_EXPLICIT_DISPLAY_SCALE
+    val parsed = parseInt(value, EmulatorProperties.Key.DisplayScale.propertyName)
+    val accepted =
+        if (sourceVersion >= 4) {
+          parsed in
+              ApplicationSettings.MIN_EXPLICIT_DISPLAY_SCALE..
+                  ApplicationSettings.MAX_EXPLICIT_DISPLAY_SCALE
+        } else {
+          parsed == 1 || parsed == 2 || parsed == 4
+        }
+    require(accepted) {
+      if (sourceVersion >= 4) {
+        "Invalid ${EmulatorProperties.Key.DisplayScale.propertyName}: $parsed " +
+            "(expected ${ApplicationSettings.MIN_EXPLICIT_DISPLAY_SCALE}.." +
+            "${ApplicationSettings.MAX_EXPLICIT_DISPLAY_SCALE})"
+      } else {
+        "Invalid ${EmulatorProperties.Key.DisplayScale.propertyName}: $parsed " +
+            "(expected 1, 2, or 4)"
+      }
+    }
+    return parsed
+  }
+
+  private fun parseLetterboxColor(value: String?): Int {
+    if (value == null) return ApplicationSettings.DEFAULT_LETTERBOX_COLOR
+    require(CANONICAL_RGB.matches(value)) {
+      "Invalid $DISPLAY_LETTERBOX_COLOR_KEY: $value (expected six uppercase hexadecimal digits)"
+    }
+    return value.toInt(16)
   }
 
   private fun parseGamepadTunings(
@@ -634,7 +712,7 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionThreeFixedKeys ||
+      key in versionFourFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           key.startsWith("btn_") ||
@@ -644,6 +722,7 @@ object ApplicationSettingsCodec {
   private const val COLLISION_CHUNK_SIZE = 60_000
   private const val MAX_COLLISION_CHUNKS = 32
   private const val MAX_SETTINGS_PROPERTIES = 2_048
+  private val CANONICAL_RGB = Regex("[0-9A-F]{6}")
   private val gamepadTuningKey =
       Regex(
           "input\\.gamepad\\.(sdl-[0-9a-f]{64})\\." +

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/DisplayProperties.kt
@@ -4,6 +4,18 @@ class DisplayProperties(private val properties: EmulatorProperties) {
   val scale
     get() = properties.applicationSettings.display.scale
 
+  val scalingMode
+    get() = properties.applicationSettings.display.scalingMode
+
+  val explicitScale
+    get() = properties.applicationSettings.display.explicitScale
+
+  val letterboxColor
+    get() = properties.applicationSettings.display.letterboxColor
+
+  val fullscreen
+    get() = properties.applicationSettings.display.fullscreen
+
   val grayscale
     get() = properties.applicationSettings.display.grayscale
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
@@ -103,7 +103,7 @@ class ApplicationSettingsDevicesTest {
     mutableTunings.clear()
 
     val encoded = ApplicationSettingsCodec.encode(document)
-    assertEquals("3", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("4", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertEquals(audioId('c'), encoded[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
     assertEquals("37", encoded[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
     assertEquals("LOW", encoded[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
@@ -163,7 +163,7 @@ class ApplicationSettingsDevicesTest {
       assertEquals(futureValues, migrated.unknownProperties)
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("3", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("4", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("default", canonical[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
       assertEquals("100", canonical[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
       assertEquals("BALANCED", canonical[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
@@ -1,0 +1,201 @@
+package eu.rekawek.coffeegb.controller.properties
+
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ApplicationSettingsDisplayTest {
+
+  @Test
+  fun `display model has legacy-compatible defaults and validates every numeric boundary`() {
+    val defaults = ApplicationSettings.Display()
+    assertEquals(ApplicationSettings.DisplayScalingMode.EXPLICIT, defaults.scalingMode)
+    assertEquals(2, defaults.explicitScale)
+    assertEquals(2, defaults.scale)
+    assertEquals(0x000000, defaults.letterboxColor)
+    assertFalse(defaults.fullscreen)
+
+    ApplicationSettings.Display(explicitScale = 1, letterboxColor = 0x000000)
+    ApplicationSettings.Display(explicitScale = 4, letterboxColor = 0xFFFFFF)
+    ApplicationSettings.DisplayScalingMode.entries.forEach { mode ->
+      ApplicationSettings.Display(scalingMode = mode)
+    }
+
+    listOf(0, 5).forEach { invalidScale ->
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.Display(explicitScale = invalidScale)
+      }
+    }
+    listOf(-1, 0x1000000).forEach { invalidColor ->
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.Display(letterboxColor = invalidColor)
+      }
+    }
+  }
+
+  @Test
+  fun `schema four display values round trip canonically and idempotently`() {
+    val explicitScales =
+        ApplicationSettings.MIN_EXPLICIT_DISPLAY_SCALE..
+            ApplicationSettings.MAX_EXPLICIT_DISPLAY_SCALE
+    ApplicationSettings.DisplayScalingMode.entries.forEach { scalingMode ->
+      explicitScales.forEach { explicitScale ->
+        listOf(0x000000, 0x203040, 0xFFFFFF).forEach { color ->
+          val document =
+              ApplicationSettingsDocument(
+                  ApplicationSettings(
+                      display =
+                          ApplicationSettings.Display(
+                              scalingMode = scalingMode,
+                              explicitScale = explicitScale,
+                              letterboxColor = color,
+                              fullscreen = true,
+                              grayscale = true,
+                              blending = false,
+                              colorCorrection = false,
+                              rotation = ApplicationSettings.Rotation.DEG_90,
+                              showSgbBorder = true,
+                          )),
+                  mapOf("plugin.display" to "preserve"),
+              )
+
+          val encoded = ApplicationSettingsCodec.encode(document)
+          assertEquals("4", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+          assertEquals(
+              scalingMode.name,
+              encoded[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY],
+          )
+          assertEquals(explicitScale.toString(), encoded["display.scale"])
+          assertEquals(
+              "%06X".format(Locale.ROOT, color),
+              encoded[ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY],
+          )
+          assertEquals("true", encoded[ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY])
+
+          val decoded = ApplicationSettingsCodec.decode(encoded)
+          assertEquals(document, decoded)
+          assertEquals(encoded, ApplicationSettingsCodec.encode(decoded))
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `schemas zero through three migrate fixed scale and preserve future display fields`() {
+    val futureValues =
+        mapOf(
+            ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "ASPECT_FIT",
+            ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "ABCDEF",
+            ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY to "true",
+        )
+
+    listOf(null, "1", "2", "3").forEach { sourceVersion ->
+      val raw =
+          buildMap {
+            sourceVersion?.let { put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, it) }
+            put("display.scale", "4")
+            putAll(futureValues)
+          }
+      val migrated = ApplicationSettingsCodec.decode(raw)
+
+      assertEquals(
+          ApplicationSettings.DisplayScalingMode.EXPLICIT,
+          migrated.settings.display.scalingMode,
+      )
+      assertEquals(4, migrated.settings.display.explicitScale)
+      assertEquals(
+          ApplicationSettings.DEFAULT_LETTERBOX_COLOR,
+          migrated.settings.display.letterboxColor,
+      )
+      assertFalse(migrated.settings.display.fullscreen)
+      assertEquals(futureValues, migrated.unknownProperties)
+
+      val canonical = ApplicationSettingsCodec.encode(migrated)
+      assertEquals("4", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("EXPLICIT", canonical[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY])
+      assertEquals("4", canonical["display.scale"])
+      assertEquals("000000", canonical[ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY])
+      assertEquals("false", canonical[ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY])
+      assertTrue(
+          canonical.keys.any {
+            it.startsWith(ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX)
+          })
+
+      val decodedAgain = ApplicationSettingsCodec.decode(canonical)
+      assertEquals(migrated, decodedAgain)
+      assertEquals(canonical, ApplicationSettingsCodec.encode(decodedAgain))
+    }
+  }
+
+  @Test
+  fun `schema three collision envelope retains future display values through schema four`() {
+    val collisions =
+        mapOf(
+            ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "INTEGER_FIT",
+            ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "123456",
+            ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY to "true",
+        )
+    val raw =
+        mapOf(
+            ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "3",
+            "${ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX}0" to
+                serializeCollisions(collisions),
+        )
+
+    val migrated = ApplicationSettingsCodec.decode(raw)
+    assertEquals(ApplicationSettings.Display(), migrated.settings.display)
+    assertEquals(collisions, migrated.unknownProperties)
+
+    val canonical = ApplicationSettingsCodec.encode(migrated)
+    assertEquals("EXPLICIT", canonical[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY])
+    assertEquals("000000", canonical[ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY])
+    assertEquals("false", canonical[ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY])
+    val decodedAgain = ApplicationSettingsCodec.decode(canonical)
+    assertEquals(migrated, decodedAgain)
+    assertEquals(canonical, ApplicationSettingsCodec.encode(decodedAgain))
+  }
+
+  @Test
+  fun `schema four rejects noncanonical display values and accepts explicit three times`() {
+    val validSchema = mapOf(ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "4")
+    val invalid =
+        listOf(
+            mapOf(ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "aspect_fit"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "FIXED"),
+            mapOf("display.scale" to "0"),
+            mapOf("display.scale" to "5"),
+            mapOf("display.scale" to "3.0"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "#123456"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "abcdef"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "12345"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "1000000"),
+            mapOf(ApplicationSettingsCodec.DISPLAY_FULLSCREEN_KEY to "yes"),
+        )
+
+    invalid.forEach { fields ->
+      assertFailsWith<IllegalArgumentException>("Expected rejection for $fields") {
+        ApplicationSettingsCodec.decode(validSchema + fields)
+      }
+    }
+
+    val explicitThree =
+        ApplicationSettingsCodec.decode(
+            validSchema +
+                mapOf(
+                    ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "EXPLICIT",
+                    "display.scale" to "3",
+                ))
+    assertEquals(3, explicitThree.settings.display.explicitScale)
+  }
+
+  private fun serializeCollisions(values: Map<String, String>): String =
+      buildString {
+        values.toSortedMap().forEach { (key, value) ->
+          append(key.length).append(':').append(key)
+          append(value.length).append(':').append(value)
+        }
+      }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
@@ -402,7 +402,7 @@ class ApplicationSettingsGeneralTest {
     val raw =
         buildMap {
           put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, "2")
-          repeat(2_031) { index -> put("plugin.$index", "value") }
+          repeat(2_028) { index -> put("plugin.$index", "value") }
           serialized.chunked(60_000).forEachIndexed { index, chunk ->
             put(
                 "${ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX}$index",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
@@ -313,7 +313,7 @@ class ApplicationSettingsStoreTest {
 
       store.update(
           store.current().withSettings {
-            copy(display = display.copy(scale = 4))
+            copy(display = display.copy(explicitScale = 4))
           })
       store.flush()
       assertEquals(4, readDocument(path).settings.display.scale)
@@ -370,10 +370,8 @@ class ApplicationSettingsStoreTest {
       properties.setProperty(EmulatorProperties.Key.SoundEnabled, "false")
       assertEquals(4, properties.display.scale)
       assertFalse(properties.sound.soundEnabled)
-      assertFailsWith<IllegalArgumentException> {
-        properties.setProperty(EmulatorProperties.Key.DisplayScale, "3")
-      }
-      assertEquals(4, properties.display.scale)
+      properties.setProperty(EmulatorProperties.Key.DisplayScale, "3")
+      assertEquals(3, properties.display.scale)
 
       // Persistence is disabled, but validated menu/facade changes remain useful in this session.
       properties.flush()
@@ -427,14 +425,14 @@ class ApplicationSettingsStoreTest {
 
           Files.readAllBytes(path).also { bytes ->
             val canonical = ApplicationSettingsStore.decodeProperties(bytes)
-            assertEquals("3", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+            assertEquals("4", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
             assertEquals(store.current(), ApplicationSettingsCodec.decode(canonical))
             assertEquals(canonical, ApplicationSettingsCodec.encode(store.current()))
           }
         }
 
     ApplicationSettingsStore(path, debounceMillis = 60_000).use { store ->
-      assertEquals("3", store.current().settings.schemaVersion.toString())
+      assertEquals("4", store.current().settings.schemaVersion.toString())
     }
     assertTrue(canonicalBytes.contentEquals(Files.readAllBytes(path)))
   }
@@ -560,9 +558,9 @@ class ApplicationSettingsStoreTest {
     val writer = CountingWriter()
     val store = ApplicationSettingsStore(path, writer, debounceMillis = 60_000)
 
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 1)) })
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 2)) })
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 4)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 1)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 2)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 4)) })
     assertEquals(4, store.current().settings.display.scale)
     assertEquals(0, writer.writes.get())
 
@@ -580,10 +578,10 @@ class ApplicationSettingsStoreTest {
     val writer = SignallingWriter()
     val store = ApplicationSettingsStore(path, writer, debounceMillis = 1_000)
     try {
-      store.update(store.current().withSettings { copy(display = display.copy(scale = 1)) })
+      store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 1)) })
       assertFalse(writer.written.await(100, TimeUnit.MILLISECONDS))
 
-      store.update(store.current().withSettings { copy(display = display.copy(scale = 4)) })
+      store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 4)) })
       assertFalse(writer.written.await(250, TimeUnit.MILLISECONDS))
       assertEquals(0, writer.writes.get())
 
@@ -606,7 +604,7 @@ class ApplicationSettingsStoreTest {
     Files.write(path, originalBytes)
     val writer = FailOnceWriter()
     val store = ApplicationSettingsStore(path, writer, debounceMillis = 60_000)
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 4)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 4)) })
 
     val failure = assertFailsWith<IOException> { store.flush() }
     assertTrue(failure.message!!.contains("injected"))
@@ -626,10 +624,10 @@ class ApplicationSettingsStoreTest {
     val path = directory.resolve("settings.properties")
     val writer = BlockingFirstWriter()
     val store = ApplicationSettingsStore(path, writer, debounceMillis = 0)
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 1)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 1)) })
     assertTrue(writer.started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
 
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 4)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 4)) })
     val closeFailure = AtomicReference<Throwable?>()
     val closeStarted = CountDownLatch(1)
     val closer =
@@ -663,7 +661,7 @@ class ApplicationSettingsStoreTest {
             debounceMillis = 0,
             closeTimeoutMillis = 100,
         )
-    store.update(store.current().withSettings { copy(display = display.copy(scale = 4)) })
+    store.update(store.current().withSettings { copy(display = display.copy(explicitScale = 4)) })
     assertTrue(writer.started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
 
     val started = System.nanoTime()
@@ -793,8 +791,11 @@ class ApplicationSettingsStoreTest {
               "display.blending" to "false",
               "display.colorCorrection" to "false",
               "display.grayscale" to "true",
+              "display.fullscreen" to "false",
+              "display.letterboxColor" to "000000",
               "display.rotation" to "270",
               "display.scale" to "4",
+              "display.scalingMode" to "EXPLICIT",
               "display.showSgbBorder" to "true",
               "fullchanger.character" to "07 ま Magnesium Powered",
               "general.recentFileCapacity" to "10",
@@ -816,7 +817,7 @@ class ApplicationSettingsStoreTest {
               "general.recent.1" to "/legacy/roms/second.gbc",
               "rom.recent.future" to "preserve future recent metadata",
               "saves.batteryEnabled" to "false",
-              "settings.schemaVersion" to "3",
+              "settings.schemaVersion" to "4",
               "sound.enabled" to "false",
               "system.bootstrapMode" to "FAST_FORWARD",
               "system.cgbGames" to "cgb0",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/DisplayPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/DisplayPropertiesTest.kt
@@ -1,10 +1,32 @@
 package eu.rekawek.coffeegb.controller.properties
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DisplayPropertiesTest {
+  @Test
+  fun `display facade exposes typed scaling letterbox and fullscreen settings`() {
+    val properties = testEmulatorProperties()
+    properties.updateApplicationSettings { current ->
+      current.copy(
+          display =
+              current.display.copy(
+                  scalingMode = ApplicationSettings.DisplayScalingMode.INTEGER_FIT,
+                  explicitScale = 3,
+                  letterboxColor = 0x203040,
+                  fullscreen = true,
+              ))
+    }
+
+    assertEquals(ApplicationSettings.DisplayScalingMode.INTEGER_FIT, properties.display.scalingMode)
+    assertEquals(3, properties.display.explicitScale)
+    assertEquals(3, properties.display.scale)
+    assertEquals(0x203040, properties.display.letterboxColor)
+    assertTrue(properties.display.fullscreen)
+  }
+
   @Test
   fun `frame blending is enabled for fresh profiles`() {
     val properties = testEmulatorProperties()

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -1,9 +1,8 @@
 # Desktop command line and settings contract
 
-This document defines the first Desktop 2.0 compatibility boundary. The portable JAR and the
-Swing application use the same command-line parser and the same typed settings model. Later
-preferences, ROM-opening, and packaging work must extend this contract rather than introduce a
-second parser or settings file.
+This document defines the Desktop 2.0 compatibility boundary. The portable JAR and the Swing
+application use the same command-line parser and the same typed settings model. ROM-opening and
+packaging work must extend this contract rather than introduce a second parser or settings file.
 
 ## Command line
 
@@ -45,16 +44,19 @@ The application owns one immutable `ApplicationSettings` value with typed `gener
 `audio`, `input`, `saves`, and `advanced` sections. The controller-facing `EmulatorProperties`
 class is a compatibility facade over that model while older menu code is migrated.
 
-Schema 3 continues to use `${user.home}/.coffeegb.properties`; schemas 0–2 are migrated in place
+Schema 4 continues to use `${user.home}/.coffeegb.properties`; schemas 0–3 are migrated in place
 so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `3` |
+| `settings.schemaVersion` | exact supported schema version | `4` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
-| `display.scale` | supported integer scale | `2` |
+| `display.scalingMode` | `INTEGER_FIT`, `ASPECT_FIT`, or `EXPLICIT` | `EXPLICIT` |
+| `display.scale` | explicit integer scale in `1..4` | `2` |
+| `display.letterboxColor` | six uppercase RGB hexadecimal digits | `000000` |
+| `display.fullscreen` | boolean | `false` |
 | `display.rotation` | `0`, `90`, `180`, or `270` degrees | `0` |
 | `display.grayscale` | boolean | `false` |
 | `display.blending` | boolean | `true` |
@@ -89,14 +91,14 @@ does not partially update the active settings.
 application may close without a redundant prompt. `ALWAYS` also confirms an idle application
 close, and `NEVER` suppresses this ordinary confirmation. A battery/autosave flush failure remains
 actionable regardless of this preference. Setting recent-file capacity to zero disables history;
-reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 3
+reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 4
 does not invent or persist an update-check preference.
 
-Unrecognized legacy keys are retained losslessly when schema 3 is saved. Keys in a reserved grammar,
+Unrecognized legacy keys are retained losslessly when schema 4 is saved. Keys in a reserved grammar,
 such as an unknown `input.*` key, remain errors so a misspelled control binding is not silently
-ignored. Schema 3 stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
+ignored. Schema 4 stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
 key beyond Coffee GB's old ten-entry history remains untouched even if capacity later grows. Schema
-3 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
+4 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
 binding is therefore unbound rather than silently restored to a default. If an older unknown key
 occupies a name reserved by a later schema, Coffee GB keeps its original key/value in bounded
 internal migration metadata rather than overwriting or reinterpreting it. At most 32 per-device
@@ -105,10 +107,12 @@ gamepad tuning profiles are retained.
 ## Preferences
 
 Open **File → Preferences…** (or <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>,</kbd>) to change the
-default ROM directory, recent-file capacity, ROM-change confirmation policy, and keyboard controls
-without editing the properties file. The Input tab shows all eight current bindings for Players
-1–4. Choose **Capture** and press a key, or use the explicit **Dialog key…** action for Enter or
-Escape. Tab remains reserved for focus navigation and Backspace remains reserved for Rewind.
+default ROM directory, recent-file capacity, ROM-change confirmation policy, display behavior, and
+keyboard controls without editing the properties file. The Display tab exposes scaling,
+letterboxing, fullscreen, rotation, DMG grayscale, frame blending, CGB color correction, and the
+Super Game Boy border. The Input tab shows all eight current bindings for Players 1–4. Choose
+**Capture** and press a key, or use the explicit **Dialog key…** action for Enter or Escape. Tab
+remains reserved for focus navigation and Backspace remains reserved for Rewind.
 Conflicting bindings identify the existing assignment and are not applied; each row also supports
 Clear and Reset. The Gamepads tab lists up to four logical assignments without calling SDL on the
 EDT. It keeps an unavailable configured controller visible, prevents duplicate explicit or
@@ -125,16 +129,61 @@ configured output after it reappears. Device, volume, mute, and latency changes 
 audio clock or DC-filter phase.
 
 **Apply** validates the complete draft, writes one settings update, and switches the live keyboard
-mapping only after persistence accepts it. **Cancel**, the window close button, and Escape discard
-unapplied edits. **Restore Defaults** only changes the visible draft until Apply is chosen.
+mapping and display only after persistence accepts it. **Cancel**, the window close button, and
+Escape discard unapplied edits. **Restore Defaults** only changes the visible draft until Apply is
+chosen.
+
+## Display scaling and fullscreen
+
+The game image and the Swing component have independent sizes. Coffee GB copies each completed
+emulated frame into an immutable private raster before publishing it to the EDT, so repainting
+cannot retain or mutate an emulator-owned pixel buffer. DMG/CGB frames use their native 160×144
+geometry; an enabled SGB border uses its native 256×224 geometry. Rotation is included before
+viewport fitting, and both axes always use the same scale.
+
+- **Integer fit** chooses the largest whole-number scale that fits. During a transient layout
+  smaller than one native frame it temporarily uses uniform aspect fit so the image is not clipped.
+- **Fit preserving aspect ratio** uses the largest uniform fractional scale that fits.
+- **Explicit 1×–4×** keeps that exact pixel scale and recenters the image. Choosing an explicit
+  scale or changing native DMG/SGB geometry repacks the window while it is windowed, and the
+  window minimum tracks the complete rotated source size. If a physical screen or native window
+  manager cannot honor that minimum, the renderer uniformly fits as a safe no-crop fallback.
+
+Unused space is letterboxed or pillarboxed with the configured RGB color. The viewport uses
+half-open geometry and conservative paint bounds, so odd device-pixel margins put the extra pixel
+on the right or bottom without stretching or cropping the final source pixel.
+
+The main window is resizable and has a base 160×144 minimum content area; windowed explicit modes
+raise that minimum as described above. **Screen → Fullscreen** enters borderless fullscreen;
+<kbd>F11</kbd> is its accelerator unless F11 is assigned to an emulated button, in which case the
+accelerator is automatically disabled and the menu command remains available. Menu radio items,
+Preferences, persisted settings, and the live renderer are synchronized through one EDT-owned
+coordinator.
+
+Entering fullscreen remembers window placement relative to the monitor's stable AWT device ID and
+current scale transform. Exiting converts through the latest per-monitor transform and clamps the
+window to the current usable work area. If that monitor disappears, Coffee GB selects the nearest
+remaining monitor deterministically. The windowed explicit-size minimum is lowered before entry so
+it cannot constrain the monitor bounds, then recomputed after exit; the restored bounds are
+preserved unless they are too small for a display-size change made while fullscreen. While
+fullscreen, move/resize notifications plus a fullscreen-only one-second monitor refresh recover
+from monitor removal, work-area changes, and per-monitor DPI changes without retaining stale
+`GraphicsDevice` instances.
+
+Swing does not expose a reliable cross-platform swap-interval or vertical-sync capability.
+Coffee GB therefore keeps its existing event-driven repaint pacing and nearest-neighbor rendering;
+it does not present a nonfunctional vsync option. A future backend may expose optional pacing only
+after it can report and test that capability, with this repaint path remaining the fallback.
 
 ## Migration and recovery
 
-A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 2 migration is a
-pure conversion into schema 3, preserves unknown keys, retains absent profile mappings as Auto, and
-canonicalizes the finite historical uppercase profile aliases. Repeating load/migrate/save produces
-the same normalized settings. Legacy text is decoded with the platform-default charset used by the
-former `FileReader`; versioned files use strict UTF-8 with deterministic ASCII escapes.
+A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 3 migration is a
+pure conversion into schema 4, preserves unknown keys, retains absent profile mappings as Auto, and
+canonicalizes the finite historical uppercase profile aliases. Existing display scales migrate to
+explicit scale with a black letterbox and windowed startup; no previous launch is unexpectedly
+forced fullscreen. Repeating load/migrate/save produces the same normalized settings. Legacy text
+is decoded with the platform-default charset used by the former `FileReader`; versioned files use
+strict UTF-8 with deterministic ASCII escapes.
 
 The complete file is bounded, parsed, migrated, and validated before it can replace the in-memory
 defaults. If syntax or a recognized value is corrupt, Coffee GB moves the original bytes to a

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDisplayController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDisplayController.kt
@@ -1,0 +1,144 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.core.events.Event
+import eu.rekawek.coffeegb.core.events.EventBus
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay
+import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetBlendingEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetColorCorrectionEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetGrayscaleEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetLetterboxColorEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetRotationEvent
+import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetScaleModeEvent
+import java.awt.Color
+import javax.swing.SwingUtilities
+
+/**
+ * Single EDT owner for persisted display choices and their live Swing/fullscreen application.
+ *
+ * Menu actions and Preferences both enter through this class. [DisplaySettingsChangedEvent] then
+ * updates every passive view without action-listener feedback loops.
+ */
+internal class DesktopDisplayController(
+    private val settings: DisplaySettingsAccess,
+    private val eventBus: EventBus,
+    private val fullscreenRuntime: FullscreenRuntime,
+    private val windowSizingRuntime: DisplayWindowSizingRuntime = DisplayWindowSizingRuntime.NOOP,
+) {
+  constructor(
+      properties: EmulatorProperties,
+      eventBus: EventBus,
+      fullscreenRuntime: FullscreenRuntime,
+      windowSizingRuntime: DisplayWindowSizingRuntime = DisplayWindowSizingRuntime.NOOP,
+  ) : this(
+      EmulatorDisplaySettingsAccess(properties),
+      eventBus,
+      fullscreenRuntime,
+      windowSizingRuntime,
+  )
+
+  fun current(): ApplicationSettings.Display = settings.current()
+
+  fun applyCurrent() = apply(current(), persist = false)
+
+  fun update(transform: (ApplicationSettings.Display) -> ApplicationSettings.Display) {
+    requireEdt()
+    apply(transform(current()), persist = true)
+  }
+
+  fun apply(
+      display: ApplicationSettings.Display,
+      persist: Boolean,
+  ) {
+    requireEdt()
+    if (persist) {
+      settings.replace(display)
+    }
+
+    val enteringFullscreen = display.fullscreen && !fullscreenRuntime.isFullscreen()
+    val exitingFullscreen = !display.fullscreen && fullscreenRuntime.isFullscreen()
+
+    // A large windowed explicit/SGB minimum must not constrain borderless fullscreen bounds.
+    // Conversely, restore the current dynamic minimum after exit even when scale/rotation did not
+    // change and SwingDisplay therefore correctly suppressed its ordinary size event.
+    if (enteringFullscreen) {
+      windowSizingRuntime.refresh(windowed = false)
+    }
+    if (exitingFullscreen) {
+      fullscreenRuntime.setFullscreen(false)
+    }
+    eventBus.post(SetScaleModeEvent(display.toRuntimeScaleMode()))
+    eventBus.post(SetRotationEvent(display.rotation.degrees))
+    eventBus.post(SetGrayscaleEvent(display.grayscale))
+    eventBus.post(SetBlendingEvent(display.blending))
+    eventBus.post(SetColorCorrectionEvent(display.colorCorrection))
+    eventBus.post(SetLetterboxColorEvent(Color(display.letterboxColor)))
+    eventBus.post(SgbDisplay.SetSgbBorder(display.showSgbBorder))
+    if (enteringFullscreen) {
+      fullscreenRuntime.setFullscreen(true)
+    }
+    if (exitingFullscreen) {
+      windowSizingRuntime.refresh(windowed = true)
+    }
+    eventBus.post(DisplaySettingsChangedEvent(display))
+  }
+
+  fun setFullscreen(fullscreen: Boolean) {
+    requireEdt()
+    if (fullscreen == current().fullscreen && fullscreen == fullscreenRuntime.isFullscreen()) {
+      return
+    }
+    update { it.copy(fullscreen = fullscreen) }
+  }
+
+  fun isFullscreen(): Boolean = fullscreenRuntime.isFullscreen()
+
+  fun close() {
+    requireEdt()
+    fullscreenRuntime.close()
+  }
+
+  private fun requireEdt() {
+    check(SwingUtilities.isEventDispatchThread()) {
+      "Display settings must be applied on the Event Dispatch Thread"
+    }
+  }
+}
+
+internal interface DisplaySettingsAccess {
+  fun current(): ApplicationSettings.Display
+
+  fun replace(display: ApplicationSettings.Display)
+}
+
+internal fun interface DisplayWindowSizingRuntime {
+  fun refresh(windowed: Boolean)
+
+  companion object {
+    val NOOP = DisplayWindowSizingRuntime {}
+  }
+}
+
+private class EmulatorDisplaySettingsAccess(
+    private val properties: EmulatorProperties,
+) : DisplaySettingsAccess {
+  override fun current(): ApplicationSettings.Display = properties.applicationSettings.display
+
+  override fun replace(display: ApplicationSettings.Display) {
+    properties.updateApplicationSettings { settings -> settings.copy(display = display) }
+  }
+}
+
+internal data class DisplaySettingsChangedEvent(
+    val display: ApplicationSettings.Display,
+) : Event
+
+internal fun ApplicationSettings.Display.toRuntimeScaleMode(): DisplayScaleMode =
+    when (scalingMode) {
+      ApplicationSettings.DisplayScalingMode.INTEGER_FIT -> DisplayScaleMode.INTEGER_FIT
+      ApplicationSettings.DisplayScalingMode.ASPECT_FIT -> DisplayScaleMode.ASPECT_FIT
+      ApplicationSettings.DisplayScalingMode.EXPLICIT ->
+          DisplayScaleMode.explicit(explicitScale)
+    }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopFullscreenRuntime.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopFullscreenRuntime.kt
@@ -1,0 +1,189 @@
+package eu.rekawek.coffeegb.swing
+
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+import java.awt.Insets
+import java.awt.Toolkit
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+/** Small runtime surface used by the display-settings coordinator and its headless tests. */
+internal interface FullscreenRuntime {
+  fun isFullscreen(): Boolean
+
+  fun setFullscreen(fullscreen: Boolean)
+
+  fun refreshScreens()
+
+  fun close()
+}
+
+/**
+ * Production AWT adapter for [FullscreenController].
+ *
+ * Monitor snapshots are rebuilt for every transition/refresh, so stale
+ * [java.awt.GraphicsDevice] instances and per-monitor transforms are never retained. The refresh
+ * timer runs only while fullscreen and covers monitor removal even when AWT emits no frame move.
+ */
+internal class DesktopFullscreenRuntime(
+    private val frame: JFrame,
+    minimumContentSize: DesktopSize,
+) : FullscreenRuntime {
+  private var transitioning = false
+  private val controller =
+      FullscreenController(
+          JFrameFullscreenWindow(frame),
+          AwtScreenLayoutProvider(frame),
+          minimumContentSize,
+      )
+  private val refreshTimer =
+      Timer(SCREEN_REFRESH_MILLIS) { controller.refreshScreens() }.apply {
+        isRepeats = true
+        isCoalesce = true
+      }
+  private val componentListener =
+      object : ComponentAdapter() {
+        override fun componentMoved(event: ComponentEvent) = refreshScreens()
+
+        override fun componentResized(event: ComponentEvent) = refreshScreens()
+
+        override fun componentShown(event: ComponentEvent) = refreshScreens()
+      }
+
+  init {
+    requireEdt()
+    frame.addComponentListener(componentListener)
+  }
+
+  override fun isFullscreen(): Boolean = controller.isFullscreen()
+
+  override fun setFullscreen(fullscreen: Boolean) {
+    requireEdt()
+    if (fullscreen == controller.isFullscreen()) return
+    transitioning = true
+    try {
+      if (fullscreen) {
+        controller.enterFullscreen()
+        refreshTimer.start()
+      } else {
+        refreshTimer.stop()
+        controller.exitFullscreen()
+      }
+    } finally {
+      transitioning = false
+    }
+  }
+
+  override fun refreshScreens() {
+    requireEdt()
+    if (transitioning) return
+    controller.refreshScreens()
+  }
+
+  override fun close() {
+    requireEdt()
+    refreshTimer.stop()
+    frame.removeComponentListener(componentListener)
+  }
+
+  private fun requireEdt() {
+    check(SwingUtilities.isEventDispatchThread()) {
+      "Fullscreen runtime must be accessed on the Event Dispatch Thread"
+    }
+  }
+
+  private companion object {
+    const val SCREEN_REFRESH_MILLIS = 1_000
+  }
+}
+
+private class JFrameFullscreenWindow(
+    private val frame: JFrame,
+) : FullscreenWindow {
+  override fun snapshot(): FullscreenWindowSnapshot {
+    val bounds = frame.bounds
+    return FullscreenWindowSnapshot(
+        DesktopBounds(
+            bounds.x,
+            bounds.y,
+            bounds.width.coerceAtLeast(1),
+            bounds.height.coerceAtLeast(1),
+        ),
+        frame.graphicsConfiguration?.device?.iDstring,
+        frame.isUndecorated,
+    )
+  }
+
+  override fun dispose() = frame.dispose()
+
+  override fun setUndecorated(undecorated: Boolean) {
+    frame.isUndecorated = undecorated
+  }
+
+  override fun setBounds(bounds: DesktopBounds) {
+    frame.setBounds(bounds.x, bounds.y, bounds.width, bounds.height)
+  }
+
+  override fun showWindow() {
+    frame.isVisible = true
+  }
+}
+
+private class AwtScreenLayoutProvider(
+    private val frame: JFrame,
+) : ScreenLayoutProvider {
+  override fun snapshot(): ScreenLayout {
+    val environment = GraphicsEnvironment.getLocalGraphicsEnvironment()
+    val defaultDevice = environment.defaultScreenDevice
+    val screens =
+        environment.screenDevices.map { device ->
+          val configuration = device.defaultConfiguration
+          ScreenSnapshot(
+              screenId = device.iDstring,
+              fullBounds = configuration.bounds.toDesktopBounds(),
+              usableBounds = configuration.usableBounds(),
+              scaleX = configuration.defaultTransform.scaleX,
+              scaleY = configuration.defaultTransform.scaleY,
+          )
+        }
+    val currentId = frame.graphicsConfiguration?.device?.iDstring
+    return ScreenLayout(
+        screens,
+        primaryScreenId =
+            defaultDevice.iDstring.takeIf { primary ->
+              screens.any { it.screenId == primary }
+            } ?: currentId,
+    )
+  }
+}
+
+private fun GraphicsConfiguration.usableBounds(): DesktopBounds {
+  val full = bounds
+  val insets =
+      try {
+        Toolkit.getDefaultToolkit().getScreenInsets(this)
+      } catch (_: RuntimeException) {
+        Insets(0, 0, 0, 0)
+      }
+  val x = full.x.toLong() + insets.left
+  val y = full.y.toLong() + insets.top
+  val width = full.width.toLong() - insets.left - insets.right
+  val height = full.height.toLong() - insets.top - insets.bottom
+  if (
+      width <= 0 ||
+          height <= 0 ||
+          x < Int.MIN_VALUE ||
+          x > Int.MAX_VALUE ||
+          y < Int.MIN_VALUE ||
+          y > Int.MAX_VALUE
+  ) {
+    return full.toDesktopBounds()
+  }
+  return DesktopBounds(x.toInt(), y.toInt(), width.toInt(), height.toInt())
+}
+
+private fun java.awt.Rectangle.toDesktopBounds(): DesktopBounds =
+    DesktopBounds(x, y, width, height)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditor.kt
@@ -1,0 +1,315 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.awt.event.KeyEvent
+import java.util.Locale
+import javax.swing.BorderFactory
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JTextField
+import javax.swing.SwingUtilities
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+
+/** Draft-only display editor. It performs no persistence, device discovery, or runtime mutation. */
+internal class DisplayPreferencesEditor private constructor(
+    initial: ApplicationSettings.Display,
+    private val defaults: ApplicationSettings.Display,
+    @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
+) : JPanel(GridBagLayout()) {
+  constructor(
+      initial: ApplicationSettings.Display,
+      defaults: ApplicationSettings.Display = ApplicationSettings.Display(),
+  ) : this(initial, defaults, requireEdt())
+
+  internal data class ScalingModeOption(
+      val mode: ApplicationSettings.DisplayScalingMode,
+      val label: String,
+  ) {
+    override fun toString(): String = label
+  }
+
+  internal data class ScaleOption(
+      val scale: Int,
+  ) {
+    override fun toString(): String = "${scale}×"
+  }
+
+  internal data class RotationOption(
+      val rotation: ApplicationSettings.Rotation,
+  ) {
+    override fun toString(): String = "${rotation.degrees}°"
+  }
+
+  internal val scalingMode =
+      JComboBox(SCALING_MODES.toTypedArray()).apply {
+        selectedItem = SCALING_MODES.first { it.mode == initial.scalingMode }
+        accessibleContext.accessibleName = "Display scaling mode"
+        accessibleContext.accessibleDescription =
+            "Choose integer fit, aspect fit, or a fixed explicit scale."
+      }
+  internal val explicitScale =
+      JComboBox(SCALES.toTypedArray()).apply {
+        selectedItem = SCALES.first { it.scale == initial.explicitScale }
+        accessibleContext.accessibleName = "Explicit display scale"
+        accessibleContext.accessibleDescription =
+            "Choose a fixed display scale from one times through four times."
+      }
+  internal val letterboxColor =
+      JTextField(formatColor(initial.letterboxColor), 8).apply {
+        accessibleContext.accessibleName = "Letterbox color"
+        accessibleContext.accessibleDescription =
+            "Enter a six-digit RGB color in #RRGGBB form."
+      }
+  internal val letterboxPreview =
+      JPanel().apply {
+        background = Color(initial.letterboxColor)
+        isOpaque = true
+        preferredSize = Dimension(48, letterboxColor.preferredSize.height)
+        minimumSize = Dimension(32, letterboxColor.minimumSize.height)
+        border = BorderFactory.createLineBorder(Color.GRAY)
+        accessibleContext.accessibleName = "Letterbox color preview"
+        accessibleContext.accessibleDescription = formatColor(initial.letterboxColor)
+      }
+  internal val letterboxColorError =
+      JLabel(" ").apply {
+        foreground = ERROR_COLOR
+        accessibleContext.accessibleName = "Letterbox color error"
+      }
+  internal val fullscreen =
+      JCheckBox("Fullscreen", initial.fullscreen).apply {
+        mnemonic = KeyEvent.VK_F
+        accessibleContext.accessibleName = "Fullscreen"
+      }
+  internal val rotation =
+      JComboBox(ROTATIONS.toTypedArray()).apply {
+        selectedItem = ROTATIONS.first { it.rotation == initial.rotation }
+        accessibleContext.accessibleName = "Display rotation"
+      }
+  internal val grayscale =
+      JCheckBox("Use grayscale palette", initial.grayscale).apply {
+        mnemonic = KeyEvent.VK_G
+        accessibleContext.accessibleName = "Use grayscale palette"
+      }
+  internal val blending =
+      JCheckBox("Blend adjacent frames", initial.blending).apply {
+        mnemonic = KeyEvent.VK_B
+        accessibleContext.accessibleName = "Blend adjacent frames"
+      }
+  internal val colorCorrection =
+      JCheckBox("Apply CGB color correction", initial.colorCorrection).apply {
+        mnemonic = KeyEvent.VK_C
+        accessibleContext.accessibleName = "Apply CGB color correction"
+      }
+  internal val showSgbBorder =
+      JCheckBox("Show Super Game Boy border", initial.showSgbBorder).apply {
+        mnemonic = KeyEvent.VK_O
+        accessibleContext.accessibleName = "Show Super Game Boy border"
+      }
+
+  init {
+    getAccessibleContext().accessibleName = "Display preferences"
+    getAccessibleContext().accessibleDescription =
+        "Configure scaling, letterboxing, fullscreen, rotation, and display filters."
+    border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+    createRows()
+
+    scalingMode.addActionListener {
+      requireEdt()
+      updateExplicitScaleEnabled()
+    }
+    letterboxColor.document.addDocumentListener(
+        object : DocumentListener {
+          override fun insertUpdate(event: DocumentEvent) = updateColorPreview()
+
+          override fun removeUpdate(event: DocumentEvent) = updateColorPreview()
+
+          override fun changedUpdate(event: DocumentEvent) = updateColorPreview()
+        })
+    updateExplicitScaleEnabled()
+  }
+
+  internal fun validatedDisplay(): ApplicationSettings.Display {
+    requireEdt()
+    val parsedColor =
+        parseColor(letterboxColor.text)
+            ?: run {
+              letterboxColorError.text = COLOR_ERROR
+              throw PreferenceEditorValidationException(COLOR_ERROR, letterboxColor)
+            }
+    letterboxColorError.text = " "
+    return ApplicationSettings.Display(
+        scalingMode = (scalingMode.selectedItem as ScalingModeOption).mode,
+        explicitScale = (explicitScale.selectedItem as ScaleOption).scale,
+        letterboxColor = parsedColor,
+        fullscreen = fullscreen.isSelected,
+        grayscale = grayscale.isSelected,
+        blending = blending.isSelected,
+        colorCorrection = colorCorrection.isSelected,
+        rotation = (rotation.selectedItem as RotationOption).rotation,
+        showSgbBorder = showSgbBorder.isSelected,
+    )
+  }
+
+  internal fun restoreDefaults() {
+    requireEdt()
+    scalingMode.selectedItem = SCALING_MODES.first { it.mode == defaults.scalingMode }
+    explicitScale.selectedItem = SCALES.first { it.scale == defaults.explicitScale }
+    letterboxColor.text = formatColor(defaults.letterboxColor)
+    fullscreen.isSelected = defaults.fullscreen
+    rotation.selectedItem = ROTATIONS.first { it.rotation == defaults.rotation }
+    grayscale.isSelected = defaults.grayscale
+    blending.isSelected = defaults.blending
+    colorCorrection.isSelected = defaults.colorCorrection
+    showSgbBorder.isSelected = defaults.showSgbBorder
+    letterboxColorError.text = " "
+    updateExplicitScaleEnabled()
+    updateColorPreview()
+  }
+
+  private fun createRows() {
+    val constraints =
+        GridBagConstraints().apply {
+          anchor = GridBagConstraints.LINE_START
+          fill = GridBagConstraints.HORIZONTAL
+          insets = Insets(4, 4, 4, 4)
+        }
+
+    val scalingLabel = JLabel("Scaling mode:")
+    scalingLabel.displayedMnemonic = KeyEvent.VK_S
+    scalingLabel.labelFor = scalingMode
+    addRow(constraints, 0, scalingLabel, scalingMode)
+
+    val explicitScaleLabel = JLabel("Explicit scale:")
+    explicitScaleLabel.displayedMnemonic = KeyEvent.VK_X
+    explicitScaleLabel.labelFor = explicitScale
+    addRow(constraints, 1, explicitScaleLabel, explicitScale)
+
+    val letterboxLabel = JLabel("Letterbox color:")
+    letterboxLabel.displayedMnemonic = KeyEvent.VK_L
+    letterboxLabel.labelFor = letterboxColor
+    val colorRow = JPanel(BorderLayout(8, 0))
+    colorRow.add(letterboxColor, BorderLayout.CENTER)
+    colorRow.add(letterboxPreview, BorderLayout.LINE_END)
+    addRow(constraints, 2, letterboxLabel, colorRow)
+
+    constraints.gridx = 1
+    constraints.gridy = 3
+    constraints.weightx = 1.0
+    add(letterboxColorError, constraints)
+
+    constraints.gridx = 1
+    constraints.gridy = 4
+    add(fullscreen, constraints)
+
+    val rotationLabel = JLabel("Rotation:")
+    rotationLabel.displayedMnemonic = KeyEvent.VK_R
+    rotationLabel.labelFor = rotation
+    addRow(constraints, 5, rotationLabel, rotation)
+
+    constraints.gridx = 1
+    constraints.gridy = 6
+    add(grayscale, constraints)
+    constraints.gridy = 7
+    add(blending, constraints)
+    constraints.gridy = 8
+    add(colorCorrection, constraints)
+    constraints.gridy = 9
+    add(showSgbBorder, constraints)
+
+    constraints.gridx = 0
+    constraints.gridy = 10
+    constraints.gridwidth = 2
+    constraints.weightx = 1.0
+    constraints.weighty = 1.0
+    constraints.fill = GridBagConstraints.BOTH
+    add(JPanel(), constraints)
+  }
+
+  private fun addRow(
+      constraints: GridBagConstraints,
+      row: Int,
+      label: JLabel,
+      field: Component,
+  ) {
+    constraints.gridx = 0
+    constraints.gridy = row
+    constraints.gridwidth = 1
+    constraints.weightx = 0.0
+    constraints.weighty = 0.0
+    constraints.fill = GridBagConstraints.NONE
+    add(label, constraints)
+
+    constraints.gridx = 1
+    constraints.weightx = 1.0
+    constraints.fill = GridBagConstraints.HORIZONTAL
+    add(field, constraints)
+  }
+
+  private fun updateExplicitScaleEnabled() {
+    explicitScale.isEnabled =
+        (scalingMode.selectedItem as? ScalingModeOption)?.mode ==
+            ApplicationSettings.DisplayScalingMode.EXPLICIT
+  }
+
+  private fun updateColorPreview() {
+    requireEdt()
+    val parsed = parseColor(letterboxColor.text)
+    if (parsed == null) {
+      return
+    }
+    letterboxColorError.text = " "
+    letterboxPreview.background = Color(parsed)
+    letterboxPreview.accessibleContext.accessibleDescription = formatColor(parsed)
+  }
+
+  private companion object {
+    const val COLOR_ERROR = "Enter a color in #RRGGBB form."
+    val ERROR_COLOR = Color(0xB0, 0x00, 0x20)
+    val SCALING_MODES =
+        listOf(
+            ScalingModeOption(
+                ApplicationSettings.DisplayScalingMode.INTEGER_FIT,
+                "Integer fit",
+            ),
+            ScalingModeOption(
+                ApplicationSettings.DisplayScalingMode.ASPECT_FIT,
+                "Fit preserving aspect ratio",
+            ),
+            ScalingModeOption(
+                ApplicationSettings.DisplayScalingMode.EXPLICIT,
+                "Explicit scale",
+            ),
+        )
+    val SCALES =
+        (ApplicationSettings.MIN_EXPLICIT_DISPLAY_SCALE..
+                ApplicationSettings.MAX_EXPLICIT_DISPLAY_SCALE)
+            .map(::ScaleOption)
+    val ROTATIONS = ApplicationSettings.Rotation.entries.map(::RotationOption)
+
+    fun formatColor(rgb: Int): String = "#%06X".format(Locale.ROOT, rgb)
+
+    fun parseColor(value: String): Int? {
+      val trimmed = value.trim()
+      if (!trimmed.matches(Regex("#[0-9A-Fa-f]{6}"))) {
+        return null
+      }
+      return trimmed.substring(1).toInt(16)
+    }
+
+    fun requireEdt() {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "Display preferences must be constructed and accessed on the EDT"
+      }
+    }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/FullscreenController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/FullscreenController.kt
@@ -1,0 +1,359 @@
+package eu.rekawek.coffeegb.swing
+
+import javax.swing.SwingUtilities
+import kotlin.math.min
+
+/** Positive logical size in the coordinate space used by a host window. */
+internal data class DesktopSize(val width: Int, val height: Int) {
+  init {
+    require(width > 0 && height > 0) { "Desktop size must be positive" }
+  }
+}
+
+/**
+ * Immutable half-open desktop rectangle. Negative coordinates are valid for monitors positioned
+ * left of or above the primary display.
+ */
+internal data class DesktopBounds(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+) {
+  init {
+    require(width > 0 && height > 0) { "Desktop bounds must be positive" }
+    require(rightExclusive <= Int.MAX_VALUE.toLong() + 1L) {
+      "Desktop bounds extend beyond the integer coordinate space"
+    }
+    require(bottomExclusive <= Int.MAX_VALUE.toLong() + 1L) {
+      "Desktop bounds extend beyond the integer coordinate space"
+    }
+  }
+
+  val rightExclusive: Long
+    get() = x.toLong() + width
+
+  val bottomExclusive: Long
+    get() = y.toLong() + height
+
+  fun contains(other: DesktopBounds): Boolean =
+      other.x >= x &&
+          other.y >= y &&
+          other.rightExclusive <= rightExclusive &&
+          other.bottomExclusive <= bottomExclusive
+
+  fun intersectionArea(other: DesktopBounds): Long {
+    val left = maxOf(x.toLong(), other.x.toLong())
+    val top = maxOf(y.toLong(), other.y.toLong())
+    val right = minOf(rightExclusive, other.rightExclusive)
+    val bottom = minOf(bottomExclusive, other.bottomExclusive)
+    if (right <= left || bottom <= top) return 0
+    return Math.multiplyExact(right - left, bottom - top)
+  }
+
+  /** Squared gap between two rectangles; zero means they overlap or touch. */
+  fun distanceSquared(other: DesktopBounds): Double {
+    val horizontal =
+        when {
+          rightExclusive < other.x.toLong() -> other.x.toDouble() - rightExclusive
+          other.rightExclusive < x.toLong() -> x.toDouble() - other.rightExclusive
+          else -> 0.0
+        }
+    val vertical =
+        when {
+          bottomExclusive < other.y.toLong() -> other.y.toDouble() - bottomExclusive
+          other.bottomExclusive < y.toLong() -> y.toDouble() - other.bottomExclusive
+          else -> 0.0
+        }
+    return horizontal * horizontal + vertical * vertical
+  }
+}
+
+/**
+ * One immutable GraphicsConfiguration-like snapshot supplied by a production adapter.
+ *
+ * [screenId] must be the stable GraphicsDevice identity, not an array index. Fullscreen uses
+ * [fullBounds] exactly; restored window placement is constrained to [usableBounds]. Scale values
+ * convert remembered device-pixel placement through the latest per-monitor transform.
+ */
+internal data class ScreenSnapshot(
+    val screenId: String,
+    val fullBounds: DesktopBounds,
+    val usableBounds: DesktopBounds,
+    val scaleX: Double,
+    val scaleY: Double,
+) {
+  init {
+    require(screenId.isNotBlank()) { "Screen ID must not be blank" }
+    require(fullBounds.contains(usableBounds)) {
+      "Usable screen bounds must be contained by full screen bounds"
+    }
+    require(scaleX.isFinite() && scaleX > 0.0) { "Screen X scale must be finite and positive" }
+    require(scaleY.isFinite() && scaleY > 0.0) { "Screen Y scale must be finite and positive" }
+  }
+}
+
+/**
+ * Defensive, point-in-time monitor layout. A stale/missing primary ID is tolerated and resolved
+ * deterministically by geometry and stable screen ID.
+ */
+internal class ScreenLayout(
+    screens: Collection<ScreenSnapshot>,
+    val primaryScreenId: String? = null,
+) {
+  val screens: List<ScreenSnapshot> = screens.toList()
+
+  init {
+    require(this.screens.isNotEmpty()) { "At least one screen is required" }
+    require(this.screens.map(ScreenSnapshot::screenId).toSet().size == this.screens.size) {
+      "Screen IDs must be unique"
+    }
+  }
+
+  fun screen(screenId: String?): ScreenSnapshot? =
+      screenId?.let { expected -> screens.firstOrNull { it.screenId == expected } }
+
+  fun primary(): ScreenSnapshot =
+      screen(primaryScreenId)
+          ?: screens.minWith(screenTieBreaker())
+
+  /**
+   * Uses an exact ID first, then largest overlap, then nearest geometry. Ties prefer the designated
+   * primary and finally stable coordinate/ID order, so identical monitor geometries remain
+   * deterministic.
+   */
+  fun resolve(screenId: String?, reference: DesktopBounds): ScreenSnapshot {
+    screen(screenId)?.let {
+      return it
+    }
+    val maximumIntersection = screens.maxOf { it.fullBounds.intersectionArea(reference) }
+    if (maximumIntersection > 0) {
+      return screens
+          .filter { it.fullBounds.intersectionArea(reference) == maximumIntersection }
+          .minWith(screenTieBreaker())
+    }
+    return nearest(reference)
+  }
+
+  fun nearest(reference: DesktopBounds): ScreenSnapshot =
+      screens.minWith(
+          compareBy<ScreenSnapshot>(
+              { it.fullBounds.distanceSquared(reference) },
+              { if (it.screenId == primaryScreenId) 0 else 1 },
+              { it.fullBounds.x },
+              { it.fullBounds.y },
+              { it.screenId },
+          ))
+
+  private fun screenTieBreaker(): Comparator<ScreenSnapshot> =
+      compareBy(
+          { if (it.screenId == primaryScreenId) 0 else 1 },
+          { it.fullBounds.x },
+          { it.fullBounds.y },
+          { it.screenId },
+      )
+}
+
+internal data class FullscreenWindowSnapshot(
+    val bounds: DesktopBounds,
+    val screenId: String?,
+    val undecorated: Boolean,
+)
+
+/** Headless seam for the small set of JFrame operations whose ordering is significant. */
+internal interface FullscreenWindow {
+  fun snapshot(): FullscreenWindowSnapshot
+
+  fun dispose()
+
+  fun setUndecorated(undecorated: Boolean)
+
+  fun setBounds(bounds: DesktopBounds)
+
+  fun showWindow()
+}
+
+internal fun interface ScreenLayoutProvider {
+  fun snapshot(): ScreenLayout
+}
+
+internal fun interface EdtOwnership {
+  fun isEventDispatchThread(): Boolean
+
+  companion object {
+    val SWING = EdtOwnership { SwingUtilities.isEventDispatchThread() }
+  }
+}
+
+/**
+ * EDT-owned, borderless-fullscreen state machine independent from AWT monitor enumeration.
+ *
+ * The remembered window placement is stored relative to its stable screen ID in device pixels.
+ * Restoring through the newest screen snapshot therefore survives a DPI transform change without
+ * reusing stale logical coordinates. Missing screens use nearest geometry with a primary/ID
+ * tie-break and every restored rectangle is clamped to current usable bounds.
+ */
+internal class FullscreenController(
+    private val window: FullscreenWindow,
+    private val screenProvider: ScreenLayoutProvider,
+    private val minimumWindowSize: DesktopSize,
+    private val edtOwnership: EdtOwnership = EdtOwnership.SWING,
+) {
+  private var fullscreen = false
+  private var rememberedPlacement: RememberedPlacement? = null
+  private var activeFullscreenScreenId: String? = null
+  private var activeFullscreenBounds: DesktopBounds? = null
+
+  fun isFullscreen(): Boolean = fullscreen
+
+  fun activeScreenId(): String? = activeFullscreenScreenId
+
+  fun enterFullscreen() {
+    requireEdt()
+    if (fullscreen) return
+
+    val layout = screenProvider.snapshot()
+    val before = window.snapshot()
+    val target = layout.resolve(before.screenId, before.bounds)
+    val remembered = remember(before, target)
+
+    window.dispose()
+    window.setUndecorated(true)
+    window.setBounds(target.fullBounds)
+    window.showWindow()
+
+    rememberedPlacement = remembered
+    activeFullscreenScreenId = target.screenId
+    activeFullscreenBounds = target.fullBounds
+    fullscreen = true
+  }
+
+  fun exitFullscreen() {
+    requireEdt()
+    if (!fullscreen) return
+
+    val layout = screenProvider.snapshot()
+    val remembered = checkNotNull(rememberedPlacement)
+    val target =
+        layout.screen(remembered.screenId)
+            ?: layout.nearest(remembered.sourceFullBounds)
+    val restored = restoreAndClamp(remembered, target)
+
+    window.dispose()
+    window.setUndecorated(remembered.undecorated)
+    window.setBounds(restored)
+    window.showWindow()
+
+    fullscreen = false
+    rememberedPlacement = null
+    activeFullscreenScreenId = null
+    activeFullscreenBounds = null
+  }
+
+  fun toggleFullscreen() {
+    requireEdt()
+    if (fullscreen) exitFullscreen() else enterFullscreen()
+  }
+
+  /**
+   * Applies a current GraphicsConfiguration snapshot while fullscreen. This covers monitor removal,
+   * work-area changes, and per-monitor DPI transitions without repeating dispose/decorate calls.
+   */
+  fun refreshScreens() {
+    requireEdt()
+    if (!fullscreen) return
+
+    val layout = screenProvider.snapshot()
+    val reference =
+        activeFullscreenBounds
+            ?: checkNotNull(rememberedPlacement).sourceFullBounds
+    val target =
+        layout.screen(activeFullscreenScreenId)
+            ?: layout.nearest(reference)
+    if (target.fullBounds != activeFullscreenBounds) {
+      window.setBounds(target.fullBounds)
+    }
+    activeFullscreenScreenId = target.screenId
+    activeFullscreenBounds = target.fullBounds
+  }
+
+  private fun remember(
+      snapshot: FullscreenWindowSnapshot,
+      screen: ScreenSnapshot,
+  ): RememberedPlacement {
+    val relativeX = snapshot.bounds.x.toLong() - screen.usableBounds.x
+    val relativeY = snapshot.bounds.y.toLong() - screen.usableBounds.y
+    return RememberedPlacement(
+        screenId = screen.screenId,
+        sourceFullBounds = screen.fullBounds,
+        undecorated = snapshot.undecorated,
+        deviceX = relativeX * screen.scaleX,
+        deviceY = relativeY * screen.scaleY,
+        deviceWidth = snapshot.bounds.width * screen.scaleX,
+        deviceHeight = snapshot.bounds.height * screen.scaleY,
+    )
+  }
+
+  private fun restoreAndClamp(
+      placement: RememberedPlacement,
+      target: ScreenSnapshot,
+  ): DesktopBounds {
+    val rawX = target.usableBounds.x + placement.deviceX / target.scaleX
+    val rawY = target.usableBounds.y + placement.deviceY / target.scaleY
+    val rawWidth = placement.deviceWidth / target.scaleX
+    val rawHeight = placement.deviceHeight / target.scaleY
+    return clampToUsable(rawX, rawY, rawWidth, rawHeight, target.usableBounds)
+  }
+
+  private fun clampToUsable(
+      rawX: Double,
+      rawY: Double,
+      rawWidth: Double,
+      rawHeight: Double,
+      usable: DesktopBounds,
+  ): DesktopBounds {
+    val minimumWidth = min(minimumWindowSize.width, usable.width)
+    val minimumHeight = min(minimumWindowSize.height, usable.height)
+    val width = safeRound(rawWidth).coerceIn(minimumWidth, usable.width)
+    val height = safeRound(rawHeight).coerceIn(minimumHeight, usable.height)
+
+    val maximumX = usable.rightExclusive - width
+    val maximumY = usable.bottomExclusive - height
+    val x =
+        safeRoundToLong(rawX)
+            .coerceIn(usable.x.toLong(), maximumX)
+            .toInt()
+    val y =
+        safeRoundToLong(rawY)
+            .coerceIn(usable.y.toLong(), maximumY)
+            .toInt()
+    return DesktopBounds(x, y, width, height)
+  }
+
+  private fun safeRound(value: Double): Int =
+      safeRoundToLong(value).coerceIn(1L, Int.MAX_VALUE.toLong()).toInt()
+
+  private fun safeRoundToLong(value: Double): Long =
+      when {
+        value.isNaN() -> 0L
+        value >= Long.MAX_VALUE.toDouble() -> Long.MAX_VALUE
+        value <= Long.MIN_VALUE.toDouble() -> Long.MIN_VALUE
+        else -> Math.round(value)
+      }
+
+  private fun requireEdt() {
+    check(edtOwnership.isEventDispatchThread()) {
+      "Fullscreen transitions must run on the Event Dispatch Thread"
+    }
+  }
+
+  private data class RememberedPlacement(
+      val screenId: String,
+      val sourceFullBounds: DesktopBounds,
+      val undecorated: Boolean,
+      val deviceX: Double,
+      val deviceY: Double,
+      val deviceWidth: Double,
+      val deviceHeight: Double,
+  )
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
@@ -52,6 +52,7 @@ internal data class PreferencesEdit(
     val romDirectory: Path?,
     val recentFileCapacity: Int,
     val confirmationPolicy: RomChangeConfirmationPolicy,
+    val display: ApplicationSettings.Display,
     val keyboard:
         Map<
             ControllerProperties.PlayerButton,
@@ -78,6 +79,7 @@ internal data class PreferencesEdit(
                   recentFileCapacity = recentFileCapacity,
                   romChangeConfirmationPolicy = confirmationPolicy,
               ),
+          display = display,
           audio = audio,
           input =
               current.input.copy(
@@ -137,6 +139,8 @@ internal class PreferencesPanel private constructor(
               it.policy == initial.general.romChangeConfirmationPolicy
             }
       }
+  internal val displayEditor =
+      DisplayPreferencesEditor(initial.display, defaults.display)
   internal val keyboardEditor = KeyboardMappingEditor(initial.input, defaults.input)
   internal val gamepadEditor =
       GamepadPreferencesEditor(initial.input, defaults.input, gamepadSnapshots)
@@ -151,6 +155,7 @@ internal class PreferencesPanel private constructor(
 
     tabs.accessibleContext.accessibleName = "Preference categories"
     tabs.addTab("General", createGeneralPanel())
+    tabs.addTab("Display", JScrollPane(displayEditor).apply { border = null })
     tabs.addTab("Input", JScrollPane(keyboardEditor).apply { border = null })
     tabs.addTab("Gamepads", JScrollPane(gamepadEditor).apply { border = null })
     tabs.addTab("Audio", JScrollPane(audioEditor).apply { border = null })
@@ -174,6 +179,7 @@ internal class PreferencesPanel private constructor(
         CONFIRMATION_OPTIONS.first {
           it.policy == defaults.general.romChangeConfirmationPolicy
         }
+    displayEditor.restoreDefaults()
     keyboardEditor.resetToDefaults()
     gamepadEditor.restoreDefaults()
     audioEditor.restoreDefaults()
@@ -185,6 +191,17 @@ internal class PreferencesPanel private constructor(
     clearErrors()
     val directory = validateDirectory()
     val capacity = validateRecentCapacity()
+    val display =
+        try {
+          displayEditor.validatedDisplay()
+        } catch (failure: PreferenceEditorValidationException) {
+          validationSummary.text = failure.message ?: "Resolve the display settings error."
+          tabs.selectedIndex = DISPLAY_TAB
+          throw PreferencesValidationException(
+              validationSummary.text,
+              failure.invalidComponent,
+          )
+        }
     val input =
         try {
           keyboardEditor.validatedDraft()
@@ -219,6 +236,7 @@ internal class PreferencesPanel private constructor(
         romDirectory = directory,
         recentFileCapacity = capacity,
         confirmationPolicy = (confirmationPolicy.selectedItem as ConfirmationOption).policy,
+        display = display,
         keyboard = input.keyboard,
         gamepads = gamepad.selections,
         gamepadTunings = gamepad.tunings,
@@ -434,9 +452,10 @@ internal class PreferencesPanel private constructor(
 
   private companion object {
     const val GENERAL_TAB = 0
-    const val INPUT_TAB = 1
-    const val GAMEPADS_TAB = 2
-    const val AUDIO_TAB = 3
+    const val DISPLAY_TAB = 1
+    const val INPUT_TAB = 2
+    const val GAMEPADS_TAB = 3
+    const val AUDIO_TAB = 4
     val ERROR_COLOR = Color(0xB0, 0x00, 0x20)
     val CONFIRMATION_OPTIONS =
         listOf(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -18,6 +18,7 @@ import eu.rekawek.coffeegb.swing.io.AudioRuntimeConfiguration
 import eu.rekawek.coffeegb.swing.io.AudioSystemSound
 import eu.rekawek.coffeegb.swing.io.DesktopPlayerInput
 import eu.rekawek.coffeegb.swing.io.DesktopTiltInput
+import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
 import eu.rekawek.coffeegb.swing.io.GamepadCatalog
 import eu.rekawek.coffeegb.swing.io.GamepadConfiguration
 import eu.rekawek.coffeegb.swing.io.SwingAccelerometer
@@ -25,9 +26,11 @@ import eu.rekawek.coffeegb.swing.io.SwingDisplay
 import eu.rekawek.coffeegb.swing.io.SwingGamepad
 import eu.rekawek.coffeegb.swing.io.SwingJoypad
 import eu.rekawek.coffeegb.swing.io.SwingTiltKeys
+import java.awt.Dimension
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
+import javax.swing.SwingUtilities
 
 class SwingEmulator(
     private val eventBus: EventBus,
@@ -51,6 +54,10 @@ class SwingEmulator(
   private val connectionController: ConnectionController
 
   private lateinit var controller: Controller
+
+  private var boundFrame: JFrame? = null
+
+  private var boundPanel: JPanel? = null
 
   init {
     display = SwingDisplay(properties.display, eventBus, "main")
@@ -142,11 +149,23 @@ class SwingEmulator(
     gamepad.releaseForLifecycleChange()
   }
 
-  fun bind(jFrame: JFrame) {
+  fun minimumContentSize(): Dimension = Dimension(MINIMUM_CONTENT_WIDTH, MINIMUM_CONTENT_HEIGHT)
+
+  fun minimumContentSizeForCurrentMode(windowed: Boolean): Dimension =
+      minimumDisplayContentSize(display.scaleMode, display.preferredSize, windowed)
+
+  fun bind(
+      jFrame: JFrame,
+      isWindowedLayout: () -> Boolean = { true },
+  ) {
     val mainPanel = JPanel()
     mainPanel.setLayout(BoxLayout(mainPanel, BoxLayout.X_AXIS))
+    mainPanel.minimumSize = minimumContentSize()
+    display.minimumSize = minimumContentSize()
     mainPanel.add(display)
     display.addMouseMotionListener(accelerometer)
+    boundFrame = jFrame
+    boundPanel = mainPanel
 
     jFrame.contentPane = mainPanel
     jFrame.addKeyListener(joypad)
@@ -156,16 +175,132 @@ class SwingEmulator(
     jFrame.addMouseMotionListener(accelerometer)
 
     eventBus.register<SwingDisplay.DisplaySizeUpdatedEvent> {
-      mainPanel.preferredSize = it.preferredSize
-      // Setting preferredSize doesn't invalidate, and a pack() that leaves the frame the
-      // same size (e.g. re-selecting the current scale, or a rotation that preserves the
-      // dimensions) never triggers the reshape that refreshes the window's cached preferred
-      // size - after which every later pack() reads the stale size and stops resizing.
-      // Invalidating up from the panel clears the cache at each level so pack() recomputes.
-      mainPanel.invalidate()
-      jFrame.pack()
+      check(SwingUtilities.isEventDispatchThread()) {
+        "Display window sizing must run on the Event Dispatch Thread"
+      }
+      val windowed = isWindowedLayout()
+      applyDisplayWindowSizing(
+          jFrame,
+          mainPanel,
+          it.preferredSize,
+          windowed,
+          forceExplicitPack = true,
+      )
     }
   }
+
+  /**
+   * Refreshes top-level constraints at a fullscreen boundary even when renderer geometry did not
+   * change. On exit, pack only if the restored content area cannot contain the current exact
+   * explicit size; otherwise preserve the remembered window bounds.
+   */
+  fun refreshDisplayWindowSizing(windowed: Boolean) {
+    check(SwingUtilities.isEventDispatchThread()) {
+      "Display window sizing must run on the Event Dispatch Thread"
+    }
+    val frame = checkNotNull(boundFrame) { "The emulator display is not bound to a window" }
+    val panel = checkNotNull(boundPanel) { "The emulator display is not bound to a panel" }
+    val preferred = display.preferredSize
+    val currentContent =
+        Dimension(
+            (frame.width - frame.insets.left - frame.insets.right).coerceAtLeast(0),
+            (frame.height -
+                    frame.insets.top -
+                    frame.insets.bottom -
+                    (frame.jMenuBar?.height ?: 0))
+                .coerceAtLeast(0),
+        )
+    applyDisplayWindowSizing(
+        frame,
+        panel,
+        preferred,
+        windowed,
+        forceExplicitPack =
+            shouldPackExplicitWindow(
+                display.scaleMode,
+                preferred,
+                currentContent,
+                windowed,
+            ),
+    )
+  }
+
+  private fun applyDisplayWindowSizing(
+      frame: JFrame,
+      panel: JPanel,
+      preferred: Dimension,
+      windowed: Boolean,
+      forceExplicitPack: Boolean,
+  ) {
+    panel.preferredSize = Dimension(preferred)
+    val minimum = minimumDisplayContentSize(display.scaleMode, preferred, windowed)
+    panel.minimumSize = minimum
+    display.minimumSize = minimum
+    if (frame.isDisplayable) {
+      frame.minimumSize =
+          minimumFrameSize(
+              minimum,
+              frame.insets,
+              frame.jMenuBar?.preferredSize?.height ?: 0,
+          )
+    }
+    // Setting preferredSize doesn't invalidate, and a pack() that leaves the frame the same size
+    // never triggers the reshape that refreshes the window's cached preferred size. Invalidating
+    // up from the panel makes every later pack recompute it.
+    panel.invalidate()
+    if (forceExplicitPack && display.scaleMode.isExplicit && windowed) {
+      frame.pack()
+    } else {
+      panel.revalidate()
+      frame.validate()
+    }
+  }
+
+  private companion object {
+    const val MINIMUM_CONTENT_WIDTH = 160
+    const val MINIMUM_CONTENT_HEIGHT = 144
+  }
+}
+
+/**
+ * Explicit scale is a real windowed pixel-size contract, so manual resizing cannot crop it.
+ * Fullscreen and fit modes retain the sensible native-frame minimum; the viewport supplies a
+ * uniform fit fallback if the host cannot honor an explicit top-level minimum.
+ */
+internal fun minimumDisplayContentSize(
+    scaleMode: DisplayScaleMode,
+    preferredSize: Dimension,
+    windowed: Boolean,
+): Dimension {
+  require(preferredSize.width > 0 && preferredSize.height > 0) {
+    "Preferred display size must be positive"
+  }
+  val base = Dimension(160, 144)
+  if (!windowed || !scaleMode.isExplicit) {
+    return base
+  }
+  return Dimension(
+      maxOf(base.width, preferredSize.width),
+      maxOf(base.height, preferredSize.height),
+  )
+}
+
+internal fun shouldPackExplicitWindow(
+    scaleMode: DisplayScaleMode,
+    preferredSize: Dimension,
+    currentContentSize: Dimension,
+    windowed: Boolean,
+): Boolean {
+  require(preferredSize.width > 0 && preferredSize.height > 0) {
+    "Preferred display size must be positive"
+  }
+  require(currentContentSize.width >= 0 && currentContentSize.height >= 0) {
+    "Current display content size must not be negative"
+  }
+  return windowed &&
+      scaleMode.isExplicit &&
+      (currentContentSize.width < preferredSize.width ||
+          currentContentSize.height < preferredSize.height)
 }
 
 internal fun ApplicationSettings.toGamepadConfiguration(): GamepadConfiguration =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -17,6 +17,8 @@ import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.sound.Sound
 import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.Insets
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.io.File
@@ -41,6 +43,10 @@ class SwingGui private constructor(
 
   private lateinit var mainWindow: JFrame
 
+  private lateinit var displayController: DesktopDisplayController
+
+  private var applicationDisposeRequested = false
+
   private var activeWindowTitle = "Coffee GB"
 
   private var romLoading = false
@@ -56,12 +62,24 @@ class SwingGui private constructor(
 
   private fun startGui() {
     mainWindow = JFrame("Coffee GB")
+    val minimumContentSize = emulator.minimumContentSize()
+    displayController =
+        DesktopDisplayController(
+            properties,
+            eventBus,
+            DesktopFullscreenRuntime(
+                mainWindow,
+                DesktopSize(minimumContentSize.width, minimumContentSize.height),
+            ),
+            DisplayWindowSizingRuntime(emulator::refreshDisplayWindowSizing),
+        )
 
     SwingMenu(
             properties,
             mainWindow,
             eventBus,
             romSessionState,
+            displayController,
             ::showPreferences,
             ::requestClose,
         )
@@ -100,16 +118,28 @@ class SwingGui private constructor(
           }
 
           override fun windowClosed(windowEvent: WindowEvent) {
-            stopGui()
+            // Borderless fullscreen requires dispose/re-show so JFrame decorations can change.
+            // Only the explicit application-close path owns runtime shutdown.
+            if (applicationDisposeRequested) {
+              stopGui()
+            }
           }
         })
 
-    emulator.bind(mainWindow)
+    emulator.bind(mainWindow) { !displayController.current().fullscreen }
     mainWindow.pack()
     mainWindow.repaint()
     mainWindow.setLocationRelativeTo(null)
-    mainWindow.isResizable = false
+    mainWindow.minimumSize =
+        minimumFrameSize(
+            emulator.minimumContentSizeForCurrentMode(
+                windowed = !displayController.current().fullscreen),
+            mainWindow.insets,
+            mainWindow.jMenuBar?.preferredSize?.height ?: 0,
+        )
+    mainWindow.isResizable = true
     mainWindow.isVisible = true
+    displayController.applyCurrent()
     properties.consumeLoadWarning()?.let { warning ->
       JOptionPane.showMessageDialog(
           mainWindow,
@@ -195,6 +225,8 @@ class SwingGui private constructor(
     if (!proceed) {
       return
     }
+    displayController.close()
+    applicationDisposeRequested = true
     mainWindow.dispose()
   }
 
@@ -212,6 +244,7 @@ class SwingGui private constructor(
       val applied = properties.applicationSettings
       emulator.applyKeyboardMapping(applied.input.toPlayerMapping())
       emulator.applyDeviceSettings(applied)
+      displayController.apply(applied.display, persist = false)
       eventBus.post(Sound.SoundEnabledEvent(applied.audio.enabled))
     }
   }
@@ -298,4 +331,20 @@ internal fun launchDesktopShutdownWatchdog(
         isDaemon = true
         start()
       }
+}
+
+internal fun minimumFrameSize(
+    content: Dimension,
+    insets: Insets,
+    menuHeight: Int,
+): Dimension {
+  require(content.width > 0 && content.height > 0) { "Minimum content size must be positive" }
+  require(menuHeight >= 0) { "Menu height must not be negative" }
+  return Dimension(
+      Math.addExact(content.width, Math.addExact(insets.left, insets.right)),
+      Math.addExact(
+          content.height,
+          Math.addExact(menuHeight, Math.addExact(insets.top, insets.bottom)),
+      ),
+  )
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -26,6 +26,7 @@ import eu.rekawek.coffeegb.controller.network.ConnectionController.StartClientEv
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StartServerEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopClientEvent
 import eu.rekawek.coffeegb.controller.network.ConnectionController.StopServerEvent
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.BootstrapMode
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties.Key.CgbGamesType
@@ -41,13 +42,7 @@ import eu.rekawek.coffeegb.core.ir.FullChanger
 import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera
 import eu.rekawek.coffeegb.swing.io.WebcamCameraSource
 import eu.rekawek.coffeegb.core.genie.PatchFactory
-import eu.rekawek.coffeegb.core.sgb.SgbDisplay
 import eu.rekawek.coffeegb.core.sound.Sound
-import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetBlendingEvent
-import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetColorCorrectionEvent
-import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetGrayscaleEvent
-import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetRotationEvent
-import eu.rekawek.coffeegb.swing.io.SwingDisplay.SetScaleEvent
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
@@ -59,6 +54,7 @@ import java.awt.event.MouseEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.io.File
+import javax.swing.ButtonGroup
 import javax.swing.DefaultListCellRenderer
 import javax.swing.DefaultListModel
 import javax.swing.JCheckBoxMenuItem
@@ -71,6 +67,7 @@ import javax.swing.JMenuBar
 import javax.swing.JMenuItem
 import javax.swing.JOptionPane
 import javax.swing.JPanel
+import javax.swing.JRadioButtonMenuItem
 import javax.swing.JScrollPane
 import javax.swing.JTextField
 import javax.swing.KeyStroke
@@ -84,6 +81,7 @@ internal class SwingMenu(
     private val window: JFrame,
     private val eventBus: EventBus,
     private val romSessionState: RomSessionState,
+    private val displayController: DesktopDisplayController,
     private val onPreferences: () -> Unit,
     private val onQuit: () -> Unit,
 ) {
@@ -784,66 +782,11 @@ internal class SwingMenu(
   }
 
   private fun createScreenMenu(): JMenu {
-    val screenMenu = JMenu("Screen")
-
-    val scale = JMenu("Scale")
-    screenMenu.add(scale)
-
-    for (s in mutableListOf(1, 2, 4)) {
-      val item = JCheckBoxMenuItem(s.toString() + "x", s == properties.display.scale)
-      item.addActionListener {
-        eventBus.post(SetScaleEvent(s))
-        uncheckAllBut(scale, item)
-        properties.setProperty(EmulatorProperties.Key.DisplayScale, s.toString())
-      }
-      scale.add(item)
-    }
-
-    val rotate = JMenu("Rotate")
-    screenMenu.add(rotate)
-
-    for (deg in mutableListOf(0, 90, 180, 270)) {
-      val label = if (deg == 0) "None" else "$deg°"
-      val item = JCheckBoxMenuItem(label, deg == properties.display.rotation)
-      item.addActionListener {
-        eventBus.post(SetRotationEvent(deg))
-        uncheckAllBut(rotate, item)
-        properties.setProperty(EmulatorProperties.Key.DisplayRotation, deg.toString())
-      }
-      rotate.add(item)
-    }
-
-    val grayscale = JCheckBoxMenuItem("DMG grayscale", properties.display.grayscale)
-    screenMenu.add(grayscale)
-    grayscale.addActionListener {
-      eventBus.post(SetGrayscaleEvent(grayscale.state))
-      properties.setProperty(EmulatorProperties.Key.DisplayGrayscale, grayscale.state.toString())
-    }
-
-    val colorCorrection =
-        JCheckBoxMenuItem("CGB color correction", properties.display.colorCorrection)
-    screenMenu.add(colorCorrection)
-    colorCorrection.addActionListener {
-      eventBus.post(SetColorCorrectionEvent(colorCorrection.state))
-      properties.setProperty(
-          EmulatorProperties.Key.DisplayColorCorrection, colorCorrection.state.toString())
-    }
-
-    val blending = JCheckBoxMenuItem("LCD ghosting (frame blend)", properties.display.blending)
-    screenMenu.add(blending)
-    blending.addActionListener {
-      eventBus.post(SetBlendingEvent(blending.state))
-      properties.setProperty(EmulatorProperties.Key.DisplayBlending, blending.state.toString())
-    }
-
-    val showSgbBorder = JCheckBoxMenuItem("Show SGB border", properties.display.showSgbBorder)
-    screenMenu.add(showSgbBorder)
-    showSgbBorder.addActionListener {
-      properties.setProperty(EmulatorProperties.Key.ShowSgbBorder, showSgbBorder.state.toString())
-      eventBus.post(SgbDisplay.SetSgbBorder(showSgbBorder.state))
-    }
-
-    return screenMenu
+    return createScreenMenu(
+        displayController,
+        eventBus,
+        keyboardBindings = { properties.applicationSettings.input.keyboard.values },
+    )
   }
 
   private fun createAudioMenu(): JMenu {
@@ -1172,4 +1115,150 @@ internal class SwingMenu(
       }
     }
   }
+}
+
+/**
+ * Builds the display controls around the same coordinator used by Preferences.
+ *
+ * Kept as a small seam so radio grouping, accelerators, and event-driven synchronization can be
+ * exercised without constructing the rest of the desktop menu or touching the filesystem.
+ */
+internal fun createScreenMenu(
+    displayController: DesktopDisplayController,
+    eventBus: EventBus,
+    keyboardBindings: () -> Collection<ApplicationSettings.KeyboardKey>,
+): JMenu {
+  check(SwingUtilities.isEventDispatchThread()) {
+    "The Screen menu must be created on the Event Dispatch Thread"
+  }
+  val screenMenu = JMenu("Screen")
+  val initial = displayController.current()
+
+  /**
+   * F11 is conventional and modifier-free, but emulator bindings are user-owned. If it is mapped
+   * to a Game Boy button, the menu remains available and the accelerator is disabled instead of
+   * delivering one physical press to two owners.
+   */
+  fun fullscreenAccelerator(): KeyStroke? =
+      if (keyboardBindings().none { it.code == KeyEvent.VK_F11 }) {
+        KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0)
+      } else {
+        null
+      }
+
+  val fullscreen = JCheckBoxMenuItem("Fullscreen", initial.fullscreen)
+  fullscreen.accelerator = fullscreenAccelerator()
+  fullscreen.accessibleContext.accessibleName = "Fullscreen"
+  fullscreen.addActionListener { displayController.setFullscreen(fullscreen.state) }
+  screenMenu.add(fullscreen)
+  screenMenu.addSeparator()
+
+  val scale = JMenu("Scale")
+  screenMenu.add(scale)
+  val scaleGroup = ButtonGroup()
+  val scaleItems =
+      mutableMapOf<Pair<ApplicationSettings.DisplayScalingMode, Int>, JRadioButtonMenuItem>()
+
+  fun addScale(
+      title: String,
+      mode: ApplicationSettings.DisplayScalingMode,
+      explicitScale: Int = initial.explicitScale,
+  ) {
+    val key =
+        mode to
+            if (mode == ApplicationSettings.DisplayScalingMode.EXPLICIT) {
+              explicitScale
+            } else {
+              0
+            }
+    val selected =
+        initial.scalingMode == mode &&
+            (mode != ApplicationSettings.DisplayScalingMode.EXPLICIT ||
+                initial.explicitScale == explicitScale)
+    val item = JRadioButtonMenuItem(title, selected)
+    item.addActionListener {
+      displayController.update { current ->
+        current.copy(scalingMode = mode, explicitScale = explicitScale)
+      }
+    }
+    scaleGroup.add(item)
+    scale.add(item)
+    scaleItems[key] = item
+  }
+  addScale("Integer fit", ApplicationSettings.DisplayScalingMode.INTEGER_FIT)
+  addScale("Fit to window", ApplicationSettings.DisplayScalingMode.ASPECT_FIT)
+  scale.addSeparator()
+  for (factor in
+      ApplicationSettings.MIN_EXPLICIT_DISPLAY_SCALE..
+          ApplicationSettings.MAX_EXPLICIT_DISPLAY_SCALE) {
+    addScale("${factor}x", ApplicationSettings.DisplayScalingMode.EXPLICIT, factor)
+  }
+
+  val rotate = JMenu("Rotate")
+  screenMenu.add(rotate)
+  val rotateGroup = ButtonGroup()
+  val rotateItems = mutableMapOf<Int, JRadioButtonMenuItem>()
+  for (rotation in ApplicationSettings.Rotation.entries) {
+    val degrees = rotation.degrees
+    val label = if (degrees == 0) "None" else "$degrees°"
+    val item = JRadioButtonMenuItem(label, rotation == initial.rotation)
+    item.addActionListener {
+      displayController.update { current -> current.copy(rotation = rotation) }
+    }
+    rotateGroup.add(item)
+    rotate.add(item)
+    rotateItems[degrees] = item
+  }
+
+  val grayscale = JCheckBoxMenuItem("DMG grayscale", initial.grayscale)
+  screenMenu.add(grayscale)
+  grayscale.addActionListener {
+    displayController.update { it.copy(grayscale = grayscale.state) }
+  }
+
+  val colorCorrection =
+      JCheckBoxMenuItem("CGB color correction", initial.colorCorrection)
+  screenMenu.add(colorCorrection)
+  colorCorrection.addActionListener {
+    displayController.update { it.copy(colorCorrection = colorCorrection.state) }
+  }
+
+  val blending = JCheckBoxMenuItem("LCD ghosting (frame blend)", initial.blending)
+  screenMenu.add(blending)
+  blending.addActionListener {
+    displayController.update { it.copy(blending = blending.state) }
+  }
+
+  val showSgbBorder = JCheckBoxMenuItem("Show SGB border", initial.showSgbBorder)
+  screenMenu.add(showSgbBorder)
+  showSgbBorder.addActionListener {
+    displayController.update { it.copy(showSgbBorder = showSgbBorder.state) }
+  }
+
+  fun synchronize(display: ApplicationSettings.Display) {
+    val scaleKey =
+        display.scalingMode to
+            if (display.scalingMode == ApplicationSettings.DisplayScalingMode.EXPLICIT) {
+              display.explicitScale
+            } else {
+              0
+            }
+    scaleItems[scaleKey]?.isSelected = true
+    rotateItems[display.rotation.degrees]?.isSelected = true
+    fullscreen.accelerator = fullscreenAccelerator()
+    fullscreen.state = display.fullscreen
+    grayscale.state = display.grayscale
+    colorCorrection.state = display.colorCorrection
+    blending.state = display.blending
+    showSgbBorder.state = display.showSgbBorder
+  }
+  eventBus.register<DisplaySettingsChangedEvent> { event ->
+    if (SwingUtilities.isEventDispatchThread()) {
+      synchronize(event.display)
+    } else {
+      SwingUtilities.invokeLater { synchronize(event.display) }
+    }
+  }
+
+  return screenMenu
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshot.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshot.java
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
+import java.util.Objects;
+
+/**
+ * A private-raster frame that is copied once and never mutated after publication.
+ */
+final class DisplayFrameSnapshot {
+
+    private final int width;
+
+    private final int height;
+
+    private final BufferedImage image;
+
+    private DisplayFrameSnapshot(int width, int height, int[] rgb) {
+        this.width = width;
+        this.height = height;
+        this.image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        int[] imagePixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
+        System.arraycopy(rgb, 0, imagePixels, 0, imagePixels.length);
+    }
+
+    static DisplayFrameSnapshot copyOf(int width, int height, int[] rgb) {
+        Objects.requireNonNull(rgb, "rgb");
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Frame dimensions must be positive");
+        }
+        int expectedLength = Math.multiplyExact(width, height);
+        if (rgb.length != expectedLength) {
+            throw new IllegalArgumentException(
+                    "Frame pixel count must be exactly " + expectedLength);
+        }
+        return new DisplayFrameSnapshot(width, height, rgb);
+    }
+
+    int width() {
+        return width;
+    }
+
+    int height() {
+        return height;
+    }
+
+    int rgbAt(int x, int y) {
+        if (x < 0 || x >= width || y < 0 || y >= height) {
+            throw new IndexOutOfBoundsException("(" + x + ", " + y + ")");
+        }
+        return image.getRGB(x, y) & 0xffffff;
+    }
+
+    void paint(Graphics2D graphics) {
+        graphics.drawImage(image, 0, 0, null);
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayScaleMode.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayScaleMode.java
@@ -1,0 +1,49 @@
+package eu.rekawek.coffeegb.swing.io;
+
+/**
+ * Defines how an emulated frame is scaled inside the Swing display component.
+ */
+public enum DisplayScaleMode {
+
+    /** Use the largest whole-number scale that fits the component. */
+    INTEGER_FIT(0),
+
+    /** Use all available space while preserving the source aspect ratio. */
+    ASPECT_FIT(0),
+
+    EXPLICIT_1X(1),
+
+    EXPLICIT_2X(2),
+
+    EXPLICIT_3X(3),
+
+    EXPLICIT_4X(4);
+
+    private final int explicitScale;
+
+    DisplayScaleMode(int explicitScale) {
+        this.explicitScale = explicitScale;
+    }
+
+    public boolean isExplicit() {
+        return explicitScale != 0;
+    }
+
+    public int explicitScale() {
+        if (!isExplicit()) {
+            throw new IllegalStateException(name() + " does not have an explicit scale");
+        }
+        return explicitScale;
+    }
+
+    public static DisplayScaleMode explicit(int scale) {
+        return switch (scale) {
+            case 1 -> EXPLICIT_1X;
+            case 2 -> EXPLICIT_2X;
+            case 3 -> EXPLICIT_3X;
+            case 4 -> EXPLICIT_4X;
+            default -> throw new IllegalArgumentException(
+                    "Explicit display scale must be between 1 and 4");
+        };
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayViewport.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayViewport.java
@@ -1,0 +1,226 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.util.Objects;
+
+/**
+ * Immutable, device-pixel viewport geometry for one emulated frame.
+ *
+ * <p>The exact width and height may be fractional in aspect-fit mode. Rendering uses
+ * {@link #scale()} for both axes, so rounding the conservative {@link #paintBounds()} never
+ * introduces a non-uniform stretch. When centering leaves an odd device pixel, the extra pixel is
+ * deliberately placed on the right or bottom edge.</p>
+ */
+public final class DisplayViewport {
+
+    private static final double INTEGER_EPSILON = 1e-9;
+
+    private final int componentWidth;
+
+    private final int componentHeight;
+
+    private final int sourceWidth;
+
+    private final int sourceHeight;
+
+    private final int rotation;
+
+    private final int x;
+
+    private final int y;
+
+    private final double width;
+
+    private final double height;
+
+    private final double scale;
+
+    private DisplayViewport(
+            int componentWidth,
+            int componentHeight,
+            int sourceWidth,
+            int sourceHeight,
+            int rotation,
+            int x,
+            int y,
+            double width,
+            double height,
+            double scale) {
+        this.componentWidth = componentWidth;
+        this.componentHeight = componentHeight;
+        this.sourceWidth = sourceWidth;
+        this.sourceHeight = sourceHeight;
+        this.rotation = rotation;
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        this.scale = scale;
+    }
+
+    public static DisplayViewport calculate(
+            int componentWidth,
+            int componentHeight,
+            int sourceWidth,
+            int sourceHeight,
+            int rotation,
+            DisplayScaleMode mode) {
+        if (componentWidth < 0 || componentHeight < 0) {
+            throw new IllegalArgumentException("Component dimensions must not be negative");
+        }
+        if (sourceWidth <= 0 || sourceHeight <= 0) {
+            throw new IllegalArgumentException("Source dimensions must be positive");
+        }
+        Objects.requireNonNull(mode, "mode");
+
+        int normalizedRotation = normalizeRotation(rotation);
+        int rotatedWidth = swapsAxes(normalizedRotation) ? sourceHeight : sourceWidth;
+        int rotatedHeight = swapsAxes(normalizedRotation) ? sourceWidth : sourceHeight;
+
+        double fitScale = Math.min(
+                componentWidth / (double) rotatedWidth,
+                componentHeight / (double) rotatedHeight);
+        double scale;
+        if (mode == DisplayScaleMode.INTEGER_FIT) {
+            double integerScale = Math.floor(fitScale);
+            // A transient layout can make the component smaller than one emulated frame. Keep
+            // the complete image visible instead of choosing the only fitting integer (zero).
+            scale = integerScale >= 1 ? integerScale : fitScale;
+        } else if (mode == DisplayScaleMode.ASPECT_FIT) {
+            scale = fitScale;
+        } else {
+            scale = mode.explicitScale();
+        }
+
+        double width = rotatedWidth * scale;
+        double height = rotatedHeight * scale;
+        int x = centeredOrigin(componentWidth, width);
+        int y = centeredOrigin(componentHeight, height);
+        return new DisplayViewport(
+                componentWidth,
+                componentHeight,
+                sourceWidth,
+                sourceHeight,
+                normalizedRotation,
+                x,
+                y,
+                width,
+                height,
+                scale);
+    }
+
+    public static Dimension preferredSize(
+            int sourceWidth, int sourceHeight, int rotation, DisplayScaleMode mode) {
+        if (sourceWidth <= 0 || sourceHeight <= 0) {
+            throw new IllegalArgumentException("Source dimensions must be positive");
+        }
+        Objects.requireNonNull(mode, "mode");
+        int normalizedRotation = normalizeRotation(rotation);
+        int factor = mode.isExplicit() ? mode.explicitScale() : 1;
+        int width = Math.multiplyExact(sourceWidth, factor);
+        int height = Math.multiplyExact(sourceHeight, factor);
+        return swapsAxes(normalizedRotation)
+                ? new Dimension(height, width)
+                : new Dimension(width, height);
+    }
+
+    private static int centeredOrigin(int available, double content) {
+        return (int) Math.floor((available - content) / 2.0);
+    }
+
+    private static boolean swapsAxes(int rotation) {
+        return rotation == 90 || rotation == 270;
+    }
+
+    private static int normalizeRotation(int rotation) {
+        int normalized = Math.floorMod(rotation, 360);
+        if (normalized % 90 != 0) {
+            throw new IllegalArgumentException("Rotation must be a multiple of 90 degrees");
+        }
+        return normalized;
+    }
+
+    public int x() {
+        return x;
+    }
+
+    public int y() {
+        return y;
+    }
+
+    public double width() {
+        return width;
+    }
+
+    public double height() {
+        return height;
+    }
+
+    public double scale() {
+        return scale;
+    }
+
+    public int rotation() {
+        return rotation;
+    }
+
+    public int rotatedSourceWidth() {
+        return swapsAxes(rotation) ? sourceHeight : sourceWidth;
+    }
+
+    public int rotatedSourceHeight() {
+        return swapsAxes(rotation) ? sourceWidth : sourceHeight;
+    }
+
+    /**
+     * Returns the component-clipped integer bounds covering every device pixel the exact
+     * transform can touch.
+     */
+    public Rectangle paintBounds() {
+        int left = clamp(x, 0, componentWidth);
+        int top = clamp(y, 0, componentHeight);
+        int right = clamp(ceilStable(x + width), 0, componentWidth);
+        int bottom = clamp(ceilStable(y + height), 0, componentHeight);
+        return new Rectangle(left, top, Math.max(0, right - left), Math.max(0, bottom - top));
+    }
+
+    /**
+     * Returns the exact, uniformly scaled transform from unrotated source pixels to the
+     * component.
+     */
+    public AffineTransform sourceToComponentTransform() {
+        AffineTransform transform = AffineTransform.getTranslateInstance(x, y);
+        transform.scale(scale, scale);
+        switch (rotation) {
+            case 90 -> {
+                transform.translate(sourceHeight, 0);
+                transform.quadrantRotate(1);
+            }
+            case 180 -> {
+                transform.translate(sourceWidth, sourceHeight);
+                transform.quadrantRotate(2);
+            }
+            case 270 -> {
+                transform.translate(0, sourceWidth);
+                transform.quadrantRotate(3);
+            }
+            default -> {
+            }
+        }
+        return transform;
+    }
+
+    private static int ceilStable(double value) {
+        double nearestInteger = Math.rint(value);
+        if (Math.abs(value - nearestInteger) < INTEGER_EPSILON) {
+            return (int) nearestInteger;
+        }
+        return (int) Math.ceil(value);
+    }
+
+    private static int clamp(int value, int minimum, int maximum) {
+        return Math.max(minimum, Math.min(maximum, value));
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayViewport.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayViewport.java
@@ -91,7 +91,10 @@ public final class DisplayViewport {
         } else if (mode == DisplayScaleMode.ASPECT_FIT) {
             scale = fitScale;
         } else {
-            scale = mode.explicitScale();
+            // Windowed explicit modes are protected by a matching top-level minimum size. Keep a
+            // uniform fit fallback here for smaller physical screens, transient native layout
+            // constraints, and fullscreen: exact scale must never turn into clipped source pixels.
+            scale = Math.min(mode.explicitScale(), fitScale);
         }
 
         double width = rotatedWidth * scale;

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -27,8 +27,6 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private static final int NOTIFICATION_DURATION_MS = 1500;
 
-    private static final Color DEFAULT_LETTERBOX_COLOR = Color.BLACK;
-
     private final EventBus eventBus;
 
     private final int[] waitingFrame;
@@ -78,7 +76,7 @@ public class SwingDisplay extends JPanel implements Runnable {
         requireEventDispatchThread("SwingDisplay construction");
         this.eventBus = eventBus;
         setOpaque(true);
-        setBackground(DEFAULT_LETTERBOX_COLOR);
+        setBackground(new Color(properties.getLetterboxColor()));
         waitingFrame = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
         displayedFrame = new AtomicReference<>(DisplayFrameSnapshot.copyOf(
                 DISPLAY_WIDTH,
@@ -86,7 +84,7 @@ public class SwingDisplay extends JPanel implements Runnable {
                 new int[DISPLAY_WIDTH * DISPLAY_HEIGHT]));
         this.grayscale = properties.getGrayscale();
         this.rotation = normalizeRotation(properties.getRotation());
-        this.scaleMode = legacyScaleMode(properties.getScale());
+        this.scaleMode = initialScaleMode(properties);
         setBlending(properties.getBlending());
         setColorCorrection(properties.getColorCorrection());
 
@@ -188,12 +186,20 @@ public class SwingDisplay extends JPanel implements Runnable {
     }
 
     private void setScaleMode(DisplayScaleMode mode) {
-        scaleMode = Objects.requireNonNull(mode, "mode");
+        DisplayScaleMode requiredMode = Objects.requireNonNull(mode, "mode");
+        if (requiredMode == scaleMode) {
+            return;
+        }
+        scaleMode = requiredMode;
         requestPreferredSizeUpdate();
     }
 
     private void setRotation(int degrees) {
-        this.rotation = normalizeRotation(degrees);
+        int normalized = normalizeRotation(degrees);
+        if (normalized == rotation) {
+            return;
+        }
+        this.rotation = normalized;
         requestPreferredSizeUpdate();
     }
 
@@ -213,6 +219,14 @@ public class SwingDisplay extends JPanel implements Runnable {
         } else {
             return DisplayScaleMode.EXPLICIT_4X;
         }
+    }
+
+    private static DisplayScaleMode initialScaleMode(DisplayProperties properties) {
+        return switch (properties.getScalingMode()) {
+            case INTEGER_FIT -> DisplayScaleMode.INTEGER_FIT;
+            case ASPECT_FIT -> DisplayScaleMode.ASPECT_FIT;
+            case EXPLICIT -> DisplayScaleMode.explicit(properties.getExplicitScale());
+        };
     }
 
     private void requestPreferredSizeUpdate() {
@@ -254,6 +268,10 @@ public class SwingDisplay extends JPanel implements Runnable {
             setBackground(copiedColor);
             repaint();
         });
+    }
+
+    public DisplayScaleMode getScaleMode() {
+        return scaleMode;
     }
 
     @Override

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -1,20 +1,22 @@
 package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.controller.Controller;
-import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
-import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.controller.properties.DisplayProperties;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
-import eu.rekawek.coffeegb.controller.properties.DisplayProperties;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferInt;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static eu.rekawek.coffeegb.core.gpu.Display.DISPLAY_HEIGHT;
 import static eu.rekawek.coffeegb.core.gpu.Display.DISPLAY_WIDTH;
@@ -25,28 +27,27 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private static final int NOTIFICATION_DURATION_MS = 1500;
 
+    private static final Color DEFAULT_LETTERBOX_COLOR = Color.BLACK;
+
     private final EventBus eventBus;
-
-    private BufferedImage img;
-
-    private int[] imgPixels;
-
-    /** Guards replacement, upload, and painting of {@link #img}'s directly accessed raster. */
-    private final Object rasterLock = new Object();
 
     private final int[] waitingFrame;
 
-    private boolean isSgbBorder;
+    private final AtomicReference<DisplayFrameSnapshot> displayedFrame;
+
+    private final AtomicLong preferredSizeRevision = new AtomicLong();
+
+    private PendingFrame pendingFrame;
+
+    private volatile int displayWidth = DISPLAY_WIDTH;
+
+    private volatile int displayHeight = DISPLAY_HEIGHT;
 
     private volatile boolean doStop;
 
     private volatile boolean isStopped;
 
-    private boolean frameIsWaiting;
-
-    private boolean resetBlendForWaitingFrame;
-
-    private int scale;
+    private volatile DisplayScaleMode scaleMode;
 
     private boolean grayscale;
 
@@ -54,7 +55,7 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private boolean colorCorrection;
 
-    private int rotation;
+    private volatile int rotation;
 
     private int[] previousFrame;
 
@@ -74,18 +75,32 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
+        requireEventDispatchThread("SwingDisplay construction");
         this.eventBus = eventBus;
-        createFrameImage(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        setOpaque(true);
+        setBackground(DEFAULT_LETTERBOX_COLOR);
         waitingFrame = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+        displayedFrame = new AtomicReference<>(DisplayFrameSnapshot.copyOf(
+                DISPLAY_WIDTH,
+                DISPLAY_HEIGHT,
+                new int[DISPLAY_WIDTH * DISPLAY_HEIGHT]));
+        this.grayscale = properties.getGrayscale();
+        this.rotation = normalizeRotation(properties.getRotation());
+        this.scaleMode = legacyScaleMode(properties.getScale());
+        setBlending(properties.getBlending());
+        setColorCorrection(properties.getColorCorrection());
+
         eventBus.register(this::onDmgFrame, Display.DmgFrameReadyEvent.class, callerId);
         eventBus.register(this::onGbcFrame, Display.GbcFrameReadyEvent.class, callerId);
         eventBus.register(this::onSgbFrame, SgbDisplay.SgbFrameReadyEvent.class, callerId);
         eventBus.register(this::onHardwareProfile, Controller.HardwareProfileEvent.class, callerId);
         eventBus.register(e -> setScale(e.scale), SetScaleEvent.class);
-        eventBus.register(e -> this.grayscale = e.grayscale, SetGrayscaleEvent.class);
+        eventBus.register(e -> setScaleMode(e.mode), SetScaleModeEvent.class);
+        eventBus.register(e -> setGrayscale(e.grayscale), SetGrayscaleEvent.class);
         eventBus.register(e -> setBlending(e.blending), SetBlendingEvent.class);
         eventBus.register(e -> setColorCorrection(e.colorCorrection), SetColorCorrectionEvent.class);
         eventBus.register(e -> setRotation(e.rotation), SetRotationEvent.class);
+        eventBus.register(e -> setLetterboxColor(e.color), SetLetterboxColorEvent.class);
         eventBus.register(e -> this.rumbling = e.on(), RumbleEvent.class, callerId);
         eventBus.register(e -> showNotification("State saved (slot " + e.getSlot() + ")"),
                 Controller.SnapshotSavedEvent.class, callerId);
@@ -99,11 +114,7 @@ public class SwingDisplay extends JPanel implements Runnable {
                 Controller.RomLoadingCancelledEvent.class);
         eventBus.register(e -> clearPersistentNotification(),
                 Controller.EmulationStartedEvent.class, callerId);
-        this.grayscale = properties.getGrayscale();
-        this.rotation = normalizeRotation(properties.getRotation());
-        setBlending(properties.getBlending());
-        setColorCorrection(properties.getColorCorrection());
-        setScale(properties.getScale());
+        requestPreferredSizeUpdate();
     }
 
     private synchronized void onHardwareProfile(Controller.HardwareProfileEvent e) {
@@ -111,69 +122,79 @@ public class SwingDisplay extends JPanel implements Runnable {
     }
 
     private synchronized void onGbcFrame(Display.GbcFrameReadyEvent e) {
+        requireFrameLength(e.pixels().length, DISPLAY_WIDTH, DISPLAY_HEIGHT);
         e.toRgb(waitingFrame, colorCorrection);
-        setBorder(false);
-        frameQueued(false);
+        setFrameSize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        frameQueued(DISPLAY_WIDTH, DISPLAY_HEIGHT, false);
     }
 
     private synchronized void onDmgFrame(Display.DmgFrameReadyEvent e) {
         if (hardwareProfile.capabilities().superGameboyBorder()) {
             return;
         }
+        requireFrameLength(e.pixels().length, DISPLAY_WIDTH, DISPLAY_HEIGHT);
         e.toRgb(waitingFrame, grayscale);
-        setBorder(false);
-        frameQueued(e.lcdBlank());
+        setFrameSize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        frameQueued(DISPLAY_WIDTH, DISPLAY_HEIGHT, e.lcdBlank());
     }
 
     private synchronized void onSgbFrame(SgbDisplay.SgbFrameReadyEvent e) {
+        int width = e.includeBorder() ? SGB_DISPLAY_WIDTH : DISPLAY_WIDTH;
+        int height = e.includeBorder() ? SGB_DISPLAY_HEIGHT : DISPLAY_HEIGHT;
+        requireFrameLength(e.buffer().length, width, height);
         e.toRgb(waitingFrame, grayscale);
-        setBorder(e.includeBorder());
-        frameQueued(false);
+        setFrameSize(width, height);
+        frameQueued(width, height, false);
+    }
+
+    private static void requireFrameLength(int actualLength, int width, int height) {
+        int expectedLength = Math.multiplyExact(width, height);
+        if (actualLength != expectedLength) {
+            throw new IllegalArgumentException(
+                    "Frame pixel count must be exactly " + expectedLength);
+        }
     }
 
     /**
-     * Keep the newest panel state while the display thread has not uploaded the pending
+     * Keep the newest panel state while the display thread has not published the pending
      * frame yet. In particular, LCD-off can replace a just-finished partial scanout before
      * Swing paints it instead of leaving that stale transition visible for a host frame.
      */
-    private void frameQueued(boolean resetBlend) {
-        resetBlendForWaitingFrame = resetBlend;
-        if (!frameIsWaiting) {
-            frameIsWaiting = true;
-            notify();
+    private void frameQueued(int width, int height, boolean resetBlend) {
+        if (!Thread.holdsLock(this)) {
+            throw new IllegalStateException(
+                    "Frame queue must be updated while holding the display lock");
+        }
+        int size = Math.multiplyExact(width, height);
+        pendingFrame = new PendingFrame(
+                width, height, Arrays.copyOf(waitingFrame, size), resetBlend);
+        notifyAll();
+    }
+
+    private void setFrameSize(int width, int height) {
+        if (!Thread.holdsLock(this)) {
+            throw new IllegalStateException(
+                    "Frame size must be updated while holding the display lock");
+        }
+        if (width != displayWidth || height != displayHeight) {
+            displayWidth = width;
+            displayHeight = height;
+            requestPreferredSizeUpdate();
         }
     }
 
-    private void setBorder(boolean isSgbBorder) {
-        if (isSgbBorder != this.isSgbBorder) {
-            this.isSgbBorder = isSgbBorder;
-            createFrameImage(getDisplayWidth(), getDisplayHeight());
-            setScale(scale);
-        }
+    private void setScale(int scale) {
+        setScaleMode(legacyScaleMode(scale));
     }
 
-    /**
-     * The image raster is written directly (setRGB would convert every pixel through the
-     * color model); TYPE_INT_RGB matches the int-packed RGB produced by the emulator.
-     */
-    private void createFrameImage(int width, int height) {
-        synchronized (rasterLock) {
-            img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-            imgPixels = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
-        }
+    private void setScaleMode(DisplayScaleMode mode) {
+        scaleMode = Objects.requireNonNull(mode, "mode");
+        requestPreferredSizeUpdate();
     }
 
-    private synchronized void setScale(int scale) {
-        this.scale = scale;
-        setPreferredSize(rotatedPreferredSize());
-        eventBus.post(new DisplaySizeUpdatedEvent(getPreferredSize()));
-    }
-
-    private synchronized void setRotation(int degrees) {
+    private void setRotation(int degrees) {
         this.rotation = normalizeRotation(degrees);
-        setPreferredSize(rotatedPreferredSize());
-        eventBus.post(new DisplaySizeUpdatedEvent(getPreferredSize()));
-        repaint();
+        requestPreferredSizeUpdate();
     }
 
     private static int normalizeRotation(int degrees) {
@@ -182,56 +203,92 @@ public class SwingDisplay extends JPanel implements Runnable {
         return (r / 90) * 90;
     }
 
-    private Dimension rotatedPreferredSize() {
-        int w = getDisplayWidth() * scale;
-        int h = getDisplayHeight() * scale;
-        return (rotation == 90 || rotation == 270) ? new Dimension(h, w) : new Dimension(w, h);
+    private static DisplayScaleMode legacyScaleMode(int scale) {
+        if (scale <= 1) {
+            return DisplayScaleMode.EXPLICIT_1X;
+        } else if (scale == 2) {
+            return DisplayScaleMode.EXPLICIT_2X;
+        } else if (scale == 3) {
+            return DisplayScaleMode.EXPLICIT_3X;
+        } else {
+            return DisplayScaleMode.EXPLICIT_4X;
+        }
     }
 
-    // run() uploads directly into img's raster. The EDT uses the dedicated raster lock while
-    // scanning it, or alternating frames can be shown with a horizontal boundary between the
-    // old and new pictures (F-1 Race, issue #147). Do not use the component monitor here:
-    // Swing paints children while holding the AWT tree lock, and border resizing takes that
-    // lock while handling a synchronized frame callback.
+    private void requestPreferredSizeUpdate() {
+        int width;
+        int height;
+        int localRotation;
+        DisplayScaleMode localMode;
+        long revision;
+        synchronized (this) {
+            width = displayWidth;
+            height = displayHeight;
+            localRotation = rotation;
+            localMode = scaleMode;
+            revision = preferredSizeRevision.incrementAndGet();
+        }
+        Dimension preferredSize =
+                DisplayViewport.preferredSize(width, height, localRotation, localMode);
+        runOnEventDispatchThread(() -> {
+            requireEventDispatchThread("Display size update");
+            if (preferredSizeRevision.get() != revision) {
+                return;
+            }
+            Dimension appliedSize = new Dimension(preferredSize);
+            setPreferredSize(appliedSize);
+            revalidate();
+            eventBus.post(new DisplaySizeUpdatedEvent(appliedSize));
+            repaint();
+        });
+    }
+
+    /**
+     * Updates the letterbox/pillarbox color. Calls from emulation or settings threads are
+     * marshalled to the EDT.
+     */
+    public void setLetterboxColor(Color color) {
+        Color copiedColor = Objects.requireNonNull(color, "color");
+        runOnEventDispatchThread(() -> {
+            requireEventDispatchThread("Letterbox color update");
+            setBackground(copiedColor);
+            repaint();
+        });
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
+        requireEventDispatchThread("Display painting");
         super.paintComponent(g);
 
-        int localScale = scale;
-        BufferedImage localImg;
-        synchronized (rasterLock) {
-            localImg = img;
-        }
-        int w = localImg.getWidth() * localScale;
-        int h = localImg.getHeight() * localScale;
-        Graphics2D g2d = (Graphics2D) g.create();
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+        DisplayFrameSnapshot frame = displayedFrame.get();
+        DisplayViewport viewport = DisplayViewport.calculate(
+                getWidth(),
+                getHeight(),
+                frame.width(),
+                frame.height(),
+                rotation,
+                scaleMode);
+        Graphics2D frameGraphics = (Graphics2D) g.create();
+        frameGraphics.setRenderingHint(
+                RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+        frameGraphics.setRenderingHint(
+                RenderingHints.KEY_RENDERING,
+                RenderingHints.VALUE_RENDER_SPEED);
         if (rumbling) {
             rumblePhase++;
-            g2d.translate((rumblePhase & 2) == 0 ? 1 : -1, (rumblePhase & 1) == 0 ? 1 : -1);
+            frameGraphics.translate(
+                    (rumblePhase & 2) == 0 ? 1 : -1,
+                    (rumblePhase & 1) == 0 ? 1 : -1);
         }
-        switch (rotation) {
-            case 90 -> {
-                g2d.translate(h, 0);
-                g2d.rotate(Math.PI / 2);
-            }
-            case 180 -> {
-                g2d.translate(w, h);
-                g2d.rotate(Math.PI);
-            }
-            case 270 -> {
-                g2d.translate(0, w);
-                g2d.rotate(3 * Math.PI / 2);
-            }
-            default -> {
-            }
-        }
-        synchronized (rasterLock) {
-            g2d.drawImage(localImg, 0, 0, w, h, null);
-        }
-        paintNotification(g2d, w, h, localScale);
-        g2d.dispose();
+        frameGraphics.transform(viewport.sourceToComponentTransform());
+        frame.paint(frameGraphics);
+        frameGraphics.dispose();
+
+        Graphics2D notificationGraphics = (Graphics2D) g.create();
+        paintNotification(notificationGraphics, viewport);
+        notificationGraphics.dispose();
     }
 
     private void showNotification(String text) {
@@ -255,7 +312,7 @@ public class SwingDisplay extends JPanel implements Runnable {
     }
 
     private void repaintNotification(int repaintAfterMs) {
-        SwingUtilities.invokeLater(() -> {
+        runOnEventDispatchThread(() -> {
             repaint();
             if (repaintAfterMs > 0) {
                 Timer timer = new Timer(repaintAfterMs, e -> repaint());
@@ -265,13 +322,15 @@ public class SwingDisplay extends JPanel implements Runnable {
         });
     }
 
-    private void paintNotification(Graphics2D g, int width, int height, int localScale) {
+    private void paintNotification(Graphics2D g, DisplayViewport viewport) {
         String persistentText = persistentNotificationText;
         String text = persistentText != null ? persistentText : notificationText;
         if (text == null || (persistentText == null && System.nanoTime() >= notificationExpiresAt)) {
             return;
         }
 
+        Rectangle bounds = viewport.paintBounds();
+        int localScale = Math.max(1, (int) Math.floor(viewport.scale()));
         int fontSize = Math.max(12, 7 * localScale);
         g.setFont(new Font(Font.SANS_SERIF, Font.BOLD, fontSize));
         FontMetrics metrics = g.getFontMetrics();
@@ -279,8 +338,8 @@ public class SwingDisplay extends JPanel implements Runnable {
         int paddingY = Math.max(4, 2 * localScale);
         int boxWidth = metrics.stringWidth(text) + 2 * paddingX;
         int boxHeight = metrics.getHeight() + 2 * paddingY;
-        int x = (width - boxWidth) / 2;
-        int y = height - boxHeight - Math.max(4, 4 * localScale);
+        int x = bounds.x + (bounds.width - boxWidth) / 2;
+        int y = bounds.y + bounds.height - boxHeight - Math.max(4, 4 * localScale);
         int arc = Math.max(6, 4 * localScale);
 
         g.setColor(new Color(0, 0, 0, 190));
@@ -289,45 +348,40 @@ public class SwingDisplay extends JPanel implements Runnable {
         g.drawString(text, x + paddingX, y + paddingY + metrics.getAscent());
     }
 
-    private int getDisplayWidth() {
-        return isSgbBorder ? SGB_DISPLAY_WIDTH : DISPLAY_WIDTH;
-    }
-
-    private int getDisplayHeight() {
-        return isSgbBorder ? SGB_DISPLAY_HEIGHT : DISPLAY_HEIGHT;
-    }
-
     @Override
     public void run() {
         doStop = false;
         isStopped = false;
-        frameIsWaiting = false;
 
         while (!doStop) {
+            PendingFrame frame;
             synchronized (this) {
-                if (frameIsWaiting) {
-                    if (blending) {
-                        if (resetBlendForWaitingFrame) {
-                            // LCD-off is a new panel state, not another rendered frame to
-                            // average. Retaining a partial scanout here creates ghost sprites.
-                            previousFrame = null;
-                        }
-                        blendWithPreviousFrame();
-                    }
-                    synchronized (rasterLock) {
-                        System.arraycopy(waitingFrame, 0, imgPixels, 0,
-                                getDisplayWidth() * getDisplayHeight());
-                    }
-                    repaint();
-                    frameIsWaiting = false;
-                } else {
+                while (!doStop && pendingFrame == null) {
                     try {
                         wait(10);
                     } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
+                        Thread.currentThread().interrupt();
+                        doStop = true;
                     }
                 }
+                if (doStop) {
+                    break;
+                }
+                frame = pendingFrame;
+                pendingFrame = null;
+                if (blending) {
+                    if (frame.resetBlend()) {
+                        // LCD-off is a new panel state, not another rendered frame to
+                        // average. Retaining a partial scanout here creates ghost sprites.
+                        previousFrame = null;
+                    }
+                    blendWithPreviousFrame(frame.rgb());
+                }
             }
+
+            displayedFrame.set(DisplayFrameSnapshot.copyOf(
+                    frame.width(), frame.height(), frame.rgb()));
+            requestRepaint();
         }
         isStopped = true;
         synchronized (this) {
@@ -338,11 +392,13 @@ public class SwingDisplay extends JPanel implements Runnable {
     public void stop() {
         doStop = true;
         synchronized (this) {
+            notifyAll();
             while (!isStopped) {
                 try {
                     wait(10);
                 } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    return;
                 }
             }
         }
@@ -350,6 +406,10 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private synchronized void setColorCorrection(boolean colorCorrection) {
         this.colorCorrection = colorCorrection;
+    }
+
+    private synchronized void setGrayscale(boolean grayscale) {
+        this.grayscale = grayscale;
     }
 
     private synchronized void setBlending(boolean blending) {
@@ -361,22 +421,49 @@ public class SwingDisplay extends JPanel implements Runnable {
      * Approximates the ghosting of the original LCD by averaging with the previous frame;
      * games flickering sprites at 30 Hz (like Chikyuu Kaihou Gun ZAS) rely on it.
      */
-    private void blendWithPreviousFrame() {
-        int size = getDisplayWidth() * getDisplayHeight();
+    private void blendWithPreviousFrame(int[] frame) {
+        int size = frame.length;
         if (previousFrame == null || previousFrame.length != size) {
-            previousFrame = new int[size];
-            System.arraycopy(waitingFrame, 0, previousFrame, 0, size);
+            previousFrame = frame.clone();
             return;
         }
         for (int i = 0; i < size; i++) {
-            int a = waitingFrame[i];
+            int a = frame[i];
             int b = previousFrame[i];
             previousFrame[i] = a;
-            waitingFrame[i] = (((a ^ b) & 0xfefefe) >> 1) + (a & b);
+            frame[i] = (((a ^ b) & 0xfefefe) >> 1) + (a & b);
+        }
+    }
+
+    DisplayFrameSnapshot displayedFrame() {
+        return displayedFrame.get();
+    }
+
+    private void requestRepaint() {
+        runOnEventDispatchThread(this::repaint);
+    }
+
+    private static void runOnEventDispatchThread(Runnable runnable) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            runnable.run();
+        } else {
+            SwingUtilities.invokeLater(runnable);
+        }
+    }
+
+    private static void requireEventDispatchThread(String operation) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            throw new IllegalStateException(operation + " must run on the Event Dispatch Thread");
         }
     }
 
     public record SetScaleEvent(int scale) implements Event {
+    }
+
+    public record SetScaleModeEvent(DisplayScaleMode mode) implements Event {
+        public SetScaleModeEvent {
+            Objects.requireNonNull(mode, "mode");
+        }
     }
 
     public record SetGrayscaleEvent(boolean grayscale) implements Event {
@@ -388,9 +475,26 @@ public class SwingDisplay extends JPanel implements Runnable {
     public record SetRotationEvent(int rotation) implements Event {
     }
 
+    public record SetLetterboxColorEvent(Color color) implements Event {
+        public SetLetterboxColorEvent {
+            Objects.requireNonNull(color, "color");
+        }
+    }
+
     public record SetBlendingEvent(boolean blending) implements Event {
     }
 
     public record DisplaySizeUpdatedEvent(Dimension preferredSize) implements Event {
+        public DisplaySizeUpdatedEvent {
+            preferredSize = new Dimension(Objects.requireNonNull(preferredSize, "preferredSize"));
+        }
+
+        @Override
+        public Dimension preferredSize() {
+            return new Dimension(preferredSize);
+        }
+    }
+
+    private record PendingFrame(int width, int height, int[] rgb, boolean resetBlend) {
     }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDisplayControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDisplayControllerTest.kt
@@ -1,0 +1,189 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay
+import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
+import eu.rekawek.coffeegb.swing.io.SwingDisplay
+import java.awt.Color
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DesktopDisplayControllerTest {
+  @Test
+  fun `one coordinator persists and publishes the complete live display state`() {
+    val initial = ApplicationSettings.Display()
+    val settings = FakeDisplaySettings(initial)
+    val fullscreen = FakeFullscreenRuntime()
+    val eventBus = EventBusImpl()
+    var scaleMode: DisplayScaleMode? = null
+    var rotation: Int? = null
+    var grayscale: Boolean? = null
+    var blending: Boolean? = null
+    var colorCorrection: Boolean? = null
+    var letterbox: Color? = null
+    var sgbBorder: Boolean? = null
+    var synchronized: ApplicationSettings.Display? = null
+    eventBus.register<SwingDisplay.SetScaleModeEvent> { scaleMode = it.mode() }
+    eventBus.register<SwingDisplay.SetRotationEvent> { rotation = it.rotation() }
+    eventBus.register<SwingDisplay.SetGrayscaleEvent> { grayscale = it.grayscale() }
+    eventBus.register<SwingDisplay.SetBlendingEvent> { blending = it.blending() }
+    eventBus.register<SwingDisplay.SetColorCorrectionEvent> {
+      colorCorrection = it.colorCorrection()
+    }
+    eventBus.register<SwingDisplay.SetLetterboxColorEvent> { letterbox = it.color() }
+    eventBus.register<SgbDisplay.SetSgbBorder> { sgbBorder = it.borderEnabled() }
+    eventBus.register<DisplaySettingsChangedEvent> { synchronized = it.display }
+
+    val updated =
+        initial.copy(
+            scalingMode = ApplicationSettings.DisplayScalingMode.EXPLICIT,
+            explicitScale = 3,
+            letterboxColor = 0x123456,
+            fullscreen = true,
+            rotation = ApplicationSettings.Rotation.DEG_270,
+            grayscale = true,
+            blending = false,
+            colorCorrection = false,
+            showSgbBorder = true,
+        )
+    lateinit var controller: DesktopDisplayController
+    SwingUtilities.invokeAndWait {
+      controller = DesktopDisplayController(settings, eventBus, fullscreen)
+      controller.apply(updated, persist = true)
+    }
+
+    assertEquals(updated, settings.display)
+    assertEquals(1, settings.replacements)
+    assertEquals(DisplayScaleMode.EXPLICIT_3X, scaleMode)
+    assertEquals(270, rotation)
+    assertEquals(true, grayscale)
+    assertEquals(false, blending)
+    assertEquals(false, colorCorrection)
+    assertEquals(Color(0x123456), letterbox)
+    assertEquals(true, sgbBorder)
+    assertEquals(updated, synchronized)
+    assertTrue(fullscreen.fullscreenState)
+
+    SwingUtilities.invokeAndWait {
+      controller.update {
+        it.copy(
+            scalingMode = ApplicationSettings.DisplayScalingMode.INTEGER_FIT,
+            fullscreen = false,
+        )
+      }
+      controller.close()
+    }
+    assertEquals(DisplayScaleMode.INTEGER_FIT, scaleMode)
+    assertFalse(fullscreen.fullscreenState)
+    assertTrue(fullscreen.closed)
+    eventBus.close()
+  }
+
+  @Test
+  fun `applying an already persisted preference draft does not write it twice`() {
+    val display =
+        ApplicationSettings.Display(
+            scalingMode = ApplicationSettings.DisplayScalingMode.ASPECT_FIT,
+            letterboxColor = 0x010203,
+        )
+    val settings = FakeDisplaySettings(display)
+    val fullscreen = FakeFullscreenRuntime()
+    val eventBus = EventBusImpl()
+    var published: ApplicationSettings.Display? = null
+    eventBus.register<DisplaySettingsChangedEvent> { published = it.display }
+
+    SwingUtilities.invokeAndWait {
+      DesktopDisplayController(settings, eventBus, fullscreen)
+          .apply(display, persist = false)
+    }
+
+    assertEquals(0, settings.replacements)
+    assertEquals(display, published)
+    eventBus.close()
+  }
+
+  @Test
+  fun `fullscreen boundaries refresh sizing around transitions even when geometry events repeat`() {
+    val initial = ApplicationSettings.Display(fullscreen = true)
+    val settings = FakeDisplaySettings(initial)
+    val operations = mutableListOf<String>()
+    val fullscreen =
+        FakeFullscreenRuntime(fullscreenState = true) { enabled ->
+          operations += "fullscreen:$enabled"
+        }
+    val eventBus = EventBusImpl()
+    eventBus.register<SwingDisplay.SetScaleModeEvent> { operations += "scale" }
+    val controller =
+        onEdt {
+          DesktopDisplayController(
+              settings,
+              eventBus,
+              fullscreen,
+              DisplayWindowSizingRuntime { windowed -> operations += "windowed:$windowed" },
+          )
+        }
+
+    onEdt { controller.apply(initial.copy(fullscreen = false), persist = true) }
+    assertEquals(listOf("fullscreen:false", "scale", "windowed:true"), operations)
+
+    operations.clear()
+    onEdt { controller.apply(initial.copy(fullscreen = true), persist = true) }
+    assertEquals(listOf("windowed:false", "scale", "fullscreen:true"), operations)
+
+    // A source/explicit-size change while fullscreen uses the base fullscreen minimum. Exiting
+    // must still force a windowed sizing refresh even if the subsequent scale event is unchanged.
+    operations.clear()
+    val larger = initial.copy(explicitScale = 4, fullscreen = true)
+    onEdt { controller.apply(larger, persist = true) }
+    assertEquals(listOf("scale"), operations)
+
+    operations.clear()
+    onEdt { controller.apply(larger.copy(fullscreen = false), persist = true) }
+    assertEquals(listOf("fullscreen:false", "scale", "windowed:true"), operations)
+    eventBus.close()
+  }
+
+  private fun <T> onEdt(action: () -> T): T {
+    var result: Result<T>? = null
+    SwingUtilities.invokeAndWait { result = runCatching(action) }
+    return checkNotNull(result).getOrThrow()
+  }
+
+  private class FakeDisplaySettings(
+      var display: ApplicationSettings.Display,
+  ) : DisplaySettingsAccess {
+    var replacements = 0
+
+    override fun current(): ApplicationSettings.Display = display
+
+    override fun replace(display: ApplicationSettings.Display) {
+      this.display = display
+      replacements++
+    }
+  }
+
+  private class FakeFullscreenRuntime(
+      var fullscreenState: Boolean = false,
+      private val onSet: (Boolean) -> Unit = {},
+  ) : FullscreenRuntime {
+    var closed = false
+
+    override fun isFullscreen(): Boolean = fullscreenState
+
+    override fun setFullscreen(fullscreen: Boolean) {
+      this.fullscreenState = fullscreen
+      onSet(fullscreen)
+    }
+
+    override fun refreshScreens() = Unit
+
+    override fun close() {
+      closed = true
+    }
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
@@ -365,7 +365,7 @@ class DevicePreferencesEditorsTest {
       assertEquals("Gamepads", panel.tabs.getTitleAt(panel.tabs.selectedIndex))
       assertTrue(panel.validationSummary.text.contains("multiple players"))
       assertEquals(
-          listOf("General", "Input", "Gamepads", "Audio"),
+          listOf("General", "Display", "Input", "Gamepads", "Audio"),
           (0 until panel.tabs.tabCount).map(panel.tabs::getTitleAt),
       )
       assertEquals("Gamepad preferences", panel.gamepadEditor.accessibleContext.accessibleName)

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditorTest.kt
@@ -1,0 +1,205 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import java.awt.Component
+import java.awt.Container
+import java.awt.event.KeyEvent
+import java.util.concurrent.FutureTask
+import javax.swing.JLabel
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DisplayPreferencesEditorTest {
+
+  @Test
+  fun `all display fields produce one validated immutable draft`() =
+      onEdt {
+        val editor = DisplayPreferencesEditor(ApplicationSettings.Display())
+
+        selectScalingMode(editor, ApplicationSettings.DisplayScalingMode.INTEGER_FIT)
+        selectScale(editor, 4)
+        editor.letterboxColor.text = "#1a2B3c"
+        editor.fullscreen.isSelected = true
+        selectRotation(editor, ApplicationSettings.Rotation.DEG_270)
+        editor.grayscale.isSelected = true
+        editor.blending.isSelected = false
+        editor.colorCorrection.isSelected = false
+        editor.showSgbBorder.isSelected = true
+
+        assertEquals(
+            ApplicationSettings.Display(
+                scalingMode = ApplicationSettings.DisplayScalingMode.INTEGER_FIT,
+                explicitScale = 4,
+                letterboxColor = 0x1A2B3C,
+                fullscreen = true,
+                grayscale = true,
+                blending = false,
+                colorCorrection = false,
+                rotation = ApplicationSettings.Rotation.DEG_270,
+                showSgbBorder = true,
+            ),
+            editor.validatedDisplay(),
+        )
+      }
+
+  @Test
+  fun `explicit scale is enabled only in explicit mode without losing its draft value`() =
+      onEdt {
+        val editor =
+            DisplayPreferencesEditor(
+                ApplicationSettings.Display(
+                    scalingMode = ApplicationSettings.DisplayScalingMode.EXPLICIT,
+                    explicitScale = 3,
+                ))
+
+        assertTrue(editor.explicitScale.isEnabled)
+        selectScalingMode(editor, ApplicationSettings.DisplayScalingMode.ASPECT_FIT)
+        assertFalse(editor.explicitScale.isEnabled)
+        selectScalingMode(editor, ApplicationSettings.DisplayScalingMode.INTEGER_FIT)
+        assertFalse(editor.explicitScale.isEnabled)
+        selectScalingMode(editor, ApplicationSettings.DisplayScalingMode.EXPLICIT)
+        assertTrue(editor.explicitScale.isEnabled)
+        assertEquals(3, editor.validatedDisplay().explicitScale)
+      }
+
+  @Test
+  fun `letterbox field updates its preview and reports malformed RGB at the field`() =
+      onEdt {
+        val editor =
+            DisplayPreferencesEditor(
+                ApplicationSettings.Display(letterboxColor = 0x112233))
+
+        editor.letterboxColor.text = "#aBcDeF"
+        assertEquals(0xABCDEF, editor.letterboxPreview.background.rgb and 0xFFFFFF)
+        assertEquals("#ABCDEF", editor.letterboxPreview.accessibleContext.accessibleDescription)
+        assertEquals(0xABCDEF, editor.validatedDisplay().letterboxColor)
+
+        editor.letterboxColor.text = "ABCDEF"
+        val failure =
+            assertFailsWith<PreferenceEditorValidationException> {
+              editor.validatedDisplay()
+            }
+        assertSame(editor.letterboxColor, failure.invalidComponent)
+        assertEquals("Enter a color in #RRGGBB form.", editor.letterboxColorError.text)
+        assertEquals(0xABCDEF, editor.letterboxPreview.background.rgb and 0xFFFFFF)
+      }
+
+  @Test
+  fun `restore defaults changes the draft only and refreshes dependent controls`() =
+      onEdt {
+        val defaults =
+            ApplicationSettings.Display(
+                scalingMode = ApplicationSettings.DisplayScalingMode.ASPECT_FIT,
+                explicitScale = 1,
+                letterboxColor = 0x445566,
+                fullscreen = true,
+                grayscale = true,
+                blending = false,
+                colorCorrection = false,
+                rotation = ApplicationSettings.Rotation.DEG_180,
+                showSgbBorder = true,
+            )
+        val editor =
+            DisplayPreferencesEditor(
+                ApplicationSettings.Display(
+                    scalingMode = ApplicationSettings.DisplayScalingMode.EXPLICIT,
+                    explicitScale = 4,
+                    letterboxColor = 0xFFFFFF,
+                ),
+                defaults,
+            )
+
+        editor.restoreDefaults()
+
+        assertEquals(defaults, editor.validatedDisplay())
+        assertEquals("#445566", editor.letterboxColor.text)
+        assertFalse(editor.explicitScale.isEnabled)
+      }
+
+  @Test
+  fun `display controls have accessible names label associations and mnemonics`() =
+      onEdt {
+        val editor = DisplayPreferencesEditor(ApplicationSettings.Display())
+        val labels = descendants(editor).filterIsInstance<JLabel>().toList()
+
+        assertSame(
+            editor.scalingMode,
+            labels.single { it.text == "Scaling mode:" }.labelFor,
+        )
+        assertSame(
+            editor.explicitScale,
+            labels.single { it.text == "Explicit scale:" }.labelFor,
+        )
+        assertSame(
+            editor.letterboxColor,
+            labels.single { it.text == "Letterbox color:" }.labelFor,
+        )
+        assertSame(
+            editor.rotation,
+            labels.single { it.text == "Rotation:" }.labelFor,
+        )
+        assertEquals(
+            KeyEvent.VK_S,
+            labels.single { it.text == "Scaling mode:" }.displayedMnemonic,
+        )
+        assertEquals("Display scaling mode", editor.scalingMode.accessibleContext.accessibleName)
+        assertEquals(
+            "Letterbox color preview",
+            editor.letterboxPreview.accessibleContext.accessibleName,
+        )
+        assertEquals("Fullscreen", editor.fullscreen.accessibleContext.accessibleName)
+      }
+
+  @Test
+  fun `display editor rejects construction outside the Event Dispatch Thread`() {
+    assertFailsWith<IllegalStateException> {
+      DisplayPreferencesEditor(ApplicationSettings.Display())
+    }
+  }
+
+  private fun selectScalingMode(
+      editor: DisplayPreferencesEditor,
+      mode: ApplicationSettings.DisplayScalingMode,
+  ) {
+    editor.scalingMode.selectedItem =
+        (0 until editor.scalingMode.itemCount)
+            .map(editor.scalingMode::getItemAt)
+            .single { it.mode == mode }
+  }
+
+  private fun selectScale(editor: DisplayPreferencesEditor, scale: Int) {
+    editor.explicitScale.selectedItem =
+        (0 until editor.explicitScale.itemCount)
+            .map(editor.explicitScale::getItemAt)
+            .single { it.scale == scale }
+  }
+
+  private fun selectRotation(
+      editor: DisplayPreferencesEditor,
+      rotation: ApplicationSettings.Rotation,
+  ) {
+    editor.rotation.selectedItem =
+        (0 until editor.rotation.itemCount)
+            .map(editor.rotation::getItemAt)
+            .single { it.rotation == rotation }
+  }
+
+  private fun descendants(component: Component): Sequence<Component> =
+      sequence {
+        yield(component)
+        if (component is Container) {
+          component.components.forEach { yieldAll(descendants(it)) }
+        }
+      }
+
+  private fun <T> onEdt(action: () -> T): T {
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/FullscreenControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/FullscreenControllerTest.kt
@@ -1,0 +1,440 @@
+package eu.rekawek.coffeegb.swing
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FullscreenControllerTest {
+
+  @Test
+  fun `enter and exit use the required dispose decoration bounds show order`() {
+    val primary = screen("primary", bounds(0, 0, 1920, 1080), bounds(0, 0, 1920, 1040))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val initial = bounds(120, 80, 800, 600)
+    val window = FakeWindow(FullscreenWindowSnapshot(initial, "primary", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+
+    assertTrue(controller.isFullscreen())
+    assertEquals("primary", controller.activeScreenId())
+    assertEquals(
+        listOf(
+            WindowOperation.Dispose,
+            WindowOperation.Decoration(true),
+            WindowOperation.Bounds(primary.fullBounds),
+            WindowOperation.Show,
+        ),
+        window.operations,
+    )
+
+    controller.exitFullscreen()
+
+    assertFalse(controller.isFullscreen())
+    assertEquals(null, controller.activeScreenId())
+    assertEquals(
+        listOf(
+            WindowOperation.Dispose,
+            WindowOperation.Decoration(true),
+            WindowOperation.Bounds(primary.fullBounds),
+            WindowOperation.Show,
+            WindowOperation.Dispose,
+            WindowOperation.Decoration(false),
+            WindowOperation.Bounds(initial),
+            WindowOperation.Show,
+        ),
+        window.operations,
+    )
+  }
+
+  @Test
+  fun `exit restores the previous decoration state`() {
+    val primary = screen("primary", bounds(0, 0, 1280, 720))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(30, 40, 640, 480), "primary", true))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Decoration(true), window.operations[5])
+  }
+
+  @Test
+  fun `explicit transitions are idempotent while toggle alternates`() {
+    val primary = screen("primary", bounds(0, 0, 1280, 720))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(30, 40, 640, 480), "primary", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+    controller.enterFullscreen()
+    assertEquals(4, window.operations.size)
+
+    controller.exitFullscreen()
+    controller.exitFullscreen()
+    assertEquals(8, window.operations.size)
+
+    controller.toggleFullscreen()
+    assertTrue(controller.isFullscreen())
+    controller.toggleFullscreen()
+    assertFalse(controller.isFullscreen())
+    assertEquals(16, window.operations.size)
+  }
+
+  @Test
+  fun `stable ID distinguishes monitors with identical geometry and scale`() {
+    val first = screen("display-a", bounds(0, 0, 1920, 1080))
+    val second = screen("display-b", bounds(0, 0, 1920, 1080))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(first, second), "display-a"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(100, 100, 700, 500), "display-b", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+
+    assertEquals("display-b", controller.activeScreenId())
+  }
+
+  @Test
+  fun `disconnected stable ID recovers even when replacement geometry is identical`() {
+    val first = screen("display-a", bounds(0, 0, 1920, 1080))
+    val removed = screen("display-b", bounds(0, 0, 1920, 1080))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(first, removed), "display-a"))
+    val initial = bounds(100, 100, 700, 500)
+    val window = FakeWindow(FullscreenWindowSnapshot(initial, "display-b", false))
+    val controller = controller(window, provider)
+    controller.enterFullscreen()
+    window.operations.clear()
+
+    provider.layout = ScreenLayout(listOf(first), "display-a")
+    controller.refreshScreens()
+
+    assertEquals("display-a", controller.activeScreenId())
+    assertTrue(window.operations.isEmpty())
+
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(initial), window.operations[2])
+  }
+
+  @Test
+  fun `disconnected monitor moves fullscreen and restored window to nearest current screen`() {
+    val primary = screen("primary", bounds(0, 0, 1000, 800))
+    val removed =
+        screen(
+            "removed",
+            bounds(5000, 0, 1000, 800),
+            bounds(5000, 0, 1000, 760),
+        )
+    val nearest =
+        screen(
+            "nearest",
+            bounds(6300, 0, 1000, 800),
+            bounds(6300, 0, 1000, 760),
+        )
+    val provider =
+        MutableScreenProvider(ScreenLayout(listOf(primary, removed, nearest), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(5100, 70, 700, 500), "removed", false))
+    val controller = controller(window, provider)
+    controller.enterFullscreen()
+    window.operations.clear()
+
+    provider.layout = ScreenLayout(listOf(primary, nearest), "primary")
+    controller.refreshScreens()
+
+    assertEquals("nearest", controller.activeScreenId())
+    assertEquals(
+        listOf<WindowOperation>(WindowOperation.Bounds(nearest.fullBounds)),
+        window.operations,
+    )
+
+    controller.exitFullscreen()
+
+    assertEquals(
+        WindowOperation.Bounds(bounds(6400, 70, 700, 500)),
+        window.operations[window.operations.lastIndex - 1],
+    )
+  }
+
+  @Test
+  fun `equal-distance disconnected monitor fallback prefers primary then stable ID`() {
+    val removed = screen("removed", bounds(1000, 0, 1000, 800))
+    val primary = screen("primary", bounds(0, 0, 1000, 800))
+    val other = screen("other", bounds(2000, 0, 1000, 800))
+    val provider =
+        MutableScreenProvider(ScreenLayout(listOf(other, primary, removed), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(1100, 50, 500, 400), "removed", false))
+    val controller = controller(window, provider)
+    controller.enterFullscreen()
+
+    provider.layout = ScreenLayout(listOf(other, primary), "primary")
+    controller.refreshScreens()
+
+    assertEquals("primary", controller.activeScreenId())
+  }
+
+  @Test
+  fun `negative monitor coordinates remain negative after restore`() {
+    val left =
+        screen(
+            "left",
+            bounds(-1920, -120, 1920, 1080),
+            bounds(-1920, -80, 1920, 1040),
+        )
+    val primary = screen("primary", bounds(0, 0, 1920, 1080))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary, left), "primary"))
+    val initial = bounds(-1800, -40, 900, 600)
+    val window = FakeWindow(FullscreenWindowSnapshot(initial, "left", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(initial), window.operations[6])
+  }
+
+  @Test
+  fun `per-monitor scale change preserves device placement and exact fullscreen bounds`() {
+    val initialScreen =
+        screen(
+            "primary",
+            bounds(0, 0, 1536, 864),
+            bounds(0, 0, 1536, 824),
+            scaleX = 1.25,
+            scaleY = 1.25,
+        )
+    val provider = MutableScreenProvider(ScreenLayout(listOf(initialScreen), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(100, 80, 800, 600), "primary", false))
+    val controller = controller(window, provider, DesktopSize(160, 144))
+    controller.enterFullscreen()
+    window.operations.clear()
+
+    val changedScreen =
+        screen(
+            "primary",
+            bounds(0, 0, 960, 540),
+            bounds(0, 0, 960, 500),
+            scaleX = 2.0,
+            scaleY = 2.0,
+        )
+    provider.layout = ScreenLayout(listOf(changedScreen), "primary")
+    controller.refreshScreens()
+    controller.refreshScreens()
+
+    // Refresh sets the exact GraphicsConfiguration rectangle once, without scale arithmetic.
+    assertEquals(
+        listOf<WindowOperation>(WindowOperation.Bounds(changedScreen.fullBounds)),
+        window.operations,
+    )
+
+    controller.exitFullscreen()
+
+    // 100*1.25/2 rounds to 63; 80*1.25/2 is 50. Physical 1000x750 becomes 500x375.
+    val restored = bounds(63, 50, 500, 375)
+    assertEquals(
+        WindowOperation.Bounds(restored),
+        window.operations[window.operations.lastIndex - 1],
+    )
+    assertTrue(restored.rightExclusive <= changedScreen.usableBounds.rightExclusive)
+    assertTrue(restored.bottomExclusive <= changedScreen.usableBounds.bottomExclusive)
+  }
+
+  @Test
+  fun `tiny remembered bounds grow to minimum size`() {
+    val primary =
+        screen("primary", bounds(0, 0, 1200, 900), bounds(0, 0, 1200, 860))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(400, 300, 10, 8), "primary", false))
+    val controller = controller(window, provider, DesktopSize(320, 288))
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(bounds(400, 300, 320, 288)), window.operations[6])
+  }
+
+  @Test
+  fun `oversized remembered bounds shrink to current usable screen`() {
+    val primary =
+        screen("primary", bounds(0, 0, 1920, 1080), bounds(0, 0, 1920, 1040))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(100, 100, 4000, 3000), "primary", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(primary.usableBounds), window.operations[6])
+  }
+
+  @Test
+  fun `off-screen remembered bounds clamp without forcing legitimate coordinates positive`() {
+    val primary =
+        screen("primary", bounds(0, 0, 1920, 1080), bounds(0, 0, 1920, 1040))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(5000, -3000, 800, 600), "primary", false))
+    val controller = controller(window, provider)
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(bounds(1120, 0, 800, 600)), window.operations[6])
+  }
+
+  @Test
+  fun `screen smaller than minimum uses the complete usable screen`() {
+    val tiny = screen("tiny", bounds(-100, -100, 120, 90), bounds(-95, -95, 100, 70))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(tiny), "tiny"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(-90, -90, 5, 5), "tiny", false))
+    val controller = controller(window, provider, DesktopSize(320, 288))
+
+    controller.enterFullscreen()
+    controller.exitFullscreen()
+
+    assertEquals(WindowOperation.Bounds(tiny.usableBounds), window.operations[6])
+  }
+
+  @Test
+  fun `missing screen ID uses overlap then nearest geometry deterministically`() {
+    val primary = screen("primary", bounds(0, 0, 1000, 800))
+    val right = screen("right", bounds(1000, 0, 1000, 800))
+    val layout = ScreenLayout(listOf(right, primary), "primary")
+
+    assertEquals(
+        "right",
+        layout.resolve("disconnected", bounds(1500, 100, 300, 300)).screenId,
+    )
+    assertEquals(
+        "right",
+        layout.resolve("disconnected", bounds(2400, 100, 200, 200)).screenId,
+    )
+    // The reference is equidistant/touching both screens, so the declared primary wins.
+    assertEquals(
+        "primary",
+        layout.resolve("disconnected", bounds(999, 900, 2, 10)).screenId,
+    )
+  }
+
+  @Test
+  fun `all transition entry points reject non-EDT access before observing dependencies`() {
+    val primary = screen("primary", bounds(0, 0, 1000, 800))
+    val provider = MutableScreenProvider(ScreenLayout(listOf(primary), "primary"))
+    val window =
+        FakeWindow(FullscreenWindowSnapshot(bounds(100, 100, 500, 400), "primary", false))
+    val controller =
+        FullscreenController(
+            window,
+            provider,
+            DesktopSize(320, 288),
+            EdtOwnership { false },
+        )
+
+    assertFailsWith<IllegalStateException> { controller.enterFullscreen() }
+    assertFailsWith<IllegalStateException> { controller.exitFullscreen() }
+    assertFailsWith<IllegalStateException> { controller.toggleFullscreen() }
+    assertFailsWith<IllegalStateException> { controller.refreshScreens() }
+
+    assertFalse(controller.isFullscreen())
+    assertTrue(window.operations.isEmpty())
+    assertEquals(0, provider.snapshotCalls)
+  }
+
+  @Test
+  fun `screen snapshots validate transforms IDs and usable geometry`() {
+    assertFailsWith<IllegalArgumentException> {
+      screen("", bounds(0, 0, 100, 100))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      screen("screen", bounds(0, 0, 100, 100), bounds(-1, 0, 100, 100))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      screen("screen", bounds(0, 0, 100, 100), scaleX = Double.NaN)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      ScreenLayout(
+          listOf(
+              screen("duplicate", bounds(0, 0, 100, 100)),
+              screen("duplicate", bounds(100, 0, 100, 100)),
+          ))
+    }
+
+    val mutable = mutableListOf(screen("stable", bounds(0, 0, 100, 100)))
+    val layout = ScreenLayout(mutable, "stable")
+    mutable.clear()
+    assertEquals(listOf("stable"), layout.screens.map(ScreenSnapshot::screenId))
+  }
+
+  private fun controller(
+      window: FakeWindow,
+      provider: MutableScreenProvider,
+      minimum: DesktopSize = DesktopSize(320, 288),
+  ): FullscreenController =
+      FullscreenController(window, provider, minimum, EdtOwnership { true })
+
+  private fun screen(
+      id: String,
+      full: DesktopBounds,
+      usable: DesktopBounds = full,
+      scaleX: Double = 1.0,
+      scaleY: Double = 1.0,
+  ): ScreenSnapshot = ScreenSnapshot(id, full, usable, scaleX, scaleY)
+
+  private fun bounds(x: Int, y: Int, width: Int, height: Int): DesktopBounds =
+      DesktopBounds(x, y, width, height)
+
+  private class MutableScreenProvider(var layout: ScreenLayout) : ScreenLayoutProvider {
+    var snapshotCalls = 0
+
+    override fun snapshot(): ScreenLayout {
+      snapshotCalls++
+      return layout
+    }
+  }
+
+  private class FakeWindow(initial: FullscreenWindowSnapshot) : FullscreenWindow {
+    var current = initial
+    val operations = mutableListOf<WindowOperation>()
+
+    override fun snapshot(): FullscreenWindowSnapshot = current
+
+    override fun dispose() {
+      operations += WindowOperation.Dispose
+    }
+
+    override fun setUndecorated(undecorated: Boolean) {
+      operations += WindowOperation.Decoration(undecorated)
+      current = current.copy(undecorated = undecorated)
+    }
+
+    override fun setBounds(bounds: DesktopBounds) {
+      operations += WindowOperation.Bounds(bounds)
+      current = current.copy(bounds = bounds)
+    }
+
+    override fun showWindow() {
+      operations += WindowOperation.Show
+    }
+  }
+
+  private sealed interface WindowOperation {
+    data object Dispose : WindowOperation
+
+    data class Decoration(val undecorated: Boolean) : WindowOperation
+
+    data class Bounds(val bounds: DesktopBounds) : WindowOperation
+
+    data object Show : WindowOperation
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -54,7 +54,11 @@ class PreferencesDialogTest {
                     recentFileCapacity = 4,
                     romChangeConfirmationPolicy = RomChangeConfirmationPolicy.ALWAYS,
                 ),
-            display = ApplicationSettings.Display(scale = 4, grayscale = true),
+            display =
+                ApplicationSettings.Display(
+                    explicitScale = 4,
+                    grayscale = true,
+                ),
             audio = ApplicationSettings.Audio(enabled = false),
             input = currentInput,
             saves = ApplicationSettings.Saves(batterySavesEnabled = false),
@@ -64,6 +68,12 @@ class PreferencesDialogTest {
             romDirectory = Paths.get("new"),
             recentFileCapacity = 2,
             confirmationPolicy = RomChangeConfirmationPolicy.NEVER,
+            display =
+                ApplicationSettings.Display(
+                    scalingMode = ApplicationSettings.DisplayScalingMode.ASPECT_FIT,
+                    letterboxColor = 0x202020,
+                    fullscreen = true,
+                ),
             keyboard = emptyMap(),
             gamepads = mapOf(0 to GamepadSelection.Disabled),
             gamepadTunings =
@@ -87,7 +97,7 @@ class PreferencesDialogTest {
     assertTrue(updated.input.keyboard.isEmpty())
     assertEquals(edit.gamepads, updated.input.gamepads)
     assertEquals(edit.gamepadTunings, updated.input.gamepadTunings)
-    assertEquals(current.display, updated.display)
+    assertEquals(edit.display, updated.display)
     assertEquals(edit.audio, updated.audio)
     assertEquals(current.saves, updated.saves)
     assertEquals(current.advanced, updated.advanced)
@@ -115,6 +125,7 @@ class PreferencesDialogTest {
         assertEquals(ApplicationSettings.DEFAULT_RECENT_FILE_CAPACITY, received?.recentFileCapacity)
         assertEquals(ApplicationSettings.Input.defaults().keyboard, received?.keyboard)
         assertEquals(ApplicationSettings.Input.defaults().gamepads, received?.gamepads)
+        assertEquals(ApplicationSettings.Display(), received?.display)
         assertEquals(ApplicationSettings.Audio(), received?.audio)
       }
 
@@ -139,6 +150,13 @@ class PreferencesDialogTest {
                         enabled = false,
                         volume = 13,
                         latency = ApplicationSettings.AudioLatency.LOW,
+                    ),
+                display =
+                    ApplicationSettings.Display(
+                        scalingMode = ApplicationSettings.DisplayScalingMode.INTEGER_FIT,
+                        letterboxColor = 0x303030,
+                        fullscreen = true,
+                        rotation = ApplicationSettings.Rotation.DEG_90,
                     ),
                 input =
                     defaults.input.copy(
@@ -174,6 +192,7 @@ class PreferencesDialogTest {
         assertEquals(defaults.input.keyboard, restored.keyboard)
         assertEquals(defaults.input.gamepads, restored.gamepads)
         assertEquals(defaults.input.gamepadTunings, restored.gamepadTunings)
+        assertEquals(defaults.display, restored.display)
         assertEquals(defaults.audio, restored.audio)
         assertEquals(0, applyCount)
         assertEquals(1, closeCount)
@@ -233,6 +252,33 @@ class PreferencesDialogTest {
       }
 
   @Test
+  fun `invalid display color selects Display and keeps the dialog open`() =
+      onEdt {
+        var applyCount = 0
+        var closeCount = 0
+        val panel = PreferencesPanel(ApplicationSettings())
+        val actions =
+            PreferencesDialogActions(
+                panel,
+                applyEdit = { applyCount++ },
+                close = { closeCount++ },
+            )
+
+        panel.tabs.selectedIndex = 0
+        panel.displayEditor.letterboxColor.text = "not-a-color"
+        actions.apply()
+
+        assertEquals(0, applyCount)
+        assertEquals(0, closeCount)
+        assertEquals("Display", panel.tabs.getTitleAt(panel.tabs.selectedIndex))
+        assertEquals(
+            "Enter a color in #RRGGBB form.",
+            panel.displayEditor.letterboxColorError.text,
+        )
+        assertSame(panel.displayEditor.letterboxColor, panel.focusOwnerOrInvalidComponent())
+      }
+
+  @Test
   fun `general fields have label associations and accessible names`() =
       onEdt {
         val panel = PreferencesPanel(ApplicationSettings())
@@ -253,6 +299,10 @@ class PreferencesDialogTest {
         assertEquals("Default ROM directory", panel.directoryField.accessibleContext.accessibleName)
         assertEquals("Recent files to keep", panel.recentCapacity.accessibleContext.accessibleName)
         assertFalse(panel.tabs.accessibleContext.accessibleName.isNullOrBlank())
+        assertEquals(
+            listOf("General", "Display", "Input", "Gamepads", "Audio"),
+            (0 until panel.tabs.tabCount).map(panel.tabs::getTitleAt),
+        )
       }
 
   @Test
@@ -303,7 +353,7 @@ class PreferencesDialogTest {
   fun `leaving the Input tab cancels keyboard capture`() =
       onEdt {
         val panel = PreferencesPanel(ApplicationSettings())
-        panel.tabs.selectedIndex = 1
+        panel.tabs.selectedIndex = 2
         val capture =
             descendants(panel.keyboardEditor)
                 .filterIsInstance<AbstractButton>()

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
@@ -1,0 +1,221 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
+import eu.rekawek.coffeegb.swing.io.SwingDisplay
+import java.awt.event.KeyEvent
+import java.util.concurrent.FutureTask
+import javax.swing.JCheckBoxMenuItem
+import javax.swing.JMenu
+import javax.swing.JMenuItem
+import javax.swing.JRadioButtonMenuItem
+import javax.swing.KeyStroke
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ScreenMenuTest {
+
+  @Test
+  fun `scale and rotation choices are exclusive radios whose clicks update the coordinator`() {
+    Fixture(
+            ApplicationSettings.Display(
+                scalingMode = ApplicationSettings.DisplayScalingMode.ASPECT_FIT,
+                explicitScale = 4,
+                rotation = ApplicationSettings.Rotation.DEG_90,
+            ))
+        .use { fixture ->
+          val scale = onScreenMenuEdt { fixture.menu.submenu("Scale") }
+          val rotate = onScreenMenuEdt { fixture.menu.submenu("Rotate") }
+          onScreenMenuEdt {
+            val scaleItems = scale.items()
+            val rotateItems = rotate.items()
+            assertEquals(
+                listOf("Integer fit", "Fit to window", "1x", "2x", "3x", "4x"),
+                scaleItems.map { it.text },
+            )
+            assertTrue(scaleItems.all { it is JRadioButtonMenuItem })
+            assertEquals(listOf("Fit to window"), scaleItems.selectedLabels())
+            assertEquals(
+                listOf("None", "90°", "180°", "270°"),
+                rotateItems.map { it.text },
+            )
+            assertTrue(rotateItems.all { it is JRadioButtonMenuItem })
+            assertEquals(listOf("90°"), rotateItems.selectedLabels())
+          }
+
+          var runtimeScale: DisplayScaleMode? = null
+          fixture.eventBus.register<SwingDisplay.SetScaleModeEvent> {
+            runtimeScale = it.mode()
+          }
+          onScreenMenuEdt { scale.item("3x").doClick() }
+
+          assertEquals(
+              ApplicationSettings.DisplayScalingMode.EXPLICIT,
+              fixture.settings.display.scalingMode,
+          )
+          assertEquals(3, fixture.settings.display.explicitScale)
+          assertEquals(DisplayScaleMode.EXPLICIT_3X, runtimeScale)
+          onScreenMenuEdt {
+            assertEquals(listOf("3x"), scale.items().selectedLabels())
+          }
+
+          onScreenMenuEdt { rotate.item("270°").doClick() }
+
+          assertEquals(ApplicationSettings.Rotation.DEG_270, fixture.settings.display.rotation)
+          onScreenMenuEdt {
+            assertEquals(listOf("270°"), rotate.items().selectedLabels())
+          }
+          assertEquals(2, fixture.settings.replacements)
+        }
+  }
+
+  @Test
+  fun `off-EDT display event synchronizes every control without listener feedback`() {
+    Fixture(ApplicationSettings.Display()).use { fixture ->
+      val synchronized =
+          ApplicationSettings.Display(
+              scalingMode = ApplicationSettings.DisplayScalingMode.EXPLICIT,
+              explicitScale = 4,
+              fullscreen = true,
+              grayscale = true,
+              blending = false,
+              colorCorrection = false,
+              rotation = ApplicationSettings.Rotation.DEG_180,
+              showSgbBorder = true,
+          )
+      fixture.settings.display = synchronized
+
+      val publisher =
+          Thread(
+              { fixture.eventBus.post(DisplaySettingsChangedEvent(synchronized)) },
+              "screen-menu-test-publisher",
+          )
+      publisher.start()
+      publisher.join()
+      flushScreenMenuEdt()
+
+      onScreenMenuEdt {
+        assertEquals(listOf("4x"), fixture.menu.submenu("Scale").items().selectedLabels())
+        assertEquals(listOf("180°"), fixture.menu.submenu("Rotate").items().selectedLabels())
+        assertTrue(fixture.menu.checkItem("Fullscreen").state)
+        assertTrue(fixture.menu.checkItem("DMG grayscale").state)
+        assertFalse(fixture.menu.checkItem("LCD ghosting (frame blend)").state)
+        assertFalse(fixture.menu.checkItem("CGB color correction").state)
+        assertTrue(fixture.menu.checkItem("Show SGB border").state)
+      }
+      assertEquals(0, fixture.settings.replacements)
+    }
+  }
+
+  @Test
+  fun `F11 toggles fullscreen only while it is free from emulator bindings`() {
+    Fixture(ApplicationSettings.Display()).use { fixture ->
+      val fullscreen = onScreenMenuEdt { fixture.menu.checkItem("Fullscreen") }
+      val f11 = KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0)
+
+      onScreenMenuEdt { assertEquals(f11, fullscreen.accelerator) }
+      onScreenMenuEdt { fullscreen.doClick() }
+      assertTrue(fixture.settings.display.fullscreen)
+      assertTrue(fixture.fullscreen.fullscreenState)
+      assertEquals(1, fixture.settings.replacements)
+
+      fixture.keyboardBindings +=
+          ApplicationSettings.KeyboardKey.fromKeyCode(KeyEvent.VK_F11)
+      onScreenMenuEdt {
+        fixture.eventBus.post(DisplaySettingsChangedEvent(fixture.settings.display))
+      }
+      onScreenMenuEdt { assertNull(fullscreen.accelerator) }
+
+      fixture.keyboardBindings.clear()
+      onScreenMenuEdt {
+        fixture.eventBus.post(DisplaySettingsChangedEvent(fixture.settings.display))
+      }
+      onScreenMenuEdt { assertEquals(f11, fullscreen.accelerator) }
+
+      onScreenMenuEdt { fullscreen.doClick() }
+      assertFalse(fixture.settings.display.fullscreen)
+      assertFalse(fixture.fullscreen.fullscreenState)
+      assertEquals(2, fixture.settings.replacements)
+    }
+  }
+
+  private class Fixture(
+      initial: ApplicationSettings.Display,
+  ) : AutoCloseable {
+    val eventBus = EventBusImpl()
+    val settings = FakeDisplaySettings(initial)
+    val fullscreen = FakeFullscreenRuntime()
+    val keyboardBindings = mutableListOf<ApplicationSettings.KeyboardKey>()
+    val menu =
+        onScreenMenuEdt {
+          createScreenMenu(
+              DesktopDisplayController(settings, eventBus, fullscreen),
+              eventBus,
+              keyboardBindings = { keyboardBindings.toList() },
+          )
+        }
+
+    override fun close() {
+      eventBus.close()
+    }
+  }
+
+  private class FakeDisplaySettings(
+      var display: ApplicationSettings.Display,
+  ) : DisplaySettingsAccess {
+    var replacements = 0
+
+    override fun current(): ApplicationSettings.Display = display
+
+    override fun replace(display: ApplicationSettings.Display) {
+      this.display = display
+      replacements++
+    }
+  }
+
+  private class FakeFullscreenRuntime : FullscreenRuntime {
+    var fullscreenState = false
+
+    override fun isFullscreen(): Boolean = fullscreenState
+
+    override fun setFullscreen(fullscreen: Boolean) {
+      fullscreenState = fullscreen
+    }
+
+    override fun refreshScreens() = Unit
+
+    override fun close() = Unit
+  }
+
+  private fun JMenu.submenu(text: String): JMenu =
+      items().filterIsInstance<JMenu>().single { it.text == text }
+
+  private fun JMenu.checkItem(text: String): JCheckBoxMenuItem =
+      items().filterIsInstance<JCheckBoxMenuItem>().single { it.text == text }
+
+  private fun JMenu.item(text: String): JMenuItem =
+      items().single { it.text == text }
+
+  private fun JMenu.items(): List<JMenuItem> =
+      (0 until itemCount).mapNotNull(::getItem)
+
+  private fun List<JMenuItem>.selectedLabels(): List<String> =
+      filter { it.isSelected }.map { it.text }
+
+}
+
+private fun flushScreenMenuEdt() {
+  onScreenMenuEdt {}
+}
+
+private fun <T> onScreenMenuEdt(action: () -> T): T {
+  val task = FutureTask(action)
+  SwingUtilities.invokeAndWait(task)
+  return task.get()
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
@@ -1,13 +1,109 @@
 package eu.rekawek.coffeegb.swing
 
+import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
+import java.awt.Dimension
+import java.awt.Insets
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.Test
 
 class SwingGuiShutdownTest {
+  @Test
+  fun `minimum frame size includes content chrome and menu without display assumptions`() {
+    assertEquals(
+        Dimension(172, 181),
+        minimumFrameSize(
+            content = Dimension(160, 144),
+            insets = Insets(20, 5, 7, 7),
+            menuHeight = 10,
+        ),
+    )
+    assertFailsWith<IllegalArgumentException> {
+      minimumFrameSize(Dimension(160, 144), Insets(0, 0, 0, 0), -1)
+    }
+  }
+
+  @Test
+  fun `windowed explicit mode tracks full rotated or SGB content while fit and fullscreen do not`() {
+    assertEquals(
+        Dimension(960, 1_024),
+        minimumDisplayContentSize(
+            DisplayScaleMode.EXPLICIT_4X,
+            Dimension(960, 1_024),
+            windowed = true,
+        ),
+    )
+    assertEquals(
+        Dimension(160, 160),
+        minimumDisplayContentSize(
+            DisplayScaleMode.EXPLICIT_1X,
+            Dimension(144, 160),
+            windowed = true,
+        ),
+    )
+    assertEquals(
+        Dimension(160, 144),
+        minimumDisplayContentSize(
+            DisplayScaleMode.ASPECT_FIT,
+            Dimension(256, 224),
+            windowed = true,
+        ),
+    )
+    assertEquals(
+        Dimension(160, 144),
+        minimumDisplayContentSize(
+            DisplayScaleMode.EXPLICIT_4X,
+            Dimension(1_024, 896),
+            windowed = false,
+        ),
+    )
+  }
+
+  @Test
+  fun `fullscreen SGB growth packs on exit only when restored content is too small`() {
+    val sgbFourTimes = Dimension(1_024, 896)
+    assertTrue(
+        shouldPackExplicitWindow(
+            DisplayScaleMode.EXPLICIT_4X,
+            sgbFourTimes,
+            currentContentSize = Dimension(320, 288),
+            windowed = true,
+        ))
+    assertFalse(
+        shouldPackExplicitWindow(
+            DisplayScaleMode.EXPLICIT_4X,
+            sgbFourTimes,
+            currentContentSize = sgbFourTimes,
+            windowed = true,
+        ))
+    assertFalse(
+        shouldPackExplicitWindow(
+            DisplayScaleMode.EXPLICIT_4X,
+            sgbFourTimes,
+            currentContentSize = Dimension(1_200, 1_000),
+            windowed = true,
+        ))
+    assertFalse(
+        shouldPackExplicitWindow(
+            DisplayScaleMode.EXPLICIT_4X,
+            sgbFourTimes,
+            currentContentSize = Dimension(320, 288),
+            windowed = false,
+        ))
+    assertFalse(
+        shouldPackExplicitWindow(
+            DisplayScaleMode.ASPECT_FIT,
+            sgbFourTimes,
+            currentContentSize = Dimension(320, 288),
+            windowed = true,
+        ))
+  }
+
   @Test
   fun `desktop shutdown leaves the EDT and keeps the process alive until teardown completes`() {
     val ran = CountDownLatch(1)

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshotTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshotTest.java
@@ -1,0 +1,52 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import org.junit.Test;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class DisplayFrameSnapshotTest {
+
+    @Test
+    public void snapshotCopiesInputAndDoesNotExposeItsRaster() {
+        int[] emulatorOwned = {0x123456, 0xabcdef};
+
+        DisplayFrameSnapshot snapshot = DisplayFrameSnapshot.copyOf(2, 1, emulatorOwned);
+        emulatorOwned[0] = 0;
+        emulatorOwned[1] = 0;
+
+        assertEquals(0x123456, snapshot.rgbAt(0, 0));
+        assertEquals(0xabcdef, snapshot.rgbAt(1, 0));
+    }
+
+    @Test
+    public void paintingReadsSnapshotWithoutChangingItsPixels() {
+        DisplayFrameSnapshot snapshot =
+                DisplayFrameSnapshot.copyOf(2, 1, new int[]{0x010203, 0xa0b0c0});
+        BufferedImage target = new BufferedImage(2, 1, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = target.createGraphics();
+        try {
+            snapshot.paint(graphics);
+        } finally {
+            graphics.dispose();
+        }
+
+        assertEquals(0x010203, target.getRGB(0, 0) & 0xffffff);
+        assertEquals(0xa0b0c0, target.getRGB(1, 0) & 0xffffff);
+        assertEquals(0x010203, snapshot.rgbAt(0, 0));
+        assertEquals(0xa0b0c0, snapshot.rgbAt(1, 0));
+    }
+
+    @Test
+    public void snapshotRequiresAnExactPixelCount() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayFrameSnapshot.copyOf(2, 2, new int[3]));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayFrameSnapshot.copyOf(2, 2, new int[5]));
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
@@ -141,12 +141,13 @@ public class DisplayViewportTest {
     }
 
     @Test
-    public void explicitScaleDefinesDeterministicLeadingEdgeCropWhenComponentIsTooSmall() {
+    public void explicitScaleFallsBackUniformlyInsteadOfCroppingWhenComponentIsTooSmall() {
         DisplayViewport viewport = DisplayViewport.calculate(
                 319, 287, 160, 144, 0, DisplayScaleMode.EXPLICIT_2X);
 
-        assertEquals(-1, viewport.x());
-        assertEquals(-1, viewport.y());
+        assertEquals(287.0 / 144.0, viewport.scale(), EPSILON);
+        assertEquals(0, viewport.x());
+        assertEquals(0, viewport.y());
         assertEquals(new Rectangle(0, 0, 319, 287), viewport.paintBounds());
     }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
@@ -1,0 +1,234 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import org.junit.Test;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.geom.Point2D;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class DisplayViewportTest {
+
+    private static final double EPSILON = 1e-9;
+
+    @Test
+    public void integerFitUsesLargestWholeDmgScaleAndCentersOddRemainders() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                805, 725, 160, 144, 0, DisplayScaleMode.INTEGER_FIT);
+
+        assertEquals(5.0, viewport.scale(), EPSILON);
+        assertEquals(2, viewport.x());
+        assertEquals(2, viewport.y());
+        assertEquals(800.0, viewport.width(), EPSILON);
+        assertEquals(720.0, viewport.height(), EPSILON);
+        assertEquals(new Rectangle(2, 2, 800, 720), viewport.paintBounds());
+        // The odd spare pixels deliberately remain on the trailing edges.
+        assertEquals(3, 805 - viewport.paintBounds().x - viewport.paintBounds().width);
+        assertEquals(3, 725 - viewport.paintBounds().y - viewport.paintBounds().height);
+    }
+
+    @Test
+    public void integerFitUsesSgbBorderDimensions() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                1_030, 900, 256, 224, 0, DisplayScaleMode.INTEGER_FIT);
+
+        assertEquals(4.0, viewport.scale(), EPSILON);
+        assertEquals(new Rectangle(3, 2, 1_024, 896), viewport.paintBounds());
+    }
+
+    @Test
+    public void undersizedIntegerFitFallsBackToUniformFractionalFit() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                100, 100, 160, 144, 0, DisplayScaleMode.INTEGER_FIT);
+
+        assertEquals(0.625, viewport.scale(), EPSILON);
+        assertEquals(100.0, viewport.width(), EPSILON);
+        assertEquals(90.0, viewport.height(), EPSILON);
+        assertEquals(new Rectangle(0, 5, 100, 90), viewport.paintBounds());
+    }
+
+    @Test
+    public void aspectFitKeepsOneExactScaleAndReportsConservativePixelBounds() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                1_000, 700, 160, 144, 0, DisplayScaleMode.ASPECT_FIT);
+
+        assertEquals(700.0 / 144.0, viewport.scale(), EPSILON);
+        assertEquals(160 * viewport.scale(), viewport.width(), EPSILON);
+        assertEquals(144 * viewport.scale(), viewport.height(), EPSILON);
+        assertEquals(111, viewport.x());
+        assertEquals(0, viewport.y());
+        assertEquals(new Rectangle(111, 0, 778, 700), viewport.paintBounds());
+        assertUniformTransform(viewport, 160, 144);
+    }
+
+    @Test
+    public void aspectFitHandlesExactSgbPillarboxGeometry() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                1_000, 700, 256, 224, 0, DisplayScaleMode.ASPECT_FIT);
+
+        assertEquals(3.125, viewport.scale(), EPSILON);
+        assertEquals(800.0, viewport.width(), EPSILON);
+        assertEquals(700.0, viewport.height(), EPSILON);
+        assertEquals(new Rectangle(100, 0, 800, 700), viewport.paintBounds());
+    }
+
+    @Test
+    public void ninetyDegreeRotationFitsUsingSwappedSourceDimensions() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                300, 333, 160, 144, 90, DisplayScaleMode.INTEGER_FIT);
+
+        assertEquals(2.0, viewport.scale(), EPSILON);
+        assertEquals(144, viewport.rotatedSourceWidth());
+        assertEquals(160, viewport.rotatedSourceHeight());
+        assertEquals(new Rectangle(6, 6, 288, 320), viewport.paintBounds());
+        assertRotatedCornersStayInsideExactViewport(viewport, 160, 144);
+    }
+
+    @Test
+    public void twoHundredSeventyDegreeAspectFitUsesSwappedSgbDimensions() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                701, 900, 256, 224, 270, DisplayScaleMode.ASPECT_FIT);
+
+        assertEquals(701.0 / 224.0, viewport.scale(), EPSILON);
+        assertEquals(701.0, viewport.width(), EPSILON);
+        assertEquals(256 * viewport.scale(), viewport.height(), EPSILON);
+        assertEquals(0, viewport.x());
+        assertEquals(49, viewport.y());
+        assertEquals(new Rectangle(0, 49, 701, 802), viewport.paintBounds());
+        assertRotatedCornersStayInsideExactViewport(viewport, 256, 224);
+    }
+
+    @Test
+    public void oneHundredEightyDegreeTransformPreservesTheDmgViewport() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                321, 289, 160, 144, 180, DisplayScaleMode.EXPLICIT_2X);
+
+        assertEquals(0, viewport.x());
+        assertEquals(0, viewport.y());
+        assertEquals(new Rectangle(0, 0, 320, 288), viewport.paintBounds());
+        Point2D mappedOrigin = viewport.sourceToComponentTransform()
+                .transform(new Point2D.Double(0, 0), null);
+        Point2D mappedOpposite = viewport.sourceToComponentTransform()
+                .transform(new Point2D.Double(160, 144), null);
+        assertEquals(320.0, mappedOrigin.getX(), EPSILON);
+        assertEquals(288.0, mappedOrigin.getY(), EPSILON);
+        assertEquals(0.0, mappedOpposite.getX(), EPSILON);
+        assertEquals(0.0, mappedOpposite.getY(), EPSILON);
+    }
+
+    @Test
+    public void eachExplicitScaleIsExactAndCenteredWithoutRescalingToFit() {
+        DisplayScaleMode[] modes = {
+                DisplayScaleMode.EXPLICIT_1X,
+                DisplayScaleMode.EXPLICIT_2X,
+                DisplayScaleMode.EXPLICIT_3X,
+                DisplayScaleMode.EXPLICIT_4X
+        };
+        for (int i = 0; i < modes.length; i++) {
+            int factor = i + 1;
+            DisplayViewport viewport = DisplayViewport.calculate(
+                    1_001, 901, 160, 144, 0, modes[i]);
+
+            assertEquals(factor, viewport.scale(), EPSILON);
+            assertEquals(160.0 * factor, viewport.width(), EPSILON);
+            assertEquals(144.0 * factor, viewport.height(), EPSILON);
+            assertEquals((int) Math.floor((1_001 - 160.0 * factor) / 2.0), viewport.x());
+            assertEquals((int) Math.floor((901 - 144.0 * factor) / 2.0), viewport.y());
+        }
+    }
+
+    @Test
+    public void explicitScaleDefinesDeterministicLeadingEdgeCropWhenComponentIsTooSmall() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                319, 287, 160, 144, 0, DisplayScaleMode.EXPLICIT_2X);
+
+        assertEquals(-1, viewport.x());
+        assertEquals(-1, viewport.y());
+        assertEquals(new Rectangle(0, 0, 319, 287), viewport.paintBounds());
+    }
+
+    @Test
+    public void zeroSizedComponentProducesAnEmptyPaintBound() {
+        DisplayViewport viewport = DisplayViewport.calculate(
+                0, 0, 160, 144, 0, DisplayScaleMode.ASPECT_FIT);
+
+        assertEquals(0.0, viewport.scale(), EPSILON);
+        assertEquals(new Rectangle(), viewport.paintBounds());
+    }
+
+    @Test
+    public void preferredSizeUsesIntrinsicSizeForFitAndExplicitFactorOtherwise() {
+        assertEquals(
+                new Dimension(160, 144),
+                DisplayViewport.preferredSize(
+                        160, 144, 0, DisplayScaleMode.INTEGER_FIT));
+        assertEquals(
+                new Dimension(224, 256),
+                DisplayViewport.preferredSize(
+                        256, 224, 90, DisplayScaleMode.ASPECT_FIT));
+        assertEquals(
+                new Dimension(576, 640),
+                DisplayViewport.preferredSize(
+                        160, 144, 270, DisplayScaleMode.EXPLICIT_4X));
+    }
+
+    @Test
+    public void invalidDimensionsAndNonQuarterTurnRotationsAreRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayViewport.calculate(
+                        -1, 10, 160, 144, 0, DisplayScaleMode.ASPECT_FIT));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayViewport.calculate(
+                        10, 10, 0, 144, 0, DisplayScaleMode.ASPECT_FIT));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayViewport.calculate(
+                        10, 10, 160, 144, 45, DisplayScaleMode.ASPECT_FIT));
+    }
+
+    @Test
+    public void explicitScaleFactoryCoversOnlyTheSupportedOneThroughFourRange() {
+        assertEquals(DisplayScaleMode.EXPLICIT_1X, DisplayScaleMode.explicit(1));
+        assertEquals(DisplayScaleMode.EXPLICIT_2X, DisplayScaleMode.explicit(2));
+        assertEquals(DisplayScaleMode.EXPLICIT_3X, DisplayScaleMode.explicit(3));
+        assertEquals(DisplayScaleMode.EXPLICIT_4X, DisplayScaleMode.explicit(4));
+        assertThrows(IllegalArgumentException.class, () -> DisplayScaleMode.explicit(0));
+        assertThrows(IllegalArgumentException.class, () -> DisplayScaleMode.explicit(5));
+    }
+
+    private static void assertUniformTransform(
+            DisplayViewport viewport, int sourceWidth, int sourceHeight) {
+        Point2D origin = viewport.sourceToComponentTransform()
+                .transform(new Point2D.Double(0, 0), null);
+        Point2D horizontal = viewport.sourceToComponentTransform()
+                .transform(new Point2D.Double(sourceWidth, 0), null);
+        Point2D vertical = viewport.sourceToComponentTransform()
+                .transform(new Point2D.Double(0, sourceHeight), null);
+
+        assertEquals(sourceWidth * viewport.scale(), origin.distance(horizontal), EPSILON);
+        assertEquals(sourceHeight * viewport.scale(), origin.distance(vertical), EPSILON);
+    }
+
+    private static void assertRotatedCornersStayInsideExactViewport(
+            DisplayViewport viewport, int sourceWidth, int sourceHeight) {
+        Point2D[] corners = {
+                new Point2D.Double(0, 0),
+                new Point2D.Double(sourceWidth, 0),
+                new Point2D.Double(0, sourceHeight),
+                new Point2D.Double(sourceWidth, sourceHeight)
+        };
+        for (Point2D corner : corners) {
+            Point2D mapped = viewport.sourceToComponentTransform().transform(corner, null);
+            assertTrue(mapped.getX() >= viewport.x() - EPSILON);
+            assertTrue(mapped.getX() <= viewport.x() + viewport.width() + EPSILON);
+            assertTrue(mapped.getY() >= viewport.y() - EPSILON);
+            assertTrue(mapped.getY() <= viewport.y() + viewport.height() + EPSILON);
+        }
+        assertUniformTransform(viewport, sourceWidth, sourceHeight);
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -5,27 +5,54 @@ import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import org.junit.Test;
 
+import javax.swing.SwingUtilities;
+import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_HEIGHT;
+import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_WIDTH;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SwingDisplayTest {
+
+    @Test
+    public void constructionRequiresTheEventDispatchThread() {
+        assertFalse(SwingUtilities.isEventDispatchThread());
+        assertThrows(
+                IllegalStateException.class,
+                () -> new SwingDisplay(
+                        new EmulatorProperties().getDisplay(),
+                        EventBus.NULL_EVENT_BUS,
+                        "test"));
+    }
 
     @Test
     public void romLoadingShowsPersistentNotificationUntilLoadingFinishes() throws Exception {
         EventBusImpl root = new EventBusImpl(null, null, false);
         EventBus session = root.fork("test");
-        SwingDisplay display = new SwingDisplay(
-                new EmulatorProperties().getDisplay(), root, "test");
+        SwingDisplay display = newDisplay(root);
         Field textField = SwingDisplay.class.getDeclaredField("persistentNotificationText");
         textField.setAccessible(true);
 
@@ -49,23 +76,14 @@ public class SwingDisplayTest {
     public void snapshotCompletionEventsShowAnOnScreenNotification() throws Exception {
         EventBusImpl root = new EventBusImpl(null, null, false);
         EventBus session = root.fork("test");
-        SwingDisplay display = new SwingDisplay(
-                new EmulatorProperties().getDisplay(), root, "test");
+        SwingDisplay display = newDisplay(root);
         Field textField = SwingDisplay.class.getDeclaredField("notificationText");
         textField.setAccessible(true);
 
         session.post(new Controller.SnapshotSavedEvent(3));
         assertEquals("State saved (slot 3)", textField.get(display));
 
-        display.setSize(display.getPreferredSize());
-        BufferedImage target = new BufferedImage(
-                display.getWidth(), display.getHeight(), BufferedImage.TYPE_INT_RGB);
-        Graphics graphics = target.getGraphics();
-        try {
-            display.paintComponent(graphics);
-        } finally {
-            graphics.dispose();
-        }
+        BufferedImage target = paintAtPreferredSize(display);
         boolean hasVisibleText = false;
         for (int y = 0; y < target.getHeight() && !hasVisibleText; y++) {
             for (int x = 0; x < target.getWidth(); x++) {
@@ -85,47 +103,85 @@ public class SwingDisplayTest {
     @Test
     public void newestFrameReplacesPendingTransitionFrame() throws Exception {
         EventBusImpl eventBus = new EventBusImpl(null, "test", false);
-        SwingDisplay display = new SwingDisplay(
-                new EmulatorProperties().getDisplay(), eventBus, "test");
+        SwingDisplay display = newDisplay(eventBus);
         int[] transition = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
-        java.util.Arrays.fill(transition, 3);
+        Arrays.fill(transition, 3);
         int[] blank = new int[transition.length];
+        int[] expectedBlank = dmgRgb(blank);
 
         eventBus.post(new Display.DmgFrameReadyEvent(transition));
         eventBus.post(new Display.DmgFrameReadyEvent(blank));
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            awaitDisplayedFrame(display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expectedBlank);
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
 
-        Field waitingFrameField = SwingDisplay.class.getDeclaredField("waitingFrame");
-        waitingFrameField.setAccessible(true);
-        int[] waitingFrame = (int[]) waitingFrameField.get(display);
-        int[] expected = new int[waitingFrame.length];
-        new Display.DmgFrameReadyEvent(blank).toRgb(
-                expected, new EmulatorProperties().getDisplay().getGrayscale());
-        assertArrayEquals(expected, waitingFrame);
+    @Test
+    public void queuedFrameDoesNotRetainTheEmulatorOwnedBuffer() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        int[] emulatorOwned = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        Arrays.fill(emulatorOwned, 3);
+        int[] expected = dmgRgb(emulatorOwned);
+
+        eventBus.post(new Display.DmgFrameReadyEvent(emulatorOwned));
+        Arrays.fill(emulatorOwned, 0);
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            awaitDisplayedFrame(display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expected);
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void cgbFrameIsTranslatedAndCopiedBeforePublication() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        int[] emulatorOwned = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        Arrays.fill(emulatorOwned, 0x4210);
+        int[] expected = gbcRgb(emulatorOwned);
+
+        eventBus.post(new Display.GbcFrameReadyEvent(emulatorOwned));
+        Arrays.fill(emulatorOwned, 0);
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            awaitDisplayedFrame(display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expected);
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
     }
 
     @Test
     public void lcdBlankDoesNotBlendWithTransitionFrame() throws Exception {
         EventBusImpl eventBus = new EventBusImpl(null, "test", false);
-        SwingDisplay display = new SwingDisplay(
-                new EmulatorProperties().getDisplay(), eventBus, "test");
+        SwingDisplay display = newDisplay(eventBus);
         eventBus.post(new SwingDisplay.SetBlendingEvent(true));
         Thread displayThread = daemonThread(display);
         displayThread.start();
 
         int size = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
         int[] scene = new int[size];
-        java.util.Arrays.fill(scene, 3);
+        Arrays.fill(scene, 3);
         int[] transition = new int[size];
         transition[0] = 3;
         int[] blank = new int[size];
-        int[] expectedBlank = new int[size];
-        new Display.DmgFrameReadyEvent(blank).toRgb(
-                expectedBlank, new EmulatorProperties().getDisplay().getGrayscale());
+        int[] expectedBlank = dmgRgb(blank);
 
         Field previousFrameField = SwingDisplay.class.getDeclaredField("previousFrame");
         previousFrameField.setAccessible(true);
-        Field imagePixelsField = SwingDisplay.class.getDeclaredField("imgPixels");
-        imagePixelsField.setAccessible(true);
         try {
             eventBus.post(new Display.DmgFrameReadyEvent(scene));
             awaitArray(previousFrameField, display, dmgRgb(scene));
@@ -135,11 +191,138 @@ public class SwingDisplayTest {
 
             eventBus.post(new Display.DmgFrameReadyEvent(blank, true));
             awaitArray(previousFrameField, display, expectedBlank);
-            assertArrayEquals(expectedBlank, (int[]) imagePixelsField.get(display));
+            awaitDisplayedFrame(
+                    display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expectedBlank);
         } finally {
             display.stop();
             displayThread.join(2_000);
             eventBus.close();
+        }
+    }
+
+    @Test
+    public void sgbFrameDimensionsArePublishedIndependentlyFromTheComponentSize() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        int[] border = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+        Arrays.fill(border, 0x123456);
+        int[] expected = border.clone();
+
+        onEdt(() -> display.setSize(777, 555));
+        eventBus.post(new SgbDisplay.SgbFrameReadyEvent(border, true));
+        Arrays.fill(border, 0);
+        flushEdt();
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            DisplayFrameSnapshot snapshot =
+                    awaitDisplayedFrame(display, SGB_DISPLAY_WIDTH, SGB_DISPLAY_HEIGHT, expected);
+            assertEquals(0x123456, snapshot.rgbAt(SGB_DISPLAY_WIDTH - 1, SGB_DISPLAY_HEIGHT - 1));
+            assertEquals(new Dimension(512, 448), onEdt(display::getPreferredSize));
+            assertEquals(new Dimension(777, 555), onEdt(() -> {
+                return display.getSize();
+            }));
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void displaySizeUpdatesAreAppliedAndPublishedOnTheEdt() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        AtomicBoolean allEventsOnEdt = new AtomicBoolean(true);
+        AtomicInteger eventCount = new AtomicInteger();
+        AtomicReference<Dimension> latestSize = new AtomicReference<>();
+        eventBus.register(event -> {
+            allEventsOnEdt.compareAndSet(true, SwingUtilities.isEventDispatchThread());
+            eventCount.incrementAndGet();
+            latestSize.set(event.preferredSize());
+        }, SwingDisplay.DisplaySizeUpdatedEvent.class);
+
+        eventBus.post(new SwingDisplay.SetScaleModeEvent(DisplayScaleMode.EXPLICIT_3X));
+        flushEdt();
+        assertEquals(new Dimension(480, 432), latestSize.get());
+        assertEquals(new Dimension(480, 432), onEdt(display::getPreferredSize));
+
+        eventBus.post(new SwingDisplay.SetRotationEvent(90));
+        flushEdt();
+        assertEquals(new Dimension(432, 480), latestSize.get());
+        assertEquals(new Dimension(432, 480), onEdt(display::getPreferredSize));
+        assertEquals(2, eventCount.get());
+        assertTrue(allEventsOnEdt.get());
+        eventBus.close();
+    }
+
+    @Test
+    public void displaySizeEventDefensivelyCopiesItsDimension() {
+        Dimension original = new Dimension(320, 288);
+        SwingDisplay.DisplaySizeUpdatedEvent event =
+                new SwingDisplay.DisplaySizeUpdatedEvent(original);
+        original.setSize(1, 1);
+        Dimension received = event.preferredSize();
+        received.setSize(2, 2);
+
+        assertEquals(new Dimension(320, 288), event.preferredSize());
+    }
+
+    @Test
+    public void paintingUsesViewportLetterboxingAndTheConfiguredNeutralColor() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        Color letterbox = new Color(12, 34, 56);
+        int[] frame = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        int[] expected = dmgRgb(frame);
+        AtomicBoolean backgroundChangedOnEdt = new AtomicBoolean();
+        onEdt(() -> display.addPropertyChangeListener(
+                "background",
+                event -> backgroundChangedOnEdt.set(SwingUtilities.isEventDispatchThread())));
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            eventBus.post(new SwingDisplay.SetLetterboxColorEvent(letterbox));
+            eventBus.post(new SwingDisplay.SetScaleModeEvent(DisplayScaleMode.ASPECT_FIT));
+            eventBus.post(new Display.DmgFrameReadyEvent(frame));
+            awaitDisplayedFrame(display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expected);
+            flushEdt();
+
+            BufferedImage target = onEdt(() -> {
+                display.setSize(500, 300);
+                BufferedImage image =
+                        new BufferedImage(500, 300, BufferedImage.TYPE_INT_RGB);
+                Graphics graphics = image.getGraphics();
+                try {
+                    display.paintComponent(graphics);
+                } finally {
+                    graphics.dispose();
+                }
+                return image;
+            });
+
+            assertEquals(letterbox.getRGB() & 0xffffff, target.getRGB(0, 150) & 0xffffff);
+            assertEquals(expected[0], target.getRGB(250, 150) & 0xffffff);
+            assertTrue(backgroundChangedOnEdt.get());
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void paintingRequiresTheEventDispatchThread() throws Exception {
+        SwingDisplay display = newDisplay();
+        BufferedImage target = new BufferedImage(320, 288, BufferedImage.TYPE_INT_RGB);
+        Graphics graphics = target.getGraphics();
+        try {
+            IllegalStateException error = assertThrows(
+                    IllegalStateException.class,
+                    () -> display.paintComponent(graphics));
+            assertTrue(error.getMessage().contains("Event Dispatch Thread"));
+        } finally {
+            graphics.dispose();
         }
     }
 
@@ -151,8 +334,8 @@ public class SwingDisplayTest {
         assertFalse(Modifier.isSynchronized(modifiers));
 
         SwingDisplay display = newDisplay();
+        onEdt(() -> display.setSize(display.getPreferredSize()));
         BufferedImage target = new BufferedImage(1024, 1024, BufferedImage.TYPE_INT_RGB);
-        Graphics graphics = target.getGraphics();
         CountDownLatch monitorHeld = new CountDownLatch(1);
         CountDownLatch releaseMonitor = new CountDownLatch(1);
         CountDownLatch painted = new CountDownLatch(1);
@@ -164,67 +347,58 @@ public class SwingDisplayTest {
                 await(releaseMonitor);
             }
         });
-        Thread painter = daemonThread(() -> paint(display, graphics, painted, failure));
+        Thread scheduler = daemonThread(() -> {
+            try {
+                onEdt(() -> {
+                    Graphics graphics = target.getGraphics();
+                    try {
+                        display.paintComponent(graphics);
+                    } finally {
+                        graphics.dispose();
+                    }
+                });
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                painted.countDown();
+            }
+        });
         holder.start();
         assertTrue(monitorHeld.await(2, TimeUnit.SECONDS));
         try {
-            painter.start();
+            scheduler.start();
             assertTrue("painting blocked on the component monitor",
                     painted.await(2, TimeUnit.SECONDS));
         } finally {
             releaseMonitor.countDown();
             holder.join(2_000);
-            painter.join(2_000);
-            graphics.dispose();
+            scheduler.join(2_000);
         }
         assertNull(failure.get());
     }
 
-    @Test
-    public void paintingUsesTheDedicatedRasterLock() throws Exception {
-        Field lockField = SwingDisplay.class.getDeclaredField("rasterLock");
-        assertTrue(Modifier.isPrivate(lockField.getModifiers()));
-        assertTrue(Modifier.isFinal(lockField.getModifiers()));
-        lockField.setAccessible(true);
-
-        SwingDisplay display = newDisplay();
-        Object rasterLock = lockField.get(display);
-        BufferedImage target = new BufferedImage(1024, 1024, BufferedImage.TYPE_INT_RGB);
-        Graphics graphics = target.getGraphics();
-        CountDownLatch started = new CountDownLatch(1);
-        CountDownLatch painted = new CountDownLatch(1);
-        AtomicReference<Throwable> failure = new AtomicReference<>();
-        Thread painter = daemonThread(() -> {
-            started.countDown();
-            paint(display, graphics, painted, failure);
-        });
-
-        boolean blocked = false;
-        synchronized (rasterLock) {
-            painter.start();
-            assertTrue(started.await(2, TimeUnit.SECONDS));
-            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-            while (painted.getCount() != 0 && System.nanoTime() < deadline) {
-                if (painter.getState() == Thread.State.BLOCKED) {
-                    blocked = true;
-                    break;
-                }
-                Thread.yield();
-            }
-            assertTrue("painting did not wait for the raster lock", blocked);
-        }
-
-        try {
-            assertTrue(painted.await(2, TimeUnit.SECONDS));
-            assertNull(failure.get());
-        } finally {
-            painter.join(2_000);
-            graphics.dispose();
-        }
+    private static SwingDisplay newDisplay() throws Exception {
+        return newDisplay(EventBus.NULL_EVENT_BUS);
     }
 
-    private static SwingDisplay newDisplay() {
-        return new SwingDisplay(new EmulatorProperties().getDisplay(), EventBus.NULL_EVENT_BUS, "test");
+    private static SwingDisplay newDisplay(EventBus eventBus) throws Exception {
+        return onEdt(() -> new SwingDisplay(
+                new EmulatorProperties().getDisplay(), eventBus, "test"));
+    }
+
+    private static BufferedImage paintAtPreferredSize(SwingDisplay display) throws Exception {
+        return onEdt(() -> {
+            display.setSize(display.getPreferredSize());
+            BufferedImage target = new BufferedImage(
+                    display.getWidth(), display.getHeight(), BufferedImage.TYPE_INT_RGB);
+            Graphics graphics = target.getGraphics();
+            try {
+                display.paintComponent(graphics);
+            } finally {
+                graphics.dispose();
+            }
+            return target;
+        });
     }
 
     private static Thread daemonThread(Runnable runnable) {
@@ -240,29 +414,76 @@ public class SwingDisplayTest {
         return rgb;
     }
 
+    private static int[] gbcRgb(int[] pixels) {
+        int[] rgb = new int[pixels.length];
+        new Display.GbcFrameReadyEvent(pixels).toRgb(
+                rgb, new EmulatorProperties().getDisplay().getColorCorrection());
+        return rgb;
+    }
+
+    private static DisplayFrameSnapshot awaitDisplayedFrame(
+            SwingDisplay display, int width, int height, int[] expected) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (System.nanoTime() < deadline) {
+            DisplayFrameSnapshot actual = display.displayedFrame();
+            if (actual.width() == width
+                    && actual.height() == height
+                    && frameEquals(actual, expected)) {
+                return actual;
+            }
+            Thread.yield();
+        }
+        fail("display thread did not publish the expected frame");
+        throw new AssertionError();
+    }
+
+    private static boolean frameEquals(DisplayFrameSnapshot actual, int[] expected) {
+        if (expected.length != actual.width() * actual.height()) {
+            return false;
+        }
+        for (int i = 0; i < expected.length; i++) {
+            int x = i % actual.width();
+            int y = i / actual.width();
+            if (actual.rgbAt(x, y) != expected[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static void awaitArray(Field field, Object target, int[] expected) throws Exception {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (System.nanoTime() < deadline) {
             synchronized (target) {
                 int[] actual = (int[]) field.get(target);
-                if (actual != null && java.util.Arrays.equals(expected, actual)) {
+                if (actual != null && Arrays.equals(expected, actual)) {
                     return;
                 }
             }
             Thread.yield();
         }
-        fail("display thread did not upload the expected frame");
+        fail("display thread did not retain the expected blend history");
     }
 
-    private static void paint(SwingDisplay display, Graphics graphics, CountDownLatch painted,
-                              AtomicReference<Throwable> failure) {
-        try {
-            display.paintComponent(graphics);
-        } catch (Throwable t) {
-            failure.set(t);
-        } finally {
-            painted.countDown();
+    private static void flushEdt() throws Exception {
+        onEdt(() -> {
+        });
+    }
+
+    private static void onEdt(ThrowingRunnable runnable) throws Exception {
+        onEdt(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    private static <T> T onEdt(Callable<T> callable) throws Exception {
+        if (SwingUtilities.isEventDispatchThread()) {
+            return callable.call();
         }
+        FutureTask<T> task = new FutureTask<>(callable);
+        SwingUtilities.invokeAndWait(task);
+        return task.get();
     }
 
     private static void await(CountDownLatch latch) {
@@ -272,5 +493,10 @@ public class SwingDisplayTest {
             Thread.currentThread().interrupt();
             throw new AssertionError(e);
         }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -251,6 +251,12 @@ public class SwingDisplayTest {
         flushEdt();
         assertEquals(new Dimension(432, 480), latestSize.get());
         assertEquals(new Dimension(432, 480), onEdt(display::getPreferredSize));
+
+        // Reapplying settings for a fullscreen-only change must not repack and overwrite the
+        // restored window bounds.
+        eventBus.post(new SwingDisplay.SetScaleModeEvent(DisplayScaleMode.EXPLICIT_3X));
+        eventBus.post(new SwingDisplay.SetRotationEvent(90));
+        flushEdt();
         assertEquals(2, eventCount.get());
         assertTrue(allEventsOnEdt.get());
         eventBus.close();


### PR DESCRIPTION
## Summary

- make the Swing window resizable and separate emulated frame dimensions from component dimensions
- add integer-fit, aspect-fit, and explicit 1×–4× scaling with exact aspect-preserving letterboxing for DMG, CGB, and SGB output
- add schema-4 Display preferences for scaling, letterbox color, fullscreen, palette/blending/color correction, rotation, and SGB border
- add borderless fullscreen with stable monitor identity, bounds restoration/clamping, disconnected-monitor recovery, and per-monitor DPI refresh
- synchronize radio/toggle Screen menu items, Preferences, persisted settings, and runtime state; reserve F11 only when it does not collide with an emulator binding

## Invariants and fallbacks

All Swing creation and mutation remains on the EDT. Renderer updates flow through the event bus, and repainting consumes immutable frame snapshots rather than emulator-owned buffers. Fullscreen drops the windowed explicit-size minimum before entry and recomputes it after exit, including no-op geometry transitions, without treating the dispose/re-show cycle as application shutdown.

Schemas 0–3 migrate idempotently to explicit 2×, black letterboxing, and windowed mode while preserving the unknown-key collision envelope. Swing has no reliable portable swap-interval API, so the documented fallback keeps event-driven repaint pacing instead of exposing a fake vsync setting.

## Validation

- `mvn -B clean package --file pom.xml`: green across the complete reactor (791 core, 484 controller with 2 skipped, 169 Swing)
- focused display/controller lifecycle suite: 37/37 green after the fullscreen-boundary regression fix
- production Linux/Xvfb smoke: Display Preferences rendered cleanly and the real `DesktopFullscreenRuntime` entered/exited an undecorated visible `JFrame` while restoring bounds
- packaged JAR: `--help` and `--version` exit 0; invalid option exits 2
- pure viewport, immutable-frame, EDT ownership, menu synchronization, settings migration, fullscreen monitor/DPI recovery, DMG/CGB/SGB geometry, and shutdown lifecycle tests included

Phase 3's unified ROM-opening foundation is unblocked and already underway.

Closes #335
Part of #316
