### PR TITLE
Support Super Donkey Kong 5 multicart registers

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -356,6 +356,7 @@ public final class CartridgeProperties {
     private static boolean isMakonNtOld2(RomInfo info) {
         int headerCrc = info.crc32(0x0100, 0x50);
         return headerCrc == 0x5758d6d9 // Caise Gedou 24-in-1 / Super 21-in-1
+                || headerCrc == 0x0b1b808a // Super Donkey Kong 5 (rumble)
                 || info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2.java
@@ -71,8 +71,11 @@ public class MakonNtOld2 implements MemoryController {
         value &= 0xff;
         if (address >= 0x2000 && address < 0x4000) {
             selectRomBank(value);
-        } else if (address == 0x5001) {
-            setRumbleEnabled((value & 0x80) != 0);
+        } else if (address >= 0x5000 && address < 0x6000
+                && (address & 0x03) == 0x01) {
+            if (address == 0x5001) {
+                setRumbleEnabled((value & 0x80) != 0);
+            }
             updateMotor(value);
 
             int newBaseRomBank = (value & 0x3f) * 2;
@@ -80,7 +83,8 @@ public class MakonNtOld2 implements MemoryController {
                 baseRomBank = newBaseRomBank;
                 mappedRomBank = 1;
             }
-        } else if (address == 0x5002) {
+        } else if (address >= 0x5000 && address < 0x6000
+                && (address & 0x03) == 0x02) {
             gameRomBankMask = switch (value & 0x0f) {
                 case 0x08 -> 0x0f; // 256 KiB
                 case 0x0c -> 0x07; // 128 KiB
@@ -89,7 +93,8 @@ public class MakonNtOld2 implements MemoryController {
                 default -> 0x1f;   // 512 KiB
             };
             updateMotor(value);
-        } else if (address == 0x5003) {
+        } else if (address >= 0x5000 && address < 0x6000
+                && (address & 0x03) == 0x03) {
             updateMotor(value);
             weirdMode = (value & 0x10) != 0;
             selectRomBank(selectedRomBank);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -51,6 +51,21 @@ public class MakonNtOld2Test {
     }
 
     @Test
+    public void detectsSuperDonkeyKong5HeaderFingerprint() throws IOException {
+        byte[] data = multicartRom(0xc0);
+        Arrays.fill(data, 0x0100, 0x0150, (byte) 0);
+        // Synthetic 0x50-byte header with CRC-32 0b1b808a.
+        byte[] crcSuffix = {0x5d, 0x36, 0x7a, (byte) 0xe6};
+        System.arraycopy(crcSuffix, 0, data, 0x014c, crcSuffix.length);
+
+        Rom rom = new Rom(data);
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_OLD_2,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof MakonNtOld2);
+    }
+
+    @Test
     public void masksBanksToTheSelectedGameSizeAndSupportsAlternateWiring()
             throws IOException {
         MemoryController mapper = new MakonNtOld2(
@@ -71,6 +86,20 @@ public class MakonNtOld2Test {
         assertEquals(97, mapper.getByte(0x4000));
         mapper.setByte(0x2000, 4);
         assertEquals(98, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void mirrorsMulticartRegistersAcrossThe5000Range() throws IOException {
+        MemoryController mapper = new MakonNtOld2(
+                new Rom(multicartRom(0xe0)), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x50e9, 0x20); // low address bits 1: base bank 64
+        mapper.setByte(0x50ee, 0x0c); // low address bits 2: 128 KiB mask
+        mapper.setByte(0x50ef, 0x10); // low address bits 3: alternate wiring
+        mapper.setByte(0x2137, 0x02); // alternate wiring maps bank 2 to bank 1
+
+        assertEquals(64, mapper.getByte(0x0000));
+        assertEquals(65, mapper.getByte(0x4000));
     }
 
     @Test


### PR DESCRIPTION
## Summary

The rumble release of Super Donkey Kong 5 from #381 stayed blank because it was not detected as a Makon/NT old type 2 board and because this cartridge accesses the three multicart registers through mirrored addresses in the 0x5xxx range.

The patch adds an exact header fingerprint and decodes registers by their low address bits across 0x5000-0x5fff. Rumble remains gated to the physical 0x5001 register while mirrored banking writes update the base, mask, and wiring mode. Regression tests cover detection, mirrored register behavior, and save-state restoration.

ROM SHA-256: 728be24a6d3cc815175595300ad8516032e68371585b82d6a3d20615ea22625.

## Verification

- Before: persistent blank output.
- After: the intro and gameplay progression match current mGBA frame-for-frame through the deterministic input replay.
- `/opt/maven/bin/mvn -pl core -Dtest=MakonNtOld2Test test`: focused mapper tests passed.
- `/opt/maven/bin/mvn -pl core test`: 876 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

Stable post-fix screenshots were captured locally and compared with mGBA. The available GitHub CLI cannot upload them, so they were not committed.

Fixes #381