### PR TITLE
Add coherent desktop debugger shell

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -910,6 +910,7 @@ class BasicController private constructor(
         }
         is QueuedDebugCommand.Snapshot ->
             command.complete(DebugResult.success(captureDebugSnapshot()))
+        is QueuedDebugCommand.Inspect -> handleDebugInspection(command)
         is QueuedDebugCommand.Step -> handleDebugStep(command)
         is QueuedDebugCommand.ConfigureHistory -> handleDebugConfigureHistory(command)
         is QueuedDebugCommand.HistoryStatus ->
@@ -1270,6 +1271,25 @@ class BasicController private constructor(
       command.fail(
           DebugErrorCode.SIDE_EFFECTFUL_ADDRESS,
           "The requested range contains a side-effectful or unavailable address",
+      )
+    }
+  }
+
+  private fun handleDebugInspection(command: QueuedDebugCommand.Inspect) {
+    val gameboy = checkNotNull(session).gameboy
+    try {
+      val snapshot = captureDebugSnapshot()
+      command.complete(
+          DebugResult.success(gameboy.inspectDebugMemory(snapshot, command.request)))
+    } catch (_: UnsupportedOperationException) {
+      command.fail(
+          DebugErrorCode.UNSUPPORTED_ADDRESS_SPACE,
+          "An inspection range has no side-effect-free debugger view",
+      )
+    } catch (_: IllegalArgumentException) {
+      command.fail(
+          DebugErrorCode.SIDE_EFFECTFUL_ADDRESS,
+          "An inspection range contains a side-effectful or unavailable address",
       )
     }
   }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/AgentDisassembler.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/AgentDisassembler.kt
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.controller.agent
 
-import eu.rekawek.coffeegb.core.cpu.Opcodes
-import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugDisassembler
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
 
 /** Stateless formatter over an immutable debug memory block. */
