### PR TITLE
Add general Vast Fame VF001 protection

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -107,6 +107,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer\$DelayedWindowWriteState",
           "eu.rekawek.coffeegb.core.memory.cart.type.XploderGb\$XploderGbState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Vf001Zook\$Vf001ZookState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Vf001General\$Vf001GeneralState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -852,6 +852,20 @@ internal object StateSemantics {
           it.range("streamLength", 0, 32); it.range("bankPortRun", 0, 3)
           it.require(it.int("bankPortRun") <= it.int("streamLength"), "has a bank-port run longer than its stream")
         }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Vf001General\$Vf001GeneralState"] =
+        constrained("VF001 config, injection, replacement, and nested MBC5 state retain their protocol bounds.") {
+          it.recordType("delegateMemento", MBC5_STATE)
+          it.range("runningValue", 0, 0xff); it.range("cur6000", 0, 0xff)
+          it.require(it.intArray("cur700x").size == 15, "must have fifteen config registers")
+          it.intValues("cur700x", 0, 0xff)
+          it.range("sequenceStartBank", 0, 0xff); it.range("sequenceStartAddress", 0, 0xffff)
+          it.range("sequenceLength", 0, 4)
+          it.require(it.intArray("sequence").size == 4, "must have a four-byte injection buffer")
+          it.intValues("sequence", 0, 0xff)
+          it.range("sequenceBytesLeft", 0, it.int("sequenceLength"))
+          it.range("replacementStartAddress", 0, 0xffff)
+          it.range("replacementSourceBank", 0, 0xff); it.range("selectedRomBank", 0, 0x1ff)
+        }
     target["eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera\$PocketCameraState"] =
         constrained("Pocket Camera ROM/RAM selectors and camera register bytes are bounded.") {
           it.range("romBank", 0, 0x3f); it.range("ramBank", 0, 0x0f)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/LegacySerializationBoundaryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/LegacySerializationBoundaryTest.kt
@@ -104,7 +104,7 @@ class LegacySerializationBoundaryTest {
       )
     }
     assertEquals(87, compatibilityRecords)
-    assertEquals(93, StateTypeRegistry.recordClasses.size)
+    assertEquals(94, StateTypeRegistry.recordClasses.size)
     assertEquals(91, StateTypeRegistry.legacyRecordClasses.size)
     assertTrue(
         StateTypeRegistry.recordClasses.take(87).all(ComponentState::class.java::isAssignableFrom))

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -58,6 +58,24 @@ class StateCoverageMatrixTest {
             mapper("Vf001Zook", listOf(0x7081 to 0x46, 0x7081 to 0x58, 0x7081 to 0x54)) {
               Vf001Zook(it, Battery.NULL_BATTERY)
             },
+            mapper(
+                "Vf001General",
+                listOf(
+                    0x0000 to 0x0a,
+                    0x7000 to 0x96,
+                    0x7001 to 0x00,
+                    0x7002 to 0x01,
+                    0x7003 to 0x80,
+                    0x7004 to 0x11,
+                    0x7005 to 0xaa,
+                    0x7006 to 0x22,
+                    0x7007 to 0xdd,
+                    0x7000 to 0x25,
+                    0x2000 to 0x03,
+                    0xa000 to 0x3b,
+                ),
+                listOf(0x0100, 0x0101, 0x0102, 0x0103, 0x4000, 0xa000),
+            ) { Vf001General(it, Battery.NULL_BATTERY) },
             mapper("Mbc6", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0x3000 to 0x04, 0xa000 to 0x35)) {
               Mbc6(it, Battery.NULL_BATTERY)
             },
@@ -164,7 +182,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(26, registeredMapperRecords.size)
+    assertEquals(27, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -750,6 +768,7 @@ class StateCoverageMatrixTest {
             "LiCheng",
             "XploderGb",
             "Vf001Zook",
+            "Vf001General",
             "Mbc6",
             "Mbc7",
             "Mmm01",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -23,7 +23,7 @@ class StateInventoryTest {
           "- `${type.name}`: $fields"
         }
 
-    assertEquals(93, runtime.size)
+    assertEquals(94, runtime.size)
     assertEquals(runtime, documented)
     assertEquals(11, StateTypeRegistry.enumClasses.size)
   }
@@ -63,7 +63,7 @@ class StateInventoryTest {
             }
             .sorted()
 
-    assertEquals(102, discovered.size)
+    assertEquals(103, discovered.size)
     assertTrue(discovered.all { '\\' !in it })
     assertEquals(discovered, documented)
   }
