### PR TITLE
Move debugger windows into Debug menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ fixed-capacity CPU/memory/interrupt traces with cursor-visible overwrite account
 inspection is deliberately limited to side-effect-free views, and the adapter exposes no live
 emulator objects or memory-write backdoor. The complete safe-point, breakpoint, trace, and
 performance contract is in [`docs/debug-port.md`](docs/debug-port.md).
-The modeless **Tools > Debugger** window, coherent panes, keyboard controls, bounded trace opt-in,
-and privacy/retention behavior are documented in
+The modeless windows under the top-level **Debug** menu, coherent panes, keyboard controls,
+bounded trace opt-in, and privacy/retention behavior are documented in
 [`docs/desktop-debugger.md`](docs/desktop-debugger.md).
 Deterministic input recordings use the bounded, ROM-free `CGBR` container documented in
 [`docs/replay-format-v1.md`](docs/replay-format-v1.md); playback runs in a service-isolated session

--- a/docs/desktop-debugger.md
+++ b/docs/desktop-debugger.md
@@ -1,9 +1,11 @@
 # Desktop debugger
 
-Open **Tools > Debugger** to show Coffee GB's modeless debugger window. The window can remain open
-while the game runs and never calls the emulator core directly: every command goes through the
-current session's `DebugPort` and is applied at an emulation safe point. A linked/rollback session
-may publish an inspection-only or unsupported port; the window reports the negotiated capabilities
+Open a specific modeless debugger window from **Debug > Execution**, **Memory**, **Breakpoints**,
+**Video**, **Hardware & I/O**, **Audio**, or **Timeline**. Built-in arrangements are under
+**Debug > Layout**. The debugger windows have no menu bars of their own and can remain open while
+the game runs. They never call the emulator core directly: every command goes through the current
+session's `DebugPort` and is applied at an emulation safe point. A linked/rollback session may
+publish an inspection-only or unsupported port; each window reports the negotiated capabilities
 instead of offering unsafe one-machine controls.
 
 ## Snapshot identity and panes

--- a/docs/realtime-debugger-ui-proposal.md
+++ b/docs/realtime-debugger-ui-proposal.md
@@ -23,9 +23,10 @@ CPU, Graphics, Timing, and Full; there is no custom-preset or **Save Layout As**
 
 Coffee GB now presents debugging as a **workspace of modeless Swing windows**, not one large dialog
 containing mutually exclusive tabs. The workspace has independent **Execution**, **Memory**,
-**Breakpoints**, **Video**, **Hardware & I/O**, **Audio**, and **Timeline** windows. Window menus
-open, hide, raise, and tile them; four built-in layouts provide CPU, graphics, timing, and full
-arrangements. Bounds, visibility, hold state, and the selected built-in layout are persisted.
+**Breakpoints**, **Video**, **Hardware & I/O**, **Audio**, and **Timeline** windows. The emulator's
+top-level **Debug** menu opens or raises each window; its **Layout** submenu provides CPU, graphics,
+timing, and full arrangements. Debugger windows deliberately have no menu bars of their own.
+Bounds, hold state, and the selected built-in layout are persisted.
 
 Every visible, non-held window updates automatically while the game runs. There is no Refresh
 action, and Pause is run control rather than an inspection prerequisite. A local **Hold updates**
@@ -41,7 +42,7 @@ precision, copying, and accessibility. Raster lanes and rolling audio waveforms 
 
 | Area | Implemented in July 2026 | Explicitly remaining |
 | --- | --- | --- |
-| Window model | One retained workspace owns seven independent modeless windows, built-in layouts, tiling, visibility, bounds, and per-window Hold | Custom named presets, layout-save UI, persisted inner split/column state, and detachable Video tabs |
+| Window model | One retained workspace owns seven independent modeless windows, top-level Debug navigation, built-in arranged layouts, bounds, and per-window Hold | Custom named presets, layout-save UI, persisted inner split/column state, and detachable Video tabs |
 | Updates | One 50 ms timer drives a single-flight 20 Hz scalar stream; run-control and interest changes request immediate samples; no workspace Refresh action | A measured frame-ready subscription, if future profiling justifies one |
 | CPU | Structured register cells, flag indicators, execution fields, one decoded instruction, and stack table | Bank-aware scrolling disassembly, symbols/source, watches, call stack, and step-over/out |
 | Memory | Live side-effect-free hex/ASCII table, address-space combo, bounded start/length spinners, PC/SP follow, and byte-change highlighting | Generic bank selection, Follow HL, editing, and side-effectful I/O/VRAM/OAM reads |
