### PR TITLE
Route macOS Dock quit through desktop shutdown

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
@@ -14,6 +14,7 @@ import java.awt.Toolkit
 import java.awt.Window
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.awt.desktop.QuitResponse
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.KeyEvent
@@ -506,9 +507,9 @@ internal fun createRomOpenErrorPanel(failure: RomOpenFailure): JPanel {
 }
 
 /**
- * Installs the platform open-file callback before settings or Swing construction can delay it.
- * Deliveries received during startup are queued and identical CLI/platform startup deliveries are
- * collapsed once the desktop ROM coordinator is ready.
+ * Retains platform open-file callbacks received before settings or Swing construction completes.
+ * Identical CLI/platform startup deliveries are collapsed once the desktop ROM coordinator is
+ * ready.
  */
 internal class DesktopOpenFilesBridge(
     private val uiExecutor: Executor =
@@ -564,6 +565,68 @@ internal class DesktopOpenFilesBridge(
 
   private companion object {
     const val MAX_PENDING_DELIVERIES = 16
+  }
+}
+
+/**
+ * Queues and coalesces native application-quit requests outside the platform callback. A request
+ * received before the Swing close coordinator attaches is retained until it is ready.
+ */
+internal class DesktopQuitBridge(
+    private val uiExecutor: Executor =
+        Executor { task -> SwingUtilities.invokeLater(task) },
+) {
+  private val lock = Any()
+  private var pending = false
+  private var deliveryInFlight = false
+  private var receiver: (() -> Unit)? = null
+
+  fun accept() {
+    val target =
+        synchronized(lock) {
+          val current = receiver
+          if (current == null) {
+            pending = true
+            null
+          } else if (deliveryInFlight) {
+            null
+          } else {
+            deliveryInFlight = true
+            current
+          }
+        }
+    target?.let(::dispatch)
+  }
+
+  fun attach(receiver: () -> Unit) {
+    val target =
+        synchronized(lock) {
+          check(this.receiver == null) { "Desktop quit bridge is already attached" }
+          this.receiver = receiver
+          if (pending) {
+            pending = false
+            deliveryInFlight = true
+            receiver
+          } else {
+            null
+          }
+        }
+    target?.let(::dispatch)
+  }
+
+  private fun dispatch(receiver: () -> Unit) {
+    try {
+      uiExecutor.execute {
+        try {
+          receiver()
+        } finally {
+          synchronized(lock) { deliveryInFlight = false }
+        }
+      }
+    } catch (failure: RuntimeException) {
+      synchronized(lock) { deliveryInFlight = false }
+      throw failure
+    }
   }
 }
 
@@ -780,6 +843,30 @@ internal fun installDesktopOpenFileHandler(open: (List<Path>) -> Unit): Boolean 
     LOG.warn("Desktop open-file integration is unavailable", failure)
     false
   }
+}
+
+internal fun installDesktopQuitHandler(quit: () -> Unit): Boolean {
+  if (!Desktop.isDesktopSupported()) {
+    return false
+  }
+  return try {
+    val desktop = Desktop.getDesktop()
+    if (!desktop.isSupported(Desktop.Action.APP_QUIT_HANDLER)) {
+      false
+    } else {
+      desktop.setQuitHandler { _, response -> handleDesktopQuitRequest(response, quit) }
+      true
+    }
+  } catch (failure: RuntimeException) {
+    LOG.warn("Desktop quit integration is unavailable", failure)
+    false
+  }
+}
+
+/** Cancels Java's synchronous default exit before handing termination to the desktop coordinator. */
+internal fun handleDesktopQuitRequest(response: QuitResponse, quit: () -> Unit) {
+  response.cancelQuit()
+  quit()
 }
 
 internal fun formatByteCount(bytes: Long): String =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -84,6 +84,8 @@ class SwingGui private constructor(
 
   private lateinit var menu: SwingMenu
 
+  private val desktopQuit = DesktopQuitBridge()
+
   private var activeWindowTitle = "Coffee GB"
 
   private var romLoading = false
@@ -291,6 +293,10 @@ class SwingGui private constructor(
             mainWindow.jMenuBar?.preferredSize?.height ?: 0,
         )
     mainWindow.isResizable = true
+    // Claim native Quit only after every coordinated-shutdown dependency exists. Attaching before
+    // installation also guarantees a callback can only enqueue, never run inside AppKit dispatch.
+    desktopQuit.attach(::requestClose)
+    installDesktopQuitHandler(desktopQuit::accept)
     mainWindow.isVisible = true
     displayController.applyCurrent()
     properties.consumeLoadWarning()?.let { warning ->
@@ -594,11 +600,11 @@ class SwingGui private constructor(
 }
 
 /**
- * Opens the platform delivery gate before native extraction can delay startup.
+ * Opens the platform file delivery gate before native extraction can delay startup.
  *
  * Both operations deliberately run on the caller's launcher thread: native bootstrap must finish
  * before settings construct gamepad backends or the EDT constructs camera UI, while an OS
- * open-file callback received during bootstrap is retained by [DesktopOpenFilesBridge].
+ * open-file callbacks received during bootstrap are retained by [DesktopOpenFilesBridge].
  */
 internal fun prepareDesktopLaunch(
     desktopOpenFiles: DesktopOpenFilesBridge,

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
@@ -6,6 +6,7 @@ import java.awt.Container
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
+import java.awt.desktop.QuitResponse
 import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
@@ -244,6 +245,52 @@ class DesktopRomOpenTest {
     val delivered = mutableListOf<List<Path>>()
     bridge.attach(null, delivered::add)
     assertEquals(listOf(listOf(earlyRom)), delivered)
+  }
+
+  @Test
+  fun `native quit is cancelled synchronously before the close request reaches Swing`() {
+    val queued = mutableListOf<Runnable>()
+    val bridge = DesktopQuitBridge(Executor(queued::add))
+    val calls = mutableListOf<String>()
+    val response =
+        object : QuitResponse {
+          override fun cancelQuit() {
+            calls += "cancel native quit"
+          }
+
+          override fun performQuit() {
+            calls += "perform native quit"
+          }
+        }
+    bridge.attach { calls += "request coordinated close" }
+
+    handleDesktopQuitRequest(response, bridge::accept)
+
+    assertEquals(listOf("cancel native quit"), calls)
+    assertEquals(1, queued.size)
+    queued.single().run()
+    assertEquals(listOf("cancel native quit", "request coordinated close"), calls)
+  }
+
+  @Test
+  fun `desktop quit bridge coalesces requests before attachment and while delivery is queued`() {
+    val queued = mutableListOf<Runnable>()
+    val bridge = DesktopQuitBridge(Executor(queued::add))
+    var requests = 0
+
+    repeat(3) { bridge.accept() }
+    bridge.attach { requests++ }
+
+    assertEquals(1, queued.size)
+    repeat(3) { bridge.accept() }
+    assertEquals(1, queued.size)
+    queued.removeFirst().run()
+    assertEquals(1, requests)
+
+    bridge.accept()
+    assertEquals(1, queued.size)
+    queued.single().run()
+    assertEquals(2, requests)
   }
 
   @Test


### PR DESCRIPTION
**AI-generated comment:**

## Summary
- route macOS Dock and application-menu Quit through the existing coordinated desktop shutdown path
- cancel Java's synchronous native quit before queuing the close request onto Swing
- retain early requests and coalesce repeated native quit callbacks while close confirmation is pending

## Testing
- mvn -B -pl swing -Dtest=DesktopRomOpenTest,SwingGuiShutdownTest test (40 tests)
- mvn -B clean package