@@ -9,51 +8,6 @@ internal object AgentDisassembler {
 
   fun disassemble(address: Int, memory: DebugMemoryBlock): String {
     require(memory.startAddress() == address) { "Memory block does not start at the instruction" }
-    require(memory.length() > 0) { "At least one opcode byte is required" }
-    val opcode1 = memory.unsignedByteAt(0)
-    if (opcode1 == 0xcb) {
-      require(memory.length() >= 2) { "Extended opcode is truncated" }
-      val opcode2 = memory.unsignedByteAt(1)
-      val opcode = Opcodes.EXT_COMMANDS[opcode2]
-      return labelView(
-          String.format("%04X: CB %02X %s", address, opcode2, opcode?.label ?: "UNKNOWN"),
-          memory,
-      )
-    }
-
-    val opcode = Opcodes.COMMANDS[opcode1]
-    var label = opcode?.label ?: "UNKNOWN"
-    val length = opcode?.operandLength ?: 0
-    require(memory.length() >= length + 1) { "Instruction operands are truncated" }
-    val bytes = mutableListOf(String.format("%02X", opcode1))
-    if (length >= 1) {
-      val value = memory.unsignedByteAt(1)
-      bytes.add(String.format("%02X", value))
-      label = label.replace("d8", String.format("%02X", value))
-      label = label.replace("r8", String.format("%02X", value))
-      label = label.replace("a8", String.format("%02X", value))
-    }
-    if (length >= 2) {
-      val low = memory.unsignedByteAt(1)
-      val high = memory.unsignedByteAt(2)
-      val value = high shl 8 or low
-      bytes.add(String.format("%02X", high))
-      label = label.replace("d16", String.format("%04X", value))
-      label = label.replace("a16", String.format("%04X", value))
-    }
-    return labelView(
-        String.format("%04X: %-11s %s", address, bytes.joinToString(" "), label),
-        memory,
-    )
-  }
-
-  private fun labelView(disassembly: String, memory: DebugMemoryBlock): String {
-    val view =
-        when (memory.addressSpace()) {
-          DebugAddressSpace.ROM ->
-              "parser-corrected ROM image, not the mapped CPU window"
-          else -> memory.addressSpace().name
-        }
-    return "$disassembly [best-effort: $view]"
+    return DebugDisassembler.disassemble(memory)
   }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/HeadlessAgentSession.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/HeadlessAgentSession.kt
@@ -11,6 +11,8 @@ import eu.rekawek.coffeegb.core.debug.DebugErrorCode
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugInstrumentation
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
 import eu.rekawek.coffeegb.core.debug.DebugPort
 import eu.rekawek.coffeegb.core.debug.DebugResult
 import eu.rekawek.coffeegb.core.debug.DebugSnapshot
@@ -348,6 +350,11 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
     fun readMemory(request: DebugMemoryRequest): DebugMemoryBlock =
         machine.readDebugMemory(request)
 
+    fun inspect(
+        snapshot: DebugSnapshot,
+        request: DebugInspectionRequest,
+    ): DebugInspectionResult = machine.inspectDebugMemory(snapshot, request)
+
     fun setButton(button: DebugButton, pressed: Boolean) {
       val coreButton = Button.valueOf(button.name)
       eventBus.post(if (pressed) ButtonPressEvent(coreButton) else ButtonReleaseEvent(coreButton))
@@ -518,6 +525,43 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
 
     override fun snapshot(): CompletionStage<DebugResult<DebugSnapshot>> =
         enqueueDebug { state -> DebugResult.success(state.snapshot()) }
+
+    override fun inspect(
+        request: DebugInspectionRequest?
+    ): CompletionStage<DebugResult<DebugInspectionResult>> =
+        if (request == null) {
+          rejectedDebugStage(
+              DebugResult.failure(
+                  DebugErrorCode.INVALID_ARGUMENT,
+                  "Inspection request is required",
+              ))
+        } else if (
+            request.blockCount() > capabilities.maxInspectionBlocks() ||
+                request.totalBytes() > capabilities.maxInspectionBytes()
+        ) {
+          rejectedDebugStage(
+              DebugResult.failure(
+                  DebugErrorCode.INVALID_ARGUMENT,
+                  "Inspection request exceeds the negotiated limits",
+              ))
+        } else {
+          enqueueDebug { state ->
+            try {
+              val snapshot = state.snapshot()
+              DebugResult.success(state.inspect(snapshot, request))
+            } catch (failure: UnsupportedOperationException) {
+              DebugResult.failure(
+                  DebugErrorCode.UNSUPPORTED_ADDRESS_SPACE,
+                  failure.message ?: "Unsupported debug address space",
+              )
+            } catch (failure: IllegalArgumentException) {
+              DebugResult.failure(
+                  DebugErrorCode.SIDE_EFFECTFUL_ADDRESS,
+                  failure.message ?: "Invalid debug inspection request",
+              )
+            }
+          }
+        }
 
     override fun step(kind: DebugStepKind?): CompletionStage<DebugResult<DebugStepResult>> =
         if (kind == null) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/debug/QueuedDebugPort.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/debug/QueuedDebugPort.kt
@@ -6,6 +6,8 @@ import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
 import eu.rekawek.coffeegb.core.debug.DebugCapabilities
 import eu.rekawek.coffeegb.core.debug.DebugError
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugPort
@@ -95,6 +97,36 @@ internal class QueuedDebugPort(
         )
     return submit(validation) { requestId, completion ->
       QueuedDebugCommand.Snapshot(requestId, generation, completion)
+    }
+  }
+
+  override fun inspect(
+      request: DebugInspectionRequest?
+  ): CompletionStage<DebugResult<DebugInspectionResult>> {
+    val validation =
+        when {
+          request == null ->
+              DebugError(DebugErrorCode.INVALID_ARGUMENT, "Inspection request is required")
+          !debugCapabilities.coherentInspection() ->
+              DebugError(
+                  DebugErrorCode.UNSUPPORTED_ADDRESS_SPACE,
+                  "Coherent inspection is unavailable for this session",
+              )
+          request.blockCount() > debugCapabilities.maxInspectionBlocks() ||
+              request.totalBytes() > debugCapabilities.maxInspectionBytes() ->
+              DebugError(
+                  DebugErrorCode.INVALID_ARGUMENT,
+                  "Inspection request exceeds the negotiated limits",
+              )
+          else -> null
+        }
+    return submit(validation) { requestId, completion ->
+      QueuedDebugCommand.Inspect(
+          requestId,
+          generation,
+          requireNotNull(request),
+          completion,
+      )
     }
   }
 
@@ -602,6 +634,13 @@ internal sealed class QueuedDebugCommand<T> protected constructor(
       sessionGeneration: Long,
       completion: (DebugResult<DebugSnapshot>) -> Boolean,
   ) : QueuedDebugCommand<DebugSnapshot>(requestId, sessionGeneration, completion)
+
+  class Inspect internal constructor(
+      requestId: Long,
+      sessionGeneration: Long,
+      val request: DebugInspectionRequest,
+      completion: (DebugResult<DebugInspectionResult>) -> Boolean,
+  ) : QueuedDebugCommand<DebugInspectionResult>(requestId, sessionGeneration, completion)
 
   class Step internal constructor(
       requestId: Long,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/debug/UnsupportedDebugPort.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/debug/UnsupportedDebugPort.kt
@@ -6,6 +6,8 @@ import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
 import eu.rekawek.coffeegb.core.debug.DebugCapabilities
 import eu.rekawek.coffeegb.core.debug.DebugError
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugPort
@@ -46,6 +48,10 @@ internal class UnsupportedDebugPort(
   override fun resume(): CompletionStage<DebugResult<DebugSnapshot>> = unavailable()
 
   override fun snapshot(): CompletionStage<DebugResult<DebugSnapshot>> = unavailable()
+
+  override fun inspect(
+      request: DebugInspectionRequest?
+  ): CompletionStage<DebugResult<DebugInspectionResult>> = unavailable()
 
   override fun step(kind: DebugStepKind?): CompletionStage<DebugResult<DebugStepResult>> =
       unavailable()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/AgentTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/AgentTest.kt
@@ -1,7 +1,10 @@
 package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugRegisters
 import eu.rekawek.coffeegb.core.debug.DebugResult
@@ -37,6 +40,36 @@ import org.junit.rules.TemporaryFolder
 class AgentTest {
 
   @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun headlessInspectionBindsPcStackAndMemoryToOneSnapshot() {
+    Agent(testRom(0x3e, 0x7b, 0x00)).use { agent ->
+      val request =
+          DebugInspectionRequest(
+              listOf(
+                  DebugAnchoredMemoryRequest(DebugInspectionAnchor.PROGRAM_COUNTER, 0, 3),
+                  DebugAnchoredMemoryRequest(DebugInspectionAnchor.STACK_POINTER, -2, 2),
+              ),
+              listOf(DebugMemoryRequest(DebugAddressSpace.HIGH_RAM, 0xff80, 1)),
+          )
+
+      val result = awaitDebug(agent.debugPort.inspect(request))
+
+      assertTrue(result.isSuccess, result.toString())
+      val inspection = result.value()
+      assertEquals(
+          inspection.snapshot().registers().pc(),
+          inspection.anchoredBlocks()[0].startAddress(),
+      )
+      assertEquals(0x3e, inspection.anchoredBlocks()[0].unsignedByteAt(0))
+      assertEquals(0x7b, inspection.anchoredBlocks()[0].unsignedByteAt(1))
+      assertEquals(
+          inspection.snapshot().registers().sp() - 2,
+          inspection.anchoredBlocks()[1].startAddress(),
+      )
+      assertEquals(request, inspection.request())
+    }
+  }
 
   @Test
   fun headlessBreakpointAutomaticallyPausesWithoutAnExtraTickAndRetainsTrace() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
@@ -18,9 +18,12 @@ import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugBreakpointHit
 import eu.rekawek.coffeegb.core.debug.DebugButton
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugPort
 import eu.rekawek.coffeegb.core.debug.DebugStepKind
@@ -683,7 +686,61 @@ class BasicControllerDebugPortTest {
   @Test
   fun memoryInspectionAcceptsOnlyExplicitSideEffectFreeRanges() {
     withController { _, port, _, _, _ ->
-      assertTrue(await(port.pause()).isSuccess)
+      val paused = await(port.pause()).value()
+      assertTrue(port.capabilities().coherentInspection())
+      assertEquals(16, port.capabilities().maxInspectionBlocks())
+      assertEquals(4096, port.capabilities().maxInspectionBytes())
+
+      val coherentRequest =
+          DebugInspectionRequest(
+              listOf(
+                  DebugAnchoredMemoryRequest(
+                      DebugInspectionAnchor.PROGRAM_COUNTER,
+                      0,
+                      3,
+                  ),
+                  DebugAnchoredMemoryRequest(
+                      DebugInspectionAnchor.STACK_POINTER,
+                      -2,
+                      2,
+                  ),
+              ),
+              listOf(DebugMemoryRequest(DebugAddressSpace.HIGH_RAM, 0xff80, 4)),
+          )
+      val inspected = await(port.inspect(coherentRequest))
+      assertTrue(inspected.isSuccess)
+      val inspection = inspected.value()
+      assertEquals(coherentRequest, inspection.request())
+      assertEquals(paused.masterTick(), inspection.snapshot().masterTick())
+      assertEquals(paused.frame(), inspection.snapshot().frame())
+      assertEquals(paused.framePosition(), inspection.snapshot().framePosition())
+      assertEquals(paused.registers(), inspection.snapshot().registers())
+      assertEquals(
+          inspection.snapshot().registers().pc(),
+          inspection.anchoredBlocks()[0].startAddress(),
+      )
+      assertEquals(DebugAddressSpace.ROM, inspection.anchoredBlocks()[0].addressSpace())
+      assertEquals(
+          inspection.snapshot().registers().sp() - 2,
+          inspection.anchoredBlocks()[1].startAddress(),
+      )
+      assertEquals(4, inspection.memoryBlocks().single().length())
+
+      val unsafePcOffset = 0x8000 - inspection.snapshot().registers().pc()
+      val unsafeInspection =
+          await(
+              port.inspect(
+                  DebugInspectionRequest(
+                      listOf(
+                          DebugAnchoredMemoryRequest(
+                              DebugInspectionAnchor.PROGRAM_COUNTER,
+                              unsafePcOffset,
+                              1,
+                          )),
+                      listOf(DebugMemoryRequest(DebugAddressSpace.HIGH_RAM, 0xff80, 1)),
+                  )))
+      assertTrue(unsafeInspection.isFailure)
+      assertEquals(DebugErrorCode.SIDE_EFFECTFUL_ADDRESS, unsafeInspection.error().code())
 
       val hram =
           await(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/debug/QueuedDebugPortTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/debug/QueuedDebugPortTest.kt
@@ -9,8 +9,13 @@ import eu.rekawek.coffeegb.core.debug.DebugCpuState
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
 import eu.rekawek.coffeegb.core.debug.DebugExecutionState
 import eu.rekawek.coffeegb.core.debug.DebugFeatureState
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
 import eu.rekawek.coffeegb.core.debug.DebugInterruptState
 import eu.rekawek.coffeegb.core.debug.DebugMapperState
+import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugPpuMode
 import eu.rekawek.coffeegb.core.debug.DebugPpuState
@@ -51,6 +56,62 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class QueuedDebugPortTest {
+  @Test
+  fun `inspection validates negotiated bounds and preserves its typed FIFO envelope`() {
+    val request =
+        DebugInspectionRequest(
+            listOf(
+                DebugAnchoredMemoryRequest(DebugInspectionAnchor.PROGRAM_COUNTER, 0, 3),
+                DebugAnchoredMemoryRequest(DebugInspectionAnchor.STACK_POINTER, -2, 2),
+            ),
+            listOf(DebugMemoryRequest(DebugAddressSpace.WORK_RAM, 0xc000, 1)),
+        )
+    val unavailable =
+        QueuedDebugPort(
+            1,
+            DebugCapabilities(true, true, true, true, true, false, true, 0),
+            1,
+        )
+    val bounded = QueuedDebugPort(2, capabilities(maxMemoryReadLength = 4), 1)
+    val port = QueuedDebugPort(17, capabilities(), 1)
+    try {
+      assertFailure(port.inspect(null), DebugErrorCode.INVALID_ARGUMENT)
+      assertFailure(
+          unavailable.inspect(DebugInspectionRequest(emptyList(), emptyList())),
+          DebugErrorCode.UNSUPPORTED_ADDRESS_SPACE,
+      )
+      assertFailure(bounded.inspect(request), DebugErrorCode.INVALID_ARGUMENT)
+      assertEquals(0, port.outstandingRequestCount())
+
+      val stage = port.inspect(request)
+      val command = assertIs<QueuedDebugCommand.Inspect>(port.pollCommand())
+      assertEquals(1, command.requestId)
+      assertEquals(17, command.sessionGeneration)
+      assertEquals(request, command.request)
+
+      val snapshot = snapshot(masterTick = 42, frame = 3)
+      val result =
+          DebugInspectionResult(
+              snapshot,
+              request,
+              listOf(
+                  DebugMemoryBlock(DebugAddressSpace.ROM, 0x100, byteArrayOf(0x3e, 0x12, 0)),
+                  DebugMemoryBlock(DebugAddressSpace.SYSTEM_BUS, 0xfffc, byteArrayOf(1, 2)),
+              ),
+              listOf(DebugMemoryBlock(DebugAddressSpace.WORK_RAM, 0xc000, byteArrayOf(3))),
+          )
+      assertTrue(command.complete(DebugResult.success(result)))
+      assertEquals(result, await(stage).value())
+    } finally {
+      unavailable.close()
+      bounded.close()
+      port.close()
+      assertTrue(unavailable.awaitResultDispatcherTermination(5, TimeUnit.SECONDS))
+      assertTrue(bounded.awaitResultDispatcherTermination(5, TimeUnit.SECONDS))
+      assertTrue(port.awaitResultDispatcherTermination(5, TimeUnit.SECONDS))
+    }
+  }
+
   @Test
   fun `history commands validate before admission and preserve FIFO typed completion`() {
     val port = QueuedDebugPort(17, advancedCapabilities(), 3)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -12,6 +12,8 @@ import eu.rekawek.coffeegb.core.debug.DebugExecutionState;
 import eu.rekawek.coffeegb.core.debug.DebugFeatureState;
 import eu.rekawek.coffeegb.core.debug.DebugInterruptState;
 import eu.rekawek.coffeegb.core.debug.DebugInstrumentation;
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest;
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult;
 import eu.rekawek.coffeegb.core.debug.DebugMapperState;
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock;
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest;
@@ -61,6 +63,8 @@ import eu.rekawek.coffeegb.core.timer.Timer;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -997,6 +1001,22 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         return new DebugMemoryBlock(request.addressSpace(), address,
                 mmu.readDebugMemory(address, request.length()));
+    }
+
+    /** Copies every requested block against one already-captured coherent snapshot. */
+    public DebugInspectionResult inspectDebugMemory(
+            DebugSnapshot snapshot, DebugInspectionRequest request) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(request, "request");
+        var anchoredBlocks = new ArrayList<DebugMemoryBlock>(request.anchoredRequests().size());
+        for (var anchoredRequest : request.anchoredRequests()) {
+            anchoredBlocks.add(readDebugMemory(anchoredRequest.resolve(snapshot)));
+        }
+        var memoryBlocks = new ArrayList<DebugMemoryBlock>(request.memoryRequests().size());
+        for (var memoryRequest : request.memoryRequests()) {
+            memoryBlocks.add(readDebugMemory(memoryRequest));
+        }
+        return new DebugInspectionResult(snapshot, request, anchoredBlocks, memoryBlocks);
     }
 
     private DebugPpuMode toDebugPpuMode() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugAnchoredMemoryRequest.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugAnchoredMemoryRequest.java
@@ -1,0 +1,45 @@
+package eu.rekawek.coffeegb.core.debug;
+
+import java.util.Objects;
+
+/** A bounded memory range resolved relative to a register in the inspection's own snapshot. */
+public record DebugAnchoredMemoryRequest(
+        DebugInspectionAnchor anchor,
+        int offset,
+        int length) {
+
+    public DebugAnchoredMemoryRequest {
+        Objects.requireNonNull(anchor, "anchor");
+        DebugValueChecks.range("offset", offset, -0xffff, 0xffff);
+        DebugValueChecks.range("length", length, 1, DebugInspectionRequest.MAX_TOTAL_BYTES);
+    }
+
+    /**
+     * Resolves this range against the supplied coherent snapshot.
+     *
+     * <p>Program-counter addresses below {@code 8000} select the parser-corrected physical ROM
+     * image. This is a best-effort source view, not the mapper's live banked CPU window. Every
+     * other anchored range selects the side-effect-free system-bus view and may still be rejected
+     * by the session if it targets an unsafe address.
+     */
+    public DebugMemoryRequest resolve(DebugSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        int anchorAddress = switch (anchor) {
+            case PROGRAM_COUNTER -> snapshot.registers().pc();
+            case STACK_POINTER -> snapshot.registers().sp();
+        };
+        long start = (long) anchorAddress + offset;
+        long end = start + length;
+        if (start < 0 || end > DebugMemoryRequest.MAX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Anchored memory request leaves the 16-bit address space");
+        }
+        DebugAddressSpace addressSpace = anchor == DebugInspectionAnchor.PROGRAM_COUNTER
+                && start < 0x8000 ? DebugAddressSpace.ROM : DebugAddressSpace.SYSTEM_BUS;
+        if (addressSpace == DebugAddressSpace.ROM && end > 0x8000) {
+            throw new IllegalArgumentException(
+                    "Program-counter request crosses the best-effort ROM-view boundary");
+        }
+        return new DebugMemoryRequest(addressSpace, (int) start, length);
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugCapabilities.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugCapabilities.java
@@ -117,6 +117,20 @@ public record DebugCapabilities(
         };
     }
 
+    /** Coherent inspection is available when both snapshots and pure memory copies are available. */
+    public boolean coherentInspection() {
+        return snapshot && memoryRead;
+    }
+
+    public int maxInspectionBlocks() {
+        return coherentInspection() ? DebugInspectionRequest.MAX_BLOCKS : 0;
+    }
+
+    public int maxInspectionBytes() {
+        return coherentInspection()
+                ? Math.min(maxMemoryReadLength, DebugInspectionRequest.MAX_TOTAL_BYTES) : 0;
+    }
+
     public boolean breakpoints() {
         return !breakpointKinds.isEmpty();
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugDisassembler.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugDisassembler.java
@@ -1,0 +1,68 @@
+package eu.rekawek.coffeegb.core.debug;
+
+import eu.rekawek.coffeegb.core.cpu.Opcodes;
+import eu.rekawek.coffeegb.core.cpu.opcode.Opcode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Stateless, platform-neutral best-effort formatter over one detached debug memory block. */
+public final class DebugDisassembler {
+
+    private DebugDisassembler() {
+    }
+
+    /** Formats the first instruction in {@code memory}, whose start address is its displayed PC. */
+    public static String disassemble(DebugMemoryBlock memory) {
+        if (memory == null) {
+            throw new NullPointerException("memory");
+        }
+        if (memory.length() == 0) {
+            throw new IllegalArgumentException("At least one opcode byte is required");
+        }
+        int address = memory.startAddress();
+        int opcode1 = memory.unsignedByteAt(0);
+        if (opcode1 == 0xcb) {
+            if (memory.length() < 2) {
+                throw new IllegalArgumentException("Extended opcode is truncated");
+            }
+            int opcode2 = memory.unsignedByteAt(1);
+            Opcode opcode = Opcodes.EXT_COMMANDS.get(opcode2);
+            String label = opcode == null ? "UNKNOWN" : opcode.getLabel();
+            return labelView(String.format("%04X: CB %02X %s", address, opcode2, label), memory);
+        }
+
+        Opcode opcode = Opcodes.COMMANDS.get(opcode1);
+        String label = opcode == null ? "UNKNOWN" : opcode.getLabel();
+        int operandLength = opcode == null ? 0 : opcode.getOperandLength();
+        if (memory.length() < operandLength + 1) {
+            throw new IllegalArgumentException("Instruction operands are truncated");
+        }
+        List<String> bytes = new ArrayList<>(operandLength + 1);
+        bytes.add(String.format("%02X", opcode1));
+        if (operandLength >= 1) {
+            int value = memory.unsignedByteAt(1);
+            bytes.add(String.format("%02X", value));
+            label = label.replace("d8", String.format("%02X", value))
+                    .replace("r8", String.format("%02X", value))
+                    .replace("a8", String.format("%02X", value));
+        }
+        if (operandLength >= 2) {
+            int low = memory.unsignedByteAt(1);
+            int high = memory.unsignedByteAt(2);
+            int value = high << 8 | low;
+            bytes.add(String.format("%02X", high));
+            label = label.replace("d16", String.format("%04X", value))
+                    .replace("a16", String.format("%04X", value));
+        }
+        return labelView(
+                String.format("%04X: %-11s %s", address, String.join(" ", bytes), label), memory);
+    }
+
+    private static String labelView(String disassembly, DebugMemoryBlock memory) {
+        String view = memory.addressSpace() == DebugAddressSpace.ROM
+                ? "parser-corrected ROM image, not the mapped CPU window"
+                : memory.addressSpace().name();
+        return disassembly + " [best-effort: " + view + "]";
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionAnchor.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionAnchor.java
@@ -1,0 +1,7 @@
+package eu.rekawek.coffeegb.core.debug;
+
+/** Register-relative origins resolved from the snapshot captured by one inspection command. */
+public enum DebugInspectionAnchor {
+    PROGRAM_COUNTER,
+    STACK_POINTER
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionRequest.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionRequest.java
@@ -1,0 +1,48 @@
+package eu.rekawek.coffeegb.core.debug;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Bounded set of register-relative and explicit ranges copied at one debugger safe point. */
+public record DebugInspectionRequest(
+        List<DebugAnchoredMemoryRequest> anchoredRequests,
+        List<DebugMemoryRequest> memoryRequests) {
+
+    public static final int MAX_BLOCKS = 16;
+
+    public static final int MAX_TOTAL_BYTES = 4096;
+
+    public DebugInspectionRequest {
+        Objects.requireNonNull(anchoredRequests, "anchoredRequests");
+        Objects.requireNonNull(memoryRequests, "memoryRequests");
+        anchoredRequests = List.copyOf(anchoredRequests);
+        memoryRequests = List.copyOf(memoryRequests);
+        if (anchoredRequests.size() + memoryRequests.size() > MAX_BLOCKS) {
+            throw new IllegalArgumentException("Inspection request exceeds the block limit");
+        }
+        long totalBytes = 0;
+        for (DebugAnchoredMemoryRequest request : anchoredRequests) {
+            totalBytes += Objects.requireNonNull(request, "anchored request").length();
+        }
+        for (DebugMemoryRequest request : memoryRequests) {
+            int length = Objects.requireNonNull(request, "memory request").length();
+            if (length == 0) {
+                throw new IllegalArgumentException("Inspection memory ranges must not be empty");
+            }
+            totalBytes += length;
+        }
+        if (totalBytes > MAX_TOTAL_BYTES) {
+            throw new IllegalArgumentException(
+                    "Inspection request exceeds the aggregate byte limit");
+        }
+    }
+
+    public int blockCount() {
+        return anchoredRequests.size() + memoryRequests.size();
+    }
+
+    public int totalBytes() {
+        return anchoredRequests.stream().mapToInt(DebugAnchoredMemoryRequest::length).sum()
+                + memoryRequests.stream().mapToInt(DebugMemoryRequest::length).sum();
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionResult.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInspectionResult.java
@@ -1,0 +1,42 @@
+package eu.rekawek.coffeegb.core.debug;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Snapshot and caller-owned memory blocks captured without an intervening emulation tick. */
+public record DebugInspectionResult(
+        DebugSnapshot snapshot,
+        DebugInspectionRequest request,
+        List<DebugMemoryBlock> anchoredBlocks,
+        List<DebugMemoryBlock> memoryBlocks) {
+
+    public DebugInspectionResult {
+        Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(request, "request");
+        Objects.requireNonNull(anchoredBlocks, "anchoredBlocks");
+        Objects.requireNonNull(memoryBlocks, "memoryBlocks");
+        anchoredBlocks = List.copyOf(anchoredBlocks);
+        memoryBlocks = List.copyOf(memoryBlocks);
+        if (anchoredBlocks.size() != request.anchoredRequests().size()
+                || memoryBlocks.size() != request.memoryRequests().size()) {
+            throw new IllegalArgumentException("Inspection result block counts do not match request");
+        }
+        for (int i = 0; i < anchoredBlocks.size(); i++) {
+            requireMatchingBlock(
+                    request.anchoredRequests().get(i).resolve(snapshot), anchoredBlocks.get(i));
+        }
+        for (int i = 0; i < memoryBlocks.size(); i++) {
+            requireMatchingBlock(request.memoryRequests().get(i), memoryBlocks.get(i));
+        }
+    }
+
+    private static void requireMatchingBlock(
+            DebugMemoryRequest request, DebugMemoryBlock block) {
+        Objects.requireNonNull(block, "memory block");
+        if (block.addressSpace() != request.addressSpace()
+                || block.startAddress() != request.address()
+                || block.length() != request.length()) {
+            throw new IllegalArgumentException("Inspection result block does not match request");
+        }
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugPort.java
@@ -29,6 +29,8 @@ public interface DebugPort extends AutoCloseable {
 
     CompletionStage<DebugResult<DebugSnapshot>> snapshot();
 
+    CompletionStage<DebugResult<DebugInspectionResult>> inspect(DebugInspectionRequest request);
+
     CompletionStage<DebugResult<DebugStepResult>> step(DebugStepKind kind);
 
     /** Reconfigures and clears the bounded reverse-history timeline. */

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyDebugViewTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyDebugViewTest.java
@@ -1,13 +1,19 @@
 package eu.rekawek.coffeegb.core;
 
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace;
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest;
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor;
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest;
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 
 public class GameboyDebugViewTest {
@@ -67,6 +73,48 @@ public class GameboyDebugViewTest {
                     new DebugMemoryRequest(DebugAddressSpace.SYSTEM_BUS, 0xff0f, 1)));
             assertThrows(UnsupportedOperationException.class, () -> gameboy.readDebugMemory(
                     new DebugMemoryRequest(DebugAddressSpace.IO_REGISTERS, 0xff0f, 1)));
+        }
+    }
+
+    @Test
+    public void inspectionCopiesPcStackAndExplicitRangesAgainstOneSnapshot() throws Exception {
+        byte[] rom = testRom();
+        rom[0x100] = 0x3e;
+        rom[0x101] = 0x42;
+        try (Gameboy gameboy = gameboy(rom)) {
+            gameboy.enableDebugRetirementTracking();
+            gameboy.getAddressSpace().setByte(0xfffc, 0x12);
+            gameboy.getAddressSpace().setByte(0xfffd, 0x34);
+            gameboy.getAddressSpace().setByte(0xc000, 0x56);
+            var snapshot = gameboy.captureDebugSnapshot(9, 12, 0, 0, 0, true);
+            var request = new DebugInspectionRequest(
+                    List.of(
+                            new DebugAnchoredMemoryRequest(
+                                    DebugInspectionAnchor.PROGRAM_COUNTER, 0, 3),
+                            new DebugAnchoredMemoryRequest(
+                                    DebugInspectionAnchor.STACK_POINTER, -2, 2)),
+                    List.of(new DebugMemoryRequest(
+                            DebugAddressSpace.WORK_RAM, 0xc000, 1)));
+
+            var result = gameboy.inspectDebugMemory(snapshot, request);
+
+            assertSame(snapshot, result.snapshot());
+            assertSame(request, result.request());
+            assertEquals(0x3e, result.anchoredBlocks().get(0).unsignedByteAt(0));
+            assertEquals(0x42, result.anchoredBlocks().get(0).unsignedByteAt(1));
+            assertEquals(DebugAddressSpace.ROM,
+                    result.anchoredBlocks().get(0).addressSpace());
+            assertEquals(0x12, result.anchoredBlocks().get(1).unsignedByteAt(0));
+            assertEquals(0x34, result.anchoredBlocks().get(1).unsignedByteAt(1));
+            assertEquals(0x56, result.memoryBlocks().get(0).unsignedByteAt(0));
+
+            var mixedUnsafeRequest = new DebugInspectionRequest(
+                    List.of(),
+                    List.of(
+                            new DebugMemoryRequest(DebugAddressSpace.WORK_RAM, 0xc000, 1),
+                            new DebugMemoryRequest(DebugAddressSpace.IO_REGISTERS, 0xff0f, 1)));
+            assertThrows(UnsupportedOperationException.class,
+                    () -> gameboy.inspectDebugMemory(snapshot, mixedUnsafeRequest));
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/ConsoleTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/ConsoleTest.java
@@ -271,6 +271,12 @@ public class ConsoleTest {
         }
 
         @Override
+        public CompletionStage<DebugResult<DebugInspectionResult>> inspect(
+                DebugInspectionRequest request) {
+            return unsupported();
+        }
+
+        @Override
         public CompletionStage<DebugResult<DebugStepResult>> step(DebugStepKind kind) {
             stepCalls++;
             lastStepKind = kind;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiContractTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiContractTest.java
@@ -82,6 +82,11 @@ public class DebugApiContractTest {
             DebugHistoryPosition.class,
             DebugHistoryStatus.class,
             DebugHistoryTruncationReason.class,
+            DebugAnchoredMemoryRequest.class,
+            DebugDisassembler.class,
+            DebugInspectionAnchor.class,
+            DebugInspectionRequest.class,
+            DebugInspectionResult.class,
             DebugInterruptCondition.class,
             DebugInterruptState.class,
             DebugInterruptType.class,
@@ -142,6 +147,10 @@ public class DebugApiContractTest {
         assertReturnType("snapshot",
                 "java.util.concurrent.CompletionStage<eu.rekawek.coffeegb.core.debug.DebugResult"
                         + "<eu.rekawek.coffeegb.core.debug.DebugSnapshot>>");
+        assertReturnType("inspect",
+                "java.util.concurrent.CompletionStage<eu.rekawek.coffeegb.core.debug.DebugResult"
+                        + "<eu.rekawek.coffeegb.core.debug.DebugInspectionResult>>",
+                DebugInspectionRequest.class);
         assertReturnType("step",
                 "java.util.concurrent.CompletionStage<eu.rekawek.coffeegb.core.debug.DebugResult"
                         + "<eu.rekawek.coffeegb.core.debug.DebugStepResult>>",

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiModelTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiModelTest.java
@@ -12,7 +12,9 @@ import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult;
 import eu.rekawek.coffeegb.core.debug.trace.TraceCategory;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -88,6 +90,82 @@ public class DebugApiModelTest {
     }
 
     @Test
+    public void inspectionRequestsAreBoundedImmutableAndResolveTheirOwnSnapshotAnchors() {
+        DebugAnchoredMemoryRequest code = new DebugAnchoredMemoryRequest(
+                DebugInspectionAnchor.PROGRAM_COUNTER, 0, 3);
+        DebugAnchoredMemoryRequest stack = new DebugAnchoredMemoryRequest(
+                DebugInspectionAnchor.STACK_POINTER, -2, 2);
+        DebugMemoryRequest memory = new DebugMemoryRequest(
+                DebugAddressSpace.WORK_RAM, 0xc000, 4);
+        List<DebugAnchoredMemoryRequest> anchors = new ArrayList<>(List.of(code, stack));
+        List<DebugMemoryRequest> ranges = new ArrayList<>(List.of(memory));
+        DebugInspectionRequest request = new DebugInspectionRequest(anchors, ranges);
+        anchors.clear();
+        ranges.clear();
+
+        assertEquals(3, request.blockCount());
+        assertEquals(9, request.totalBytes());
+        assertEquals(new DebugMemoryRequest(DebugAddressSpace.ROM, 0x100, 3),
+                code.resolve(snapshot(true)));
+        assertEquals(new DebugMemoryRequest(DebugAddressSpace.SYSTEM_BUS, 0xfffc, 2),
+                stack.resolve(snapshot(true)));
+        assertEquals(2, request.anchoredRequests().size());
+        assertEquals(1, request.memoryRequests().size());
+        assertThrows(UnsupportedOperationException.class,
+                () -> request.memoryRequests().clear());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new DebugAnchoredMemoryRequest(DebugInspectionAnchor.PROGRAM_COUNTER, 0, 0));
+        assertThrows(IllegalArgumentException.class, () ->
+                new DebugAnchoredMemoryRequest(DebugInspectionAnchor.PROGRAM_COUNTER,
+                        0x7eff, 2).resolve(snapshot(true)));
+        assertThrows(IllegalArgumentException.class, () ->
+                new DebugAnchoredMemoryRequest(DebugInspectionAnchor.STACK_POINTER,
+                        2, 1).resolve(snapshot(true)));
+        assertThrows(IllegalArgumentException.class, () ->
+                new DebugInspectionRequest(List.of(), List.of(
+                        new DebugMemoryRequest(DebugAddressSpace.ROM, 0, 4096),
+                        new DebugMemoryRequest(DebugAddressSpace.ROM, 4096, 1))));
+        assertThrows(IllegalArgumentException.class, () ->
+                new DebugInspectionRequest(
+                        java.util.Collections.nCopies(17, code), List.of()));
+    }
+
+    @Test
+    public void inspectionResultPinsRequestOrderAndSnapshotIdentity() {
+        DebugSnapshot snapshot = snapshot(true);
+        DebugAnchoredMemoryRequest code = new DebugAnchoredMemoryRequest(
+                DebugInspectionAnchor.PROGRAM_COUNTER, 0, 2);
+        DebugMemoryRequest memory = new DebugMemoryRequest(
+                DebugAddressSpace.SYSTEM_BUS, 0xc000, 1);
+        DebugInspectionRequest request = new DebugInspectionRequest(
+                List.of(code), List.of(memory));
+        DebugMemoryBlock codeBlock = new DebugMemoryBlock(
+                DebugAddressSpace.ROM, 0x100, new byte[]{0x3e, 0x12});
+        DebugMemoryBlock memoryBlock = new DebugMemoryBlock(
+                DebugAddressSpace.SYSTEM_BUS, 0xc000, new byte[]{0x34});
+        List<DebugMemoryBlock> anchoredBlocks = new ArrayList<>(List.of(codeBlock));
+        List<DebugMemoryBlock> memoryBlocks = new ArrayList<>(List.of(memoryBlock));
+
+        DebugInspectionResult result = new DebugInspectionResult(
+                snapshot, request, anchoredBlocks, memoryBlocks);
+        anchoredBlocks.clear();
+        memoryBlocks.clear();
+
+        assertSame(snapshot, result.snapshot());
+        assertSame(request, result.request());
+        assertEquals(List.of(codeBlock), result.anchoredBlocks());
+        assertEquals(List.of(memoryBlock), result.memoryBlocks());
+        assertThrows(IllegalArgumentException.class, () -> new DebugInspectionResult(
+                snapshot, request, List.of(), List.of(memoryBlock)));
+        assertThrows(IllegalArgumentException.class, () -> new DebugInspectionResult(
+                snapshot, request,
+                List.of(new DebugMemoryBlock(
+                        DebugAddressSpace.ROM, 0x101, new byte[]{0x3e, 0x12})),
+                List.of(memoryBlock)));
+    }
+
+    @Test
     public void snapshotIsCoherentDetachedValueData() {
         DebugSnapshot snapshot = snapshot(true);
         assertEquals(7, snapshot.sessionGeneration());
@@ -149,6 +227,9 @@ public class DebugApiModelTest {
         assertFalse(capabilities.supports(DebugStepKind.MACHINE_CYCLE));
         assertTrue(capabilities.supports(DebugStepKind.FRAME));
         assertEquals(4096, capabilities.maxMemoryReadLength());
+        assertTrue(capabilities.coherentInspection());
+        assertEquals(DebugInspectionRequest.MAX_BLOCKS, capabilities.maxInspectionBlocks());
+        assertEquals(4096, capabilities.maxInspectionBytes());
         assertEquals(DebugHistoryCapabilities.disabled(), capabilities.history());
 
         assertThrows(IllegalArgumentException.class,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugDisassemblerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugDisassemblerTest.java
@@ -1,0 +1,37 @@
+package eu.rekawek.coffeegb.core.debug;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class DebugDisassemblerTest {
+
+    @Test
+    public void formatsDetachedBaseAndExtendedOpcodesWithTheirSourceView() {
+        String base = DebugDisassembler.disassemble(new DebugMemoryBlock(
+                DebugAddressSpace.ROM, 0x4000, new byte[]{0x3e, 0x7b, 0}));
+        assertTrue(base, base.startsWith("4000: 3E 7B"));
+        assertTrue(base, base.contains("LD A,7B"));
+        assertTrue(base, base.contains(
+                "best-effort: parser-corrected ROM image, not the mapped CPU window"));
+
+        String extended = DebugDisassembler.disassemble(new DebugMemoryBlock(
+                DebugAddressSpace.SYSTEM_BUS, 0xc000,
+                new byte[]{(byte) 0xcb, 0x7c}));
+        assertTrue(extended, extended.startsWith("C000: CB 7C"));
+        assertTrue(extended, extended.endsWith("[best-effort: SYSTEM_BUS]"));
+    }
+
+    @Test
+    public void rejectsEmptyAndTruncatedInstructionBlocks() {
+        assertThrows(IllegalArgumentException.class, () -> DebugDisassembler.disassemble(
+                new DebugMemoryBlock(DebugAddressSpace.ROM, 0x100, new byte[]{})));
+        assertThrows(IllegalArgumentException.class, () -> DebugDisassembler.disassemble(
+                new DebugMemoryBlock(DebugAddressSpace.ROM, 0x100, new byte[]{0x01})));
+        assertThrows(IllegalArgumentException.class, () -> DebugDisassembler.disassemble(
+                new DebugMemoryBlock(DebugAddressSpace.ROM, 0x100,
+                        new byte[]{(byte) 0xcb})));
+        assertThrows(NullPointerException.class, () -> DebugDisassembler.disassemble(null));
+    }
+}

--- a/docs/debug-port.md
+++ b/docs/debug-port.md
@@ -3,11 +3,11 @@
 ## Scope
 
 This document pins the Phase 1 debugger foundation, the Phase 2 CPU breakpoint/trace contract, the
-Phase 3 peripheral event contract, and the Phase 5/6 bounded reverse-execution contract implemented
-by `DebugPort`. The API is platform-neutral and exposes immutable values only. It does not expose
-a mutable core component, an AWT/Swing type, a live array, or a reflection escape hatch. The model
-is still an internal Coffee GB API until a later change explicitly versions it for third-party
-use.
+Phase 3 peripheral event contract, the Phase 5/6 bounded reverse-execution contract, and the Phase
+7 coherent inspection seam implemented by `DebugPort`. The API is platform-neutral and exposes
+immutable values only. It does not expose a mutable core component, an AWT/Swing type, a live
+array, or a reflection escape hatch. The model is still an internal Coffee GB API until a later
+change explicitly versions it for third-party use.
 
 Phase 1 supplies pause/resume, coherent snapshots, negotiated stepping, bounded side-effect-free
 memory reads, and deterministic button input. Phase 2 adds negotiated breakpoints/watchpoints and
@@ -17,7 +17,8 @@ the debug-port-backed console described below. The separate Phase 4 deterministi
 and `CGBR` v1 contract are documented in [replay-format-v1.md](replay-format-v1.md). Phase 5 adds
 the explicitly enabled checkpoint ring and direct reverse-frame operation described below. Phase
 6 adds deterministic replay-forward reverse-instruction, a retained-future cursor, and explicit
-branch invalidation. A debugger UI remains a later phase.
+branch invalidation. Phase 7 binds PC/SP-relative and explicit memory copies to one snapshot for
+desktop debugger panes.
 
 ## Session publication and capabilities
 
@@ -39,6 +40,7 @@ The current implementations advertise:
 | machine-cycle step | no | yes | no |
 | frame step | yes | yes | no |
 | memory read | yes, at most 4096 bytes | yes, at most 4096 bytes | no |
+| coherent inspection | yes, 16 blocks / 4096 aggregate bytes | same | no |
 | button input | yes | yes | no |
 | breakpoints | yes, 7 kinds / at most 128 | yes, 7 kinds / at most 128 | no |
 | trace | all 10 `TraceCategory` values / at most 65,536 entries | same | no |
@@ -107,8 +109,9 @@ These counters reset for a new session generation and are deliberately absent fr
 rewind snapshots. Clients must not compare counters from different generations or merge component
 values from snapshots with different sequences.
 
-Submitting a plain memory read or snapshot while the machine is running is safe because the owner
-performs it between ticks. The returned value is immutable, but it may become stale immediately;
+Submitting a plain memory read, snapshot, or coherent inspection while the machine is running is
+safe because the owner performs it between ticks. The returned value is immutable, but it may
+become stale immediately;
 clients should label it with its generation/sequence rather than combining it with a later view.
 Mapper banks use `-1` and mapper feature flags use `DebugFeatureState.UNKNOWN` when the concrete
 mapper has no pure inspection seam; clients must not interpret an unknown value as disabled.
@@ -398,6 +401,23 @@ without changing the current configuration.
 
 Every read is a bounded copy. The current core exposes a parser-corrected loaded-ROM-image view and
 MMU-owned RAM without invoking mapper logic or the ordinary CPU-bus read path:
+
+`inspect(request)` combines one snapshot with ordered memory copies at the same safe point. An
+inspection may contain up to 16 blocks and 4096 bytes in total (further bounded by the session's
+negotiated memory-read maximum). It returns the original immutable request alongside separate,
+ordered anchored and explicit block lists, so clients can map every block without relying on
+display labels. Either every range is copied or the command returns one typed failure; partial
+results are never published.
+
+Anchored ranges resolve a signed offset from the PC or SP in the inspection's own snapshot. A PC
+range starting below `8000` uses the parser-corrected physical `ROM` image and may not cross the
+`8000` boundary. This is deliberately best-effort code provenance: in the switchable bank it is
+not the mapper's live CPU window. Every other anchor uses the pure `SYSTEM_BUS` view and therefore
+fails with `SIDE_EFFECTFUL_ADDRESS` outside WRAM/echo/HRAM. The platform-neutral
+`DebugDisassembler` formats a detached code block and includes that provenance in its output.
+Coherent inspection is advertised when both snapshot and memory-read capabilities are available;
+constructing or polling ordinary emulation state does no inspection work when no command is
+submitted.
 
 | Address-space ID | Accepted range | Notes |
 |---|---|---|

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerPresentation.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerPresentation.kt
@@ -1,0 +1,818 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
+import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
+import eu.rekawek.coffeegb.core.debug.DebugResult
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugInterruptCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugMemoryCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugOpcodeCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPpuCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugSerialCondition
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryTruncationReason
+import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult
+import java.util.Collections
+import java.util.Locale
+
+/**
+ * Pure formatting and validation for the desktop debugger.
+ *
+ * This layer deliberately owns no Swing component and never waits for a debug command. The EDT
+ * can therefore transform completed debug DTOs into immutable values and unit tests can exercise
+ * the same code in a headless JVM.
+ */
+internal object DebuggerPresentation {
+
+  private val addressToken = "(?:0[xX]|\\${'$'})?[0-9A-Fa-f]{1,4}"
+  private val addressPattern = Regex("^($addressToken)$")
+  private val rangePattern = Regex("^($addressToken)(?:\\s*(?:-|\\.\\.|:)\\s*($addressToken))?$")
+  private val bytePattern = Regex("^(?:0[xX]|\\${'$'})?([0-9A-Fa-f]{1,2})$")
+
+  fun parseAddress(text: String): DebuggerParsedValue<Int> {
+    val input = text.trim()
+    val match = addressPattern.matchEntire(input)
+        ?: return DebuggerParsedValue.invalid(addressError())
+    return DebuggerParsedValue.valid(parseHexToken(match.groupValues[1]))
+  }
+
+  fun parseAddressRange(text: String): DebuggerParsedValue<DebuggerAddressRange> {
+    val input = text.trim()
+    val match = rangePattern.matchEntire(input)
+        ?: return DebuggerParsedValue.invalid(
+            "Use one 16-bit hexadecimal address or an inclusive range, for example " +
+                "${'$'}C000-${'$'}C0FF."
+        )
+    val start = parseHexToken(match.groupValues[1])
+    val end = match.groupValues[2].takeIf(String::isNotEmpty)?.let(::parseHexToken) ?: start
+    if (end < start) {
+      return DebuggerParsedValue.invalid(
+          "Range end ${formatWord(end)} must not precede ${formatWord(start)}."
+      )
+    }
+    return DebuggerParsedValue.valid(DebuggerAddressRange(start, end))
+  }
+
+  fun parseByte(text: String, fieldName: String = "Value"): DebuggerParsedValue<Int> {
+    val input = text.trim()
+    val match = bytePattern.matchEntire(input)
+        ?: return DebuggerParsedValue.invalid(
+            "$fieldName must be an 8-bit hexadecimal value, for example ${'$'}7F."
+        )
+    return DebuggerParsedValue.valid(parseHexToken(match.groupValues[1]))
+  }
+
+  fun parseProgramCounterCondition(text: String): DebuggerParsedValue<DebugPcCondition> =
+      parseAddressRange(text).map { DebugPcCondition(it.startAddress, it.endAddress) }
+
+  fun parseMemoryCondition(
+      rangeText: String,
+      access: DebugMemoryAccess,
+      valueText: String = "",
+      maskText: String = "",
+  ): DebuggerParsedValue<DebugMemoryCondition> {
+    val range = parseAddressRange(rangeText)
+    if (!range.isValid) return DebuggerParsedValue.invalid(range.error!!)
+    if (valueText.isBlank()) {
+      if (maskText.isNotBlank()) {
+        return DebuggerParsedValue.invalid("A value is required when a value mask is set.")
+      }
+      return DebuggerParsedValue.valid(
+          DebugMemoryCondition(access, range.value!!.startAddress, range.value.endAddress)
+      )
+    }
+    val value = parseByte(valueText)
+    if (!value.isValid) return DebuggerParsedValue.invalid(value.error!!)
+    if (maskText.isBlank()) {
+      return DebuggerParsedValue.valid(
+          DebugMemoryCondition(
+              access,
+              range.value!!.startAddress,
+              range.value.endAddress,
+              value.value!!,
+          )
+      )
+    }
+    val mask = parseByte(maskText, "Mask")
+    if (!mask.isValid) return DebuggerParsedValue.invalid(mask.error!!)
+    if (mask.value == 0) {
+      return DebuggerParsedValue.invalid("Mask must contain at least one set bit.")
+    }
+    return DebuggerParsedValue.valid(
+        DebugMemoryCondition(
+            access,
+            range.value!!.startAddress,
+            range.value.endAddress,
+            value.value!!,
+            mask.value!!,
+        )
+    )
+  }
+
+  fun formatByte(value: Int): String {
+    require(value in 0..0xff) { "Byte value is outside 0..255: $value" }
+    return "${'$'}${value.toString(16).padStart(2, '0').uppercase(Locale.ROOT)}"
+  }
+
+  fun formatWord(value: Int): String {
+    require(value in 0..0xffff) { "Word value is outside 0..65535: $value" }
+    return "${'$'}${value.toString(16).padStart(4, '0').uppercase(Locale.ROOT)}"
+  }
+
+  /** Explicit form is suitable for labels and screen readers. */
+  fun formatFlags(value: Int): String {
+    require(value in 0..0xff && value and 0x0f == 0) { "Invalid Game Boy F register: $value" }
+    return listOf(7 to "Z", 6 to "N", 5 to "H", 4 to "C")
+        .joinToString(" ") { (bit, name) -> "$name=${if (value and (1 shl bit) != 0) 1 else 0}" }
+  }
+
+  /** Compact four-character form, with a dash for each clear flag. */
+  fun formatCompactFlags(value: Int): String {
+    require(value in 0..0xff && value and 0x0f == 0) { "Invalid Game Boy F register: $value" }
+    return listOf(7 to 'Z', 6 to 'N', 5 to 'H', 4 to 'C')
+        .joinToString("") { (bit, name) -> if (value and (1 shl bit) != 0) "$name" else "-" }
+  }
+
+  fun snapshot(snapshot: DebugSnapshot): DebuggerSnapshotView {
+    val registers = snapshot.registers
+    return DebuggerSnapshotView(
+        identity = DebuggerSnapshotIdentity.from(snapshot),
+        paused = snapshot.paused,
+        frame = snapshot.frame,
+        framePosition = snapshot.framePosition,
+        timingText =
+            "Frame ${snapshot.frame}, position ${snapshot.framePosition}, " +
+                "tick ${snapshot.masterTick}",
+        registers =
+            DebuggerRegisterView(
+                a = formatByte(registers.a),
+                f = formatByte(registers.f),
+                b = formatByte(registers.b),
+                c = formatByte(registers.c),
+                d = formatByte(registers.d),
+                e = formatByte(registers.e),
+                h = formatByte(registers.h),
+                l = formatByte(registers.l),
+                af = formatWord(registers.af()),
+                bc = formatWord(registers.bc()),
+                de = formatWord(registers.de()),
+                hl = formatWord(registers.hl()),
+                sp = formatWord(registers.sp),
+                pc = formatWord(registers.pc),
+                flags = formatFlags(registers.f),
+                compactFlags = formatCompactFlags(registers.f),
+            ),
+        cpuState = humanize(snapshot.execution.cpuState.name),
+        opcode =
+            when {
+              snapshot.execution.extendedOpcode >= 0 ->
+                  "${formatByte(0xcb)} ${formatByte(snapshot.execution.extendedOpcode)}"
+              snapshot.execution.opcode >= 0 -> formatByte(snapshot.execution.opcode)
+              else -> "Unavailable"
+            },
+        mapper = snapshot.mapper.mapperId,
+    )
+  }
+
+  fun capabilities(capabilities: DebugCapabilities): DebuggerCapabilityView =
+      DebuggerCapabilityView(
+          pauseResume = capabilities.pauseResume,
+          snapshots = capabilities.snapshot,
+          instructionStep = capabilities.instructionStep,
+          machineCycleStep = capabilities.machineCycleStep,
+          frameStep = capabilities.frameStep,
+          memoryRead = capabilities.memoryRead,
+          maxMemoryReadLength = capabilities.maxMemoryReadLength,
+          coherentInspection = capabilities.coherentInspection(),
+          maxInspectionBlocks = capabilities.maxInspectionBlocks(),
+          maxInspectionBytes = capabilities.maxInspectionBytes(),
+          breakpointKinds =
+              immutableCopy(capabilities.breakpointKinds.map { humanize(it.name) }.sorted()),
+          maxBreakpoints = capabilities.maxBreakpoints,
+          reverseHistory = capabilities.history.checkpointHistory,
+          reverseFrame = capabilities.history.reverseFrame,
+          reverseInstruction = capabilities.history.reverseInstruction,
+      )
+
+  /** Presents a block whose coherence is guaranteed by its containing inspection result. */
+  fun memory(
+      inspection: DebugInspectionResult,
+      block: DebugMemoryBlock,
+      bytesPerRow: Int = 16,
+  ): DebuggerMemoryView {
+    require(
+        inspection.anchoredBlocks.any { it === block } ||
+            inspection.memoryBlocks.any { it === block }
+    ) { "Memory block is not owned by this inspection result" }
+    val identity = DebuggerSnapshotIdentity.from(inspection.snapshot)
+    return memory(identity, DebuggerMemoryCapture(identity, block), bytesPerRow)
+  }
+
+  fun breakpointRows(
+      breakpoints: Collection<DebugBreakpoint>,
+      capabilities: DebugCapabilities? = null,
+  ): List<DebuggerBreakpointRow> =
+      immutableCopy(
+          breakpoints.map { breakpoint ->
+            val kind = breakpoint.condition.kind()
+            val supported = capabilities?.supports(kind) ?: true
+            val kindText = humanize(kind.name)
+            val conditionText = formatCondition(breakpoint.condition)
+            DebuggerBreakpointRow(
+                id = breakpoint.id.value,
+                enabled = breakpoint.enabled,
+                supported = supported,
+                kind = kindText,
+                condition = conditionText,
+                accessibilityText =
+                    "Breakpoint ${breakpoint.id.value}, $kindText, $conditionText, " +
+                        when {
+                          !supported -> "unsupported in this session"
+                          breakpoint.enabled -> "enabled"
+                          else -> "disabled"
+                        },
+            )
+          }
+      )
+
+  fun memory(
+      expectedIdentity: DebuggerSnapshotIdentity,
+      capture: DebuggerMemoryCapture,
+      bytesPerRow: Int = 16,
+  ): DebuggerMemoryView {
+    require(bytesPerRow in 1..32) { "Memory row width must be between 1 and 32" }
+    val coherence = capture.identity.coherenceWith(expectedIdentity)
+    val rows = ArrayList<DebuggerMemoryRow>()
+    var index = 0
+    while (index < capture.block.length()) {
+      val count = minOf(bytesPerRow, capture.block.length() - index)
+      val bytes = (0 until count).map { capture.block.unsignedByteAt(index + it) }
+      rows +=
+          DebuggerMemoryRow(
+              address = capture.block.startAddress() + index,
+              addressText = formatWord(capture.block.startAddress() + index),
+              bytes = immutableCopy(bytes),
+              hexText = bytes.joinToString(" ") { formatByte(it).removePrefix("${'$'}") },
+              asciiText = bytes.joinToString("") { byte ->
+                if (byte in 0x20..0x7e) byte.toChar().toString() else "."
+              },
+          )
+      index += count
+    }
+    return DebuggerMemoryView(
+        identity = capture.identity,
+        addressSpace = capture.block.addressSpace(),
+        startAddress = capture.block.startAddress(),
+        length = capture.block.length(),
+        coherence = coherence,
+        coherenceExplanation = coherence.explanation,
+        rows = immutableCopy(rows),
+    )
+  }
+
+  fun stack(
+      snapshot: DebugSnapshot,
+      capabilities: DebugCapabilities,
+      capture: DebuggerMemoryCapture?,
+      requestedBytes: Int = 16,
+  ): DebuggerStackView {
+    require(requestedBytes in 1..256) { "Stack length must be between 1 and 256" }
+    val identity = DebuggerSnapshotIdentity.from(snapshot)
+    if (!capabilities.memoryRead) {
+      return DebuggerStackView.unavailable(
+          identity,
+          requestedBytes,
+          "Stack is unavailable because this session does not support memory reads.",
+      )
+    }
+    if (capture == null) {
+      return DebuggerStackView.unavailable(
+          identity,
+          requestedBytes,
+          "Stack is unavailable until memory at SP ${formatWord(snapshot.registers.sp)} is read.",
+      )
+    }
+    val coherence = capture.identity.coherenceWith(identity)
+    if (coherence != DebuggerMemoryCoherence.COHERENT) {
+      return DebuggerStackView.unavailable(
+          identity,
+          requestedBytes,
+          "Stack is unavailable because ${coherence.explanation!!.replaceFirstChar { it.lowercase() }}",
+      )
+    }
+    if (capture.block.addressSpace() != DebugAddressSpace.SYSTEM_BUS) {
+      return DebuggerStackView.unavailable(
+          identity,
+          requestedBytes,
+          "Stack requires a system-bus memory read at SP ${formatWord(snapshot.registers.sp)}.",
+      )
+    }
+    val sp = snapshot.registers.sp
+    if (sp < capture.block.startAddress() || sp >= capture.block.endExclusive()) {
+      return DebuggerStackView.unavailable(
+          identity,
+          requestedBytes,
+          "Stack memory does not include SP ${formatWord(sp)}.",
+      )
+    }
+    val addressSpaceBytes = 0x10000 - sp
+    val blockBytes = capture.block.endExclusive() - sp
+    val count = minOf(requestedBytes, addressSpaceBytes, blockBytes)
+    val startIndex = sp - capture.block.startAddress()
+    val entries =
+        (0 until count).map { offset ->
+          val value = capture.block.unsignedByteAt(startIndex + offset)
+          DebuggerStackEntry(
+              offset = offset,
+              address = sp + offset,
+              addressText = formatWord(sp + offset),
+              value = value,
+              valueText = formatByte(value),
+          )
+        }
+    val clipped = count < requestedBytes
+    val explanation =
+        when {
+          !clipped -> null
+          addressSpaceBytes < requestedBytes ->
+              "Stack view is clipped at the end of the 16-bit address space."
+          else -> "Stack view is clipped to the returned memory block."
+        }
+    return DebuggerStackView(
+        identity = identity,
+        available = true,
+        requestedBytes = requestedBytes,
+        entries = immutableCopy(entries),
+        clipped = clipped,
+        explanation = explanation,
+    )
+  }
+
+  /** Uses the stack-pointer-relative block captured with the inspection's coherent snapshot. */
+  fun stack(
+      inspection: DebugInspectionResult,
+      capabilities: DebugCapabilities,
+      requestedBytes: Int = 16,
+  ): DebuggerStackView {
+    val stackBlock =
+        inspection.request.anchoredRequests
+            .withIndex()
+            .firstOrNull { (index, request) ->
+              request.anchor == DebugInspectionAnchor.STACK_POINTER &&
+                  inspection.anchoredBlocks[index].let { block ->
+                    inspection.snapshot.registers.sp in
+                        block.startAddress() until block.endExclusive()
+                  }
+            }
+            ?.let { inspection.anchoredBlocks[it.index] }
+    val identity = DebuggerSnapshotIdentity.from(inspection.snapshot)
+    return stack(
+        inspection.snapshot,
+        capabilities,
+        stackBlock?.let { DebuggerMemoryCapture(identity, it) },
+        requestedBytes,
+    )
+  }
+
+  fun history(
+      capabilities: DebugCapabilities,
+      status: DebugHistoryStatus?,
+  ): DebuggerHistoryView {
+    if (!capabilities.history.checkpointHistory) {
+      val unsupported = DebuggerActionState.unavailable("Reverse history is unsupported.")
+      return DebuggerHistoryView(
+          enabled = false,
+          checkpointCount = 0,
+          retainedBytes = 0,
+          cursor = "Unavailable",
+          retainedRange = "Unavailable",
+          futureCheckpointCount = 0,
+          truncation = "None",
+          reverseFrame = unsupported,
+          reverseInstruction = unsupported,
+      )
+    }
+    if (status == null) {
+      val waiting = DebuggerActionState.unavailable("Waiting for reverse-history status.")
+      return DebuggerHistoryView(
+          enabled = false,
+          checkpointCount = 0,
+          retainedBytes = 0,
+          cursor = "Waiting for status",
+          retainedRange = "Waiting for status",
+          futureCheckpointCount = 0,
+          truncation = "None",
+          reverseFrame = waiting,
+          reverseInstruction = waiting,
+      )
+    }
+    val enabled = status.configuration.enabled
+    val cursor = status.cursor
+    val oldest = status.oldest
+    val newest = status.newest
+    val commonUnavailable =
+        when {
+          !enabled -> "Enable reverse history to step backward."
+          status.checkpointCount == 0 -> "Waiting for the first frame checkpoint."
+          else -> null
+        }
+    val frameReason =
+        commonUnavailable
+            ?: when {
+              !capabilities.history.reverseFrame -> "Reverse-frame stepping is unsupported."
+              cursor!!.framePosition == 0 && cursor.masterTick <= oldest!!.masterTick ->
+                  "The oldest retained frame is selected."
+              else -> null
+            }
+    val instructionReason =
+        commonUnavailable
+            ?: when {
+              !capabilities.history.reverseInstruction ->
+                  "Reverse-instruction stepping is unsupported."
+              cursor!!.masterTick <= oldest!!.masterTick ->
+                  "The oldest retained instruction range is selected."
+              else -> null
+            }
+    return DebuggerHistoryView(
+        enabled = enabled,
+        checkpointCount = status.checkpointCount,
+        retainedBytes = status.retainedBytes,
+        cursor =
+            cursor?.let {
+              "Frame ${it.frame}, position ${it.framePosition}, tick ${it.masterTick}"
+            } ?: "No checkpoint",
+        retainedRange =
+            if (oldest == null || newest == null) {
+              "No checkpoints retained"
+            } else {
+              "Frame ${oldest.frame} / tick ${oldest.masterTick} to " +
+                  "frame ${newest.frame} / tick ${newest.masterTick}"
+            },
+        futureCheckpointCount = status.futureCheckpointCount,
+        truncation = truncationText(status.lastTruncationReason),
+        reverseFrame = action(frameReason),
+        reverseInstruction = action(instructionReason),
+    )
+  }
+
+  fun reverseOutcome(
+      result: DebugResult<DebugReverseStepResult>,
+  ): DebuggerReverseOutcome {
+    if (result.isFailure) {
+      val error = result.error()
+      return DebuggerReverseOutcome(
+          completed = false,
+          step = null,
+          errorCode = error.code().name,
+          message = error.message(),
+      )
+    }
+    val value = result.value()
+    val step =
+        DebuggerReverseStepView(
+            kind = humanize(value.kind.name),
+            identity = DebuggerSnapshotIdentity.from(value.snapshot),
+            restoredPosition =
+                "Frame ${value.restoredPosition.frame}, " +
+                    "position ${value.restoredPosition.framePosition}, " +
+                    "tick ${value.restoredPosition.masterTick}",
+            replayAnchor =
+                "Checkpoint ${value.replayAnchor.checkpointId} at " +
+                    "frame ${value.replayAnchor.frame}, tick ${value.replayAnchor.masterTick}",
+            futureCheckpointCount = value.history.futureCheckpointCount,
+        )
+    return DebuggerReverseOutcome(
+        completed = true,
+        step = step,
+        errorCode = null,
+        message =
+            "Restored ${step.kind.lowercase(Locale.ROOT)} at ${step.restoredPosition.lowercaseFirst()}.",
+    )
+  }
+
+  private fun formatCondition(condition: DebugBreakpointCondition): String =
+      when (condition) {
+        is DebugPcCondition ->
+            if (condition.isExact) formatWord(condition.startAddress)
+            else "${formatWord(condition.startAddress)}-${formatWord(condition.endAddress)}"
+        is DebugMemoryCondition ->
+            buildString {
+              append(humanize(condition.access().name))
+              append(' ')
+              append(formatRange(condition.startAddress(), condition.endAddress()))
+              if (condition.hasValueConstraint()) {
+                append(", value ")
+                append(formatByte(condition.value()))
+                if (condition.valueMask() != 0xff) {
+                  append(", mask ")
+                  append(formatByte(condition.valueMask()))
+                }
+              }
+            }
+        is DebugOpcodeCondition ->
+            if (condition.cbPrefixed) "CB ${formatByte(condition.opcode)}"
+            else formatByte(condition.opcode)
+        is DebugInterruptCondition -> humanize(condition.interrupt.name)
+        is DebugPpuCondition ->
+            buildList {
+                  if (condition.constrainsFrame()) add("frame ${condition.frame}")
+                  if (condition.constrainsLy()) add("LY ${condition.ly}")
+                  if (condition.constrainsMode()) add("mode ${humanize(condition.mode!!.name)}")
+                }
+                .joinToString(", ")
+        is DebugSerialCondition ->
+            buildString {
+              append(humanize(condition.event().name))
+              if (condition.hasValueConstraint()) {
+                append(", value ")
+                append(formatByte(condition.value()))
+                if (condition.valueMask() != 0xff) {
+                  append(", mask ")
+                  append(formatByte(condition.valueMask()))
+                }
+              }
+            }
+        is DebugCounterCondition -> "${humanize(condition.counter.name)} = ${condition.value}"
+        else -> condition.toString()
+      }
+
+  private fun formatRange(start: Int, end: Int): String =
+      if (start == end) formatWord(start) else "${formatWord(start)}-${formatWord(end)}"
+
+  private fun truncationText(reason: DebugHistoryTruncationReason): String =
+      when (reason) {
+        DebugHistoryTruncationReason.NONE -> "None"
+        else -> humanize(reason.name)
+      }
+
+  private fun action(reason: String?): DebuggerActionState =
+      reason?.let(DebuggerActionState::unavailable) ?: DebuggerActionState.available()
+
+  private fun parseHexToken(token: String): Int {
+    val digits =
+        when {
+          token.startsWith("0x", ignoreCase = true) -> token.substring(2)
+          token.startsWith("${'$'}") -> token.substring(1)
+          else -> token
+        }
+    return digits.toInt(16)
+  }
+
+  private fun addressError(): String =
+      "Address must be a 16-bit hexadecimal value, for example ${'$'}C000 or 0xC000."
+
+  private fun humanize(value: String): String =
+      value.lowercase(Locale.ROOT).replace('_', ' ').replaceFirstChar { it.titlecase(Locale.ROOT) }
+
+  private fun String.lowercaseFirst(): String = replaceFirstChar { it.lowercase(Locale.ROOT) }
+
+  private fun <T> immutableCopy(values: Collection<T>): List<T> =
+      Collections.unmodifiableList(ArrayList(values))
+}
+
+internal class DebuggerParsedValue<T> private constructor(val value: T?, val error: String?) {
+  init {
+    require((value == null) != (error == null)) { "A parsed value is either valid or invalid" }
+    require(error == null || error.isNotBlank()) { "A parse error must not be blank" }
+  }
+
+  val isValid: Boolean
+    get() = error == null
+
+  fun <R> map(transform: (T) -> R): DebuggerParsedValue<R> =
+      if (isValid) valid(transform(value!!)) else invalid(error!!)
+
+  companion object {
+    fun <T> valid(value: T): DebuggerParsedValue<T> = DebuggerParsedValue(value, null)
+
+    fun <T> invalid(error: String): DebuggerParsedValue<T> = DebuggerParsedValue(null, error)
+  }
+}
+
+internal data class DebuggerAddressRange(val startAddress: Int, val endAddress: Int) {
+  init {
+    require(startAddress in 0..0xffff) { "Start address is outside 16 bits" }
+    require(endAddress in startAddress..0xffff) { "End address precedes start or exceeds 16 bits" }
+  }
+
+  val length: Int
+    get() = endAddress - startAddress + 1
+
+  val isExact: Boolean
+    get() = startAddress == endAddress
+
+  fun memoryRequest(addressSpace: DebugAddressSpace): DebugMemoryRequest =
+      DebugMemoryRequest(addressSpace, startAddress, length)
+}
+
+internal data class DebuggerSnapshotIdentity(
+    val sessionGeneration: Long,
+    val sequence: Long,
+    val masterTick: Long,
+) {
+  init {
+    require(sessionGeneration >= 0 && sequence >= 0 && masterTick >= 0) {
+      "Snapshot identity coordinates must be non-negative"
+    }
+  }
+
+  val label: String
+    get() = "Session $sessionGeneration, snapshot $sequence, tick $masterTick"
+
+  fun coherenceWith(expected: DebuggerSnapshotIdentity): DebuggerMemoryCoherence =
+      when {
+        sessionGeneration != expected.sessionGeneration -> DebuggerMemoryCoherence.DIFFERENT_SESSION
+        this != expected -> DebuggerMemoryCoherence.STALE_SNAPSHOT
+        else -> DebuggerMemoryCoherence.COHERENT
+      }
+
+  companion object {
+    fun from(snapshot: DebugSnapshot): DebuggerSnapshotIdentity =
+        DebuggerSnapshotIdentity(
+            snapshot.sessionGeneration,
+            snapshot.sequence,
+            snapshot.masterTick,
+        )
+  }
+}
+
+internal data class DebuggerSnapshotView(
+    val identity: DebuggerSnapshotIdentity,
+    val paused: Boolean,
+    val frame: Long,
+    val framePosition: Int,
+    val timingText: String,
+    val registers: DebuggerRegisterView,
+    val cpuState: String,
+    val opcode: String,
+    val mapper: String,
+)
+
+internal data class DebuggerRegisterView(
+    val a: String,
+    val f: String,
+    val b: String,
+    val c: String,
+    val d: String,
+    val e: String,
+    val h: String,
+    val l: String,
+    val af: String,
+    val bc: String,
+    val de: String,
+    val hl: String,
+    val sp: String,
+    val pc: String,
+    val flags: String,
+    val compactFlags: String,
+)
+
+internal data class DebuggerCapabilityView(
+    val pauseResume: Boolean,
+    val snapshots: Boolean,
+    val instructionStep: Boolean,
+    val machineCycleStep: Boolean,
+    val frameStep: Boolean,
+    val memoryRead: Boolean,
+    val maxMemoryReadLength: Int,
+    val coherentInspection: Boolean,
+    val maxInspectionBlocks: Int,
+    val maxInspectionBytes: Int,
+    val breakpointKinds: List<String>,
+    val maxBreakpoints: Int,
+    val reverseHistory: Boolean,
+    val reverseFrame: Boolean,
+    val reverseInstruction: Boolean,
+)
+
+internal data class DebuggerBreakpointRow(
+    val id: Long,
+    val enabled: Boolean,
+    val supported: Boolean,
+    val kind: String,
+    val condition: String,
+    val accessibilityText: String,
+)
+
+/** The identity is supplied by the caller because DebugMemoryBlock itself has no coordinates. */
+internal data class DebuggerMemoryCapture(
+    val identity: DebuggerSnapshotIdentity,
+    val block: DebugMemoryBlock,
+)
+
+internal enum class DebuggerMemoryCoherence(val explanation: String?) {
+  COHERENT(null),
+  STALE_SNAPSHOT("Memory belongs to a different snapshot in this session."),
+  DIFFERENT_SESSION("Memory belongs to a different emulation session."),
+}
+
+internal data class DebuggerMemoryView(
+    val identity: DebuggerSnapshotIdentity,
+    val addressSpace: DebugAddressSpace,
+    val startAddress: Int,
+    val length: Int,
+    val coherence: DebuggerMemoryCoherence,
+    val coherenceExplanation: String?,
+    val rows: List<DebuggerMemoryRow>,
+)
+
+internal data class DebuggerMemoryRow(
+    val address: Int,
+    val addressText: String,
+    val bytes: List<Int>,
+    val hexText: String,
+    val asciiText: String,
+)
+
+internal data class DebuggerStackEntry(
+    val offset: Int,
+    val address: Int,
+    val addressText: String,
+    val value: Int,
+    val valueText: String,
+)
+
+internal data class DebuggerStackView(
+    val identity: DebuggerSnapshotIdentity,
+    val available: Boolean,
+    val requestedBytes: Int,
+    val entries: List<DebuggerStackEntry>,
+    val clipped: Boolean,
+    val explanation: String?,
+) {
+  init {
+    require(available == entries.isNotEmpty()) {
+      "An available stack contains entries; an unavailable stack does not"
+    }
+    require(!clipped || available) { "An unavailable stack cannot be clipped" }
+    require(available || !explanation.isNullOrBlank()) {
+      "An unavailable stack requires an explanation"
+    }
+  }
+
+  companion object {
+    fun unavailable(
+        identity: DebuggerSnapshotIdentity,
+        requestedBytes: Int,
+        explanation: String,
+    ): DebuggerStackView =
+        DebuggerStackView(identity, false, requestedBytes, emptyList(), false, explanation)
+  }
+}
+
+internal data class DebuggerActionState(val enabled: Boolean, val explanation: String?) {
+  init {
+    require(enabled == (explanation == null)) {
+      "An enabled action has no explanation; a disabled action requires one"
+    }
+  }
+
+  companion object {
+    fun available(): DebuggerActionState = DebuggerActionState(true, null)
+
+    fun unavailable(explanation: String): DebuggerActionState =
+        DebuggerActionState(false, explanation)
+  }
+}
+
+internal data class DebuggerHistoryView(
+    val enabled: Boolean,
+    val checkpointCount: Int,
+    val retainedBytes: Long,
+    val cursor: String,
+    val retainedRange: String,
+    val futureCheckpointCount: Int,
+    val truncation: String,
+    val reverseFrame: DebuggerActionState,
+    val reverseInstruction: DebuggerActionState,
+)
+
+internal data class DebuggerReverseStepView(
+    val kind: String,
+    val identity: DebuggerSnapshotIdentity,
+    val restoredPosition: String,
+    val replayAnchor: String,
+    val futureCheckpointCount: Int,
+)
+
+internal data class DebuggerReverseOutcome(
+    val completed: Boolean,
+    val step: DebuggerReverseStepView?,
+    val errorCode: String?,
+    val message: String,
+) {
+  init {
+    require(completed == (step != null)) { "Only completed outcomes contain a reverse step" }
+    require(completed == (errorCode == null)) { "Only failed outcomes contain an error code" }
+    require(message.isNotBlank()) { "A reverse outcome requires display text" }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
@@ -1,0 +1,1276 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.Controller
+import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugDisassembler
+import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
+import eu.rekawek.coffeegb.core.debug.DebugPort
+import eu.rekawek.coffeegb.core.debug.DebugResult
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot
+import eu.rekawek.coffeegb.core.debug.DebugStepKind
+import eu.rekawek.coffeegb.core.debug.DebugStepResult
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
+import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dialog
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.GridLayout
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JDialog
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JSplitPane
+import javax.swing.JTabbedPane
+import javax.swing.JTable
+import javax.swing.JTextArea
+import javax.swing.JTextField
+import javax.swing.ListSelectionModel
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+import javax.swing.table.AbstractTableModel
+import org.slf4j.LoggerFactory
+
+/** Modeless desktop debugger retained by [DesktopDebuggerController]. */
+internal class DebuggerWindow(owner: JFrame) : DesktopDebuggerView {
+  private val panel = DebuggerPanel()
+  private val dialog = JDialog(owner, "Coffee GB Debugger", Dialog.ModalityType.MODELESS)
+  private var positioned = false
+  private var closed = false
+
+  init {
+    requireDebuggerWindowEdt("Debugger window construction")
+    dialog.defaultCloseOperation = JDialog.HIDE_ON_CLOSE
+    dialog.minimumSize = Dimension(900, 620)
+    dialog.preferredSize = Dimension(1120, 760)
+    dialog.contentPane = panel
+    dialog.accessibleContext.accessibleName = "Coffee GB debugger"
+    dialog.addWindowListener(
+        object : WindowAdapter() {
+          override fun windowClosing(event: WindowEvent) {
+            panel.setPollingActive(false)
+          }
+
+          override fun windowClosed(event: WindowEvent) {
+            panel.setPollingActive(false)
+          }
+        })
+    dialog.addComponentListener(
+        object : ComponentAdapter() {
+          override fun componentShown(event: ComponentEvent) {
+            panel.setPollingActive(true)
+          }
+
+          override fun componentHidden(event: ComponentEvent) {
+            panel.setPollingActive(false)
+          }
+        })
+    dialog.pack()
+  }
+
+  override fun updateSession(event: Controller.SessionDebugPortEvent) {
+    requireDebuggerWindowEdt("Debugger session update")
+    if (!closed) panel.updateSession(event)
+  }
+
+  override fun showWindow() {
+    requireDebuggerWindowEdt("Debugger window opening")
+    if (closed) return
+    if (!positioned) {
+      dialog.setLocationRelativeTo(dialog.owner)
+      positioned = true
+    }
+    dialog.isVisible = true
+    panel.setPollingActive(true)
+    dialog.toFront()
+    dialog.requestFocus()
+  }
+
+  override fun close() {
+    requireDebuggerWindowEdt("Debugger window disposal")
+    if (closed) return
+    closed = true
+    panel.close()
+    dialog.dispose()
+  }
+}
+
+/** Narrow adapter that keeps the panel independently testable from the full DebugPort surface. */
+internal interface DebuggerClient {
+  val generation: Long
+  val capabilities: DebugCapabilities
+
+  fun inspect(request: DebugInspectionRequest): CompletionStage<DebugResult<DebugInspectionResult>>
+
+  fun pause(): CompletionStage<DebugResult<DebugSnapshot>>
+
+  fun resume(): CompletionStage<DebugResult<DebugSnapshot>>
+
+  fun step(kind: DebugStepKind): CompletionStage<DebugResult<DebugStepResult>>
+
+  fun stepBackward(kind: DebugStepKind): CompletionStage<DebugResult<DebugReverseStepResult>>
+
+  fun configureHistory(
+      configuration: DebugHistoryConfiguration
+  ): CompletionStage<DebugResult<DebugHistoryStatus>>
+
+  fun historyStatus(): CompletionStage<DebugResult<DebugHistoryStatus>>
+
+  fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>>
+
+  fun setBreakpoint(
+      breakpoint: DebugBreakpoint
+  ): CompletionStage<DebugResult<DebugBreakpoint>>
+
+  fun removeBreakpoint(
+      breakpointId: DebugBreakpointId
+  ): CompletionStage<DebugResult<Void>>
+}
+
+private class DebugPortDebuggerClient(private val port: DebugPort) : DebuggerClient {
+  override val generation: Long
+    get() = port.sessionGeneration()
+
+  override val capabilities: DebugCapabilities
+    get() = port.capabilities()
+
+  override fun inspect(
+      request: DebugInspectionRequest
+  ): CompletionStage<DebugResult<DebugInspectionResult>> = port.inspect(request)
+
+  override fun pause(): CompletionStage<DebugResult<DebugSnapshot>> = port.pause()
+
+  override fun resume(): CompletionStage<DebugResult<DebugSnapshot>> = port.resume()
+
+  override fun step(kind: DebugStepKind): CompletionStage<DebugResult<DebugStepResult>> =
+      port.step(kind)
+
+  override fun stepBackward(
+      kind: DebugStepKind
+  ): CompletionStage<DebugResult<DebugReverseStepResult>> = port.stepBackward(kind)
+
+  override fun configureHistory(
+      configuration: DebugHistoryConfiguration
+  ): CompletionStage<DebugResult<DebugHistoryStatus>> = port.configureHistory(configuration)
+
+  override fun historyStatus(): CompletionStage<DebugResult<DebugHistoryStatus>> =
+      port.historyStatus()
+
+  override fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>> =
+      port.listBreakpoints()
+
+  override fun setBreakpoint(
+      breakpoint: DebugBreakpoint
+  ): CompletionStage<DebugResult<DebugBreakpoint>> = port.setBreakpoint(breakpoint)
+
+  override fun removeBreakpoint(
+      breakpointId: DebugBreakpointId
+  ): CompletionStage<DebugResult<Void>> = port.removeBreakpoint(breakpointId)
+}
+
+/**
+ * EDT-owned, headless-constructible debugger content.
+ *
+ * Debug calls only enqueue work. Their continuations return to the EDT and are correlated by
+ * window epoch, client identity, session generation, and request id before touching Swing state.
+ */
+internal class DebuggerPanel(
+    private val clientFactory: (DebugPort) -> DebuggerClient = ::DebugPortDebuggerClient,
+    pollingIntervalMillis: Int = DEFAULT_POLLING_INTERVAL_MILLIS,
+) : JPanel(BorderLayout(6, 6)), AutoCloseable {
+  internal val sessionLabel = JLabel("No emulation session")
+  internal val snapshotLabel = JLabel("Waiting for a debug snapshot")
+  internal val statusLabel = JLabel("Debugger ready")
+  internal val runButton = JButton("Release debug pause")
+  internal val pauseButton = JButton("Pause")
+  internal val stepInstructionButton = JButton("Step instruction")
+  internal val stepFrameButton = JButton("Step frame")
+  internal val backInstructionButton = JButton("Back instruction")
+  internal val backFrameButton = JButton("Back frame")
+  internal val refreshButton = JButton("Refresh")
+  internal val historyToggle = JCheckBox("Record reverse history")
+  internal val registersArea = debuggerTextArea("CPU registers", 8, 28)
+  internal val machineArea = debuggerTextArea("Machine summary", 13, 42)
+  internal val disassemblyArea = debuggerTextArea("Current instruction", 5, 70)
+  internal val stackArea = debuggerTextArea("Stack bytes", 12, 28)
+  internal val memoryArea = debuggerTextArea("Memory hex view", 22, 76)
+  internal val memorySpace = JComboBox(SAFE_MEMORY_SPACES)
+  internal val memoryRange = JTextField("\$C000-\$C07F", 15)
+  internal val memoryReadButton = JButton("Read")
+  internal val breakpointKind = JComboBox(BreakpointEditorKind.entries.toTypedArray())
+  internal val breakpointRange = JTextField("\$0100", 13)
+  internal val breakpointValue = JTextField("", 4)
+  internal val breakpointMask = JTextField("", 4)
+  internal val breakpointAddButton = JButton("Add")
+  internal val breakpointRemoveButton = JButton("Remove")
+  internal val breakpointModel = DebuggerBreakpointTableModel(::toggleBreakpoint)
+  internal val breakpointTable = JTable(breakpointModel)
+  internal val historyLabel = JLabel("Reverse history status unavailable")
+
+  private val pollingTimer =
+      Timer(pollingIntervalMillis) { requestRefresh() }.apply { isRepeats = true }
+  private var client: DebuggerClient? = null
+  private var latestGeneration = NO_GENERATION
+  private var snapshot: DebugSnapshot? = null
+  private var historyStatus: DebugHistoryStatus? = null
+  private var selectedMemory: DebugMemoryRequest? = null
+  private var windowEpoch = 0L
+  private var nextRequestId = 1L
+  private var refreshInFlight = false
+  private var refreshAgain = false
+  private var snapshotOnlyRefreshPending = false
+  private var metadataInFlight = false
+  private var metadataAgain = false
+  private var commandInFlight = false
+  private var pollingActive = false
+  private var updatingHistoryToggle = false
+  private var closed = false
+  private var lastAppliedStateRequestId = 0L
+
+  init {
+    requireDebuggerWindowEdt("Debugger panel construction")
+    require(pollingIntervalMillis > 0) { "Debugger polling interval must be positive" }
+    border = BorderFactory.createEmptyBorder(6, 6, 6, 6)
+
+    sessionLabel.accessibleContext.accessibleName = "Debugger session"
+    snapshotLabel.accessibleContext.accessibleName = "Debugger snapshot identity"
+    statusLabel.accessibleContext.accessibleName = "Debugger status"
+    historyLabel.accessibleContext.accessibleName = "Reverse history status"
+
+    val header = JPanel(GridLayout(0, 1, 2, 2))
+    header.add(sessionLabel)
+    header.add(snapshotLabel)
+    header.add(historyLabel)
+
+    val toolbar = JPanel(FlowLayout(FlowLayout.LEADING, 5, 2))
+    listOf(
+            runButton,
+            pauseButton,
+            stepInstructionButton,
+            stepFrameButton,
+            backInstructionButton,
+            backFrameButton,
+            refreshButton,
+        )
+        .forEach(toolbar::add)
+    toolbar.add(historyToggle)
+
+    val north = JPanel(BorderLayout(4, 4))
+    north.add(header, BorderLayout.NORTH)
+    north.add(toolbar, BorderLayout.CENTER)
+    add(north, BorderLayout.NORTH)
+
+    val tabs = JTabbedPane()
+    tabs.accessibleContext.accessibleName = "Debugger panes"
+    tabs.addTab("CPU", cpuPanel())
+    tabs.addTab("Memory", memoryPanel())
+    tabs.addTab("Breakpoints", breakpointPanel())
+    add(tabs, BorderLayout.CENTER)
+
+    statusLabel.border = BorderFactory.createEmptyBorder(3, 4, 2, 4)
+    add(statusLabel, BorderLayout.SOUTH)
+
+    runButton.accessibleContext.accessibleDescription =
+        "Release the debugger-owned pause; an application-owned pause may remain"
+    runButton.toolTipText =
+        "Release the debugger-owned pause; an application-owned pause may remain"
+    pauseButton.accessibleContext.accessibleDescription = "Pause at the next safe point"
+    stepInstructionButton.accessibleContext.accessibleDescription = "Execute one CPU instruction"
+    stepFrameButton.accessibleContext.accessibleDescription = "Run to the next frame boundary"
+    backInstructionButton.accessibleContext.accessibleDescription =
+        "Restore the previous recorded instruction boundary"
+    backFrameButton.accessibleContext.accessibleDescription =
+        "Restore the previous recorded frame boundary"
+    refreshButton.accessibleContext.accessibleDescription = "Refresh the coherent debugger view"
+    historyToggle.accessibleContext.accessibleDescription =
+        "Enable or disable bounded reverse-execution history"
+
+    runButton.addActionListener { runCommand() }
+    pauseButton.addActionListener { pauseCommand() }
+    stepInstructionButton.addActionListener { stepCommand(DebugStepKind.INSTRUCTION) }
+    stepFrameButton.addActionListener { stepCommand(DebugStepKind.FRAME) }
+    backInstructionButton.addActionListener { reverseCommand(DebugStepKind.INSTRUCTION) }
+    backFrameButton.addActionListener { reverseCommand(DebugStepKind.FRAME) }
+    refreshButton.addActionListener {
+      requestRefresh()
+      requestMetadata()
+    }
+    historyToggle.addActionListener {
+      if (!updatingHistoryToggle) {
+        val requestedEnabled = historyToggle.isSelected
+        // Swing changes the checkbox before this listener runs. Restore the authoritative state
+        // until the asynchronous command succeeds so a typed failure cannot leave a false claim.
+        applyHistory(historyStatus)
+        configureHistory(requestedEnabled)
+      }
+    }
+    memoryReadButton.addActionListener { selectMemoryRange() }
+    breakpointAddButton.addActionListener { addBreakpoint() }
+    breakpointRemoveButton.addActionListener { removeSelectedBreakpoint() }
+    breakpointTable.selectionModel.addListSelectionListener { updateControlState() }
+    breakpointKind.addActionListener { updateBreakpointEditor() }
+
+    updateBreakpointEditor()
+    clearSessionView()
+    updateControlState()
+  }
+
+  private fun cpuPanel(): Component {
+    val scalar = JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scroll(registersArea), scroll(machineArea))
+    scalar.resizeWeight = 0.34
+    scalar.isContinuousLayout = true
+    val codeAndStack =
+        JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scroll(disassemblyArea), scroll(stackArea))
+    codeAndStack.resizeWeight = 0.7
+    codeAndStack.isContinuousLayout = true
+    return JSplitPane(JSplitPane.VERTICAL_SPLIT, scalar, codeAndStack).apply {
+      resizeWeight = 0.62
+      isContinuousLayout = true
+    }
+  }
+
+  private fun memoryPanel(): Component {
+    memorySpace.accessibleContext.accessibleName = "Memory address space"
+    memoryRange.accessibleContext.accessibleName = "Memory address or range"
+    memoryReadButton.accessibleContext.accessibleDescription =
+        "Read the selected bounded range at one coherent safe point"
+    val controls = JPanel(FlowLayout(FlowLayout.LEADING))
+    controls.add(JLabel("Space:"))
+    controls.add(memorySpace)
+    controls.add(JLabel("Range:"))
+    controls.add(memoryRange)
+    controls.add(memoryReadButton)
+    return JPanel(BorderLayout(4, 4)).apply {
+      add(controls, BorderLayout.NORTH)
+      add(scroll(memoryArea), BorderLayout.CENTER)
+    }
+  }
+
+  private fun breakpointPanel(): Component {
+    breakpointTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+    breakpointTable.fillsViewportHeight = true
+    breakpointTable.autoCreateRowSorter = false
+    breakpointTable.accessibleContext.accessibleName = "Breakpoints and watchpoints"
+    breakpointTable.columnModel.getColumn(0).preferredWidth = 65
+    breakpointTable.columnModel.getColumn(1).preferredWidth = 70
+    breakpointTable.columnModel.getColumn(2).preferredWidth = 140
+    breakpointTable.columnModel.getColumn(3).preferredWidth = 420
+
+    breakpointKind.accessibleContext.accessibleName = "Breakpoint type"
+    breakpointRange.accessibleContext.accessibleName = "Breakpoint address or range"
+    breakpointValue.accessibleContext.accessibleName = "Optional watchpoint byte value"
+    breakpointMask.accessibleContext.accessibleName = "Optional watchpoint byte mask"
+    val editor = JPanel(FlowLayout(FlowLayout.LEADING))
+    editor.add(JLabel("Type:"))
+    editor.add(breakpointKind)
+    editor.add(JLabel("Address/range:"))
+    editor.add(breakpointRange)
+    editor.add(JLabel("Value:"))
+    editor.add(breakpointValue)
+    editor.add(JLabel("Mask:"))
+    editor.add(breakpointMask)
+    editor.add(breakpointAddButton)
+    editor.add(breakpointRemoveButton)
+    return JPanel(BorderLayout(4, 4)).apply {
+      add(editor, BorderLayout.NORTH)
+      add(JScrollPane(breakpointTable), BorderLayout.CENTER)
+    }
+  }
+
+  fun updateSession(event: Controller.SessionDebugPortEvent) {
+    requireDebuggerWindowEdt("Debugger session update")
+    val port = event.debugPort
+    val nextClient = port?.let(clientFactory)
+    updateClient(event.generation, nextClient)
+  }
+
+  internal fun updateClient(generation: Long, nextClient: DebuggerClient?) {
+    requireDebuggerWindowEdt("Debugger client update")
+    if (closed || generation < latestGeneration) return
+    if (nextClient != null && nextClient.generation != generation) return
+    latestGeneration = generation
+    client = nextClient
+    windowEpoch++
+    snapshot = null
+    historyStatus = null
+    selectedMemory = null
+    refreshInFlight = false
+    refreshAgain = false
+    snapshotOnlyRefreshPending = false
+    metadataInFlight = false
+    metadataAgain = false
+    commandInFlight = false
+    lastAppliedStateRequestId = 0L
+    breakpointModel.replace(emptyList(), null)
+    syncPollingTimer()
+    if (nextClient == null) {
+      clearSessionView()
+      sessionLabel.text = "Session $generation ended"
+      statusLabel.text = "No active debug port"
+    } else {
+      val coherentInspection = nextClient.capabilities.coherentInspection()
+      sessionLabel.text =
+          "Session $generation — ${DebuggerPresentation.capabilities(nextClient.capabilities).summary()}"
+      snapshotLabel.text =
+          if (coherentInspection) "Waiting for a coherent snapshot"
+          else "Coherent inspection is unavailable for this session"
+      historyLabel.text = "Waiting for reverse history status"
+      registersArea.text =
+          if (coherentInspection) "Waiting for CPU state" else "Snapshot inspection unavailable"
+      machineArea.text =
+          if (coherentInspection) "Waiting for machine state" else "Snapshot inspection unavailable"
+      disassemblyArea.text =
+          if (coherentInspection) "Pause to inspect the current instruction"
+          else "Disassembly unavailable"
+      stackArea.text =
+          if (coherentInspection) "Pause to inspect stack memory" else "Stack inspection unavailable"
+      memoryArea.text =
+          if (coherentInspection) "Choose a bounded range, pause, and select Read"
+          else "Memory inspection unavailable"
+      statusLabel.text =
+          if (coherentInspection) "Session attached"
+          else "Session attached; coherent inspection unsupported"
+      if (pollingActive) {
+        requestRefresh()
+        requestMetadata()
+      }
+    }
+    updateControlState()
+  }
+
+  fun setPollingActive(active: Boolean) {
+    requireDebuggerWindowEdt("Debugger polling state change")
+    if (closed || pollingActive == active) return
+    pollingActive = active
+    windowEpoch++
+    if (active) {
+      syncPollingTimer()
+      requestRefresh()
+      requestMetadata()
+    } else {
+      syncPollingTimer()
+      refreshAgain = false
+      metadataAgain = false
+      releaseRetainedSessionState()
+    }
+    updateControlState()
+  }
+
+  internal fun requestRefresh() {
+    requireDebuggerWindowEdt("Debugger refresh")
+    val attached = client ?: return
+    if (closed || !pollingActive || !attached.capabilities.coherentInspection()) return
+    if (refreshInFlight) {
+      refreshAgain = true
+      return
+    }
+    val plan = inspectionPlan(attached)
+    val token = token(attached)
+    refreshInFlight = true
+    updateControlState()
+    val stage =
+        try {
+          attached.inspect(plan.request)
+        } catch (failure: RuntimeException) {
+          refreshInFlight = false
+          showFailure("Refresh", failure)
+          updateControlState()
+          return
+        }
+    stage.whenComplete { result, failure ->
+      dispatchSwingMutation {
+        if (!sameSession(token)) return@dispatchSwingMutation
+        refreshInFlight = false
+        if (token.epoch == windowEpoch && pollingActive) {
+          when {
+            failure != null -> showFailure("Refresh", failure)
+            result == null -> statusLabel.text = "Refresh returned no result"
+            result.isFailure -> {
+              if (result.error().code() == DebugErrorCode.SIDE_EFFECTFUL_ADDRESS &&
+                  plan.request.anchoredRequests().isNotEmpty()) {
+                // Register-relative ranges were planned from the previous snapshot but resolve
+                // against the new safe point. If another pause owner moved PC/SP across a safe
+                // boundary, first obtain a fresh scalar snapshot and then re-plan once from it.
+                snapshotOnlyRefreshPending = true
+                refreshAgain = true
+                statusLabel.text =
+                    "Inspection registers moved; refreshing the snapshot before retrying"
+              } else {
+                showFailure("Refresh", result)
+              }
+            }
+            else -> {
+              val inspection = result.value()
+              when {
+                inspection.request() != plan.request ->
+                    statusLabel.text = "Refresh returned a mismatched inspection response"
+                token.requestId < lastAppliedStateRequestId -> Unit
+                else -> {
+                  lastAppliedStateRequestId = token.requestId
+                  applyInspection(plan, inspection)
+                }
+              }
+            }
+          }
+        }
+        val repeat = refreshAgain && pollingActive
+        refreshAgain = false
+        updateControlState()
+        if (repeat) requestRefresh()
+      }
+    }
+  }
+
+  private fun inspectionPlan(attached: DebuggerClient): InspectionPlan {
+    if (snapshotOnlyRefreshPending) {
+      snapshotOnlyRefreshPending = false
+      return InspectionPlan(DebugInspectionRequest(emptyList(), emptyList()), null, null, false)
+    }
+    val anchored = ArrayList<DebugAnchoredMemoryRequest>(2)
+    var codeIndex: Int? = null
+    var stackIndex: Int? = null
+    var remainingBytes = attached.capabilities.maxInspectionBytes()
+    val previous = snapshot
+    if (attached.capabilities.memoryRead() && previous?.paused() == true) {
+      pcAnchoredLength(
+              previous.registers().pc(),
+              minOf(MAX_INSTRUCTION_BYTES, remainingBytes),
+          )
+          ?.let { length ->
+        codeIndex = anchored.size
+        anchored +=
+            DebugAnchoredMemoryRequest(DebugInspectionAnchor.PROGRAM_COUNTER, 0, length)
+        remainingBytes -= length
+      }
+      stackAnchoredLength(previous.registers().sp(), minOf(STACK_BYTES, remainingBytes))?.let {
+          length ->
+        stackIndex = anchored.size
+        anchored += DebugAnchoredMemoryRequest(DebugInspectionAnchor.STACK_POINTER, 0, length)
+        remainingBytes -= length
+      }
+    }
+    val explicit =
+        selectedMemory
+            ?.takeIf {
+              previous?.paused() == true &&
+                  attached.capabilities.memoryRead() &&
+                  it.length() <= remainingBytes
+            }
+            ?.let(::listOf)
+            ?: emptyList()
+    return InspectionPlan(
+        DebugInspectionRequest(anchored, explicit),
+        codeIndex,
+        stackIndex,
+        explicit.isNotEmpty(),
+    )
+  }
+
+  private fun applyInspection(plan: InspectionPlan, result: DebugInspectionResult) {
+    requireDebuggerWindowEdt("Debugger inspection rendering")
+    val wasRunning = snapshot?.paused() == false
+    val view = DebuggerPresentation.snapshot(result.snapshot())
+    snapshot = result.snapshot()
+    snapshotLabel.text =
+        "${view.identity.label} — ${if (view.paused) "PAUSED" else "RUNNING"} — ${view.timingText}"
+    registersArea.text = view.registers.render()
+    machineArea.text = renderMachine(result.snapshot())
+
+    if (!view.paused) {
+      disassemblyArea.text = "Paused-only view; instruction bytes are not sampled while running."
+      stackArea.text = "Paused-only view; stack bytes are not sampled while running."
+      memoryArea.text = "Paused-only view; memory is blank while the emulator is running."
+    } else {
+      val identity = view.identity
+      val code = plan.codeIndex?.let { result.anchoredBlocks()[it] }
+      disassemblyArea.text =
+          code?.let {
+            runCatching { DebugDisassembler.disassemble(it) }
+                .getOrElse { failure -> "Disassembly unavailable: ${failure.message}" }
+          } ?: "Current PC is outside the side-effect-free ROM/WRAM/HRAM inspection views."
+
+      val stackCapture =
+          plan.stackIndex?.let {
+            DebuggerMemoryCapture(identity, result.anchoredBlocks()[it])
+          }
+      stackArea.text =
+          DebuggerPresentation.stack(result.snapshot(), client!!.capabilities, stackCapture, STACK_BYTES)
+              .render()
+
+      memoryArea.text =
+          if (plan.includesExplicitMemory) {
+            val capture = DebuggerMemoryCapture(identity, result.memoryBlocks().single())
+            DebuggerPresentation.memory(identity, capture).render()
+          } else {
+            "Choose a bounded range and select Read."
+          }
+    }
+    statusLabel.text = "Snapshot refreshed"
+
+    // A first paused snapshot deliberately carries no register-relative ranges. Queue exactly one
+    // follow-up so those ranges are resolved against their own coherent snapshot.
+    if (view.paused && plan.request.blockCount() == 0 && client?.capabilities?.memoryRead() == true) {
+      refreshAgain = true
+    }
+    if (wasRunning && view.paused) requestMetadata()
+    updateControlState()
+  }
+
+  private fun requestMetadata() {
+    requireDebuggerWindowEdt("Debugger metadata refresh")
+    val attached = client ?: return
+    if (closed || !pollingActive) return
+    if (metadataInFlight) {
+      metadataAgain = true
+      return
+    }
+    val token = token(attached)
+    metadataInFlight = true
+    val breakpoints =
+        if (attached.capabilities.breakpoints()) attached.listBreakpoints()
+        else completedResult(DebugResult.success(DebugBreakpointList(emptyList())))
+    val history =
+        if (attached.capabilities.history().checkpointHistory()) attached.historyStatus()
+        else completedResult<DebugResult<DebugHistoryStatus>?>(null)
+    breakpoints.thenCombine(history) { breakpointResult, historyResult ->
+          MetadataResult(breakpointResult, historyResult)
+        }
+        .whenComplete { result, failure ->
+          dispatchSwingMutation {
+            if (!sameSession(token)) return@dispatchSwingMutation
+            metadataInFlight = false
+            if (token.epoch == windowEpoch && pollingActive) {
+              when {
+                failure != null -> showFailure("Metadata refresh", failure)
+                result == null -> statusLabel.text = "Metadata refresh returned no result"
+                result.breakpoints.isFailure -> showFailure("Breakpoint refresh", result.breakpoints)
+                else -> {
+                  breakpointModel.replace(
+                      result.breakpoints.value().breakpoints(),
+                      attached.capabilities,
+                  )
+                  val historyResult = result.history
+                  if (historyResult != null) {
+                    if (historyResult.isFailure) showFailure("History refresh", historyResult)
+                    else applyHistory(historyResult.value())
+                  } else {
+                    applyHistory(null)
+                  }
+                }
+              }
+            }
+            val repeat = metadataAgain && pollingActive
+            metadataAgain = false
+            updateControlState()
+            if (repeat) requestMetadata()
+          }
+        }
+  }
+
+  private fun applyHistory(status: DebugHistoryStatus?) {
+    historyStatus = status
+    val attached = client ?: return
+    val view = DebuggerPresentation.history(attached.capabilities, status)
+    historyLabel.text =
+        if (!attached.capabilities.history().checkpointHistory()) {
+          "Reverse history unsupported"
+        } else {
+          "History: ${if (view.enabled) "ON" else "OFF"}, ${view.checkpointCount} checkpoints, " +
+              "${view.futureCheckpointCount} future — ${view.cursor}"
+        }
+    updatingHistoryToggle = true
+    try {
+      historyToggle.isSelected = view.enabled
+    } finally {
+      updatingHistoryToggle = false
+    }
+  }
+
+  private fun pauseCommand() {
+    val attached = client ?: return
+    executeCommand("Pause", attached::pause) { value ->
+      value?.let(::applyCommandSnapshot)
+    }
+  }
+
+  private fun runCommand() {
+    val attached = client ?: return
+    executeCommand("Release debug pause", attached::resume) { value ->
+      value?.let(::applyCommandSnapshot)
+    }
+  }
+
+  private fun stepCommand(kind: DebugStepKind) {
+    val attached = client ?: return
+    executeCommand("Step ${kind.name.lowercase()}", { attached.step(kind) }) { value ->
+      value?.let {
+        applyCommandSnapshot(it.snapshot())
+        statusLabel.text =
+            "${it.kind()} step stopped at ${it.stopReason()} after ${it.ticksExecuted()} ticks"
+      }
+    }
+  }
+
+  private fun reverseCommand(kind: DebugStepKind) {
+    val attached = client ?: return
+    executeCommand("Reverse ${kind.name.lowercase()}", { attached.stepBackward(kind) }) { value ->
+      value?.let {
+        applyCommandSnapshot(it.snapshot())
+        applyHistory(it.history())
+        val outcome = DebuggerPresentation.reverseOutcome(DebugResult.success(it))
+        statusLabel.text = outcome.message
+      }
+    }
+  }
+
+  private fun configureHistory(enabled: Boolean) {
+    val attached = client ?: return
+    val capabilities = attached.capabilities.history()
+    val configuration =
+        if (!enabled) {
+          DebugHistoryConfiguration.disabled()
+        } else {
+          DebugHistoryConfiguration(
+              true,
+              minOf(DebugHistoryConfiguration.DEFAULT_MAX_FRAMES, capabilities.maxFrames()),
+              minOf(
+                  DebugHistoryConfiguration.DEFAULT_MEMORY_BUDGET_BYTES,
+                  capabilities.maxMemoryBudgetBytes(),
+              ),
+          )
+        }
+    executeCommand(
+        if (enabled) "Enable reverse history" else "Disable reverse history",
+        { attached.configureHistory(configuration) },
+    ) { value -> value?.let(::applyHistory) }
+  }
+
+  private fun selectMemoryRange() {
+    val attached = client ?: return
+    val parsed = DebuggerPresentation.parseAddressRange(memoryRange.text)
+    if (!parsed.isValid) {
+      statusLabel.text = parsed.error
+      return
+    }
+    val range = parsed.value!!
+    val available =
+        (attached.capabilities.maxInspectionBytes() - MAX_INSTRUCTION_BYTES - STACK_BYTES)
+            .coerceAtLeast(0)
+    if (range.length > available) {
+      statusLabel.text = "Memory range exceeds the $available-byte debugger view limit."
+      return
+    }
+    val request = range.memoryRequest(memorySpace.selectedItem as DebugAddressSpace)
+    val validation = validateMemoryRequest(request)
+    if (validation != null) {
+      statusLabel.text = validation
+      return
+    }
+    selectedMemory = request
+    statusLabel.text = "Memory range selected; refreshing coherent view"
+    requestRefresh()
+  }
+
+  private fun addBreakpoint() {
+    val attached = client ?: return
+    val editorKind = breakpointKind.selectedItem as BreakpointEditorKind
+    val parsed: DebuggerParsedValue<out DebugBreakpointCondition> =
+        if (editorKind == BreakpointEditorKind.PROGRAM_COUNTER) {
+          DebuggerPresentation.parseProgramCounterCondition(breakpointRange.text)
+        } else {
+          DebuggerPresentation.parseMemoryCondition(
+              breakpointRange.text,
+              editorKind.access!!,
+              breakpointValue.text,
+              breakpointMask.text,
+          )
+        }
+    if (!parsed.isValid) {
+      statusLabel.text = parsed.error
+      return
+    }
+    val condition = parsed.value!!
+    if (!attached.capabilities.supports(condition.kind())) {
+      statusLabel.text = "${condition.kind()} breakpoints are unsupported in this session."
+      return
+    }
+    if (breakpointModel.rowCount >= attached.capabilities.maxBreakpoints()) {
+      statusLabel.text = "The session breakpoint limit has been reached."
+      return
+    }
+    val id = breakpointModel.nextId()
+    val breakpoint = DebugBreakpoint(DebugBreakpointId(id), true, condition)
+    executeCommand("Add breakpoint $id", { attached.setBreakpoint(breakpoint) }) {}
+  }
+
+  private fun toggleBreakpoint(breakpoint: DebugBreakpoint, enabled: Boolean) {
+    val attached = client ?: return
+    if (commandInFlight || breakpoint.enabled() == enabled) return
+    executeCommand(
+        if (enabled) "Enable breakpoint ${breakpoint.id().value()}"
+        else "Disable breakpoint ${breakpoint.id().value()}",
+        { attached.setBreakpoint(breakpoint.withEnabled(enabled)) },
+    ) {}
+  }
+
+  private fun removeSelectedBreakpoint() {
+    val attached = client ?: return
+    val row = breakpointTable.selectedRow
+    if (row < 0) return
+    val modelRow = breakpointTable.convertRowIndexToModel(row)
+    val breakpoint = breakpointModel.breakpointAt(modelRow)
+    executeCommand(
+        "Remove breakpoint ${breakpoint.id().value()}",
+        { attached.removeBreakpoint(breakpoint.id()) },
+    ) {}
+  }
+
+  private fun updateBreakpointEditor() {
+    val memory = (breakpointKind.selectedItem as? BreakpointEditorKind)?.access != null
+    breakpointValue.isEnabled = memory
+    breakpointMask.isEnabled = memory
+    updateControlState()
+  }
+
+  private fun applyCommandSnapshot(value: DebugSnapshot) {
+    snapshot = value
+    val view = DebuggerPresentation.snapshot(value)
+    snapshotLabel.text =
+        "${view.identity.label} — ${if (view.paused) "PAUSED" else "RUNNING"} — ${view.timingText}"
+    registersArea.text = view.registers.render()
+    machineArea.text = renderMachine(value)
+  }
+
+  private fun <T> executeCommand(
+      label: String,
+      operation: () -> CompletionStage<DebugResult<T>>,
+      onSuccess: (T?) -> Unit,
+  ) {
+    requireDebuggerWindowEdt("Debugger command")
+    val attached = client ?: return
+    if (closed || commandInFlight) return
+    val token = token(attached)
+    commandInFlight = true
+    statusLabel.text = "$label…"
+    updateControlState()
+    val stage =
+        try {
+          operation()
+        } catch (failure: RuntimeException) {
+          commandInFlight = false
+          showFailure(label, failure)
+          updateControlState()
+          return
+        }
+    stage.whenComplete { result, failure ->
+      dispatchSwingMutation {
+        if (!sameSession(token)) return@dispatchSwingMutation
+        commandInFlight = false
+        if (token.epoch == windowEpoch && pollingActive) {
+          when {
+            failure != null -> showFailure(label, failure)
+            result == null -> statusLabel.text = "$label returned no result"
+            result.isFailure -> showFailure(label, result)
+            else -> {
+              lastAppliedStateRequestId = maxOf(lastAppliedStateRequestId, token.requestId)
+              onSuccess(result.value())
+              if (statusLabel.text == "$label…") statusLabel.text = "$label completed"
+              requestRefresh()
+              requestMetadata()
+            }
+          }
+        }
+        updateControlState()
+      }
+    }
+  }
+
+  private fun updateControlState() {
+    val attached = client
+    val capabilities = attached?.capabilities
+    val paused = snapshot?.paused() == true
+    val running = snapshot?.paused() == false
+    val usable = !closed && attached != null && !commandInFlight
+    runButton.isEnabled = usable && capabilities!!.pauseResume() && paused
+    pauseButton.isEnabled = usable && capabilities!!.pauseResume() && (running || snapshot == null)
+    stepInstructionButton.isEnabled = usable && paused && capabilities!!.instructionStep()
+    stepFrameButton.isEnabled = usable && paused && capabilities!!.frameStep()
+
+    val historyView =
+        capabilities?.let { DebuggerPresentation.history(it, historyStatus) }
+    backInstructionButton.isEnabled =
+        usable && paused && historyView?.reverseInstruction?.enabled == true
+    backInstructionButton.toolTipText = historyView?.reverseInstruction?.explanation
+    backFrameButton.isEnabled = usable && paused && historyView?.reverseFrame?.enabled == true
+    backFrameButton.toolTipText = historyView?.reverseFrame?.explanation
+    refreshButton.isEnabled =
+        !closed &&
+            attached != null &&
+            capabilities!!.coherentInspection() &&
+            pollingActive &&
+            !refreshInFlight
+    historyToggle.isEnabled =
+        usable && capabilities?.history()?.checkpointHistory() == true
+    memorySpace.isEnabled = usable && paused && capabilities?.coherentInspection() == true
+    memoryRange.isEnabled = usable && paused && capabilities?.coherentInspection() == true
+    memoryReadButton.isEnabled = usable && paused && capabilities?.coherentInspection() == true
+
+    val editorKind = breakpointKind.selectedItem as? BreakpointEditorKind
+    val editorSupported =
+        when {
+          editorKind == null || capabilities == null -> false
+          editorKind == BreakpointEditorKind.PROGRAM_COUNTER ->
+              capabilities.supports(DebugBreakpointKind.PROGRAM_COUNTER)
+          else -> capabilities.supports(DebugBreakpointKind.MEMORY)
+        }
+    breakpointKind.isEnabled = usable && capabilities?.breakpoints() == true
+    breakpointRange.isEnabled = usable && editorSupported
+    breakpointValue.isEnabled = usable && editorSupported && editorKind?.access != null
+    breakpointMask.isEnabled = usable && editorSupported && editorKind?.access != null
+    breakpointAddButton.isEnabled = usable && editorSupported
+    breakpointRemoveButton.isEnabled =
+        usable && capabilities?.breakpoints() == true && breakpointTable.selectedRow >= 0
+    breakpointTable.isEnabled = usable && capabilities?.breakpoints() == true
+  }
+
+  private fun clearSessionView() {
+    sessionLabel.text = "No emulation session"
+    snapshotLabel.text = "Waiting for a debug snapshot"
+    historyLabel.text = "Reverse history status unavailable"
+    registersArea.text = "No CPU state"
+    machineArea.text = "No machine state"
+    disassemblyArea.text = "No disassembly"
+    stackArea.text = "No stack"
+    memoryArea.text = "No memory"
+    updatingHistoryToggle = true
+    try {
+      historyToggle.isSelected = false
+    } finally {
+      updatingHistoryToggle = false
+    }
+  }
+
+  private fun releaseRetainedSessionState() {
+    snapshot = null
+    historyStatus = null
+    selectedMemory = null
+    snapshotOnlyRefreshPending = false
+    breakpointModel.replace(emptyList(), client?.capabilities)
+    snapshotLabel.text = "Debugger hidden; retained snapshot released"
+    historyLabel.text = "Debugger hidden; reverse-history state released"
+    registersArea.text = "Debugger hidden; CPU state released"
+    machineArea.text = "Debugger hidden; machine state released"
+    disassemblyArea.text = "Debugger hidden; disassembly released"
+    stackArea.text = "Debugger hidden; stack state released"
+    memoryArea.text = "Debugger hidden; memory view released"
+    updatingHistoryToggle = true
+    try {
+      historyToggle.isSelected = false
+    } finally {
+      updatingHistoryToggle = false
+    }
+    statusLabel.text = "Debugger hidden; retained state released"
+  }
+
+  private fun showFailure(operation: String, result: DebugResult<*>) {
+    val error = result.error()
+    statusLabel.text = "$operation failed — ${error.code()}: ${error.message()}"
+  }
+
+  private fun showFailure(operation: String, failure: Throwable) {
+    LOG.warn("Debugger operation failed unexpectedly: $operation", failure)
+    statusLabel.text = "$operation failed — unexpected internal error"
+  }
+
+  private fun token(attached: DebuggerClient): RequestToken =
+      RequestToken(windowEpoch, attached, attached.generation, nextRequestId++)
+
+  private fun sameSession(token: RequestToken): Boolean =
+      !closed && client === token.client && latestGeneration == token.generation
+
+  private fun syncPollingTimer() {
+    if (pollingActive && client?.capabilities?.coherentInspection() == true) {
+      pollingTimer.start()
+    } else {
+      pollingTimer.stop()
+    }
+  }
+
+  override fun close() {
+    requireDebuggerWindowEdt("Debugger panel disposal")
+    if (closed) return
+    closed = true
+    pollingActive = false
+    windowEpoch++
+    pollingTimer.stop()
+    client = null
+    snapshot = null
+    historyStatus = null
+    selectedMemory = null
+    snapshotOnlyRefreshPending = false
+    breakpointModel.replace(emptyList(), null)
+    clearSessionView()
+    statusLabel.text = "Debugger closed"
+    updateControlState()
+  }
+
+  private data class RequestToken(
+      val epoch: Long,
+      val client: DebuggerClient,
+      val generation: Long,
+      val requestId: Long,
+  )
+
+  private data class InspectionPlan(
+      val request: DebugInspectionRequest,
+      val codeIndex: Int?,
+      val stackIndex: Int?,
+      val includesExplicitMemory: Boolean,
+  )
+
+  private data class MetadataResult(
+      val breakpoints: DebugResult<DebugBreakpointList>,
+      val history: DebugResult<DebugHistoryStatus>?,
+  )
+
+  private companion object {
+    val LOG = LoggerFactory.getLogger(DebuggerPanel::class.java)
+    const val DEFAULT_POLLING_INTERVAL_MILLIS = 400
+    const val MAX_INSTRUCTION_BYTES = 3
+    const val STACK_BYTES = 16
+    const val NO_GENERATION = -1L
+    val SAFE_MEMORY_SPACES =
+        arrayOf(
+            DebugAddressSpace.SYSTEM_BUS,
+            DebugAddressSpace.ROM,
+            DebugAddressSpace.WORK_RAM,
+            DebugAddressSpace.HIGH_RAM,
+        )
+  }
+}
+
+internal enum class BreakpointEditorKind(
+    private val label: String,
+    val access: DebugMemoryAccess?,
+) {
+  PROGRAM_COUNTER("Program counter", null),
+  READ("Memory read", DebugMemoryAccess.READ),
+  WRITE("Memory write", DebugMemoryAccess.WRITE),
+  EXECUTE("Memory execute", DebugMemoryAccess.EXECUTE);
+
+  override fun toString(): String = label
+}
+
+internal class DebuggerBreakpointTableModel(
+    private val onToggle: (DebugBreakpoint, Boolean) -> Unit,
+) : AbstractTableModel() {
+  private var breakpoints: List<DebugBreakpoint> = emptyList()
+  private var rows: List<DebuggerBreakpointRow> = emptyList()
+
+  override fun getRowCount(): Int = rows.size
+
+  override fun getColumnCount(): Int = COLUMNS.size
+
+  override fun getColumnName(column: Int): String = COLUMNS[column]
+
+  override fun getColumnClass(columnIndex: Int): Class<*> =
+      if (columnIndex == 0) java.lang.Boolean::class.java else String::class.java
+
+  override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean =
+      columnIndex == 0 && rows[rowIndex].supported
+
+  override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+    val row = rows[rowIndex]
+    return when (columnIndex) {
+      0 -> row.enabled
+      1 -> row.id.toString()
+      2 -> row.kind
+      3 -> row.condition
+      else -> error("Unknown breakpoint column: $columnIndex")
+    }
+  }
+
+  override fun setValueAt(value: Any?, rowIndex: Int, columnIndex: Int) {
+    if (columnIndex != 0 || value !is Boolean) return
+    onToggle(breakpoints[rowIndex], value)
+  }
+
+  fun breakpointAt(row: Int): DebugBreakpoint = breakpoints[row]
+
+  fun nextId(): Long {
+    val maximum = breakpoints.maxOfOrNull { it.id().value() } ?: -1L
+    check(maximum < Long.MAX_VALUE) { "Breakpoint identifiers are exhausted" }
+    return maximum + 1
+  }
+
+  fun replace(values: List<DebugBreakpoint>, capabilities: DebugCapabilities?) {
+    breakpoints = values.toList()
+    rows = DebuggerPresentation.breakpointRows(breakpoints, capabilities)
+    fireTableDataChanged()
+  }
+
+  private companion object {
+    val COLUMNS = arrayOf("Enabled", "ID", "Kind", "Condition")
+  }
+}
+
+private fun debuggerTextArea(name: String, rows: Int, columns: Int): JTextArea =
+    JTextArea(rows, columns).apply {
+      isEditable = false
+      lineWrap = false
+      font = Font(Font.MONOSPACED, Font.PLAIN, font.size)
+      accessibleContext.accessibleName = name
+      caretPosition = 0
+    }
+
+private fun scroll(component: Component): JScrollPane = JScrollPane(component)
+
+private fun DebuggerRegisterView.render(): String =
+    """
+    A  $a    F  $f    AF $af
+    B  $b    C  $c    BC $bc
+    D  $d    E  $e    DE $de
+    H  $h    L  $l    HL $hl
+    SP $sp
+    PC $pc
+    Flags $compactFlags  ($flags)
+    """.trimIndent()
+
+private fun renderMachine(snapshot: DebugSnapshot): String {
+  val execution = snapshot.execution()
+  val interrupts = snapshot.interrupts()
+  val timer = snapshot.timer()
+  val ppu = snapshot.ppu()
+  val apu = snapshot.apu()
+  val mapper = snapshot.mapper()
+  return """
+    CPU       ${execution.cpuState()}  opcode=${execution.opcode()} cb=${execution.extendedOpcode()} cycle=${execution.machineCycle()}
+    Retired   ${execution.retiredInstructions()}  speed=${if (execution.doubleSpeed()) "double" else "normal"}  haltBug=${execution.haltBug()}
+    Interrupt IME=${interrupts.ime()} pending=${DebuggerPresentation.formatByte(interrupts.pendingFlags())} IF=${DebuggerPresentation.formatByte(interrupts.requestFlags())} IE=${DebuggerPresentation.formatByte(interrupts.enableFlags())}
+    Timer     DIV=${DebuggerPresentation.formatWord(timer.dividerCounter())} TIMA=${DebuggerPresentation.formatByte(timer.tima())} TMA=${DebuggerPresentation.formatByte(timer.tma())} TAC=${DebuggerPresentation.formatByte(timer.tac())}
+    PPU       ${ppu.mode()} LY=${ppu.line()} dot=${ppu.dot()} LCD=${if (ppu.lcdEnabled()) "on" else "off"}
+    APU       ${if (apu.enabled()) "on" else "off"} channels=${listOf(apu.channel1Enabled(), apu.channel2Enabled(), apu.channel3Enabled(), apu.channel4Enabled()).map { if (it) 1 else 0 }.joinToString("")}
+    Mapper    ${mapper.mapperId()} ROM bank=${mapper.romBank()} RAM bank=${mapper.ramBank()} RAM=${mapper.ramEnabled()}
+  """.trimIndent()
+}
+
+private fun DebuggerMemoryView.render(): String =
+    buildString {
+      append(identity.label)
+      append(" — ")
+      append(addressSpace)
+      append(" — ")
+      append(length)
+      append(" bytes\n")
+      coherenceExplanation?.let { append("WARNING: $it\n") }
+      rows.forEach { row ->
+        append(row.addressText)
+        append(": ")
+        append(row.hexText.padEnd(47))
+        append("  ")
+        append(row.asciiText)
+        append('\n')
+      }
+    }.trimEnd()
+
+private fun DebuggerStackView.render(): String =
+    if (!available) {
+      explanation!!
+    } else {
+      buildString {
+        append(identity.label)
+        append('\n')
+        entries.forEach { entry ->
+          append(if (entry.offset == 0) "SP -> " else "      ")
+          append(entry.addressText)
+          append("  ")
+          append(entry.valueText)
+          append('\n')
+        }
+        explanation?.let { append(it) }
+      }.trimEnd()
+    }
+
+private fun DebuggerCapabilityView.summary(): String =
+    buildList {
+          if (pauseResume) add("run control")
+          if (instructionStep) add("instruction step")
+          if (frameStep) add("frame step")
+          if (memoryRead) add("memory")
+          if (maxBreakpoints > 0) add("breakpoints")
+          if (reverseHistory) add("reverse history")
+        }
+        .ifEmpty { listOf("inspection unavailable") }
+        .joinToString(", ")
+
+private fun pcAnchoredLength(address: Int, maximum: Int): Int? {
+  val endExclusive =
+      when (address) {
+        in 0x0000..0x7fff -> 0x8000
+        in 0xc000..0xfdff -> 0xfe00
+        in 0xff80..0xfffe -> 0xffff
+        else -> return null
+      }
+  return minOf(maximum, endExclusive - address).takeIf { it > 0 }
+}
+
+private fun stackAnchoredLength(address: Int, maximum: Int): Int? {
+  val endExclusive =
+      when (address) {
+        in 0xc000..0xfdff -> 0xfe00
+        in 0xff80..0xfffe -> 0xffff
+        else -> return null
+      }
+  return minOf(maximum, endExclusive - address).takeIf { it > 0 }
+}
+
+private fun validateMemoryRequest(request: DebugMemoryRequest): String? {
+  val start = request.address()
+  val end = request.endExclusive()
+  val valid =
+      when (request.addressSpace()) {
+        DebugAddressSpace.ROM -> start >= 0 && end <= 0x10000
+        DebugAddressSpace.WORK_RAM -> start >= 0xc000 && end <= 0xfe00
+        DebugAddressSpace.HIGH_RAM -> start >= 0xff80 && end <= 0xffff
+        DebugAddressSpace.SYSTEM_BUS ->
+            start >= 0xc000 && end <= 0xfe00 || start >= 0xff80 && end <= 0xffff
+        else -> false
+      }
+  return if (valid) null
+  else "The selected range is outside this side-effect-free address-space view."
+}
+
+private fun <T> completedResult(value: T): CompletionStage<T> =
+    CompletableFuture.completedFuture(value).minimalCompletionStage()
+
+private fun requireDebuggerWindowEdt(operation: String) {
+  check(SwingUtilities.isEventDispatchThread()) {
+    "$operation must run on the Event Dispatch Thread"
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDebuggerController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDebuggerController.kt
@@ -1,0 +1,124 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.Controller
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.core.events.EventBus
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+
+/**
+ * A modeless debugger surface whose lifetime is owned by [DesktopDebuggerController].
+ *
+ * [close] disposes only view-owned resources; the emulation session retains ownership of every
+ * port supplied through [updateSession].
+ */
+internal interface DesktopDebuggerView : AutoCloseable {
+  /** Replaces or revokes the view's session-bound command port. */
+  fun updateSession(event: Controller.SessionDebugPortEvent)
+
+  /** Shows, raises, or reopens the retained modeless surface. */
+  fun showWindow()
+}
+
+/** Keeps the Swing owner explicit while allowing the lifecycle controller to be tested headlessly. */
+internal fun interface DesktopDebuggerViewFactory {
+  fun create(owner: JFrame): DesktopDebuggerView
+}
+
+/**
+ * EDT-owned bridge between session debug-port publication and the modeless desktop debugger.
+ *
+ * The controller retains at most one view. Closing the window hides it, so the Tools command can
+ * reopen the same surface. Session generations are monotonic and a revocation is terminal for its
+ * generation; delayed older publications therefore cannot resurrect a stopped or replaced port.
+ * The session owns [eu.rekawek.coffeegb.core.debug.DebugPort], so this class never closes one.
+ */
+internal class DesktopDebuggerController(
+    rootEventBus: EventBus,
+    private val createView: () -> DesktopDebuggerView,
+) : AutoCloseable {
+  private val eventBus: EventBus
+  private var latestGeneration = NO_GENERATION
+  private var currentSession: Controller.SessionDebugPortEvent? = null
+  private var view: DesktopDebuggerView? = null
+  private var closed = false
+
+  constructor(
+      owner: JFrame,
+      rootEventBus: EventBus,
+      viewFactory: DesktopDebuggerViewFactory,
+  ) : this(rootEventBus, { viewFactory.create(owner) })
+
+  init {
+    requireDebuggerEdt("Desktop debugger controller construction")
+    eventBus = rootEventBus.fork("desktop-debugger")
+    eventBus.register<Controller.SessionDebugPortEvent> { event ->
+      dispatchSwingMutation {
+        if (closed || !acceptSessionEvent(event)) return@dispatchSwingMutation
+        view?.updateSession(event)
+      }
+    }
+  }
+
+  fun showDebugger() {
+    requireDebuggerEdt("Desktop debugger opening")
+    if (closed) return
+    val target =
+        view
+            ?: createView().also { created ->
+              currentSession?.let(created::updateSession)
+              view = created
+            }
+    target.showWindow()
+  }
+
+  private fun acceptSessionEvent(event: Controller.SessionDebugPortEvent): Boolean {
+    val generation = event.generation
+    if (generation < 0 || generation < latestGeneration) return false
+
+    val port = event.debugPort
+    if (port != null && port.sessionGeneration() != generation) return false
+
+    if (generation == latestGeneration) {
+      val currentPort = currentSession?.debugPort
+      // Revocation is terminal. A late publication for the same generation must not resurrect it.
+      if (currentPort == null) return false
+      // A generation identifies one immutable command-port instance.
+      if (port != null) return false
+    }
+
+    latestGeneration = generation
+    currentSession = event
+    return true
+  }
+
+  override fun close() {
+    requireDebuggerEdt("Desktop debugger controller disposal")
+    if (closed) return
+    closed = true
+    currentSession = null
+
+    var failure: Exception? = null
+    try {
+      eventBus.close()
+    } catch (problem: Exception) {
+      failure = problem
+    }
+    try {
+      view?.close()
+    } catch (problem: Exception) {
+      failure?.addSuppressed(problem) ?: run { failure = problem }
+    } finally {
+      view = null
+    }
+    failure?.let { throw it }
+  }
+
+  private companion object {
+    const val NO_GENERATION = -1L
+  }
+}
+
+private fun requireDebuggerEdt(operation: String) {
+  check(SwingUtilities.isEventDispatchThread()) { "$operation must run on the Event Dispatch Thread" }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -88,6 +88,8 @@ class SwingGui private constructor(
 
   private lateinit var stateUxController: StateUxDesktopController
 
+  private lateinit var debuggerController: DesktopDebuggerController
+
   private lateinit var menu: SwingMenu
 
   private val desktopQuit = DesktopQuitBridge()
@@ -111,6 +113,7 @@ class SwingGui private constructor(
           // persistence failure or watchdog timeout retains a quiesced (not closed) ROM service.
           menu.closeCameraAfterSuccessfulStop(CAMERA_SHUTDOWN_BUDGET_MILLIS)
           romOpen.close()
+          runDesktopEdtStep(debuggerController::close)
           runDesktopEdtStep(stateUxController::close)
           console?.stop()
           closeDesktopSettingsRecoverably(
@@ -179,6 +182,12 @@ class SwingGui private constructor(
             eventBus,
             emulator::captureDisplayImage,
         )
+    debuggerController =
+        DesktopDebuggerController(
+            mainWindow,
+            eventBus,
+            DesktopDebuggerViewFactory { owner -> DebuggerWindow(owner) },
+        )
 
     romOpen =
         DesktopRomOpen(
@@ -207,6 +216,7 @@ class SwingGui private constructor(
             )
           },
           romOpen::close,
+          { runDesktopEdtStep(debuggerController::close) },
           { runDesktopEdtStep(windowSizeController::close) },
           properties::close,
           mobileAdapterConfiguration::close,
@@ -222,6 +232,7 @@ class SwingGui private constructor(
             romOpen::open,
             ::acceptRomLifecycle,
             ::showPreferences,
+            debuggerController::showDebugger,
             stateUxController::saveSlot,
             stateUxController::loadSlot,
             stateUxController::showBrowser,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -119,6 +119,7 @@ internal class SwingMenu(
     private val onOpenRom: (path: java.nio.file.Path, source: RomOpenSource) -> Unit,
     private val acceptRomLifecycle: (Long?) -> Boolean,
     private val onPreferences: () -> Unit,
+    private val onDebugger: () -> Unit,
     private val onSaveState: (slot: Int) -> Unit,
     private val onLoadState: (slot: Int) -> Unit,
     private val onManageStates: () -> Unit,
@@ -249,6 +250,7 @@ internal class SwingMenu(
     menuBar.add(createAudioMenu())
     menuBar.add(createPeripheralsMenu())
     menuBar.add(createLinkMenu())
+    menuBar.add(createToolsMenu(onDebugger))
     window.jMenuBar = menuBar
   }
 
@@ -1277,4 +1279,18 @@ internal fun createScreenMenu(
   }
 
   return screenMenu
+}
+
+/** Builds the always-available desktop tooling entry without depending on an active ROM. */
+internal fun createToolsMenu(onDebugger: () -> Unit): JMenu {
+  check(SwingUtilities.isEventDispatchThread()) {
+    "The Tools menu must be created on the Event Dispatch Thread"
+  }
+  val toolsMenu = JMenu("Tools")
+  val debugger = JMenuItem("Debugger")
+  debugger.accessibleContext.accessibleDescription =
+      "Open the modeless debugger for the current emulation session"
+  debugger.addActionListener { onDebugger() }
+  toolsMenu.add(debugger)
+  return toolsMenu
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPanelTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPanelTest.kt
@@ -1,0 +1,584 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugApuState
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugCpuState
+import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugExecutionState
+import eu.rekawek.coffeegb.core.debug.DebugFeatureState
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
+import eu.rekawek.coffeegb.core.debug.DebugInterruptState
+import eu.rekawek.coffeegb.core.debug.DebugMapperState
+import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.DebugPpuState
+import eu.rekawek.coffeegb.core.debug.DebugRegisters
+import eu.rekawek.coffeegb.core.debug.DebugResult
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot
+import eu.rekawek.coffeegb.core.debug.DebugStepKind
+import eu.rekawek.coffeegb.core.debug.DebugStepResult
+import eu.rekawek.coffeegb.core.debug.DebugTimerState
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryCapabilities
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryTruncationReason
+import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.FutureTask
+import javax.swing.SwingUtilities
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DebuggerPanelTest {
+
+  @Test
+  fun `older refresh completion cannot overwrite a newer pause command snapshot`() {
+    val client = RecordingDebuggerClient(1, capabilities())
+    val panel = attach(client)
+    try {
+      assertEquals(1, client.inspections.size)
+
+      onEdt { panel.pauseButton.doClick() }
+      assertEquals(1, client.pauses.size)
+      assertContains(onEdt { panel.statusLabel.text }, "Pause")
+
+      client.pauses.single().complete(DebugResult.success(snapshot(1, 2, paused = true)))
+      flushEdt()
+      assertContains(onEdt { panel.snapshotLabel.text }, "snapshot 2")
+      assertContains(onEdt { panel.snapshotLabel.text }, "PAUSED")
+
+      val oldRefresh = client.inspections.first()
+      oldRefresh.completion.complete(
+          DebugResult.success(inspection(oldRefresh.request, snapshot(1, 1, paused = false))))
+      flushEdt()
+
+      assertContains(onEdt { panel.snapshotLabel.text }, "snapshot 2")
+      assertContains(onEdt { panel.snapshotLabel.text }, "PAUSED")
+      assertEquals(2, client.inspections.size)
+      assertEquals(
+          listOf(DebugInspectionAnchor.PROGRAM_COUNTER, DebugInspectionAnchor.STACK_POINTER),
+          client.inspections.last().request.anchoredRequests().map { it.anchor() },
+      )
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `completion from a replaced client cannot clear or render over the new session`() {
+    val oldClient = RecordingDebuggerClient(4, capabilities())
+    val newClient = RecordingDebuggerClient(5, capabilities())
+    val panel = attach(oldClient)
+    try {
+      onEdt { panel.updateClient(5, newClient) }
+      assertEquals(1, oldClient.inspections.size)
+      assertEquals(1, newClient.inspections.size)
+
+      val oldRefresh = oldClient.inspections.single()
+      oldRefresh.completion.complete(
+          DebugResult.success(inspection(oldRefresh.request, snapshot(4, 99, paused = false))))
+      flushEdt()
+
+      assertContains(onEdt { panel.sessionLabel.text }, "Session 5")
+      assertFalse(onEdt { panel.snapshotLabel.text }.contains("snapshot 99"))
+      assertFalse(onEdt { panel.refreshButton.isEnabled })
+
+      val newRefresh = newClient.inspections.single()
+      newRefresh.completion.complete(
+          DebugResult.success(inspection(newRefresh.request, snapshot(5, 1, paused = false))))
+      flushEdt()
+
+      assertContains(onEdt { panel.snapshotLabel.text }, "Session 5, snapshot 1")
+      assertTrue(onEdt { panel.refreshButton.isEnabled })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `completion after hide cannot restore released session state`() {
+    val client = RecordingDebuggerClient(6, capabilities())
+    val panel = attach(client)
+    try {
+      val pending = client.inspections.single()
+      onEdt { panel.setPollingActive(false) }
+
+      completeInspection(pending, snapshot(6, 77, paused = true))
+      flushEdt()
+
+      assertContains(onEdt { panel.snapshotLabel.text }, "released")
+      assertFalse(onEdt { panel.snapshotLabel.text }.contains("snapshot 77"))
+      assertContains(onEdt { panel.registersArea.text }, "released")
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `unexpected failures do not expose exception details in the status view`() {
+    val client = RecordingDebuggerClient(7, capabilities())
+    val panel = attach(client)
+    try {
+      client.inspections.single().completion.completeExceptionally(
+          IllegalStateException("Sensitive path: /private/roms/game.gb"))
+      flushEdt()
+
+      assertContains(onEdt { panel.statusLabel.text }, "unexpected internal error")
+      assertFalse(onEdt { panel.statusLabel.text }.contains("/private/roms/game.gb"))
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `command completion gates controls and restores state after success or typed failure`() {
+    val client = RecordingDebuggerClient(7, capabilities())
+    val panel = attach(client)
+    try {
+      completeInspection(client.inspections.single(), snapshot(7, 1, paused = false))
+      flushEdt()
+      assertTrue(onEdt { panel.pauseButton.isEnabled })
+      assertFalse(onEdt { panel.runButton.isEnabled })
+
+      onEdt { panel.pauseButton.doClick() }
+      assertEquals(1, client.pauses.size)
+      assertFalse(onEdt { panel.pauseButton.isEnabled })
+      assertFalse(onEdt { panel.runButton.isEnabled })
+      assertFalse(onEdt { panel.stepInstructionButton.isEnabled })
+
+      client.pauses.single().complete(DebugResult.success(snapshot(7, 2, paused = true)))
+      flushEdt()
+      assertContains(onEdt { panel.snapshotLabel.text }, "snapshot 2")
+      assertContains(onEdt { panel.snapshotLabel.text }, "PAUSED")
+      assertTrue(onEdt { panel.runButton.isEnabled })
+      assertFalse(onEdt { panel.pauseButton.isEnabled })
+      assertTrue(onEdt { panel.stepInstructionButton.isEnabled })
+      assertEquals("Pause completed", onEdt { panel.statusLabel.text })
+
+      onEdt { panel.runButton.doClick() }
+      assertEquals(1, client.resumes.size)
+      assertFalse(onEdt { panel.runButton.isEnabled })
+      client.resumes.single().complete(
+          DebugResult.failure(DebugErrorCode.ALREADY_RUNNING, "Injected command failure"))
+      flushEdt()
+
+      assertContains(onEdt { panel.statusLabel.text }, "ALREADY_RUNNING")
+      assertContains(onEdt { panel.statusLabel.text }, "Injected command failure")
+      assertTrue(onEdt { panel.runButton.isEnabled })
+      assertFalse(onEdt { panel.pauseButton.isEnabled })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `inspection planning reserves anchored bytes inside the negotiated aggregate bound`() {
+    val client = RecordingDebuggerClient(8, capabilities(maxInspectionBytes = 256))
+    val panel = attach(client)
+    try {
+      completeInspection(client.inspections.single(), snapshot(8, 1, paused = true))
+      flushEdt()
+      assertEquals(2, client.inspections.size)
+
+      completeInspection(client.inspections.last(), snapshot(8, 2, paused = true))
+      flushEdt()
+      assertEquals(2, client.inspections.size)
+
+      onEdt {
+        panel.memoryRange.text = "\$C000-\$C0FF"
+        panel.memoryReadButton.doClick()
+      }
+      assertEquals(2, client.inspections.size)
+      assertContains(onEdt { panel.statusLabel.text }, "237-byte")
+
+      onEdt {
+        panel.memoryRange.text = "\$C000-\$C0EC"
+        panel.memoryReadButton.doClick()
+      }
+      assertEquals(3, client.inspections.size)
+      val request = client.inspections.last().request
+      assertEquals(3, request.blockCount())
+      assertEquals(256, request.totalBytes())
+      assertEquals(237, request.memoryRequests().single().length())
+      assertTrue(request.blockCount() <= client.capabilities.maxInspectionBlocks())
+      assertTrue(request.totalBytes() <= client.capabilities.maxInspectionBytes())
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `polling does not submit inspection when coherent inspection is unavailable`() {
+    val client = RecordingDebuggerClient(9, capabilities(coherentInspection = false))
+    val panel = attach(client)
+    try {
+      assertTrue(client.inspections.isEmpty())
+      assertFalse(onEdt { panel.refreshButton.isEnabled })
+      assertContains(onEdt { panel.sessionLabel.text }, "inspection unavailable")
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `unsafe stack pointer is omitted without losing the coherent CPU snapshot`() {
+    val client = RecordingDebuggerClient(10, capabilities())
+    val panel = attach(client)
+    try {
+      completeInspection(client.inspections.single(), snapshot(10, 1, paused = true, sp = 0x100))
+      flushEdt()
+
+      assertEquals(2, client.inspections.size)
+      val request = client.inspections.last().request
+      assertEquals(
+          listOf(DebugInspectionAnchor.PROGRAM_COUNTER),
+          request.anchoredRequests().map { it.anchor() },
+      )
+
+      completeInspection(client.inspections.last(), snapshot(10, 2, paused = true, sp = 0x100))
+      flushEdt()
+      assertContains(onEdt { panel.snapshotLabel.text }, "snapshot 2")
+      assertContains(onEdt { panel.stackArea.text }, "unavailable")
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `register boundary race retries through a snapshot-only inspection`() {
+    val client = RecordingDebuggerClient(11, capabilities())
+    val panel = attach(client)
+    try {
+      completeInspection(client.inspections.single(), snapshot(11, 1, paused = true))
+      flushEdt()
+
+      val staleAnchoredCall = client.inspections.last()
+      assertTrue(staleAnchoredCall.request.anchoredRequests().isNotEmpty())
+      staleAnchoredCall.completion.complete(
+          DebugResult.failure(
+              DebugErrorCode.SIDE_EFFECTFUL_ADDRESS,
+              "Registers crossed a safe inspection boundary",
+          ))
+      flushEdt()
+
+      assertEquals(3, client.inspections.size)
+      val snapshotOnlyCall = client.inspections.last()
+      assertEquals(0, snapshotOnlyCall.request.blockCount())
+
+      completeInspection(
+          snapshotOnlyCall,
+          snapshot(11, 2, paused = true, pc = 0x7fff, sp = 0x100),
+      )
+      flushEdt()
+
+      assertEquals(4, client.inspections.size)
+      val replanned = client.inspections.last().request
+      assertEquals(1, replanned.anchoredRequests().size)
+      assertEquals(DebugInspectionAnchor.PROGRAM_COUNTER, replanned.anchoredRequests().single().anchor())
+      assertEquals(1, replanned.anchoredRequests().single().length())
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `hiding releases rendered debug state before the retained window can reopen`() {
+    val client = RecordingDebuggerClient(12, capabilities())
+    val panel = attach(client)
+    try {
+      completeInspection(client.inspections.single(), snapshot(12, 1, paused = true))
+      flushEdt()
+      completeInspection(client.inspections.last(), snapshot(12, 2, paused = true))
+      flushEdt()
+      assertContains(onEdt { panel.snapshotLabel.text }, "snapshot 2")
+
+      onEdt { panel.setPollingActive(false) }
+
+      assertContains(onEdt { panel.snapshotLabel.text }, "released")
+      assertContains(onEdt { panel.registersArea.text }, "released")
+      assertContains(onEdt { panel.memoryArea.text }, "released")
+      assertFalse(onEdt { panel.snapshotLabel.text }.contains("snapshot 2"))
+      assertFalse(onEdt { panel.refreshButton.isEnabled })
+      assertEquals(0, onEdt { panel.breakpointModel.rowCount })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `running to paused transition and manual refresh reload reverse metadata`() {
+    val client = RecordingDebuggerClient(13, capabilities(history = true))
+    val panel = attach(client)
+    try {
+      assertEquals(1, client.historyRequests.size)
+      client.historyRequests.single().complete(DebugResult.success(emptyHistoryStatus()))
+      completeInspection(client.inspections.single(), snapshot(13, 1, paused = false))
+      flushEdt()
+
+      onEdt { panel.requestRefresh() }
+      completeInspection(client.inspections.last(), snapshot(13, 2, paused = true))
+      flushEdt()
+      assertEquals(2, client.historyRequests.size)
+
+      client.historyRequests.last().complete(DebugResult.success(emptyHistoryStatus()))
+      completeInspection(client.inspections.last(), snapshot(13, 3, paused = true))
+      flushEdt()
+      onEdt { panel.refreshButton.doClick() }
+      assertEquals(3, client.historyRequests.size)
+      assertEquals(4, client.inspections.size)
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `history toggle keeps authoritative state when configuration fails`() {
+    val client = RecordingDebuggerClient(14, capabilities(history = true))
+    val panel = attach(client)
+    try {
+      client.historyRequests.single().complete(DebugResult.success(emptyHistoryStatus()))
+      flushEdt()
+      assertFalse(onEdt { panel.historyToggle.isSelected })
+
+      onEdt { panel.historyToggle.doClick() }
+
+      assertEquals(1, client.historyConfigurations.size)
+      assertTrue(client.historyConfigurations.single().configuration.enabled())
+      assertFalse(onEdt { panel.historyToggle.isSelected })
+
+      client.historyConfigurations.single().completion.complete(
+          DebugResult.failure(
+              DebugErrorCode.UNSUPPORTED_TOPOLOGY,
+              "Injected history configuration failure",
+          ))
+      flushEdt()
+
+      assertFalse(onEdt { panel.historyToggle.isSelected })
+      assertContains(onEdt { panel.statusLabel.text }, "UNSUPPORTED_TOPOLOGY")
+      assertContains(onEdt { panel.statusLabel.text }, "Injected history configuration failure")
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  private fun attach(client: RecordingDebuggerClient): DebuggerPanel =
+      onEdt {
+        DebuggerPanel(
+                clientFactory = { error("DebugPort factory is not used by this test") },
+                pollingIntervalMillis = 60_000,
+            )
+            .also { panel ->
+              panel.updateClient(client.generation, client)
+              panel.setPollingActive(true)
+            }
+      }
+
+  private fun completeInspection(call: InspectionCall, snapshot: DebugSnapshot) {
+    call.completion.complete(DebugResult.success(inspection(call.request, snapshot)))
+  }
+
+  private fun inspection(
+      request: DebugInspectionRequest,
+      snapshot: DebugSnapshot,
+  ): DebugInspectionResult {
+    val anchored =
+        request.anchoredRequests().map { anchored ->
+          val resolved = anchored.resolve(snapshot)
+          memoryBlock(resolved.addressSpace(), resolved.address(), resolved.length())
+        }
+    val memory =
+        request.memoryRequests().map { range ->
+          memoryBlock(range.addressSpace(), range.address(), range.length())
+        }
+    return DebugInspectionResult(snapshot, request, anchored, memory)
+  }
+
+  private fun memoryBlock(
+      addressSpace: DebugAddressSpace,
+      address: Int,
+      length: Int,
+  ): DebugMemoryBlock =
+      DebugMemoryBlock(
+          addressSpace,
+          address,
+          ByteArray(length) { index -> if (index == 0) 0 else index.toByte() },
+      )
+
+  private fun snapshot(
+      generation: Long,
+      sequence: Long,
+      paused: Boolean,
+      pc: Int = 0x100,
+      sp: Int = 0xc000,
+  ): DebugSnapshot =
+      DebugSnapshot(
+          generation,
+          sequence,
+          sequence * 10,
+          sequence,
+          0,
+          paused,
+          DebugRegisters(0x12, 0xb0, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, sp, pc),
+          DebugInterruptState(true, false, 0x01, 0x01, 0x01),
+          DebugTimerState(0x1234, 0x10, 0x20, 0x04, false, 0),
+          DebugPpuState(
+              true,
+              DebugPpuMode.OAM_SEARCH,
+              0,
+              0,
+              0x91,
+              0x82,
+              0,
+              0,
+              0,
+              0,
+              0,
+          ),
+          DebugApuState(true, 0, false, false, false, false, 0, 0, 0x80),
+          DebugMapperState(
+              "test",
+              -1,
+              -1,
+              DebugFeatureState.UNKNOWN,
+              DebugFeatureState.UNKNOWN,
+              DebugFeatureState.UNKNOWN,
+          ),
+          DebugExecutionState(DebugCpuState.OPCODE_FETCH, 0, -1, 0, false, false, sequence),
+      )
+
+  private fun capabilities(
+      maxInspectionBytes: Int = 4096,
+      coherentInspection: Boolean = true,
+      history: Boolean = false,
+  ): DebugCapabilities =
+      if (coherentInspection) {
+        DebugCapabilities(
+            true,
+            true,
+            true,
+            false,
+            true,
+            true,
+            true,
+            maxInspectionBytes,
+            emptySet(),
+            0,
+            emptySet(),
+            0,
+            0,
+            if (history) {
+              DebugHistoryCapabilities(
+                  true,
+                  true,
+                  true,
+                  DebugHistoryConfiguration.DEFAULT_MAX_FRAMES,
+                  DebugHistoryConfiguration.DEFAULT_MEMORY_BUDGET_BYTES,
+              )
+            } else {
+              DebugHistoryCapabilities.disabled()
+            },
+        )
+      } else {
+        DebugCapabilities(false, false, false, false, false, false, false, 0)
+      }
+
+  private fun emptyHistoryStatus(): DebugHistoryStatus =
+      DebugHistoryStatus(
+          DebugHistoryConfiguration.disabled(),
+          0,
+          0L,
+          0L,
+          null,
+          null,
+          null,
+          0,
+          DebugHistoryTruncationReason.NONE,
+      )
+
+  private fun flushEdt() {
+    onEdt { Unit }
+  }
+
+  private fun <T> onEdt(action: () -> T): T {
+    if (SwingUtilities.isEventDispatchThread()) return action()
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+
+  private data class InspectionCall(
+      val request: DebugInspectionRequest,
+      val completion: CompletableFuture<DebugResult<DebugInspectionResult>>,
+  )
+
+  private data class HistoryConfigurationCall(
+      val configuration: DebugHistoryConfiguration,
+      val completion: CompletableFuture<DebugResult<DebugHistoryStatus>>,
+  )
+
+  private class RecordingDebuggerClient(
+      override val generation: Long,
+      override val capabilities: DebugCapabilities,
+  ) : DebuggerClient {
+    val inspections = mutableListOf<InspectionCall>()
+    val pauses = mutableListOf<CompletableFuture<DebugResult<DebugSnapshot>>>()
+    val resumes = mutableListOf<CompletableFuture<DebugResult<DebugSnapshot>>>()
+    val historyRequests = mutableListOf<CompletableFuture<DebugResult<DebugHistoryStatus>>>()
+    val historyConfigurations = mutableListOf<HistoryConfigurationCall>()
+
+    override fun inspect(
+        request: DebugInspectionRequest
+    ): CompletionStage<DebugResult<DebugInspectionResult>> =
+        CompletableFuture<DebugResult<DebugInspectionResult>>().also { completion ->
+          inspections += InspectionCall(request, completion)
+        }
+
+    override fun pause(): CompletionStage<DebugResult<DebugSnapshot>> =
+        CompletableFuture<DebugResult<DebugSnapshot>>().also(pauses::add)
+
+    override fun resume(): CompletionStage<DebugResult<DebugSnapshot>> =
+        CompletableFuture<DebugResult<DebugSnapshot>>().also(resumes::add)
+
+    override fun step(kind: DebugStepKind): CompletionStage<DebugResult<DebugStepResult>> =
+        unsupported()
+
+    override fun stepBackward(
+        kind: DebugStepKind
+    ): CompletionStage<DebugResult<DebugReverseStepResult>> = unsupported()
+
+    override fun configureHistory(
+        configuration: DebugHistoryConfiguration
+    ): CompletionStage<DebugResult<DebugHistoryStatus>> =
+        CompletableFuture<DebugResult<DebugHistoryStatus>>().also { completion ->
+          historyConfigurations += HistoryConfigurationCall(configuration, completion)
+        }
+
+    override fun historyStatus(): CompletionStage<DebugResult<DebugHistoryStatus>> =
+        CompletableFuture<DebugResult<DebugHistoryStatus>>().also(historyRequests::add)
+
+    override fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>> =
+        CompletableFuture.completedFuture(DebugResult.success(DebugBreakpointList(emptyList())))
+
+    override fun setBreakpoint(
+        breakpoint: DebugBreakpoint
+    ): CompletionStage<DebugResult<DebugBreakpoint>> = unsupported()
+
+    override fun removeBreakpoint(
+        breakpointId: DebugBreakpointId
+    ): CompletionStage<DebugResult<Void>> = unsupported()
+
+    private fun <T> unsupported(): CompletionStage<DebugResult<T>> =
+        CompletableFuture.completedFuture(
+            DebugResult.failure(DebugErrorCode.UNSUPPORTED_TOPOLOGY, "Unsupported in panel test"))
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPresentationTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPresentationTest.kt
@@ -1,0 +1,482 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
+import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
+import eu.rekawek.coffeegb.core.debug.DebugApuState
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugCpuState
+import eu.rekawek.coffeegb.core.debug.DebugErrorCode
+import eu.rekawek.coffeegb.core.debug.DebugExecutionState
+import eu.rekawek.coffeegb.core.debug.DebugFeatureState
+import eu.rekawek.coffeegb.core.debug.DebugInterruptState
+import eu.rekawek.coffeegb.core.debug.DebugInspectionAnchor
+import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
+import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
+import eu.rekawek.coffeegb.core.debug.DebugMapperState
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.DebugPpuState
+import eu.rekawek.coffeegb.core.debug.DebugRegisters
+import eu.rekawek.coffeegb.core.debug.DebugResult
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot
+import eu.rekawek.coffeegb.core.debug.DebugStepKind
+import eu.rekawek.coffeegb.core.debug.DebugTimerState
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugMemoryCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPpuCondition
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryCapabilities
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryPoint
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryPosition
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryTruncationReason
+import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult
+import java.util.EnumSet
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DebuggerPresentationTest {
+
+  @Test
+  fun `address and inclusive range parsers accept conventional hexadecimal forms`() {
+    assertEquals(0xc000, DebuggerPresentation.parseAddress("  ${'$'}c000 ").value)
+    assertEquals(0xffff, DebuggerPresentation.parseAddress("0xFFFF").value)
+    assertEquals(0x1234, DebuggerPresentation.parseAddress("1234").value)
+
+    val range = DebuggerPresentation.parseAddressRange("${'$'}C000 .. 0xC0ff").value
+    assertNotNull(range)
+    assertEquals(0xc000, range.startAddress)
+    assertEquals(0xc0ff, range.endAddress)
+    assertEquals(0x100, range.length)
+    assertFalse(range.isExact)
+    assertEquals(0x100, range.memoryRequest(DebugAddressSpace.SYSTEM_BUS).length())
+
+    val exact = DebuggerPresentation.parseAddressRange("42").value
+    assertNotNull(exact)
+    assertTrue(exact.isExact)
+    assertEquals(0x42, exact.startAddress)
+  }
+
+  @Test
+  fun `address and byte parsers return stable display errors instead of throwing`() {
+    val malformed = DebuggerPresentation.parseAddress("0x10000")
+    val descending = DebuggerPresentation.parseAddressRange("${'$'}C100-${'$'}C000")
+    val badByte = DebuggerPresentation.parseByte("100")
+
+    assertFalse(malformed.isValid)
+    assertContains(malformed.error!!, "16-bit")
+    assertFalse(descending.isValid)
+    assertContains(descending.error!!, "must not precede")
+    assertFalse(badByte.isValid)
+    assertContains(badByte.error!!, "8-bit")
+  }
+
+  @Test
+  fun `condition parsers create typed immutable breakpoint conditions`() {
+    val pc = DebuggerPresentation.parseProgramCounterCondition("100-10f").value
+    assertEquals(DebugPcCondition.range(0x100, 0x10f), pc)
+
+    val memory =
+        DebuggerPresentation.parseMemoryCondition(
+                "${'$'}C000:${'$'}C0FF",
+                DebugMemoryAccess.WRITE,
+                valueText = "a5",
+                maskText = "f0",
+            )
+            .value
+    assertNotNull(memory)
+    assertEquals(0xc000, memory.startAddress())
+    assertEquals(0xc0ff, memory.endAddress())
+    assertEquals(0xa5, memory.value())
+    assertEquals(0xf0, memory.valueMask())
+
+    val maskWithoutValue =
+        DebuggerPresentation.parseMemoryCondition(
+            "c000",
+            DebugMemoryAccess.READ,
+            maskText = "ff",
+        )
+    val zeroMask =
+        DebuggerPresentation.parseMemoryCondition(
+            "c000",
+            DebugMemoryAccess.READ,
+            valueText = "1",
+            maskText = "0",
+        )
+    assertContains(maskWithoutValue.error!!, "value is required")
+    assertContains(zeroMask.error!!, "at least one set bit")
+  }
+
+  @Test
+  fun `hex flags and register presentation are fixed width and accessible`() {
+    assertEquals("${'$'}00", DebuggerPresentation.formatByte(0))
+    assertEquals("${'$'}ABCD", DebuggerPresentation.formatWord(0xabcd))
+    assertEquals("Z=1 N=0 H=1 C=0", DebuggerPresentation.formatFlags(0xa0))
+    assertEquals("Z-H-", DebuggerPresentation.formatCompactFlags(0xa0))
+
+    val view = DebuggerPresentation.snapshot(snapshot(sp = 0xfffe))
+    assertEquals(DebuggerSnapshotIdentity(7, 11, 250), view.identity)
+    assertEquals("Session 7, snapshot 11, tick 250", view.identity.label)
+    assertEquals("${'$'}12A0", view.registers.af)
+    assertEquals("${'$'}FFFE", view.registers.sp)
+    assertEquals("${'$'}CB ${'$'}11", view.opcode)
+    assertContains(view.timingText, "Frame 2")
+  }
+
+  @Test
+  fun `breakpoint rows preserve identity state support and readable conditions`() {
+    val breakpoints =
+        listOf(
+            DebugBreakpoint(
+                DebugBreakpointId(3),
+                true,
+                DebugMemoryCondition(DebugMemoryAccess.WRITE, 0xc000, 0xc0ff, 0xa0, 0xf0),
+            ),
+            DebugBreakpoint(DebugBreakpointId(4), false, DebugPcCondition.at(0x150)),
+            DebugBreakpoint(
+                DebugBreakpointId(5),
+                true,
+                DebugPpuCondition.at(2, 42, DebugPpuMode.HBLANK),
+            ),
+        )
+    val rows = DebuggerPresentation.breakpointRows(breakpoints, pcOnlyCapabilities())
+
+    assertEquals(3L, rows[0].id)
+    assertFalse(rows[0].supported)
+    assertEquals("Write ${'$'}C000-${'$'}C0FF, value ${'$'}A0, mask ${'$'}F0", rows[0].condition)
+    assertContains(rows[0].accessibilityText, "unsupported in this session")
+    assertTrue(rows[1].supported)
+    assertFalse(rows[1].enabled)
+    assertEquals("${'$'}0150", rows[1].condition)
+    assertEquals("frame 2, LY 42, mode Hblank", rows[2].condition)
+  }
+
+  @Test
+  fun `memory rows are detached display values and explicitly report coherence`() {
+    val expected = DebuggerSnapshotIdentity(7, 11, 250)
+    val block =
+        DebugMemoryBlock(
+            DebugAddressSpace.SYSTEM_BUS,
+            0xc000,
+            byteArrayOf(0x41, 0x7f, 0x20, 0xff.toByte()),
+        )
+    val coherent =
+        DebuggerPresentation.memory(expected, DebuggerMemoryCapture(expected, block), bytesPerRow = 2)
+    assertEquals(DebuggerMemoryCoherence.COHERENT, coherent.coherence)
+    assertNull(coherent.coherenceExplanation)
+    assertEquals("41 7F", coherent.rows[0].hexText)
+    assertEquals("A.", coherent.rows[0].asciiText)
+    assertEquals(listOf(0x20, 0xff), coherent.rows[1].bytes)
+    assertFailsWith<UnsupportedOperationException> {
+      (coherent.rows as MutableList).clear()
+    }
+    assertFailsWith<UnsupportedOperationException> {
+      (coherent.rows[0].bytes as MutableList).clear()
+    }
+
+    val stale =
+        DebuggerPresentation.memory(
+            expected,
+            DebuggerMemoryCapture(expected.copy(sequence = 10), block),
+        )
+    assertEquals(DebuggerMemoryCoherence.STALE_SNAPSHOT, stale.coherence)
+    assertContains(stale.coherenceExplanation!!, "different snapshot")
+
+    val replaced =
+        DebuggerPresentation.memory(
+            expected,
+            DebuggerMemoryCapture(expected.copy(sessionGeneration = 6), block),
+        )
+    assertEquals(DebuggerMemoryCoherence.DIFFERENT_SESSION, replaced.coherence)
+  }
+
+  @Test
+  fun `stack view explains unavailable reads and clips safely at address-space end`() {
+    val snapshot = snapshot(sp = 0xfffe)
+    val identity = DebuggerSnapshotIdentity.from(snapshot)
+    val noMemory =
+        DebuggerPresentation.stack(snapshot, capabilities(memoryRead = false), null, 4)
+    assertFalse(noMemory.available)
+    assertContains(noMemory.explanation!!, "does not support memory reads")
+
+    val stale =
+        DebuggerPresentation.stack(
+            snapshot,
+            capabilities(),
+            DebuggerMemoryCapture(
+                identity.copy(sequence = identity.sequence - 1),
+                DebugMemoryBlock(
+                    DebugAddressSpace.SYSTEM_BUS,
+                    0xfffe,
+                    byteArrayOf(1, 2),
+                ),
+            ),
+            4,
+        )
+    assertFalse(stale.available)
+    assertContains(stale.explanation!!, "different snapshot")
+
+    val clipped =
+        DebuggerPresentation.stack(
+            snapshot,
+            capabilities(),
+            DebuggerMemoryCapture(
+                identity,
+                DebugMemoryBlock(
+                    DebugAddressSpace.SYSTEM_BUS,
+                    0xfffe,
+                    byteArrayOf(0x34, 0x12),
+                ),
+            ),
+            4,
+        )
+    assertTrue(clipped.available)
+    assertTrue(clipped.clipped)
+    assertContains(clipped.explanation!!, "16-bit address space")
+    assertEquals(listOf("${'$'}FFFE", "${'$'}FFFF"), clipped.entries.map { it.addressText })
+    assertEquals(listOf("${'$'}34", "${'$'}12"), clipped.entries.map { it.valueText })
+  }
+
+  @Test
+  fun `stack distinguishes an incomplete response from an unsupported stack`() {
+    val snapshot = snapshot(sp = 0xc000)
+    val identity = DebuggerSnapshotIdentity.from(snapshot)
+    val stack =
+        DebuggerPresentation.stack(
+            snapshot,
+            capabilities(),
+            DebuggerMemoryCapture(
+                identity,
+                DebugMemoryBlock(DebugAddressSpace.SYSTEM_BUS, 0xc000, byteArrayOf(1, 2)),
+            ),
+            requestedBytes = 4,
+        )
+
+    assertTrue(stack.available)
+    assertTrue(stack.clipped)
+    assertContains(stack.explanation!!, "returned memory block")
+  }
+
+  @Test
+  fun `inspection overloads derive coherent memory and stack identity without caller tagging`() {
+    val snapshot = snapshot(sp = 0xc000)
+    val stackBlock =
+        DebugMemoryBlock(DebugAddressSpace.SYSTEM_BUS, 0xc000, byteArrayOf(0x34, 0x12))
+    val inspection =
+        DebugInspectionResult(
+            snapshot,
+            DebugInspectionRequest(
+                listOf(
+                    DebugAnchoredMemoryRequest(DebugInspectionAnchor.STACK_POINTER, 0, 2)
+                ),
+                emptyList(),
+            ),
+            listOf(stackBlock),
+            emptyList(),
+        )
+
+    val memory = DebuggerPresentation.memory(inspection, stackBlock)
+    val stack = DebuggerPresentation.stack(inspection, capabilities(), requestedBytes = 2)
+
+    assertEquals(DebuggerSnapshotIdentity.from(snapshot), memory.identity)
+    assertEquals(DebuggerMemoryCoherence.COHERENT, memory.coherence)
+    assertTrue(stack.available)
+    assertFalse(stack.clipped)
+    assertEquals(listOf("${'$'}34", "${'$'}12"), stack.entries.map { it.valueText })
+  }
+
+  @Test
+  fun `history actions distinguish unsupported disabled exhausted and available states`() {
+    val unsupported = DebuggerPresentation.history(capabilities(history = false), null)
+    assertFalse(unsupported.reverseFrame.enabled)
+    assertContains(unsupported.reverseFrame.explanation!!, "unsupported")
+
+    val available = DebuggerPresentation.history(capabilities(), historyStatus())
+    assertTrue(available.enabled)
+    assertEquals(3, available.checkpointCount)
+    assertEquals(1, available.futureCheckpointCount)
+    assertEquals("User rewind", available.truncation)
+    assertTrue(available.reverseFrame.enabled)
+    assertTrue(available.reverseInstruction.enabled)
+    assertContains(available.cursor, "position 12")
+
+    val atOldest =
+        historyStatus(
+            cursor = DebugHistoryPosition(100, 1, 0),
+            futureCheckpointCount = 2,
+        )
+    val exhausted = DebuggerPresentation.history(capabilities(), atOldest)
+    assertFalse(exhausted.reverseFrame.enabled)
+    assertFalse(exhausted.reverseInstruction.enabled)
+    assertContains(exhausted.reverseFrame.explanation!!, "oldest retained frame")
+
+    val insideOldestFrame =
+        DebuggerPresentation.history(
+            capabilities(),
+            historyStatus(
+                cursor = DebugHistoryPosition(150, 1, 50),
+                futureCheckpointCount = 2,
+            ),
+        )
+    assertTrue(insideOldestFrame.reverseFrame.enabled)
+  }
+
+  @Test
+  fun `reverse outcomes preserve coherent snapshot identity and present failures`() {
+    val status = historyStatus()
+    val result =
+        DebugReverseStepResult(
+            DebugStepKind.INSTRUCTION,
+            status.cursor,
+            DebugHistoryPoint(2, 200, 2),
+            snapshot(sp = 0xc000),
+            status,
+        )
+    val success = DebuggerPresentation.reverseOutcome(DebugResult.success(result))
+    assertTrue(success.completed)
+    val step = assertNotNull(success.step)
+    assertEquals(DebuggerSnapshotIdentity(7, 11, 250), step.identity)
+    assertContains(step.replayAnchor, "Checkpoint 2")
+    assertEquals(1, step.futureCheckpointCount)
+    assertNull(success.errorCode)
+
+    val failure =
+        DebuggerPresentation.reverseOutcome(
+            DebugResult.failure(DebugErrorCode.HISTORY_EXHAUSTED, "No earlier instruction retained")
+        )
+    assertFalse(failure.completed)
+    assertNull(failure.step)
+    assertEquals("HISTORY_EXHAUSTED", failure.errorCode)
+    assertEquals("No earlier instruction retained", failure.message)
+  }
+
+  @Test
+  fun `capability view exposes negotiated limits without inventing support`() {
+    val view = DebuggerPresentation.capabilities(pcOnlyCapabilities())
+    assertTrue(view.pauseResume)
+    assertEquals(256, view.maxMemoryReadLength)
+    assertTrue(view.coherentInspection)
+    assertEquals(16, view.maxInspectionBlocks)
+    assertEquals(256, view.maxInspectionBytes)
+    assertEquals(listOf("Program counter"), view.breakpointKinds)
+    assertEquals(8, view.maxBreakpoints)
+    assertFalse(view.reverseHistory)
+  }
+
+  private fun snapshot(sp: Int): DebugSnapshot =
+      DebugSnapshot(
+          7,
+          11,
+          250,
+          2,
+          12,
+          true,
+          DebugRegisters(0x12, 0xa0, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, sp, 0x150),
+          DebugInterruptState(true, false, 0x01, 0x01, 0x01),
+          DebugTimerState(0x1234, 0x10, 0x20, 0x04, false, 0),
+          DebugPpuState(
+              true,
+              DebugPpuMode.OAM_SEARCH,
+              2,
+              12,
+              0x91,
+              0x82,
+              0,
+              0,
+              0,
+              0,
+              0,
+          ),
+          DebugApuState(true, 0, false, false, false, false, 0x77, 0xf3, 0x80),
+          DebugMapperState(
+              "MBC1",
+              1,
+              0,
+              DebugFeatureState.ENABLED,
+              DebugFeatureState.UNKNOWN,
+              DebugFeatureState.DISABLED,
+          ),
+          DebugExecutionState(DebugCpuState.EXECUTING, 0xcb, 0x11, 1, false, false, 20),
+      )
+
+  private fun capabilities(
+      memoryRead: Boolean = true,
+      history: Boolean = true,
+  ): DebugCapabilities {
+    val historyCapabilities =
+        if (history) {
+          DebugHistoryCapabilities(
+              true,
+              true,
+              true,
+              120,
+              DebugHistoryConfiguration.MIN_MEMORY_BUDGET_BYTES,
+          )
+        } else {
+          DebugHistoryCapabilities.disabled()
+        }
+    return DebugCapabilities(
+        true,
+        true,
+        true,
+        true,
+        true,
+        memoryRead,
+        true,
+        if (memoryRead) 256 else 0,
+        EnumSet.allOf(DebugBreakpointKind::class.java),
+        32,
+        emptySet(),
+        0,
+        0,
+        historyCapabilities,
+    )
+  }
+
+  private fun pcOnlyCapabilities(): DebugCapabilities =
+      DebugCapabilities(
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          true,
+          256,
+          EnumSet.of(DebugBreakpointKind.PROGRAM_COUNTER),
+          8,
+          emptySet(),
+          0,
+          0,
+      )
+
+  private fun historyStatus(
+      cursor: DebugHistoryPosition = DebugHistoryPosition(250, 2, 12),
+      futureCheckpointCount: Int = 1,
+  ): DebugHistoryStatus =
+      DebugHistoryStatus(
+          DebugHistoryConfiguration(
+              true,
+              120,
+              DebugHistoryConfiguration.MIN_MEMORY_BUDGET_BYTES,
+          ),
+          3,
+          1024,
+          0,
+          DebugHistoryPoint(1, 100, 1),
+          DebugHistoryPoint(3, 300, 3),
+          cursor,
+          futureCheckpointCount,
+          DebugHistoryTruncationReason.USER_REWIND,
+      )
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDebuggerControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDebuggerControllerTest.kt
@@ -1,0 +1,187 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.Controller
+import eu.rekawek.coffeegb.core.debug.DebugPort
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import java.lang.reflect.Proxy
+import java.util.concurrent.FutureTask
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JMenuItem
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DesktopDebuggerControllerTest {
+
+  @Test
+  fun `one retained view follows monotonic replacement and terminal revocation on the EDT`() {
+    val rootEventBus = EventBusImpl()
+    val portCloseCalls = AtomicInteger()
+    val firstPort = debugPort(2, portCloseCalls)
+    val replacementPort = debugPort(3, portCloseCalls)
+    val mismatchedPort = debugPort(4, portCloseCalls)
+    val view = RecordingDebuggerView()
+    val factoryCalls = AtomicInteger()
+    val controller =
+        onEdt {
+          DesktopDebuggerController(rootEventBus) {
+            factoryCalls.incrementAndGet()
+            view
+          }
+        }
+
+    onEdt {
+      controller.showDebugger()
+      controller.showDebugger()
+    }
+    assertEquals(1, factoryCalls.get())
+    assertEquals(listOf("show", "show"), view.calls)
+
+    // Events intentionally originate outside Swing. Acceptance happens only after each callback
+    // reaches the EDT, where an older queued publication can no longer replace generation 2.
+    rootEventBus.post(Controller.SessionDebugPortEvent(2, firstPort))
+    rootEventBus.post(Controller.SessionDebugPortEvent(1, debugPort(1, portCloseCalls)))
+    flushEdt()
+    assertEquals(listOf(2L), view.sessions.map { it.generation })
+    assertSame(firstPort, view.sessions.single().debugPort)
+
+    rootEventBus.post(Controller.SessionDebugPortEvent(2, firstPort))
+    rootEventBus.post(Controller.SessionDebugPortEvent(2, null))
+    rootEventBus.post(Controller.SessionDebugPortEvent(2, firstPort))
+    rootEventBus.post(Controller.SessionDebugPortEvent(3, mismatchedPort))
+    rootEventBus.post(Controller.SessionDebugPortEvent(3, replacementPort))
+    flushEdt()
+
+    assertEquals(listOf(2L, 2L, 3L), view.sessions.map { it.generation })
+    assertEquals(listOf(firstPort, null, replacementPort), view.sessions.map { it.debugPort })
+    assertTrue(view.allCallsWereEdt)
+
+    onEdt {
+      controller.close()
+      controller.close()
+      controller.showDebugger()
+    }
+    assertEquals(1, view.closeCalls)
+    assertEquals(0, portCloseCalls.get(), "the emulation session owns every DebugPort")
+
+    // Closing the fork unregisters the desktop subscriber but leaves the shared root usable.
+    rootEventBus.post(Controller.SessionDebugPortEvent(4, debugPort(4, portCloseCalls)))
+    flushEdt()
+    assertEquals(listOf(2L, 2L, 3L), view.sessions.map { it.generation })
+    rootEventBus.close()
+  }
+
+  @Test
+  fun `opening after publication primes the view before showing it`() {
+    val rootEventBus = EventBusImpl()
+    val view = RecordingDebuggerView()
+    val controller = onEdt { DesktopDebuggerController(rootEventBus) { view } }
+    val port = debugPort(7)
+
+    rootEventBus.post(Controller.SessionDebugPortEvent(7, port))
+    flushEdt()
+    assertTrue(view.calls.isEmpty())
+
+    onEdt { controller.showDebugger() }
+
+    assertEquals(listOf("session:7:available", "show"), view.calls)
+    assertSame(port, view.sessions.single().debugPort)
+    onEdt { controller.close() }
+    rootEventBus.close()
+  }
+
+  @Test
+  fun `controller lifecycle entry points reject non-EDT callers`() {
+    val rootEventBus = EventBusImpl()
+    assertFailsWith<IllegalStateException> {
+      DesktopDebuggerController(rootEventBus) { RecordingDebuggerView() }
+    }
+
+    val controller =
+        onEdt { DesktopDebuggerController(rootEventBus) { RecordingDebuggerView() } }
+    assertFailsWith<IllegalStateException> { controller.showDebugger() }
+    assertFailsWith<IllegalStateException> { controller.close() }
+
+    onEdt { controller.close() }
+    rootEventBus.close()
+  }
+
+  @Test
+  fun `tools menu always exposes the debugger action`() {
+    val actions = AtomicInteger()
+    val menu = onEdt { createToolsMenu { actions.incrementAndGet() } }
+
+    onEdt {
+      assertEquals("Tools", menu.text)
+      assertTrue(menu.isEnabled)
+      val item = menu.menuComponents.filterIsInstance<JMenuItem>().single()
+      assertEquals("Debugger", item.text)
+      assertTrue(item.isEnabled)
+      assertFalse(item.accessibleContext.accessibleDescription.isNullOrBlank())
+      item.doClick()
+    }
+    assertEquals(1, actions.get())
+    assertFailsWith<IllegalStateException> { createToolsMenu {} }
+  }
+
+  private class RecordingDebuggerView : DesktopDebuggerView {
+    val calls = mutableListOf<String>()
+    val sessions = mutableListOf<Controller.SessionDebugPortEvent>()
+    var closeCalls = 0
+    var allCallsWereEdt = true
+
+    override fun updateSession(event: Controller.SessionDebugPortEvent) {
+      recordEdt()
+      sessions += event
+      calls += "session:${event.generation}:${if (event.debugPort == null) "revoked" else "available"}"
+    }
+
+    override fun showWindow() {
+      recordEdt()
+      calls += "show"
+    }
+
+    override fun close() {
+      recordEdt()
+      closeCalls++
+      calls += "close"
+    }
+
+    private fun recordEdt() {
+      allCallsWereEdt = allCallsWereEdt && SwingUtilities.isEventDispatchThread()
+    }
+  }
+
+  private fun debugPort(generation: Long, closeCalls: AtomicInteger = AtomicInteger()): DebugPort {
+    val type = DebugPort::class.java
+    return type.cast(
+        Proxy.newProxyInstance(type.classLoader, arrayOf(type)) { proxy, method, arguments ->
+          when (method.name) {
+            "sessionGeneration" -> generation
+            "isClosed" -> false
+            "close" -> {
+              closeCalls.incrementAndGet()
+              null
+            }
+            "equals" -> proxy === arguments?.singleOrNull()
+            "hashCode" -> System.identityHashCode(proxy)
+            "toString" -> "TestDebugPort(generation=$generation)"
+            else -> throw AssertionError("Unexpected DebugPort call: ${method.name}")
+          }
+        })
+  }
+
+  private fun flushEdt() {
+    onEdt { Unit }
+  }
+
+  private fun <T> onEdt(action: () -> T): T {
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+}


### PR DESCRIPTION
## Summary

- add a bounded coherent inspection API that captures the CPU snapshot, PC/SP-relative bytes, and explicit safe memory ranges at one emulation safe point
- add a retained modeless desktop debugger with run control, disassembly, stack/memory, breakpoints, and reverse-history status
- preserve asynchronous session/request correlation, hide-time data release, typed failures, and side-effect-free reads

## User impact

The desktop app now exposes Tools > Debugger for coherent live inspection and safe run control without blocking the emulation or Swing threads.

## Validation

- `mvn -B test`
- `mvn -B -pl swing -am -Dtest=DebuggerPanelTest,DebuggerPresentationTest,DesktopDebuggerControllerTest -Dsurefire.failIfNoSpecifiedTests=false test` (28 tests)
- `git diff --check`

Part of #315.