@@ -80,21 +81,19 @@ view, calm enough for long sessions, and predictable across Windows, macOS, and 
 
 ## Workspace and window model
 
-`Tools > Debug Workspace` opens the saved visible windows or, on first use, the CPU layout
-containing **Execution**, **Memory**, and **Breakpoints**. The emulator window remains independent.
-Normal debugging does not use modal debugger dialogs.
+The emulator's top-level menu contains **Debug > Execution**, **Memory**, **Breakpoints**,
+**Video**, **Hardware & I/O**, **Audio**, and **Timeline**. Selecting an entry shows or raises only
+that window while leaving other visible debugger windows alone. **Debug > Layout** contains the
+four built-in arrangements: **CPU debugging**, **Graphics debugging**, **Timing and I/O**, and
+**Full workspace**. Applying one replaces the visible set with that arrangement and positions its
+windows. There is no named custom-layout editor, **Save Layout As**, reset-layout action,
+**Bring All to Front**, or standalone **Tile Visible Windows** command.
 
-The **Window** menu contains:
+The child windows have no **Window**, **Layout**, or **View** menu and no menu bar. Copy, run-control,
+and font-zoom shortcuts remain installed directly on each window. Normal debugging does not use
+modal debugger dialogs.
 
-- checkable entries for every tool window;
-- **Bring All to Front**;
-- **Tile Visible Windows**.
-
-The separate **Layout** menu contains the four built-in layouts: **CPU**, **Graphics**,
-**Timing and I/O**, and **Full workspace**. There is no named custom-layout editor, **Save Layout
-As**, or reset-layout action.
-
-Window bounds, visibility, Hold state, and the selected built-in layout are persisted. Snapshot
+Window bounds, Hold state, and the selected built-in layout are persisted. Snapshot
 data, ROM bytes, memory, traces, breakpoint hits, symbols, paths, copied data, inner split
 positions, table columns, and Video controls are not persisted. Saved bounds outside the current
 screen topology are discarded in favor of normal placement.
@@ -378,8 +377,9 @@ catch up.
 
 Implemented presentation-layer types include:
 
-- `DebuggerWorkspace` — modeless tool-window lifecycle, built-in layouts, persisted bounds,
-  visibility/Hold state, menus, and shared key bindings;
+- `DebuggerWorkspace` — modeless tool-window lifecycle, built-in layouts, persisted bounds and
+  Hold state, visibility/interest tracking, and shared key bindings; top-level navigation belongs
+  to `SwingMenu`;
 - `DebuggerPanel` — sole inspection planner, trace owner, request correlator, cadence owner, and
   EDT integration point;
 - `DebuggerExecutionPanel`, `DebuggerMemoryPanel`, `DebuggerBreakpointPanel`,
@@ -470,8 +470,8 @@ The following are deliberate current limitations and must not be implied by the 
 
 Delivered in the current tree:
 
-- seven retained modeless tool windows with built-in CPU/Graphics/Timing/Full layouts, persisted
-  bounds/visibility/Hold state, tiling, and session-safe lifecycle;
+- seven retained modeless tool windows with top-level Debug navigation, built-in
+  CPU/Graphics/Timing/Full arrangements, persisted bounds/Hold state, and session-safe lifecycle;
 - one single-flight 20 Hz coherent planner with hidden/held interest withdrawal and immediate
   command/interest refresh demand;
 - structured Execution, live safe Memory with PC/SP follow, typed breakpoint cards with dedicated

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWindow.kt
@@ -91,10 +91,16 @@ internal class DebuggerWindow(owner: JFrame) : DesktopDebuggerView {
     if (!closed) workspace.updateSession(event)
   }
 
