### PR TITLE
Add Xploder GB pass-through mapper support

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -1,8 +1,9 @@
 package eu.rekawek.coffeegb.controller
 
 /**
- * Audited explicit component-state types paired by ID with Coffee GB 1.7.14 compatibility
- * records. The two class inventories are deliberately disjoint.
+ * Audited explicit component-state types and Coffee GB 1.7.14 compatibility records. The two
+ * class inventories are deliberately disjoint. Newly appended portable types do not acquire
+ * compatibility records because no released local snapshot could contain them.
  *
  * IDs are the one-based position in each list for portable StateFile v1. The codec deliberately
  * uses this exact audited inventory so a future record or enum cannot silently become decodable.
@@ -104,6 +105,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.genie.Genie\$GameSharkPatchState",
           "eu.rekawek.coffeegb.core.gpu.Gpu\$PendingPpuWriteState",
           "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$DelayedWindowWriteState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.XploderGb\$XploderGbState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -837,6 +837,13 @@ internal object StateSemantics {
         constrained("MBC5 exposes a nine-bit ROM bank and four-bit RAM/rumble register.") {
           it.range("selectedRamBank", 0, 0x0f); it.range("selectedRomBank", 0, 0x1ff)
         }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.XploderGb\$XploderGbState"] =
+        constrained("Xploder exposes byte ROM banking, sixteen RAM banks, and a fixed 128 KiB RAM image.") {
+          it.recordType("batteryMemento", MEMORY_BATTERY_STATE, FILE_BATTERY_STATE)
+          it.require(it.intArray("ram").size == 16 * 0x2000, "must have sixteen 8 KiB RAM banks")
+          it.intValues("ram", 0, 0xff)
+          it.range("selectedRomBank", 0, 0xff); it.range("selectedRamBank", 0, 0x0f)
+        }
     target["eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera\$PocketCameraState"] =
         constrained("Pocket Camera ROM/RAM selectors and camera register bytes are bounded.") {
           it.range("romBank", 0, 0x3f); it.range("ramBank", 0, 0x0f)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/LegacySerializationBoundaryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/LegacySerializationBoundaryTest.kt
@@ -104,7 +104,7 @@ class LegacySerializationBoundaryTest {
       )
     }
     assertEquals(87, compatibilityRecords)
-    assertEquals(91, StateTypeRegistry.recordClasses.size)
+    assertEquals(92, StateTypeRegistry.recordClasses.size)
     assertEquals(91, StateTypeRegistry.legacyRecordClasses.size)
     assertTrue(
         StateTypeRegistry.recordClasses.take(87).all(ComponentState::class.java::isAssignableFrom))
@@ -126,7 +126,7 @@ class LegacySerializationBoundaryTest {
         "Normal and compatibility record registries must be disjoint",
     )
     val legacyLeafClasses = StateTypeRegistry.legacyRecordClasses.takeLast(4).toSet()
-    StateTypeRegistry.recordClasses.takeLast(4)
+    StateTypeRegistry.recordClasses.drop(87).take(4)
         .zip(StateTypeRegistry.legacyRecordClasses.takeLast(4))
         .forEachIndexed { index, (normal, legacy) ->
           assertEquals(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -52,6 +52,9 @@ class StateCoverageMatrixTest {
                     0xa000 to 0x3b,
                 ),
             ) { LiCheng(mutableRom(0x1e), Battery.NULL_BATTERY) },
+            mapper("XploderGb", listOf(0x0006 to 0x25, 0x0007 to 0x0a, 0xa000 to 0x3b)) {
+              XploderGb(it, Battery.NULL_BATTERY)
+            },
             mapper("Mbc6", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0x3000 to 0x04, 0xa000 to 0x35)) {
               Mbc6(it, Battery.NULL_BATTERY)
             },
@@ -158,7 +161,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(24, registeredMapperRecords.size)
+    assertEquals(25, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -579,6 +582,10 @@ class StateCoverageMatrixTest {
         )
         .forEach { (address, value) -> controller.setByte(address, value) }
     if (controller is WisdomTree) controller.setByte(0x0029, 0)
+    if (controller is XploderGb) {
+      controller.setByte(0x0006, 0x7d)
+      controller.setByte(0x0007, 0x0f)
+    }
     repeat(3) { controller.tick() }
   }
 
@@ -737,6 +744,7 @@ class StateCoverageMatrixTest {
             "Mbc3",
             "Mbc5",
             "LiCheng",
+            "XploderGb",
             "Mbc6",
             "Mbc7",
             "Mmm01",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -23,7 +23,7 @@ class StateInventoryTest {
           "- `${type.name}`: $fields"
         }
 
-    assertEquals(91, runtime.size)
+    assertEquals(92, runtime.size)
     assertEquals(runtime, documented)
     assertEquals(11, StateTypeRegistry.enumClasses.size)
   }
@@ -63,7 +63,7 @@ class StateInventoryTest {
             }
             .sorted()
 
-    assertEquals(100, discovered.size)
+    assertEquals(101, discovered.size)
     assertTrue(discovered.all { '\\' !in it })
     assertEquals(discovered, documented)
   }
@@ -71,7 +71,7 @@ class StateInventoryTest {
   @Test
   fun everyAdmittedRecordHasAnExplicitSemanticPolicyAndRationale() {
     assertEquals(StateTypeRegistry.recordClassNames.toSet(), StateSemantics.policyAudit.keys)
-    assertEquals(91, StateSemantics.policyAudit.size)
+    assertEquals(92, StateSemantics.policyAudit.size)
     assertTrue(StateSemantics.policyAudit.values.all { it.isNotBlank() })
   }
 

--- a/controller/src/test/resources/sgb-baselines/model-decision-fingerprints.tsv
+++ b/controller/src/test/resources/sgb-baselines/model-decision-fingerprints.tsv
@@ -58,7 +58,7 @@ core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java	21c6c
 core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java	88871bd68d6536f575f0408a552cc830a5ebef334f48efd8acd6dda9efb01a81
 core/src/main/java/eu/rekawek/coffeegb/core/memory/OamEchoRam.java	be80f590f7b90d4a4d4218884d9eef3f59e6faf9f5444c71231ae069175c209b
 core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java	a978c0c211d961cb8dbea351ee966688a67a0c5b631fa3deb993d718150a4ecb
-core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java	08e6b97ef115d4a6a1f56347442172cdd1b56d073fdb2d238b32bf95f0b7fc54
+core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java	b5f0db3e5ce50ade13f608d40bff663f3fd42e03de4068eaad444c8f4ba25638
 core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java	e9d582677dee455dc05525376632f88e4d84546ddd905a40299143215b012f54
 core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomSourceSnapshot.java	31294a694422869e695dbe37b0f4eaad4c06d3d011fa6bba17749a5646986be2
 core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/SevenZArchiveWorker.java	1a35c077c510b21d70fed9ddccf5ad2a6583e127ad3b2d68b58667a29cee4eef

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -91,6 +91,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case SACHEN_MMC2_LINEAR -> new SachenMmc(rom, true, false);
             case SACHEN_COOKED -> new SachenMmc(rom, 0);
             case DATEL -> new Datel(rom, battery);
+            case XPLODER_GB -> new XploderGb(rom, battery);
             case WISDOM_TREE -> new WisdomTree(rom);
             case MBC1 -> new Mbc1(rom, battery);
             case POCKET_CAMERA -> new PocketCamera(rom, battery);
@@ -223,7 +224,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
     }
 
     private static Battery createBattery(Rom rom, BatteryStorage configuredStorage) {
-        if (rom.getType().isBattery()) {
+        boolean xploderGb = rom.getCartridgeProperties().getMapper()
+                == CartridgeProperties.Mapper.XPLODER_GB;
+        if (rom.getType().isBattery() || xploderGb) {
             // Existing MBC implementations expose RAM in 8 KiB banks. Plain ROM+RAM
             // is the exception: its 2 KiB header size is mirrored across A000-BFFF.
             int ramSize = rom.getType() == CartridgeType.ROM_RAM_BATTERY
@@ -232,6 +235,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
                 ramSize = 0x8000;
             }
             if (rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.SL_MULTICART) {
+                ramSize = 0x20000;
+            }
+            if (xploderGb) {
                 ramSize = 0x20000;
             }
             if (ramSize == 0 && rom.getType().isRam()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -33,6 +33,7 @@ public final class CartridgeProperties {
         SACHEN_MMC2_LINEAR,
         SACHEN_COOKED,
         DATEL,
+        XPLODER_GB,
         WISDOM_TREE,
         MBC1,
         POCKET_CAMERA,
@@ -59,7 +60,8 @@ public final class CartridgeProperties {
         SACHEN_OPEN_BUS_BANKS,
         CGB0_REVISION,
         MEALYBUG_DMG_BLOB,
-        CODEBREAKER_RUMBLE
+        CODEBREAKER_RUMBLE,
+        PRESERVE_INVALID_HEADER_CHECKSUM
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -131,6 +133,8 @@ public final class CartridgeProperties {
                     Mapper.DATEL),
             features("Datel colour header", CartridgeProperties::hasDatelCgbHeader,
                     Feature.DATEL_CGB_HEADER),
+            profile("Future Console Design Xploder GB", CartridgeProperties::isXploderGb,
+                    Mapper.XPLODER_GB, Feature.PRESERVE_INVALID_HEADER_CHECKSUM),
             mapper("Wisdom Tree 32 KiB banking", CartridgeProperties::isWisdomTree,
                     Mapper.WISDOM_TREE),
             mapper("Xin Shuma Baobei Huang MBC5 wiring",
@@ -443,6 +447,13 @@ public final class CartridgeProperties {
 
     private static boolean hasDatelCgbHeader(RomInfo info) {
         return isDatel(info);
+    }
+
+    private static boolean isXploderGb(RomInfo info) {
+        // Xploder is a pass-through cheat cartridge, so its own logo area contains
+        // an FCD credit line. Both known firmware revisions share this fingerprint.
+        return info.rawType() == 0x69
+                && info.crc32(0x0104, 0x30) == 0xf13ffa9a;
     }
 
     private static boolean isSachen(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Rom.java
@@ -132,6 +132,8 @@ public class Rom {
         // Dimensionless Sample, #76 - it renders past a SKIP boot but hangs the boot ROM).
         // BGB, SameBoy and real flashcarts silently fix it; only touches already-invalid ROMs.
         if (!cartridgeProperties.has(CartridgeProperties.Feature.SCRAMBLED_SACHEN_HEADER)
+                && !cartridgeProperties.has(
+                        CartridgeProperties.Feature.PRESERVE_INVALID_HEADER_CHECKSUM)
                 && rom.length > 0x014D) {
             int headerChecksum = 0;
             for (int a = 0x0134; a <= 0x014C; a++) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java
@@ -1,0 +1,134 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+import java.util.Arrays;
+
+/** Future Console Design's Xploder GB pass-through cheat cartridge. */
+public class XploderGb implements MemoryController {
+
+    private static final int RAM_BANK_SIZE = 0x2000;
+
+    private static final int RAM_BANKS = 16;
+
+    private final int[] rom;
+
+    private final int romBanks;
+
+    private final int[] ram = new int[RAM_BANKS * RAM_BANK_SIZE];
+
+    private final Battery battery;
+
+    private int selectedRomBank = 1;
+
+    private int selectedRamBank;
+
+    private boolean ramUpdated;
+
+    public XploderGb(Rom rom, Battery battery) {
+        this.rom = rom.getRom();
+        this.romBanks = Math.max(1, (this.rom.length + 0x3fff) / 0x4000);
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (address == 0x0006) {
+            selectedRomBank = value;
+        } else if (address == 0x0007) {
+            selectedRamBank = value & 0x0f;
+        } else if (address >= 0xa000 && address < 0xc000) {
+            ram[getRamAddress(address)] = value;
+            ramUpdated = true;
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x4000) {
+            return getRomByte(address);
+        } else if (address >= 0x4000 && address < 0x8000) {
+            int bank = Math.floorMod(selectedRomBank, romBanks);
+            return getRomByte(bank * 0x4000 + address - 0x4000);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ram[getRamAddress(address)];
+        }
+        throw new IllegalArgumentException(Integer.toHexString(address));
+    }
+
+    private int getRomByte(int address) {
+        return address < rom.length ? rom[address] : 0xff;
+    }
+
+    private int getRamAddress(int address) {
+        return selectedRamBank * RAM_BANK_SIZE + address - 0xa000;
+    }
+
+    @Override
+    public void flushRam() {
+        if (ramUpdated) {
+            battery.saveRam(ram);
+            battery.flush();
+        }
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new XploderGbState(battery.captureState(), ram.clone(), selectedRomBank,
+                selectedRamBank, ramUpdated);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new XploderGbState(battery.captureState(capture), capture.ints(ram),
+                selectedRomBank, selectedRamBank, ramUpdated);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof XploderGbState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        if (mem.ram.length != ram.length) {
+            throw new IllegalArgumentException("ComponentState RAM length doesn't match");
+        }
+        battery.restoreState(mem.batteryMemento);
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        selectedRomBank = mem.selectedRomBank;
+        selectedRamBank = mem.selectedRamBank;
+        ramUpdated = mem.ramUpdated;
+    }
+
+    private record XploderGbState(ComponentState<Battery> batteryMemento, int[] ram,
+                                   int selectedRomBank, int selectedRamBank,
+                                   boolean ramUpdated)
+            implements ComponentState<MemoryController> {
+    }
+
+    /** Importer-only compatibility record for released local snapshots. */
+    private record XploderGbMemento(Memento<Battery> batteryMemento, int[] ram,
+                                     int selectedRomBank, int selectedRamBank,
+                                     boolean ramUpdated)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java
@@ -1,6 +1,5 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
-import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -125,10 +124,4 @@ public class XploderGb implements MemoryController {
             implements ComponentState<MemoryController> {
     }
 
-    /** Importer-only compatibility record for released local snapshots. */
-    private record XploderGbMemento(Memento<Battery> batteryMemento, int[] ram,
-                                     int selectedRomBank, int selectedRamBank,
-                                     boolean ramUpdated)
-            implements Memento<MemoryController> {
-    }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGbTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGbTest.java
@@ -1,0 +1,96 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XploderGbTest {
+
+    private static final byte[] CLEAN_ROOM_HEADER = {
+            0x52, 0x55, 0x53, 0x54, 0x59, 0x42, 0x4f, 0x49,
+            0x20, 0x58, 0x50, 0x4c, 0x4f, 0x44, 0x45, 0x52,
+            0x20, 0x47, 0x42, 0x20, 0x46, 0x43, 0x44, 0x20,
+            0x43, 0x4c, 0x45, 0x41, 0x4e, 0x52, 0x4f, 0x4f,
+            0x4d, 0x20, 0x53, 0x49, 0x47, 0x21, 0x21, 0x21,
+            0x21, 0x21, 0x21, 0x21, 0x0a, (byte) 0xc6, (byte) 0xe6, (byte) 0xb2
+    };
+
+    @Test
+    public void detectsXploderBoardFromCreditArea() throws IOException {
+        Rom rom = new Rom(xploderRom());
+
+        assertEquals(CartridgeProperties.Mapper.XPLODER_GB,
+                rom.getCartridgeProperties().getMapper());
+        assertEquals(0, rom.getRom()[0x014d]);
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof XploderGb);
+    }
+
+    @Test
+    public void banksRomThroughRegister0006() throws IOException {
+        MemoryController mapper = mapper();
+
+        assertEquals(1, mapper.getByte(0x4000));
+        mapper.setByte(0x0006, 6);
+        assertEquals(6, mapper.getByte(0x4000));
+        mapper.setByte(0x0006, 0);
+        assertEquals(0, mapper.getByte(0x4000));
+        mapper.setByte(0x0006, 9);
+        assertEquals(1, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void exposesSixteenUngatedRamBanks() throws IOException {
+        MemoryController mapper = mapper();
+
+        mapper.setByte(0x0007, 0);
+        mapper.setByte(0xb000, 0x11);
+        mapper.setByte(0x0007, 14);
+        mapper.setByte(0xb000, 0x22);
+        assertEquals(0x22, mapper.getByte(0xb000));
+        mapper.setByte(0x0007, 0);
+        assertEquals(0x11, mapper.getByte(0xb000));
+    }
+
+    @Test
+    public void stateRoundTripPreservesRegistersAndRam() throws IOException {
+        MemoryController mapper = mapper();
+        mapper.setByte(0x0006, 6);
+        mapper.setByte(0x0007, 14);
+        mapper.setByte(0xb000, 0x5a);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x0006, 2);
+        mapper.setByte(0x0007, 1);
+        mapper.setByte(0xb000, 0x33);
+        mapper.restoreState(state);
+
+        assertEquals(6, mapper.getByte(0x4000));
+        assertEquals(0x5a, mapper.getByte(0xb000));
+    }
+
+    private static MemoryController mapper() throws IOException {
+        return new XploderGb(new Rom(xploderRom()), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] xploderRom() {
+        byte[] data = new byte[0x20000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        System.arraycopy(CLEAN_ROOM_HEADER, 0, data, 0x0104, CLEAN_ROOM_HEADER.length);
+        data[0x0147] = 0x69;
+        data[0x0148] = 0x67;
+        data[0x0149] = 0x6e;
+        return data;
+    }
+}

--- a/docs/legacy-state-retirement.md
+++ b/docs/legacy-state-retirement.md
@@ -51,7 +51,7 @@ carries the compatibility leaves.
 The architecture test strips the marked compatibility declarations and proves that the remaining
 live owner source has no `Memento<T>` or compatibility-leaf dependency. It also proves that every
 normal record is non-serializable, the normal and compatibility registries are disjoint, and the
-91 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
+92 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
 remain pinned.
 
 ## Supported migration inputs and limits

--- a/docs/sgb-conformance-baselines.md
+++ b/docs/sgb-conformance-baselines.md
@@ -5,8 +5,8 @@ used those artifacts to complete the platform-neutral practical command set, iss
 independent local SGB P1-P4 host input, and issue #343 established immutable per-session hardware
 profiles and clocks. Issue #344 added the evidence-backed `sgb2` identity and exact SGB-family
 clock contract. Issue #345 adds the evidence-backed `mgb` identity and an enforceable contributor
-extension process. Neither phase changes the practical SGB command set. The 91 portable record IDs
-and every StateFile-v1 field remain unchanged.
+extension process. Neither phase changes the practical SGB command set. The original 91 portable
+record IDs and every existing StateFile-v1 field remain unchanged; mapper records append after them.
 
 ## Checked-in sources of truth
 

--- a/docs/state-file-v1.md
+++ b/docs/state-file-v1.md
@@ -160,17 +160,18 @@ Every value starts with a one-byte tag:
 
 Float NaN payloads and signed zero are preserved with `doubleToRawLongBits`. Int32-map keys are
 strictly increasing and unique. Record type IDs are the one-based stable entries of the audited
-91-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
+92-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
 The 11 enum type IDs use the same audited ordering, while enum value IDs are an explicit v1
 one-based registry verified against the production enum names. Class names from input are never
 loaded or instantiated.
 
-The record ID/name/field registry is the exact ordered 91-record appendix in
+The record ID/name/field registry is the exact ordered 92-record appendix in
 [state-memento-schema.md](state-memento-schema.md), where each bullet's one-based position is its
 ID. IDs 88 through 91 deliberately name non-serializable normal-state leaves; the local legacy
 importer has ID-aligned historical descriptor classes with the same field schemas. StateFile does
 not encode either JVM class name, so this runtime/compatibility separation does not change v1
-bytes. The v1 enum registry is:
+bytes. ID 92 is the append-only Xploder mapper state and has no legacy descriptor because no
+released Java-serialized snapshot could contain it. The v1 enum registry is:
 
 | Type ID | Enum | Value IDs in order starting at 1 |
 |---:|---|---|

--- a/docs/state-file-v2.md
+++ b/docs/state-file-v2.md
@@ -65,7 +65,8 @@ of a linked root carries its own explicit ID.
 
 ## Payload and compatibility
 
-Payload section schema 1 and all 91 numeric record IDs are byte-for-byte unchanged. In v2, the
+Payload section schema 1 and the original 91 numeric record IDs are byte-for-byte unchanged; the
+Xploder mapper state is appended as ID 92. In v2, the
 MBC3 `subSecondTicks` scalar is the explicit profile's numerator-domain phase:
 
 | Identity | Valid phase | Live increment per machine tick |

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -8,7 +8,7 @@ Before mutation, apply checks the hardware tag, nested record/mapper tree, invar
 serial endpoint and component-state root, cartridge RTC locations, runtime DTO, held input, and linked
 topology against the already-configured target. Null is admitted only for audited owner/field or
 array-element positions, not inferred from the non-null value's type. The adapter then reconstructs
-the complete replacement and applies the semantic policy registered for each of the 91 admitted
+the complete replacement and applies the semantic policy registered for each of the 92 admitted
 record types. Those policies reject invalid indices, counts, capacities, command phases, and scalar
 relationships before the first live mutation. If an unexpected component apply nevertheless
 throws, the adapter restores the machine, both RTC locations, serial endpoint/runtime, held
@@ -32,8 +32,8 @@ Protocol v8 remains StateFile-v1-only and rejects MGB before linked construction
 The exact remaining compatibility surface and removal policy are documented in
 [legacy-state-retirement.md](legacy-state-retirement.md).
 
-The exact field-by-field inventory of all 91 admitted production record types is committed in
-[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 100
+The exact field-by-field inventory of all 92 admitted production record types is committed in
+[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 101
 production state contracts and capture owner/call-site files is committed in
 [state-originator-sites.md](state-originator-sites.md). `StateTypeRegistry` is the executable type
 allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral an
@@ -102,7 +102,7 @@ component state; the six fields named above are in the detached supplement; and 
 Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
 `Mbc3`/RTC, `Mbc5`, `LiCheng`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`, `PocketCamera`, `Huc1`, `Huc3`,
 `Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
-`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
+`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, `XploderGb`, and `Datel` with a real MBC3
 pass-through slot. For each family the matrix captures a non-idle setup, runs address/tick probes,
 restores through the detached graph, reruns the same probes, and compares both observable trace and
 final state. Dedicated mid-operation cases capture MBC6 during JEDEC unlock/ID/program sequences,
@@ -144,7 +144,7 @@ types are rejected through the adapter before its live-mutation callback.
 Records whose fields are deliberately not range-constrained still have an explicit policy and
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
 documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
-are validated by nested records. `StateInventoryTest` requires the policy-key set to equal all 91
+are validated by nested records. `StateInventoryTest` requires the policy-key set to equal all 92
 admitted record types, so a new state record cannot enter the model without an audited choice. Rollback
 is retained for unexpected failures in legacy restore code; it is not the validation path for a
 deterministically malformed detached candidate.

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -1,6 +1,6 @@
 # Audited state-record schema
 
-This is the exact captured-field inventory for all 91 production record types admitted by
+This is the exact captured-field inventory for all 92 production record types admitted by
 `StateTypeRegistry`. Each bullet's one-based position is its stable StateFile-v1 record type ID;
 each line names the non-serializable `ComponentState` record and every component captured by
 `captureState`. The
@@ -127,3 +127,4 @@ altering the 1.7.13/1.7.14 migration schema listed below.
 - `eu.rekawek.coffeegb.core.genie.Genie$GameSharkPatchState`: mode, bank, address, data
 - `eu.rekawek.coffeegb.core.gpu.Gpu$PendingPpuWriteState`: address, value, mask, remainingDots
 - `eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer$DelayedWindowWriteState`: value, remainingDots
+- `eu.rekawek.coffeegb.core.memory.cart.type.XploderGb$XploderGbState`: batteryMemento, ram, selectedRomBank, selectedRamBank, ramUpdated

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -96,6 +96,7 @@ the ordinary deep-owned `captureState()` contract, or any portable/legacy byte s
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/WisdomTree.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/rumble/CodeBreakerRumble.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/BarcodeBoySerialEndpoint.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/serial/ByteReceivingSerialEndpoint.java`


### PR DESCRIPTION
## Summary

The exact Xploder GB v1.2.3E firmware from #371 stayed blank because raw cartridge type 0x69 was unsupported and generic invalid-header normalization overwrote byte 0x014d, which this firmware uses as data.

The patch detects the Future Console Design credit-area fingerprint, preserves this firmware header, and implements its pass-through board: fixed bank zero, ROM bank register 0x0006, sixteen ungated 8 KiB RAM banks selected at 0x0007, battery persistence, and save-state support.

ROM SHA-256: 6d8ffb51e8cb7e11bef0cb833c44a123b2a57486bf2302d3cfb0b6964bda7c16.

## Verification

- Before: blank output for the standalone firmware.
- After: the Blaze boot logo renders at stable frames 110-360, followed by the expected standalone pass-through wait state. Current Rustyboi produces the same sequence for this exact dump.
- `/opt/maven/bin/mvn -pl core -Dtest=XploderGbTest test`: 4 passed.
- `/opt/maven/bin/mvn -pl core test`: 878 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

A stable screenshot of the corrected Blaze logo was captured locally. The available GitHub CLI cannot upload it, so it was not committed.

Fixes #371