### PR TITLE
Fix macOS Maven test temp paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,10 @@
         <skipTests>false</skipTests>
         <skip.unit.tests>${skipTests}</skip.unit.tests>
         <integration.test.threadCount>2</integration.test.threadCount>
-        <coffee-gb.test.tmpdir>${java.io.tmpdir}</coffee-gb.test.tmpdir>
+        <!-- Keep ordinary test files inside the module build tree. macOS exposes its system
+             temporary directory through /var, which is a symlink to /private/var; battery-path
+             safety checks correctly reject such logical paths unless callers resolve them first. -->
+        <coffee-gb.test.tmpdir>${project.build.directory}</coffee-gb.test.tmpdir>
     </properties>
     <build>
         <pluginManagement>

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
@@ -49,6 +49,8 @@ public class NativePackagingScriptTest {
         assertTrue(sh.contains("pwd -P"));
         assertTrue(ps.contains("-Dcoffee-gb.test.tmpdir=$MavenTemp"));
         assertTrue(ps.contains("Resolve-Path -LiteralPath $MavenTemp"));
+        assertTrue(pom.contains(
+                "<coffee-gb.test.tmpdir>${project.build.directory}</coffee-gb.test.tmpdir>"));
         assertTrue(pom.contains("-Djava.io.tmpdir=\"${coffee-gb.test.tmpdir}\""));
         assertTrue(pom.contains(
                 "<artifactId>maven-jar-plugin</artifactId>\n"


### PR DESCRIPTION
**AI-generated comment:**

## Summary

- keep ordinary Surefire temp files inside each Maven module's build directory
- avoid macOS `/var` symlink aliases tripping the intentional storage path-safety checks
- retain native packaging's physical temp override and production symlink protections
- guard the default temp-root configuration with packaging regression coverage

## Root cause

On macOS, `java.io.tmpdir` commonly starts with `/var/folders/...`, while `/var` is a symlink to `/private/var`. Battery and state storage correctly reject paths containing symbolic-link ancestors. Surefire inherited the logical `/var` path, so storage operations failed safely and produced the reported stale, zero-length, and missing-file assertions.

## Validation

- reproduced the exact reported 31-test result (16 failures and 2 errors) under a synthetic symlinked host temp path before the fix
- reran those 31 tests successfully after the fix
- verified `NativePackagingScriptTest`
- ran `JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=<symlink> mvn -B clean package`: 1,841 tests passed, 2 skipped, all modules packaged
- confirmed `ProtocolV9ConsentTransferTest`: 21 passed in 0.12 seconds