-  override fun showWindow() {
-    requireDebuggerWindowEdt("Debugger window opening")
+  override fun showTool(tool: DebuggerWorkspaceTool) {
+    requireDebuggerWindowEdt("Debugger tool opening")
     if (closed) return
-    workspace.showWindow()
+    workspace.showTool(tool)
+  }
+
+  override fun applyLayout(layout: DebuggerWorkspaceLayout) {
+    requireDebuggerWindowEdt("Debugger layout opening")
+    if (closed) return
+    workspace.applyLayout(layout)
   }
 
   override fun close() {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWorkspace.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DebuggerWorkspace.kt
@@ -16,18 +16,12 @@ import java.util.EnumMap
 import java.util.prefs.Preferences
 import javax.swing.AbstractAction
 import javax.swing.BorderFactory
-import javax.swing.ButtonGroup
 import javax.swing.JCheckBox
-import javax.swing.JCheckBoxMenuItem
 import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.JFrame
 import javax.swing.JLabel
-import javax.swing.JMenu
-import javax.swing.JMenuBar
-import javax.swing.JMenuItem
 import javax.swing.JPanel
-import javax.swing.JRadioButtonMenuItem
 import javax.swing.KeyStroke
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
@@ -56,7 +50,6 @@ internal enum class DebuggerWorkspaceLayout(val title: String) {
 
 internal data class DebuggerWorkspaceToolPreferences(
     val bounds: Rectangle? = null,
-    val visible: Boolean = false,
     val held: Boolean = false,
 )
 
@@ -68,7 +61,7 @@ internal data class DebuggerWorkspacePreferences(
       tools[tool] ?: DebuggerWorkspaceToolPreferences()
 }
 
-/** Only window placement, visibility, and update-hold presentation state are persisted. */
+/** Only window placement, update-hold state, and the last applied built-in layout are persisted. */
 internal class DebuggerWorkspacePreferencesStore(
     private val node: Preferences =
         Preferences.userNodeForPackage(DebuggerWindow::class.java).node("debugger-workspace-v2"),
@@ -90,7 +83,6 @@ internal class DebuggerWorkspacePreferencesStore(
                           .takeIf(::validBounds)
                   DebuggerWorkspaceToolPreferences(
                       bounds = bounds,
-                      visible = node.getBoolean("$prefix-visible", false),
                       held = node.getBoolean("$prefix-held", false),
                   )
                 }
@@ -113,7 +105,6 @@ internal class DebuggerWorkspacePreferencesStore(
           node.putInt("$prefix-width", bounds.width)
           node.putInt("$prefix-height", bounds.height)
         }
-        node.putBoolean("$prefix-visible", state.visible)
         node.putBoolean("$prefix-held", state.held)
       }
       node.put("layout", value.layout.name)
@@ -136,14 +127,8 @@ internal class DebuggerWorkspace(
 ) : AutoCloseable {
   private val loaded = preferencesStore.load()
   private val windows = EnumMap<DebuggerWorkspaceTool, ToolWindow>(DebuggerWorkspaceTool::class.java)
-  private val visibilityMenuItems =
-      DebuggerWorkspaceTool.entries.associateWith { mutableListOf<JCheckBoxMenuItem>() }
-  private val layoutMenuItems =
-      DebuggerWorkspaceLayout.entries.associateWith { mutableListOf<JRadioButtonMenuItem>() }
   private var currentLayout = loaded.layout
-  private var opened = false
   private var closed = false
-  private var changingLayout = false
 
   init {
     require(SwingUtilities.isEventDispatchThread()) { "Debugger workspace construction must run on EDT" }
@@ -151,27 +136,16 @@ internal class DebuggerWorkspace(
       val saved = loaded.state(tool)
       windows[tool] = ToolWindow(tool, panel.workspaceComponent(tool), saved)
     }
-    syncVisibilityMenus()
-    syncLayoutMenus()
     panel.setWorkspaceMode(true)
     updatePanelInterest()
   }
 
-  fun showWindow() {
-    check(SwingUtilities.isEventDispatchThread()) { "Debugger workspace opening must run on EDT" }
+  fun showTool(tool: DebuggerWorkspaceTool) {
+    check(SwingUtilities.isEventDispatchThread()) { "Debugger tool opening must run on EDT" }
     if (closed) return
-    if (!opened) {
-      opened = true
-      val requested = windows.filterValues { it.savedVisible }.keys
-      if (requested.isEmpty()) applyLayout(currentLayout) else requested.forEach(::showTool)
-    } else if (windows.values.none { it.dialog.isVisible }) {
-      applyLayout(currentLayout)
-    } else {
-      windows.values.filter { it.dialog.isVisible }.forEach { window ->
-        window.dialog.toFront()
-      }
-    }
+    revealTool(tool)
     updatePanelInterest()
+    savePreferences()
   }
 
   fun updateSession(event: eu.rekawek.coffeegb.controller.Controller.SessionDebugPortEvent) {
@@ -195,35 +169,22 @@ internal class DebuggerWorkspace(
   internal fun heldTools(): Set<DebuggerWorkspaceTool> =
       windows.filterValues { it.hold.isSelected }.keys.toSet()
 
-  private fun showTool(tool: DebuggerWorkspaceTool) {
+  private fun revealTool(tool: DebuggerWorkspaceTool) {
     val window = windows.getValue(tool)
     if (!window.positioned) positionWindow(tool, window)
     window.dialog.isVisible = true
     window.dialog.toFront()
   }
 
-  private fun setToolVisible(tool: DebuggerWorkspaceTool, visible: Boolean) {
-    if (visible) showTool(tool) else windows.getValue(tool).dialog.isVisible = false
-    if (!changingLayout) {
-      currentLayout = detectLayout() ?: currentLayout
-      updatePanelInterest()
-      savePreferences()
+  fun applyLayout(layout: DebuggerWorkspaceLayout) {
+    check(SwingUtilities.isEventDispatchThread()) { "Debugger layout opening must run on EDT" }
+    if (closed) return
+    currentLayout = layout
+    val visible = toolsFor(layout)
+    windows.forEach { (tool, window) ->
+      if (tool in visible) revealTool(tool) else window.dialog.isVisible = false
     }
-  }
-
-  private fun applyLayout(layout: DebuggerWorkspaceLayout) {
-    changingLayout = true
-    try {
-      currentLayout = layout
-      val visible = toolsFor(layout)
-      windows.forEach { (tool, window) ->
-        if (tool in visible) showTool(tool) else window.dialog.isVisible = false
-      }
-      tile(visible.toList())
-    } finally {
-      changingLayout = false
-    }
-    syncLayoutMenus()
+    tile(visible.toList())
     updatePanelInterest()
     savePreferences()
   }
@@ -250,11 +211,6 @@ internal class DebuggerWorkspace(
             )
         DebuggerWorkspaceLayout.FULL -> DebuggerWorkspaceTool.entries.toSet()
       }
-
-  private fun detectLayout(): DebuggerWorkspaceLayout? {
-    val visible = visibleTools()
-    return DebuggerWorkspaceLayout.entries.firstOrNull { toolsFor(it) == visible }
-  }
 
   private fun tile(tools: List<DebuggerWorkspaceTool>) {
     if (tools.isEmpty()) return
@@ -327,80 +283,11 @@ internal class DebuggerWorkspace(
         windows.mapValues { (_, window) ->
           DebuggerWorkspaceToolPreferences(
               bounds = window.dialog.bounds.takeIf { window.positioned },
-              visible = window.dialog.isVisible,
               held = window.hold.isSelected,
           )
         }
     preferencesStore.save(DebuggerWorkspacePreferences(states, currentLayout))
   }
-
-  private fun menuBar(activeTool: DebuggerWorkspaceTool): JMenuBar =
-      JMenuBar().apply {
-        add(
-            JMenu("Window").apply {
-              mnemonic = KeyEvent.VK_W
-              DebuggerWorkspaceTool.entries.forEach { tool ->
-                add(
-                    JCheckBoxMenuItem(tool.title).apply {
-                      isSelected = windows[tool]?.dialog?.isVisible == true || tool == activeTool
-                      addActionListener { setToolVisible(tool, isSelected) }
-                      visibilityMenuItems.getValue(tool).add(this)
-                    })
-              }
-              addSeparator()
-              add(
-                  JMenuItem("Bring All to Front").apply {
-                    addActionListener {
-                      windows.values.filter { it.dialog.isVisible }.forEach { it.dialog.toFront() }
-                    }
-                  })
-              add(
-                  JMenuItem("Tile Visible Windows").apply {
-                    addActionListener { tile(visibleTools().sortedBy { it.ordinal }) }
-                  })
-            })
-        add(
-            JMenu("Layout").apply {
-              mnemonic = KeyEvent.VK_L
-              val group = ButtonGroup()
-              DebuggerWorkspaceLayout.entries.forEach { layout ->
-                val item = JRadioButtonMenuItem(layout.title, layout == currentLayout)
-                group.add(item)
-                layoutMenuItems.getValue(layout).add(item)
-                item.addActionListener { applyLayout(layout) }
-                add(item)
-              }
-            })
-        add(
-            JMenu("View").apply {
-              mnemonic = KeyEvent.VK_V
-              add(
-                  JMenuItem("Copy ${activeTool.title}").apply {
-                    accelerator =
-                        KeyStroke.getKeyStroke(KeyEvent.VK_C, debuggerMenuShortcutMask())
-                    addActionListener { panel.copyWorkspaceTool(activeTool) }
-                  })
-              addSeparator()
-              add(
-                  JMenuItem("Increase Font Size").apply {
-                    accelerator =
-                        KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, debuggerMenuShortcutMask())
-                    addActionListener { panel.workspaceZoom(DebuggerUiPreferences.FONT_SCALE_STEP) }
-                  })
-              add(
-                  JMenuItem("Decrease Font Size").apply {
-                    accelerator =
-                        KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, debuggerMenuShortcutMask())
-                    addActionListener { panel.workspaceZoom(-DebuggerUiPreferences.FONT_SCALE_STEP) }
-                  })
-              add(
-                  JMenuItem("Reset Font Size").apply {
-                    accelerator =
-                        KeyStroke.getKeyStroke(KeyEvent.VK_0, debuggerMenuShortcutMask())
-                    addActionListener { panel.workspaceResetZoom() }
-                  })
-            })
-      }
 
   private inner class ToolWindow(
       val tool: DebuggerWorkspaceTool,
@@ -411,7 +298,6 @@ internal class DebuggerWorkspace(
     val hold = JCheckBox("Hold updates", preferences.held)
     val live = JLabel("LIVE", SwingConstants.CENTER)
     val footer = JLabel("Waiting for a debugger session")
-    val savedVisible = preferences.visible
     val savedBounds = preferences.bounds
     var positioned = false
     private var heldFooterText: String? = null
@@ -441,13 +327,11 @@ internal class DebuggerWorkspace(
       dialog.preferredSize = tool.preferredSize
       dialog.contentPane = root
       dialog.accessibleContext.accessibleName = tool.accessibleName
-      dialog.jMenuBar = menuBar(tool)
       installWorkspaceBindings(root, tool)
       dialog.addWindowListener(
           object : WindowAdapter() {
             override fun windowClosing(event: WindowEvent) {
               SwingUtilities.invokeLater {
-                syncVisibilityMenus()
                 updatePanelInterest()
                 savePreferences()
               }
@@ -456,12 +340,10 @@ internal class DebuggerWorkspace(
       dialog.addComponentListener(
           object : ComponentAdapter() {
             override fun componentShown(event: ComponentEvent) {
-              syncVisibilityMenus()
               updatePanelInterest()
             }
 
             override fun componentHidden(event: ComponentEvent) {
-              syncVisibilityMenus()
               updatePanelInterest()
               savePreferences()
             }
@@ -504,18 +386,6 @@ internal class DebuggerWorkspace(
     fun sessionChanged() {
       heldFooterText = null
       updateStatus()
-    }
-  }
-
-  private fun syncVisibilityMenus() {
-    windows.forEach { (tool, window) ->
-      visibilityMenuItems.getValue(tool).forEach { item -> item.isSelected = window.dialog.isVisible }
-    }
-  }
-
-  private fun syncLayoutMenus() {
-    layoutMenuItems.forEach { (layout, items) ->
-      items.forEach { item -> item.isSelected = layout == currentLayout }
     }
   }
 
@@ -567,6 +437,24 @@ internal class DebuggerWorkspace(
         "workspace-copy",
     ) {
       panel.copyWorkspaceTool(tool)
+    }
+    bind(
+        KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, debuggerMenuShortcutMask()),
+        "workspace-zoom-in",
+    ) {
+      panel.workspaceZoom(DebuggerUiPreferences.FONT_SCALE_STEP)
+    }
+    bind(
+        KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, debuggerMenuShortcutMask()),
+        "workspace-zoom-out",
+    ) {
+      panel.workspaceZoom(-DebuggerUiPreferences.FONT_SCALE_STEP)
+    }
+    bind(
+        KeyStroke.getKeyStroke(KeyEvent.VK_0, debuggerMenuShortcutMask()),
+        "workspace-zoom-reset",
+    ) {
+      panel.workspaceResetZoom()
     }
   }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDebuggerController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDebuggerController.kt
@@ -16,8 +16,11 @@ internal interface DesktopDebuggerView : AutoCloseable {
   /** Replaces or revokes the view's session-bound command port. */
   fun updateSession(event: Controller.SessionDebugPortEvent)
 
-  /** Shows, raises, or reopens the retained modeless tool windows. */
-  fun showWindow()
+  /** Shows or raises one retained modeless debugger window. */
+  fun showTool(tool: DebuggerWorkspaceTool)
+
+  /** Shows and arranges the windows belonging to one built-in layout. */
+  fun applyLayout(layout: DebuggerWorkspaceLayout)
 }
 
 /** Keeps the Swing owner explicit while allowing the lifecycle controller to be tested headlessly. */
@@ -28,8 +31,8 @@ internal fun interface DesktopDebuggerViewFactory {
 /**
  * EDT-owned bridge between session debug-port publication and the modeless desktop debugger.
  *
- * The controller retains at most one workspace. Closing its tool windows hides them, so the Tools
- * command can reopen the same workspace. Session generations are monotonic and a revocation is
+ * The controller retains at most one workspace. Closing a tool window hides it, so the main Debug
+ * menu can reopen the same window. Session generations are monotonic and a revocation is
  * terminal for its generation; delayed older publications therefore cannot resurrect a stopped or
  * replaced port.
  * The session owns [eu.rekawek.coffeegb.core.debug.DebugPort], so this class never closes one.
@@ -61,17 +64,24 @@ internal class DesktopDebuggerController(
     }
   }
 
-  fun showDebugger() {
-    requireDebuggerEdt("Desktop debugger opening")
+  fun showTool(tool: DebuggerWorkspaceTool) {
+    requireDebuggerEdt("Desktop debugger tool opening")
     if (closed) return
-    val target =
-        view
-            ?: createView().also { created ->
-              currentSession?.let(created::updateSession)
-              view = created
-            }
-    target.showWindow()
+    retainedView().showTool(tool)
   }
+
+  fun applyLayout(layout: DebuggerWorkspaceLayout) {
+    requireDebuggerEdt("Desktop debugger layout opening")
+    if (closed) return
+    retainedView().applyLayout(layout)
+  }
+
+  private fun retainedView(): DesktopDebuggerView =
+      view
+          ?: createView().also { created ->
+            currentSession?.let(created::updateSession)
+            view = created
+          }
 
   private fun acceptSessionEvent(event: Controller.SessionDebugPortEvent): Boolean {
     val generation = event.generation

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -232,7 +232,10 @@ class SwingGui private constructor(
             romOpen::open,
             ::acceptRomLifecycle,
             ::showPreferences,
-            debuggerController::showDebugger,
+            DebuggerMenuActions(
+                debuggerController::showTool,
+                debuggerController::applyLayout,
+            ),
             stateUxController::saveSlot,
             stateUxController::loadSlot,
             stateUxController::showBrowser,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -71,6 +71,11 @@ internal data class ManagedStateMenuAvailability(
     val localSessionActive: Boolean = false,
 )
 
+internal data class DebuggerMenuActions(
+    val showTool: (DebuggerWorkspaceTool) -> Unit,
+    val applyLayout: (DebuggerWorkspaceLayout) -> Unit,
+)
+
 /** Keeps modeless managed-state controls aligned across local/link ownership transitions. */
 internal class ManagedStateMenuAvailabilityBinding(
     eventBus: EventBus,
@@ -119,7 +124,7 @@ internal class SwingMenu(
     private val onOpenRom: (path: java.nio.file.Path, source: RomOpenSource) -> Unit,
     private val acceptRomLifecycle: (Long?) -> Boolean,
     private val onPreferences: () -> Unit,
-    private val onDebugger: () -> Unit,
+    private val debuggerActions: DebuggerMenuActions,
     private val onSaveState: (slot: Int) -> Unit,
     private val onLoadState: (slot: Int) -> Unit,
     private val onManageStates: () -> Unit,
@@ -250,7 +255,7 @@ internal class SwingMenu(
     menuBar.add(createAudioMenu())
     menuBar.add(createPeripheralsMenu())
     menuBar.add(createLinkMenu())
-    menuBar.add(createToolsMenu(onDebugger))
+    menuBar.add(createDebugMenu(debuggerActions))
     window.jMenuBar = menuBar
   }
 
@@ -1281,16 +1286,35 @@ internal fun createScreenMenu(
   return screenMenu
 }
 
-/** Builds the always-available desktop tooling entry without depending on an active ROM. */
-internal fun createToolsMenu(onDebugger: () -> Unit): JMenu {
+/** Builds the always-available debugger navigation without depending on an active ROM. */
+internal fun createDebugMenu(actions: DebuggerMenuActions): JMenu {
   check(SwingUtilities.isEventDispatchThread()) {
-    "The Tools menu must be created on the Event Dispatch Thread"
+    "The Debug menu must be created on the Event Dispatch Thread"
   }
-  val toolsMenu = JMenu("Tools")
-  val debugger = JMenuItem("Debug Workspace")
-  debugger.accessibleContext.accessibleDescription =
-      "Open the realtime modeless debugger workspace for the current emulation session"
-  debugger.addActionListener { onDebugger() }
-  toolsMenu.add(debugger)
-  return toolsMenu
+  return JMenu("Debug").apply {
+    mnemonic = KeyEvent.VK_D
+    DebuggerWorkspaceTool.entries.forEach { tool ->
+      add(
+          JMenuItem(tool.title).apply {
+            accessibleContext.accessibleDescription =
+                "Show or raise the ${tool.title} debugger window"
+            addActionListener { actions.showTool(tool) }
+          })
+    }
+    addSeparator()
+    add(
+        JMenu("Layout").apply {
+          mnemonic = KeyEvent.VK_L
+          accessibleContext.accessibleDescription =
+              "Show and arrange a built-in debugger window layout"
+          DebuggerWorkspaceLayout.entries.forEach { layout ->
+            add(
+                JMenuItem(layout.title).apply {
+                  accessibleContext.accessibleDescription =
+                      "Show and arrange the ${layout.title} layout"
+                  addActionListener { actions.applyLayout(layout) }
+                })
+          }
+        })
+  }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDebuggerControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopDebuggerControllerTest.kt
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.events.EventBusImpl
 import java.lang.reflect.Proxy
 import java.util.concurrent.FutureTask
 import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JMenu
 import javax.swing.JMenuItem
 import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
@@ -35,11 +36,11 @@ class DesktopDebuggerControllerTest {
         }
 
     onEdt {
-      controller.showDebugger()
-      controller.showDebugger()
+      controller.showTool(DebuggerWorkspaceTool.EXECUTION)
+      controller.applyLayout(DebuggerWorkspaceLayout.FULL)
     }
     assertEquals(1, factoryCalls.get())
-    assertEquals(listOf("show", "show"), view.calls)
+    assertEquals(listOf("tool:EXECUTION", "layout:FULL"), view.calls)
 
     // Events intentionally originate outside Swing. Acceptance happens only after each callback
     // reaches the EDT, where an older queued publication can no longer replace generation 2.
@@ -63,7 +64,8 @@ class DesktopDebuggerControllerTest {
     onEdt {
       controller.close()
       controller.close()
-      controller.showDebugger()
+      controller.showTool(DebuggerWorkspaceTool.MEMORY)
+      controller.applyLayout(DebuggerWorkspaceLayout.CPU)
     }
     assertEquals(1, view.closeCalls)
     assertEquals(0, portCloseCalls.get(), "the emulation session owns every DebugPort")
@@ -86,9 +88,9 @@ class DesktopDebuggerControllerTest {
     flushEdt()
     assertTrue(view.calls.isEmpty())
 
-    onEdt { controller.showDebugger() }
+    onEdt { controller.showTool(DebuggerWorkspaceTool.AUDIO) }
 
-    assertEquals(listOf("session:7:available", "show"), view.calls)
+    assertEquals(listOf("session:7:available", "tool:AUDIO"), view.calls)
     assertSame(port, view.sessions.single().debugPort)
     onEdt { controller.close() }
     rootEventBus.close()
@@ -103,7 +105,12 @@ class DesktopDebuggerControllerTest {
 
     val controller =
         onEdt { DesktopDebuggerController(rootEventBus) { RecordingDebuggerView() } }
-    assertFailsWith<IllegalStateException> { controller.showDebugger() }
+    assertFailsWith<IllegalStateException> {
+      controller.showTool(DebuggerWorkspaceTool.EXECUTION)
+    }
+    assertFailsWith<IllegalStateException> {
+      controller.applyLayout(DebuggerWorkspaceLayout.CPU)
+    }
     assertFailsWith<IllegalStateException> { controller.close() }
 
     onEdt { controller.close() }
@@ -111,21 +118,41 @@ class DesktopDebuggerControllerTest {
   }
 
   @Test
-  fun `tools menu always exposes the debugger action`() {
-    val actions = AtomicInteger()
-    val menu = onEdt { createToolsMenu { actions.incrementAndGet() } }
+  fun `debug menu exposes every window and a separate layout submenu`() {
+    val tools = mutableListOf<DebuggerWorkspaceTool>()
+    val layouts = mutableListOf<DebuggerWorkspaceLayout>()
+    val actions = DebuggerMenuActions(tools::add, layouts::add)
+    val menu = onEdt { createDebugMenu(actions) }
 
     onEdt {
-      assertEquals("Tools", menu.text)
+      assertEquals("Debug", menu.text)
       assertTrue(menu.isEnabled)
-      val item = menu.menuComponents.filterIsInstance<JMenuItem>().single()
-      assertEquals("Debug Workspace", item.text)
-      assertTrue(item.isEnabled)
-      assertFalse(item.accessibleContext.accessibleDescription.isNullOrBlank())
-      item.doClick()
+      assertEquals(DebuggerWorkspaceTool.entries.size + 2, menu.menuComponentCount)
+      val toolItems = menu.menuComponents.take(DebuggerWorkspaceTool.entries.size)
+      assertTrue(toolItems.all { it is JMenuItem && it !is JMenu })
+      assertEquals(
+          DebuggerWorkspaceTool.entries.map { it.title },
+          toolItems.map { (it as JMenuItem).text },
+      )
+      toolItems.map { it as JMenuItem }.forEach { item ->
+        assertTrue(item.isEnabled)
+        assertFalse(item.accessibleContext.accessibleDescription.isNullOrBlank())
+        item.doClick()
+      }
+
+      val layoutMenu = menu.menuComponents.filterIsInstance<JMenu>().single()
+      assertEquals("Layout", layoutMenu.text)
+      assertFalse(layoutMenu.accessibleContext.accessibleDescription.isNullOrBlank())
+      val layoutItems = layoutMenu.menuComponents.filterIsInstance<JMenuItem>()
+      assertEquals(DebuggerWorkspaceLayout.entries.map { it.title }, layoutItems.map { it.text })
+      layoutItems.forEach { item ->
+        assertFalse(item.accessibleContext.accessibleDescription.isNullOrBlank())
+        item.doClick()
+      }
     }
-    assertEquals(1, actions.get())
-    assertFailsWith<IllegalStateException> { createToolsMenu {} }
+    assertEquals(DebuggerWorkspaceTool.entries.toList(), tools)
+    assertEquals(DebuggerWorkspaceLayout.entries.toList(), layouts)
+    assertFailsWith<IllegalStateException> { createDebugMenu(actions) }
   }
 
   private class RecordingDebuggerView : DesktopDebuggerView {
@@ -140,9 +167,14 @@ class DesktopDebuggerControllerTest {
       calls += "session:${event.generation}:${if (event.debugPort == null) "revoked" else "available"}"
     }
 
-    override fun showWindow() {
+    override fun showTool(tool: DebuggerWorkspaceTool) {
       recordEdt()
-      calls += "show"
+      calls += "tool:${tool.name}"
+    }
+
+    override fun applyLayout(layout: DebuggerWorkspaceLayout) {
+      recordEdt()
+      calls += "layout:${layout.name}"
     }
 
     override fun close() {


### PR DESCRIPTION
## Summary

- replace the top-level Tools entry with a dedicated Debug menu
- expose every debugger window directly and move presets into Debug > Layout
- remove debugger child-window menus and obsolete View, tile, and bring-to-front commands
- preserve direct copy, zoom, and run-control shortcuts

## Testing

- /opt/maven/bin/mvn -pl swing -am test
- 2,458 tests passed with zero failures or errors; 4 skipped