### PR TITLE
Add camera selection to Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ local SGB controller slots, so every linked machine masks the live four-slot des
 - **Broad cartridge support:** MBC1/1M, MBC2, MBC3 with RTC and MBC30, MBC5,
   MBC6 with flash, MBC7 with EEPROM/accelerometer, MMM01, HuC1, HuC3, TAMA5,
   Pocket Camera, and numerous unlicensed and multicart mappers.
-- **Accessories:** webcam-backed Game Boy Camera, Game Boy Printer with PNG
-  export, Barcode Boy, Full Changer infrared, Datel Action Replay pass-through,
-  cartridge rumble, and tilt input.
+- **Accessories:** webcam-backed Game Boy Camera with a persisted camera-device choice,
+  Game Boy Printer with PNG export, Barcode Boy, Full Changer infrared, Datel Action
+  Replay pass-through, cartridge rumble, and tilt input.
 - **Desktop controls and display:** keyboard and game-controller input, scaling,
   rotation, grayscale, CGB color correction, LCD ghosting, and an SGB-border toggle.
 - **Cheats:** Game Genie and GameShark codes, plus a bundled searchable

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -17,6 +17,7 @@ data class ApplicationSettings(
     val display: Display = Display(),
     val audio: Audio = Audio(),
     val input: Input = Input.defaults(),
+    val peripherals: Peripherals = Peripherals(),
     val saves: Saves = Saves(),
     val advanced: Advanced = Advanced(),
     val desktop: Desktop = Desktop(),
@@ -379,6 +380,18 @@ data class ApplicationSettings(
     }
   }
 
