### PR TITLE
Detect the Super 21 in 1 Makon multicart

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -354,7 +354,9 @@ public final class CartridgeProperties {
     }
 
     private static boolean isMakonNtOld2(RomInfo info) {
-        return info.data.length > 0x80000
+        int headerCrc = info.crc32(0x0100, 0x50);
+        return headerCrc == 0x5758d6d9 // Caise Gedou 24-in-1 / Super 21-in-1
+                || info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -42,6 +43,11 @@ public class MakonNtOld2Test {
 
         mapper.setByte(0x2000, 3);
         assertEquals(67, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void detectsSuper21In1HeaderFingerprint() throws IOException {
+        assertNtOld2Header(new byte[] {0x26, (byte) 0xef, (byte) 0xa7, (byte) 0xd3});
     }
 
     @Test
@@ -129,5 +135,17 @@ public class MakonNtOld2Test {
         data[0x0147] = 0x19; // MBC5 in the menu's standard header
         data[0x0148] = 0x06; // 2 MiB
         return data;
+    }
+
+    private static void assertNtOld2Header(byte[] crcSuffix) throws IOException {
+        byte[] data = multicartRom(0xc0);
+        Arrays.fill(data, 0x0100, 0x0150, (byte) 0);
+        System.arraycopy(crcSuffix, 0, data, 0x014c, crcSuffix.length);
+
+        Rom rom = new Rom(data);
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_OLD_2,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof MakonNtOld2);
     }
 }


### PR DESCRIPTION
## Summary

Super 21 in 1 from #380 was treated as a standard cartridge instead of the existing Makon/NT old type 2 board. Its menu therefore changed visible labels while reads remained in the first physical game, so every selection launched Alleyway.

The patch adds the exact 80-byte header fingerprint for this dump to the existing conservative mapper detection and adds a clean-room CRC fixture to prevent regression.

ROM SHA-256: fb0f14bc0752a31d6e47f846b1583c5310244663e32e9312e06198b1a8e00b74.

## Verification

- Replayed the exact report path with deterministic headless auto-mode emulation and skipped bootstrap.
- Selected the second menu entry with Down and Start.
- Before: Alleyway launched.
- After: Super Mario launches, matching current mGBA at the same input sequence.
- `/opt/maven/bin/mvn -pl core -Dtest=MakonNtOld2Test test`: focused mapper tests passed.
- `/opt/maven/bin/mvn -pl core test`: 875 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

A stable after-fix screenshot of the selected second game was captured locally and compared with mGBA. The available GitHub CLI cannot upload it, so it was not committed.

Fixes #380