### PR TITLE
Dismiss link loading overlay after startup

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -118,8 +118,11 @@ public class SwingDisplay extends JPanel implements Runnable {
                 Controller.LoadRomFailedEvent.class);
         eventBus.register(e -> clearPersistentNotification(),
                 Controller.RomLoadingCancelledEvent.class);
+        // LinkedController publishes the local owner lifecycle from its "session" bus while
+        // forwarding frame/audio output through the caller-filtered "main" bus. Loading is a
+        // host lifecycle notification, so its successful terminal event must remain unfiltered.
         eventBus.register(e -> clearPersistentNotification(),
-                Controller.EmulationStartedEvent.class, callerId);
+                Controller.EmulationStartedEvent.class);
         // Session teardown silently quiesces core outputs after its bus stops. Reset host-only
         // visual rumble through the owner lifecycle while subscribers are still active.
         eventBus.register(e -> this.rumbling = false, Controller.RomLoadingEvent.class);

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -74,6 +74,22 @@ public class SwingDisplayTest {
     }
 
     @Test
+    public void linkedControllerOwnerStartClearsPersistentLoadingNotification() throws Exception {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        EventBus linkedController = root.fork("session");
+        SwingDisplay display = newDisplay(root, "main");
+        Field textField = SwingDisplay.class.getDeclaredField("persistentNotificationText");
+        textField.setAccessible(true);
+
+        linkedController.post(new Controller.RomLoadingEvent(new File("linked.gb")));
+        assertEquals("Loading…", textField.get(display));
+
+        linkedController.post(new Controller.EmulationStartedEvent("LINKED"));
+        assertNull(textField.get(display));
+        root.close();
+    }
+
+    @Test
     public void snapshotCompletionEventsShowAnOnScreenNotification() throws Exception {
         EventBusImpl root = new EventBusImpl(null, null, false);
         EventBus session = root.fork("test");
@@ -418,8 +434,12 @@ public class SwingDisplayTest {
     }
 
     private static SwingDisplay newDisplay(EventBus eventBus) throws Exception {
+        return newDisplay(eventBus, "test");
+    }
+
+    private static SwingDisplay newDisplay(EventBus eventBus, String callerId) throws Exception {
         return onEdt(() -> new SwingDisplay(
-                new EmulatorProperties().getDisplay(), eventBus, "test"));
+                new EmulatorProperties().getDisplay(), eventBus, callerId));
     }
 
     private static BufferedImage paintAtPreferredSize(SwingDisplay display) throws Exception {


### PR DESCRIPTION
**AI-generated comment:**

## Summary
- clear the persistent loading overlay when linked emulation reports a successful start
- treat the successful start as the same host lifecycle event as loading, regardless of its event-bus caller
- add a regression test with the display on `main` and linked lifecycle events on `session`

## Verification
- `mvn -B -pl swing -am -Dtest=SwingDisplayTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B clean package`