### PR TITLE
Support Li Cheng unlicensed cartridge banking

### DIFF
--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -42,6 +42,16 @@ class StateCoverageMatrixTest {
             mapper("Mbc5", listOf(0x0000 to 0x0a, 0x2000 to 0x25, 0x4000 to 0x0a, 0xa000 to 0x34)) {
               Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
             },
+            mapper(
+                "LiCheng",
+                listOf(
+                    0x0000 to 0x0a,
+                    0x2100 to 0x25,
+                    0x2200 to 0x11,
+                    0x4000 to 0x0a,
+                    0xa000 to 0x3b,
+                ),
+            ) { LiCheng(mutableRom(0x1e), Battery.NULL_BATTERY) },
             mapper("Mbc6", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0x3000 to 0x04, 0xa000 to 0x35)) {
               Mbc6(it, Battery.NULL_BATTERY)
             },
@@ -726,6 +736,7 @@ class StateCoverageMatrixTest {
             "Mbc2",
             "Mbc3",
             "Mbc5",
+            "LiCheng",
             "Mbc6",
             "Mbc7",
             "Mmm01",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -63,7 +63,7 @@ class StateInventoryTest {
             }
             .sorted()
 
-    assertEquals(99, discovered.size)
+    assertEquals(100, discovered.size)
     assertTrue(discovered.all { '\\' !in it })
     assertEquals(discovered, documented)
   }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -83,6 +83,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
