### PR TITLE
Persist desktop window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ General and System behavior, 1×/2×/4× window sizing, letterboxing, fullscreen
 four-player keyboard bindings, gamepad assignment/tuning, audio device/volume/mute/latency, and
 Saves policy (directory, battery saves, rewind bounds, autosave, and resume) without manual editing.
 The resizable display always fits the complete DMG/CGB or SGB-border image while preserving its
-aspect ratio; fullscreen restores and clamps prior window placement across monitor and DPI changes.
+aspect ratio. The last normal window size is restored on launch, while fullscreen restores and
+clamps prior window placement across monitor and DPI changes.
 The complete typed schema, validation,
 rendering fallback, migration, device fallback, and recovery rules are documented in the
 [desktop command-line and settings contract](docs/desktop-settings.md). For keyboard mappings, use

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -19,6 +19,7 @@ data class ApplicationSettings(
     val input: Input = Input.defaults(),
     val saves: Saves = Saves(),
     val advanced: Advanced = Advanced(),
+    val desktop: Desktop = Desktop(),
 ) {
   init {
     require(schemaVersion == CURRENT_SCHEMA_VERSION) {
@@ -148,6 +149,21 @@ data class ApplicationSettings(
       fun fromDegrees(degrees: Int): Rotation =
           entries.firstOrNull { it.degrees == degrees }
               ?: throw IllegalArgumentException("Display rotation must be 0, 90, 180, or 270")
+    }
+  }
+
+  /** Desktop-shell state that is deliberately independent from editable display preferences. */
+  data class Desktop(
+      val windowSize: WindowSize? = null,
+  )
+
+  /** Last normal, windowed outer-frame size. Placement and maximized state are not persisted. */
+  data class WindowSize(
+      val width: Int,
+      val height: Int,
+  ) {
+    init {
+      require(width > 0 && height > 0) { "Desktop window size must be positive" }
     }
   }
 
@@ -533,7 +549,7 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 5
+    const val CURRENT_SCHEMA_VERSION = 6
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -25,6 +25,8 @@ object ApplicationSettingsCodec {
   const val DISPLAY_SCALING_MODE_KEY = "display.scalingMode"
   const val DISPLAY_LETTERBOX_COLOR_KEY = "display.letterboxColor"
   const val DISPLAY_FULLSCREEN_KEY = "display.fullscreen"
+  const val DESKTOP_WINDOW_WIDTH_KEY = "desktop.windowWidth"
+  const val DESKTOP_WINDOW_HEIGHT_KEY = "desktop.windowHeight"
   const val SAVE_DIRECTORY_KEY = "saves.directory"
   const val PREVIOUS_SAVE_DIRECTORY_PREFIX = "saves.previousDirectory."
   const val REWIND_ENABLED_KEY = "saves.rewindEnabled"
@@ -57,6 +59,8 @@ object ApplicationSettingsCodec {
               AUTOSAVE_POLICY_KEY,
               RESUME_POLICY_KEY,
           )
+  private val versionSixFixedKeys =
+      versionFiveFixedKeys + setOf(DESKTOP_WINDOW_WIDTH_KEY, DESKTOP_WINDOW_HEIGHT_KEY)
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -75,6 +79,7 @@ object ApplicationSettingsCodec {
             version == "2" ||
             version == "3" ||
             version == "4" ||
+            version == "5" ||
             version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
@@ -131,6 +136,10 @@ object ApplicationSettingsCodec {
     known[DISPLAY_LETTERBOX_COLOR_KEY] =
         "%06X".format(Locale.ROOT, settings.display.letterboxColor)
     known[DISPLAY_FULLSCREEN_KEY] = settings.display.fullscreen.toString()
+    settings.desktop.windowSize?.let { size ->
+      known[DESKTOP_WINDOW_WIDTH_KEY] = size.width.toString()
+      known[DESKTOP_WINDOW_HEIGHT_KEY] = size.height.toString()
+    }
     known[EmulatorProperties.Key.DisplayGrayscale.propertyName] = settings.display.grayscale.toString()
     known[EmulatorProperties.Key.DisplayBlending.propertyName] = settings.display.blending.toString()
     known[EmulatorProperties.Key.DisplayColorCorrection.propertyName] =
@@ -412,12 +421,21 @@ object ApplicationSettingsCodec {
                     fullChangerCharacter =
                         raw[EmulatorProperties.Key.FullChangerCharacter.propertyName],
                 ),
+            desktop =
+                ApplicationSettings.Desktop(
+                    windowSize =
+                        if (sourceVersion >= 6) {
+                          parseDesktopWindowSize(raw)
+                        } else {
+                          null
+                        }),
         )
 
     val preservedCollisions =
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
         when {
+          sourceVersion >= 6 -> versionSixFixedKeys
           sourceVersion >= 5 -> versionFiveFixedKeys
           sourceVersion >= 4 -> versionFourFixedKeys
           sourceVersion >= 3 -> versionThreeFixedKeys
@@ -600,6 +618,27 @@ object ApplicationSettingsCodec {
       }
     }
     return parsed
+  }
+
+  private fun parseDesktopWindowSize(
+      raw: Map<String, String>
+  ): ApplicationSettings.WindowSize? {
+    val widthValue = raw[DESKTOP_WINDOW_WIDTH_KEY]
+    val heightValue = raw[DESKTOP_WINDOW_HEIGHT_KEY]
+    require((widthValue == null) == (heightValue == null)) {
+      "$DESKTOP_WINDOW_WIDTH_KEY and $DESKTOP_WINDOW_HEIGHT_KEY must be stored together"
+    }
+    if (widthValue == null || heightValue == null) return null
+    val width = parseInt(widthValue, DESKTOP_WINDOW_WIDTH_KEY)
+    val height = parseInt(heightValue, DESKTOP_WINDOW_HEIGHT_KEY)
+    return try {
+      ApplicationSettings.WindowSize(width, height)
+    } catch (failure: IllegalArgumentException) {
+      throw IllegalArgumentException(
+          "Invalid desktop window size: ${width}x$height (expected positive dimensions)",
+          failure,
+      )
+    }
   }
 
   private fun parseLetterboxColor(value: String?): Int {
@@ -862,7 +901,7 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionFiveFixedKeys ||
+      key in versionSixFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           isKnownPreviousSaveDirectoryKey(key, supportsPreviousDirectories = true) ||

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDesktopTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDesktopTest.kt
@@ -1,0 +1,145 @@
+package eu.rekawek.coffeegb.controller.properties
+
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ApplicationSettingsDesktopTest {
+
+  @Test
+  fun `desktop defaults omit window geometry and dimensions must be positive`() {
+    val defaults = ApplicationSettings()
+    assertNull(defaults.desktop.windowSize)
+
+    val encoded = ApplicationSettingsCodec.encode(ApplicationSettingsDocument(defaults))
+    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY in encoded)
+    assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY in encoded)
+
+    ApplicationSettings.WindowSize(1, 1)
+    ApplicationSettings.WindowSize(Int.MAX_VALUE, Int.MAX_VALUE)
+    listOf(0, -1, Int.MIN_VALUE).forEach { invalid ->
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.WindowSize(invalid, 480)
+      }
+      assertFailsWith<IllegalArgumentException> {
+        ApplicationSettings.WindowSize(640, invalid)
+      }
+    }
+  }
+
+  @Test
+  fun `schema six window size round trips canonically with unknown settings`() {
+    val size = ApplicationSettings.WindowSize(937, 641)
+    val document =
+        ApplicationSettingsDocument(
+            ApplicationSettings(desktop = ApplicationSettings.Desktop(size)),
+            mapOf("plugin.desktop" to "preserved"),
+        )
+
+    val encoded = ApplicationSettingsCodec.encode(document)
+    assertEquals("937", encoded[ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY])
+    assertEquals("641", encoded[ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY])
+    assertEquals(document, ApplicationSettingsCodec.decode(encoded))
+    assertEquals(encoded, ApplicationSettingsCodec.encode(ApplicationSettingsCodec.decode(encoded)))
+  }
+
+  @Test
+  fun `schemas zero through five preserve future window keys without applying them`() {
+    val future =
+        mapOf(
+            ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY to "901",
+            ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY to "607",
+        )
+
+    listOf<String?>(null, "1", "2", "3", "4", "5").forEach { version ->
+      val raw =
+          buildMap {
+            version?.let { put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, it) }
+            putAll(future)
+          }
+      val migrated = ApplicationSettingsCodec.decode(raw)
+      assertNull(migrated.settings.desktop.windowSize, "schema ${version ?: 0}")
+      assertEquals(future, migrated.unknownProperties, "schema ${version ?: 0}")
+
+      val canonical = ApplicationSettingsCodec.encode(migrated)
+      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY in canonical)
+      assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY in canonical)
+      assertTrue(
+          canonical.keys.any {
+            it.startsWith(ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX)
+          })
+      assertEquals(migrated, ApplicationSettingsCodec.decode(canonical))
+    }
+  }
+
+  @Test
+  fun `schema six rejects partial malformed overflowing and nonpositive geometry`() {
+    val schema = mapOf(ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "6")
+    val invalid =
+        listOf(
+            mapOf(ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY to "640"),
+            mapOf(ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY to "480"),
+            windowFields("zero", "480"),
+            windowFields("640", "zero"),
+            windowFields("2147483648", "480"),
+            windowFields("640", "2147483648"),
+            windowFields("0", "480"),
+            windowFields("640", "0"),
+            windowFields("-1", "480"),
+            windowFields("640", "-1"),
+        )
+
+    invalid.forEach { fields ->
+      assertFailsWith<IllegalArgumentException>("Expected rejection for $fields") {
+        ApplicationSettingsCodec.decode(schema + fields)
+      }
+    }
+  }
+
+  @Test
+  fun `window size survives settings close and reload without losing unknown values`() {
+    val directory = Files.createTempDirectory("coffee-gb-window-size")
+    val path = directory.resolve("settings.properties")
+    val original =
+        ApplicationSettingsDocument(
+            ApplicationSettings(),
+            mapOf("plugin.desktop" to "keep me"),
+        )
+    Files.write(
+        path,
+        ApplicationSettingsStore.encodeProperties(ApplicationSettingsCodec.encode(original)),
+    )
+
+    EmulatorProperties(path, debounceMillis = 60_000).use { properties ->
+      properties.updateApplicationSettings { current ->
+        current.copy(
+            desktop =
+                current.desktop.copy(
+                    windowSize = ApplicationSettings.WindowSize(812, 577)))
+      }
+    }
+
+    EmulatorProperties(path, debounceMillis = 60_000).use { reloaded ->
+      assertEquals(
+          ApplicationSettings.WindowSize(812, 577),
+          reloaded.applicationSettings.desktop.windowSize,
+      )
+      val document =
+          ApplicationSettingsCodec.decode(
+              ApplicationSettingsStore.decodeProperties(Files.readAllBytes(path)))
+      assertEquals("keep me", document.unknownProperties["plugin.desktop"])
+    }
+  }
+
+  private fun windowFields(width: String, height: String): Map<String, String> =
+      mapOf(
+          ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY to width,
+          ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY to height,
+      )
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
@@ -103,7 +103,7 @@ class ApplicationSettingsDevicesTest {
     mutableTunings.clear()
 
     val encoded = ApplicationSettingsCodec.encode(document)
-    assertEquals("5", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertEquals(audioId('c'), encoded[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
     assertEquals("37", encoded[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
     assertEquals("LOW", encoded[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
@@ -163,7 +163,7 @@ class ApplicationSettingsDevicesTest {
       assertEquals(futureValues, migrated.unknownProperties)
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("5", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("default", canonical[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
       assertEquals("100", canonical[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
       assertEquals("BALANCED", canonical[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
@@ -63,7 +63,7 @@ class ApplicationSettingsDisplayTest {
               )
 
           val encoded = ApplicationSettingsCodec.encode(document)
-          assertEquals("5", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+          assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
           assertEquals(
               scalingMode.name,
               encoded[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY],
@@ -114,7 +114,7 @@ class ApplicationSettingsDisplayTest {
       assertEquals(futureValues, migrated.unknownProperties)
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("5", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("EXPLICIT", canonical[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY])
       assertEquals("4", canonical["display.scale"])
       assertEquals("000000", canonical[ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY])

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsSavesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsSavesTest.kt
@@ -39,7 +39,7 @@ class ApplicationSettingsSavesTest {
       assertEquals(future, migrated.unknownProperties, "schema ${version ?: 0}")
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("5", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("false", canonical[ApplicationSettingsCodec.BATTERY_SAVES_KEY])
       assertEquals("true", canonical[ApplicationSettingsCodec.REWIND_ENABLED_KEY])
       assertEquals("30", canonical[ApplicationSettingsCodec.REWIND_SECONDS_KEY])
@@ -80,7 +80,7 @@ class ApplicationSettingsSavesTest {
     previous.clear()
 
     val encoded = ApplicationSettingsCodec.encode(document)
-    assertEquals("5", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertEquals(
         Path.of("/new/é").toString(),
         encoded[ApplicationSettingsCodec.SAVE_DIRECTORY_KEY],

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
@@ -425,14 +425,14 @@ class ApplicationSettingsStoreTest {
 
           Files.readAllBytes(path).also { bytes ->
             val canonical = ApplicationSettingsStore.decodeProperties(bytes)
-            assertEquals("5", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+            assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
             assertEquals(store.current(), ApplicationSettingsCodec.decode(canonical))
             assertEquals(canonical, ApplicationSettingsCodec.encode(store.current()))
           }
         }
 
     ApplicationSettingsStore(path, debounceMillis = 60_000).use { store ->
-      assertEquals("5", store.current().settings.schemaVersion.toString())
+      assertEquals("6", store.current().settings.schemaVersion.toString())
     }
     assertTrue(canonicalBytes.contentEquals(Files.readAllBytes(path)))
   }
@@ -829,7 +829,7 @@ class ApplicationSettingsStoreTest {
               "saves.rewindEnabled" to "true",
               "saves.rewindMemoryMiB" to "64",
               "saves.rewindSeconds" to "30",
-              "settings.schemaVersion" to "5",
+              "settings.schemaVersion" to "6",
               "sound.enabled" to "false",
               "system.bootstrapMode" to "FAST_FORWARD",
               "system.cgbGames" to "cgb0",

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -42,15 +42,16 @@ particular, `--use-bootstrap` and `--disable-battery-saves` do not change the ne
 ## Typed settings model
 
 The application owns one immutable `ApplicationSettings` value with typed `general`, `display`,
-`audio`, `input`, `saves`, and `advanced` sections. The controller-facing `EmulatorProperties`
-class is a compatibility facade over that model while older menu code is migrated.
+`audio`, `input`, `saves`, `advanced`, and desktop-shell sections. The controller-facing
+`EmulatorProperties` class is a compatibility facade over that model while older menu code is
+migrated.
 
-Schema 4 continues to use `${user.home}/.coffeegb.properties`; schemas 0–3 are migrated in place
+Schema 6 continues to use `${user.home}/.coffeegb.properties`; schemas 0–5 are migrated in place
 so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `4` |
+| `settings.schemaVersion` | exact supported schema version | `6` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
@@ -63,6 +64,7 @@ so the portable JAR remains compatible during the migration window.
 | `display.blending` | boolean | `true` |
 | `display.colorCorrection` | boolean | `true` |
 | `display.showSgbBorder` | boolean | `false` |
+| `desktop.windowWidth`, `desktop.windowHeight` | optional positive outer-frame dimensions; both or neither | absent |
 | `sound.enabled` | boolean | `true` |
 | `audio.outputDevice` | `default` or stable Java Sound device ID | `default` |
 | `audio.masterVolume` | integer percentage in `0..100` | `100` |
@@ -92,14 +94,14 @@ does not partially update the active settings.
 application may close without a redundant prompt. `ALWAYS` also confirms an idle application
 close, and `NEVER` suppresses this ordinary confirmation. A battery/autosave flush failure remains
 actionable regardless of this preference. Setting recent-file capacity to zero disables history;
-reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 4
+reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 6
 does not invent or persist an update-check preference.
 
-Unrecognized legacy keys are retained losslessly when schema 4 is saved. Keys in a reserved grammar,
+Unrecognized legacy keys are retained losslessly when the current schema is saved. Keys in a reserved grammar,
 such as an unknown `input.*` key, remain errors so a misspelled control binding is not silently
-ignored. Schema 4 stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
+ignored. The current schema stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
 key beyond Coffee GB's old ten-entry history remains untouched even if capacity later grows. Schema
-4 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
+6 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
 binding is therefore unbound rather than silently restored to a default. If an older unknown key
 occupies a name reserved by a later schema, Coffee GB keeps its original key/value in bounded
 internal migration metadata rather than overwriting or reinterpreting it. At most 32 per-device
@@ -162,6 +164,13 @@ available. <kbd>Escape</kbd> always leaves fullscreen when the main game window 
 remaining available to windowed emulation and dialogs. Menu radio items, Preferences, persisted
 settings, and the live renderer are synchronized through one EDT-owned coordinator.
 
+Coffee GB stores the last normal, windowed outer-frame width and height. On the next launch that
+size is clamped to the current frame minimum and primary usable work area, then centered as before.
+Fullscreen, maximized, and iconified dimensions never replace the saved normal size; window
+position and maximized state are intentionally not persisted. Live-resize updates are coalesced,
+while a final normal size is captured before a successful settings close. If settings are read-only,
+window geometry remains session-only and the existing file is untouched.
+
 Entering fullscreen remembers window placement relative to the monitor's stable AWT device ID and
 current scale transform. Exiting converts through the latest per-monitor transform and clamps the
 window to the current usable work area. If that monitor disappears, Coffee GB selects the nearest
@@ -179,11 +188,12 @@ after it can report and test that capability, with this repaint path remaining t
 
 ## Migration and recovery
 
-A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 3 migration is a
-pure conversion into schema 4, preserves unknown keys, retains absent profile mappings as Auto, and
+A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 5 migration is a
+pure conversion into schema 6, preserves unknown keys, retains absent profile mappings as Auto, and
 canonicalizes the finite historical uppercase profile aliases. Existing display scales migrate to
 explicit scale with a black letterbox and windowed startup; no previous launch is unexpectedly
-forced fullscreen. Repeating load/migrate/save produces the same normalized settings. Legacy text
+forced fullscreen. Older schemas have no saved desktop size and retain the existing packed,
+centered startup. Repeating load/migrate/save produces the same normalized settings. Legacy text
 is decoded with the platform-default charset used by the former `FileReader`; versioned files use
 strict UTF-8 with deterministic ASCII escapes.
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -162,11 +162,9 @@ is 30 seconds and 64 MiB.
 ## Settings compatibility note
 
 This feature adds the optional `saves.rewindMemoryMiB` property to settings schema 5. Missing values
-decode as 64 MiB, so schema-5 files written before this feature remain valid. Schema 5 was introduced
-by the immediately preceding recent-ROM/settings phase; this phase deliberately extends that same
-version instead of creating a migration that depends on parallel branch order. If another branch
-consumes schema 5 before these changes are rebased, move this key's fixed-key ownership and migration
-tests to the next schema number as one isolated block.
+decode as 64 MiB, so schema-5 files written before this feature remain valid. Later desktop-window
+geometry advances the current document to schema 6; schema-5 save fields retain their original
+ownership and continue to decode before the schema-6 desktop section is applied.
 
 For the binary format and persistence guarantees, see [StateFile v2](state-file-v2.md) and
 [atomic persistence](atomic-persistence.md).

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopWindowSizeController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopWindowSizeController.kt
@@ -1,0 +1,269 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import java.awt.event.WindowStateListener
+import javax.swing.JFrame
+import javax.swing.Timer
+
+internal const val DESKTOP_WINDOW_SIZE_COMMIT_DELAY_MILLIS = 250
+
+/** Persisted desktop geometry access kept separate from editable display preferences. */
+internal interface DesktopWindowSizeSettings {
+  fun current(): ApplicationSettings.WindowSize?
+
+  fun canPersist(): Boolean
+
+  fun replace(size: ApplicationSettings.WindowSize)
+}
+
+/** Headless seam for the small set of JFrame operations needed by size persistence. */
+internal interface DesktopWindowSizeHost {
+  fun currentSize(): DesktopSize
+
+  fun minimumSize(): DesktopSize
+
+  fun maximumSize(): DesktopSize
+
+  fun resize(size: DesktopSize)
+
+  fun isNormalWindow(): Boolean
+
+  fun listen(listener: () -> Unit): DesktopWindowResizeSubscription
+}
+
+internal fun interface DesktopWindowResizeSubscription {
+  fun remove()
+}
+
+/** Coalesces live-resize events while retaining an explicit close-time flush boundary. */
+internal interface DesktopWindowSizeCommitScheduler {
+  fun restart(action: () -> Unit)
+
+  fun cancel()
+}
+
+/**
+ * EDT-owned launch-to-launch persistence for the last normal, windowed outer-frame size.
+ *
+ * Fullscreen and maximized bounds are transient host state and must never replace the user's
+ * windowed size. The listener is removed before settings closure so a late dispose/resize event
+ * cannot update a closed store.
+ */
+internal class DesktopWindowSizeController(
+    private val settings: DesktopWindowSizeSettings,
+    private val host: DesktopWindowSizeHost,
+    private val commitScheduler: DesktopWindowSizeCommitScheduler =
+        SwingDesktopWindowSizeCommitScheduler(),
+    private val edtOwnership: EdtOwnership = EdtOwnership.SWING,
+) {
+  private var subscription: DesktopWindowResizeSubscription? = null
+  private var observedSize: ApplicationSettings.WindowSize? = null
+  private var installed = false
+  private var closed = false
+
+  constructor(
+      properties: EmulatorProperties,
+      frame: JFrame,
+      isFullscreen: () -> Boolean,
+  ) : this(
+      EmulatorDesktopWindowSizeSettings(properties),
+      JFrameDesktopWindowSizeHost(frame, isFullscreen),
+  )
+
+  /** Applies a saved size after the frame has been packed and its minimum has been established. */
+  fun restore() {
+    requireEdt()
+    check(subscription == null) { "Desktop window size must be restored before listening" }
+    check(!closed) { "Desktop window size controller is closed" }
+    val saved = settings.current() ?: return
+    val restored =
+        clampRestoredWindowSize(
+            saved,
+            minimum = host.minimumSize(),
+            maximum = host.maximumSize(),
+        )
+    host.resize(restored)
+    // AWT and the host window manager may adjust setSize(), so canonicalize what was accepted.
+    val canonical = host.currentSize().toApplicationWindowSize()
+    observedSize = canonical
+    if (canonical != saved) {
+      persist(canonical)
+    }
+  }
+
+  /** Starts observing after startup layout/fullscreen application has reached a stable state. */
+  fun install() {
+    requireEdt()
+    check(!closed) { "Desktop window size controller is closed" }
+    if (installed) return
+    attach()
+  }
+
+  /** Captures the exact last size and detaches while a recoverable settings close is attempted. */
+  fun suspend() {
+    requireEdt()
+    check(!closed) { "Desktop window size controller is closed" }
+    if (!installed) return
+    commitScheduler.cancel()
+    captureSettledNormalWindowSize()
+    subscription?.remove()
+    subscription = null
+    installed = false
+  }
+
+  /** Reattaches after a recoverable settings-close failure retained the desktop window. */
+  fun resume() {
+    requireEdt()
+    check(!closed) { "Desktop window size controller is closed" }
+    if (installed) return
+    attach()
+  }
+
+  /** Captures any final normal size and permanently prevents later settings access. */
+  fun close() {
+    requireEdt()
+    if (closed) return
+    suspend()
+    commitScheduler.cancel()
+    closed = true
+  }
+
+  private fun attach() {
+    subscription = host.listen(::scheduleSettledCapture)
+    installed = true
+
+    val current = host.currentSize().toApplicationWindowSize()
+    val restoredBaseline = observedSize
+    if (restoredBaseline == null) {
+      // Establish a baseline without turning the initial pack into a persisted user resize.
+      observedSize = current
+    } else if (host.isNormalWindow() && current != restoredBaseline) {
+      // Showing, restoring, or rearming a frame may reveal a final host geometry adjustment.
+      scheduleSettledCapture()
+    }
+  }
+
+  private fun scheduleSettledCapture() {
+    requireEdt()
+    if (closed || !installed) return
+    // Resize and window-state events can arrive in either order. Sample only after both settle.
+    commitScheduler.restart(::captureSettledNormalWindowSize)
+  }
+
+  private fun captureSettledNormalWindowSize() {
+    requireEdt()
+    if (closed || !installed || !host.isNormalWindow()) return
+    val current = host.currentSize().toApplicationWindowSize()
+    if (current == observedSize) return
+    observedSize = current
+    persist(current)
+  }
+
+  private fun persist(size: ApplicationSettings.WindowSize) {
+    if (settings.canPersist()) {
+      settings.replace(size)
+    }
+  }
+
+  private fun requireEdt() {
+    check(edtOwnership.isEventDispatchThread()) {
+      "Desktop window size persistence must run on the Event Dispatch Thread"
+    }
+  }
+}
+
+/** Clamps an independently saved width and height to the current host's usable range. */
+internal fun clampRestoredWindowSize(
+    saved: ApplicationSettings.WindowSize,
+    minimum: DesktopSize,
+    maximum: DesktopSize,
+): DesktopSize {
+  val minimumWidth = minOf(minimum.width, maximum.width)
+  val minimumHeight = minOf(minimum.height, maximum.height)
+  return DesktopSize(
+      saved.width.coerceIn(minimumWidth, maximum.width),
+      saved.height.coerceIn(minimumHeight, maximum.height),
+  )
+}
+
+private fun DesktopSize.toApplicationWindowSize(): ApplicationSettings.WindowSize =
+    ApplicationSettings.WindowSize(width, height)
+
+private class EmulatorDesktopWindowSizeSettings(
+    private val properties: EmulatorProperties,
+) : DesktopWindowSizeSettings {
+  override fun current(): ApplicationSettings.WindowSize? =
+      properties.applicationSettings.desktop.windowSize
+
+  override fun canPersist(): Boolean = !properties.isReadOnly()
+
+  override fun replace(size: ApplicationSettings.WindowSize) {
+    properties.updateApplicationSettings { current ->
+      current.copy(desktop = current.desktop.copy(windowSize = size))
+    }
+  }
+}
+
+private class SwingDesktopWindowSizeCommitScheduler : DesktopWindowSizeCommitScheduler {
+  private var pending: (() -> Unit)? = null
+  private val timer =
+      Timer(DESKTOP_WINDOW_SIZE_COMMIT_DELAY_MILLIS) {
+        val action = pending
+        pending = null
+        action?.invoke()
+      }.apply { isRepeats = false }
+
+  override fun restart(action: () -> Unit) {
+    pending = action
+    timer.restart()
+  }
+
+  override fun cancel() {
+    timer.stop()
+    pending = null
+  }
+}
+
+private class JFrameDesktopWindowSizeHost(
+    private val frame: JFrame,
+    private val isFullscreen: () -> Boolean,
+) : DesktopWindowSizeHost {
+  override fun currentSize(): DesktopSize =
+      DesktopSize(frame.width.coerceAtLeast(1), frame.height.coerceAtLeast(1))
+
+  override fun minimumSize(): DesktopSize =
+      DesktopSize(frame.minimumSize.width.coerceAtLeast(1), frame.minimumSize.height.coerceAtLeast(1))
+
+  override fun maximumSize(): DesktopSize {
+    val usable = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
+    return DesktopSize(usable.width.coerceAtLeast(1), usable.height.coerceAtLeast(1))
+  }
+
+  override fun resize(size: DesktopSize) {
+    frame.setSize(size.width, size.height)
+  }
+
+  override fun isNormalWindow(): Boolean {
+    val transientStates = Frame.ICONIFIED or Frame.MAXIMIZED_BOTH
+    return !isFullscreen() && frame.extendedState and transientStates == 0
+  }
+
+  override fun listen(listener: () -> Unit): DesktopWindowResizeSubscription {
+    val componentAdapter =
+        object : ComponentAdapter() {
+          override fun componentResized(event: ComponentEvent) = listener()
+        }
+    val windowStateListener = WindowStateListener { listener() }
+    frame.addComponentListener(componentAdapter)
+    frame.addWindowStateListener(windowStateListener)
+    return DesktopWindowResizeSubscription {
+      frame.removeWindowStateListener(windowStateListener)
+      frame.removeComponentListener(componentAdapter)
+    }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -74,6 +74,8 @@ class SwingGui private constructor(
 
   private lateinit var displayController: DesktopDisplayController
 
+  private lateinit var windowSizeController: DesktopWindowSizeController
+
   private lateinit var fullscreenEscape: FullscreenEscapeDispatcher
 
   private lateinit var romOpen: DesktopRomOpen
@@ -121,11 +123,18 @@ class SwingGui private constructor(
           romOpen.close()
           runDesktopEdtStep(stateUxController::close)
           console?.stop()
-          // No process-wide key dispatcher may persist display settings once store closure begins.
-          // Removal runs on the EDT, so a queued Escape either completes before this boundary or
-          // cannot race the settings close below.
-          runDesktopEdtStep(fullscreenEscape::close)
-          closeSettings()
+          closeDesktopSettingsRecoverably(
+              suspendWindowSize = { runDesktopEdtStep(windowSizeController::suspend) },
+              closeSettings = {
+                // No process-wide key dispatcher may persist display settings once store closure
+                // begins. Removal runs on the EDT, so a queued Escape either completes before this
+                // boundary or cannot race the settings close below.
+                runDesktopEdtStep(fullscreenEscape::close)
+                closeSettings()
+              },
+              resumeWindowSize = { runDesktopEdtStep(windowSizeController::resume) },
+              finishWindowSize = { runDesktopEdtStep(windowSizeController::close) },
+          )
           jvmShutdown.markCompleted()
         },
         timeoutMillis = DESKTOP_SHUTDOWN_TIMEOUT_MILLIS,
@@ -156,6 +165,12 @@ class SwingGui private constructor(
                 DesktopSize(minimumContentSize.width, minimumContentSize.height),
             ),
             DisplayWindowSizingRuntime(emulator::refreshDisplayWindowSizing),
+        )
+    windowSizeController =
+        DesktopWindowSizeController(
+            properties,
+            mainWindow,
+            isFullscreen = displayController::isFullscreen,
         )
     fullscreenEscape =
         FullscreenEscapeDispatcher(
@@ -199,6 +214,7 @@ class SwingGui private constructor(
             )
           },
           romOpen::close,
+          { runDesktopEdtStep(windowSizeController::close) },
           properties::close,
       )
     }
@@ -283,8 +299,6 @@ class SwingGui private constructor(
     emulator.bind(mainWindow) { !displayController.current().fullscreen }
     installRomDropTarget()
     mainWindow.pack()
-    mainWindow.repaint()
-    mainWindow.setLocationRelativeTo(null)
     mainWindow.minimumSize =
         minimumFrameSize(
             emulator.minimumContentSizeForCurrentMode(
@@ -292,6 +306,9 @@ class SwingGui private constructor(
             mainWindow.insets,
             mainWindow.jMenuBar?.preferredSize?.height ?: 0,
         )
+    windowSizeController.restore()
+    mainWindow.repaint()
+    mainWindow.setLocationRelativeTo(null)
     mainWindow.isResizable = true
     // Claim native Quit only after every coordinated-shutdown dependency exists. Attaching before
     // installation also guarantees a callback can only enqueue, never run inside AppKit dispatch.
@@ -299,6 +316,7 @@ class SwingGui private constructor(
     installDesktopQuitHandler(desktopQuit::accept)
     mainWindow.isVisible = true
     displayController.applyCurrent()
+    windowSizeController.install()
     properties.consumeLoadWarning()?.let { warning ->
       JOptionPane.showMessageDialog(
           mainWindow,
@@ -732,6 +750,27 @@ internal fun stopEmulatorBeforeCamera(
 ) {
   stopEmulator()
   cameraAfterStop?.invoke()
+}
+
+/** Keeps window-size observation recoverable until the settings store has closed successfully. */
+internal fun closeDesktopSettingsRecoverably(
+    suspendWindowSize: () -> Unit,
+    closeSettings: () -> Unit,
+    resumeWindowSize: () -> Unit,
+    finishWindowSize: () -> Unit,
+) {
+  suspendWindowSize()
+  try {
+    closeSettings()
+  } catch (failure: Exception) {
+    try {
+      resumeWindowSize()
+    } catch (resumeFailure: Exception) {
+      failure.addSuppressed(resumeFailure)
+    }
+    throw failure
+  }
+  finishWindowSize()
 }
 
 /**

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopWindowSizeControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopWindowSizeControllerTest.kt
@@ -1,0 +1,361 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DesktopWindowSizeControllerTest {
+
+  @Test
+  fun `no saved size retains the packed baseline and a later resize persists exactly`() {
+    val settings = FakeSettings()
+    val host = FakeHost(size = DesktopSize(480, 360))
+    val scheduler = FakeScheduler()
+    val controller = controller(settings, host, scheduler)
+
+    controller.restore()
+    controller.install()
+
+    assertTrue(host.resizedTo.isEmpty())
+    assertTrue(settings.replacements.isEmpty())
+    host.fireResize()
+    assertTrue(settings.replacements.isEmpty(), "the initial component event is not a user resize")
+
+    host.size = DesktopSize(733, 519)
+    host.fireResize()
+    assertTrue(settings.replacements.isEmpty(), "live resize is coalesced off the event callback")
+    scheduler.fire()
+    assertEquals(ApplicationSettings.WindowSize(733, 519), settings.current())
+    assertEquals(listOf(ApplicationSettings.WindowSize(733, 519)), settings.replacements)
+  }
+
+  @Test
+  fun `restoration clamps dimensions independently to the current usable range`() {
+    val settings = FakeSettings(ApplicationSettings.WindowSize(100, Int.MAX_VALUE))
+    val host =
+        FakeHost(
+            size = DesktopSize(480, 360),
+            minimum = DesktopSize(300, 200),
+            maximum = DesktopSize(800, 600),
+        )
+    val controller = controller(settings, host)
+
+    controller.restore()
+
+    assertEquals(listOf(DesktopSize(300, 600)), host.resizedTo)
+    assertEquals(ApplicationSettings.WindowSize(300, 600), settings.current())
+    assertEquals(listOf(ApplicationSettings.WindowSize(300, 600)), settings.replacements)
+
+    assertEquals(
+        DesktopSize(200, 150),
+        clampRestoredWindowSize(
+            ApplicationSettings.WindowSize(Int.MAX_VALUE, Int.MAX_VALUE),
+            minimum = DesktopSize(300, 200),
+            maximum = DesktopSize(200, 150),
+        ),
+        "a tiny work area wins over the ordinary frame minimum",
+    )
+  }
+
+  @Test
+  fun `restoration persists the size actually accepted by the host`() {
+    val saved = ApplicationSettings.WindowSize(700, 500)
+    val settings = FakeSettings(saved)
+    val host =
+        FakeHost(
+            size = DesktopSize(480, 360),
+            resizeAdjustment = { DesktopSize(it.width + 16, it.height + 9) },
+        )
+
+    controller(settings, host).restore()
+
+    assertEquals(listOf(DesktopSize(700, 500)), host.resizedTo)
+    assertEquals(ApplicationSettings.WindowSize(716, 509), settings.current())
+    assertEquals(listOf(ApplicationSettings.WindowSize(716, 509)), settings.replacements)
+  }
+
+  @Test
+  fun `fullscreen maximized and iconified resize events never replace the normal size`() {
+    val saved = ApplicationSettings.WindowSize(640, 480)
+    val settings = FakeSettings(saved)
+    val host = FakeHost(size = DesktopSize(400, 300))
+    val controller = controller(settings, host)
+    controller.restore()
+    controller.install()
+
+    host.normalWindow = false
+    host.size = DesktopSize(1_920, 1_080)
+    host.fireResize()
+    controller.scheduler.fire()
+    assertEquals(saved, settings.current())
+    assertTrue(settings.replacements.isEmpty())
+
+    host.normalWindow = true
+    host.size = DesktopSize(640, 480)
+    host.fireWindowStateChange()
+    controller.scheduler.fire()
+    assertTrue(settings.replacements.isEmpty(), "restoring the old normal bounds is not a change")
+
+    host.size = DesktopSize(701, 503)
+    host.fireResize()
+    controller.scheduler.fire()
+    assertEquals(ApplicationSettings.WindowSize(701, 503), settings.current())
+  }
+
+  @Test
+  fun `resize and state events in either order retain only confirmed normal geometry`() {
+    val saved = ApplicationSettings.WindowSize(640, 480)
+    val settings = FakeSettings(saved)
+    val host = FakeHost(size = DesktopSize(400, 300))
+    val controller = controller(settings, host)
+    controller.restore()
+    controller.install()
+
+    // X11 may deliver maximized bounds before the separate window-state transition.
+    host.size = DesktopSize(1_920, 1_040)
+    host.fireResize()
+    host.normalWindow = false
+    host.fireWindowStateChange()
+    controller.scheduler.fire()
+    assertTrue(settings.replacements.isEmpty())
+
+    // The inverse ordering is also valid while restoring a normal window.
+    host.size = DesktopSize(684, 517)
+    host.fireResize()
+    host.normalWindow = true
+    host.fireWindowStateChange()
+    controller.scheduler.fire()
+    assertEquals(
+        listOf(ApplicationSettings.WindowSize(684, 517)),
+        settings.replacements,
+    )
+  }
+
+  @Test
+  fun `close captures an undelivered final resize and removes the listener before disposal`() {
+    val settings = FakeSettings()
+    val host = FakeHost(size = DesktopSize(480, 360))
+    val controller = controller(settings, host)
+    controller.install()
+
+    host.size = DesktopSize(777, 555)
+    controller.close()
+
+    assertEquals(ApplicationSettings.WindowSize(777, 555), settings.current())
+    assertEquals(1, host.removedListeners)
+    host.size = DesktopSize(999, 888)
+    host.fireResize()
+    assertEquals(ApplicationSettings.WindowSize(777, 555), settings.current())
+    assertEquals(1, settings.replacements.size)
+
+    controller.close()
+    assertEquals(1, host.removedListeners, "close is idempotent")
+  }
+
+  @Test
+  fun `suspend flushes and resume tracks geometry after a recoverable close failure`() {
+    val settings = FakeSettings()
+    val host = FakeHost(size = DesktopSize(480, 360))
+    val controller = controller(settings, host)
+    controller.install()
+
+    host.size = DesktopSize(700, 500)
+    host.fireResize()
+    controller.suspend()
+    assertEquals(ApplicationSettings.WindowSize(700, 500), settings.current())
+    assertEquals(1, host.removedListeners)
+
+    controller.resume()
+    host.size = DesktopSize(720, 540)
+    host.fireResize()
+    controller.scheduler.fire()
+    assertEquals(ApplicationSettings.WindowSize(720, 540), settings.current())
+    assertEquals(2, settings.replacements.size)
+  }
+
+  @Test
+  fun `close before installation cannot overwrite a saved size with partial startup geometry`() {
+    val saved = ApplicationSettings.WindowSize(640, 480)
+    val settings = FakeSettings(saved)
+    val host = FakeHost(size = DesktopSize(1, 1))
+    val controller = controller(settings, host)
+
+    controller.close()
+
+    assertEquals(saved, settings.current())
+    assertTrue(settings.replacements.isEmpty())
+    assertEquals(0, host.removedListeners)
+  }
+
+  @Test
+  fun `read only settings ignore restoration resize and close mutations`() {
+    val saved = ApplicationSettings.WindowSize(100, 900)
+    val settings = FakeSettings(saved, writable = false)
+    val host =
+        FakeHost(
+            size = DesktopSize(480, 360),
+            minimum = DesktopSize(300, 200),
+            maximum = DesktopSize(800, 600),
+        )
+    val controller = controller(settings, host)
+
+    controller.restore()
+    controller.install()
+    host.size = DesktopSize(711, 522)
+    host.fireResize()
+    controller.scheduler.fire()
+    controller.close()
+
+    assertEquals(saved, settings.current())
+    assertTrue(settings.replacements.isEmpty())
+  }
+
+  @Test
+  fun `resize bursts commit only their latest normal size`() {
+    val settings = FakeSettings()
+    val host = FakeHost()
+    val controller = controller(settings, host)
+    controller.install()
+
+    repeat(25) { index ->
+      host.size = DesktopSize(600 + index, 400 + index)
+      host.fireResize()
+    }
+
+    assertTrue(settings.replacements.isEmpty())
+    assertEquals(25, controller.scheduler.restartCount)
+    controller.scheduler.fire()
+    assertEquals(
+        listOf(ApplicationSettings.WindowSize(624, 424)),
+        settings.replacements,
+    )
+  }
+
+  @Test
+  fun `controller rejects every restore listen and close mutation away from the EDT`() {
+    val settings = FakeSettings(ApplicationSettings.WindowSize(640, 480))
+    val host = FakeHost()
+    val controller =
+        DesktopWindowSizeController(
+            settings,
+            host,
+            edtOwnership = EdtOwnership { false },
+        )
+
+    assertFailsWith<IllegalStateException> { controller.restore() }
+    assertFailsWith<IllegalStateException> { controller.install() }
+    assertFailsWith<IllegalStateException> { controller.close() }
+    assertNull(host.listener)
+    assertTrue(settings.replacements.isEmpty())
+  }
+
+  private fun controller(
+      settings: FakeSettings,
+      host: FakeHost,
+      scheduler: FakeScheduler = FakeScheduler(),
+  ): TestController {
+    val controller =
+        DesktopWindowSizeController(
+            settings,
+            host,
+            commitScheduler = scheduler,
+            edtOwnership = EdtOwnership { true },
+        )
+    return TestController(controller, scheduler)
+  }
+
+  private data class TestController(
+      val delegate: DesktopWindowSizeController,
+      val scheduler: FakeScheduler,
+  ) {
+    fun restore() = delegate.restore()
+
+    fun install() = delegate.install()
+
+    fun suspend() = delegate.suspend()
+
+    fun resume() = delegate.resume()
+
+    fun close() = delegate.close()
+  }
+
+  private class FakeSettings(
+      private var size: ApplicationSettings.WindowSize? = null,
+      private val writable: Boolean = true,
+  ) : DesktopWindowSizeSettings {
+    val replacements = mutableListOf<ApplicationSettings.WindowSize>()
+
+    override fun current(): ApplicationSettings.WindowSize? = size
+
+    override fun canPersist(): Boolean = writable
+
+    override fun replace(size: ApplicationSettings.WindowSize) {
+      this.size = size
+      replacements += size
+    }
+  }
+
+  private class FakeHost(
+      var size: DesktopSize = DesktopSize(480, 360),
+      var minimum: DesktopSize = DesktopSize(172, 181),
+      var maximum: DesktopSize = DesktopSize(1_920, 1_040),
+      var normalWindow: Boolean = true,
+      var resizeAdjustment: (DesktopSize) -> DesktopSize = { it },
+  ) : DesktopWindowSizeHost {
+    val resizedTo = mutableListOf<DesktopSize>()
+    var listener: (() -> Unit)? = null
+    var removedListeners = 0
+
+    override fun currentSize(): DesktopSize = size
+
+    override fun minimumSize(): DesktopSize = minimum
+
+    override fun maximumSize(): DesktopSize = maximum
+
+    override fun resize(size: DesktopSize) {
+      this.size = resizeAdjustment(size)
+      resizedTo += size
+    }
+
+    override fun isNormalWindow(): Boolean = normalWindow
+
+    override fun listen(listener: () -> Unit): DesktopWindowResizeSubscription {
+      check(this.listener == null)
+      this.listener = listener
+      return DesktopWindowResizeSubscription {
+        if (this.listener != null) {
+          this.listener = null
+          removedListeners++
+        }
+      }
+    }
+
+    fun fireResize() = listener?.invoke()
+
+    fun fireWindowStateChange() = listener?.invoke()
+  }
+
+  private class FakeScheduler : DesktopWindowSizeCommitScheduler {
+    private var action: (() -> Unit)? = null
+    var restartCount = 0
+      private set
+
+    override fun restart(action: () -> Unit) {
+      this.action = action
+      restartCount++
+    }
+
+    override fun cancel() {
+      action = null
+    }
+
+    fun fire() {
+      val pending = action
+      action = null
+      pending?.invoke()
+    }
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -76,6 +76,9 @@ class PreferencesDialogTest {
                     datelSlotRom = Paths.get("datel-hidden.gb"),
                     fullChangerCharacter = "7",
                 ),
+            desktop =
+                ApplicationSettings.Desktop(
+                    windowSize = ApplicationSettings.WindowSize(913, 617)),
         )
     val edit =
         PreferencesEdit(
@@ -119,6 +122,7 @@ class PreferencesDialogTest {
     assertEquals(edit.audio, updated.audio)
     assertEquals(current.saves, updated.saves)
     assertEquals(edit.advanced, updated.advanced)
+    assertEquals(current.desktop, updated.desktop)
   }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
@@ -15,10 +15,48 @@ import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.junit.Test
 
 class SwingGuiShutdownTest {
+
+  @Test
+  fun `successful settings close finishes suspended window size persistence`() {
+    val calls = mutableListOf<String>()
+
+    closeDesktopSettingsRecoverably(
+        suspendWindowSize = { calls += "suspend" },
+        closeSettings = { calls += "settings" },
+        resumeWindowSize = { calls += "resume" },
+        finishWindowSize = { calls += "finish" },
+    )
+
+    assertEquals(listOf("suspend", "settings", "finish"), calls)
+  }
+
+  @Test
+  fun `failed settings close rearms window size persistence and retains the failure`() {
+    val calls = mutableListOf<String>()
+    val expected = IOException("settings close failed")
+
+    val actual =
+        assertFailsWith<IOException> {
+          closeDesktopSettingsRecoverably(
+              suspendWindowSize = { calls += "suspend" },
+              closeSettings = {
+                calls += "settings"
+                throw expected
+              },
+              resumeWindowSize = { calls += "resume" },
+              finishWindowSize = { calls += "finish" },
+          )
+        }
+
+    assertSame(expected, actual)
+    assertEquals(listOf("suspend", "settings", "resume"), calls)
+  }
+
   @Test
   fun `JVM shutdown attempts every teardown step and preserves the first failure`() {
     val calls = mutableListOf<String>()


### PR DESCRIPTION
**AI-generated comment:**

## Summary

- persist and restore the last normal, windowed outer-frame size across launches
- clamp restored dimensions to the current frame minimum and usable work area without saving position, fullscreen, maximized, or iconified geometry
- coalesce live resize events, handle resize/window-state ordering, preserve close-time updates, and rearm persistence after a recoverable settings-close failure
- advance typed settings to schema 6 with strict paired desktop dimensions and lossless schema 0–5 migration/collision preservation

## Validation

- `mvn -B clean package -Dkotlin.compiler.daemon=false` — 1,875 tests passed, 2 skipped
- `java -jar swing/target/coffee-gb-1.7.15-SNAPSHOT.jar --package-smoke`
- packaged Swing desktop startup and bounded normal shutdown under Xvfb
- two independent final code/test reviews