+  /** Host peripherals whose selection is independent from emulated link-port state. */
+  data class Peripherals(
+      val cameraDeviceIndex: Int = DEFAULT_CAMERA_DEVICE_INDEX,
+  ) {
+    init {
+      require(cameraDeviceIndex in MIN_CAMERA_DEVICE_INDEX..MAX_CAMERA_DEVICE_INDEX) {
+        "Camera device index must be between $MIN_CAMERA_DEVICE_INDEX and " +
+            MAX_CAMERA_DEVICE_INDEX
+      }
+    }
+  }
+
   data class GamepadTuning(
       val movementDeadZone: Int = DEFAULT_GAMEPAD_MOVEMENT_DEAD_ZONE,
       val tiltDeadZone: Int = DEFAULT_GAMEPAD_TILT_DEAD_ZONE,
@@ -549,7 +562,7 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 6
+    const val CURRENT_SCHEMA_VERSION = 7
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50
@@ -561,6 +574,9 @@ data class ApplicationSettings(
     const val DEFAULT_GAMEPAD_TILT_DEAD_ZONE = 4_096
     const val MAX_GAMEPAD_DEAD_ZONE = 32_766
     const val MAX_GAMEPAD_TUNINGS = 32
+    const val MIN_CAMERA_DEVICE_INDEX = 0
+    const val DEFAULT_CAMERA_DEVICE_INDEX = 0
+    const val MAX_CAMERA_DEVICE_INDEX = 15
     const val MIN_EXPLICIT_DISPLAY_SCALE = 1
     const val DEFAULT_EXPLICIT_DISPLAY_SCALE = 2
     const val MAX_EXPLICIT_DISPLAY_SCALE = 4

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -22,6 +22,7 @@ object ApplicationSettingsCodec {
   const val AUDIO_VOLUME_KEY = "audio.masterVolume"
   const val AUDIO_LATENCY_KEY = "audio.latencyPreset"
   const val GAMEPAD_TUNING_PREFIX = "input.gamepad."
+  const val CAMERA_DEVICE_INDEX_KEY = "peripherals.cameraDeviceIndex"
   const val DISPLAY_SCALING_MODE_KEY = "display.scalingMode"
   const val DISPLAY_LETTERBOX_COLOR_KEY = "display.letterboxColor"
   const val DISPLAY_FULLSCREEN_KEY = "display.fullscreen"
@@ -61,6 +62,7 @@ object ApplicationSettingsCodec {
           )
   private val versionSixFixedKeys =
       versionFiveFixedKeys + setOf(DESKTOP_WINDOW_WIDTH_KEY, DESKTOP_WINDOW_HEIGHT_KEY)
+  private val versionSevenFixedKeys = versionSixFixedKeys + CAMERA_DEVICE_INDEX_KEY
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -80,6 +82,7 @@ object ApplicationSettingsCodec {
             version == "3" ||
             version == "4" ||
             version == "5" ||
+            version == "6" ||
             version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
@@ -156,6 +159,7 @@ object ApplicationSettingsCodec {
         }
     known[AUDIO_VOLUME_KEY] = settings.audio.volume.toString()
     known[AUDIO_LATENCY_KEY] = settings.audio.latency.name
+    known[CAMERA_DEVICE_INDEX_KEY] = settings.peripherals.cameraDeviceIndex.toString()
     known[BATTERY_SAVES_KEY] = settings.saves.batterySavesEnabled.toString()
     settings.saves.directory?.let { known[SAVE_DIRECTORY_KEY] = it.toString() }
     settings.saves.previousDirectories.forEachIndexed { index, path ->
@@ -338,6 +342,20 @@ object ApplicationSettingsCodec {
                         },
                 ),
             input = input,
+            peripherals =
+                ApplicationSettings.Peripherals(
+                    cameraDeviceIndex =
+                        if (sourceVersion >= 7) {
+                          parseRangedInt(
+                              raw[CAMERA_DEVICE_INDEX_KEY],
+                              ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX,
+                              CAMERA_DEVICE_INDEX_KEY,
+                              ApplicationSettings.MIN_CAMERA_DEVICE_INDEX,
+                              ApplicationSettings.MAX_CAMERA_DEVICE_INDEX,
+                          )
+                        } else {
+                          ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX
+                        }),
             saves =
                 ApplicationSettings.Saves(
                     directory =
@@ -435,6 +453,7 @@ object ApplicationSettingsCodec {
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
         when {
+          sourceVersion >= 7 -> versionSevenFixedKeys
           sourceVersion >= 6 -> versionSixFixedKeys
           sourceVersion >= 5 -> versionFiveFixedKeys
           sourceVersion >= 4 -> versionFourFixedKeys
@@ -901,7 +920,7 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionSixFixedKeys ||
+      key in versionSevenFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           isKnownPreviousSaveDirectoryKey(key, supportsPreviousDirectories = true) ||

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDesktopTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDesktopTest.kt
@@ -16,7 +16,7 @@ class ApplicationSettingsDesktopTest {
     assertNull(defaults.desktop.windowSize)
 
     val encoded = ApplicationSettingsCodec.encode(ApplicationSettingsDocument(defaults))
-    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("7", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY in encoded)
     assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY in encoded)
 
@@ -33,7 +33,7 @@ class ApplicationSettingsDesktopTest {
   }
 
   @Test
-  fun `schema six window size round trips canonically with unknown settings`() {
+  fun `window size round trips canonically with unknown settings`() {
     val size = ApplicationSettings.WindowSize(937, 641)
     val document =
         ApplicationSettingsDocument(
@@ -67,7 +67,7 @@ class ApplicationSettingsDesktopTest {
       assertEquals(future, migrated.unknownProperties, "schema ${version ?: 0}")
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("7", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_WIDTH_KEY in canonical)
       assertFalse(ApplicationSettingsCodec.DESKTOP_WINDOW_HEIGHT_KEY in canonical)
       assertTrue(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
@@ -103,7 +103,7 @@ class ApplicationSettingsDevicesTest {
     mutableTunings.clear()
 
     val encoded = ApplicationSettingsCodec.encode(document)
-    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("7", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertEquals(audioId('c'), encoded[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
     assertEquals("37", encoded[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
     assertEquals("LOW", encoded[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
@@ -163,7 +163,7 @@ class ApplicationSettingsDevicesTest {
       assertEquals(futureValues, migrated.unknownProperties)
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("7", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("default", canonical[ApplicationSettingsCodec.AUDIO_OUTPUT_KEY])
       assertEquals("100", canonical[ApplicationSettingsCodec.AUDIO_VOLUME_KEY])
       assertEquals("BALANCED", canonical[ApplicationSettingsCodec.AUDIO_LATENCY_KEY])
@@ -262,7 +262,112 @@ class ApplicationSettingsDevicesTest {
   }
 
   @Test
-  fun `controller facades expose applied audio and gamepad tuning snapshots`() {
+  fun `camera device model has an explicit bounded default`() {
+    assertEquals(
+        ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX,
+        ApplicationSettings.Peripherals().cameraDeviceIndex,
+    )
+    ApplicationSettings.Peripherals(ApplicationSettings.MIN_CAMERA_DEVICE_INDEX)
+    ApplicationSettings.Peripherals(ApplicationSettings.MAX_CAMERA_DEVICE_INDEX)
+    listOf(
+            ApplicationSettings.MIN_CAMERA_DEVICE_INDEX - 1,
+            ApplicationSettings.MAX_CAMERA_DEVICE_INDEX + 1,
+        )
+        .forEach { invalid ->
+          assertFailsWith<IllegalArgumentException> {
+            ApplicationSettings.Peripherals(invalid)
+          }
+        }
+  }
+
+  @Test
+  fun `schema seven camera choice round trips and rejects malformed indexes`() {
+    val document =
+        ApplicationSettingsDocument(
+            ApplicationSettings(
+                peripherals =
+                    ApplicationSettings.Peripherals(
+                        ApplicationSettings.MAX_CAMERA_DEVICE_INDEX)),
+            mapOf("plugin.camera-filter" to "sepia"),
+        )
+
+    val encoded = ApplicationSettingsCodec.encode(document)
+
+    assertEquals("7", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals(
+        ApplicationSettings.MAX_CAMERA_DEVICE_INDEX.toString(),
+        encoded[ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY],
+    )
+    assertEquals(document, ApplicationSettingsCodec.decode(encoded))
+
+    listOf(
+            "camera",
+            "-1",
+            (ApplicationSettings.MAX_CAMERA_DEVICE_INDEX + 1).toString(),
+            "2147483648",
+        )
+        .forEach { invalid ->
+          assertFailsWith<IllegalArgumentException>("Expected rejection for $invalid") {
+            ApplicationSettingsCodec.decode(
+                mapOf(
+                    ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "7",
+                    ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY to invalid,
+                ))
+          }
+        }
+  }
+
+  @Test
+  fun `schemas zero through six preserve future camera choice without activating it`() {
+    (0..6).forEach { sourceVersion ->
+      val raw =
+          buildMap {
+            if (sourceVersion > 0) {
+              put(ApplicationSettingsCodec.SCHEMA_VERSION_KEY, sourceVersion.toString())
+            }
+            put(ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY, "4")
+          }
+
+      val migrated = ApplicationSettingsCodec.decode(raw)
+
+      assertEquals(
+          ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX,
+          migrated.settings.peripherals.cameraDeviceIndex,
+      )
+      assertEquals(
+          "4",
+          migrated.unknownProperties[ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY],
+      )
+      val canonical = ApplicationSettingsCodec.encode(migrated)
+      assertEquals("0", canonical[ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY])
+      assertTrue(
+          canonical.keys.any {
+            it.startsWith(ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX)
+          })
+      assertEquals(migrated, ApplicationSettingsCodec.decode(canonical))
+    }
+  }
+
+  @Test
+  fun `schema six collision envelope retains future camera choice through schema seven`() {
+    val collision = mapOf(ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY to "9")
+    val migrated =
+        ApplicationSettingsCodec.decode(
+            mapOf(
+                ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "6",
+                "${ApplicationSettingsCodec.PRESERVED_UNKNOWN_COLLISIONS_PREFIX}0" to
+                    serializeCollisions(collision),
+            ))
+
+    assertEquals(ApplicationSettings.Peripherals(), migrated.settings.peripherals)
+    assertEquals(collision, migrated.unknownProperties)
+    val canonical = ApplicationSettingsCodec.encode(migrated)
+    assertEquals("0", canonical[ApplicationSettingsCodec.CAMERA_DEVICE_INDEX_KEY])
+    assertEquals(migrated, ApplicationSettingsCodec.decode(canonical))
+  }
+
+  @Test
+  fun `controller facades expose and persist applied device snapshots`() {
     val path = Files.createTempDirectory("coffee-gb-devices").resolve("settings.properties")
     val stableId = gamepadId('1')
     val audio =
@@ -284,6 +389,7 @@ class ApplicationSettingsDevicesTest {
         current.copy(
             audio = audio,
             input = current.input.copy(gamepadTunings = mapOf(stableId to tuning)),
+            peripherals = ApplicationSettings.Peripherals(cameraDeviceIndex = 7),
         )
       }
 
@@ -294,6 +400,7 @@ class ApplicationSettingsDevicesTest {
       assertEquals(mapOf(stableId to tuning), properties.gamepadTunings)
       assertEquals(tuning, properties.gamepadTuning(stableId))
       assertEquals(ApplicationSettings.GamepadTuning(), properties.gamepadTuning(gamepadId('2')))
+      assertEquals(7, properties.applicationSettings.peripherals.cameraDeviceIndex)
       properties.flush()
     }
 
@@ -302,6 +409,7 @@ class ApplicationSettingsDevicesTest {
             ApplicationSettingsStore.decodeProperties(Files.readAllBytes(path)))
     assertEquals(audio, persisted.settings.audio)
     assertEquals(mapOf(stableId to tuning), persisted.settings.input.gamepadTunings)
+    assertEquals(7, persisted.settings.peripherals.cameraDeviceIndex)
   }
 
   private fun gamepadId(fill: Char): String = "sdl-" + fill.toString().repeat(64)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
@@ -63,7 +63,7 @@ class ApplicationSettingsDisplayTest {
               )
 
           val encoded = ApplicationSettingsCodec.encode(document)
-          assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+          assertEquals("7", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
           assertEquals(
               scalingMode.name,
               encoded[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY],
@@ -114,7 +114,7 @@ class ApplicationSettingsDisplayTest {
       assertEquals(futureValues, migrated.unknownProperties)
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("7", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("EXPLICIT", canonical[ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY])
       assertEquals("4", canonical["display.scale"])
       assertEquals("000000", canonical[ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY])

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsSavesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsSavesTest.kt
@@ -39,7 +39,7 @@ class ApplicationSettingsSavesTest {
       assertEquals(future, migrated.unknownProperties, "schema ${version ?: 0}")
 
       val canonical = ApplicationSettingsCodec.encode(migrated)
-      assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+      assertEquals("7", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
       assertEquals("false", canonical[ApplicationSettingsCodec.BATTERY_SAVES_KEY])
       assertEquals("true", canonical[ApplicationSettingsCodec.REWIND_ENABLED_KEY])
       assertEquals("30", canonical[ApplicationSettingsCodec.REWIND_SECONDS_KEY])
@@ -80,7 +80,7 @@ class ApplicationSettingsSavesTest {
     previous.clear()
 
     val encoded = ApplicationSettingsCodec.encode(document)
-    assertEquals("6", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+    assertEquals("7", encoded[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
     assertEquals(
         Path.of("/new/é").toString(),
         encoded[ApplicationSettingsCodec.SAVE_DIRECTORY_KEY],

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
@@ -425,14 +425,14 @@ class ApplicationSettingsStoreTest {
 
           Files.readAllBytes(path).also { bytes ->
             val canonical = ApplicationSettingsStore.decodeProperties(bytes)
-            assertEquals("6", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
+            assertEquals("7", canonical[ApplicationSettingsCodec.SCHEMA_VERSION_KEY])
             assertEquals(store.current(), ApplicationSettingsCodec.decode(canonical))
             assertEquals(canonical, ApplicationSettingsCodec.encode(store.current()))
           }
         }
 
     ApplicationSettingsStore(path, debounceMillis = 60_000).use { store ->
-      assertEquals("6", store.current().settings.schemaVersion.toString())
+      assertEquals("7", store.current().settings.schemaVersion.toString())
     }
     assertTrue(canonicalBytes.contentEquals(Files.readAllBytes(path)))
   }
@@ -829,7 +829,8 @@ class ApplicationSettingsStoreTest {
               "saves.rewindEnabled" to "true",
               "saves.rewindMemoryMiB" to "64",
               "saves.rewindSeconds" to "30",
-              "settings.schemaVersion" to "6",
+              "peripherals.cameraDeviceIndex" to "0",
+              "settings.schemaVersion" to "7",
               "sound.enabled" to "false",
               "system.bootstrapMode" to "FAST_FORWARD",
               "system.cgbGames" to "cgb0",

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -42,16 +42,16 @@ particular, `--use-bootstrap` and `--disable-battery-saves` do not change the ne
 ## Typed settings model
 
 The application owns one immutable `ApplicationSettings` value with typed `general`, `display`,
-`audio`, `input`, `saves`, `advanced`, and desktop-shell sections. The controller-facing
+`audio`, `input`, `peripherals`, `saves`, `advanced`, and desktop-shell sections. The controller-facing
 `EmulatorProperties` class is a compatibility facade over that model while older menu code is
 migrated.
 
-Schema 6 continues to use `${user.home}/.coffeegb.properties`; schemas 0–5 are migrated in place
+Schema 7 continues to use `${user.home}/.coffeegb.properties`; schemas 0–6 are migrated in place
 so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `6` |
+| `settings.schemaVersion` | exact supported schema version | `7` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
@@ -84,6 +84,7 @@ so the portable JAR remains compatible during the migration window.
 | `input.gamepad.<stable-id>.tiltDeadZone` | raw SDL threshold in `0..32766` | `4096` |
 | `input.gamepad.<stable-id>.invertMovementX/Y` | boolean | `false` |
 | `input.gamepad.<stable-id>.invertTiltX/Y` | boolean | `false` |
+| `peripherals.cameraDeviceIndex` | OpenCV camera device index in `0..15` | `0` |
 
 Recognized values are validated before becoming live settings. Boolean values are exactly `true`
 or `false` (case-insensitive); numeric settings have explicit ranges; hardware profiles,
@@ -94,14 +95,14 @@ does not partially update the active settings.
 application may close without a redundant prompt. `ALWAYS` also confirms an idle application
 close, and `NEVER` suppresses this ordinary confirmation. A battery/autosave flush failure remains
 actionable regardless of this preference. Setting recent-file capacity to zero disables history;
-reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 6
+reducing it removes the oldest excess entries. Coffee GB has no update-check mechanism, so schema 7
 does not invent or persist an update-check preference.
 
 Unrecognized legacy keys are retained losslessly when the current schema is saved. Keys in a reserved grammar,
 such as an unknown `input.*` key, remain errors so a misspelled control binding is not silently
 ignored. The current schema stores active history under `general.recent.*`, so a numeric `rom.recent.*` legacy
 key beyond Coffee GB's old ten-entry history remains untouched even if capacity later grows. Schema
-6 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
+7 writes every active keyboard binding and the explicit P1 gamepad selection; an absent versioned
 binding is therefore unbound rather than silently restored to a default. If an older unknown key
 occupies a name reserved by a later schema, Coffee GB keeps its original key/value in bounded
 internal migration metadata rather than overwriting or reinterpreting it. At most 32 per-device
@@ -125,6 +126,14 @@ and exposes independent movement/tilt dead zones and X/Y inversion for each stab
 mapping change releases all held input and waits for a neutral physical sample before accepting new
 presses.
 
+The Peripherals tab selects Camera 1 (Coffee GB's default and the first OpenCV camera slot) or
+another numbered camera for the webcam-backed Game Boy Camera. OpenCV exposes portable numeric
+device slots but not stable cross-platform camera names, so reconnecting hardware can change their
+order. Merely opening Preferences never probes or opens a camera. Applying a different choice
+reopens the source asynchronously only when **Peripherals → Enable Game Boy Camera** is already
+enabled; otherwise the choice is remembered for the next enable request. A failed explicit choice
+remains selected and is never silently replaced with a different camera.
+
 The Audio tab enumerates Java Sound outputs on a cancellable background worker. It supports system
 default or an explicit descriptor-hashed output, a 0–100 master-volume slider, mute, and
 LOW/BALANCED/SAFE bounded-latency presets. If an explicit output disappears, playback retains the configured ID,
@@ -133,8 +142,8 @@ no output can be opened. While fallback remains active, Coffee GB periodically r
 configured output after it reappears. Device, volume, mute, and latency changes do not reset emulated
 audio clock or DC-filter phase.
 
-**Apply** validates the complete draft, writes one settings update, and switches the live keyboard
-mapping and display only after persistence accepts it. **Cancel**, the window close button, and
+**Apply** validates the complete draft, writes one settings update, and switches the live keyboard,
+camera, and display settings only after persistence accepts it. **Cancel**, the window close button, and
 Escape discard unapplied edits. **Restore Defaults** only changes the visible draft until Apply is
 chosen.
 
@@ -188,8 +197,8 @@ after it can report and test that capability, with this repaint path remaining t
 
 ## Migration and recovery
 
-A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 5 migration is a
-pure conversion into schema 6, preserves unknown keys, retains absent profile mappings as Auto, and
+A file without `settings.schemaVersion` is legacy schema 0. Schema 0 through schema 6 migration is a
+pure conversion into schema 7, preserves unknown keys, retains absent profile mappings as Auto, and
 canonicalizes the finite historical uppercase profile aliases. Existing display scales migrate to
 explicit scale with a black letterbox and windowed startup; no previous launch is unexpectedly
 forced fullscreen. Older schemas have no saved desktop size and retain the existing packed,

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -165,6 +165,8 @@ This feature adds the optional `saves.rewindMemoryMiB` property to settings sche
 decode as 64 MiB, so schema-5 files written before this feature remain valid. Later desktop-window
 geometry advances the current document to schema 6; schema-5 save fields retain their original
 ownership and continue to decode before the schema-6 desktop section is applied.
+Camera-device selection later advances the current document to schema 7; schemas 0-6 preserve the
+future camera key without interpreting it during migration.
 
 For the binary format and persistence guarantees, see [StateFile v2](state-file-v2.md) and
 [atomic persistence](atomic-persistence.md).

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/CameraPeripheralController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/CameraPeripheralController.kt
@@ -30,7 +30,8 @@ internal sealed interface CameraPeripheralUiState {
  * emulator. Cancellation or disposal closes every stale source on a worker before it can escape.
  */
 internal class CameraPeripheralController<T : CameraSource>(
-    private val opener: () -> T?,
+    private val opener: (Int) -> T?,
+    initialDeviceIndex: Int = 0,
     private val sourceCloser: (T) -> Unit,
     private val publisher: (CameraSource?) -> Unit,
     private val stateConsumer: (CameraPeripheralUiState) -> Unit,
@@ -44,9 +45,15 @@ internal class CameraPeripheralController<T : CameraSource>(
     private val edtOwnership: () -> Boolean = SwingUtilities::isEventDispatchThread,
 ) : Closeable {
 
+  init {
+    require(initialDeviceIndex >= 0) { "camera device index must not be negative" }
+  }
+
   private val stateLock = Any()
 
   private var operation = 0L
+
+  private var deviceIndex = initialDeviceIndex
 
   private var desired = false
 
@@ -63,12 +70,38 @@ internal class CameraPeripheralController<T : CameraSource>(
       return
     }
 
+    startOpening(failIfClosed = true)
+  }
+
+  /** Selects a source without enabling a disabled camera; an active source is replaced safely. */
+  fun selectDevice(deviceIndex: Int) {
+    requireEdt()
+    require(deviceIndex >= 0) { "camera device index must not be negative" }
+    val restart =
+        synchronized(stateLock) {
+          if (closed || this.deviceIndex == deviceIndex) return
+          this.deviceIndex = deviceIndex
+          desired
+        }
+    if (restart) {
+      // close() is intentionally allowed off the EDT. If it wins this race, selection is already
+      // terminal and this internal restart becomes a no-op rather than surfacing an Apply failure.
+      startOpening(failIfClosed = false)
+    }
+  }
+
+  private fun startOpening(failIfClosed: Boolean) {
     val current: Long
+    val requestedDeviceIndex: Int
     val previous: T?
     synchronized(stateLock) {
-      check(!closed) { "camera peripheral controller is closed" }
+      if (closed) {
+        check(!failIfClosed) { "camera peripheral controller is closed" }
+        return
+      }
       operation++
       current = operation
+      requestedDeviceIndex = deviceIndex
       desired = true
       pending?.cancel(true)
       pending = null
@@ -82,7 +115,7 @@ internal class CameraPeripheralController<T : CameraSource>(
 
     val submitted =
         try {
-          executor.submit { openOnWorker(current) }
+          executor.submit { openOnWorker(current, requestedDeviceIndex) }
         } catch (_: RejectedExecutionException) {
           failSubmission(current)
           return
@@ -115,11 +148,11 @@ internal class CameraPeripheralController<T : CameraSource>(
     stateConsumer(CameraPeripheralUiState.Disabled)
   }
 
-  private fun openOnWorker(expectedOperation: Long) {
+  private fun openOnWorker(expectedOperation: Long, requestedDeviceIndex: Int) {
     check(!SwingUtilities.isEventDispatchThread()) { "camera open must not run on the EDT" }
     val source =
         try {
-          opener()
+          opener(requestedDeviceIndex)
         } catch (failure: Throwable) {
           LOG.warn("Failed to open the camera peripheral", failure)
           null

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PeripheralsPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PeripheralsPreferencesEditor.kt
@@ -1,0 +1,114 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.awt.event.KeyEvent
+import javax.swing.BorderFactory
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+/** Draft-only host-peripheral editor. Opening Preferences never probes or opens camera hardware. */
+internal class PeripheralsPreferencesEditor private constructor(
+    initial: ApplicationSettings.Peripherals,
+    private val defaults: ApplicationSettings.Peripherals,
+    @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
+) : JPanel(GridBagLayout()) {
+  constructor(
+      initial: ApplicationSettings.Peripherals,
+      defaults: ApplicationSettings.Peripherals = ApplicationSettings.Peripherals(),
+  ) : this(initial, defaults, requireEdt())
+
+  internal data class CameraOption(
+      val deviceIndex: Int,
+      val label: String,
+  ) {
+    override fun toString(): String = label
+  }
+
+  internal val cameraDevice =
+      JComboBox(CAMERA_OPTIONS.toTypedArray()).apply {
+        accessibleContext.accessibleName = "Game Boy Camera device"
+        accessibleContext.accessibleDescription = CAMERA_ORDER_EXPLANATION
+        toolTipText = CAMERA_ORDER_EXPLANATION
+        selectedItem = CAMERA_OPTIONS.first { it.deviceIndex == initial.cameraDeviceIndex }
+      }
+
+  init {
+    getAccessibleContext().accessibleName = "Peripheral preferences"
+    getAccessibleContext().accessibleDescription =
+        "Choose host devices used by emulated Game Boy peripherals."
+    border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+
+    val constraints =
+        GridBagConstraints().apply {
+          anchor = GridBagConstraints.LINE_START
+          fill = GridBagConstraints.HORIZONTAL
+          insets = Insets(4, 4, 4, 4)
+        }
+    val cameraLabel = JLabel("Game Boy Camera:")
+    cameraLabel.displayedMnemonic = KeyEvent.VK_C
+    cameraLabel.labelFor = cameraDevice
+    constraints.gridx = 0
+    constraints.gridy = 0
+    constraints.weightx = 0.0
+    add(cameraLabel, constraints)
+
+    constraints.gridx = 1
+    constraints.weightx = 1.0
+    add(cameraDevice, constraints)
+
+    val explanation = JLabel("<html>$CAMERA_ORDER_EXPLANATION</html>")
+    explanation.accessibleContext.accessibleName = "Camera device ordering note"
+    constraints.gridx = 0
+    constraints.gridy = 1
+    constraints.gridwidth = 2
+    constraints.weightx = 1.0
+    add(explanation, constraints)
+
+    constraints.gridy = 2
+    constraints.weighty = 1.0
+    constraints.fill = GridBagConstraints.BOTH
+    add(JPanel(), constraints)
+  }
+
+  internal fun validatedPeripherals(): ApplicationSettings.Peripherals {
+    requireEdt()
+    val selected = cameraDevice.selectedItem as CameraOption
+    return ApplicationSettings.Peripherals(cameraDeviceIndex = selected.deviceIndex)
+  }
+
+  internal fun restoreDefaults() {
+    requireEdt()
+    cameraDevice.selectedItem =
+        CAMERA_OPTIONS.first { it.deviceIndex == defaults.cameraDeviceIndex }
+  }
+
+  private companion object {
+    const val CAMERA_ORDER_EXPLANATION =
+        "Camera order is supplied by the operating system and can change after reconnecting devices."
+    val CAMERA_OPTIONS =
+        (ApplicationSettings.MIN_CAMERA_DEVICE_INDEX..
+                ApplicationSettings.MAX_CAMERA_DEVICE_INDEX)
+            .map { deviceIndex ->
+              val number = deviceIndex + 1
+              CameraOption(
+                  deviceIndex,
+                  if (deviceIndex == ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX) {
+                    "Camera $number (Coffee GB default)"
+                  } else {
+                    "Camera $number"
+                  },
+              )
+            }
+
+    fun requireEdt() {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "Peripheral preferences must be constructed and accessed on the EDT"
+      }
+    }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
@@ -67,6 +67,7 @@ internal data class PreferencesEdit(
         >,
     val gamepads: Map<Int, ApplicationSettings.GamepadSelection>,
     val gamepadTunings: Map<String, ApplicationSettings.GamepadTuning>,
+    val cameraDeviceIndex: Int,
     val audio: ApplicationSettings.Audio,
     val saves: ApplicationSettings.Saves? = null,
     val advanced: ApplicationSettings.Advanced? = null,
@@ -106,6 +107,7 @@ internal data class PreferencesEdit(
                   gamepads = gamepads,
                   gamepadTunings = gamepadTunings,
               ),
+          peripherals = current.peripherals.copy(cameraDeviceIndex = cameraDeviceIndex),
       )
 }
 
@@ -168,6 +170,8 @@ internal class PreferencesPanel private constructor(
   internal val keyboardEditor = KeyboardMappingEditor(initial.input, defaults.input)
   internal val gamepadEditor =
       GamepadPreferencesEditor(initial.input, defaults.input, gamepadSnapshots)
+  internal val peripheralsEditor =
+      PeripheralsPreferencesEditor(initial.peripherals, defaults.peripherals)
   internal val audioEditor =
       AudioPreferencesEditor(initial.audio, defaults.audio, audioDevices)
   internal val savesEditor =
@@ -185,6 +189,7 @@ internal class PreferencesPanel private constructor(
     tabs.addTab("Display", JScrollPane(displayEditor).apply { border = null })
     tabs.addTab("Input", JScrollPane(keyboardEditor).apply { border = null })
     tabs.addTab("Gamepads", JScrollPane(gamepadEditor).apply { border = null })
+    tabs.addTab("Peripherals", JScrollPane(peripheralsEditor).apply { border = null })
     tabs.addTab("Audio", JScrollPane(audioEditor).apply { border = null })
     tabs.addTab("Saves", JScrollPane(savesEditor).apply { border = null })
     tabs.addChangeListener {
@@ -211,6 +216,7 @@ internal class PreferencesPanel private constructor(
     systemEditor.restoreDefaults()
     keyboardEditor.resetToDefaults()
     gamepadEditor.restoreDefaults()
+    peripheralsEditor.restoreDefaults()
     audioEditor.restoreDefaults()
     savesEditor.restoreDefaults()
     clearErrors()
@@ -281,6 +287,7 @@ internal class PreferencesPanel private constructor(
         keyboard = input.keyboard,
         gamepads = gamepad.selections,
         gamepadTunings = gamepad.tunings,
+        cameraDeviceIndex = peripheralsEditor.validatedPeripherals().cameraDeviceIndex,
         audio = audio,
         saves = saves,
         advanced = systemEditor.validatedAdvanced(),
@@ -507,8 +514,9 @@ internal class PreferencesPanel private constructor(
     const val DISPLAY_TAB = 2
     const val INPUT_TAB = 3
     const val GAMEPADS_TAB = 4
-    const val AUDIO_TAB = 5
-    const val SAVES_TAB = 6
+    const val PERIPHERALS_TAB = 5
+    const val AUDIO_TAB = 6
+    const val SAVES_TAB = 7
     val ERROR_COLOR = Color(0xB0, 0x00, 0x20)
     val CONFIRMATION_OPTIONS =
         listOf(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -545,6 +545,7 @@ class SwingGui private constructor(
       val applied = properties.applicationSettings
       emulator.applyKeyboardMapping(applied.input.toPlayerMapping())
       emulator.applyDeviceSettings(applied)
+      menu.applyCameraSettings(applied.peripherals)
       displayController.apply(
           applied.display,
           persist = false,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -118,6 +118,8 @@ internal class SwingMenu(
 
   private var pauseSupport: Boolean = false
 
+  private var cameraDeviceIndex = properties.applicationSettings.peripherals.cameraDeviceIndex
+
   private lateinit var cameraController: CameraPeripheralController<WebcamCameraSource>
 
   private lateinit var cameraShutdown: BoundedCameraShutdown
@@ -220,6 +222,16 @@ internal class SwingMenu(
   fun closeCameraAfterSuccessfulStop(timeoutMillis: Long) {
     if (::cameraShutdown.isInitialized) {
       cameraShutdown.closeAndAwait(timeoutMillis)
+    }
+  }
+
+  fun applyCameraSettings(peripherals: ApplicationSettings.Peripherals) {
+    check(SwingUtilities.isEventDispatchThread()) {
+      "Camera preferences must be applied from the Event Dispatch Thread"
+    }
+    cameraDeviceIndex = peripherals.cameraDeviceIndex
+    if (::cameraController.isInitialized) {
+      cameraController.selectDevice(peripherals.cameraDeviceIndex)
     }
   }
 
@@ -638,6 +650,7 @@ internal class SwingMenu(
     cameraController =
         CameraPeripheralController(
             opener = WebcamCameraSource::open,
+            initialDeviceIndex = cameraDeviceIndex,
             sourceCloser = WebcamCameraSource::close,
             publisher = PocketCamera::setCameraSource,
             stateConsumer = { state ->
@@ -653,7 +666,7 @@ internal class SwingMenu(
               if (state == CameraPeripheralUiState.OpenFailed && window.isDisplayable) {
                 JOptionPane.showMessageDialog(
                     window,
-                    "No webcam could be opened.",
+                    "Camera ${cameraDeviceIndex + 1} could not be opened.",
                     "Game Boy Camera",
                     JOptionPane.ERROR_MESSAGE,
                 )

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/WebcamCameraSource.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/WebcamCameraSource.java
@@ -52,7 +52,21 @@ public class WebcamCameraSource implements CameraSource, AutoCloseable {
      * @return the source, or {@code null} if the native library is unavailable (e.g. an
      * unsupported architecture) or no camera can be opened
      */
-    public static synchronized WebcamCameraSource open() {
+    public static WebcamCameraSource open() {
+        return open(0);
+    }
+
+    /**
+     * Loads the native library and opens one explicitly selected camera device.
+     *
+     * @param deviceIndex the non-negative OpenCV camera index
+     * @return the source, or {@code null} if the native library is unavailable or the selected
+     * device cannot be opened
+     */
+    public static synchronized WebcamCameraSource open(int deviceIndex) {
+        if (deviceIndex < 0) {
+            throw new IllegalArgumentException("Camera device index must not be negative");
+        }
         try {
             if (!nativeLoaded) {
                 String packaged =
@@ -68,16 +82,16 @@ public class WebcamCameraSource implements CameraSource, AutoCloseable {
                 }
                 nativeLoaded = true;
             }
-            VideoCapture capture = new VideoCapture(0);
+            VideoCapture capture = new VideoCapture(deviceIndex);
             if (!capture.isOpened()) {
-                LOG.warn("No webcam could be opened (device 0)");
+                LOG.warn("No webcam could be opened (device {})", deviceIndex);
                 capture.release();
                 return null;
             }
-            LOG.info("Opened webcam device 0 via OpenCV");
+            LOG.info("Opened webcam device {} via OpenCV", deviceIndex);
             return new WebcamCameraSource(capture);
         } catch (Throwable t) {
-            LOG.warn("Failed to open the webcam", t);
+            LOG.warn("Failed to open webcam device " + deviceIndex, t);
             return null;
         }
     }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/CameraPeripheralControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/CameraPeripheralControllerTest.kt
@@ -24,6 +24,7 @@ class CameraPeripheralControllerTest {
   @Test
   fun `open and close stay on worker while publication and UI stay on EDT`() {
     val source = TestSource()
+    val openedDevice = AtomicInteger(-1)
     val openOffEdt = AtomicBoolean()
     val closeOffEdt = AtomicBoolean()
     val opened = CountDownLatch(1)
@@ -33,10 +34,12 @@ class CameraPeripheralControllerTest {
     val callbacksOnEdt = AtomicBoolean(true)
     val controller =
         CameraPeripheralController(
-            opener = {
+            opener = { device ->
+              openedDevice.set(device)
               openOffEdt.set(!SwingUtilities.isEventDispatchThread())
               source
             },
+            initialDeviceIndex = 3,
             sourceCloser = {
               closeOffEdt.set(!SwingUtilities.isEventDispatchThread())
               sourceClosed.countDown()
@@ -55,6 +58,7 @@ class CameraPeripheralControllerTest {
     assertFailsWith<IllegalStateException> { controller.requestEnabled(true) }
     onEdt { controller.requestEnabled(true) }
     assertTrue(opened.await(3, TimeUnit.SECONDS))
+    assertEquals(3, openedDevice.get())
     assertTrue(openOffEdt.get())
     assertSame(source, publications.last())
 
@@ -77,7 +81,7 @@ class CameraPeripheralControllerTest {
   }
 
   @Test
-  fun `cancelled stale open is closed and only the newer result reaches the EDT`() {
+  fun `device selected during blocked open is captured per operation and stale source is closed`() {
     val first = TestSource()
     val second = TestSource()
     val firstEntered = CountDownLatch(1)
@@ -85,13 +89,14 @@ class CameraPeripheralControllerTest {
     val firstClosed = CountDownLatch(1)
     val secondEnabled = CountDownLatch(1)
     val secondClosed = CountDownLatch(1)
-    val opens = AtomicInteger()
+    val openedDevices = Collections.synchronizedList(mutableListOf<Int>())
     val publications = Collections.synchronizedList(mutableListOf<CameraSource?>())
     val states = Collections.synchronizedList(mutableListOf<CameraPeripheralUiState>())
     val controller =
         CameraPeripheralController(
-            opener = {
-              if (opens.getAndIncrement() == 0) {
+            opener = { device ->
+              openedDevices += device
+              if (device == 0) {
                 firstEntered.countDown()
                 awaitIgnoringInterrupt(releaseFirst)
                 first
@@ -120,20 +125,17 @@ class CameraPeripheralControllerTest {
 
     onEdt { controller.requestEnabled(true) }
     assertTrue(firstEntered.await(3, TimeUnit.SECONDS))
-    onEdt {
-      controller.requestEnabled(false)
-      controller.requestEnabled(true)
-    }
+    onEdt { controller.selectDevice(4) }
     releaseFirst.countDown()
 
     assertTrue(firstClosed.await(3, TimeUnit.SECONDS))
     assertTrue(secondEnabled.await(3, TimeUnit.SECONDS))
     assertFalse(publications.contains(first))
     assertSame(second, publications.last())
+    assertEquals(listOf(0, 4), openedDevices)
     assertEquals(
         listOf(
             CameraPeripheralUiState.Opening,
-            CameraPeripheralUiState.Disabled,
             CameraPeripheralUiState.Opening,
             CameraPeripheralUiState.Enabled,
         ),
@@ -147,13 +149,67 @@ class CameraPeripheralControllerTest {
   }
 
   @Test
+  fun `device preference restarts an enabled source but never enables a disabled camera`() {
+    val first = TestSource()
+    val second = TestSource()
+    val openedDevices = Collections.synchronizedList(mutableListOf<Int>())
+    val firstEnabled = CountDownLatch(1)
+    val secondEnabled = CountDownLatch(1)
+    val firstClosed = CountDownLatch(1)
+    val secondClosed = CountDownLatch(1)
+    val publications = Collections.synchronizedList(mutableListOf<CameraSource?>())
+    val controller =
+        CameraPeripheralController(
+            opener = { device ->
+              openedDevices += device
+              if (device == 0) first else second
+            },
+            sourceCloser = {
+              when (it) {
+                first -> firstClosed.countDown()
+                second -> secondClosed.countDown()
+              }
+            },
+            publisher = {
+              publications += it
+              when (it) {
+                first -> firstEnabled.countDown()
+                second -> secondEnabled.countDown()
+              }
+            },
+            stateConsumer = {},
+        )
+
+    assertFailsWith<IllegalStateException> { controller.selectDevice(5) }
+    onEdt { controller.requestEnabled(true) }
+    assertTrue(firstEnabled.await(3, TimeUnit.SECONDS))
+    onEdt { controller.selectDevice(0) }
+    assertEquals(listOf(0), openedDevices)
+
+    onEdt { controller.selectDevice(5) }
+
+    assertTrue(firstClosed.await(3, TimeUnit.SECONDS))
+    assertTrue(secondEnabled.await(3, TimeUnit.SECONDS))
+    assertEquals(listOf(0, 5), openedDevices)
+    assertEquals(listOf(first, null, second), publications)
+
+    onEdt { controller.requestEnabled(false) }
+    assertTrue(secondClosed.await(3, TimeUnit.SECONDS))
+    onEdt { controller.selectDevice(9) }
+    assertEquals(listOf(0, 5), openedDevices)
+
+    onEdt { controller.close() }
+    assertTrue(controller.awaitTermination(3, TimeUnit.SECONDS))
+  }
+
+  @Test
   fun `current open failure is reported on EDT without publishing a source`() {
     val failed = CountDownLatch(1)
     val states = Collections.synchronizedList(mutableListOf<CameraPeripheralUiState>())
     val publications = Collections.synchronizedList(mutableListOf<CameraSource?>())
     val controller =
         CameraPeripheralController<TestSource>(
-            opener = {
+            opener = { _ ->
               assertFalse(SwingUtilities.isEventDispatchThread())
               null
             },
@@ -192,7 +248,7 @@ class CameraPeripheralControllerTest {
     val executor = Executors.newSingleThreadExecutor()
     val controller =
         CameraPeripheralController(
-            opener = { source },
+            opener = { _ -> source },
             sourceCloser = {
               assertFalse(SwingUtilities.isEventDispatchThread())
               sourceClosed.countDown()
@@ -231,7 +287,7 @@ class CameraPeripheralControllerTest {
     val closes = AtomicInteger()
     val controller =
         CameraPeripheralController(
-            opener = { source },
+            opener = { _ -> source },
             sourceCloser = { closes.incrementAndGet() },
             publisher = {
               assertTrue(SwingUtilities.isEventDispatchThread())
@@ -247,6 +303,7 @@ class CameraPeripheralControllerTest {
     assertTrue(enabled.await(3, TimeUnit.SECONDS))
     controller.close()
     controller.close()
+    onEdt { controller.selectDevice(8) }
 
     assertTrue(controller.awaitTermination(3, TimeUnit.SECONDS))
     assertTrue(detached.await(3, TimeUnit.SECONDS))

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
@@ -20,6 +20,36 @@ import org.junit.Test
 class DevicePreferencesEditorsTest {
 
   @Test
+  fun `camera choices map human labels to bounded indexes and restore defaults`() =
+      onEdt {
+        val editor =
+            PeripheralsPreferencesEditor(
+                ApplicationSettings.Peripherals(cameraDeviceIndex = 7),
+                ApplicationSettings.Peripherals(cameraDeviceIndex = 2),
+            )
+
+        assertEquals(16, editor.cameraDevice.itemCount)
+        assertEquals(
+            "Camera 1 (Coffee GB default)",
+            (editor.cameraDevice.getItemAt(0) as PeripheralsPreferencesEditor.CameraOption).label,
+        )
+        assertEquals(
+            "Camera 16",
+            (editor.cameraDevice.getItemAt(15) as PeripheralsPreferencesEditor.CameraOption).label,
+        )
+        assertEquals(7, editor.validatedPeripherals().cameraDeviceIndex)
+        assertEquals(
+            "Game Boy Camera device",
+            editor.cameraDevice.accessibleContext.accessibleName,
+        )
+
+        editor.cameraDevice.selectedIndex = 15
+        assertEquals(15, editor.validatedPeripherals().cameraDeviceIndex)
+        editor.restoreDefaults()
+        assertEquals(2, editor.validatedPeripherals().cameraDeviceIndex)
+      }
+
+  @Test
   fun `gamepad snapshot choices retain unavailable assignments and persist per-device tuning`() =
       onEdt {
         val unavailableId = gamepadId('a')
@@ -371,10 +401,23 @@ class DevicePreferencesEditorsTest {
       assertEquals("Gamepads", panel.tabs.getTitleAt(panel.tabs.selectedIndex))
       assertTrue(panel.validationSummary.text.contains("multiple players"))
       assertEquals(
-          listOf("General", "System", "Display", "Input", "Gamepads", "Audio", "Saves"),
+          listOf(
+              "General",
+              "System",
+              "Display",
+              "Input",
+              "Gamepads",
+              "Peripherals",
+              "Audio",
+              "Saves",
+          ),
           (0 until panel.tabs.tabCount).map(panel.tabs::getTitleAt),
       )
       assertEquals("Gamepad preferences", panel.gamepadEditor.accessibleContext.accessibleName)
+      assertEquals(
+          "Peripheral preferences",
+          panel.peripheralsEditor.accessibleContext.accessibleName,
+      )
       assertEquals("Audio preferences", panel.audioEditor.accessibleContext.accessibleName)
     }
   }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -69,6 +69,7 @@ class PreferencesDialogTest {
                 ),
             audio = ApplicationSettings.Audio(enabled = false),
             input = currentInput,
+            peripherals = ApplicationSettings.Peripherals(cameraDeviceIndex = 3),
             saves = ApplicationSettings.Saves(batterySavesEnabled = false),
             advanced =
                 ApplicationSettings.Advanced(
@@ -97,6 +98,7 @@ class PreferencesDialogTest {
                 mapOf(
                     "sdl-" + "b".repeat(64) to
                         ApplicationSettings.GamepadTuning(tiltDeadZone = 1_024)),
+            cameraDeviceIndex = 6,
             audio =
                 ApplicationSettings.Audio(
                     enabled = true,
@@ -118,6 +120,7 @@ class PreferencesDialogTest {
     assertTrue(updated.input.keyboard.isEmpty())
     assertEquals(edit.gamepads, updated.input.gamepads)
     assertEquals(edit.gamepadTunings, updated.input.gamepadTunings)
+    assertEquals(6, updated.peripherals.cameraDeviceIndex)
     assertEquals(edit.display, updated.display)
     assertEquals(edit.audio, updated.audio)
     assertEquals(current.saves, updated.saves)
@@ -149,6 +152,7 @@ class PreferencesDialogTest {
             keyboard = latest.input.keyboard,
             gamepads = latest.input.gamepads,
             gamepadTunings = latest.input.gamepadTunings,
+            cameraDeviceIndex = latest.peripherals.cameraDeviceIndex,
             audio = latest.audio,
             advanced = dialogSnapshot.copy(bootstrapMode = BootstrapMode.NORMAL),
         )
@@ -185,6 +189,10 @@ class PreferencesDialogTest {
         assertEquals(ApplicationSettings.DEFAULT_RECENT_FILE_CAPACITY, received?.recentFileCapacity)
         assertEquals(ApplicationSettings.Input.defaults().keyboard, received?.keyboard)
         assertEquals(ApplicationSettings.Input.defaults().gamepads, received?.gamepads)
+        assertEquals(
+            ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX,
+            received?.cameraDeviceIndex,
+        )
         assertEquals(ApplicationSettings.Display(), received?.display)
         assertEquals(ApplicationSettings.Audio(), received?.audio)
         assertEquals(ApplicationSettings.Saves(), received?.saves)
@@ -410,7 +418,16 @@ class PreferencesDialogTest {
         assertEquals("Recent files to keep", panel.recentCapacity.accessibleContext.accessibleName)
         assertFalse(panel.tabs.accessibleContext.accessibleName.isNullOrBlank())
         assertEquals(
-            listOf("General", "System", "Display", "Input", "Gamepads", "Audio", "Saves"),
+            listOf(
+                "General",
+                "System",
+                "Display",
+                "Input",
+                "Gamepads",
+                "Peripherals",
+                "Audio",
+                "Saves",
+            ),
             (0 until panel.tabs.tabCount).map(panel.tabs::getTitleAt),
         )
       }


### PR DESCRIPTION
**AI-generated comment:**

## What

- Add a Peripherals tab to Preferences with Camera 1 through Camera 16.
- Persist the selected OpenCV camera index in settings schema 7.
- Use the saved selection when enabling the Game Boy Camera.
- Safely restart an active camera after Apply without enabling a disabled camera.
- Keep camera open/close work asynchronous and reject stale results during rapid changes or shutdown.

## Why

Coffee GB already supports choosing a gamepad, but the webcam-backed Game Boy Camera always used
device 0. This makes the camera source selectable while avoiding hardware probes, privacy prompts,
and camera LED flashes when Preferences is merely opened.

OpenCV exposes portable numeric device slots rather than stable cross-platform camera names. The UI
explains that operating-system ordering can change after devices are reconnected, and a failed
explicit choice is never silently replaced.

## Validation

- `mvn -B clean package -Dkotlin.compiler.daemon=false` — 1,881 tests passed, 2 skipped.
- Exact rebased head: 117 focused settings, Preferences, camera lifecycle, and shutdown tests passed.
- Packaged JAR `--package-smoke` passed.
- Visible desktop startup and normal bounded shutdown smoke passed under Xvfb.
- Three independent code reviews completed with no findings.