+            case LI_CHENG -> new LiCheng(rom, battery);
             case BBD -> new Bbd(rom, battery);
             case SINTAX -> new Sintax(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -25,6 +25,7 @@ public final class CartridgeProperties {
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
+        LI_CHENG,
         BBD,
         SINTAX,
         SACHEN_MMC1,
@@ -109,6 +110,8 @@ public final class CartridgeProperties {
                     Mapper.BHGOS_MULTICART),
             mapper("Makon/NT old type 2 multicart", CartridgeProperties::isMakonNtOld2,
                     Mapper.MAKON_NT_OLD_2),
+            mapper("Li Cheng unlicensed mapper", CartridgeProperties::isLiCheng,
+                    Mapper.LI_CHENG),
             mapper("BBD unlicensed mapper", CartridgeProperties::isBbd,
                     Mapper.BBD),
             mapper("Sintax unlicensed mapper", CartridgeProperties::isSintax,
@@ -357,6 +360,18 @@ public final class CartridgeProperties {
         return info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;
+    }
+
+    private static boolean isLiCheng(RomInfo info) {
+        int secondaryLogo = info.crc32(0x0184, 0x30);
+        boolean liChengLogo = secondaryLogo == 0xd2b57657
+                || secondaryLogo == 0x20d092e2;
+        boolean inconsistentHeader = info.rawType() == 0x01
+                || info.declaredRomBanks() != info.physicalRomBanks();
+        return (liChengLogo && inconsistentHeader)
+                // Yingxiong Tianxia / Pokemon Jade (Telefang bootleg) uses a normal
+                // secondary logo, so its header is the stable mapper fingerprint.
+                || info.crc32(0x0100, 0x50) == 0x3ef5afb2;
     }
 
     private static boolean isBbd(RomInfo info) {
@@ -723,7 +738,11 @@ public final class CartridgeProperties {
         }
 
         private int romBanks() {
-            int declaredBanks = switch (byteAt(0x0148)) {
+            return Math.max(declaredRomBanks(), physicalRomBanks());
+        }
+
+        private int declaredRomBanks() {
+            return switch (byteAt(0x0148)) {
                 case 0 -> 2;
                 case 1 -> 4;
                 case 2 -> 8;
@@ -738,8 +757,10 @@ public final class CartridgeProperties {
                 case 0x54 -> 96;
                 default -> 2;
             };
-            int physicalBanks = Math.max(2, (data.length + 0x3fff) / 0x4000);
-            return Math.max(declaredBanks, physicalBanks);
+        }
+
+        private int physicalRomBanks() {
+            return Math.max(2, (data.length + 0x3fff) / 0x4000);
         }
 
         private int crc32() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/LiCheng.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/LiCheng.java
@@ -1,0 +1,69 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+/**
+ * Li Cheng's MBC5-compatible mapper. Its low ROM-bank register only decodes addresses
+ * through 0x2100; writes to the rest of the usual MBC5 low-bank window are ignored.
+ */
+public class LiCheng implements MemoryController {
+
+    private final Mbc5 delegate;
+
+    public LiCheng(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (address > 0x2100 && address < 0x3000) {
+            return;
+        }
+        delegate.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        return delegate.getByte(address);
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return delegate.captureState();
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return delegate.captureState(capture);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        delegate.restoreState(state);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/LiChengTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/LiChengTest.java
@@ -1,0 +1,103 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LiChengTest {
+
+    @Test
+    public void detectsLiChengSecondaryLogo() throws IOException {
+        Rom rom = new Rom(liChengRom());
+
+        assertEquals(CartridgeProperties.Mapper.LI_CHENG,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof LiCheng);
+    }
+
+    @Test
+    public void detectsYingxiongTianxiaHeader() throws IOException {
+        byte[] data = bankedRom();
+        // A synthetic 0x50-byte header with CRC-32 3ef5afb2. The production
+        // fingerprint identifies the Telefang-derived Li Cheng cartridge.
+        Arrays.fill(data, 0x0100, 0x0150, (byte) 0);
+        data[0x014c] = (byte) 0xf1;
+        data[0x014d] = (byte) 0x89;
+        data[0x014e] = (byte) 0x3d;
+        data[0x014f] = (byte) 0x8e;
+
+        assertEquals(CartridgeProperties.Mapper.LI_CHENG,
+                new Rom(data).getCartridgeProperties().getMapper());
+    }
+
+    @Test
+    public void ignoresWritesAboveLiChengBankRegisterWindow() throws IOException {
+        LiCheng mapper = new LiCheng(new Rom(bankedRom()), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2100, 0x02);
+        assertEquals(0x02, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2101, 0x03);
+        mapper.setByte(0x2fff, 0x04);
+        assertEquals(0x02, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 0x05);
+        assertEquals(0x05, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void stateRoundTripPreservesMbc5Banking() throws IOException {
+        LiCheng mapper = new LiCheng(new Rom(bankedRom()), Battery.NULL_BATTERY);
+        mapper.setByte(0x2000, 0x05);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 0x02);
+        mapper.restoreState(state);
+
+        assertEquals(0x05, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void doesNotClassifyConsistentMbc5RomFromLogoCrcAlone() throws IOException {
+        byte[] data = liChengRom();
+        data[0x0147] = 0x19;
+        data[0x0148] = 0x05;
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                new Rom(data).getCartridgeProperties().getMapper());
+    }
+
+    private static byte[] liChengRom() {
+        byte[] data = bankedRom();
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x01;
+        // Forty-eight synthetic bytes with CRC-32 d2b57657, one of the Li Cheng
+        // secondary-logo fingerprints. Keeping the fixture synthetic avoids a ROM asset.
+        data[0x01b0] = 0x4e;
+        data[0x01b1] = (byte) 0xaf;
+        data[0x01b2] = 0x41;
+        data[0x01b3] = (byte) 0x9f;
+        return data;
+    }
+
+    private static byte[] bankedRom() {
+        byte[] data = new byte[0x100000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        data[0x0147] = 0x19;
+        data[0x0148] = 0x05;
+        return data;
+    }
+}

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -33,7 +33,7 @@ The exact remaining compatibility surface and removal policy are documented in
 [legacy-state-retirement.md](legacy-state-retirement.md).
 
 The exact field-by-field inventory of all 91 admitted production record types is committed in
-[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 99
+[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 100
 production state contracts and capture owner/call-site files is committed in
 [state-originator-sites.md](state-originator-sites.md). `StateTypeRegistry` is the executable type
 allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral an
@@ -100,7 +100,7 @@ component state; the six fields named above are in the detached supplement; and 
 ## Mapper coverage matrix
 
 Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
-`Mbc3`/RTC, `Mbc5`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`, `PocketCamera`, `Huc1`, `Huc3`,
+`Mbc3`/RTC, `Mbc5`, `LiCheng`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`, `PocketCamera`, `Huc1`, `Huc3`,
 `Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
 `SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
 pass-through slot. For each family the matrix captures a non-idle setup, runs address/tick probes,

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -79,6 +79,7 @@ the ordinary deep-owned `captureState()` contract, or any portable/legacy byte s
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/DuzMulticart.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc1.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Huc3.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/LiCheng.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mani32kMulticart.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc1.java`


### PR DESCRIPTION
## Summary

The exact Xin Guangming Yu Anhei 2 dump from #368, plus the related Li Cheng releases in #369, #370, #372, and #374, selected the standard mapper and then booted to blank, corrupt, or frozen output.

These cartridges are electrically MBC5-compatible, but the low ROM-bank register is only decoded through address 0x2100. Writes in the rest of the normal MBC5 low-bank window must be ignored. The patch adds a dedicated Li Cheng mapper, conservative cartridge fingerprints, state delegation, and clean-room mapper tests.

Affected ROM SHA-256 for #368: a888e9fcf0428544665ee5ef8fcd9b852b2f20a6bc0cdcdabfba0b5a15399146.

Related reports with the same mapper root cause: #369, #370, #372, #374.

## Verification

- Exact issue ROM: boots and renders beyond the former blank screen.
- Related exact dumps: all five were replayed; stable frames now agree structurally with current mGBA, including interactive gameplay for #370.
- `/opt/maven/bin/mvn -pl core -Dtest=LiChengTest test`: 5 passed.
- `/opt/maven/bin/mvn -pl core test`: 879 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

Stable post-fix screenshots were captured locally for all five exact dumps and compared with the reference emulator. The available GitHub CLI cannot upload them, so no ROM-derived image was committed.

Fixes #368