### PR TITLE
Preserve the Yinghan Zidian title screen

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -283,6 +283,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             // seams. Keep the hardware-like WRAM pattern everywhere else.
             mmu.setByte(0xc0bc, 0);
         }
+        if (cartridgeProperties.has(
+                CartridgeProperties.Feature.CLEAR_DICTIONARY_JOYPAD_STATE)) {
+            // This title leaves its five-byte joypad edge/repeat state uninitialized at
+            // D8D0-D8D4. Hardware-like WRAM garbage can therefore look like a held Start
+            // button and skip the title screen. Clear only the private input state the ROM
+            // assumes starts at zero, retaining the power-on pattern everywhere else.
+            for (int address = 0xd8d0; address <= 0xd8d4; address++) {
+                mmu.setByte(address, 0);
+            }
+        }
         mmu.setBusListener(cartridge.getSachenMmc());
 
         cpu = new Cpu(new DmaCpuAddressSpace(getAddressSpace(), dma, gbc,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -45,6 +45,7 @@ public final class CartridgeProperties {
         BLANK_CGB_BOOT_TILE,
         CLEAR_BOOT_TILEMAP,
         CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT,
+        CLEAR_DICTIONARY_JOYPAD_STATE,
         DATEL_CGB_HEADER,
         SCRAMBLED_SACHEN_HEADER,
         MBC1_MULTICART,
@@ -146,6 +147,9 @@ public final class CartridgeProperties {
             features("Dungeon Warrior prototype renderer state",
                     CartridgeProperties::isDungeonWarriorPrototype,
                     Feature.CLEAR_DUNGEON_WARRIOR_RENDERER_COUNT),
+            features("Yinghan Zidian joypad state",
+                    CartridgeProperties::isYinghanZidian,
+                    Feature.CLEAR_DICTIONARY_JOYPAD_STATE),
             features("FreeArt Intro V2", CartridgeProperties::isFreeArtIntroV2,
                     Feature.MBC1_RAM_ENABLED_AT_POWER_ON),
             features("Helitac V0.01 boot WRAM", CartridgeProperties::isHelitacV001,
@@ -556,6 +560,19 @@ public final class CartridgeProperties {
                 && info.byteAt(0x014f) == 0x86
                 && matches(info.data, 0x1be1, rendererRecordSetup)
                 && info.crc32() == 0x2910429c;
+    }
+
+    private static boolean isYinghanZidian(RomInfo info) {
+        return info.data.length == 0x100000
+                && info.hasNullTerminatedTitle("DICTIONARY")
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x1b
+                && info.byteAt(0x0148) == 0x05
+                && info.byteAt(0x0149) == 0x01
+                && info.byteAt(0x014c) == 0x01
+                && info.byteAt(0x014d) == 0x4f
+                && info.byteAt(0x014e) == 0xa9
+                && info.byteAt(0x014f) == 0x84;
     }
 
     private static boolean isHelitacV001(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/DictionaryBootWramTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/DictionaryBootWramTest.java
@@ -1,0 +1,77 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DictionaryBootWramTest {
+
+    @Test
+    public void clearsOnlyTheUninitializedJoypadState() throws IOException {
+        Rom rom = new Rom(dictionaryRom());
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_DICTIONARY_JOYPAD_STATE));
+
+        Gameboy compatible = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+
+        byte[] nearMatch = dictionaryRom();
+        nearMatch[0x014f] ^= 1;
+        Gameboy ordinary = new Gameboy.GameboyConfiguration(new Rom(nearMatch))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+
+        for (int address = 0xc000; address < 0xe000; address++) {
+            if (address >= 0xd8d0 && address <= 0xd8d4) {
+                assertEquals(Integer.toHexString(address), 0,
+                        compatible.getAddressSpace().getByte(address));
+            } else {
+                assertEquals(Integer.toHexString(address),
+                        ordinary.getAddressSpace().getByte(address),
+                        compatible.getAddressSpace().getByte(address));
+            }
+        }
+    }
+
+    @Test
+    public void nearMatchKeepsTheHardwarePowerOnValues() throws IOException {
+        byte[] data = dictionaryRom();
+        data[0x014f] ^= 1;
+
+        Rom rom = new Rom(data);
+
+        assertFalse(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.CLEAR_DICTIONARY_JOYPAD_STATE));
+        Gameboy gb = new Gameboy.GameboyConfiguration(rom)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+        assertEquals(0x66, gb.getAddressSpace().getByte(0xd8d0));
+        assertEquals(0x7d, gb.getAddressSpace().getByte(0xd8d1));
+    }
+
+    private static byte[] dictionaryRom() {
+        byte[] data = new byte[0x100000];
+        byte[] title = "DICTIONARY".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x1b;
+        data[0x0148] = 0x05;
+        data[0x0149] = 0x01;
+        data[0x014c] = 0x01;
+        data[0x014d] = 0x4f;
+        data[0x014e] = (byte) 0xa9;
+        data[0x014f] = (byte) 0x84;
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary

Yinghan Zidian from #373 skips directly to the dictionary interface under the deterministic skipped-bootstrap path.

The ROM uses five bytes at WRAM 0xd8d0-0xd8d4 as joypad edge and repeat state without initializing them first. The hardware-like WRAM power-on pattern currently places 0x66 and 0x7d there, which the title interprets as a Start transition. The patch adds a narrowly fingerprinted compatibility profile that clears only those five private state bytes while preserving the existing WRAM pattern everywhere else.

ROM SHA-256: fcfb9051727fa6948e77f7afc338334131c963394804c76238ed422edfb154a9.

## Verification

- Before: the first stable capture is already the dictionary UI.
- After: the English-Chinese Dictionary title remains visible at frames 300 and 600, matching the reference emulator.
- A near-match fixture proves the WRAM adjustment is limited to the exact title profile.
- `/opt/maven/bin/mvn -pl core -Dtest=DictionaryBootWramTest test`: 2 passed.
- `/opt/maven/bin/mvn -pl core test`: 876 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

Stable before/after title-screen screenshots were captured locally. The available GitHub CLI cannot upload them, so they were not committed.

Fixes #373