@@ -71,7 +71,7 @@ class StateInventoryTest {
   @Test
   fun everyAdmittedRecordHasAnExplicitSemanticPolicyAndRationale() {
     assertEquals(StateTypeRegistry.recordClassNames.toSet(), StateSemantics.policyAudit.keys)
-    assertEquals(93, StateSemantics.policyAudit.size)
+    assertEquals(94, StateSemantics.policyAudit.size)
     assertTrue(StateSemantics.policyAudit.values.all { it.isNotBlank() })
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -85,6 +85,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
             case LI_CHENG -> new LiCheng(rom, battery);
             case VF001_ZOOK -> new Vf001Zook(rom, battery);
+            case VF001_GENERAL -> new Vf001General(rom, battery);
             case BBD -> new Bbd(rom, battery);
             case SINTAX -> new Sintax(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -27,6 +27,7 @@ public final class CartridgeProperties {
         MAKON_NT_OLD_2,
         LI_CHENG,
         VF001_ZOOK,
+        VF001_GENERAL,
         BBD,
         SINTAX,
         SACHEN_MMC1,
@@ -118,6 +119,8 @@ public final class CartridgeProperties {
                     Mapper.LI_CHENG),
             mapper("Vast Fame VF001 Zook protection", CartridgeProperties::isVf001Zook,
                     Mapper.VF001_ZOOK),
+            mapper("Vast Fame VF001 protection", CartridgeProperties::isVf001General,
+                    Mapper.VF001_GENERAL),
             mapper("BBD unlicensed mapper", CartridgeProperties::isBbd,
                     Mapper.BBD),
             mapper("Sintax unlicensed mapper", CartridgeProperties::isSintax,
@@ -395,6 +398,12 @@ public final class CartridgeProperties {
         };
         return info.crc32(0x0184, 0x30) == 0x42b773b8
                 && matches(info.data, 0x3ef5, bankSelectThunk);
+    }
+
+    private static boolean isVf001General(RomInfo info) {
+        // Zhihuan Wang 2 shares its secondary-logo signature with genuine GGB81
+        // cartridges, but this exact image programs the distinct VF001 protocol.
+        return info.crc32() == 0xe6748d1f;
     }
 
     private static boolean isBbd(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001General.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001General.java
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.events.EventBus;
-import eu.rekawek.coffeegb.core.memento.Memento;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -205,14 +204,4 @@ public class Vf001General implements MemoryController {
             implements ComponentState<MemoryController> {
     }
 
-    /** Importer-only compatibility record for released local snapshots. */
-    private record Vf001GeneralMemento(Memento<MemoryController> delegateMemento,
-                                        boolean configMode, int runningValue, int cur6000,
-                                        int[] cur700x, int sequenceStartBank,
-                                        int sequenceStartAddress, int sequenceLength,
-                                        int[] sequence, int sequenceBytesLeft,
-                                        boolean replaceBankZero, int replacementStartAddress,
-                                        int replacementSourceBank, int selectedRomBank)
-            implements Memento<MemoryController> {
-    }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001General.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001General.java
@@ -1,0 +1,218 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+/**
+ * General Vast Fame VF001 protection layered over MBC5. Its config ports can
+ * inject a short byte sequence or replace the upper part of fixed bank zero.
+ */
+public class Vf001General implements MemoryController {
+
+    private final Mbc5 delegate;
+
+    private final int[] rom;
+
+    private final int romBanks;
+
+    private boolean configMode;
+
+    private int runningValue;
+
+    private int cur6000;
+
+    private final int[] cur700x = new int[15];
+
+    private int sequenceStartBank;
+
+    private int sequenceStartAddress;
+
+    private int sequenceLength;
+
+    private final int[] sequence = new int[4];
+
+    private int sequenceBytesLeft;
+
+    private boolean replaceBankZero;
+
+    private int replacementStartAddress;
+
+    private int replacementSourceBank;
+
+    private int selectedRomBank = 1;
+
+    public Vf001General(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+        this.rom = rom.getRom();
+        this.romBanks = Math.max(1, (this.rom.length + 0x3fff) / 0x4000);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (address >= 0x2000 && address < 0x3000) {
+            selectedRomBank = (selectedRomBank & 0x100) | value;
+        } else if (address >= 0x3000 && address < 0x4000) {
+            selectedRomBank = (selectedRomBank & 0x0ff) | ((value & 1) << 8);
+        } else if (address >= 0x6000 && address < 0x8000) {
+            writeConfig(address, value);
+        }
+        delegate.setByte(address, value);
+    }
+
+    private void writeConfig(int address, int value) {
+        int effectiveAddress = address & 0xf00f;
+        if (effectiveAddress == 0x7000 && value == 0x96) {
+            configMode = true;
+            runningValue = 0;
+            return;
+        }
+        if (effectiveAddress == 0x700f && value == 0x96) {
+            configMode = false;
+            return;
+        }
+        if (!configMode) {
+            return;
+        }
+        if (effectiveAddress >= 0x700b
+                || (effectiveAddress > 0x6000 && effectiveAddress < 0x7000)) {
+            return;
+        }
+
+        runningValue = ((runningValue >>> 1) | ((runningValue & 1) << 7)) ^ value;
+        if (effectiveAddress >= 0x7000) {
+            cur700x[effectiveAddress & 0x0f] = runningValue;
+        } else if (effectiveAddress == 0x6000) {
+            cur6000 = runningValue;
+        }
+
+        if (effectiveAddress == 0x7000) {
+            sequenceStartBank = cur700x[3];
+            sequenceStartAddress = (cur700x[2] << 8) | cur700x[1];
+            System.arraycopy(cur700x, 4, sequence, 0, sequence.length);
+            sequenceLength = switch (cur700x[0] & 0x07) {
+                case 4 -> 1;
+                case 5 -> 2;
+                case 6 -> 3;
+                case 7 -> 4;
+                default -> 0;
+            };
+        } else if (effectiveAddress == 0x7008) {
+            replacementStartAddress = (cur700x[10] << 8) | cur700x[9];
+            replacementSourceBank = cur6000;
+            replaceBankZero = (cur700x[8] & 0x0f) == 0x0f;
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x8000) {
+            if (sequenceLength > 0 && sequenceBytesLeft == 0) {
+                boolean bankMatches = sequenceStartBank == 0 && address < 0x3fff
+                        || sequenceStartBank == selectedRomBank && address >= 0x4000;
+                if (bankMatches && address == sequenceStartAddress) {
+                    sequenceBytesLeft = sequenceLength;
+                }
+            }
+            if (sequenceBytesLeft > 0) {
+                int index = sequenceLength - sequenceBytesLeft;
+                sequenceBytesLeft--;
+                return sequence[index];
+            }
+            if (replaceBankZero && address >= replacementStartAddress && address < 0x4000) {
+                int bank = Math.floorMod(replacementSourceBank, romBanks);
+                int offset = bank * 0x4000 + address;
+                return offset < rom.length ? rom[offset] : 0xff;
+            }
+        }
+        return delegate.getByte(address);
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new Vf001GeneralState(delegate.captureState(), configMode, runningValue,
+                cur6000, cur700x.clone(), sequenceStartBank, sequenceStartAddress,
+                sequenceLength, sequence.clone(), sequenceBytesLeft, replaceBankZero,
+                replacementStartAddress, replacementSourceBank, selectedRomBank);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new Vf001GeneralState(delegate.captureState(capture), configMode, runningValue,
+                cur6000, capture.ints(cur700x), sequenceStartBank, sequenceStartAddress,
+                sequenceLength, capture.ints(sequence), sequenceBytesLeft, replaceBankZero,
+                replacementStartAddress, replacementSourceBank, selectedRomBank);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+        capture.declareInts(cur700x);
+        capture.declareInts(sequence);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof Vf001GeneralState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        if (mem.cur700x.length != cur700x.length || mem.sequence.length != sequence.length) {
+            throw new IllegalArgumentException("ComponentState register length doesn't match");
+        }
+        delegate.restoreState(mem.delegateMemento);
+        configMode = mem.configMode;
+        runningValue = mem.runningValue;
+        cur6000 = mem.cur6000;
+        System.arraycopy(mem.cur700x, 0, cur700x, 0, cur700x.length);
+        sequenceStartBank = mem.sequenceStartBank;
+        sequenceStartAddress = mem.sequenceStartAddress;
+        sequenceLength = mem.sequenceLength;
+        System.arraycopy(mem.sequence, 0, sequence, 0, sequence.length);
+        sequenceBytesLeft = mem.sequenceBytesLeft;
+        replaceBankZero = mem.replaceBankZero;
+        replacementStartAddress = mem.replacementStartAddress;
+        replacementSourceBank = mem.replacementSourceBank;
+        selectedRomBank = mem.selectedRomBank;
+    }
+
+    private record Vf001GeneralState(ComponentState<MemoryController> delegateMemento,
+                                      boolean configMode, int runningValue, int cur6000,
+                                      int[] cur700x, int sequenceStartBank,
+                                      int sequenceStartAddress, int sequenceLength,
+                                      int[] sequence, int sequenceBytesLeft,
+                                      boolean replaceBankZero, int replacementStartAddress,
+                                      int replacementSourceBank, int selectedRomBank)
+            implements ComponentState<MemoryController> {
+    }
+
+    /** Importer-only compatibility record for released local snapshots. */
+    private record Vf001GeneralMemento(Memento<MemoryController> delegateMemento,
+                                        boolean configMode, int runningValue, int cur6000,
+                                        int[] cur700x, int sequenceStartBank,
+                                        int sequenceStartAddress, int sequenceLength,
+                                        int[] sequence, int sequenceBytesLeft,
+                                        boolean replaceBankZero, int replacementStartAddress,
+                                        int replacementSourceBank, int selectedRomBank)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001GeneralTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001GeneralTest.java
@@ -1,0 +1,122 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Vf001GeneralTest {
+
+    @Test
+    public void detectsZhihuanWang2ExactImage() throws IOException {
+        Rom rom = new Rom(vf001Rom());
+
+        assertEquals(CartridgeProperties.Mapper.VF001_GENERAL,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof Vf001General);
+    }
+
+    @Test
+    public void appliesByteInjectionAndBankZeroReplacement() throws IOException {
+        Vf001General mapper = mapper();
+
+        armReplacement(mapper, 0x2000, 5);
+        assertEquals(0xc5, mapper.getByte(0x2000));
+        assertEquals(0xb0, mapper.getByte(0x0000));
+
+        mapper = mapper();
+        armInjection(mapper, 0, 0x0100, new int[] {0x11, 0x22, 0x33, 0x44});
+        assertEquals(0x11, mapper.getByte(0x0100));
+        assertEquals(0x22, mapper.getByte(0x0101));
+        assertEquals(0x33, mapper.getByte(0x0102));
+        assertEquals(0x44, mapper.getByte(0x0103));
+        assertEquals(0xb0, mapper.getByte(0x0000));
+    }
+
+    @Test
+    public void stateRoundTripPreservesProtectionAndMbc5Bank() throws IOException {
+        Vf001General mapper = mapper();
+        armReplacement(mapper, 0x2000, 5);
+        armInjection(mapper, 0, 0x0100, new int[] {0x11, 0x22, 0x33, 0x44});
+        mapper.setByte(0x2000, 3);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 2);
+        mapper.restoreState(state);
+
+        assertEquals(0x11, mapper.getByte(0x0100));
+        assertEquals(0x22, mapper.getByte(0x0101));
+        assertEquals(0x33, mapper.getByte(0x0102));
+        assertEquals(0x44, mapper.getByte(0x0103));
+        assertEquals(0xc5, mapper.getByte(0x2000));
+        assertEquals(0xb3, mapper.getByte(0x4000));
+    }
+
+    private static void armInjection(Vf001General mapper, int bank, int address,
+                                     int[] bytes) {
+        Programmer programmer = new Programmer(mapper);
+        programmer.latch(0x7001, address & 0xff);
+        programmer.latch(0x7002, address >>> 8);
+        programmer.latch(0x7003, bank);
+        for (int i = 0; i < bytes.length; i++) {
+            programmer.latch(0x7004 + i, bytes[i]);
+        }
+        programmer.latch(0x7000, 3 + bytes.length);
+    }
+
+    private static void armReplacement(Vf001General mapper, int address, int bank) {
+        Programmer programmer = new Programmer(mapper);
+        programmer.latch(0x6000, bank);
+        programmer.latch(0x7009, address & 0xff);
+        programmer.latch(0x700a, address >>> 8);
+        programmer.latch(0x7008, 0x0f);
+    }
+
+    private static final class Programmer {
+
+        private final Vf001General mapper;
+
+        private int running;
+
+        private Programmer(Vf001General mapper) {
+            this.mapper = mapper;
+            mapper.setByte(0x7000, 0x96);
+        }
+
+        private void latch(int address, int wanted) {
+            int rotated = (running >>> 1) | ((running & 1) << 7);
+            mapper.setByte(address, rotated ^ wanted);
+            running = wanted;
+        }
+    }
+
+    private static Vf001General mapper() throws IOException {
+        return new Vf001General(new Rom(vf001Rom()), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] vf001Rom() {
+        byte[] data = new byte[0x80000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) (0xb0 + bank);
+            data[bank * 0x4000 + 0x2000] = (byte) (0xc0 + bank);
+        }
+        data[0x0147] = 0x1b;
+        data[0x0148] = 0x04;
+        data[0x0149] = 0x03;
+        // CRC-forcing suffix: the synthetic image's whole-ROM CRC-32 is e6748d1f.
+        data[data.length - 4] = 0x58;
+        data[data.length - 3] = 0x28;
+        data[data.length - 2] = 0x71;
+        data[data.length - 1] = 0x21;
+        return data;
+    }
+}

--- a/docs/legacy-state-retirement.md
+++ b/docs/legacy-state-retirement.md
@@ -51,7 +51,7 @@ carries the compatibility leaves.
 The architecture test strips the marked compatibility declarations and proves that the remaining
 live owner source has no `Memento<T>` or compatibility-leaf dependency. It also proves that every
 normal record is non-serializable, the normal and compatibility registries are disjoint, and the
-93 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
+94 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
 remain pinned.
 
 ## Supported migration inputs and limits

--- a/docs/state-file-v1.md
+++ b/docs/state-file-v1.md
@@ -160,19 +160,19 @@ Every value starts with a one-byte tag:
 
 Float NaN payloads and signed zero are preserved with `doubleToRawLongBits`. Int32-map keys are
 strictly increasing and unique. Record type IDs are the one-based stable entries of the audited
-93-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
+94-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
 The 11 enum type IDs use the same audited ordering, while enum value IDs are an explicit v1
 one-based registry verified against the production enum names. Class names from input are never
 loaded or instantiated.
 
-The record ID/name/field registry is the exact ordered 93-record appendix in
+The record ID/name/field registry is the exact ordered 94-record appendix in
 [state-memento-schema.md](state-memento-schema.md), where each bullet's one-based position is its
 ID. IDs 88 through 91 deliberately name non-serializable normal-state leaves; the local legacy
 importer has ID-aligned historical descriptor classes with the same field schemas. StateFile does
 not encode either JVM class name, so this runtime/compatibility separation does not change v1
 bytes. ID 92 is the append-only Xploder mapper state and ID 93 is the append-only VF001 Zook
-mapper state. Neither has a legacy descriptor because no released Java-serialized snapshot could
-contain either. The v1 enum registry is:
+mapper state. ID 94 is the append-only VF001 General mapper state. None has a legacy descriptor
+because no released Java-serialized snapshot could contain them. The v1 enum registry is:
 
 | Type ID | Enum | Value IDs in order starting at 1 |
 |---:|---|---|

--- a/docs/state-file-v2.md
+++ b/docs/state-file-v2.md
@@ -66,7 +66,8 @@ of a linked root carries its own explicit ID.
 ## Payload and compatibility
 
 Payload section schema 1 and the original 91 numeric record IDs are byte-for-byte unchanged; the
-Xploder mapper state is appended as ID 92 and the VF001 Zook mapper state as ID 93. In v2, the
+Xploder mapper state is appended as ID 92, the VF001 Zook mapper state as ID 93, and the VF001
+General mapper state as ID 94. In v2, the
 MBC3 `subSecondTicks` scalar is the explicit profile's numerator-domain phase:
 
 | Identity | Valid phase | Live increment per machine tick |

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -8,7 +8,7 @@ Before mutation, apply checks the hardware tag, nested record/mapper tree, invar
 serial endpoint and component-state root, cartridge RTC locations, runtime DTO, held input, and linked
 topology against the already-configured target. Null is admitted only for audited owner/field or
 array-element positions, not inferred from the non-null value's type. The adapter then reconstructs
-the complete replacement and applies the semantic policy registered for each of the 93 admitted
+the complete replacement and applies the semantic policy registered for each of the 94 admitted
 record types. Those policies reject invalid indices, counts, capacities, command phases, and scalar
 relationships before the first live mutation. If an unexpected component apply nevertheless
 throws, the adapter restores the machine, both RTC locations, serial endpoint/runtime, held
@@ -32,8 +32,8 @@ Protocol v8 remains StateFile-v1-only and rejects MGB before linked construction
 The exact remaining compatibility surface and removal policy are documented in
 [legacy-state-retirement.md](legacy-state-retirement.md).
 
-The exact field-by-field inventory of all 93 admitted production record types is committed in
-[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 102
+The exact field-by-field inventory of all 94 admitted production record types is committed in
+[state-memento-schema.md](state-memento-schema.md). The independently scanned list of all 103
 production state contracts and capture owner/call-site files is committed in
 [state-originator-sites.md](state-originator-sites.md). `StateTypeRegistry` is the executable type
 allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral an
@@ -100,7 +100,8 @@ component state; the six fields named above are in the detached supplement; and 
 ## Mapper coverage matrix
 
 Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
-`Mbc3`/RTC, `Mbc5`, `LiCheng`, `XploderGb`, `Vf001Zook`, `Mbc6` RAM/flash, `Mbc7`/EEPROM, `Mmm01`,
+`Mbc3`/RTC, `Mbc5`, `LiCheng`, `XploderGb`, `Vf001Zook`, `Vf001General`, `Mbc6` RAM/flash,
+`Mbc7`/EEPROM, `Mmm01`,
 `PocketCamera`, `Huc1`, `Huc3`,
 `Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
 `SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
@@ -145,7 +146,7 @@ types are rejected through the adapter before its live-mutation callback.
 Records whose fields are deliberately not range-constrained still have an explicit policy and
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
 documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
-are validated by nested records. `StateInventoryTest` requires the policy-key set to equal all 93
+are validated by nested records. `StateInventoryTest` requires the policy-key set to equal all 94
 admitted record types, so a new state record cannot enter the model without an audited choice. Rollback
 is retained for unexpected failures in legacy restore code; it is not the validation path for a
 deterministically malformed detached candidate.

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -1,6 +1,6 @@
 # Audited state-record schema
 
-This is the exact captured-field inventory for all 93 production record types admitted by
+This is the exact captured-field inventory for all 94 production record types admitted by
 `StateTypeRegistry`. Each bullet's one-based position is its stable StateFile-v1 record type ID;
 each line names the non-serializable `ComponentState` record and every component captured by
 `captureState`. The
@@ -129,3 +129,4 @@ altering the 1.7.13/1.7.14 migration schema listed below.
 - `eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer$DelayedWindowWriteState`: value, remainingDots
 - `eu.rekawek.coffeegb.core.memory.cart.type.XploderGb$XploderGbState`: batteryMemento, ram, selectedRomBank, selectedRamBank, ramUpdated
 - `eu.rekawek.coffeegb.core.memory.cart.type.Vf001Zook$Vf001ZookState`: delegateMemento, stream, streamLength, bankPortRun
+- `eu.rekawek.coffeegb.core.memory.cart.type.Vf001General$Vf001GeneralState`: delegateMemento, configMode, runningValue, cur6000, cur700x, sequenceStartBank, sequenceStartAddress, sequenceLength, sequence, sequenceBytesLeft, replaceBankZero, replacementStartAddress, replacementSourceBank, selectedRomBank

--- a/docs/state-originator-sites.md
+++ b/docs/state-originator-sites.md
@@ -95,6 +95,7 @@ the ordinary deep-owned `captureState()` contract, or any portable/legacy byte s
 - COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Sintax.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticart.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Tama5.java`
+- COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001General.java`
 - COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Vf001Zook.java`
 - OWNER `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/WisdomTree.java`
 - COMPOSITE `core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/XploderGb.java`


### PR DESCRIPTION
## Summary

Zhihuan Wang 2 from #375 stayed blank because its cartridge was not recognized as the general Vast Fame VF001 protection board. Ordinary MBC5 banking cannot satisfy the boot-time configuration protocol.

The patch adds exact conservative detection and a dedicated MBC5-compatible VF001 layer. It models the mirrored 0x6000/0x700x configuration ports, rotate/XOR accumulator, programmed byte injection, partial bank-zero replacement, and complete save-state delegation.

ROM SHA-256: 9a6398ad095b1026ec49fc9ea579ea37c22651005bb677684a89708c2979b7c8.

## Verification

- Before: persistent blank output.
- After: the illustrated opening sequence and Chinese text render at stable frame 600.
- Protocol behavior was independently cross-checked against the current Rustyboi implementation derived from the documented hhugboy VF001 behavior.
- `/opt/maven/bin/mvn -pl core -Dtest=Vf001GeneralTest test`: 3 passed.
- `/opt/maven/bin/mvn -pl core test`: 877 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: Mooneye 130, dmg-acid2 1, cgb-acid2 1, Blargg suites 8, Blargg individual 46; all passed.

A stable after-fix screenshot was captured locally. The available GitHub CLI cannot upload it, so it was not committed.

Fixes #375