### PR TITLE
Modernize Swing debugger breakpoint workflow

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -623,6 +623,9 @@ class BasicController private constructor(
             stopJob == null &&
             isRewinding &&
             session?.let { rewindManager.rewindOneStep(it) } == true
+    if (rewound) {
+      relinquishDebugBreakpointPauseOwnership()
+    }
 
     releaseClosedDebugPortIfNeeded()
     drainDebugCommands()
@@ -653,6 +656,7 @@ class BasicController private constructor(
       if (rewound || (!isEffectivelyPaused() && !isRewinding)) {
         val gameboy = session?.gameboy
         if (gameboy != null) {
+          relinquishDebugBreakpointPauseOwnership()
           if (trackDebugHistory) {
             tickWithDebugHistory(gameboy, frameTicks)
           } else {
@@ -754,13 +758,14 @@ class BasicController private constructor(
     var holdAtBoundary = false
     repeat(frameTicks) {
       if (!holdAtBoundary && !isRewinding) {
-        // A queued lifecycle control may explicitly supersede a debugger-owned mid-frame pause.
-        // Retain pause ownership, but finish this one partial frame so the ordinary FIFO can run
-        // at its established boundary.
+        // A queued lifecycle control may explicitly supersede a breakpoint-owned mid-frame stop.
+        // Retain the debugger pause while finishing this partial frame, but make the hit
+        // historical before the first guest tick so the stop reason cannot describe moved state.
         val shouldTick =
             pendingDebugAction != null || !isEffectivelyPaused() || stopAtNextBoundary
         val gameboy = session?.gameboy
         if (shouldTick && gameboy != null) {
+          relinquishDebugBreakpointPauseOwnership()
           if (debugCheckpointHistory.enabled) {
             tickWithDebugHistory(gameboy, frameTicks)
           } else {
@@ -999,7 +1004,7 @@ class BasicController private constructor(
         debugCheckpointHistory.invalidateFuture(checkNotNull(session))
         // A desktop/workflow pause is sufficient to authorize the request, but the debugger
         // acquires its own ownership so the result remains stopped if that other owner resumes.
-        debugBreakpointPauseActive = false
+        relinquishDebugBreakpointPauseOwnership()
         setDebugPaused(true)
         val retirement = gameboy.debugRetirementSequence
         pendingDebugAction =
@@ -1012,7 +1017,7 @@ class BasicController private constructor(
       }
       DebugStepKind.FRAME -> {
         debugCheckpointHistory.invalidateFuture(checkNotNull(session))
-        debugBreakpointPauseActive = false
+        relinquishDebugBreakpointPauseOwnership()
         setDebugPaused(true)
         val ticksToBoundary =
             if (debugFramePosition == 0) {
@@ -1207,8 +1212,7 @@ class BasicController private constructor(
     // restored machine; the result/status expose the original historical coordinate separately.
     rewindManager.clear()
     debugFramePosition = position.framePosition()
-    debugBreakpointPauseActive = false
-    lastDebugBreakpointHit = null
+    relinquishDebugBreakpointPauseOwnership()
     setDebugPaused(true)
     if (resetObservation) {
       resetDebugTimelineObservation(currentSession.gameboy)
@@ -1414,7 +1418,7 @@ class BasicController private constructor(
     debugBreakpointPauseActive = true
     val snapshot = captureDebugSnapshot()
     lastDebugBreakpointHit =
-        DebugBreakpointHit(match.breakpointId(), match.matchMasterTick(), snapshot)
+        DebugBreakpointHit(match.breakpoint(), match.matchMasterTick(), snapshot, true)
 
     when (val action = pendingDebugAction) {
       null -> Unit
@@ -2165,6 +2169,7 @@ class BasicController private constructor(
         }
         else -> StateCodec.applyDecoded(read.state, currentSession, context.identity)
       }
+      relinquishDebugBreakpointPauseOwnership()
       // A portable state contains the cartridge clock pause bit. Pause ownership belongs to the
       // live desktop workflow, so loading must not let an old capture override the effective
       // pause selected for this session.
@@ -2250,6 +2255,7 @@ class BasicController private constructor(
     val mobileBackendOwnership = mobileAdapterBackendOwnershipVersion()
     try {
       manager.applySnapshotReadOnly(snapshot, currentSession)
+      relinquishDebugBreakpointPauseOwnership()
       // Match managed-load ownership: a saved cartridge clock pause bit must not override the
       // effective pause chosen for the live desktop session.
       currentSession.gameboy.setCartridgeClockPaused(isEffectivelyPaused())
@@ -2899,7 +2905,7 @@ class BasicController private constructor(
 
   private fun setDebugPaused(paused: Boolean) {
     if (!paused) {
-      debugBreakpointPauseActive = false
+      relinquishDebugBreakpointPauseOwnership()
     }
     if (debugPaused == paused) {
       return
@@ -2907,6 +2913,11 @@ class BasicController private constructor(
     val wasEffectivelyPaused = isEffectivelyPaused()
     debugPaused = paused
     updateCartridgePause(wasEffectivelyPaused)
+  }
+
+  private fun relinquishDebugBreakpointPauseOwnership() {
+    debugBreakpointPauseActive = false
+    lastDebugBreakpointHit = lastDebugBreakpointHit?.withActivePause(false)
   }
 
   private fun updateCartridgePause(wasEffectivelyPaused: Boolean) {
@@ -3734,6 +3745,7 @@ class BasicController private constructor(
     val mobileBackendOwnership = mobileAdapterBackendOwnershipVersion()
     try {
       if (manager.loadSnapshot(slot, currentSession)) {
+        relinquishDebugBreakpointPauseOwnership()
         rewindManager.clear()
         debugCheckpointHistory.clear(DebugHistoryTruncationReason.SESSION_BOUNDARY)
         if (mobileExternalIo || hasMobileAdapterDisconnectedExternalIoMarker()) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/HeadlessAgentSession.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/agent/HeadlessAgentSession.kt
@@ -324,6 +324,7 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
 
     fun tick(): Boolean {
       tickBreakpointHit = null
+      markLastBreakpointHitHistorical()
       val frameReady = machine.tick()
       masterTick++
       framePosition++
@@ -334,7 +335,7 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
       }
       instrumentation.pollBreakpointMatch()?.let { match ->
         if (!paused) updatePaused(true)
-        val hit = DebugBreakpointHit(match.breakpointId(), match.matchMasterTick(), snapshot())
+        val hit = DebugBreakpointHit(match.breakpoint(), match.matchMasterTick(), snapshot(), true)
         lastBreakpointHit = hit
         tickBreakpointHit = hit
       }
@@ -382,6 +383,10 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
     fun listBreakpoints(): DebugBreakpointList = instrumentation.listBreakpoints()
 
     fun lastBreakpointHit(): DebugBreakpointHit? = lastBreakpointHit
+
+    fun markLastBreakpointHitHistorical() {
+      lastBreakpointHit = lastBreakpointHit?.withActivePause(false)
+    }
 
     fun configureTrace(configuration: TraceConfiguration): TraceConfiguration {
       val configured = instrumentation.configureTrace(configuration)
@@ -528,6 +533,7 @@ internal class HeadlessAgentSession(romFile: File) : AutoCloseable {
           if (!state.paused) {
             DebugResult.failure(DebugErrorCode.ALREADY_RUNNING, "Agent session is already running")
           } else {
+            state.markLastBreakpointHitHistorical()
             state.updatePaused(false)
             DebugResult.success(state.snapshot())
           }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/headless/HeadlessMachineSession.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/headless/HeadlessMachineSession.kt
@@ -143,7 +143,8 @@ internal class HeadlessMachineSession(
       inspection: DebugInspectionResult,
   ): DebugBreakpointHit {
     checkOwnerAndOpen()
-    return DebugBreakpointHit(match.breakpointId(), match.matchMasterTick(), inspection.snapshot())
+    return DebugBreakpointHit(
+        match.breakpoint(), match.matchMasterTick(), inspection.snapshot(), true)
   }
 
   fun hashes(): ReplayStateHashes {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/AgentTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/AgentTest.kt
@@ -113,6 +113,8 @@ class AgentTest {
       assertEquals(breakpoint.id(), hit.breakpointId())
       assertTrue(hit.snapshot().paused())
       assertTrue(hit.snapshot().masterTick() >= hit.matchMasterTick())
+      assertEquals(breakpoint, hit.breakpoint().orElseThrow())
+      assertTrue(hit.activePause())
 
       val stopped = awaitDebug(port.snapshot()).value()
       assertTrue(stopped.paused())
@@ -128,6 +130,7 @@ class AgentTest {
           stopped.execution().retiredInstructions(),
           stillStopped.execution().retiredInstructions(),
       )
+      assertTrue(awaitDebug(port.lastBreakpointHit()).value().activePause())
 
       val trace = awaitDebug(port.readTrace(TraceReadRequest.initial(128))).value()
       assertTrue(trace.entries().isNotEmpty())
@@ -136,6 +139,15 @@ class AgentTest {
             it.category() == TraceCategory.CPU || it.category() == TraceCategory.MEMORY
           })
       assertEquals(trace.entries().last().sequence(), trace.nextAfterSequence())
+
+      val replacement =
+          DebugBreakpoint(breakpoint.id(), true, DebugPcCondition.at(0xffff))
+      assertEquals(replacement, awaitDebug(port.setBreakpoint(replacement)).value())
+      assertTrue(awaitDebug(port.step(DebugStepKind.INSTRUCTION)).isSuccess)
+      val historical = awaitDebug(port.lastBreakpointHit()).value()
+      assertEquals(breakpoint, historical.breakpoint().orElseThrow())
+      assertFalse(historical.activePause())
+      assertEquals(hit.snapshot(), historical.snapshot())
     }
   }
 
@@ -160,6 +172,45 @@ class AgentTest {
           step.value().snapshot().execution().retiredInstructions(),
           hit.snapshot().execution().retiredInstructions(),
       )
+    }
+  }
+
+  @Test
+  fun directTickApisMakeABreakpointOwnedPauseHistoricalOnlyWhenTheyMove() {
+    val movers: List<(Agent) -> Unit> =
+        listOf(
+            { agent -> agent.runTicks(1) },
+            { agent -> agent.runUntilFrame(1) },
+        )
+
+    movers.forEachIndexed { index, move ->
+      Agent(testRom(0x3e, 0x12, 0x3c, 0x18, 0xfe)).use { agent ->
+        val breakpoint =
+            DebugBreakpoint(
+                DebugBreakpointId(80L + index),
+                true,
+                DebugPcCondition.at(0x100),
+            )
+        assertTrue(awaitDebug(agent.debugPort.setBreakpoint(breakpoint)).isSuccess)
+        val stoppingStep = awaitDebug(agent.debugPort.step(DebugStepKind.INSTRUCTION))
+        assertEquals(DebugStepStopReason.BREAKPOINT, stoppingStep.value().stopReason())
+        assertTrue(awaitDebug(agent.debugPort.lastBreakpointHit()).value().activePause())
+
+        agent.runTicks(0)
+        agent.runUntilFrame(0)
+        assertTrue(awaitDebug(agent.debugPort.lastBreakpointHit()).value().activePause())
+
+        assertTrue(
+            awaitDebug(
+                    agent.debugPort.setBreakpoint(
+                        DebugBreakpoint(breakpoint.id(), true, DebugPcCondition.at(0xffff))))
+                .isSuccess)
+        move(agent)
+
+        val historical = awaitDebug(agent.debugPort.lastBreakpointHit()).value()
+        assertFalse(historical.activePause())
+        assertEquals(breakpoint, historical.breakpoint().orElseThrow())
+      }
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
@@ -380,6 +380,42 @@ class BasicControllerDebugPortTest {
   }
 
   @Test
+  fun userRewindMakesTheBreakpointOwnedPauseHistorical() {
+    val rewind = RewindManager()
+    withController(rewind) { eventBus, port, _, _, _ ->
+      awaitCondition { rewind.historySize > 0 }
+      val paused = await(port.pause()).value()
+      val breakpoint =
+          DebugBreakpoint(
+              DebugBreakpointId(66),
+              true,
+              DebugCounterCondition.atFrame(paused.frame() + 1),
+          )
+      assertTrue(await(port.setBreakpoint(breakpoint)).isSuccess)
+
+      val step = await(port.step(DebugStepKind.FRAME))
+      assertTrue(step.isSuccess, step.toString())
+      assertEquals(DebugStepStopReason.BREAKPOINT, step.value().stopReason())
+      val hit = await(port.lastBreakpointHit()).value()
+      assertEquals(0, hit.snapshot().framePosition())
+      assertTrue(hit.activePause())
+
+      val retainedBeforeRewind = rewind.historySize
+      eventBus.post(Controller.RewindEvent(true))
+      awaitCondition { rewind.historySize < retainedBeforeRewind }
+      eventBus.post(Controller.RewindEvent(false))
+      awaitCondition {
+        val result = await(port.lastBreakpointHit())
+        result.isSuccess && !result.value().activePause()
+      }
+
+      val historical = await(port.lastBreakpointHit()).value()
+      assertEquals(breakpoint, historical.breakpoint().orElseThrow())
+      assertEquals(hit.snapshot(), historical.snapshot())
+    }
+  }
+
+  @Test
   fun historyRejectsLiveSensorCartridgesInThePrimaryAndDatelSlot() {
     for ((name, type) in listOf("MBC7" to 0x22, "POCKET_CAMERA" to 0xfc)) {
       withController(
@@ -491,6 +527,8 @@ class BasicControllerDebugPortTest {
       assertEquals(targetTick, hit.matchMasterTick())
       assertEquals(targetTick, hit.snapshot().masterTick())
       assertTrue(hit.snapshot().paused())
+      assertEquals(breakpoint, hit.breakpoint().orElseThrow())
+      assertTrue(hit.activePause())
 
       val stopped = await(port.snapshot()).value()
       assertEquals(targetTick, stopped.masterTick())
@@ -505,6 +543,7 @@ class BasicControllerDebugPortTest {
           stopped.execution().retiredInstructions(),
           stillStopped.execution().retiredInstructions(),
       )
+      assertTrue(await(port.lastBreakpointHit()).value().activePause())
 
       val trace = await(port.readTrace(TraceReadRequest.initial(256))).value()
       assertTrue(trace.entries().isNotEmpty())
@@ -512,6 +551,59 @@ class BasicControllerDebugPortTest {
           trace.entries().all {
             it.category() == TraceCategory.CPU || it.category() == TraceCategory.MEMORY
           })
+
+      val replacement =
+          DebugBreakpoint(
+              breakpoint.id(),
+              true,
+              DebugCounterCondition.atMasterTick(targetTick - 1),
+          )
+      assertEquals(replacement, await(port.setBreakpoint(replacement)).value())
+      val retained = await(port.lastBreakpointHit()).value()
+      assertEquals(breakpoint, retained.breakpoint().orElseThrow())
+      assertTrue(retained.activePause())
+
+      assertTrue(await(port.resume()).isSuccess)
+      val historical = await(port.lastBreakpointHit()).value()
+      assertEquals(breakpoint, historical.breakpoint().orElseThrow())
+      assertFalse(historical.activePause())
+      assertEquals(hit.snapshot(), historical.snapshot())
+    }
+  }
+
+  @Test
+  fun forcedLifecycleBoundaryMovementMakesAMidFrameHitHistorical() {
+    withController { eventBus, port, _, controller, _ ->
+      val paused = await(port.pause()).value()
+      val frameTicks = controllerSession(controller).gameboy.clockSpec.controllerTicksPerFrame()
+      val targetPosition = 64
+      val ticksToTarget =
+          if (paused.framePosition() < targetPosition) {
+            targetPosition - paused.framePosition()
+          } else {
+            frameTicks - paused.framePosition() + targetPosition
+          }
+      val breakpoint =
+          DebugBreakpoint(
+              DebugBreakpointId(65),
+              true,
+              DebugCounterCondition.atMasterTick(paused.masterTick() + ticksToTarget),
+          )
+      assertTrue(await(port.setBreakpoint(breakpoint)).isSuccess)
+      assertTrue(await(port.resume()).isSuccess)
+
+      val hit = awaitBreakpointHit(port)
+      assertEquals(targetPosition, hit.snapshot().framePosition())
+      assertTrue(hit.activePause())
+
+      // This stale cancellation is intentionally a no-op after the controller reaches its normal
+      // frame boundary, but reaching that boundary still advances beyond the breakpoint stop.
+      eventBus.post(Controller.CancelRomOpenEvent(Long.MIN_VALUE))
+      awaitCondition { !await(port.lastBreakpointHit()).value().activePause() }
+
+      val historical = await(port.lastBreakpointHit()).value()
+      assertEquals(breakpoint, historical.breakpoint().orElseThrow())
+      assertEquals(hit.snapshot(), historical.snapshot())
     }
   }
 
@@ -633,11 +725,30 @@ class BasicControllerDebugPortTest {
       eventBus.post(StateSaveRequestEvent(910, stateSession.sessionId, slot, null, null))
       awaitStateCompletion(completed, 910)
 
+      val beforeStop = await(port.snapshot()).value()
+      val breakpoint =
+          DebugBreakpoint(
+              DebugBreakpointId(67),
+              true,
+              DebugCounterCondition.atFrame(beforeStop.frame() + 1),
+          )
+      assertTrue(await(port.setBreakpoint(breakpoint)).isSuccess)
+      val stoppingStep = await(port.step(DebugStepKind.FRAME))
+      assertTrue(stoppingStep.isSuccess, stoppingStep.toString())
+      assertEquals(DebugStepStopReason.BREAKPOINT, stoppingStep.value().stopReason())
+      val breakpointHit = await(port.lastBreakpointHit()).value()
+      assertTrue(breakpointHit.activePause())
+
       val before = await(port.readTrace(TraceReadRequest.initial(256))).value()
       assertTrue(before.entries().isNotEmpty())
 
       eventBus.post(StateLoadRefRequestEvent(911, stateSession.sessionId, slot))
       awaitStateCompletion(completed, 911)
+
+      val historicalHit = await(port.lastBreakpointHit()).value()
+      assertFalse(historicalHit.activePause())
+      assertEquals(breakpoint, historicalHit.breakpoint().orElseThrow())
+      assertEquals(breakpointHit.snapshot(), historicalHit.snapshot())
 
       val after = await(port.readTrace(TraceReadRequest.initial(256))).value()
       assertTrue(after.entries().isEmpty())

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugBreakpointHit.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugBreakpointHit.java
@@ -1,14 +1,25 @@
 package eu.rekawek.coffeegb.core.debug;
 
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint;
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId;
 
 import java.util.Objects;
+import java.util.Optional;
 
-/** Breakpoint identity and match tick paired with the coherent safe-point snapshot that stopped. */
+/**
+ * Breakpoint definition and match tick paired with the coherent safe-point snapshot that stopped.
+ *
+ * <p>The captured definition describes the breakpoint at the instant it matched. Later edits or
+ * reuse of the same id therefore cannot change the explanation of a historical stop. The active
+ * pause flag is separate from the captured paused snapshot: movement makes the hit historical,
+ * while the original stopping snapshot remains immutable.
+ */
 public record DebugBreakpointHit(
         DebugBreakpointId breakpointId,
         long matchMasterTick,
-        DebugSnapshot snapshot) {
+        DebugSnapshot snapshot,
+        Optional<DebugBreakpoint> breakpoint,
+        boolean activePause) {
 
     public DebugBreakpointHit {
         Objects.requireNonNull(breakpointId, "breakpointId");
@@ -17,6 +28,7 @@ public record DebugBreakpointHit(
                     "Breakpoint match tick must not be negative: " + matchMasterTick);
         }
         Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(breakpoint, "breakpoint");
         if (!snapshot.paused()) {
             throw new IllegalArgumentException(
                     "A breakpoint hit must contain the paused stopping snapshot");
@@ -25,5 +37,45 @@ public record DebugBreakpointHit(
             throw new IllegalArgumentException(
                     "Breakpoint snapshot cannot precede its match tick");
         }
+        breakpoint.ifPresent(definition -> {
+            if (!breakpointId.equals(definition.id())) {
+                throw new IllegalArgumentException(
+                        "Breakpoint definition id must match the hit id");
+            }
+        });
+    }
+
+    /** Creates a fully described breakpoint hit. */
+    public DebugBreakpointHit(
+            DebugBreakpoint breakpoint,
+            long matchMasterTick,
+            DebugSnapshot snapshot,
+            boolean activePause) {
+        this(
+                Objects.requireNonNull(breakpoint, "breakpoint").id(),
+                matchMasterTick,
+                snapshot,
+                Optional.of(breakpoint),
+                activePause);
+    }
+
+    /**
+     * Compatibility constructor for callers that captured only the legacy breakpoint identity.
+     *
+     * <p>Owner implementations should use the definition-carrying constructor instead.
+     */
+    public DebugBreakpointHit(
+            DebugBreakpointId breakpointId,
+            long matchMasterTick,
+            DebugSnapshot snapshot) {
+        this(breakpointId, matchMasterTick, snapshot, Optional.empty(), true);
+    }
+
+    /** Returns this hit when its ownership already matches, otherwise a historical copy. */
+    public DebugBreakpointHit withActivePause(boolean activePause) {
+        return this.activePause == activePause
+                ? this
+                : new DebugBreakpointHit(
+                        breakpointId, matchMasterTick, snapshot, breakpoint, activePause);
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInstrumentation.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/DebugInstrumentation.java
@@ -46,7 +46,7 @@ public final class DebugInstrumentation implements DebugHooks {
 
     private long masterTick;
 
-    private DebugBreakpointId pendingBreakpointId;
+    private DebugBreakpoint pendingBreakpoint;
 
     private long pendingMatchTick;
 
@@ -322,7 +322,7 @@ public final class DebugInstrumentation implements DebugHooks {
             if (condition instanceof DebugCounterCondition counter
                     && counter.counter() == DebugCounterType.MASTER_TICK
                     && counter.value() == masterTick) {
-                offerImmediateMatch(breakpoint.id());
+                offerImmediateMatch(breakpoint);
                 return;
             }
         }
@@ -340,14 +340,14 @@ public final class DebugInstrumentation implements DebugHooks {
             if (condition instanceof DebugCounterCondition counter
                     && counter.counter() == DebugCounterType.FRAME
                     && counter.value() == frame) {
-                offerImmediateMatch(breakpoint.id());
+                offerImmediateMatch(breakpoint);
                 return;
             }
             if (ppuStateKnown
                     && condition instanceof DebugPpuCondition
                     && DebugBreakpointMatcher.matchesPpu(
                             breakpoint, ownerFrame, ppuLy, ppuMode)) {
-                offerImmediateMatch(breakpoint.id());
+                offerImmediateMatch(breakpoint);
                 return;
             }
         }
@@ -360,7 +360,7 @@ public final class DebugInstrumentation implements DebugHooks {
     }
 
     public void clearPendingMatch() {
-        pendingBreakpointId = null;
+        pendingBreakpoint = null;
         pendingMatchTick = 0;
         readyMatch = null;
     }
@@ -387,8 +387,8 @@ public final class DebugInstrumentation implements DebugHooks {
     }
 
     private boolean hasPendingOrReadyMatch(DebugBreakpointId breakpointId) {
-        return breakpointId.equals(pendingBreakpointId)
-                || readyMatch != null && breakpointId.equals(readyMatch.breakpointId());
+        return pendingBreakpoint != null && breakpointId.equals(pendingBreakpoint.id())
+                || readyMatch != null && breakpointId.equals(readyMatch.breakpoint().id());
     }
 
     @Override
@@ -398,7 +398,7 @@ public final class DebugInstrumentation implements DebugHooks {
             if (breakpoint.condition() instanceof DebugPcCondition
                     && DebugBreakpointMatcher.matchesInstruction(
                             breakpoint, programCounter, false, 0)) {
-                offerRetirementMatch(breakpoint.id());
+                offerRetirementMatch(breakpoint);
                 return;
             }
         }
@@ -412,7 +412,7 @@ public final class DebugInstrumentation implements DebugHooks {
             if (breakpoint.condition() instanceof DebugOpcodeCondition
                     && DebugBreakpointMatcher.matchesInstruction(
                             breakpoint, programCounter, cbPrefixed, opcode)) {
-                offerRetirementMatch(breakpoint.id());
+                offerRetirementMatch(breakpoint);
                 return;
             }
         }
@@ -435,9 +435,9 @@ public final class DebugInstrumentation implements DebugHooks {
         if (instructionKnown && opcode == 0xd9) {
             completeAcceptedInterrupt();
         }
-        if (pendingBreakpointId != null && readyMatch == null) {
-            readyMatch = new BreakpointMatch(pendingBreakpointId, pendingMatchTick);
-            pendingBreakpointId = null;
+        if (pendingBreakpoint != null && readyMatch == null) {
+            readyMatch = new BreakpointMatch(pendingBreakpoint, pendingMatchTick);
+            pendingBreakpoint = null;
             pendingMatchTick = 0;
         }
     }
@@ -474,7 +474,7 @@ public final class DebugInstrumentation implements DebugHooks {
                     // Bus accesses are themselves complete observations. Owners poll only after
                     // the enclosing Gameboy.tick(), so expose the match at that safe point even
                     // when the CPU is idle and no retirement follows (for example STOP polling).
-                    offerImmediateMatch(breakpoint.id());
+                    offerImmediateMatch(breakpoint);
                     break;
                 }
             }
@@ -507,7 +507,7 @@ public final class DebugInstrumentation implements DebugHooks {
             DebugBreakpoint breakpoint = enabledBreakpoints[i];
             if (breakpoint.condition() instanceof DebugInterruptCondition
                     && DebugBreakpointMatcher.matchesInterrupt(breakpoint, interrupt)) {
-                offerRetirementMatch(breakpoint.id());
+                offerRetirementMatch(breakpoint);
                 break;
             }
         }
@@ -568,7 +568,7 @@ public final class DebugInstrumentation implements DebugHooks {
             if (breakpoint.condition() instanceof DebugPpuCondition
                     && DebugBreakpointMatcher.matchesPpu(
                             breakpoint, ownerFrame, line, mode)) {
-                offerImmediateMatch(breakpoint.id());
+                offerImmediateMatch(breakpoint);
                 break;
             }
         }
@@ -626,7 +626,7 @@ public final class DebugInstrumentation implements DebugHooks {
                     if (breakpoint.condition() instanceof DebugSerialCondition
                             && DebugBreakpointMatcher.matchesSerial(
                                     breakpoint, event, value)) {
-                        offerImmediateMatch(breakpoint.id());
+                        offerImmediateMatch(breakpoint);
                         break;
                     }
                 }
@@ -674,27 +674,32 @@ public final class DebugInstrumentation implements DebugHooks {
         }
     }
 
-    private void offerRetirementMatch(DebugBreakpointId breakpointId) {
-        if (pendingBreakpointId == null && readyMatch == null) {
-            pendingBreakpointId = breakpointId;
+    private void offerRetirementMatch(DebugBreakpoint breakpoint) {
+        if (pendingBreakpoint == null && readyMatch == null) {
+            pendingBreakpoint = breakpoint;
             pendingMatchTick = masterTick;
         }
     }
 
-    private void offerImmediateMatch(DebugBreakpointId breakpointId) {
-        if (pendingBreakpointId == null && readyMatch == null) {
-            readyMatch = new BreakpointMatch(breakpointId, masterTick);
+    private void offerImmediateMatch(DebugBreakpoint breakpoint) {
+        if (pendingBreakpoint == null && readyMatch == null) {
+            readyMatch = new BreakpointMatch(breakpoint, masterTick);
         }
     }
 
     /** Lightweight owner-side match completed into a public hit after snapshot capture. */
-    public record BreakpointMatch(DebugBreakpointId breakpointId, long matchMasterTick) {
+    public record BreakpointMatch(DebugBreakpoint breakpoint, long matchMasterTick) {
 
         public BreakpointMatch {
-            Objects.requireNonNull(breakpointId, "breakpointId");
+            Objects.requireNonNull(breakpoint, "breakpoint");
             if (matchMasterTick < 0) {
                 throw new IllegalArgumentException("Match tick must not be negative");
             }
+        }
+
+        /** Compatibility accessor for clients that only need the breakpoint identity. */
+        public DebugBreakpointId breakpointId() {
+            return breakpoint.id();
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiModelTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugApiModelTest.java
@@ -1,7 +1,9 @@
 package eu.rekawek.coffeegb.core.debug;
 
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint;
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId;
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind;
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition;
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryCapabilities;
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration;
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryPoint;
@@ -619,14 +621,36 @@ public class DebugApiModelTest {
     }
 
     @Test
-    public void breakpointHitRequiresAPausedSnapshotAtOrAfterTheMatch() {
+    public void breakpointHitPinsItsDefinitionAndSeparatesHistoricalOwnership() {
         DebugBreakpointId id = new DebugBreakpointId(5);
-        DebugBreakpointHit hit = new DebugBreakpointHit(id, 1234, snapshot(true));
+        DebugBreakpoint definition =
+                new DebugBreakpoint(id, true, DebugPcCondition.at(0x100));
+        DebugBreakpointHit hit =
+                new DebugBreakpointHit(definition, 1234, snapshot(true), true);
         assertSame(id, hit.breakpointId());
+        assertSame(definition, hit.breakpoint().orElseThrow());
+        assertTrue(hit.activePause());
+
+        DebugBreakpointHit historical = hit.withActivePause(false);
+        assertFalse(historical.activePause());
+        assertSame(definition, historical.breakpoint().orElseThrow());
+        assertSame(hit.snapshot(), historical.snapshot());
+
+        DebugBreakpointHit legacy = new DebugBreakpointHit(id, 1234, snapshot(true));
+        assertTrue(legacy.breakpoint().isEmpty());
+        assertTrue(legacy.activePause());
         assertThrows(IllegalArgumentException.class,
                 () -> new DebugBreakpointHit(id, 1234, snapshot(false)));
         assertThrows(IllegalArgumentException.class,
                 () -> new DebugBreakpointHit(id, 1235, snapshot(true)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new DebugBreakpointHit(
+                        id,
+                        1234,
+                        snapshot(true),
+                        Optional.of(new DebugBreakpoint(
+                                new DebugBreakpointId(6), true, DebugPcCondition.at(0x100))),
+                        true));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugInstrumentationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/debug/DebugInstrumentationTest.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -137,6 +138,27 @@ public class DebugInstrumentationTest {
         instrumentation.onMemoryAccess(DebugMemoryAccess.READ, 0xc000, 0x12);
         assertTrue(instrumentation.removeBreakpoint(id));
         assertNull(instrumentation.pollBreakpointMatch());
+    }
+
+    @Test
+    public void polledMatchRetainsTheExactDefinitionAfterIdReuse() {
+        DebugInstrumentation instrumentation = instrumentation(2);
+        DebugBreakpointId id = new DebugBreakpointId(8);
+        DebugBreakpoint matched = new DebugBreakpoint(
+                id, true,
+                new DebugMemoryCondition(DebugMemoryAccess.READ, 0xc000, 0xc000));
+        instrumentation.setBreakpoint(matched);
+
+        instrumentation.onMemoryAccess(DebugMemoryAccess.READ, 0xc000, 0x12);
+        DebugInstrumentation.BreakpointMatch match = instrumentation.pollBreakpointMatch();
+
+        assertTrue(instrumentation.removeBreakpoint(id));
+        instrumentation.setBreakpoint(
+                new DebugBreakpoint(id, true, DebugPcCondition.at(0x200)));
+        assertEquals(id, match.breakpointId());
+        assertSame(matched, match.breakpoint());
+        assertEquals(DebugMemoryAccess.READ,
+                ((DebugMemoryCondition) match.breakpoint().condition()).access());
     }
 
     private static DebugInstrumentation instrumentation(int maxBreakpoints) {

--- a/docs/debug-port.md
+++ b/docs/debug-port.md
@@ -228,12 +228,24 @@ SC starts the transfer. Completion observes the final received SB value after th
 after the port has finalized its completed state.
 
 A hit is completed only at a coherent safe point, acquires the debugger pause, and records a
-`DebugBreakpointHit` containing the breakpoint ID, the tick of the observed match, and the final
-snapshot. A PC or opcode observation can precede its final snapshot by the remaining ticks of that
+`DebugBreakpointHit` containing the breakpoint ID, the immutable definition that matched, the tick
+of the observed match, and the final snapshot. Capturing the complete definition keeps the stop
+explanation stable when that ID is later edited, removed, or reused. `activePause` is true while
+that automatic stop still owns the current debugger pause. It becomes false before the next guest
+tick or after any successful state discontinuity, including resume, forward or reverse stepping,
+direct Agent ticking, lifecycle-driven partial-frame completion, user rewind, and state or snapshot
+restore. Zero-tick requests, snapshot and inspection recapture, and rejected restores do not change
+it. A new breakpoint during movement replaces the historical hit with a new active one. The
+stopping snapshot itself remains paused and immutable. The compatibility three-argument
+constructor represents legacy ID-only hits with an empty definition and defaults `activePause` to
+true; owner implementations use the definition-carrying constructor.
+
+A PC or opcode observation can precede its final snapshot by the remaining ticks of that
 instruction. A memory observation stops after its enclosing master tick, so its snapshot may
 describe a CPU partway through the instruction; this also guarantees that STOP-time bus polling
 cannot strand a watchpoint waiting for a retirement that never occurs. `lastBreakpointHit` returns
-the most recent automatic stop and reports `NO_BREAKPOINT_HIT` before the first one.
+the most recent automatic stop, including historical hits, and reports `NO_BREAKPOINT_HIT` before
+the first one.
 
 The first matching observed event before a stop wins. If several definitions match that same event,
 the lowest numeric ID wins, independent of insertion order. Editing or removing a definition
@@ -393,9 +405,10 @@ monotonic across a reverse. `DebugReverseStepResult.restoredPosition` is the his
 including its frame position; `replayAnchor` identifies the retained frame checkpoint used for a
 direct restore or scratch replay. Its `snapshot` is the coherent post-commit view labelled with the
 current live counters. The compatibility `restoredPoint()` accessor names that anchor and must not
-be mistaken for an instruction target. Breakpoint definitions and trace configuration survive;
-pending breakpoint correlation, the last hit, and retained trace entries are cleared so
-observations from two timelines cannot be spliced.
+be mistaken for an instruction target. Breakpoint definitions and trace configuration survive.
+Pending breakpoint correlation and retained trace entries are cleared so observations from two
+timelines cannot be spliced. The last hit survives as history with `activePause` false and
+continues to describe its original stopping timeline and captured definition.
 
 A successful reverse moves only the cursor. Checkpoints and transcript records after it remain
 retained and continue to count against both budgets. `futureCheckpointCount` counts retained

--- a/docs/debugger-modernization.md
+++ b/docs/debugger-modernization.md
@@ -1,0 +1,110 @@
+# Debugger modernization
+
+Coffee GB is borrowing Mesen's debugger workflow, not its implementation or visual styling. The
+reference baseline is the official MesenCE source at
+[`b2b9497`](https://github.com/nesdev-org/MesenCE/tree/b2b9497c1d4a1859deffeda4f0e3192dad46a44c).
+The useful pattern is composability: a location discovered in a stop reason, trace row, watch, or
+hardware view should lead to the same navigation and breakpoint actions.
+
+## Reference audit
+
+Mesen's debugger combines a navigable disassembly workspace, typed breakpoints, watches, decoded
+hardware state, trace/event tools, symbols, and a per-ROM workspace. Its default dock layout keeps
+code, status, watches, breakpoints, and call stack visible together; the saved layout can be
+restored on the next run. See MesenCE's
+[`DebuggerDockFactory`](https://github.com/nesdev-org/MesenCE/blob/b2b9497c1d4a1859deffeda4f0e3192dad46a44c/UI/Debugger/DebuggerDockFactory.cs)
+and
+[`DebugWorkspaceManager`](https://github.com/nesdev-org/MesenCE/blob/b2b9497c1d4a1859deffeda4f0e3192dad46a44c/UI/Debugger/Utilities/DebugWorkspaceManager.cs).
+
+The highest-value workflows are:
+
+1. **Explain every stop.** Show the triggering breakpoint and condition next to the paused state.
+2. **Make stop conditions discoverable.** Treat execution, memory, opcode, interrupt, video,
+   serial, and time/frame conditions as one searchable breakpoint workflow.
+3. **Make locations portable.** Disassembly, memory, traces, watches, labels, and hardware state
+   should share navigation and actions.
+4. **Keep context visible.** Code, registers, watches, breakpoints, and call stack should not require
+   repeated modal-window or tab switching.
+5. **Highlight change.** Watches, registers, memory, and event streams should make new values easy
+   to distinguish without relying only on color.
+
+Mesen examples include its
+[`DisassemblyView`](https://github.com/nesdev-org/MesenCE/blob/b2b9497c1d4a1859deffeda4f0e3192dad46a44c/UI/Debugger/Views/DisassemblyView.axaml),
+[`WatchListView`](https://github.com/nesdev-org/MesenCE/blob/b2b9497c1d4a1859deffeda4f0e3192dad46a44c/UI/Debugger/Views/WatchListView.axaml),
+and Game Boy
+[`GbRegisterViewer`](https://github.com/nesdev-org/MesenCE/blob/b2b9497c1d4a1859deffeda4f0e3192dad46a44c/UI/Debugger/RegisterViewer/GbRegisterViewer.cs).
+
+## Coffee GB capability map
+
+Coffee GB already has a strong asynchronous safe-point boundary. `DebugPort` provides coherent
+inspection, pause/resume, forward and reverse stepping, bounded tracing, seven typed breakpoint
+kinds, and last-hit metadata. Swing originally exposed only PC and memory breakpoints and rendered
+an automatic stop like an ordinary pause.
+
+| Workflow | Backend | Swing before modernization | Direction |
+| --- | --- | --- | --- |
+| Typed stop conditions | PC, memory, opcode, interrupt, PPU, serial, counter | PC and memory only | Breakpoint Center |
+| Exact stop reason | `lastBreakpointHit()` | Not queried | Correlated stop banner and hit row |
+| Forward/reverse control | Instruction and frame | Available | Shared action registry and configurable shortcuts |
+| Disassembly | Safe detached bytes at PC | One formatted instruction | Bank-aware location model, listing, navigation history |
+| Watches | Bounded coherent reads are available | None | Typed watch model with changed-value presentation |
+| Event inspection | Bounded typed trace | Timeline table | Filters, detail view, address navigation, raster correlation |
+| Hardware state | Decoded CPU/PPU/APU/mapper DTOs | Mostly text/tables | Field actions and change markers |
+| Workspace | Harmless layout preferences | Fixed tabs and splitters | Versioned pane IDs, layout reset, optional per-ROM data |
+| Mutation | No mutation command by design | Read-only | Explicit atomic safe-point protocol before any editor |
+
+## Delivery sequence
+
+### 1. Breakpoint Center
+
+- Card-based editor for every breakpoint kind already negotiated by the session.
+- Searchable, sortable table with create, edit, duplicate, enable/disable, remove, and current-PC
+  toggle actions.
+- A stop banner and table marker derived from `lastBreakpointHit()` and correlated with the current
+  snapshot, so a historical hit is never described as the current pause cause.
+- Last-hit metadata retains the immutable triggering definition and an explicit active/historical
+  pause state, so edits, ID reuse, recapture, rewind, or state restore cannot rewrite the story of
+  an earlier stop.
+- Session-local state only; no breakpoint condition or hit data is persisted.
+
+### 2. Shared commands and locations
+
+Introduce stable pane and command identifiers, one capability-aware action registry, configurable
+shortcuts, a command palette, and bounded back/forward navigation. Define a bank-aware
+`DebugLocation` before expanding disassembly: a CPU address alone is not enough to identify code in
+the switchable Game Boy ROM window.
+
+### 3. Watches and coherent inspection planning
+
+Add typed address/register watches, explicit display formats, old/new values, and accessible change
+text. Coalesce adjacent reads and keep the aggregate request inside `DebugInspectionRequest` bounds.
+Expressions should be shared later with conditional breakpoints and trace filters rather than
+implemented three times.
+
+### 4. Disassembly and source workflow
+
+Add a structured instruction DTO, a bank-correct listing, current-PC and breakpoint gutters,
+go-to/back/forward, run-to-cursor, and step-over/out semantics. Then layer RGBDS/SDCC symbol and
+source mapping onto the same location model.
+
+### 5. Event and hardware tools
+
+Turn the typed timeline into a filterable event inspector with details and cross-navigation. Add a
+raster position view for PPU events and actions from decoded LCD/APU/timer/DMA/interrupt fields to
+the breakpoint editor.
+
+### 6. Explicit mutation protocol
+
+Register or memory editing must not bypass `DebugPort`. It requires an atomic request containing
+the expected session and snapshot identity, capability-gated safe RAM/register targets, and defined
+history/trace invalidation. Swing editing should be added only after controller and queued-port
+tests prove those semantics.
+
+## Non-negotiable boundaries
+
+- No Swing component accesses the live emulator directly or blocks the EDT on a debug command.
+- UI completions remain correlated by window epoch, client identity, session generation, and
+  request ID.
+- ROM, boot ROM, memory captures, hit data, paths, and trace payloads are not silently persisted.
+- Unsupported linked/rollback topologies remain inspection-only and never expose unsafe controls.
+- Every state or change marker has a textual equivalent; color is supplemental.

--- a/docs/desktop-debugger.md
+++ b/docs/desktop-debugger.md
@@ -22,7 +22,7 @@ hiding, or closing the debugger cancels that work and releases its snapshot and 
 | --- | --- |
 | **CPU** | Registers and flags, execution/interrupt/timer/PPU/APU scalars, mapper banks, stack, and side-effect-free disassembly. |
 | **Memory** | One validated ROM, work-RAM, or high-RAM address/range, read only while paused. |
-| **Breakpoints** | Program-counter breakpoints and read/write/execute watchpoints with optional byte value and mask. |
+| **Breakpoints** | Searchable, sortable Breakpoint Center for PC, memory, opcode, interrupt, PPU, serial, master-tick, and frame conditions. Definitions can be added, edited, duplicated, enabled/disabled, or removed without blocking the UI. |
 | **Graphics** | Hardware mode, VRAM tile banks, background/window maps, all 40 OAM objects, DMG registers, and CGB RGB555 palettes. |
 | **Audio** | Mixer/frame-sequencer state, four APU channels, raw/decoded registers, and all 32 wave samples in text plus a supplemental graph. |
 | **Timeline** | Sequence-ordered typed events, including serial and input activity when those categories are selected. |
@@ -37,12 +37,21 @@ not mutate the machine. Table and color-preview information is also available as
 - **F6** pauses at the next safe retirement or releases the debugger-owned pause.
 - **F7** steps one instruction; **Shift+F7** steps one frame.
 - **F8** moves back one recorded instruction; **Shift+F8** moves back one recorded frame.
+- **F9** toggles an exact program-counter breakpoint at the current paused address. If imported or
+  external state contains duplicates at that address, the toggle removes all of them.
 - The platform menu shortcut plus `+`/`-` changes font size, `0` resets it, and `C` copies the
   current pane or selected table rows.
 
-Controls have keyboard mnemonics, labels are associated with their editors, tables keep normal
-focus/selection indicators, and status is always stated in text rather than by color alone. Font
-scaling covers text, row heights, and stable table column widths from 70% through 200%.
+Toolbar controls have keyboard mnemonics. The Breakpoint Center uses unambiguous Enter, F9, and
+platform-shortcut+F actions plus normal focus traversal, rather than colliding with run-control
+mnemonics. Labels are associated with their editors, tables keep normal focus/selection indicators,
+and status is always stated in text rather than by color alone. Font scaling covers text, row
+heights, and stable table column widths from 70% through 200%.
+
+When a breakpoint stops the machine, the header names the immutable triggering definition and its
+match/stop ticks. The Breakpoint Center marks that definition while it still exists. After the
+machine moves, the same information is explicitly labelled as the last historical stop rather than
+the cause of a later pause.
 
 ## Reverse history and timeline capture
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointDraft.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointDraft.kt
@@ -1,0 +1,300 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugInterruptType
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterType
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugInterruptCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugMemoryCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugOpcodeCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPpuCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugSerialCondition
+import java.math.BigInteger
+
+/**
+ * Stable editor choices kept separate from Swing components.
+ *
+ * Multiple editor choices can produce the same negotiated breakpoint kind. For example, read,
+ * write, and execute watchpoints are all [DebugBreakpointKind.MEMORY] conditions.
+ */
+internal enum class DebuggerBreakpointEditorKind(
+    val displayName: String,
+    val negotiatedKind: DebugBreakpointKind,
+) {
+  PROGRAM_COUNTER("Program counter", DebugBreakpointKind.PROGRAM_COUNTER),
+  MEMORY_READ("Memory read", DebugBreakpointKind.MEMORY),
+  MEMORY_WRITE("Memory write", DebugBreakpointKind.MEMORY),
+  MEMORY_EXECUTE("Memory execute", DebugBreakpointKind.MEMORY),
+  BASE_OPCODE("Opcode", DebugBreakpointKind.OPCODE),
+  CB_OPCODE("CB opcode", DebugBreakpointKind.OPCODE),
+  INTERRUPT("Interrupt", DebugBreakpointKind.INTERRUPT),
+  PPU_STATE("PPU state", DebugBreakpointKind.PPU_STATE),
+  SERIAL_START("Serial transfer start", DebugBreakpointKind.SERIAL),
+  SERIAL_COMPLETION("Serial transfer completion", DebugBreakpointKind.SERIAL),
+  MASTER_TICK("Master tick", DebugBreakpointKind.COUNTER),
+  FRAME_COUNTER("Frame counter", DebugBreakpointKind.COUNTER),
+  ;
+
+  override fun toString(): String = displayName
+}
+
+/** Immutable, UI-independent input for one breakpoint editor. */
+internal sealed interface DebuggerBreakpointDraft {
+  val editorKind: DebuggerBreakpointEditorKind
+
+  /** Parses this draft into an existing immutable debug-port condition. */
+  fun parse(): DebuggerParsedValue<DebugBreakpointCondition>
+
+  data class ProgramCounter(val addressText: String) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind =
+        DebuggerBreakpointEditorKind.PROGRAM_COUNTER
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> =
+        DebuggerPresentation.parseProgramCounterCondition(addressText).map { it }
+  }
+
+  data class Memory(
+      val access: DebugMemoryAccess,
+      val addressText: String,
+      val valueText: String = "",
+      val maskText: String = "",
+  ) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind =
+        when (access) {
+          DebugMemoryAccess.READ -> DebuggerBreakpointEditorKind.MEMORY_READ
+          DebugMemoryAccess.WRITE -> DebuggerBreakpointEditorKind.MEMORY_WRITE
+          DebugMemoryAccess.EXECUTE -> DebuggerBreakpointEditorKind.MEMORY_EXECUTE
+        }
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> =
+        DebuggerPresentation
+            .parseMemoryCondition(addressText, access, valueText, maskText)
+            .map { it }
+  }
+
+  data class Opcode(
+      val cbPrefixed: Boolean,
+      val opcodeText: String,
+  ) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind =
+        if (cbPrefixed) DebuggerBreakpointEditorKind.CB_OPCODE
+        else DebuggerBreakpointEditorKind.BASE_OPCODE
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> {
+      val opcode = DebuggerPresentation.parseByte(opcodeText, "Opcode")
+      if (!opcode.isValid) return DebuggerParsedValue.invalid(opcode.error!!)
+      return DebuggerParsedValue.valid(
+          if (cbPrefixed) DebugOpcodeCondition.cb(opcode.value!!)
+          else DebugOpcodeCondition.base(opcode.value!!)
+      )
+    }
+  }
+
+  data class Interrupt(val interrupt: DebugInterruptType?) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind = DebuggerBreakpointEditorKind.INTERRUPT
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> =
+        interrupt?.let { DebuggerParsedValue.valid(DebugInterruptCondition(it)) }
+            ?: DebuggerParsedValue.invalid("Choose an interrupt.")
+  }
+
+  data class Ppu(
+      val frameText: String = "",
+      val lyText: String = "",
+      val mode: DebugPpuMode? = null,
+  ) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind = DebuggerBreakpointEditorKind.PPU_STATE
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> {
+      if (frameText.isBlank() && lyText.isBlank() && mode == null) {
+        return DebuggerParsedValue.invalid(
+            "Set at least one PPU constraint: frame, LY, or mode."
+        )
+      }
+      val frame =
+          if (frameText.isBlank()) {
+            DebuggerParsedValue.valid(DebugPpuCondition.ANY_FRAME)
+          } else {
+            parseBoundedNumber(frameText, "Frame", Long.MAX_VALUE)
+          }
+      if (!frame.isValid) return DebuggerParsedValue.invalid(frame.error!!)
+
+      val ly =
+          if (lyText.isBlank()) {
+            DebuggerParsedValue.valid(DebugPpuCondition.ANY_LY.toLong())
+          } else {
+            parseBoundedNumber(lyText, "LY", MAX_PPU_LY.toLong())
+          }
+      if (!ly.isValid) return DebuggerParsedValue.invalid(ly.error!!)
+
+      return DebuggerParsedValue.valid(
+          DebugPpuCondition(frame.value!!, ly.value!!.toInt(), mode)
+      )
+    }
+  }
+
+  data class Serial(
+      val event: DebugSerialCondition.Event,
+      val valueText: String = "",
+      val maskText: String = "",
+  ) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind =
+        when (event) {
+          DebugSerialCondition.Event.TRANSFER_STARTED ->
+              DebuggerBreakpointEditorKind.SERIAL_START
+          DebugSerialCondition.Event.BYTE_TRANSFERRED ->
+              DebuggerBreakpointEditorKind.SERIAL_COMPLETION
+        }
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> {
+      if (valueText.isBlank()) {
+        if (maskText.isNotBlank()) {
+          return DebuggerParsedValue.invalid("A value is required when a value mask is set.")
+        }
+        return DebuggerParsedValue.valid(DebugSerialCondition(event))
+      }
+
+      val value = DebuggerPresentation.parseByte(valueText)
+      if (!value.isValid) return DebuggerParsedValue.invalid(value.error!!)
+      if (maskText.isBlank()) {
+        return DebuggerParsedValue.valid(DebugSerialCondition(event, value.value!!))
+      }
+
+      val mask = DebuggerPresentation.parseByte(maskText, "Mask")
+      if (!mask.isValid) return DebuggerParsedValue.invalid(mask.error!!)
+      if (mask.value == 0) {
+        return DebuggerParsedValue.invalid("Mask must contain at least one set bit.")
+      }
+      return DebuggerParsedValue.valid(
+          DebugSerialCondition(event, value.value!!, mask.value!!)
+      )
+    }
+  }
+
+  data class Counter(
+      val counter: DebugCounterType,
+      val valueText: String,
+  ) : DebuggerBreakpointDraft {
+    override val editorKind: DebuggerBreakpointEditorKind =
+        when (counter) {
+          DebugCounterType.MASTER_TICK -> DebuggerBreakpointEditorKind.MASTER_TICK
+          DebugCounterType.FRAME -> DebuggerBreakpointEditorKind.FRAME_COUNTER
+        }
+
+    override fun parse(): DebuggerParsedValue<DebugBreakpointCondition> {
+      val value = parseBoundedNumber(valueText, counter.fieldName, Long.MAX_VALUE)
+      if (!value.isValid) return DebuggerParsedValue.invalid(value.error!!)
+      return DebuggerParsedValue.valid(DebugCounterCondition(counter, value.value!!))
+    }
+  }
+
+  companion object {
+    /** Creates an editable draft for every condition currently supported by the debug port. */
+    fun from(condition: DebugBreakpointCondition): DebuggerBreakpointDraft =
+        when (condition) {
+          is DebugPcCondition ->
+              ProgramCounter(formatRange(condition.startAddress, condition.endAddress))
+          is DebugMemoryCondition ->
+              Memory(
+                  condition.access(),
+                  formatRange(condition.startAddress(), condition.endAddress()),
+                  if (condition.hasValueConstraint()) {
+                    DebuggerPresentation.formatByte(condition.value())
+                  } else {
+                    ""
+                  },
+                  if (condition.hasValueConstraint() && condition.valueMask() != 0xff) {
+                    DebuggerPresentation.formatByte(condition.valueMask())
+                  } else {
+                    ""
+                  },
+              )
+          is DebugOpcodeCondition ->
+              Opcode(condition.cbPrefixed, DebuggerPresentation.formatByte(condition.opcode))
+          is DebugInterruptCondition -> Interrupt(condition.interrupt)
+          is DebugPpuCondition ->
+              Ppu(
+                  if (condition.constrainsFrame()) condition.frame.toString() else "",
+                  if (condition.constrainsLy()) condition.ly.toString() else "",
+                  condition.mode,
+              )
+          is DebugSerialCondition ->
+              Serial(
+                  condition.event(),
+                  if (condition.hasValueConstraint()) {
+                    DebuggerPresentation.formatByte(condition.value())
+                  } else {
+                    ""
+                  },
+                  if (condition.hasValueConstraint() && condition.valueMask() != 0xff) {
+                    DebuggerPresentation.formatByte(condition.valueMask())
+                  } else {
+                    ""
+                  },
+              )
+          is DebugCounterCondition -> Counter(condition.counter, condition.value.toString())
+          else ->
+              throw IllegalArgumentException(
+                  "Unsupported breakpoint condition: ${condition.javaClass.name}"
+              )
+        }
+  }
+}
+
+private val DebugCounterType.fieldName: String
+  get() =
+      when (this) {
+        DebugCounterType.MASTER_TICK -> "Master tick"
+        DebugCounterType.FRAME -> "Frame counter"
+      }
+
+private fun parseBoundedNumber(
+    text: String,
+    fieldName: String,
+    maximum: Long,
+): DebuggerParsedValue<Long> {
+  val input = text.trim()
+  if (input.isEmpty()) return DebuggerParsedValue.invalid("$fieldName is required.")
+
+  val (digits, radix) =
+      when {
+        input.firstOrNull() == '$' -> input.drop(1) to 16
+        input.startsWith("0x", ignoreCase = true) -> input.drop(2) to 16
+        else -> input to 10
+      }
+  val validDigits =
+      digits.isNotEmpty() &&
+          if (radix == 16) digits.all(::isAsciiHexDigit)
+          else digits.all(::isAsciiDecimalDigit)
+  if (!validDigits) {
+    return DebuggerParsedValue.invalid(
+        "$fieldName must be a non-negative decimal value or hexadecimal prefixed by ${'$'} or 0x."
+    )
+  }
+
+  val value = BigInteger(digits, radix)
+  val maximumValue = BigInteger.valueOf(maximum)
+  if (value > maximumValue) {
+    return DebuggerParsedValue.invalid("$fieldName must be between 0 and $maximum.")
+  }
+  return DebuggerParsedValue.valid(value.toLong())
+}
+
+private fun isAsciiHexDigit(value: Char): Boolean =
+    value in '0'..'9' || value in 'a'..'f' || value in 'A'..'F'
+
+private fun isAsciiDecimalDigit(value: Char): Boolean = value in '0'..'9'
+
+private fun formatRange(startAddress: Int, endAddress: Int): String =
+    if (startAddress == endAddress) {
+      DebuggerPresentation.formatWord(startAddress)
+    } else {
+      "${DebuggerPresentation.formatWord(startAddress)}-" +
+          DebuggerPresentation.formatWord(endAddress)
+    }
+
+private const val MAX_PPU_LY = 153

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointPanel.kt
@@ -1,0 +1,1037 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointHit
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugInterruptType
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterType
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugSerialCondition
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.FlowLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.util.regex.Pattern
+import javax.swing.AbstractAction
+import javax.swing.BorderFactory
+import javax.swing.DefaultComboBoxModel
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JSplitPane
+import javax.swing.JTable
+import javax.swing.JTextField
+import javax.swing.KeyStroke
+import javax.swing.ListSelectionModel
+import javax.swing.RowFilter
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+import javax.swing.table.AbstractTableModel
+import javax.swing.table.TableRowSorter
+
+/** Immutable hand-off from the breakpoint editor to the asynchronous debugger owner. */
+internal data class DebuggerBreakpointSaveRequest(
+    val replacedId: DebugBreakpointId?,
+    val enabled: Boolean,
+    val draft: DebuggerBreakpointDraft,
+    val condition: DebugBreakpointCondition,
+)
+
+/**
+ * Commands emitted by [DebuggerBreakpointPanel].
+ *
+ * The panel never assumes that a command succeeded. The owning debugger applies the request and
+ * later calls [DebuggerBreakpointPanel.replace] with the authoritative backend state.
+ */
+internal data class DebuggerBreakpointPanelCallbacks(
+    val onSave: (DebuggerBreakpointSaveRequest) -> Unit = {},
+    val onRemove: (DebugBreakpoint) -> Unit = {},
+    val onToggle: (DebugBreakpoint, Boolean) -> Unit = { _, _ -> },
+    val onToggleAtCurrentPc: (Int) -> Unit = {},
+    val onStatus: (String) -> Unit = {},
+)
+
+/**
+ * Searchable Mesen-style breakpoint workspace backed only by immutable debugger DTOs.
+ *
+ * Table updates are authoritative replacements. Editing, duplicating, removing, toggling, and F9
+ * merely emit callbacks; no optimistic table mutation can make an asynchronous failure look like
+ * success.
+ */
+internal class DebuggerBreakpointPanel(
+    private val callbacks: DebuggerBreakpointPanelCallbacks = DebuggerBreakpointPanelCallbacks(),
+) : JPanel(BorderLayout(4, 4)) {
+  internal val hitLabel = JLabel(NO_HIT_TEXT)
+  internal val filterField = JTextField(24)
+  internal val clearFilterButton = JButton("Clear")
+  internal val resultCountLabel = JLabel("0 breakpoints")
+  internal val tableModel = DebuggerBreakpointWorkspaceTableModel(callbacks.onToggle)
+  internal val table = JTable(tableModel)
+  internal val editButton = JButton("Edit")
+  internal val duplicateButton = JButton("Duplicate")
+  internal val removeButton = JButton("Remove")
+  internal val toggleCurrentPcButton = JButton("Toggle PC breakpoint (F9)")
+  internal val editor = DebuggerBreakpointDraftEditor()
+  internal val saveButton = JButton("Add breakpoint")
+  internal val cancelEditButton = JButton("Clear editor")
+  internal val editorStatusLabel = JLabel(DEFAULT_EDITOR_STATUS)
+
+  private val sorter = TableRowSorter(tableModel)
+  private var capabilities: DebugCapabilities? = null
+  private var currentProgramCounter: Int? = null
+  private var editingId: DebugBreakpointId? = null
+  private var busy = false
+  private var automaticEditorStatus = false
+
+  init {
+    requireBreakpointPanelEdt("Breakpoint panel construction")
+    border = BorderFactory.createEmptyBorder(4, 4, 4, 4)
+    getAccessibleContext().accessibleName = "Breakpoint and watchpoint workspace"
+    getAccessibleContext().accessibleDescription =
+        "Search, sort, add, edit, duplicate, enable, disable, and remove debugger breakpoints"
+
+    hitLabel.accessibleContext.accessibleName = "Last breakpoint hit"
+    hitLabel.accessibleContext.accessibleDescription = hitLabel.text
+    hitLabel.addPropertyChangeListener("text") { event ->
+      hitLabel.accessibleContext.accessibleDescription = event.newValue?.toString()
+    }
+
+    configureFilter()
+    configureTable()
+    configureActions()
+    configureEditor()
+
+    val header = JPanel(BorderLayout(4, 3)).apply {
+      add(hitLabel, BorderLayout.NORTH)
+      add(filterBar(), BorderLayout.CENTER)
+      add(tableActions(), BorderLayout.SOUTH)
+    }
+    val tablePane = JPanel(BorderLayout(3, 3)).apply {
+      add(header, BorderLayout.NORTH)
+      add(JScrollPane(table), BorderLayout.CENTER)
+    }
+    val split = JSplitPane(JSplitPane.VERTICAL_SPLIT, tablePane, editorPane()).apply {
+      resizeWeight = 0.62
+      isContinuousLayout = true
+      border = null
+    }
+    add(split, BorderLayout.CENTER)
+
+    installKeyboardBindings()
+    updateControlState()
+  }
+
+  /** Replaces every displayed row and all session-scoped marker state. */
+  fun replace(
+      values: List<DebugBreakpoint>,
+      capabilities: DebugCapabilities?,
+      lastHit: DebugBreakpointHit? = null,
+      currentProgramCounter: Int? = null,
+      currentStop: Boolean = false,
+  ) {
+    requireBreakpointPanelEdt("Breakpoint workspace replacement")
+    require(currentProgramCounter == null || currentProgramCounter in 0..0xffff) {
+      "Current program counter is outside 16 bits"
+    }
+    require(!currentStop || lastHit?.activePause() == true) {
+      "A current stop requires an active breakpoint hit"
+    }
+    val selectedId = selectedBreakpoint()?.id()
+    this.capabilities = capabilities
+    tableModel.replace(values, capabilities, lastHit)
+    editor.setCapabilities(capabilities)
+    updateExecutionContext(lastHit, currentProgramCounter, currentStop)
+    restoreSelection(selectedId)
+    updateFilterCount()
+    updateControlState()
+  }
+
+  /** Updates the frequently changing stop marker and F9 address without rebuilding table rows. */
+  fun updateExecutionContext(
+      lastHit: DebugBreakpointHit?,
+      currentProgramCounter: Int?,
+      currentStop: Boolean = false,
+  ) {
+    requireBreakpointPanelEdt("Breakpoint execution-context update")
+    require(currentProgramCounter == null || currentProgramCounter in 0..0xffff) {
+      "Current program counter is outside 16 bits"
+    }
+    require(!currentStop || lastHit?.activePause() == true) {
+      "A current stop requires an active breakpoint hit"
+    }
+    this.currentProgramCounter = currentProgramCounter
+    tableModel.updateLastHit(lastHit)
+    updateHit(lastHit, currentStop)
+    updateControlState()
+  }
+
+  /** Returns a tab-separated representation of selected visible rows, or all visible rows. */
+  fun copyText(): String {
+    requireBreakpointPanelEdt("Breakpoint workspace copying")
+    val viewRows =
+        table.selectedRows
+            .asSequence()
+            .filter { it in 0 until table.rowCount }
+            .distinct()
+            .sorted()
+            .toList()
+            .ifEmpty { (0 until table.rowCount).toList() }
+    return buildString {
+          append((0 until table.columnCount).joinToString("\t") { table.getColumnName(it) })
+          viewRows.forEach { row ->
+            append('\n')
+            append(
+                (0 until table.columnCount).joinToString("\t") { column ->
+                  table.getValueAt(row, column)?.toString().orEmpty()
+                })
+          }
+        }
+        .trimEnd()
+  }
+
+  /** Finds every exact-PC definition suitable for the conventional F9 toggle action. */
+  fun breakpointsAtProgramCounter(pc: Int): List<DebugBreakpoint> {
+    requireBreakpointPanelEdt("Program-counter breakpoint lookup")
+    require(pc in 0..0xffff) { "Program counter is outside 16 bits" }
+    return tableModel
+        .breakpoints()
+        .filter { breakpoint ->
+          val condition = breakpoint.condition()
+          condition is DebugPcCondition && condition.isExact && condition.startAddress == pc
+        }
+        .sortedBy { it.id().value() }
+  }
+
+  /** Reports a completed async command and optionally clears its draft after confirmed success. */
+  fun commandSucceeded(message: String, clearEditor: Boolean = false) {
+    requireBreakpointPanelEdt("Breakpoint command success")
+    require(message.isNotBlank()) { "Breakpoint command status must not be blank" }
+    if (clearEditor) resetEditorState()
+    automaticEditorStatus = false
+    editorStatusLabel.text = message
+    updateControlState()
+  }
+
+  /** Keeps the current draft editable after an authoritative async failure. */
+  fun commandFailed(message: String) {
+    requireBreakpointPanelEdt("Breakpoint command failure")
+    require(message.isNotBlank()) { "Breakpoint command status must not be blank" }
+    automaticEditorStatus = false
+    editorStatusLabel.text = message
+    updateControlState()
+  }
+
+  /** Gates command-producing controls while the owner has an asynchronous command in flight. */
+  fun setBusy(value: Boolean) {
+    requireBreakpointPanelEdt("Breakpoint workspace busy state")
+    busy = value
+    tableModel.interactionEnabled = !value
+    updateControlState()
+  }
+
+  /** Releases all session-derived rows and editor state without persisting anything. */
+  fun clear() {
+    requireBreakpointPanelEdt("Breakpoint workspace clearing")
+    capabilities = null
+    currentProgramCounter = null
+    editingId = null
+    tableModel.replace(emptyList(), null, null)
+    editor.reset()
+    editor.setCapabilities(null)
+    filterField.text = ""
+    hitLabel.text = NO_HIT_TEXT
+    automaticEditorStatus = false
+    editorStatusLabel.text = DEFAULT_EDITOR_STATUS
+    saveButton.text = "Add breakpoint"
+    updateFilterCount()
+    updateControlState()
+  }
+
+  private fun configureFilter() {
+    filterField.accessibleContext.accessibleName = "Filter breakpoints"
+    filterField.accessibleContext.accessibleDescription =
+        "Filter the breakpoint table by identifier, type, or condition"
+    clearFilterButton.accessibleContext.accessibleDescription = "Clear the breakpoint filter"
+    resultCountLabel.accessibleContext.accessibleName = "Breakpoint filter result count"
+    filterField.document.addDocumentListener(
+        object : DocumentListener {
+          override fun insertUpdate(event: DocumentEvent) = applyFilter()
+
+          override fun removeUpdate(event: DocumentEvent) = applyFilter()
+
+          override fun changedUpdate(event: DocumentEvent) = applyFilter()
+        })
+    clearFilterButton.addActionListener {
+      filterField.text = ""
+      filterField.requestFocusInWindow()
+    }
+  }
+
+  private fun configureTable() {
+    table.rowSorter = sorter
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+    table.fillsViewportHeight = true
+    table.accessibleContext.accessibleName = "Breakpoints and watchpoints"
+    table.accessibleContext.accessibleDescription =
+        "Sortable authoritative breakpoint list; the Hit column marks the last breakpoint hit"
+    table.columnModel.getColumn(0).preferredWidth = 58
+    table.columnModel.getColumn(1).preferredWidth = 72
+    table.columnModel.getColumn(2).preferredWidth = 70
+    table.columnModel.getColumn(3).preferredWidth = 120
+    table.columnModel.getColumn(4).preferredWidth = 440
+    table.columnModel.getColumn(5).preferredWidth = 150
+    table.selectionModel.addListSelectionListener { updateControlState() }
+    table.addMouseListener(
+        object : MouseAdapter() {
+          override fun mouseClicked(event: MouseEvent) {
+            if (event.clickCount == 2 && SwingUtilities.isLeftMouseButton(event)) editSelected()
+          }
+        })
+  }
+
+  private fun configureActions() {
+    editButton.accessibleContext.accessibleDescription =
+        "Load the selected breakpoint into the typed editor; Enter also edits"
+    duplicateButton.accessibleContext.accessibleDescription =
+        "Copy the selected condition into the editor as a new breakpoint"
+    removeButton.accessibleContext.accessibleDescription =
+        "Request removal of the selected breakpoint"
+    toggleCurrentPcButton.accessibleContext.accessibleDescription =
+        "Toggle a program-counter breakpoint at the current CPU address with F9"
+    editButton.addActionListener { editSelected() }
+    duplicateButton.addActionListener { duplicateSelected() }
+    removeButton.addActionListener { selectedBreakpoint()?.let(callbacks.onRemove) }
+    toggleCurrentPcButton.addActionListener { toggleAtCurrentPc() }
+  }
+
+  private fun configureEditor() {
+    editor.accessibleContext.accessibleName = "Typed breakpoint editor"
+    saveButton.accessibleContext.accessibleDescription =
+        "Validate and request an authoritative breakpoint add or replacement"
+    cancelEditButton.accessibleContext.accessibleDescription =
+        "Cancel replacement and reset the typed breakpoint editor"
+    editorStatusLabel.accessibleContext.accessibleName = "Breakpoint editor status"
+    editorStatusLabel.accessibleContext.accessibleDescription = editorStatusLabel.text
+    editorStatusLabel.addPropertyChangeListener("text") { event ->
+      editorStatusLabel.accessibleContext.accessibleDescription = event.newValue?.toString()
+    }
+    editor.onChange = { updateControlState() }
+    saveButton.addActionListener { saveEditor() }
+    cancelEditButton.addActionListener { resetEditor("Breakpoint editor cleared") }
+  }
+
+  private fun filterBar(): Component =
+      JPanel(FlowLayout(FlowLayout.LEADING, 5, 1)).apply {
+        val label = JLabel("Filter:")
+        label.labelFor = filterField
+        add(label)
+        add(filterField)
+        add(clearFilterButton)
+        add(resultCountLabel)
+      }
+
+  private fun tableActions(): Component =
+      JPanel(FlowLayout(FlowLayout.LEADING, 5, 1)).apply {
+        add(editButton)
+        add(duplicateButton)
+        add(removeButton)
+        add(toggleCurrentPcButton)
+      }
+
+  private fun editorPane(): Component =
+      JPanel(BorderLayout(4, 3)).apply {
+        border = BorderFactory.createTitledBorder("Breakpoint editor")
+        add(editor, BorderLayout.CENTER)
+        add(
+            JPanel(BorderLayout(4, 2)).apply {
+              add(editorStatusLabel, BorderLayout.CENTER)
+              add(
+                  JPanel(FlowLayout(FlowLayout.TRAILING, 5, 1)).apply {
+                    add(cancelEditButton)
+                    add(saveButton)
+                  },
+                  BorderLayout.EAST,
+              )
+            },
+            BorderLayout.SOUTH,
+        )
+      }
+
+  private fun installKeyboardBindings() {
+    val tableInput = table.getInputMap(JComponent.WHEN_FOCUSED)
+    tableInput.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), ACTION_EDIT)
+    table.actionMap.put(
+        ACTION_EDIT,
+        object : AbstractAction() {
+          override fun actionPerformed(event: java.awt.event.ActionEvent?) = editSelected()
+        },
+    )
+
+    val input = getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+    input.put(KeyStroke.getKeyStroke(KeyEvent.VK_F9, 0), ACTION_TOGGLE_CURRENT_PC)
+    actionMap.put(
+        ACTION_TOGGLE_CURRENT_PC,
+        object : AbstractAction() {
+          override fun actionPerformed(event: java.awt.event.ActionEvent?) = toggleAtCurrentPc()
+        },
+    )
+    input.put(
+        KeyStroke.getKeyStroke(KeyEvent.VK_F, debuggerMenuShortcutMask()),
+        ACTION_FOCUS_FILTER,
+    )
+    actionMap.put(
+        ACTION_FOCUS_FILTER,
+        object : AbstractAction() {
+          override fun actionPerformed(event: java.awt.event.ActionEvent?) {
+            filterField.requestFocusInWindow()
+            filterField.selectAll()
+          }
+        },
+    )
+  }
+
+  private fun applyFilter() {
+    val query = filterField.text.trim()
+    sorter.rowFilter =
+        if (query.isEmpty()) null
+        else RowFilter.regexFilter("(?i)${Pattern.quote(query)}")
+    updateFilterCount()
+    updateControlState()
+  }
+
+  private fun updateFilterCount() {
+    val visible = table.rowCount
+    val total = tableModel.rowCount
+    resultCountLabel.text =
+        when {
+          total == 0 -> "0 breakpoints"
+          visible == total -> "$total ${plural(total, "breakpoint", "breakpoints")}"
+          else -> "$visible of $total breakpoints"
+        }
+  }
+
+  private fun editSelected() {
+    val breakpoint = selectedBreakpoint() ?: return
+    editingId = breakpoint.id()
+    editor.load(DebuggerBreakpointDraft.from(breakpoint.condition()))
+    editor.enabledCheckBox.isSelected = breakpoint.enabled()
+    saveButton.text = "Save breakpoint #${breakpoint.id().value()}"
+    automaticEditorStatus = false
+    editorStatusLabel.text = "Editing breakpoint #${breakpoint.id().value()}"
+    updateControlState()
+    editor.focusPrimaryEditor()
+  }
+
+  private fun duplicateSelected() {
+    val breakpoint = selectedBreakpoint() ?: return
+    editingId = null
+    editor.load(DebuggerBreakpointDraft.from(breakpoint.condition()))
+    editor.enabledCheckBox.isSelected = breakpoint.enabled()
+    saveButton.text = "Add breakpoint"
+    automaticEditorStatus = false
+    editorStatusLabel.text = "Duplicating breakpoint #${breakpoint.id().value()} as a new definition"
+    updateControlState()
+    editor.focusPrimaryEditor()
+  }
+
+  private fun saveEditor() {
+    if (!editor.selectedKindSupported || busy) return
+    val draft = editor.draft()
+    val parsed = draft.parse()
+    if (!parsed.isValid) {
+      showStatus(parsed.error!!)
+      editor.focusPrimaryEditor()
+      return
+    }
+    val pendingMessage =
+        editingId?.let { "Saving breakpoint #${it.value()}…" } ?: "Adding breakpoint…"
+    showStatus(pendingMessage)
+    callbacks.onSave(
+        DebuggerBreakpointSaveRequest(
+            editingId,
+            editor.enabledCheckBox.isSelected,
+            draft,
+            parsed.value!!,
+        ))
+  }
+
+  private fun resetEditor(message: String) {
+    resetEditorState()
+    showStatus(message)
+    updateControlState()
+  }
+
+  private fun resetEditorState() {
+    editingId = null
+    editor.reset()
+    saveButton.text = "Add breakpoint"
+  }
+
+  private fun toggleAtCurrentPc() {
+    val pc = currentProgramCounter
+    if (pc == null) {
+      showStatus("Pause and refresh before toggling a breakpoint at the current PC")
+      return
+    }
+    if (busy || capabilities?.supports(editor.programCounterNegotiatedKind) != true) return
+    showStatus("Toggling program-counter breakpoint at ${DebuggerPresentation.formatWord(pc)}…")
+    callbacks.onToggleAtCurrentPc(pc)
+  }
+
+  private fun selectedBreakpoint(): DebugBreakpoint? {
+    val viewRow = table.selectedRow
+    if (viewRow < 0 || viewRow >= table.rowCount) return null
+    return tableModel.breakpointAt(table.convertRowIndexToModel(viewRow))
+  }
+
+  private fun restoreSelection(id: DebugBreakpointId?) {
+    if (id == null) {
+      table.clearSelection()
+      return
+    }
+    val modelRow = tableModel.indexOf(id)
+    if (modelRow < 0) {
+      table.clearSelection()
+      return
+    }
+    val viewRow = table.convertRowIndexToView(modelRow)
+    if (viewRow >= 0) table.setRowSelectionInterval(viewRow, viewRow) else table.clearSelection()
+  }
+
+  private fun updateHit(hit: DebugBreakpointHit?, currentStop: Boolean) {
+    hitLabel.text =
+        hit?.let {
+          "${if (currentStop) "Current stop" else "Last hit"}: " +
+              "breakpoint #${it.breakpointId().value()} matched at tick " +
+              "${it.matchMasterTick()} and stopped at tick ${it.snapshot().masterTick()}"
+        } ?: NO_HIT_TEXT
+  }
+
+  private fun updateControlState() {
+    val selected = selectedBreakpoint()
+    val supportsBreakpoints = capabilities?.breakpoints() == true
+    val usable = supportsBreakpoints && !busy
+    table.isEnabled = usable
+    tableModel.interactionEnabled = usable
+    editButton.isEnabled = usable && selected != null
+    duplicateButton.isEnabled = usable && selected != null && selected.condition().let {
+      capabilities?.supports(it.kind()) == true
+    }
+    removeButton.isEnabled = usable && selected != null
+    toggleCurrentPcButton.isEnabled =
+        usable &&
+            currentProgramCounter != null &&
+            capabilities?.supports(editor.programCounterNegotiatedKind) == true
+    clearFilterButton.isEnabled = filterField.text.isNotEmpty()
+    editor.setInteractionEnabled(usable)
+    saveButton.isEnabled = usable && editor.selectedKindSupported
+    cancelEditButton.isEnabled = !busy
+    val unavailableMessage =
+        when {
+          !supportsBreakpoints -> "Breakpoint editing is unavailable in this session"
+          !editor.selectedKindSupported ->
+              "${editor.selectedKind.displayName} is unsupported in this session"
+          else -> null
+        }
+    if (unavailableMessage != null &&
+        (automaticEditorStatus || editorStatusLabel.text == DEFAULT_EDITOR_STATUS)) {
+      automaticEditorStatus = true
+      editorStatusLabel.text = unavailableMessage
+    } else if (unavailableMessage == null && automaticEditorStatus) {
+      automaticEditorStatus = false
+      editorStatusLabel.text =
+          editingId?.let { "Editing breakpoint #${it.value()}" } ?: DEFAULT_EDITOR_STATUS
+    }
+  }
+
+  private fun showStatus(message: String) {
+    automaticEditorStatus = false
+    editorStatusLabel.text = message
+    callbacks.onStatus(message)
+  }
+
+  private companion object {
+    const val NO_HIT_TEXT = "No breakpoint hit recorded in this session"
+    const val DEFAULT_EDITOR_STATUS = "Enter a breakpoint condition"
+    const val ACTION_EDIT = "debugger-breakpoint-edit"
+    const val ACTION_TOGGLE_CURRENT_PC = "debugger-breakpoint-toggle-current-pc"
+    const val ACTION_FOCUS_FILTER = "debugger-breakpoint-focus-filter"
+  }
+}
+
+/** Authoritative sortable rows for [DebuggerBreakpointPanel]. */
+internal class DebuggerBreakpointWorkspaceTableModel(
+    private val onToggle: (DebugBreakpoint, Boolean) -> Unit,
+) : AbstractTableModel() {
+  private var breakpoints = emptyList<DebugBreakpoint>()
+  private var rows = emptyList<DebuggerBreakpointRow>()
+  private var lastHitId: DebugBreakpointId? = null
+  var interactionEnabled: Boolean = true
+    set(value) {
+      if (field == value) return
+      field = value
+      if (rowCount > 0) fireTableRowsUpdated(0, rowCount - 1)
+    }
+
+  override fun getRowCount(): Int = rows.size
+
+  override fun getColumnCount(): Int = COLUMNS.size
+
+  override fun getColumnName(column: Int): String = COLUMNS[column]
+
+  override fun getColumnClass(columnIndex: Int): Class<*> =
+      when (columnIndex) {
+        1 -> Boolean::class.javaObjectType
+        2 -> Long::class.javaObjectType
+        else -> String::class.java
+      }
+
+  override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean =
+      interactionEnabled && columnIndex == 1 && rows[rowIndex].supported
+
+  override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+    val breakpoint = breakpoints[rowIndex]
+    val row = rows[rowIndex]
+    return when (columnIndex) {
+      0 -> if (breakpoint.id() == lastHitId) "Last hit" else ""
+      1 -> row.enabled
+      2 -> row.id
+      3 -> row.kind
+      4 -> row.condition
+      5 -> if (row.supported) "Supported" else "Unsupported in this session"
+      else -> error("Unknown breakpoint workspace column: $columnIndex")
+    }
+  }
+
+  override fun setValueAt(value: Any?, rowIndex: Int, columnIndex: Int) {
+    if (!isCellEditable(rowIndex, columnIndex) || value !is Boolean) return
+    val breakpoint = breakpoints[rowIndex]
+    if (breakpoint.enabled() != value) onToggle(breakpoint, value)
+  }
+
+  fun replace(
+      values: List<DebugBreakpoint>,
+      capabilities: DebugCapabilities?,
+      lastHit: DebugBreakpointHit?,
+  ) {
+    breakpoints = values.toList()
+    rows = DebuggerPresentation.breakpointRows(breakpoints, capabilities)
+    this.lastHitId = markerId(lastHit)
+    fireTableDataChanged()
+  }
+
+  fun updateLastHit(hit: DebugBreakpointHit?) {
+    val value = markerId(hit)
+    if (lastHitId == value) return
+    val previous = lastHitId
+    lastHitId = value
+    previous?.let(::indexOf)?.takeIf { it >= 0 }?.let { fireTableRowsUpdated(it, it) }
+    value?.let(::indexOf)?.takeIf { it >= 0 }?.let { fireTableRowsUpdated(it, it) }
+  }
+
+  fun breakpointAt(row: Int): DebugBreakpoint = breakpoints[row]
+
+  fun indexOf(id: DebugBreakpointId): Int = breakpoints.indexOfFirst { it.id() == id }
+
+  fun breakpoints(): List<DebugBreakpoint> = breakpoints
+
+  private fun markerId(hit: DebugBreakpointHit?): DebugBreakpointId? {
+    val definition = hit?.breakpoint()?.orElse(null) ?: return null
+    return definition.id().takeIf { id ->
+      breakpoints.any { it.id() == id && it == definition }
+    }
+  }
+
+  private companion object {
+    val COLUMNS = arrayOf("Hit", "Enabled", "ID", "Kind", "Condition", "Session support")
+  }
+}
+
+/** Card-based editor which maps each visible form directly to one immutable draft variant. */
+internal class DebuggerBreakpointDraftEditor : JPanel(BorderLayout(4, 4)) {
+  internal val kindCombo = JComboBox<DebuggerBreakpointEditorKind>()
+  internal val enabledCheckBox = JCheckBox("Enabled", true)
+  internal val addressField = JTextField("\$0100", 15)
+  internal val memoryAddressField = JTextField("\$C000", 15)
+  internal val valueField = JTextField("", 5)
+  internal val maskField = JTextField("", 5)
+  internal val opcodeField = JTextField("\$00", 5)
+  internal val interruptCombo = JComboBox(DebugInterruptType.entries.toTypedArray())
+  internal val ppuFrameField = JTextField("", 12)
+  internal val ppuLyField = JTextField("", 5)
+  internal val ppuModeCombo = JComboBox(PpuModeChoice.entries.toTypedArray())
+  internal val serialValueField = JTextField("", 5)
+  internal val serialMaskField = JTextField("", 5)
+  internal val counterField = JTextField("0", 18)
+
+  private val cardLayout = CardLayout()
+  private val cards = JPanel(cardLayout)
+  private var capabilities: DebugCapabilities? = null
+  private var interactionEnabled = false
+  internal var onChange: () -> Unit = {}
+  val programCounterNegotiatedKind =
+      DebuggerBreakpointEditorKind.PROGRAM_COUNTER.negotiatedKind
+
+  val selectedKind: DebuggerBreakpointEditorKind
+    get() = kindCombo.selectedItem as DebuggerBreakpointEditorKind
+
+  val selectedKindSupported: Boolean
+    get() = capabilities?.supports(selectedKind.negotiatedKind) == true
+
+  init {
+    requireBreakpointPanelEdt("Breakpoint editor construction")
+    kindCombo.model = DefaultComboBoxModel(DebuggerBreakpointEditorKind.entries.toTypedArray())
+    kindCombo.renderer = BreakpointKindRenderer { capabilities }
+    kindCombo.accessibleContext.accessibleName = "Breakpoint condition type"
+    kindCombo.accessibleContext.accessibleDescription =
+        "Select one of the breakpoint types negotiated with the current session"
+    enabledCheckBox.accessibleContext.accessibleDescription =
+        "Create or save the breakpoint as enabled or disabled"
+
+    configureField(addressField, "Breakpoint address or inclusive range")
+    configureField(memoryAddressField, "Watchpoint address or inclusive range")
+    configureField(valueField, "Optional observed memory byte value")
+    configureField(maskField, "Optional observed memory byte mask")
+    configureField(opcodeField, "Opcode byte")
+    configureField(ppuFrameField, "Optional PPU owner frame")
+    configureField(ppuLyField, "Optional PPU scanline from 0 through 153")
+    configureField(serialValueField, "Optional serial byte value")
+    configureField(serialMaskField, "Optional serial byte mask")
+    configureField(counterField, "Non-negative counter value")
+    interruptCombo.accessibleContext.accessibleName = "Accepted interrupt"
+    ppuModeCombo.accessibleContext.accessibleName = "Optional PPU mode"
+
+    cards.add(addressCard(addressField, memory = false), CARD_PROGRAM_COUNTER)
+    cards.add(addressCard(memoryAddressField, memory = true), CARD_MEMORY)
+    cards.add(singleFieldCard("Opcode:", opcodeField), CARD_OPCODE)
+    cards.add(comboCard("Interrupt:", interruptCombo), CARD_INTERRUPT)
+    cards.add(ppuCard(), CARD_PPU)
+    cards.add(serialCard(), CARD_SERIAL)
+    cards.add(singleFieldCard("Value:", counterField), CARD_COUNTER)
+
+    val selector = JPanel(FlowLayout(FlowLayout.LEADING, 5, 1)).apply {
+      add(labelFor("Type:", kindCombo))
+      add(kindCombo)
+      add(enabledCheckBox)
+    }
+    add(selector, BorderLayout.NORTH)
+    add(cards, BorderLayout.CENTER)
+
+    kindCombo.addActionListener {
+      showSelectedCard()
+      onChange()
+    }
+    enabledCheckBox.addActionListener { onChange() }
+    showSelectedCard()
+  }
+
+  fun setCapabilities(value: DebugCapabilities?) {
+    requireBreakpointPanelEdt("Breakpoint editor capability update")
+    capabilities = value
+    kindCombo.repaint()
+    updateEnabledState()
+  }
+
+  fun setInteractionEnabled(value: Boolean) {
+    requireBreakpointPanelEdt("Breakpoint editor interaction update")
+    interactionEnabled = value
+    updateEnabledState()
+  }
+
+  fun draft(): DebuggerBreakpointDraft =
+      when (selectedKind) {
+        DebuggerBreakpointEditorKind.PROGRAM_COUNTER ->
+            DebuggerBreakpointDraft.ProgramCounter(addressField.text)
+        DebuggerBreakpointEditorKind.MEMORY_READ ->
+            memoryDraft(DebugMemoryAccess.READ)
+        DebuggerBreakpointEditorKind.MEMORY_WRITE ->
+            memoryDraft(DebugMemoryAccess.WRITE)
+        DebuggerBreakpointEditorKind.MEMORY_EXECUTE ->
+            memoryDraft(DebugMemoryAccess.EXECUTE)
+        DebuggerBreakpointEditorKind.BASE_OPCODE ->
+            DebuggerBreakpointDraft.Opcode(false, opcodeField.text)
+        DebuggerBreakpointEditorKind.CB_OPCODE ->
+            DebuggerBreakpointDraft.Opcode(true, opcodeField.text)
+        DebuggerBreakpointEditorKind.INTERRUPT ->
+            DebuggerBreakpointDraft.Interrupt(interruptCombo.selectedItem as? DebugInterruptType)
+        DebuggerBreakpointEditorKind.PPU_STATE ->
+            DebuggerBreakpointDraft.Ppu(
+                ppuFrameField.text,
+                ppuLyField.text,
+                (ppuModeCombo.selectedItem as PpuModeChoice).mode,
+            )
+        DebuggerBreakpointEditorKind.SERIAL_START ->
+            serialDraft(DebugSerialCondition.Event.TRANSFER_STARTED)
+        DebuggerBreakpointEditorKind.SERIAL_COMPLETION ->
+            serialDraft(DebugSerialCondition.Event.BYTE_TRANSFERRED)
+        DebuggerBreakpointEditorKind.MASTER_TICK ->
+            DebuggerBreakpointDraft.Counter(DebugCounterType.MASTER_TICK, counterField.text)
+        DebuggerBreakpointEditorKind.FRAME_COUNTER ->
+            DebuggerBreakpointDraft.Counter(DebugCounterType.FRAME, counterField.text)
+      }
+
+  fun load(draft: DebuggerBreakpointDraft) {
+    requireBreakpointPanelEdt("Breakpoint draft loading")
+    kindCombo.selectedItem = draft.editorKind
+    when (draft) {
+      is DebuggerBreakpointDraft.ProgramCounter -> addressField.text = draft.addressText
+      is DebuggerBreakpointDraft.Memory -> {
+        memoryAddressField.text = draft.addressText
+        valueField.text = draft.valueText
+        maskField.text = draft.maskText
+      }
+      is DebuggerBreakpointDraft.Opcode -> opcodeField.text = draft.opcodeText
+      is DebuggerBreakpointDraft.Interrupt -> interruptCombo.selectedItem = draft.interrupt
+      is DebuggerBreakpointDraft.Ppu -> {
+        ppuFrameField.text = draft.frameText
+        ppuLyField.text = draft.lyText
+        ppuModeCombo.selectedItem = PpuModeChoice.from(draft.mode)
+      }
+      is DebuggerBreakpointDraft.Serial -> {
+        serialValueField.text = draft.valueText
+        serialMaskField.text = draft.maskText
+      }
+      is DebuggerBreakpointDraft.Counter -> counterField.text = draft.valueText
+    }
+    showSelectedCard()
+    onChange()
+  }
+
+  fun reset() {
+    requireBreakpointPanelEdt("Breakpoint editor reset")
+    kindCombo.selectedItem = DebuggerBreakpointEditorKind.PROGRAM_COUNTER
+    enabledCheckBox.isSelected = true
+    addressField.text = "\$0100"
+    memoryAddressField.text = "\$C000"
+    valueField.text = ""
+    maskField.text = ""
+    opcodeField.text = "\$00"
+    interruptCombo.selectedIndex = 0
+    ppuFrameField.text = ""
+    ppuLyField.text = ""
+    ppuModeCombo.selectedItem = PpuModeChoice.ANY
+    serialValueField.text = ""
+    serialMaskField.text = ""
+    counterField.text = "0"
+    showSelectedCard()
+    onChange()
+  }
+
+  fun focusPrimaryEditor() {
+    when (selectedKind) {
+      DebuggerBreakpointEditorKind.PROGRAM_COUNTER -> addressField
+      DebuggerBreakpointEditorKind.MEMORY_READ,
+      DebuggerBreakpointEditorKind.MEMORY_WRITE,
+      DebuggerBreakpointEditorKind.MEMORY_EXECUTE -> memoryAddressField
+      DebuggerBreakpointEditorKind.BASE_OPCODE,
+      DebuggerBreakpointEditorKind.CB_OPCODE -> opcodeField
+      DebuggerBreakpointEditorKind.INTERRUPT -> interruptCombo
+      DebuggerBreakpointEditorKind.PPU_STATE -> ppuFrameField
+      DebuggerBreakpointEditorKind.SERIAL_START,
+      DebuggerBreakpointEditorKind.SERIAL_COMPLETION -> serialValueField
+      DebuggerBreakpointEditorKind.MASTER_TICK,
+      DebuggerBreakpointEditorKind.FRAME_COUNTER -> counterField
+    }.requestFocusInWindow()
+  }
+
+  private fun memoryDraft(access: DebugMemoryAccess): DebuggerBreakpointDraft.Memory =
+      DebuggerBreakpointDraft.Memory(
+          access,
+          memoryAddressField.text,
+          valueField.text,
+          maskField.text,
+      )
+
+  private fun serialDraft(event: DebugSerialCondition.Event): DebuggerBreakpointDraft.Serial =
+      DebuggerBreakpointDraft.Serial(event, serialValueField.text, serialMaskField.text)
+
+  private fun showSelectedCard() {
+    cardLayout.show(cards, cardName(selectedKind))
+    updateEnabledState()
+  }
+
+  private fun updateEnabledState() {
+    val enabled = interactionEnabled && selectedKindSupported
+    kindCombo.isEnabled = interactionEnabled && capabilities?.breakpoints() == true
+    enabledCheckBox.isEnabled = enabled
+    listOf(
+            addressField,
+            memoryAddressField,
+            valueField,
+            maskField,
+            opcodeField,
+            interruptCombo,
+            ppuFrameField,
+            ppuLyField,
+            ppuModeCombo,
+            serialValueField,
+            serialMaskField,
+            counterField,
+        )
+        .forEach { it.isEnabled = enabled }
+  }
+
+  private fun addressCard(address: JTextField, memory: Boolean): JPanel =
+      formPanel().apply {
+        addFormRow(0, "Address/range:", address)
+        if (memory) {
+          addFormRow(1, "Value:", valueField)
+          addFormRow(2, "Mask:", maskField)
+        }
+      }
+
+  private fun ppuCard(): JPanel =
+      formPanel().apply {
+        addFormRow(0, "Frame:", ppuFrameField)
+        addFormRow(1, "LY:", ppuLyField)
+        addFormRow(2, "Mode:", ppuModeCombo)
+      }
+
+  private fun serialCard(): JPanel =
+      formPanel().apply {
+        addFormRow(0, "Value:", serialValueField)
+        addFormRow(1, "Mask:", serialMaskField)
+      }
+
+  private fun singleFieldCard(label: String, field: Component): JPanel =
+      formPanel().apply { addFormRow(0, label, field) }
+
+  private fun comboCard(label: String, combo: Component): JPanel =
+      singleFieldCard(label, combo)
+
+  private fun formPanel(): JPanel = JPanel(GridBagLayout())
+
+  private fun JPanel.addFormRow(row: Int, text: String, field: Component) {
+    add(
+        labelFor(text, field),
+        GridBagConstraints().apply {
+          gridx = 0
+          gridy = row
+          anchor = GridBagConstraints.LINE_END
+          insets = Insets(2, 3, 2, 5)
+        },
+    )
+    add(
+        field,
+        GridBagConstraints().apply {
+          gridx = 1
+          gridy = row
+          weightx = 1.0
+          fill = GridBagConstraints.HORIZONTAL
+          anchor = GridBagConstraints.LINE_START
+          insets = Insets(2, 0, 2, 3)
+        },
+    )
+  }
+
+  private fun configureField(field: JTextField, accessibleName: String) {
+    field.accessibleContext.accessibleName = accessibleName
+    field.document.addDocumentListener(
+        object : DocumentListener {
+          override fun insertUpdate(event: DocumentEvent) = onChange()
+
+          override fun removeUpdate(event: DocumentEvent) = onChange()
+
+          override fun changedUpdate(event: DocumentEvent) = onChange()
+        })
+  }
+
+  private fun cardName(kind: DebuggerBreakpointEditorKind): String =
+      when (kind) {
+        DebuggerBreakpointEditorKind.PROGRAM_COUNTER -> CARD_PROGRAM_COUNTER
+        DebuggerBreakpointEditorKind.MEMORY_READ,
+        DebuggerBreakpointEditorKind.MEMORY_WRITE,
+        DebuggerBreakpointEditorKind.MEMORY_EXECUTE -> CARD_MEMORY
+        DebuggerBreakpointEditorKind.BASE_OPCODE,
+        DebuggerBreakpointEditorKind.CB_OPCODE -> CARD_OPCODE
+        DebuggerBreakpointEditorKind.INTERRUPT -> CARD_INTERRUPT
+        DebuggerBreakpointEditorKind.PPU_STATE -> CARD_PPU
+        DebuggerBreakpointEditorKind.SERIAL_START,
+        DebuggerBreakpointEditorKind.SERIAL_COMPLETION -> CARD_SERIAL
+        DebuggerBreakpointEditorKind.MASTER_TICK,
+        DebuggerBreakpointEditorKind.FRAME_COUNTER -> CARD_COUNTER
+      }
+
+  private companion object {
+    const val CARD_PROGRAM_COUNTER = "program-counter"
+    const val CARD_MEMORY = "memory"
+    const val CARD_OPCODE = "opcode"
+    const val CARD_INTERRUPT = "interrupt"
+    const val CARD_PPU = "ppu"
+    const val CARD_SERIAL = "serial"
+    const val CARD_COUNTER = "counter"
+  }
+}
+
+internal enum class PpuModeChoice(val mode: DebugPpuMode?, private val label: String) {
+  ANY(null, "Any mode"),
+  DISABLED(DebugPpuMode.DISABLED, "Disabled"),
+  HBLANK(DebugPpuMode.HBLANK, "HBlank"),
+  VBLANK(DebugPpuMode.VBLANK, "VBlank"),
+  OAM_SEARCH(DebugPpuMode.OAM_SEARCH, "OAM search"),
+  PIXEL_TRANSFER(DebugPpuMode.PIXEL_TRANSFER, "Pixel transfer");
+
+  override fun toString(): String = label
+
+  companion object {
+    fun from(mode: DebugPpuMode?): PpuModeChoice = entries.first { it.mode == mode }
+  }
+}
+
+private class BreakpointKindRenderer(
+    private val capabilities: () -> DebugCapabilities?,
+) : DefaultListCellRenderer() {
+  override fun getListCellRendererComponent(
+      list: JList<*>?,
+      value: Any?,
+      index: Int,
+      isSelected: Boolean,
+      cellHasFocus: Boolean,
+  ): Component {
+    val component =
+        super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
+    val kind = value as? DebuggerBreakpointEditorKind
+    if (kind != null) {
+      val supported = capabilities()?.supports(kind.negotiatedKind) == true
+      component.text = kind.displayName + if (supported || capabilities() == null) "" else " — unsupported"
+      if (!supported && capabilities() != null && !isSelected) {
+        component.foreground = disabledForeground(component.foreground)
+      }
+    }
+    return component
+  }
+
+  private fun disabledForeground(fallback: Color): Color =
+      UIManager.getColor("Label.disabledForeground") ?: fallback
+}
+
+private fun labelFor(text: String, target: Component): JLabel =
+    JLabel(text).apply {
+      labelFor = target
+    }
+
+private fun plural(count: Int, singular: String, plural: String): String =
+    if (count == 1) singular else plural
+
+private fun requireBreakpointPanelEdt(operation: String) {
+  check(SwingUtilities.isEventDispatchThread()) { "$operation must run on the Event Dispatch Thread" }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
 import eu.rekawek.coffeegb.core.debug.DebugAnchoredMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointHit
 import eu.rekawek.coffeegb.core.debug.DebugCapabilities
 import eu.rekawek.coffeegb.core.debug.DebugDisassembler
 import eu.rekawek.coffeegb.core.debug.DebugErrorCode
@@ -12,7 +13,6 @@ import eu.rekawek.coffeegb.core.debug.DebugInspectionRequest
 import eu.rekawek.coffeegb.core.debug.DebugInspectionResult
 import eu.rekawek.coffeegb.core.debug.DebugInspectionSection
 import eu.rekawek.coffeegb.core.debug.DebugMemoryBlock
-import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
 import eu.rekawek.coffeegb.core.debug.DebugMemoryRequest
 import eu.rekawek.coffeegb.core.debug.DebugPort
 import eu.rekawek.coffeegb.core.debug.DebugResult
@@ -20,9 +20,8 @@ import eu.rekawek.coffeegb.core.debug.DebugSnapshot
 import eu.rekawek.coffeegb.core.debug.DebugStepKind
 import eu.rekawek.coffeegb.core.debug.DebugStepResult
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
-import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
-import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
 import eu.rekawek.coffeegb.core.debug.history.DebugReverseStepResult
@@ -79,7 +78,6 @@ import javax.swing.ListSelectionModel
 import javax.swing.SpinnerNumberModel
 import javax.swing.SwingUtilities
 import javax.swing.Timer
-import javax.swing.table.AbstractTableModel
 import org.slf4j.LoggerFactory
 
 /** Modeless desktop debugger retained by [DesktopDebuggerController]. */
@@ -192,6 +190,8 @@ internal interface DebuggerClient {
 
   fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>>
 
+  fun lastBreakpointHit(): CompletionStage<DebugResult<DebugBreakpointHit>>
+
   fun setBreakpoint(
       breakpoint: DebugBreakpoint
   ): CompletionStage<DebugResult<DebugBreakpoint>>
@@ -237,6 +237,9 @@ private class DebugPortDebuggerClient(private val port: DebugPort) : DebuggerCli
   override fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>> =
       port.listBreakpoints()
 
+  override fun lastBreakpointHit(): CompletionStage<DebugResult<DebugBreakpointHit>> =
+      port.lastBreakpointHit()
+
   override fun setBreakpoint(
       breakpoint: DebugBreakpoint
   ): CompletionStage<DebugResult<DebugBreakpoint>> = port.setBreakpoint(breakpoint)
@@ -263,6 +266,7 @@ internal class DebuggerPanel(
   private var uiPreferences = initialPreferences.sanitized()
   internal val sessionLabel = JLabel("No emulation session")
   internal val snapshotLabel = JLabel("Waiting for a debug snapshot")
+  internal val stopReasonLabel = JLabel("No breakpoint stop in this session")
   internal val statusLabel = JLabel("Debugger ready")
   internal val runButton = JButton("Release debug pause")
   internal val pauseButton = JButton("Pause")
@@ -280,14 +284,6 @@ internal class DebuggerPanel(
   internal val memorySpace = JComboBox(SAFE_MEMORY_SPACES)
   internal val memoryRange = JTextField("\$C000-\$C07F", 15)
   internal val memoryReadButton = JButton("Read")
-  internal val breakpointKind = JComboBox(BreakpointEditorKind.entries.toTypedArray())
-  internal val breakpointRange = JTextField("\$0100", 13)
-  internal val breakpointValue = JTextField("", 4)
-  internal val breakpointMask = JTextField("", 4)
-  internal val breakpointAddButton = JButton("Add")
-  internal val breakpointRemoveButton = JButton("Remove")
-  internal val breakpointModel = DebuggerBreakpointTableModel(::toggleBreakpoint)
-  internal val breakpointTable = JTable(breakpointModel)
   internal val historyLabel = JLabel("Reverse history status unavailable")
   internal val timelineToggle = JCheckBox("Capture trace timeline")
   internal val timelineWarning = JLabel("Timeline capture is off")
@@ -314,7 +310,15 @@ internal class DebuggerPanel(
       JSplitPane(JSplitPane.VERTICAL_SPLIT, cpuScalarSplit, cpuCodeSplit)
   internal val cpuPane = cpuPanel()
   internal val memoryPane = memoryPanel()
-  internal val breakpointPane = breakpointPanel()
+  internal val breakpointPane =
+      DebuggerBreakpointPanel(
+          DebuggerBreakpointPanelCallbacks(
+              onSave = ::saveBreakpoint,
+              onRemove = ::removeBreakpoint,
+              onToggle = ::toggleBreakpoint,
+              onToggleAtCurrentPc = ::toggleBreakpointAtCurrentPc,
+              onStatus = { message -> statusLabel.text = message },
+          ))
   internal val graphicsPane = DebuggerGraphicsPanel(copyText)
   internal val audioPane = DebuggerAudioPanel(copyText)
   internal val timelinePane = timelinePanel()
@@ -325,6 +329,9 @@ internal class DebuggerPanel(
   private var client: DebuggerClient? = null
   private var latestGeneration = NO_GENERATION
   private var snapshot: DebugSnapshot? = null
+  private var lastBreakpointHit: DebugBreakpointHit? = null
+  private var breakpointRows: List<DebugBreakpoint> = emptyList()
+  private var nextBreakpointId = 0L
   private var historyStatus: DebugHistoryStatus? = null
   private var selectedMemory: DebugMemoryRequest? = null
   @Volatile private var windowEpoch = 0L
@@ -351,6 +358,7 @@ internal class DebuggerPanel(
   @Volatile private var peripheralPreparationRequestId = 0L
   private var closed = false
   private var lastAppliedStateRequestId = 0L
+  private var lastAppliedCommandRequestId = 0L
 
   init {
     requireDebuggerWindowEdt("Debugger panel construction")
@@ -358,11 +366,13 @@ internal class DebuggerPanel(
     border = BorderFactory.createEmptyBorder(6, 6, 6, 6)
     getAccessibleContext().accessibleName = "Desktop debugger"
     getAccessibleContext().accessibleDescription =
-        "F5 refreshes, F6 toggles run control, F7 and F8 step forward and back, " +
+        "F5 refreshes, F6 toggles run control, F7 and F8 step forward and back, F9 toggles " +
+            "a program-counter breakpoint, " +
             "the menu shortcut plus or minus changes font size, and the menu shortcut C copies"
 
     sessionLabel.accessibleContext.accessibleName = "Debugger session"
     snapshotLabel.accessibleContext.accessibleName = "Debugger snapshot identity"
+    stopReasonLabel.accessibleContext.accessibleName = "Debugger stop reason"
     statusLabel.accessibleContext.accessibleName = "Debugger status"
     statusLabel.accessibleContext.accessibleDescription = statusLabel.text
     statusLabel.addPropertyChangeListener("text") { event ->
@@ -378,6 +388,7 @@ internal class DebuggerPanel(
     val header = JPanel(GridLayout(0, 1, 2, 2))
     header.add(sessionLabel)
     header.add(snapshotLabel)
+    header.add(stopReasonLabel)
     header.add(historyLabel)
 
     val toolbar = JPanel(FlowLayout(FlowLayout.LEADING, 5, 2))
@@ -482,10 +493,6 @@ internal class DebuggerPanel(
       timelineModel.setRetentionLimit(uiPreferences.timelineCapacity)
     }
     memoryReadButton.addActionListener { selectMemoryRange() }
-    breakpointAddButton.addActionListener { addBreakpoint() }
-    breakpointRemoveButton.addActionListener { removeSelectedBreakpoint() }
-    breakpointTable.selectionModel.addListSelectionListener { updateControlState() }
-    breakpointKind.addActionListener { updateBreakpointEditor() }
     tabs.addChangeListener {
       if (pollingActive) {
         syncPollingTimer()
@@ -494,7 +501,6 @@ internal class DebuggerPanel(
     }
 
     installKeyboardBindings()
-    updateBreakpointEditor()
     clearSessionView()
     applyDivider(uiPreferences.cpuScalarDivider, cpuScalarSplit)
     applyDivider(uiPreferences.cpuCodeDivider, cpuCodeSplit)
@@ -532,39 +538,6 @@ internal class DebuggerPanel(
     return JPanel(BorderLayout(4, 4)).apply {
       add(controls, BorderLayout.NORTH)
       add(scroll(memoryArea), BorderLayout.CENTER)
-    }
-  }
-
-  private fun breakpointPanel(): Component {
-    breakpointTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-    breakpointTable.fillsViewportHeight = true
-    breakpointTable.autoCreateRowSorter = false
-    breakpointTable.accessibleContext.accessibleName = "Breakpoints and watchpoints"
-    breakpointTable.columnModel.getColumn(0).preferredWidth = 65
-    breakpointTable.columnModel.getColumn(1).preferredWidth = 70
-    breakpointTable.columnModel.getColumn(2).preferredWidth = 140
-    breakpointTable.columnModel.getColumn(3).preferredWidth = 420
-
-    breakpointKind.accessibleContext.accessibleName = "Breakpoint type"
-    breakpointRange.accessibleContext.accessibleName = "Breakpoint address or range"
-    breakpointValue.accessibleContext.accessibleName = "Optional watchpoint byte value"
-    breakpointMask.accessibleContext.accessibleName = "Optional watchpoint byte mask"
-    val editor = JPanel(FlowLayout(FlowLayout.LEADING))
-    editor.add(debuggerLabel("Type:", breakpointKind, KeyEvent.VK_Y))
-    editor.add(breakpointKind)
-    editor.add(debuggerLabel("Address/range:", breakpointRange, KeyEvent.VK_A))
-    editor.add(breakpointRange)
-    editor.add(debuggerLabel("Value:", breakpointValue, KeyEvent.VK_V))
-    editor.add(breakpointValue)
-    editor.add(debuggerLabel("Mask:", breakpointMask, KeyEvent.VK_M))
-    editor.add(breakpointMask)
-    breakpointAddButton.mnemonic = KeyEvent.VK_D
-    breakpointRemoveButton.mnemonic = KeyEvent.VK_O
-    editor.add(breakpointAddButton)
-    editor.add(breakpointRemoveButton)
-    return JPanel(BorderLayout(4, 4)).apply {
-      add(editor, BorderLayout.NORTH)
-      add(JScrollPane(breakpointTable), BorderLayout.CENTER)
     }
   }
 
@@ -674,6 +647,11 @@ internal class DebuggerPanel(
     ) {
       if (backFrameButton.isEnabled) backFrameButton.doClick()
     }
+    bind(KeyStroke.getKeyStroke(KeyEvent.VK_F9, 0), ACTION_TOGGLE_PC_BREAKPOINT) {
+      if (breakpointPane.toggleCurrentPcButton.isEnabled) {
+        breakpointPane.toggleCurrentPcButton.doClick()
+      }
+    }
     bind(
         KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, shortcutMask),
         ACTION_ZOOM_IN,
@@ -739,7 +717,7 @@ internal class DebuggerPanel(
               listOf(registersArea.text, machineArea.text, disassemblyArea.text, stackArea.text)
                   .joinToString("\n\n")
           memoryPane -> memoryArea.text
-          breakpointPane -> breakpointModel.copyText(breakpointTable.selectedRows)
+          breakpointPane -> breakpointPane.copyText()
           graphicsPane -> graphicsPane.copyText()
           audioPane -> audioPane.copyText()
           timelinePane -> timelineModel.copyText(timelineTable.selectedRows)
@@ -790,6 +768,9 @@ internal class DebuggerPanel(
     client = nextClient
     windowEpoch++
     snapshot = null
+    lastBreakpointHit = null
+    breakpointRows = emptyList()
+    nextBreakpointId = 0L
     historyStatus = null
     selectedMemory = null
     refreshInFlight = false
@@ -800,6 +781,7 @@ internal class DebuggerPanel(
     metadataAgain = false
     commandInFlight = false
     lastAppliedStateRequestId = 0L
+    lastAppliedCommandRequestId = 0L
     traceCursor = -1L
     timelineModel.clear()
     graphicsPane.clear()
@@ -811,7 +793,8 @@ internal class DebuggerPanel(
           nextClient.capabilities.coherentTraceInspection() -> "Timeline capture is off"
           else -> "Coherent trace timeline is unsupported in this session"
         }
-    breakpointModel.replace(emptyList(), null)
+    breakpointPane.clear()
+    breakpointPane.replace(emptyList(), nextClient?.capabilities, null, null)
     syncPollingTimer()
     if (nextClient == null) {
       clearSessionView()
@@ -824,6 +807,7 @@ internal class DebuggerPanel(
       snapshotLabel.text =
           if (coherentInspection) "Waiting for a coherent snapshot"
           else "Coherent inspection is unavailable for this session"
+      stopReasonLabel.text = "Waiting for breakpoint stop metadata"
       historyLabel.text = "Waiting for reverse history status"
       registersArea.text =
           if (coherentInspection) "Waiting for CPU state" else "Snapshot inspection unavailable"
@@ -1101,6 +1085,7 @@ internal class DebuggerPanel(
     val wasRunning = snapshot?.paused() == false
     val view = DebuggerPresentation.snapshot(result.snapshot)
     snapshot = result.snapshot
+    renderBreakpointHit()
     snapshotLabel.text =
         "${view.identity.label} — ${if (view.paused) "PAUSED" else "RUNNING"} — ${view.timingText}"
     registersArea.text = view.registers.render()
@@ -1204,28 +1189,41 @@ internal class DebuggerPanel(
     }
     val token = token(attached)
     metadataInFlight = true
+    updateControlState()
     val breakpoints =
         if (attached.capabilities.breakpoints()) attached.listBreakpoints()
         else completedResult(DebugResult.success(DebugBreakpointList(emptyList())))
     val history =
         if (attached.capabilities.history().checkpointHistory()) attached.historyStatus()
         else completedResult<DebugResult<DebugHistoryStatus>?>(null)
-    breakpoints.thenCombine(history) { breakpointResult, historyResult ->
-          MetadataResult(breakpointResult, historyResult)
+    val lastHit =
+        if (attached.capabilities.breakpoints()) attached.lastBreakpointHit()
+        else completedResult<DebugResult<DebugBreakpointHit>?>(null)
+    breakpoints
+        .thenCombine(history) { breakpointResult, historyResult ->
+          MetadataResult(breakpointResult, historyResult, null)
         }
+        .thenCombine(lastHit) { metadata, hitResult -> metadata.copy(lastHit = hitResult) }
         .whenComplete { result, failure ->
           dispatchSwingMutation {
             if (!sameSession(token)) return@dispatchSwingMutation
             metadataInFlight = false
             if (token.epoch == windowEpoch && pollingActive) {
               when {
+                token.requestId < lastAppliedCommandRequestId -> metadataAgain = true
                 failure != null -> showFailure("Metadata refresh", failure)
                 result == null -> statusLabel.text = "Metadata refresh returned no result"
                 result.breakpoints.isFailure -> showFailure("Breakpoint refresh", result.breakpoints)
                 else -> {
-                  breakpointModel.replace(
-                      result.breakpoints.value().breakpoints(),
+                  breakpointRows = result.breakpoints.value().breakpoints()
+                  advanceBreakpointId(breakpointRows)
+                  applyBreakpointHit(result.lastHit)
+                  breakpointPane.replace(
+                      breakpointRows,
                       attached.capabilities,
+                      lastBreakpointHit,
+                      snapshot?.takeIf { it.paused() }?.registers()?.pc(),
+                      isCurrentBreakpointStop(lastBreakpointHit),
                   )
                   val historyResult = result.history
                   if (historyResult != null) {
@@ -1243,6 +1241,67 @@ internal class DebuggerPanel(
             if (repeat) requestMetadata()
           }
         }
+  }
+
+  private fun applyBreakpointHit(result: DebugResult<DebugBreakpointHit>?) {
+    when {
+      result == null -> {
+        lastBreakpointHit = null
+        renderBreakpointHit()
+      }
+      result.isFailure && result.error().code() == DebugErrorCode.NO_BREAKPOINT_HIT -> {
+        lastBreakpointHit = null
+        renderBreakpointHit()
+      }
+      result.isFailure -> {
+        lastBreakpointHit = null
+        stopReasonLabel.text =
+            "Breakpoint stop reason unavailable — ${result.error().code()}: ${result.error().message()}"
+      }
+      else -> {
+        lastBreakpointHit =
+            result.value().takeIf {
+              it.snapshot().sessionGeneration() == latestGeneration
+            }
+        renderBreakpointHit()
+      }
+    }
+  }
+
+  private fun renderBreakpointHit() {
+    val hit =
+        lastBreakpointHit?.takeIf { it.snapshot().sessionGeneration() == latestGeneration }
+    breakpointPane.updateExecutionContext(
+        hit,
+        snapshot?.takeIf { it.paused() }?.registers()?.pc(),
+        isCurrentBreakpointStop(hit),
+    )
+    if (hit == null) {
+      stopReasonLabel.text = "No breakpoint stop in this session"
+      return
+    }
+    val id = hit.breakpointId().value()
+    val condition =
+        hit.breakpoint()
+            .map { DebuggerPresentation.breakpointRows(listOf(it)).single().condition }
+            .orElse("condition unavailable")
+    val current = isCurrentBreakpointStop(hit)
+    val prefix = if (current) "Stopped by" else "Last stop:"
+    stopReasonLabel.text =
+        "$prefix breakpoint #$id — $condition — matched tick ${hit.matchMasterTick()}, " +
+            "paused tick ${hit.snapshot().masterTick()}"
+  }
+
+  private fun isCurrentBreakpointStop(hit: DebugBreakpointHit?): Boolean {
+    if (hit?.activePause() != true) return false
+    val current = snapshot ?: return false
+    return current.paused() &&
+        current.sessionGeneration() == hit.snapshot().sessionGeneration() &&
+        current.masterTick() == hit.snapshot().masterTick() &&
+        current.frame() == hit.snapshot().frame() &&
+        current.framePosition() == hit.snapshot().framePosition() &&
+        current.execution().retiredInstructions() ==
+            hit.snapshot().execution().retiredInstructions()
   }
 
   private fun applyHistory(status: DebugHistoryStatus?) {
@@ -1536,36 +1595,52 @@ internal class DebuggerPanel(
     requestRefresh()
   }
 
-  private fun addBreakpoint() {
+  private fun saveBreakpoint(request: DebuggerBreakpointSaveRequest) {
     val attached = client ?: return
-    val editorKind = breakpointKind.selectedItem as BreakpointEditorKind
-    val parsed: DebuggerParsedValue<out DebugBreakpointCondition> =
-        if (editorKind == BreakpointEditorKind.PROGRAM_COUNTER) {
-          DebuggerPresentation.parseProgramCounterCondition(breakpointRange.text)
-        } else {
-          DebuggerPresentation.parseMemoryCondition(
-              breakpointRange.text,
-              editorKind.access!!,
-              breakpointValue.text,
-              breakpointMask.text,
-          )
-        }
-    if (!parsed.isValid) {
-      statusLabel.text = parsed.error
+    if (!attached.capabilities.supports(request.condition.kind())) {
+      statusLabel.text = "${request.condition.kind()} breakpoints are unsupported in this session."
+      breakpointPane.commandFailed(statusLabel.text)
       return
     }
-    val condition = parsed.value!!
-    if (!attached.capabilities.supports(condition.kind())) {
-      statusLabel.text = "${condition.kind()} breakpoints are unsupported in this session."
-      return
-    }
-    if (breakpointModel.rowCount >= attached.capabilities.maxBreakpoints()) {
+    val replacing = request.replacedId
+    if (replacing == null && breakpointRows.size >= attached.capabilities.maxBreakpoints()) {
       statusLabel.text = "The session breakpoint limit has been reached."
+      breakpointPane.commandFailed(statusLabel.text)
       return
     }
-    val id = breakpointModel.nextId()
-    val breakpoint = DebugBreakpoint(DebugBreakpointId(id), true, condition)
-    executeCommand("Add breakpoint $id", { attached.setBreakpoint(breakpoint) }) {}
+    if (replacing == null && nextBreakpointId == Long.MAX_VALUE) {
+      statusLabel.text = "No unused breakpoint identifier remains in this session."
+      breakpointPane.commandFailed(statusLabel.text)
+      return
+    }
+    if (replacing != null && breakpointRows.none { it.id() == replacing }) {
+      statusLabel.text = "Breakpoint #${replacing.value()} no longer exists; refresh before saving."
+      breakpointPane.commandFailed(statusLabel.text)
+      return
+    }
+    val duplicate =
+        breakpointRows.firstOrNull {
+          it.id() != replacing && it.condition() == request.condition
+        }
+    if (duplicate != null) {
+      statusLabel.text =
+          "Breakpoint #${duplicate.id().value()} already uses this condition."
+      breakpointPane.commandFailed(statusLabel.text)
+      return
+    }
+    val id = replacing ?: allocateBreakpointId()
+    val breakpoint = DebugBreakpoint(id, request.enabled, request.condition)
+    val verb = if (replacing == null) "Add" else "Save"
+    executeCommand(
+        "$verb breakpoint ${id.value()}",
+        { attached.setBreakpoint(breakpoint) },
+        onFailure = breakpointPane::commandFailed,
+    ) {
+      breakpointPane.commandSucceeded(
+          "${if (replacing == null) "Added" else "Saved"} breakpoint #${id.value()}",
+          clearEditor = true,
+      )
+    }
   }
 
   private fun toggleBreakpoint(breakpoint: DebugBreakpoint, enabled: Boolean) {
@@ -1578,24 +1653,92 @@ internal class DebuggerPanel(
     ) {}
   }
 
-  private fun removeSelectedBreakpoint() {
+  private fun advanceBreakpointId(values: List<DebugBreakpoint>) {
+    val maximum = values.maxOfOrNull { it.id().value() } ?: return
+    nextBreakpointId =
+        if (maximum == Long.MAX_VALUE) Long.MAX_VALUE
+        else maxOf(nextBreakpointId, maximum + 1)
+  }
+
+  private fun allocateBreakpointId(): DebugBreakpointId {
+    check(nextBreakpointId < Long.MAX_VALUE) { "Breakpoint identifiers are exhausted" }
+    return DebugBreakpointId(nextBreakpointId++)
+  }
+
+  private fun removeBreakpoint(breakpoint: DebugBreakpoint) {
     val attached = client ?: return
-    val row = breakpointTable.selectedRow
-    if (row < 0) return
-    val modelRow = breakpointTable.convertRowIndexToModel(row)
-    val breakpoint = breakpointModel.breakpointAt(modelRow)
     executeCommand(
         "Remove breakpoint ${breakpoint.id().value()}",
         { attached.removeBreakpoint(breakpoint.id()) },
-    ) {}
+        onFailure = breakpointPane::commandFailed,
+    ) {
+      breakpointPane.commandSucceeded(
+          "Removed breakpoint #${breakpoint.id().value()}",
+          clearEditor = false,
+      )
+    }
   }
 
-  private fun updateBreakpointEditor() {
-    val memory = (breakpointKind.selectedItem as? BreakpointEditorKind)?.access != null
-    breakpointValue.isEnabled = memory
-    breakpointMask.isEnabled = memory
-    updateControlState()
+  private fun toggleBreakpointAtCurrentPc(programCounter: Int) {
+    val existing = breakpointPane.breakpointsAtProgramCounter(programCounter)
+    if (existing.isNotEmpty()) {
+      removeBreakpoints(existing)
+    } else {
+      saveBreakpoint(
+          DebuggerBreakpointSaveRequest(
+              null,
+              true,
+              DebuggerBreakpointDraft.ProgramCounter(
+                  DebuggerPresentation.formatWord(programCounter)
+              ),
+              DebugPcCondition.at(programCounter),
+          ))
+    }
   }
+
+  private fun removeBreakpoints(breakpoints: List<DebugBreakpoint>) {
+    val attached = client ?: return
+    require(breakpoints.isNotEmpty()) { "At least one breakpoint is required" }
+    val ordered = breakpoints.sortedBy { it.id().value() }
+    val description =
+        if (ordered.size == 1) {
+          "breakpoint ${ordered.single().id().value()}"
+        } else {
+          "${ordered.size} duplicate PC breakpoints"
+        }
+    executeCommand(
+        "Remove $description",
+        { removeBreakpointsSequentially(attached, ordered, 0) },
+        onFailure = { message ->
+          breakpointPane.commandFailed(message)
+          // A later removal can fail after an earlier duplicate was removed. Reload the backend
+          // list so the authoritative table never conceals that partial progress.
+          requestMetadata()
+        },
+    ) {
+      breakpointPane.commandSucceeded(
+          if (ordered.size == 1) {
+            "Removed breakpoint #${ordered.single().id().value()}"
+          } else {
+            "Removed ${ordered.size} program-counter breakpoints"
+          },
+          clearEditor = false,
+      )
+    }
+  }
+
+  private fun removeBreakpointsSequentially(
+      attached: DebuggerClient,
+      breakpoints: List<DebugBreakpoint>,
+      index: Int,
+  ): CompletionStage<DebugResult<Void>> =
+      attached.removeBreakpoint(breakpoints[index].id()).thenCompose { result ->
+        if (result.isFailure || index == breakpoints.lastIndex) {
+          CompletableFuture.completedFuture(result)
+        } else {
+          removeBreakpointsSequentially(attached, breakpoints, index + 1)
+        }
+      }
 
   private fun applyCommandSnapshot(value: DebugSnapshot) {
     snapshot = value
@@ -1606,11 +1749,13 @@ internal class DebuggerPanel(
     machineArea.text = renderMachine(value)
     graphicsPane.showNotCaptured(view.identity)
     audioPane.showNotCaptured(view.identity)
+    renderBreakpointHit()
   }
 
   private fun <T> executeCommand(
       label: String,
       operation: () -> CompletionStage<DebugResult<T>>,
+      onFailure: (String) -> Unit = {},
       onSuccess: (T?) -> Unit,
   ) {
     requireDebuggerWindowEdt("Debugger command")
@@ -1626,6 +1771,7 @@ internal class DebuggerPanel(
         } catch (failure: RuntimeException) {
           commandInFlight = false
           showFailure(label, failure)
+          onFailure(statusLabel.text)
           updateControlState()
           return
         }
@@ -1635,10 +1781,21 @@ internal class DebuggerPanel(
         commandInFlight = false
         if (token.epoch == windowEpoch && pollingActive) {
           when {
-            failure != null -> showFailure(label, failure)
-            result == null -> statusLabel.text = "$label returned no result"
-            result.isFailure -> showFailure(label, result)
+            failure != null -> {
+              showFailure(label, failure)
+              onFailure(statusLabel.text)
+            }
+            result == null -> {
+              statusLabel.text = "$label returned no result"
+              onFailure(statusLabel.text)
+            }
+            result.isFailure -> {
+              showFailure(label, result)
+              onFailure(statusLabel.text)
+            }
             else -> {
+              lastAppliedCommandRequestId =
+                  maxOf(lastAppliedCommandRequestId, token.requestId)
               lastAppliedStateRequestId = maxOf(lastAppliedStateRequestId, token.requestId)
               onSuccess(result.value())
               if (statusLabel.text == "$label…") statusLabel.text = "$label completed"
@@ -1682,22 +1839,7 @@ internal class DebuggerPanel(
     memoryRange.isEnabled = usable && paused && capabilities?.coherentInspection() == true
     memoryReadButton.isEnabled = usable && paused && capabilities?.coherentInspection() == true
 
-    val editorKind = breakpointKind.selectedItem as? BreakpointEditorKind
-    val editorSupported =
-        when {
-          editorKind == null || capabilities == null -> false
-          editorKind == BreakpointEditorKind.PROGRAM_COUNTER ->
-              capabilities.supports(DebugBreakpointKind.PROGRAM_COUNTER)
-          else -> capabilities.supports(DebugBreakpointKind.MEMORY)
-        }
-    breakpointKind.isEnabled = usable && capabilities?.breakpoints() == true
-    breakpointRange.isEnabled = usable && editorSupported
-    breakpointValue.isEnabled = usable && editorSupported && editorKind?.access != null
-    breakpointMask.isEnabled = usable && editorSupported && editorKind?.access != null
-    breakpointAddButton.isEnabled = usable && editorSupported
-    breakpointRemoveButton.isEnabled =
-        usable && capabilities?.breakpoints() == true && breakpointTable.selectedRow >= 0
-    breakpointTable.isEnabled = usable && capabilities?.breakpoints() == true
+    breakpointPane.setBusy(commandInFlight || metadataInFlight || closed)
 
     val traceSupported = capabilities?.coherentTraceInspection() == true
     val timelineOwned = traceOwner === attached && !traceDisableRequested
@@ -1714,7 +1856,7 @@ internal class DebuggerPanel(
               traceSupported &&
               !timelineOwned &&
               !traceConfigurationInFlight &&
-              capabilities?.supports(category) == true
+              capabilities.supports(category)
     }
     timelineCapacity.isEnabled =
         usable &&
@@ -1728,6 +1870,7 @@ internal class DebuggerPanel(
   private fun clearSessionView() {
     sessionLabel.text = "No emulation session"
     snapshotLabel.text = "Waiting for a debug snapshot"
+    stopReasonLabel.text = "No breakpoint stop in this session"
     historyLabel.text = "Reverse history status unavailable"
     registersArea.text = "No CPU state"
     machineArea.text = "No machine state"
@@ -1751,11 +1894,14 @@ internal class DebuggerPanel(
   private fun releaseRetainedSessionState() {
     client?.let { releaseTimelineOwnership(it, "Debugger hidden; timeline state released") }
     snapshot = null
+    lastBreakpointHit = null
+    breakpointRows = emptyList()
     historyStatus = null
     selectedMemory = null
     snapshotOnlyRefreshPending = false
-    breakpointModel.replace(emptyList(), client?.capabilities)
+    breakpointPane.clear()
     snapshotLabel.text = "Debugger hidden; retained snapshot released"
+    stopReasonLabel.text = "Debugger hidden; breakpoint stop state released"
     historyLabel.text = "Debugger hidden; reverse-history state released"
     registersArea.text = "Debugger hidden; CPU state released"
     machineArea.text = "Debugger hidden; machine state released"
@@ -1826,10 +1972,12 @@ internal class DebuggerPanel(
     activeRefreshRequestId = 0L
     if (ownsPeripheralExecutor) peripheralExecutor.shutdownNow()
     snapshot = null
+    lastBreakpointHit = null
+    breakpointRows = emptyList()
     historyStatus = null
     selectedMemory = null
     snapshotOnlyRefreshPending = false
-    breakpointModel.replace(emptyList(), null)
+    breakpointPane.clear()
     clearSessionView()
     statusLabel.text = "Debugger closed"
     updateControlState()
@@ -1908,6 +2056,7 @@ internal class DebuggerPanel(
   private data class MetadataResult(
       val breakpoints: DebugResult<DebugBreakpointList>,
       val history: DebugResult<DebugHistoryStatus>?,
+      val lastHit: DebugResult<DebugBreakpointHit>?,
   )
 
   private companion object {
@@ -1924,6 +2073,7 @@ internal class DebuggerPanel(
     const val ACTION_STEP_FRAME = "debugger-step-frame"
     const val ACTION_BACK_INSTRUCTION = "debugger-back-instruction"
     const val ACTION_BACK_FRAME = "debugger-back-frame"
+    const val ACTION_TOGGLE_PC_BREAKPOINT = "debugger-toggle-pc-breakpoint"
     const val ACTION_ZOOM_IN = "debugger-zoom-in"
     const val ACTION_ZOOM_OUT = "debugger-zoom-out"
     const val ACTION_ZOOM_RESET = "debugger-zoom-reset"
@@ -1935,97 +2085,6 @@ internal class DebuggerPanel(
             DebugAddressSpace.WORK_RAM,
             DebugAddressSpace.HIGH_RAM,
         )
-  }
-}
-
-internal enum class BreakpointEditorKind(
-    private val label: String,
-    val access: DebugMemoryAccess?,
-) {
-  PROGRAM_COUNTER("Program counter", null),
-  READ("Memory read", DebugMemoryAccess.READ),
-  WRITE("Memory write", DebugMemoryAccess.WRITE),
-  EXECUTE("Memory execute", DebugMemoryAccess.EXECUTE);
-
-  override fun toString(): String = label
-}
-
-internal class DebuggerBreakpointTableModel(
-    private val onToggle: (DebugBreakpoint, Boolean) -> Unit,
-) : AbstractTableModel() {
-  private var breakpoints: List<DebugBreakpoint> = emptyList()
-  private var rows: List<DebuggerBreakpointRow> = emptyList()
-
-  override fun getRowCount(): Int = rows.size
-
-  override fun getColumnCount(): Int = COLUMNS.size
-
-  override fun getColumnName(column: Int): String = COLUMNS[column]
-
-  override fun getColumnClass(columnIndex: Int): Class<*> =
-      if (columnIndex == 0) java.lang.Boolean::class.java else String::class.java
-
-  override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean =
-      columnIndex == 0 && rows[rowIndex].supported
-
-  override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
-    val row = rows[rowIndex]
-    return when (columnIndex) {
-      0 -> row.enabled
-      1 -> row.id.toString()
-      2 -> row.kind
-      3 -> row.condition
-      else -> error("Unknown breakpoint column: $columnIndex")
-    }
-  }
-
-  override fun setValueAt(value: Any?, rowIndex: Int, columnIndex: Int) {
-    if (columnIndex != 0 || value !is Boolean) return
-    onToggle(breakpoints[rowIndex], value)
-  }
-
-  fun breakpointAt(row: Int): DebugBreakpoint = breakpoints[row]
-
-  fun nextId(): Long {
-    val maximum = breakpoints.maxOfOrNull { it.id().value() } ?: -1L
-    check(maximum < Long.MAX_VALUE) { "Breakpoint identifiers are exhausted" }
-    return maximum + 1
-  }
-
-  fun replace(values: List<DebugBreakpoint>, capabilities: DebugCapabilities?) {
-    breakpoints = values.toList()
-    rows = DebuggerPresentation.breakpointRows(breakpoints, capabilities)
-    fireTableDataChanged()
-  }
-
-  fun copyText(selectedRows: IntArray): String {
-    val indexes =
-        selectedRows
-            .asSequence()
-            .filter { it in rows.indices }
-            .distinct()
-            .sorted()
-            .toList()
-            .ifEmpty { rows.indices.toList() }
-    return buildString {
-          append(COLUMNS.joinToString("\t"))
-          indexes.forEach { index ->
-            val row = rows[index]
-            append('\n')
-            append(row.enabled)
-            append('\t')
-            append(row.id)
-            append('\t')
-            append(row.kind)
-            append('\t')
-            append(row.condition)
-          }
-        }
-        .trimEnd()
-  }
-
-  private companion object {
-    val COLUMNS = arrayOf("Enabled", "ID", "Kind", "Condition")
   }
 }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointDraftTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointDraftTest.kt
@@ -1,0 +1,239 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugInterruptType
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterType
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugInterruptCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugMemoryCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugOpcodeCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPpuCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugSerialCondition
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DebuggerBreakpointDraftTest {
+  @Test
+  fun `editor variants expose the negotiated core kind`() {
+    assertEquals(
+        mapOf(
+            DebuggerBreakpointEditorKind.PROGRAM_COUNTER to
+                DebugBreakpointKind.PROGRAM_COUNTER,
+            DebuggerBreakpointEditorKind.MEMORY_READ to DebugBreakpointKind.MEMORY,
+            DebuggerBreakpointEditorKind.MEMORY_WRITE to DebugBreakpointKind.MEMORY,
+            DebuggerBreakpointEditorKind.MEMORY_EXECUTE to DebugBreakpointKind.MEMORY,
+            DebuggerBreakpointEditorKind.BASE_OPCODE to DebugBreakpointKind.OPCODE,
+            DebuggerBreakpointEditorKind.CB_OPCODE to DebugBreakpointKind.OPCODE,
+            DebuggerBreakpointEditorKind.INTERRUPT to DebugBreakpointKind.INTERRUPT,
+            DebuggerBreakpointEditorKind.PPU_STATE to DebugBreakpointKind.PPU_STATE,
+            DebuggerBreakpointEditorKind.SERIAL_START to DebugBreakpointKind.SERIAL,
+            DebuggerBreakpointEditorKind.SERIAL_COMPLETION to DebugBreakpointKind.SERIAL,
+            DebuggerBreakpointEditorKind.MASTER_TICK to DebugBreakpointKind.COUNTER,
+            DebuggerBreakpointEditorKind.FRAME_COUNTER to DebugBreakpointKind.COUNTER,
+        ),
+        DebuggerBreakpointEditorKind.entries.associateWith { it.negotiatedKind },
+    )
+    assertTrue(DebuggerBreakpointEditorKind.entries.all { it.displayName.isNotBlank() })
+  }
+
+  @Test
+  fun `program counter and memory drafts reuse established hexadecimal parsing`() {
+    assertEquals(
+        DebugPcCondition(0x100, 0x1ff),
+        parse(DebuggerBreakpointDraft.ProgramCounter("${'$'}0100..0x01FF")),
+    )
+    assertEquals(
+        DebugMemoryCondition(DebugMemoryAccess.READ, 0xc000, 0xc000),
+        parse(DebuggerBreakpointDraft.Memory(DebugMemoryAccess.READ, "C000")),
+    )
+    assertEquals(
+        DebugMemoryCondition(DebugMemoryAccess.WRITE, 0xc000, 0xc0ff, 0x7f),
+        parse(
+            DebuggerBreakpointDraft.Memory(
+                DebugMemoryAccess.WRITE,
+                "${'$'}C000-${'$'}C0FF",
+                "7f",
+            )
+        ),
+    )
+    assertEquals(
+        DebugMemoryCondition(DebugMemoryAccess.EXECUTE, 0x100, 0x1ff, 0xa0, 0xf0),
+        parse(
+            DebuggerBreakpointDraft.Memory(
+                DebugMemoryAccess.EXECUTE,
+                "0100:01ff",
+                "${'$'}A0",
+                "0xF0",
+            )
+        ),
+    )
+  }
+
+  @Test
+  fun `opcode interrupt and serial variants build their typed conditions`() {
+    assertEquals(
+        DebugOpcodeCondition.base(0x3e),
+        parse(DebuggerBreakpointDraft.Opcode(false, "3e")),
+    )
+    assertEquals(
+        DebugOpcodeCondition.cb(0x7c),
+        parse(DebuggerBreakpointDraft.Opcode(true, "${'$'}7C")),
+    )
+    assertEquals(
+        DebugInterruptCondition(DebugInterruptType.VBLANK),
+        parse(DebuggerBreakpointDraft.Interrupt(DebugInterruptType.VBLANK)),
+    )
+    assertEquals(
+        DebugSerialCondition(DebugSerialCondition.Event.TRANSFER_STARTED),
+        parse(DebuggerBreakpointDraft.Serial(DebugSerialCondition.Event.TRANSFER_STARTED)),
+    )
+    assertEquals(
+        DebugSerialCondition(DebugSerialCondition.Event.BYTE_TRANSFERRED, 0xa5, 0xf0),
+        parse(
+            DebuggerBreakpointDraft.Serial(
+                DebugSerialCondition.Event.BYTE_TRANSFERRED,
+                "A5",
+                "F0",
+            )
+        ),
+    )
+  }
+
+  @Test
+  fun `PPU draft accepts optional bounded decimal or explicitly hexadecimal constraints`() {
+    assertEquals(
+        DebugPpuCondition(42, 153, DebugPpuMode.PIXEL_TRANSFER),
+        parse(
+            DebuggerBreakpointDraft.Ppu(
+                frameText = "42",
+                lyText = "${'$'}99",
+                mode = DebugPpuMode.PIXEL_TRANSFER,
+            )
+        ),
+    )
+    assertEquals(
+        DebugPpuCondition.inMode(DebugPpuMode.VBLANK),
+        parse(DebuggerBreakpointDraft.Ppu(mode = DebugPpuMode.VBLANK)),
+    )
+    assertEquals(
+        DebugPpuCondition.atFrame(16),
+        parse(DebuggerBreakpointDraft.Ppu(frameText = "0x10")),
+    )
+  }
+
+  @Test
+  fun `counter drafts distinguish decimal from prefixed hexadecimal values`() {
+    assertEquals(
+        DebugCounterCondition.atMasterTick(10),
+        parse(DebuggerBreakpointDraft.Counter(DebugCounterType.MASTER_TICK, "10")),
+    )
+    assertEquals(
+        DebugCounterCondition.atMasterTick(16),
+        parse(DebuggerBreakpointDraft.Counter(DebugCounterType.MASTER_TICK, "${'$'}10")),
+    )
+    assertEquals(
+        DebugCounterCondition.atFrame(16),
+        parse(DebuggerBreakpointDraft.Counter(DebugCounterType.FRAME, "0x10")),
+    )
+    assertEquals(
+        DebugCounterCondition.atFrame(Long.MAX_VALUE),
+        parse(
+            DebuggerBreakpointDraft.Counter(
+                DebugCounterType.FRAME,
+                "${'$'}7fffffffffffffff",
+            )
+        ),
+    )
+  }
+
+  @Test
+  fun `draft validation reports missing dependent and bounded values without throwing`() {
+    assertError(DebuggerBreakpointDraft.Interrupt(null), "Choose an interrupt")
+    assertError(DebuggerBreakpointDraft.Ppu(), "at least one PPU constraint")
+    assertError(DebuggerBreakpointDraft.Ppu(lyText = "154"), "LY must be between 0 and 153")
+    assertError(DebuggerBreakpointDraft.Ppu(frameText = "-1"), "Frame must be")
+    assertError(
+        DebuggerBreakpointDraft.Counter(DebugCounterType.MASTER_TICK, ""),
+        "Master tick is required",
+    )
+    assertError(
+        DebuggerBreakpointDraft.Counter(DebugCounterType.FRAME, "9223372036854775808"),
+        "between 0 and ${Long.MAX_VALUE}",
+    )
+    assertError(
+        DebuggerBreakpointDraft.Memory(
+            DebugMemoryAccess.WRITE,
+            "${'$'}C000",
+            maskText = "F0",
+        ),
+        "value is required",
+    )
+    assertError(
+        DebuggerBreakpointDraft.Serial(
+            DebugSerialCondition.Event.TRANSFER_STARTED,
+            valueText = "12",
+            maskText = "00",
+        ),
+        "at least one set bit",
+    )
+  }
+
+  @Test
+  fun `every core condition round trips through an editable draft`() {
+    val conditions =
+        listOf<DebugBreakpointCondition>(
+            DebugPcCondition(0x100, 0x1ff),
+            DebugMemoryCondition(DebugMemoryAccess.READ, 0xc000, 0xc010),
+            DebugMemoryCondition(DebugMemoryAccess.WRITE, 0xd000, 0xd000, 0x7f),
+            DebugMemoryCondition(DebugMemoryAccess.EXECUTE, 0x100, 0x1ff, 0xa0, 0xf0),
+            DebugOpcodeCondition.base(0x3e),
+            DebugOpcodeCondition.cb(0x7c),
+            DebugInterruptCondition(DebugInterruptType.TIMER),
+            DebugPpuCondition(12, 144, DebugPpuMode.VBLANK),
+            DebugSerialCondition(DebugSerialCondition.Event.TRANSFER_STARTED, 0x81),
+            DebugSerialCondition(DebugSerialCondition.Event.BYTE_TRANSFERRED, 0xa0, 0xf0),
+            DebugCounterCondition.atMasterTick(123_456),
+            DebugCounterCondition.atFrame(789),
+        )
+
+    val drafts = conditions.map { DebuggerBreakpointDraft.from(it) }
+
+    assertEquals(DebuggerBreakpointEditorKind.entries, drafts.map { it.editorKind })
+    assertEquals(conditions, drafts.map(::parse))
+    drafts.forEach { draft ->
+      assertEquals(draft, DebuggerBreakpointDraft.from(parse(draft)))
+    }
+  }
+
+  @Test
+  fun `invalid opcode and ambiguous bare hexadecimal counters retain friendly field errors`() {
+    val opcode = DebuggerBreakpointDraft.Opcode(false, "100").parse()
+    assertFalse(opcode.isValid)
+    assertContains(opcode.error!!, "Opcode")
+
+    val counter =
+        DebuggerBreakpointDraft.Counter(DebugCounterType.FRAME, "A").parse()
+    assertFalse(counter.isValid)
+    assertContains(counter.error!!, "Frame counter")
+    assertContains(counter.error, "prefixed")
+  }
+
+  private fun parse(draft: DebuggerBreakpointDraft): DebugBreakpointCondition {
+    val result = draft.parse()
+    assertTrue(result.isValid, result.error)
+    return result.value!!
+  }
+
+  private fun assertError(draft: DebuggerBreakpointDraft, expected: String) {
+    val result = draft.parse()
+    assertFalse(result.isValid)
+    assertContains(result.error!!, expected, ignoreCase = true)
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointPanelTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerBreakpointPanelTest.kt
@@ -1,0 +1,427 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.debug.DebugApuState
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointHit
+import eu.rekawek.coffeegb.core.debug.DebugCapabilities
+import eu.rekawek.coffeegb.core.debug.DebugCpuState
+import eu.rekawek.coffeegb.core.debug.DebugExecutionState
+import eu.rekawek.coffeegb.core.debug.DebugFeatureState
+import eu.rekawek.coffeegb.core.debug.DebugInterruptState
+import eu.rekawek.coffeegb.core.debug.DebugInterruptType
+import eu.rekawek.coffeegb.core.debug.DebugMapperState
+import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess
+import eu.rekawek.coffeegb.core.debug.DebugPpuMode
+import eu.rekawek.coffeegb.core.debug.DebugPpuState
+import eu.rekawek.coffeegb.core.debug.DebugRegisters
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot
+import eu.rekawek.coffeegb.core.debug.DebugTimerState
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugCounterCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugInterruptCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugMemoryCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugOpcodeCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPpuCondition
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugSerialCondition
+import eu.rekawek.coffeegb.core.debug.history.DebugHistoryCapabilities
+import java.util.EnumSet
+import java.util.concurrent.FutureTask
+import javax.swing.JComponent
+import javax.swing.KeyStroke
+import javax.swing.SortOrder
+import javax.swing.SwingUtilities
+import javax.swing.RowSorter
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DebuggerBreakpointPanelTest {
+
+  @Test
+  fun `typed cards emit every supported condition without mutating authoritative rows`() {
+    val saves = mutableListOf<DebuggerBreakpointSaveRequest>()
+    val panel = onEdt {
+      DebuggerBreakpointPanel(
+          DebuggerBreakpointPanelCallbacks(onSave = saves::add),
+      ).also { it.replace(emptyList(), capabilities(), currentProgramCounter = 0x100) }
+    }
+    val cases =
+        listOf(
+            EditorCase(DebuggerBreakpointEditorKind.PROGRAM_COUNTER, DebugPcCondition.at(0x150)) {
+              panel.editor.addressField.text = "\$0150"
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.MEMORY_READ,
+                DebugMemoryCondition(DebugMemoryAccess.READ, 0xc000, 0xc00f, 0xa0, 0xf0),
+            ) {
+              panel.editor.memoryAddressField.text = "C000-C00F"
+              panel.editor.valueField.text = "A0"
+              panel.editor.maskField.text = "F0"
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.MEMORY_WRITE,
+                DebugMemoryCondition(DebugMemoryAccess.WRITE, 0xd000, 0xd000),
+            ) {
+              panel.editor.memoryAddressField.text = "D000"
+              panel.editor.valueField.text = ""
+              panel.editor.maskField.text = ""
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.MEMORY_EXECUTE,
+                DebugMemoryCondition(DebugMemoryAccess.EXECUTE, 0x200, 0x2ff),
+            ) {
+              panel.editor.memoryAddressField.text = "0200-02FF"
+              panel.editor.valueField.text = ""
+              panel.editor.maskField.text = ""
+            },
+            EditorCase(DebuggerBreakpointEditorKind.BASE_OPCODE, DebugOpcodeCondition.base(0x3e)) {
+              panel.editor.opcodeField.text = "3E"
+            },
+            EditorCase(DebuggerBreakpointEditorKind.CB_OPCODE, DebugOpcodeCondition.cb(0x7c)) {
+              panel.editor.opcodeField.text = "7C"
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.INTERRUPT,
+                DebugInterruptCondition(DebugInterruptType.TIMER),
+            ) {
+              panel.editor.interruptCombo.selectedItem = DebugInterruptType.TIMER
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.PPU_STATE,
+                DebugPpuCondition(12, 144, DebugPpuMode.VBLANK),
+            ) {
+              panel.editor.ppuFrameField.text = "12"
+              panel.editor.ppuLyField.text = "144"
+              panel.editor.ppuModeCombo.selectedItem = PpuModeChoice.VBLANK
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.SERIAL_START,
+                DebugSerialCondition(DebugSerialCondition.Event.TRANSFER_STARTED, 0x81),
+            ) {
+              panel.editor.serialValueField.text = "81"
+              panel.editor.serialMaskField.text = ""
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.SERIAL_COMPLETION,
+                DebugSerialCondition(DebugSerialCondition.Event.BYTE_TRANSFERRED, 0xa0, 0xf0),
+            ) {
+              panel.editor.serialValueField.text = "A0"
+              panel.editor.serialMaskField.text = "F0"
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.MASTER_TICK,
+                DebugCounterCondition.atMasterTick(1234),
+            ) {
+              panel.editor.counterField.text = "1234"
+            },
+            EditorCase(
+                DebuggerBreakpointEditorKind.FRAME_COUNTER,
+                DebugCounterCondition.atFrame(16),
+            ) {
+              panel.editor.counterField.text = "0x10"
+            },
+        )
+
+    onEdt {
+      cases.forEach { case ->
+        panel.editor.kindCombo.selectedItem = case.kind
+        case.configure()
+        assertEquals(case.expected, panel.editor.draft().parse().value)
+        panel.saveButton.doClick()
+        assertEquals(case.expected, saves.last().condition)
+        assertNull(saves.last().replacedId)
+      }
+
+      assertEquals(0, panel.table.rowCount)
+      assertEquals(12, saves.size)
+      assertEquals("Breakpoint condition type", panel.editor.kindCombo.accessibleContext.accessibleName)
+      assertSame(panel.editor.addressField, findLabel(panel, "Address/range:").labelFor)
+      assertNotNull(
+          panel
+              .getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+              .get(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_F9, 0))
+      )
+    }
+  }
+
+  @Test
+  fun `search sort edit duplicate remove and toggle preserve authoritative backend state`() {
+    val saves = mutableListOf<DebuggerBreakpointSaveRequest>()
+    val removals = mutableListOf<DebugBreakpoint>()
+    val toggles = mutableListOf<Pair<DebugBreakpoint, Boolean>>()
+    val panel = onEdt {
+      DebuggerBreakpointPanel(
+          DebuggerBreakpointPanelCallbacks(
+              onSave = saves::add,
+              onRemove = removals::add,
+              onToggle = { breakpoint, enabled -> toggles += breakpoint to enabled },
+          ))
+    }
+    val values =
+        listOf(
+            breakpoint(9, DebugPcCondition.at(0x150)),
+            breakpoint(2, DebugMemoryCondition(DebugMemoryAccess.WRITE, 0xc000, 0xc00f)),
+            breakpoint(5, DebugInterruptCondition(DebugInterruptType.SERIAL), enabled = false),
+        )
+
+    onEdt {
+      panel.replace(values, capabilities(), currentProgramCounter = 0x150)
+      assertEquals(3, panel.table.rowCount)
+      assertEquals(listOf(values[0]), panel.breakpointsAtProgramCounter(0x150))
+      assertTrue(panel.breakpointsAtProgramCounter(0x151).isEmpty())
+
+      panel.filterField.text = "write"
+      assertEquals(1, panel.table.rowCount)
+      assertEquals("1 of 3 breakpoints", panel.resultCountLabel.text)
+      assertContains(panel.copyText(), "Write \$C000-\$C00F")
+      assertFalse(panel.copyText().contains("Serial"))
+      panel.clearFilterButton.doClick()
+
+      panel.table.rowSorter.sortKeys = listOf(RowSorter.SortKey(2, SortOrder.DESCENDING))
+      assertEquals(9L, panel.table.getValueAt(0, 2))
+      panel.table.setRowSelectionInterval(0, 0)
+      val enterAction =
+          panel.table.actionMap.get(
+              panel.table
+                  .getInputMap(JComponent.WHEN_FOCUSED)
+                  .get(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ENTER, 0)))
+      enterAction.actionPerformed(null)
+      assertEquals("\$0150", panel.editor.addressField.text)
+      panel.editor.addressField.text = "\$0160"
+      panel.saveButton.doClick()
+      assertEquals(DebugBreakpointId(9), saves.single().replacedId)
+      assertEquals(DebugPcCondition.at(0x160), saves.single().condition)
+      assertEquals(DebugPcCondition.at(0x150), panel.tableModel.breakpointAt(0).condition())
+
+      panel.duplicateButton.doClick()
+      assertEquals("\$0150", panel.editor.addressField.text)
+      panel.editor.addressField.text = "\$0170"
+      panel.saveButton.doClick()
+      assertNull(saves.last().replacedId)
+      assertEquals(DebugPcCondition.at(0x170), saves.last().condition)
+
+      panel.removeButton.doClick()
+      assertEquals(values[0], removals.single())
+      assertEquals(3, panel.table.rowCount)
+
+      panel.tableModel.setValueAt(false, 0, 1)
+      assertEquals(values[0] to false, toggles.single())
+      assertEquals(true, panel.tableModel.getValueAt(0, 1))
+
+      panel.commandFailed("Save failed")
+      assertEquals("\$0170", panel.editor.addressField.text)
+      panel.commandSucceeded("Saved", clearEditor = true)
+      assertEquals("\$0100", panel.editor.addressField.text)
+      assertEquals("Saved", panel.editorStatusLabel.text)
+    }
+  }
+
+  @Test
+  fun `last hit and F9 context update independently from authoritative row replacement`() {
+    val toggledPcs = mutableListOf<Int>()
+    val panel = onEdt {
+      DebuggerBreakpointPanel(
+          DebuggerBreakpointPanelCallbacks(onToggleAtCurrentPc = toggledPcs::add),
+      )
+    }
+    val exactPc = breakpoint(4, DebugPcCondition.at(0x1234))
+    val rangePc = breakpoint(6, DebugPcCondition(0x1200, 0x12ff))
+    val hit = DebugBreakpointHit(exactPc, 99, snapshot(masterTick = 103), true)
+
+    onEdt {
+      panel.replace(listOf(exactPc, rangePc), capabilities(), hit, 0x1234)
+      assertContains(panel.hitLabel.text, "breakpoint #4")
+      assertContains(panel.hitLabel.text, "matched at tick 99")
+      assertEquals("Last hit", panel.tableModel.getValueAt(0, 0))
+      assertEquals(listOf(exactPc), panel.breakpointsAtProgramCounter(0x1234))
+      assertFalse(rangePc in panel.breakpointsAtProgramCounter(0x1234))
+
+      val actionName =
+          panel
+              .getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+              .get(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_F9, 0))
+      panel.actionMap.get(actionName).actionPerformed(null)
+      assertEquals(listOf(0x1234), toggledPcs)
+      assertEquals(2, panel.table.rowCount)
+
+      panel.updateExecutionContext(null, 0x4567)
+      assertContains(panel.hitLabel.text, "No breakpoint hit")
+      assertEquals("", panel.tableModel.getValueAt(0, 0))
+      panel.toggleCurrentPcButton.doClick()
+      assertEquals(listOf(0x1234, 0x4567), toggledPcs)
+      assertEquals(2, panel.table.rowCount)
+    }
+  }
+
+  @Test
+  fun `synchronous callback status wins over pending editor status`() {
+    lateinit var panel: DebuggerBreakpointPanel
+    panel =
+        onEdt {
+          DebuggerBreakpointPanel(
+              DebuggerBreakpointPanelCallbacks(
+                  onSave = { panel.commandFailed("Breakpoint limit reached") },
+                  onToggleAtCurrentPc = { panel.commandFailed("Toggle rejected") },
+              ))
+        }
+
+    onEdt {
+      panel.replace(emptyList(), capabilities(), null, 0x1234)
+      panel.editor.addressField.text = "\$1234"
+      panel.saveButton.doClick()
+      assertEquals("Breakpoint limit reached", panel.editorStatusLabel.text)
+
+      panel.toggleCurrentPcButton.doClick()
+      assertEquals("Toggle rejected", panel.editorStatusLabel.text)
+    }
+  }
+
+  @Test
+  fun `exact PC lookup returns duplicate definitions in stable identifier order`() {
+    val panel = onEdt { DebuggerBreakpointPanel() }
+    val first = breakpoint(9, DebugPcCondition.at(0x1234))
+    val second = breakpoint(2, DebugPcCondition.at(0x1234))
+    val range = breakpoint(1, DebugPcCondition(0x1200, 0x12ff))
+
+    onEdt {
+      panel.replace(listOf(first, range, second), capabilities(), null, 0x1234)
+      assertEquals(listOf(second, first), panel.breakpointsAtProgramCounter(0x1234))
+    }
+  }
+
+  @Test
+  fun `capability and busy gates suppress unsupported or premature commands`() {
+    val saves = mutableListOf<DebuggerBreakpointSaveRequest>()
+    val toggles = mutableListOf<Pair<DebugBreakpoint, Boolean>>()
+    val panel = onEdt {
+      DebuggerBreakpointPanel(
+          DebuggerBreakpointPanelCallbacks(
+              onSave = saves::add,
+              onToggle = { breakpoint, enabled -> toggles += breakpoint to enabled },
+          ))
+    }
+    val pc = breakpoint(1, DebugPcCondition.at(0x100))
+    val ppu = breakpoint(2, DebugPpuCondition.atLy(42))
+
+    onEdt {
+      panel.replace(listOf(pc, ppu), capabilities(DebugBreakpointKind.PROGRAM_COUNTER), null, 0x100)
+      assertEquals("Enter a breakpoint condition", panel.editorStatusLabel.text)
+      assertTrue(panel.tableModel.isCellEditable(0, 1))
+      assertFalse(panel.tableModel.isCellEditable(1, 1))
+      assertEquals("Supported", panel.tableModel.getValueAt(0, 5))
+      assertEquals("Unsupported in this session", panel.tableModel.getValueAt(1, 5))
+
+      panel.editor.kindCombo.selectedItem = DebuggerBreakpointEditorKind.PPU_STATE
+      assertFalse(panel.saveButton.isEnabled)
+      assertFalse(panel.editor.ppuLyField.isEnabled)
+      assertContains(panel.editorStatusLabel.text, "unsupported")
+      panel.saveButton.doClick()
+      assertTrue(saves.isEmpty())
+
+      panel.setBusy(true)
+      assertFalse(panel.table.isEnabled)
+      assertFalse(panel.toggleCurrentPcButton.isEnabled)
+      panel.tableModel.setValueAt(false, 0, 1)
+      assertTrue(toggles.isEmpty())
+
+      panel.setBusy(false)
+      panel.editor.kindCombo.selectedItem = DebuggerBreakpointEditorKind.PROGRAM_COUNTER
+      assertEquals("Enter a breakpoint condition", panel.editorStatusLabel.text)
+      assertTrue(panel.saveButton.isEnabled)
+      panel.clear()
+      assertEquals(0, panel.table.rowCount)
+      assertFalse(panel.saveButton.isEnabled)
+      assertFalse(panel.toggleCurrentPcButton.isEnabled)
+      assertContains(panel.hitLabel.text, "No breakpoint hit")
+    }
+
+    assertFailsWith<IllegalStateException> { panel.setBusy(false) }
+  }
+
+  private data class EditorCase(
+      val kind: DebuggerBreakpointEditorKind,
+      val expected: DebugBreakpointCondition,
+      val configure: () -> Unit,
+  )
+
+  private fun breakpoint(
+      id: Long,
+      condition: DebugBreakpointCondition,
+      enabled: Boolean = true,
+  ): DebugBreakpoint = DebugBreakpoint(DebugBreakpointId(id), enabled, condition)
+
+  private fun capabilities(vararg kinds: DebugBreakpointKind): DebugCapabilities {
+    val supported =
+        if (kinds.isEmpty()) EnumSet.allOf(DebugBreakpointKind::class.java)
+        else EnumSet.copyOf(kinds.toList())
+    return DebugCapabilities(
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        4096,
+        supported,
+        128,
+        emptySet(),
+        0,
+        0,
+        DebugHistoryCapabilities.disabled(),
+    )
+  }
+
+  private fun snapshot(masterTick: Long): DebugSnapshot =
+      DebugSnapshot(
+          1,
+          7,
+          masterTick,
+          4,
+          0,
+          true,
+          DebugRegisters(0x12, 0xb0, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xc000, 0x1234),
+          DebugInterruptState(true, false, 0x01, 0x01, 0x01),
+          DebugTimerState(0x1234, 0x10, 0x20, 0x04, false, 0),
+          DebugPpuState(true, DebugPpuMode.OAM_SEARCH, 0, 0, 0x91, 0x82, 0, 0, 0, 0, 0),
+          DebugApuState(true, 0, false, false, false, false, 0, 0, 0x80),
+          DebugMapperState(
+              "test",
+              -1,
+              -1,
+              DebugFeatureState.UNKNOWN,
+              DebugFeatureState.UNKNOWN,
+              DebugFeatureState.UNKNOWN,
+          ),
+          DebugExecutionState(DebugCpuState.OPCODE_FETCH, 0, -1, 0, false, false, 7),
+      )
+
+  private fun findLabel(panel: DebuggerBreakpointPanel, text: String): javax.swing.JLabel =
+      descendants(panel).filterIsInstance<javax.swing.JLabel>().first { it.text == text }
+
+  private fun descendants(root: java.awt.Component): List<java.awt.Component> =
+      buildList {
+        fun visit(component: java.awt.Component) {
+          add(component)
+          (component as? java.awt.Container)?.components?.forEach(::visit)
+        }
+        visit(root)
+      }
+
+  private fun <T> onEdt(action: () -> T): T {
+    if (SwingUtilities.isEventDispatchThread()) return action()
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPanelTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DebuggerPanelTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.debug.DebugAudioChannelInspection
 import eu.rekawek.coffeegb.core.debug.DebugAudioInspection
 import eu.rekawek.coffeegb.core.debug.DebugApuState
 import eu.rekawek.coffeegb.core.debug.DebugBreakpointList
+import eu.rekawek.coffeegb.core.debug.DebugBreakpointHit
 import eu.rekawek.coffeegb.core.debug.DebugByteData
 import eu.rekawek.coffeegb.core.debug.DebugCapabilities
 import eu.rekawek.coffeegb.core.debug.DebugCpuState
@@ -30,6 +31,8 @@ import eu.rekawek.coffeegb.core.debug.DebugStepResult
 import eu.rekawek.coffeegb.core.debug.DebugTimerState
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpoint
 import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointId
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugBreakpointKind
+import eu.rekawek.coffeegb.core.debug.breakpoint.DebugPcCondition
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryCapabilities
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryConfiguration
 import eu.rekawek.coffeegb.core.debug.history.DebugHistoryStatus
@@ -367,7 +370,7 @@ class DebuggerPanelTest {
       assertContains(onEdt { panel.memoryArea.text }, "released")
       assertFalse(onEdt { panel.snapshotLabel.text }.contains("snapshot 2"))
       assertFalse(onEdt { panel.refreshButton.isEnabled })
-      assertEquals(0, onEdt { panel.breakpointModel.rowCount })
+      assertEquals(0, onEdt { panel.breakpointPane.tableModel.rowCount })
     } finally {
       onEdt(panel::close)
     }
@@ -394,6 +397,364 @@ class DebuggerPanelTest {
       onEdt { panel.refreshButton.doClick() }
       assertEquals(3, client.historyRequests.size)
       assertEquals(4, client.inspections.size)
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `breakpoint metadata identifies the current stop and becomes historical after movement`() {
+    val client =
+        RecordingDebuggerClient(
+            131,
+            capabilities(breakpoints = true),
+            deferLastBreakpointHit = true,
+        )
+    val breakpoint =
+        DebugBreakpoint(DebugBreakpointId(7), true, DebugPcCondition.at(0x0150))
+    client.breakpointDefinitions = listOf(breakpoint)
+    val panel = attach(client)
+    try {
+      val stoppingSnapshot = snapshot(131, 1, paused = true, pc = 0x0150)
+      val recapturedSnapshot =
+          snapshot(
+              131,
+              2,
+              paused = true,
+              pc = 0x0150,
+              masterTick = stoppingSnapshot.masterTick(),
+              frame = stoppingSnapshot.frame(),
+              retiredInstructions = stoppingSnapshot.execution().retiredInstructions(),
+          )
+      completeInspection(client.inspections.single(), recapturedSnapshot)
+      flushEdt()
+
+      client.lastBreakpointHitRequests.single().complete(
+          DebugResult.success(DebugBreakpointHit(breakpoint, 9, stoppingSnapshot, true))
+      )
+      flushEdt()
+
+      assertContains(onEdt { panel.stopReasonLabel.text }, "Stopped by breakpoint #7")
+      assertContains(onEdt { panel.stopReasonLabel.text }, "${'$'}0150")
+      assertContains(onEdt { panel.stopReasonLabel.text }, "matched tick 9")
+
+      val followUp = client.inspections.last()
+      completeInspection(followUp, snapshot(131, 3, paused = true, pc = 0x0151))
+      flushEdt()
+
+      assertContains(onEdt { panel.stopReasonLabel.text }, "Last stop: breakpoint #7")
+      assertFalse(onEdt { panel.stopReasonLabel.text }.startsWith("Stopped by"))
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `foreign generation breakpoint metadata is rejected by every breakpoint surface`() {
+    val client =
+        RecordingDebuggerClient(
+            132,
+            capabilities(breakpoints = true),
+            deferLastBreakpointHit = true,
+        )
+    val breakpoint =
+        DebugBreakpoint(DebugBreakpointId(8), true, DebugPcCondition.at(0x0200))
+    client.breakpointDefinitions = listOf(breakpoint)
+    val panel = attach(client)
+    try {
+      completeInspection(
+          client.inspections.single(),
+          snapshot(132, 1, paused = true, pc = 0x0200),
+      )
+      flushEdt()
+
+      client.lastBreakpointHitRequests.single().complete(
+          DebugResult.success(
+              DebugBreakpointHit(
+                  breakpoint.id(),
+                  9,
+                  snapshot(999, 1, paused = true, pc = 0x0200),
+              ))
+      )
+      flushEdt()
+
+      assertEquals("No breakpoint stop in this session", onEdt { panel.stopReasonLabel.text })
+      assertContains(onEdt { panel.breakpointPane.hitLabel.text }, "No breakpoint hit")
+      assertEquals("", onEdt { panel.breakpointPane.tableModel.getValueAt(0, 0) })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `editing a hit id keeps the captured condition and clears the row marker`() {
+    val original = DebugBreakpoint(DebugBreakpointId(7), true, DebugPcCondition.at(0x0150))
+    val client =
+        RecordingDebuggerClient(
+            137,
+            capabilities(breakpoints = true),
+            deferLastBreakpointHit = true,
+        ).apply { breakpointDefinitions = listOf(original) }
+    val panel = attach(client)
+    try {
+      val stoppingSnapshot = snapshot(137, 1, paused = true, pc = 0x0150)
+      completeInspection(client.inspections.single(), stoppingSnapshot)
+      flushEdt()
+      val hit = DebugBreakpointHit(original, 9, stoppingSnapshot, true)
+      client.lastBreakpointHitRequests.single().complete(DebugResult.success(hit))
+      flushEdt()
+      assertEquals("Last hit", onEdt { panel.breakpointPane.tableModel.getValueAt(0, 0) })
+
+      onEdt {
+        panel.breakpointPane.table.setRowSelectionInterval(0, 0)
+        panel.breakpointPane.editButton.doClick()
+        panel.breakpointPane.editor.addressField.text = "\$0160"
+        panel.breakpointPane.saveButton.doClick()
+      }
+      val edit = client.breakpointSets.single()
+      assertEquals(original.id(), edit.breakpoint.id())
+      assertEquals(DebugPcCondition.at(0x0160), edit.breakpoint.condition())
+      client.breakpointDefinitions = listOf(edit.breakpoint)
+      edit.completion.complete(DebugResult.success(edit.breakpoint))
+      flushEdt()
+
+      assertEquals(2, client.lastBreakpointHitRequests.size)
+      client.lastBreakpointHitRequests.last().complete(DebugResult.success(hit))
+      flushEdt()
+
+      assertContains(onEdt { panel.stopReasonLabel.text }, "\$0150")
+      assertFalse(onEdt { panel.stopReasonLabel.text }.contains("\$0160"))
+      assertEquals("", onEdt { panel.breakpointPane.tableModel.getValueAt(0, 0) })
+      assertEquals("\$0160", onEdt { panel.breakpointPane.tableModel.getValueAt(0, 4) })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `breakpoint pane waits for a matching inspection before calling a hit current`() {
+    val breakpoint =
+        DebugBreakpoint(DebugBreakpointId(10), true, DebugPcCondition.at(0x0500))
+    val client =
+        RecordingDebuggerClient(
+            138,
+            capabilities(breakpoints = true),
+            deferLastBreakpointHit = true,
+        ).apply { breakpointDefinitions = listOf(breakpoint) }
+    val panel = attach(client)
+    try {
+      val stoppingSnapshot = snapshot(138, 1, paused = true, pc = 0x0500)
+      client.lastBreakpointHitRequests.single().complete(
+          DebugResult.success(DebugBreakpointHit(breakpoint, 9, stoppingSnapshot, true))
+      )
+      flushEdt()
+
+      assertContains(onEdt { panel.stopReasonLabel.text }, "Last stop:")
+      assertContains(onEdt { panel.breakpointPane.hitLabel.text }, "Last hit:")
+      assertFalse(onEdt { panel.breakpointPane.hitLabel.text }.contains("Current stop"))
+
+      completeInspection(
+          client.inspections.single(),
+          snapshot(
+              138,
+              2,
+              paused = true,
+              pc = 0x0500,
+              masterTick = stoppingSnapshot.masterTick(),
+              frame = stoppingSnapshot.frame(),
+              retiredInstructions = stoppingSnapshot.execution().retiredInstructions(),
+          ),
+      )
+      flushEdt()
+
+      assertContains(onEdt { panel.stopReasonLabel.text }, "Stopped by breakpoint #10")
+      assertContains(onEdt { panel.breakpointPane.hitLabel.text }, "Current stop:")
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `metadata started before a resume cannot restore the old stop reason`() {
+    val client =
+        RecordingDebuggerClient(
+            133,
+            capabilities(breakpoints = true),
+            deferLastBreakpointHit = true,
+        )
+    val breakpoint =
+        DebugBreakpoint(DebugBreakpointId(9), true, DebugPcCondition.at(0x0300))
+    client.breakpointDefinitions = listOf(breakpoint)
+    val panel = attach(client)
+    try {
+      val stoppingSnapshot = snapshot(133, 1, paused = true, pc = 0x0300)
+      completeInspection(client.inspections.single(), stoppingSnapshot)
+      flushEdt()
+
+      onEdt { panel.runButton.doClick() }
+      client.resumes.single().complete(
+          DebugResult.success(snapshot(133, 2, paused = false, pc = 0x0300))
+      )
+      flushEdt()
+
+      client.lastBreakpointHitRequests.single().complete(
+          DebugResult.success(DebugBreakpointHit(breakpoint.id(), 9, stoppingSnapshot))
+      )
+      flushEdt()
+
+      assertEquals(2, client.lastBreakpointHitRequests.size)
+      assertEquals("No breakpoint stop in this session", onEdt { panel.stopReasonLabel.text })
+      assertContains(onEdt { panel.breakpointPane.hitLabel.text }, "No breakpoint hit")
+
+      client.lastBreakpointHitRequests.last().complete(
+          DebugResult.failure(
+              DebugErrorCode.NO_BREAKPOINT_HIT,
+              "No breakpoint has stopped this session",
+          )
+      )
+      flushEdt()
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `breakpoint CRUD waits for authoritative state and never reuses allocated ids`() {
+    val initial = DebugBreakpoint(DebugBreakpointId(5), true, DebugPcCondition.at(0x0150))
+    val client = RecordingDebuggerClient(132, capabilities(breakpoints = true))
+    client.breakpointDefinitions = listOf(initial)
+    val panel = attach(client)
+    try {
+      completeInspection(
+          client.inspections.single(),
+          snapshot(132, 1, paused = true, pc = 0x0150),
+      )
+      flushEdt()
+      assertEquals(1, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      onEdt {
+        panel.breakpointPane.editor.addressField.text = "\$0160"
+        panel.breakpointPane.saveButton.doClick()
+      }
+
+      val firstAdd = client.breakpointSets.single()
+      assertEquals(6, firstAdd.breakpoint.id().value())
+      assertEquals(DebugPcCondition.at(0x0160), firstAdd.breakpoint.condition())
+      assertEquals(1, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      client.breakpointDefinitions = listOf(initial, firstAdd.breakpoint)
+      firstAdd.completion.complete(DebugResult.success(firstAdd.breakpoint))
+      flushEdt()
+      assertEquals(2, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      onEdt {
+        val modelRow = panel.breakpointPane.tableModel.indexOf(firstAdd.breakpoint.id())
+        val viewRow = panel.breakpointPane.table.convertRowIndexToView(modelRow)
+        panel.breakpointPane.table.setRowSelectionInterval(viewRow, viewRow)
+        panel.breakpointPane.removeButton.doClick()
+      }
+
+      val removal = client.breakpointRemovals.single()
+      assertEquals(firstAdd.breakpoint.id(), removal.breakpointId)
+      assertEquals(2, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      client.breakpointDefinitions = listOf(initial)
+      removal.completion.complete(DebugResult.success())
+      flushEdt()
+      assertEquals(1, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      onEdt {
+        panel.breakpointPane.editor.addressField.text = "\$0170"
+        panel.breakpointPane.saveButton.doClick()
+      }
+
+      val secondAdd = client.breakpointSets.last()
+      assertEquals(2, client.breakpointSets.size)
+      assertEquals(7, secondAdd.breakpoint.id().value())
+      assertEquals(DebugPcCondition.at(0x0170), secondAdd.breakpoint.condition())
+      assertEquals(1, onEdt { panel.breakpointPane.tableModel.rowCount })
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `session replacement clears breakpoint drafts filters and edit identity`() {
+    val oldBreakpoint =
+        DebugBreakpoint(DebugBreakpointId(5), true, DebugPcCondition.at(0x0150))
+    val oldClient = RecordingDebuggerClient(134, capabilities(breakpoints = true)).apply {
+      breakpointDefinitions = listOf(oldBreakpoint)
+    }
+    val newClient = RecordingDebuggerClient(135, capabilities(breakpoints = true))
+    val panel = attach(oldClient)
+    try {
+      completeInspection(
+          oldClient.inspections.single(),
+          snapshot(134, 1, paused = true, pc = 0x0150),
+      )
+      flushEdt()
+      onEdt {
+        panel.breakpointPane.table.setRowSelectionInterval(0, 0)
+        panel.breakpointPane.editButton.doClick()
+        panel.breakpointPane.editor.addressField.text = "\$2222"
+        panel.breakpointPane.filterField.text = "private old-session draft"
+
+        panel.updateClient(135, newClient)
+      }
+      flushEdt()
+
+      assertEquals("", onEdt { panel.breakpointPane.filterField.text })
+      assertEquals("\$0100", onEdt { panel.breakpointPane.editor.addressField.text })
+      assertEquals(0, onEdt { panel.breakpointPane.tableModel.rowCount })
+
+      onEdt {
+        panel.breakpointPane.editor.addressField.text = "\$0200"
+        panel.breakpointPane.saveButton.doClick()
+      }
+      assertEquals(1, newClient.breakpointSets.size)
+      assertEquals(0, newClient.breakpointSets.single().breakpoint.id().value())
+      assertEquals(DebugPcCondition.at(0x0200), newClient.breakpointSets.single().breakpoint.condition())
+    } finally {
+      onEdt(panel::close)
+    }
+  }
+
+  @Test
+  fun `global F9 removes every duplicate breakpoint at the paused PC`() {
+    val first = DebugBreakpoint(DebugBreakpointId(9), true, DebugPcCondition.at(0x0400))
+    val second = DebugBreakpoint(DebugBreakpointId(2), true, DebugPcCondition.at(0x0400))
+    val client = RecordingDebuggerClient(136, capabilities(breakpoints = true)).apply {
+      breakpointDefinitions = listOf(first, second)
+    }
+    val panel = attach(client)
+    try {
+      completeInspection(
+          client.inspections.single(),
+          snapshot(136, 1, paused = true, pc = 0x0400),
+      )
+      flushEdt()
+
+      onEdt {
+        val input = panel.getInputMap(javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+        val actionName = input.get(KeyStroke.getKeyStroke(KeyEvent.VK_F9, 0))
+        panel.actionMap.get(actionName).actionPerformed(null)
+      }
+
+      assertEquals(listOf(DebugBreakpointId(2)), client.breakpointRemovals.map { it.breakpointId })
+      assertEquals(2, onEdt { panel.breakpointPane.tableModel.rowCount })
+      client.breakpointRemovals.single().completion.complete(DebugResult.success())
+      flushEdt()
+
+      assertEquals(
+          listOf(DebugBreakpointId(2), DebugBreakpointId(9)),
+          client.breakpointRemovals.map { it.breakpointId },
+      )
+      client.breakpointDefinitions = emptyList()
+      client.breakpointRemovals.last().completion.complete(DebugResult.success())
+      flushEdt()
+
+      assertEquals(0, onEdt { panel.breakpointPane.tableModel.rowCount })
+      assertContains(onEdt { panel.breakpointPane.editorStatusLabel.text }, "Removed 2")
     } finally {
       onEdt(panel::close)
     }
@@ -807,6 +1168,12 @@ class DebuggerPanelTest {
                 .getInputMap(javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
                 .get(KeyStroke.getKeyStroke(KeyEvent.VK_F8, 0))
           })
+      assertNotNull(
+          onEdt {
+            panel
+                .getInputMap(javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+                .get(KeyStroke.getKeyStroke(KeyEvent.VK_F9, 0))
+          })
 
       val rowHeight = onEdt { panel.timelineTable.rowHeight }
       onEdt {
@@ -934,13 +1301,17 @@ class DebuggerPanelTest {
       paused: Boolean,
       pc: Int = 0x100,
       sp: Int = 0xc000,
+      masterTick: Long = sequence * 10,
+      frame: Long = sequence,
+      framePosition: Int = 0,
+      retiredInstructions: Long = sequence,
   ): DebugSnapshot =
       DebugSnapshot(
           generation,
           sequence,
-          sequence * 10,
-          sequence,
-          0,
+          masterTick,
+          frame,
+          framePosition,
           paused,
           DebugRegisters(0x12, 0xb0, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, sp, pc),
           DebugInterruptState(true, false, 0x01, 0x01, 0x01),
@@ -967,7 +1338,15 @@ class DebuggerPanelTest {
               DebugFeatureState.UNKNOWN,
               DebugFeatureState.UNKNOWN,
           ),
-          DebugExecutionState(DebugCpuState.OPCODE_FETCH, 0, -1, 0, false, false, sequence),
+          DebugExecutionState(
+              DebugCpuState.OPCODE_FETCH,
+              0,
+              -1,
+              0,
+              false,
+              false,
+              retiredInstructions,
+          ),
       )
 
   private fun capabilities(
@@ -975,6 +1354,7 @@ class DebuggerPanelTest {
       coherentInspection: Boolean = true,
       history: Boolean = false,
       trace: Boolean = false,
+      breakpoints: Boolean = false,
       inspectionSections: Set<DebugInspectionSection> = emptySet(),
   ): DebugCapabilities =
       if (coherentInspection) {
@@ -987,8 +1367,8 @@ class DebuggerPanelTest {
             true,
             true,
             maxInspectionBytes,
-            emptySet(),
-            0,
+            if (breakpoints) EnumSet.allOf(DebugBreakpointKind::class.java) else emptySet(),
+            if (breakpoints) 128 else 0,
             if (trace) EnumSet.allOf(TraceCategory::class.java) else emptySet(),
             if (trace) 2_000 else 0,
             if (trace) 256 else 0,
@@ -1200,10 +1580,21 @@ class DebuggerPanelTest {
       val completion: CompletableFuture<DebugResult<TraceConfiguration>>,
   )
 
+  private data class BreakpointSetCall(
+      val breakpoint: DebugBreakpoint,
+      val completion: CompletableFuture<DebugResult<DebugBreakpoint>>,
+  )
+
+  private data class BreakpointRemovalCall(
+      val breakpointId: DebugBreakpointId,
+      val completion: CompletableFuture<DebugResult<Void>>,
+  )
+
   private class RecordingDebuggerClient(
       override val generation: Long,
       override val capabilities: DebugCapabilities,
       private val failTraceDisable: Boolean = false,
+      private val deferLastBreakpointHit: Boolean = false,
   ) : DebuggerClient {
     val inspections = mutableListOf<InspectionCall>()
     val pauses = mutableListOf<CompletableFuture<DebugResult<DebugSnapshot>>>()
@@ -1211,6 +1602,11 @@ class DebuggerPanelTest {
     val historyRequests = mutableListOf<CompletableFuture<DebugResult<DebugHistoryStatus>>>()
     val historyConfigurations = mutableListOf<HistoryConfigurationCall>()
     val traceConfigurations = mutableListOf<TraceConfigurationCall>()
+    val lastBreakpointHitRequests =
+        mutableListOf<CompletableFuture<DebugResult<DebugBreakpointHit>>>()
+    val breakpointSets = mutableListOf<BreakpointSetCall>()
+    val breakpointRemovals = mutableListOf<BreakpointRemovalCall>()
+    var breakpointDefinitions: List<DebugBreakpoint> = emptyList()
 
     override fun inspect(
         request: DebugInspectionRequest
@@ -1254,15 +1650,36 @@ class DebuggerPanelTest {
         }
 
     override fun listBreakpoints(): CompletionStage<DebugResult<DebugBreakpointList>> =
-        CompletableFuture.completedFuture(DebugResult.success(DebugBreakpointList(emptyList())))
+        CompletableFuture.completedFuture(
+            DebugResult.success(DebugBreakpointList(breakpointDefinitions))
+        )
+
+    override fun lastBreakpointHit(): CompletionStage<DebugResult<DebugBreakpointHit>> =
+        CompletableFuture<DebugResult<DebugBreakpointHit>>().also { completion ->
+          lastBreakpointHitRequests += completion
+          if (!deferLastBreakpointHit) {
+            completion.complete(
+                DebugResult.failure(
+                    DebugErrorCode.NO_BREAKPOINT_HIT,
+                    "No breakpoint has stopped this session",
+                )
+            )
+          }
+        }
 
     override fun setBreakpoint(
         breakpoint: DebugBreakpoint
-    ): CompletionStage<DebugResult<DebugBreakpoint>> = unsupported()
+    ): CompletionStage<DebugResult<DebugBreakpoint>> =
+        CompletableFuture<DebugResult<DebugBreakpoint>>().also { completion ->
+          breakpointSets += BreakpointSetCall(breakpoint, completion)
+        }
 
     override fun removeBreakpoint(
         breakpointId: DebugBreakpointId
-    ): CompletionStage<DebugResult<Void>> = unsupported()
+    ): CompletionStage<DebugResult<Void>> =
+        CompletableFuture<DebugResult<Void>>().also { completion ->
+          breakpointRemovals += BreakpointRemovalCall(breakpointId, completion)
+        }
 
     private fun <T> unsupported(): CompletionStage<DebugResult<T>> =
         CompletableFuture.completedFuture(


### PR DESCRIPTION
## Summary

- replace the cramped PC/memory breakpoint controls with a searchable, sortable Breakpoint Center inspired by Mesen
- expose every breakpoint kind already supported by Coffee GB, with typed editing, validation, duplication, enable/disable, removal, session capability feedback, and an F9 PC toggle
- carry the immutable triggering breakpoint and active-pause state through the debug contract so the UI can distinguish the current stop reason from historical hits
- document the pinned Mesen audit and a phased path toward watches, bank-aware disassembly, hardware tools, and safe state mutation

## Why

Mesen treats breakpoints and the current stop reason as first-class debugger state. Coffee GB's Swing debugger previously exposed only narrow PC and memory forms and could not reliably explain whether an old hit still owned the current pause. This change establishes that interaction model while retaining the asynchronous, session-safe debug transport.

## User impact

- create and edit PC, memory, opcode, interrupt, PPU, serial, tick, and frame breakpoints from one panel
- filter and sort breakpoint definitions, duplicate them, or toggle them without optimistic UI drift
- press F9 to toggle an exact breakpoint at the paused PC
- see the exact condition responsible for the current stop; prior hits remain available as history after execution moves
- see unsupported breakpoint kinds explicitly when a session cannot execute them

## Validation

- `mvn -pl swing -am test` — 2,449 tests, 0 failures, 0 errors, 4 intentional skips
- `mvn -pl cli -am -DskipTests package` — full CLI compatibility package succeeds
- focused breakpoint model, lifecycle, async UI, filtering, sorting, F9, and session-replacement tests
- `git diff --check`
- independent implementation review found no remaining blockers

## Mesen references

The audit is pinned to MesenCE commit `b2b9497c1d4a1859deffeda4f0e3192dad46a44c`, including its dock layout, workspace manager, disassembly, watch-list, and Game Boy register-viewer implementations. The source links and capability mapping are recorded in `docs/debugger-modernization.md`.
