### PR TITLE
Expose Mobile Adapter desktop controls

### DIFF
--- a/docs/adr/0002-mobile-adapter-clean-room.md
+++ b/docs/adr/0002-mobile-adapter-clean-room.md
@@ -56,9 +56,9 @@ ownership boundaries, and final close includes a bounded retry in its persistenc
 and a retry each use their own 2,000 ms deadline shared across the writer and all still-tracked
 backends.
 
-The retained Mobile Adapter configuration dialog has a bounded owner-selected image import, while
-the current desktop continues to hide Mobile Adapter controls. Its controller reader runs off the
-EDT, rejects a symbolic link in the selected final path component, and accepts only a stable regular
+The desktop exposes its retained Mobile Adapter configuration dialog and bounded owner-selected
+image import from the **Peripherals** menu. Its controller reader runs off the EDT, rejects a
+symbolic link in the selected final path component, and accepts only a stable regular
 exact 256-byte opaque image or a validated exact 512-byte `MA`/`LM` envelope. It requires a
 non-null provider file key, compares type, identity, size, and timestamps around the open/read, and
 compares the opened channel size at both checkpoints before discarding all library metadata after

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -18,8 +18,8 @@ shutdown passed the aggregate cleanup check after remote close had already relea
 ownership. Japanese Pokémon Crystal remains a narrower adapter-recognition result; the Mobile
 Trainer run is not evidence that Crystal reached a network feature.
 The retained Mobile Adapter configuration dialog also has a bounded, owner-selected adapter-image
-import path. At the acceptance revision, the desktop kept its Mobile Adapter controls hidden; the
-import control alone did not make that retained dialog a generally exposed feature.
+import path. The desktop exposes both the exclusive link-port choice and that retained dialog from
+the **Peripherals** menu.
 
 ## Implemented deterministic boundary
 
@@ -601,16 +601,13 @@ above.
 
 ## Troubleshooting
 
-- The current desktop keeps Mobile Adapter controls hidden. The following actions describe the
-  retained configuration and link-port UI when a development integration exposes it; the adapter
-  image import does not itself change that exposure boundary.
 - Select **Peripherals → Link-port device → Mobile Adapter GB**. Status changes to
   attached only after the controller commits the endpoint; selecting another radio item detaches
   and clears it.
-- Open the Mobile Adapter configuration action to choose offline or custom-server policy. A saved
-  custom policy still performs no host I/O until session consent is granted; private/LAN targets
-  require the additional development confirmation. **Cancel active network work** rotates backend
-  ownership and closes current DNS/socket work without waiting on the EDT.
+- Open **Peripherals → Configure Mobile Adapter…** to choose offline or custom-server policy. A
+  saved custom policy still performs no host I/O until session consent is granted; private/LAN
+  targets require the additional development confirmation. **Cancel active network work** rotates
+  backend ownership and closes current DNS/socket work without waiting on the EDT.
 - **Import adapter image…** accepts only an exact opaque 256-byte image or a validated exact
   512-byte REON/libmobile envelope. `IMPORT_MALFORMED_IMAGE`, `IMPORT_NON_REGULAR_SOURCE`,
   `IMPORT_READ_FAILED`, and `IMPORT_SOURCE_CONFLICT` are stable redacted failures. The last accepted

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -477,6 +477,15 @@ close freezes the timing thread, drains the endpoint, and includes this writer i
 retryable persistence barrier; failed or timed-out durability retains the session instead of
 silently discarding the guest setup.
 
+The retained desktop window presents guest-image durability separately from owner policy saves. It
+folds the global persistence sequence on the Swing event thread: older sequences, duplicate phases,
+and phase regressions are ignored, while a retry may advance the same sequence from failed to saved.
+Pending, saved, superseded, and failed each have literal status text and a distinct semantic tone. An
+accepted failure also raises the main desktop's persistent nonmodal warning even when the
+configuration window is hidden. Both failed surfaces include the presentation-safe stable error
+code and user message, but neither surface renders or logs configuration bytes, paths, exceptions,
+or sequence, attachment, and mutation correlation identifiers.
+
 ### Bounded adapter-image import
 
 The retained configuration dialog accepts exactly one owner-selected regular file. A 256-byte

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -613,10 +613,12 @@ above.
 - Select **Peripherals → Link-port device → Mobile Adapter GB**. Status changes to
   attached only after the controller commits the endpoint; selecting another radio item detaches
   and clears it.
-- Open **Peripherals → Configure Mobile Adapter…** to choose offline or custom-server policy. A
-  saved custom policy still performs no host I/O until session consent is granted; private/LAN
-  targets require the additional development confirmation. **Cancel active network work** rotates
-  backend ownership and closes current DNS/socket work without waiting on the EDT.
+- Open **Peripherals → Configure Mobile Adapter…** to choose offline or custom-server policy,
+  including one primary exact DNS name and up to seven additional exact names which share the same
+  resolver and port mappings. A saved custom policy still performs no host I/O until session
+  consent is granted; private/LAN targets require the additional development confirmation.
+  **Cancel active network work** rotates backend ownership and closes current DNS/socket work
+  without waiting on the EDT.
 - **Import adapter image…** accepts only an exact opaque 256-byte image or a validated exact
   512-byte REON/libmobile envelope. `IMPORT_MALFORMED_IMAGE`, `IMPORT_NON_REGULAR_SOURCE`,
   `IMPORT_READ_FAILED`, and `IMPORT_SOURCE_CONFLICT` are stable redacted failures. The last accepted

--- a/docs/mobile-adapter-crystal-reon-validation.md
+++ b/docs/mobile-adapter-crystal-reon-validation.md
@@ -181,22 +181,21 @@ compatibility, production POP behavior, or general REON mail compatibility. The 
 admitted only as a configured exact guest DNS alias. Only the subsequent ROM-originated HTTP request
 observed in the pinned REON nginx access output is custom-service acceptance evidence.
 
-## Adapter-image prerequisite
+## Adapter-image workflow
 
-The retained Mobile Adapter configuration dialog now has an owner-selected import control. At the
-acceptance revision, the desktop still hid its Mobile Adapter controls, so this run does not claim
-that revision had a generally exposed workflow. The importer accepts an exact opaque 256-byte
-game-visible image, or an exact 512-byte REON/libmobile envelope only after its `MA`/`LM` magic and
-checksums plus the `LM` version and address types pass validation. It imports bytes `0..255` and
-discards the whole library region, including device, DNS, relay, token, and host metadata.
+At the acceptance revision, the desktop retained this configuration dialog but kept its controls
+hidden. The desktop now exposes the dialog and its owner-selected import control at **Peripherals →
+Configure Mobile Adapter…**. The importer accepts an exact opaque 256-byte game-visible image, or an
+exact 512-byte REON/libmobile envelope only after its `MA`/`LM` magic and checksums plus the `LM`
+version and address types pass validation. It imports bytes `0..255` and discards the whole library
+region, including device, DNS, relay, token, and host metadata.
 
 Every import attempt revokes active backend ownership and both runtime-only authorization gates,
 including stale, malformed, conflicting-source, busy, unreadable, and storage-failing attempts. An
 accepted image keeps Coffee GB's device ID and structured custom-server policy, then persists only
 the copied or extracted 256 bytes through the existing owner-only atomic store. It grants no
-network authority. This removed a latent ingestion prerequisite at the acceptance revision, but did
-not itself provide a generally exposed #399 workflow or evidence that a real game completed the
-ROM-to-REON route.
+network authority. The workflow is now manually accessible; the completed Mobile Trainer-to-REON
+result above remains the acceptance evidence rather than UI exposure alone.
 
 ## Privacy, state, and cleanup boundaries
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationDialog.kt
@@ -89,6 +89,7 @@ internal data class MobileAdapterPolicyDraft(
     val resolverIpv4Address: String,
     val resolverPort: String,
     val portMappings: List<MobileAdapterMappingDraft>,
+    val additionalDnsQueryNamesText: String = "",
 ) {
   companion object {
     fun from(policy: MobileAdapterNetworkPolicy): MobileAdapterPolicyDraft =
@@ -115,6 +116,7 @@ internal data class MobileAdapterPolicyDraft(
                             targetPort = it.targetPort.toString(),
                         )
                       },
+                  additionalDnsQueryNamesText = policy.additionalDnsQueryNames.joinToString("\n"),
               )
         }
   }
@@ -122,6 +124,7 @@ internal data class MobileAdapterPolicyDraft(
 
 internal enum class MobileAdapterPolicyField {
   DNS_QUERY_NAME,
+  ADDITIONAL_DNS_QUERY_NAMES,
   RESOLVER_ADDRESS,
   RESOLVER_PORT,
   PORT_MAPPINGS,
@@ -147,33 +150,50 @@ internal fun validateMobileAdapterPolicyDraft(
         MobileAdapterPolicyField.PORT_MAPPINGS,
     )
   }
-  return try {
-    val mappings =
-        draft.portMappings.mapIndexed { index, mapping ->
-          MobileAdapterPortMapping(
-              mapping.transport,
-              parsePort(mapping.guestPort, "Mapping ${index + 1} guest port"),
-              parsePort(mapping.targetPort, "Mapping ${index + 1} target port"),
-          )
-        }
-    MobileAdapterPolicyValidation.Valid(
+  val basePolicy =
+      try {
+        val mappings =
+            draft.portMappings.mapIndexed { index, mapping ->
+              MobileAdapterPortMapping(
+                  mapping.transport,
+                  parsePort(mapping.guestPort, "Mapping ${index + 1} guest port"),
+                  parsePort(mapping.targetPort, "Mapping ${index + 1} target port"),
+              )
+            }
         MobileAdapterNetworkPolicy.CustomServer(
             draft.dnsQueryName,
             draft.resolverIpv4Address,
             parsePort(draft.resolverPort, "Resolver port"),
             mappings,
+        )
+      } catch (failure: IllegalArgumentException) {
+        val message = failure.message ?: "The custom-server policy is invalid."
+        val field =
+            when {
+              message.startsWith("DNS query name") -> MobileAdapterPolicyField.DNS_QUERY_NAME
+              message.startsWith("Resolver address") || message.startsWith("Resolver IPv4") ->
+                  MobileAdapterPolicyField.RESOLVER_ADDRESS
+              message.startsWith("Resolver port") -> MobileAdapterPolicyField.RESOLVER_PORT
+              else -> MobileAdapterPolicyField.PORT_MAPPINGS
+            }
+        return MobileAdapterPolicyValidation.Invalid(message, field)
+      }
+  return try {
+    val additionalNames =
+        parseMobileAdapterAdditionalDnsQueryNames(draft.additionalDnsQueryNamesText)
+    MobileAdapterPolicyValidation.Valid(
+        MobileAdapterNetworkPolicy.CustomServer(
+            basePolicy.dnsQueryName,
+            basePolicy.resolverIpv4Address,
+            basePolicy.resolverPort,
+            basePolicy.portMappings,
+            additionalNames,
         ))
   } catch (failure: IllegalArgumentException) {
-    val message = failure.message ?: "The custom-server policy is invalid."
-    val field =
-        when {
-          message.startsWith("DNS query name") -> MobileAdapterPolicyField.DNS_QUERY_NAME
-          message.startsWith("Resolver address") || message.startsWith("Resolver IPv4") ->
-              MobileAdapterPolicyField.RESOLVER_ADDRESS
-          message.startsWith("Resolver port") -> MobileAdapterPolicyField.RESOLVER_PORT
-          else -> MobileAdapterPolicyField.PORT_MAPPINGS
-        }
-    MobileAdapterPolicyValidation.Invalid(message, field)
+    MobileAdapterPolicyValidation.Invalid(
+        failure.message ?: "The additional DNS query names are invalid.",
+        MobileAdapterPolicyField.ADDITIONAL_DNS_QUERY_NAMES,
+    )
   }
 }
 
@@ -1117,6 +1137,11 @@ internal class MobileAdapterConfigurationPanel(
   internal val offlineMode = JRadioButton("Offline")
   internal val customServerMode = JRadioButton("Custom Server")
   internal val queryName = JTextField(28)
+  internal val additionalDnsQueryNames =
+      JTextArea(3, 28).apply {
+        lineWrap = false
+        wrapStyleWord = false
+      }
   internal val resolverAddress = JTextField(16)
   internal val resolverPort = JTextField(6)
   internal val mappingModel = MobileAdapterMappingTableModel()
@@ -1349,9 +1374,30 @@ internal class MobileAdapterConfigurationPanel(
     modeRow.add(modeLabel, BorderLayout.WEST)
     modeRow.add(modePanel, BorderLayout.CENTER)
 
-    addFormRow(customFields, 0, "Allowed DNS name / service", queryName)
-    addFormRow(customFields, 1, "Literal IPv4 DNS resolver", resolverAddress)
-    addFormRow(customFields, 2, "Resolver port", resolverPort)
+    addFormRow(customFields, 0, "Primary DNS name / service", queryName)
+    val aliases =
+        JPanel(BorderLayout(0, tokens.spacing.compact)).apply {
+          add(JScrollPane(additionalDnsQueryNames), BorderLayout.CENTER)
+          add(
+              mobileAdapterLiteralText(
+                  "Optional: one exact DNS name per line, up to " +
+                      "${MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES}. " +
+                      "Empty lines are ignored. All names share the resolver and port mappings below.",
+                  2,
+                  "Additional DNS names help",
+              ),
+              BorderLayout.SOUTH,
+          )
+        }
+    addFormRow(
+        customFields,
+        1,
+        "Additional exact DNS names",
+        aliases,
+        additionalDnsQueryNames,
+    )
+    addFormRow(customFields, 2, "Literal IPv4 DNS resolver", resolverAddress)
+    addFormRow(customFields, 3, "Resolver port", resolverPort)
     val mappings = createMappingsPanel()
     val customContent = JPanel(BorderLayout(0, tokens.spacing.related))
     customContent.add(customFields, BorderLayout.NORTH)
@@ -1424,7 +1470,7 @@ internal class MobileAdapterConfigurationPanel(
   private fun configureListeners() {
     offlineMode.addActionListener { if (!rendering) publishDraft() }
     customServerMode.addActionListener { if (!rendering) publishDraft() }
-    listOf(queryName, resolverAddress, resolverPort).forEach { field ->
+    listOf(queryName, additionalDnsQueryNames, resolverAddress, resolverPort).forEach { field ->
       field.document.addDocumentListener(
           object : DocumentListener {
             override fun insertUpdate(event: DocumentEvent) = publishDraft()
@@ -1504,9 +1550,12 @@ internal class MobileAdapterConfigurationPanel(
   }
 
   private fun configureAccessibility() {
-    queryName.accessibleContext.accessibleName = "Allowed DNS name or service"
+    queryName.accessibleContext.accessibleName = "Primary DNS name or service"
     queryName.accessibleContext.accessibleDescription =
-        "The exact saved custom-service DNS name eligible for Mobile Adapter requests"
+        "The primary exact saved custom-service DNS name eligible for Mobile Adapter requests"
+    additionalDnsQueryNames.accessibleContext.accessibleName = "Additional exact DNS names"
+    additionalDnsQueryNames.accessibleContext.accessibleDescription =
+        "Optional exact saved DNS names, one per line, sharing the same resolver and port mappings"
     resolverAddress.accessibleContext.accessibleName = "Literal IPv4 DNS resolver"
     resolverAddress.accessibleContext.accessibleDescription =
         "Canonical dotted-decimal IPv4 address for the saved custom DNS resolver"
@@ -1515,7 +1564,7 @@ internal class MobileAdapterConfigurationPanel(
     offlineMode.accessibleContext.accessibleDescription =
         "Disable outbound Mobile Adapter custom-server networking in the saved policy"
     customServerMode.accessibleContext.accessibleDescription =
-        "Configure one exact custom service and bounded port mappings"
+        "Configure a primary exact custom service, optional exact aliases, and bounded port mappings"
     networkConsent.accessibleContext.accessibleDescription =
         "Grant or revoke the memory-only policy-wide custom-server permission"
     privateLocal.accessibleContext.accessibleDescription =
@@ -1535,6 +1584,8 @@ internal class MobileAdapterConfigurationPanel(
   private fun installLimits() {
     installMobileAdapterDocumentLimit(
         queryName, MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES)
+    installMobileAdapterDocumentLimit(
+        additionalDnsQueryNames, MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS)
     installMobileAdapterDocumentLimit(resolverAddress, MAX_MOBILE_ADAPTER_IPV4_TEXT_CHARS)
     installMobileAdapterDocumentLimit(resolverPort, MAX_MOBILE_ADAPTER_PORT_TEXT_CHARS)
   }
@@ -1552,28 +1603,35 @@ internal class MobileAdapterConfigurationPanel(
           resolverIpv4Address = resolverAddress.text,
           resolverPort = resolverPort.text,
           portMappings = mappingModel.snapshot(),
+          additionalDnsQueryNamesText = additionalDnsQueryNames.text,
       )
 
   private fun applyDraft(draft: MobileAdapterPolicyDraft) {
     offlineMode.isSelected = draft.mode == MobileAdapterNetworkMode.OFFLINE
     customServerMode.isSelected = draft.mode == MobileAdapterNetworkMode.CUSTOM_SERVER
     queryName.text = draft.dnsQueryName
+    additionalDnsQueryNames.text = draft.additionalDnsQueryNamesText
     resolverAddress.text = draft.resolverIpv4Address
     resolverPort.text = draft.resolverPort
     mappingModel.replace(draft.portMappings)
   }
 
   private fun setPolicyFieldsEnabled(enabled: Boolean) {
-    listOf(queryName, resolverAddress, resolverPort, mappingsTable).forEach {
-      it.isEnabled = enabled
-    }
+    listOf(queryName, additionalDnsQueryNames, resolverAddress, resolverPort, mappingsTable)
+        .forEach { it.isEnabled = enabled }
     offlineMode.isEnabled = current.savePhase == MobileAdapterSavePhase.IDLE
     customServerMode.isEnabled = current.savePhase == MobileAdapterSavePhase.IDLE
   }
 
-  private fun addFormRow(panel: JPanel, row: Int, text: String, field: JComponent) {
+  private fun addFormRow(
+      panel: JPanel,
+      row: Int,
+      text: String,
+      field: JComponent,
+      labelTarget: JComponent = field,
+  ) {
     val label = JLabel(text)
-    label.labelFor = field
+    label.labelFor = labelTarget
     panel.add(
         label,
         GridBagConstraints().apply {
@@ -1811,6 +1869,29 @@ internal fun parseMobileAdapterMappings(value: String): List<MobileAdapterPortMa
   return mappings
 }
 
+internal fun parseMobileAdapterAdditionalDnsQueryNames(value: String): List<String> {
+  require(value.length <= MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS) {
+    "Additional DNS query names must contain at most " +
+        "$MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS characters."
+  }
+  val names =
+      ArrayList<String>(MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES)
+  value.lineSequence().forEach { name ->
+    if (name.isEmpty()) return@forEach
+    require(name.length <= MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES) {
+      "Each additional DNS query name must contain at most " +
+          "${MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES} characters."
+    }
+    require(
+        names.size < MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES) {
+          "At most ${MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES} " +
+              "additional DNS query names are allowed."
+        }
+    names.add(name)
+  }
+  return names
+}
+
 private fun parsePort(value: String, label: String): Int =
     value
         .takeIf { it.length in 1..5 && it.all { character -> character in '0'..'9' } }
@@ -1822,6 +1903,9 @@ internal const val MAX_MOBILE_ADAPTER_MAPPING_TEXT_CHARS = 1_024
 internal const val MAX_MOBILE_ADAPTER_MAPPING_LINE_CHARS = 64
 internal const val MAX_MOBILE_ADAPTER_IPV4_TEXT_CHARS = 15
 internal const val MAX_MOBILE_ADAPTER_PORT_TEXT_CHARS = 5
+internal const val MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS =
+    MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES *
+        (MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES + 1)
 private val MOBILE_ADAPTER_MAPPING_WHITESPACE = Regex("\\s+")
 
 internal fun installMobileAdapterDocumentLimit(component: JTextComponent, maxChars: Int) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationDialog.kt
@@ -190,6 +190,71 @@ internal enum class MobileAdapterStatusTone {
   ERROR,
 }
 
+internal data class MobileAdapterGuestImagePersistencePresentation(
+    val status: String,
+    val tone: MobileAdapterStatusTone,
+)
+
+internal data class MobileAdapterGuestImagePersistenceCursor(
+    val sequence: Long,
+    val phase: Controller.MobileAdapterConfigurationPersistencePhase,
+)
+
+internal fun presentMobileAdapterGuestImagePersistence(
+    phase: Controller.MobileAdapterConfigurationPersistencePhase,
+    error: MobileAdapterConfigurationError?,
+): MobileAdapterGuestImagePersistencePresentation =
+    when (phase) {
+      Controller.MobileAdapterConfigurationPersistencePhase.PENDING ->
+          MobileAdapterGuestImagePersistencePresentation(
+              "Changes received from the emulated Mobile Adapter are active and being saved. Keep Coffee GB open until saving finishes.",
+              MobileAdapterStatusTone.WARNING,
+          )
+      Controller.MobileAdapterConfigurationPersistencePhase.SAVED ->
+          MobileAdapterGuestImagePersistencePresentation(
+              "Changes received from the emulated Mobile Adapter are active and saved. No action is needed.",
+              MobileAdapterStatusTone.SUCCESS,
+          )
+      Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED ->
+          MobileAdapterGuestImagePersistencePresentation(
+              "Pending changes received from the emulated Mobile Adapter were replaced by the owner-selected adapter image. Review the imported image before continuing.",
+              MobileAdapterStatusTone.NEUTRAL,
+          )
+      Controller.MobileAdapterConfigurationPersistencePhase.FAILED -> {
+        val stableError = checkNotNull(error)
+        MobileAdapterGuestImagePersistencePresentation(
+            "${stableError.code}: ${stableError.userMessage} Changes received from the emulated Mobile Adapter remain active for this session but could not be saved. Check private configuration storage, then retry by closing Coffee GB again.",
+            MobileAdapterStatusTone.ERROR,
+        )
+      }
+    }
+
+/**
+ * Accepts the globally sequenced guest-image durability stream without carrying its correlation
+ * metadata into presentation. A failed write remains retryable, so a later saved/superseded phase
+ * for that same sequence must be allowed to replace the warning.
+ */
+internal fun acceptsMobileAdapterGuestImagePersistence(
+    current: MobileAdapterGuestImagePersistenceCursor?,
+    sequence: Long,
+    phase: Controller.MobileAdapterConfigurationPersistencePhase,
+): Boolean {
+  if (current == null || sequence > current.sequence) return true
+  if (sequence < current.sequence) return false
+  return mobileAdapterGuestImagePersistencePhaseOrder(phase) >
+      mobileAdapterGuestImagePersistencePhaseOrder(current.phase)
+}
+
+private fun mobileAdapterGuestImagePersistencePhaseOrder(
+    phase: Controller.MobileAdapterConfigurationPersistencePhase
+): Int =
+    when (phase) {
+      Controller.MobileAdapterConfigurationPersistencePhase.PENDING -> 0
+      Controller.MobileAdapterConfigurationPersistencePhase.FAILED -> 1
+      Controller.MobileAdapterConfigurationPersistencePhase.SAVED,
+      Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED -> 2
+    }
+
 internal data class MobileAdapterSessionPresentation(
     val summary: String,
     val cancelEnabled: Boolean,
@@ -282,6 +347,8 @@ internal data class MobileAdapterConfigurationPresentation(
     val savePhase: MobileAdapterSavePhase,
     val networkConsent: Boolean,
     val privateLocalDevelopment: Boolean,
+    val guestImageStatus: String,
+    val guestImageStatusTone: MobileAdapterStatusTone,
     val policyStatus: String,
     val policyStatusTone: MobileAdapterStatusTone,
     val session: MobileAdapterSessionPresentation,
@@ -400,6 +467,7 @@ internal class MobileAdapterConfigurationWindowHost(
     private val viewFactory: MobileAdapterConfigurationWindowViewFactory,
     private val decisions: MobileAdapterConfigurationDecisionPrompter,
     private val onSummary: (MobileAdapterConfigurationSummary) -> Unit = {},
+    private val onGuestImagePersistenceFailure: (String) -> Unit = {},
     private val imageSelector: MobileAdapterConfigurationImageSelector =
         MobileAdapterConfigurationImageSelector { null },
 ) : AutoCloseable {
@@ -413,6 +481,12 @@ internal class MobileAdapterConfigurationWindowHost(
   private var savePhase = MobileAdapterSavePhase.IDLE
   private var policyStatus = "Review saved policy and session-only permissions separately."
   private var policyStatusTone = MobileAdapterStatusTone.NEUTRAL
+  private var guestImagePersistence =
+      MobileAdapterGuestImagePersistencePresentation(
+          "No guest-authored adapter image changes have been received this session.",
+          MobileAdapterStatusTone.NEUTRAL,
+      )
+  private var guestImagePersistenceCursor: MobileAdapterGuestImagePersistenceCursor? = null
   private var closed = false
   private var saveGeneration = 0L
 
@@ -428,6 +502,7 @@ internal class MobileAdapterConfigurationWindowHost(
         DesktopThemeTokens.capture(DesktopAppearance.SYSTEM)
       },
       onSummary: (MobileAdapterConfigurationSummary) -> Unit = {},
+      onGuestImagePersistenceFailure: (String) -> Unit = {},
   ) : this(
       coordinator = coordinator,
       rootEventBus = rootEventBus,
@@ -444,12 +519,14 @@ internal class MobileAdapterConfigurationWindowHost(
           },
       decisions = DesktopMobileAdapterConfigurationDecisionPrompter(owner, dialogFactory),
       onSummary = onSummary,
+      onGuestImagePersistenceFailure = onGuestImagePersistenceFailure,
       imageSelector = DesktopMobileAdapterConfigurationImageSelector(owner),
   )
 
   init {
     requireMobileAdapterEdt("Mobile Adapter window host construction")
     registerNetworkStatus()
+    registerGuestImagePersistenceStatus()
     publish()
   }
 
@@ -744,6 +821,8 @@ internal class MobileAdapterConfigurationWindowHost(
           savePhase = savePhase,
           networkConsent = runtime.networkConsent,
           privateLocalDevelopment = runtime.privateLocalDevelopment,
+          guestImageStatus = guestImagePersistence.status,
+          guestImageStatusTone = guestImagePersistence.tone,
           policyStatus = policyStatus,
           policyStatusTone = policyStatusTone,
           session =
@@ -770,6 +849,28 @@ internal class MobileAdapterConfigurationWindowHost(
         if (previous == null || next.attachmentId >= previous.attachmentId) {
           network = next
           publish()
+        }
+      }
+    }
+  }
+
+  private fun registerGuestImagePersistenceStatus() {
+    eventBus.register<Controller.MobileAdapterConfigurationPersistenceStatusEvent> { event ->
+      dispatchSwingMutation {
+        if (closed ||
+            !acceptsMobileAdapterGuestImagePersistence(
+                guestImagePersistenceCursor,
+                event.sequence,
+                event.phase,
+            )) {
+          return@dispatchSwingMutation
+        }
+        guestImagePersistenceCursor =
+            MobileAdapterGuestImagePersistenceCursor(event.sequence, event.phase)
+        guestImagePersistence = presentMobileAdapterGuestImagePersistence(event.phase, event.error)
+        publish()
+        if (event.phase == Controller.MobileAdapterConfigurationPersistencePhase.FAILED) {
+          onGuestImagePersistenceFailure(guestImagePersistence.status)
         }
       }
     }
@@ -1029,6 +1130,8 @@ internal class MobileAdapterConfigurationPanel(
       JCheckBox("Development only: allow loopback and private/LAN destinations")
   internal val sessionStatus = mobileAdapterLiteralText("", 3, "Current session status")
   internal val cancelNetwork = JButton("Cancel active network work")
+  internal val guestImageStatus =
+      mobileAdapterLiteralText("", 3, "Guest-authored adapter image persistence status")
   internal val policyStatus = mobileAdapterLiteralText("", 3, "Mobile Adapter policy status")
   internal val importImageButton = JButton("Import adapter image…")
   internal val reloadButton = JButton("Reload policy")
@@ -1119,6 +1222,8 @@ internal class MobileAdapterConfigurationPanel(
       sessionStatus.accessibleContext.accessibleDescription = next.session.summary
       cancelNetwork.isEnabled = next.session.cancelEnabled
 
+      guestImageStatus.text = next.guestImageStatus
+      guestImageStatus.accessibleContext.accessibleDescription = next.guestImageStatus
       policyStatus.text = next.policyStatus
       policyStatus.accessibleContext.accessibleDescription = next.policyStatus
       importImageButton.text =
@@ -1173,6 +1278,7 @@ internal class MobileAdapterConfigurationPanel(
     mappingsTable.selectionBackground = tokens.focus
     mappingsTable.selectionForeground = contrastingMobileAdapterText(tokens.focus)
     policyStatus.background = tokens.surface
+    guestImageStatus.background = tokens.surface
     sessionStatus.background = tokens.surface
     startupSummary.background = tokens.surface
     validationStatus.background = tokens.surface
@@ -1217,9 +1323,12 @@ internal class MobileAdapterConfigurationPanel(
         )
     val buttonRow = JPanel(FlowLayout(FlowLayout.LEADING, 0, 0))
     buttonRow.add(importImageButton)
+    val actionsAndStatus = JPanel(BorderLayout(0, tokens.spacing.related))
+    actionsAndStatus.add(buttonRow, BorderLayout.NORTH)
+    actionsAndStatus.add(guestImageStatus, BorderLayout.CENTER)
     val content = JPanel(BorderLayout(0, tokens.spacing.related))
     content.add(explanation, BorderLayout.CENTER)
-    content.add(buttonRow, BorderLayout.SOUTH)
+    content.add(actionsAndStatus, BorderLayout.SOUTH)
     imageSection.add(heading, BorderLayout.NORTH)
     imageSection.add(content, BorderLayout.CENTER)
     return imageSection
@@ -1489,6 +1598,7 @@ internal class MobileAdapterConfigurationPanel(
 
   private fun applyStatusColors() {
     validationStatus.foreground = tokens.danger
+    guestImageStatus.foreground = colorFor(current.guestImageStatusTone)
     policyStatus.foreground = colorFor(current.policyStatusTone)
     sessionStatus.foreground = colorFor(current.session.tone)
   }
@@ -1519,6 +1629,9 @@ internal class MobileAdapterConfigurationPanel(
           savePhase = MobileAdapterSavePhase.IDLE,
           networkConsent = false,
           privateLocalDevelopment = false,
+          guestImageStatus =
+              "No guest-authored adapter image changes have been received this session.",
+          guestImageStatusTone = MobileAdapterStatusTone.NEUTRAL,
           policyStatus = "",
           policyStatusTone = MobileAdapterStatusTone.NEUTRAL,
           session = MobileAdapterSessionPresentation("", false),

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PeripheralsPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PeripheralsPreferencesEditor.kt
@@ -6,23 +6,31 @@ import java.awt.GridBagLayout
 import java.awt.Insets
 import java.awt.event.KeyEvent
 import javax.swing.BorderFactory
+import javax.swing.JButton
 import javax.swing.JComboBox
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.JTextArea
 import javax.swing.SwingUtilities
 
 /** Draft-only host-peripheral editor. Opening Preferences never probes or opens camera hardware. */
 internal class PeripheralsPreferencesEditor private constructor(
     initial: ApplicationSettings.Peripherals,
     private val defaults: ApplicationSettings.Peripherals,
+    mobileAdapterSummary: String,
+    private val configureMobileAdapter: () -> Unit,
     @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
 ) : JPanel(GridBagLayout()) {
   constructor(
       initial: ApplicationSettings.Peripherals,
       defaults: ApplicationSettings.Peripherals = ApplicationSettings.Peripherals(),
+      mobileAdapterSummary: String = "Offline · networking blocked for this session",
+      configureMobileAdapter: () -> Unit = {},
   ) : this(
       initial,
       defaults,
+      mobileAdapterSummary,
+      configureMobileAdapter,
       requireEdt(),
   )
 
@@ -39,6 +47,26 @@ internal class PeripheralsPreferencesEditor private constructor(
         getAccessibleContext().accessibleDescription = CAMERA_ORDER_EXPLANATION
         toolTipText = CAMERA_ORDER_EXPLANATION
         selectedItem = CAMERA_OPTIONS.first { it.deviceIndex == initial.cameraDeviceIndex }
+      }
+  internal val mobileAdapterStatus =
+      JTextArea(mobileAdapterSummary, 3, 36).apply {
+        isEditable = false
+        isFocusable = false
+        isOpaque = false
+        lineWrap = true
+        wrapStyleWord = true
+        border = null
+        putClientProperty("html.disable", true)
+        getAccessibleContext().accessibleName = "Mobile Adapter configuration summary"
+        getAccessibleContext().accessibleDescription = text
+      }
+  internal val configureMobileAdapterButton =
+      JButton("Configure Mobile Adapter…").apply {
+        mnemonic = KeyEvent.VK_M
+        getAccessibleContext().accessibleName = "Configure Mobile Adapter"
+        getAccessibleContext().accessibleDescription =
+            "Open the retained Mobile Adapter policy and current-session window"
+        addActionListener { configureMobileAdapter() }
       }
 
   init {
@@ -73,10 +101,25 @@ internal class PeripheralsPreferencesEditor private constructor(
     constraints.weightx = 1.0
     add(explanation, constraints)
 
+    val mobileHeading = JLabel("Mobile Adapter GB:")
     constraints.gridx = 0
     constraints.gridy = 2
     constraints.gridwidth = 2
     constraints.weightx = 1.0
+    constraints.weighty = 0.0
+    constraints.fill = GridBagConstraints.HORIZONTAL
+    constraints.insets = Insets(16, 4, 4, 4)
+    add(mobileHeading, constraints)
+
+    constraints.gridy = 3
+    constraints.insets = Insets(4, 4, 4, 4)
+    add(mobileAdapterStatus, constraints)
+
+    constraints.gridy = 4
+    constraints.fill = GridBagConstraints.NONE
+    add(configureMobileAdapterButton, constraints)
+
+    constraints.gridy = 5
     constraints.weighty = 1.0
     constraints.fill = GridBagConstraints.BOTH
     add(JPanel(), constraints)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
@@ -260,6 +260,8 @@ internal class PreferencesPanel private constructor(
     initialCategory: PreferencesCategory = PreferencesCategory.GENERAL,
     categoryChanged: (PreferencesCategory) -> Unit = {},
     private val draftChanged: (Boolean) -> Unit = {},
+    mobileAdapterSummary: String = "Offline · networking blocked for this session",
+    configureMobileAdapter: () -> Unit = {},
     @Suppress("UNUSED_PARAMETER") edtGuard: Unit,
 ) : JPanel(BorderLayout(12, 8)), DesktopThemeRefreshHook {
   constructor(
@@ -274,6 +276,8 @@ internal class PreferencesPanel private constructor(
       initialCategory: PreferencesCategory = PreferencesCategory.GENERAL,
       categoryChanged: (PreferencesCategory) -> Unit = {},
       draftChanged: (Boolean) -> Unit = {},
+      mobileAdapterSummary: String = "Offline · networking blocked for this session",
+      configureMobileAdapter: () -> Unit = {},
   ) : this(
       initial,
       defaults,
@@ -285,6 +289,8 @@ internal class PreferencesPanel private constructor(
       initialCategory,
       categoryChanged,
       draftChanged,
+      mobileAdapterSummary,
+      configureMobileAdapter,
       requireEdt(),
   )
 
@@ -363,6 +369,8 @@ internal class PreferencesPanel private constructor(
       PeripheralsPreferencesEditor(
           initial.peripherals,
           defaults.peripherals,
+          mobileAdapterSummary,
+          configureMobileAdapter,
       )
   internal val audioEditor =
       AudioPreferencesEditor(initial.audio, defaults.audio, audioDevices)
@@ -1128,6 +1136,21 @@ internal class PreferencesValidationException(
     val invalidComponent: Component,
 ) : IllegalArgumentException(message)
 
+internal fun requestMobileAdapterConfigurationHandoff(
+    isDirty: Boolean,
+    confirmDiscard: () -> Boolean,
+    stopBackgroundWork: () -> Unit,
+    closePreferences: () -> Unit,
+    defer: ((() -> Unit) -> Unit) = { SwingUtilities.invokeLater(it) },
+    configureMobileAdapter: () -> Unit,
+): Boolean {
+  if (isDirty && !confirmDiscard()) return false
+  stopBackgroundWork()
+  closePreferences()
+  defer(configureMobileAdapter)
+  return true
+}
+
 /** Owns only the modal window lifecycle. Persistence and runtime changes belong to [SwingGui]. */
 internal object PreferencesDialog {
   fun show(
@@ -1141,6 +1164,8 @@ internal object PreferencesDialog {
           PreferencesPersistencePresentation.PERSISTENT,
       initialCategory: PreferencesCategory = PreferencesCategory.GENERAL,
       initialBounds: Rectangle? = null,
+      mobileAdapterSummary: String = "Offline · networking blocked for this session",
+      configureMobileAdapter: () -> Unit = {},
       onCategoryChanged: (PreferencesCategory) -> Unit = {},
       onBoundsChanged: (Rectangle) -> Unit = {},
       onClosed: () -> Unit = {},
@@ -1171,6 +1196,16 @@ internal object PreferencesDialog {
             initialCategory = initialCategory,
             categoryChanged = onCategoryChanged,
             draftChanged = { refreshFooter() },
+            mobileAdapterSummary = mobileAdapterSummary,
+            configureMobileAdapter = {
+              requestMobileAdapterConfigurationHandoff(
+                  isDirty = panel.isDirty(),
+                  confirmDiscard = { confirmDiscardChanges(dialog) },
+                  stopBackgroundWork = panel::stopBackgroundWork,
+                  closePreferences = dialog::dispose,
+                  configureMobileAdapter = configureMobileAdapter,
+              )
+            },
         )
 
     refreshFooter = {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SerialPeripheralMenuBinding.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SerialPeripheralMenuBinding.kt
@@ -97,7 +97,6 @@ internal fun serialPeripheralTransitionPrerequisites(
 internal class SerialPeripheralMenuBinding(
     private val eventBus: EventBus,
     initialSelection: SerialPeripheralSelection = SerialPeripheralSelection.PEER_TO_PEER,
-    private val mobileAdapterVisible: Boolean = true,
     private val transitionPrerequisites:
         (SerialPeripheralSelection) -> List<SerialPeripheralTransitionPrerequisite> = {
           emptyList()
@@ -108,14 +107,11 @@ internal class SerialPeripheralMenuBinding(
   val statusItem = JMenuItem()
   val items: Map<SerialPeripheralSelection, JRadioButtonMenuItem>
 
-  private val initialVisibleSelection =
-      initialSelection.takeIf(::isVisible) ?: SerialPeripheralSelection.PEER_TO_PEER
-
   @Volatile
   private var current =
       SerialPeripheralUiSnapshot(
-          selection = initialVisibleSelection,
-          statusSelection = initialVisibleSelection,
+          selection = initialSelection,
+          statusSelection = initialSelection,
           status = SerialPeripheralStatus.DETACHED,
       )
 
@@ -124,7 +120,7 @@ internal class SerialPeripheralMenuBinding(
   init {
     val group = ButtonGroup()
     val mutableItems = EnumMap<SerialPeripheralSelection, JRadioButtonMenuItem>(SerialPeripheralSelection::class.java)
-    DISPLAY_ORDER.filter(::isVisible).forEach { selection ->
+    DISPLAY_ORDER.forEach { selection ->
       val item = JRadioButtonMenuItem(label(selection), selection == initialSelection)
       item.accessibleContext.accessibleDescription = description(selection)
       item.addActionListener {
@@ -181,7 +177,6 @@ internal class SerialPeripheralMenuBinding(
 
     eventBus.register<Controller.SerialPeripheralSelectionChangedEvent> { event ->
       dispatchSwingMutation {
-        if (!isVisible(event.selection)) return@dispatchSwingMutation
         val previous = current
         if (event.selection != SerialPeripheralSelection.MOBILE_ADAPTER_GB) {
           mobileNetwork = null
@@ -198,7 +193,6 @@ internal class SerialPeripheralMenuBinding(
     }
     eventBus.register<Controller.SerialPeripheralStatusEvent> { event ->
       dispatchSwingMutation {
-        if (!isVisible(event.selection)) return@dispatchSwingMutation
         if (event.status == SerialPeripheralStatus.UNAVAILABLE) {
           // A failed preparation/handoff leaves the controller's prior owner committed. Swing's
           // radio model selects on click, so explicitly roll that optimistic visual state back.
@@ -215,7 +209,6 @@ internal class SerialPeripheralMenuBinding(
       }
     }
     eventBus.register<Controller.MobileAdapterNetworkStatusEvent> { event ->
-      if (!mobileAdapterVisible) return@register
       val detached = MobileAdapterNetworkUiSnapshot.from(event)
       dispatchSwingMutation {
         val previous = mobileNetwork
@@ -252,9 +245,6 @@ internal class SerialPeripheralMenuBinding(
   fun snapshot(): SerialPeripheralUiSnapshot = current
 
   fun isSelected(selection: SerialPeripheralSelection): Boolean = items[selection]?.isSelected == true
-
-  private fun isVisible(selection: SerialPeripheralSelection): Boolean =
-      mobileAdapterVisible || selection != SerialPeripheralSelection.MOBILE_ADAPTER_GB
 
   private fun postSelectionWithoutOwnershipRollback(selection: SerialPeripheralSelection) {
     try {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -246,6 +246,11 @@ class SwingGui private constructor(
               )
             },
             tokenProvider = { themeManager.current?.tokens ?: initialTheme.tokens },
+            onGuestImagePersistenceFailure = { message ->
+              if (::desktopUiCoordinator.isInitialized) {
+                desktopUiCoordinator.warning(message)
+              }
+            },
         )
     stateUxController =
         StateUxDesktopController(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -401,6 +401,7 @@ class SwingGui private constructor(
             ),
             desktopActions,
             emulator::isLinkedControllerActive,
+            mobileAdapterWindow::show,
             { themeManager.current?.tokens ?: initialTheme.tokens },
             { message ->
               desktopUiCoordinator.warning(message, DesktopCommand.PREFERENCES)
@@ -907,6 +908,9 @@ class SwingGui private constructor(
     check(mainWindow.jMenuBar != null && mainWindow.contentPane.componentCount > 0) {
       "Desktop startup smoke requires the production menu and display content"
     }
+    check(hasMobileAdapterDesktopControls(mainWindow.jMenuBar)) {
+      "Desktop startup smoke requires the production Mobile Adapter controls"
+    }
     val marker =
         try {
           Path.of(markerText).toAbsolutePath().normalize()
@@ -915,7 +919,8 @@ class SwingGui private constructor(
           exitProcess(1)
         }
     val evidence =
-        "Coffee GB desktop ready OK: edt=true, visible=true, displayable=true, menu=true\n"
+        "Coffee GB desktop ready OK: edt=true, visible=true, displayable=true, menu=true, " +
+            "mobile-adapter=true\n"
     writeDesktopStartupEvidence(marker, evidence) { failure ->
       if (failure != null) {
         LOG.error("Unable to write desktop startup smoke evidence", failure)
@@ -950,6 +955,8 @@ class SwingGui private constructor(
             requestedCategory
                 ?: desktopUiStateController.lastPreferencesCategory().toPreferencesCategory(),
         initialBounds = desktopUiStateController.utilityBounds(DesktopUtilityWindow.PREFERENCES),
+        mobileAdapterSummary = mobileAdapterWindow.currentSummary().preferencesText(),
+        configureMobileAdapter = mobileAdapterWindow::showOrRaise,
         onCategoryChanged = { category ->
           desktopUiStateController.rememberPreferencesCategory(category.toDesktopCategory())
         },

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -47,6 +47,32 @@ internal data class DebuggerMenuActions(
 /** A dynamic Pause/Resume label is a command, not a checked state in the platform menu. */
 internal fun pauseResumeMenuItem(action: Action): JMenuItem = JMenuItem(action)
 
+internal fun mobileAdapterConfigurationMenuItem(onShow: () -> Unit): JMenuItem =
+    JMenuItem("Configure Mobile Adapter…").apply {
+      accessibleContext.accessibleDescription =
+          "Import a private adapter image, configure a custom service, grant session permissions, and inspect network status"
+      addActionListener { onShow() }
+    }
+
+internal fun hasMobileAdapterDesktopControls(menuBar: JMenuBar): Boolean {
+  val peripherals =
+      menuBar.components.filterIsInstance<JMenu>().singleOrNull { it.text == "Peripherals" }
+          ?: return false
+  val linkPort =
+      peripherals.menuComponents.filterIsInstance<JMenu>().singleOrNull {
+        it.text == "Link-port device"
+      } ?: return false
+  val ownerVisible =
+      linkPort.menuComponents.filterIsInstance<JMenuItem>().any {
+        it.text == "Mobile Adapter GB" && it.isVisible && it.isEnabled
+      }
+  val configurationVisible =
+      peripherals.menuComponents.filterIsInstance<JMenuItem>().any {
+        it.text == "Configure Mobile Adapter…" && it.isVisible && it.isEnabled
+      }
+  return ownerVisible && configurationVisible
+}
+
 private enum class StopGameDecision {
   STOP,
   KEEP_PLAYING,
@@ -107,6 +133,7 @@ internal class SwingMenu(
     private val debuggerActions: DebuggerMenuActions,
     private val desktopActions: DesktopActionRegistry,
     private val isLinkedControllerActive: () -> Boolean,
+    private val onMobileAdapterConfiguration: () -> Unit,
     currentThemeTokens: () -> DesktopThemeTokens,
     private val onDesktopStatus: (String) -> Unit = {},
 ) {
@@ -430,7 +457,6 @@ internal class SwingMenu(
     serialPeripheralBinding =
         SerialPeripheralMenuBinding(
             eventBus,
-            mobileAdapterVisible = false,
             transitionPrerequisites = { selection ->
               serialPeripheralTransitionPrerequisites(
                   selection,
@@ -441,6 +467,7 @@ internal class SwingMenu(
             },
         )
     peripheralsMenu.add(serialPeripheralBinding.menu)
+    peripheralsMenu.add(mobileAdapterConfigurationMenuItem(onMobileAdapterConfiguration))
 
     val actionReplaySlot = JMenuItem("Action Replay Slot…")
     actionReplaySlot.accessibleContext.accessibleDescription =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DevicePreferencesEditorsTest.kt
@@ -50,18 +50,24 @@ class DevicePreferencesEditorsTest {
       }
 
   @Test
-  fun `peripherals page only exposes supported host peripherals`() =
+  fun `peripherals page presents redacted Mobile Adapter summary and opens configuration`() =
       onEdt {
+        var configureCalls = 0
+        val summary = "Custom Server · 2 mappings · networking blocked for this session"
         val editor =
             PeripheralsPreferencesEditor(
                 ApplicationSettings.Peripherals(),
+                mobileAdapterSummary = summary,
+                configureMobileAdapter = { configureCalls++ },
             )
 
-        assertFalse(
-            editor.components.filterIsInstance<javax.swing.JLabel>().any { label ->
-              label.text.contains("Mobile Adapter")
-            },
+        assertEquals(summary, editor.mobileAdapterStatus.text)
+        assertEquals(
+            "Mobile Adapter configuration summary",
+            editor.mobileAdapterStatus.accessibleContext.accessibleName,
         )
+        editor.configureMobileAdapterButton.doClick()
+        assertEquals(1, configureCalls)
       }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationUiStateTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationUiStateTest.kt
@@ -71,6 +71,7 @@ class MobileAdapterConfigurationUiStateTest {
                 "192.168.10.20",
                 5353,
                 listOf(MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080)),
+                listOf("private-alias.example"),
             ),
         )
     val text =
@@ -84,6 +85,7 @@ class MobileAdapterConfigurationUiStateTest {
     assertTrue(text.contains("custom server"))
     assertTrue(text.contains("Custom-server mappings: 1"))
     assertFalse(text.contains("private-service"))
+    assertFalse(text.contains("private-alias"))
     assertFalse(text.contains("192.168"))
     assertFalse(text.contains("18080"))
   }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationWindowTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationWindowTest.kt
@@ -24,8 +24,10 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JLabel
 import javax.swing.SwingUtilities
 import javax.swing.JTextArea
+import javax.swing.text.AbstractDocument
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -40,7 +42,8 @@ class MobileAdapterConfigurationWindowTest {
                 MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "80", "18080"),
                 MobileAdapterMappingDraft(MobileAdapterTransport.UDP, "53", "15353"),
             ))
-    val policy = assertIs<MobileAdapterPolicyValidation.Valid>(validateMobileAdapterPolicyDraft(valid))
+    val policy =
+        assertIs<MobileAdapterPolicyValidation.Valid>(validateMobileAdapterPolicyDraft(valid))
     assertEquals(
         listOf(
             MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080),
@@ -56,7 +59,8 @@ class MobileAdapterConfigurationWindowTest {
                     MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "80", "18080"),
                     MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "80", "28080"),
                 )))
-    assertTrue(assertIs<MobileAdapterPolicyValidation.Invalid>(duplicate).message.contains("only one"))
+    assertTrue(
+        assertIs<MobileAdapterPolicyValidation.Invalid>(duplicate).message.contains("only one"))
 
     val excessive =
         validateMobileAdapterPolicyDraft(
@@ -72,7 +76,82 @@ class MobileAdapterConfigurationWindowTest {
     val unicodePort =
         validateMobileAdapterPolicyDraft(
             customDraft(listOf(MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "１２", "80"))))
-    assertTrue(assertIs<MobileAdapterPolicyValidation.Invalid>(unicodePort).message.contains("decimal"))
+    assertTrue(
+        assertIs<MobileAdapterPolicyValidation.Invalid>(unicodePort).message.contains("decimal"))
+  }
+
+  @Test
+  fun `additional exact DNS names normalize sort and retain precise validation attribution`() {
+    val valid =
+        validateMobileAdapterPolicyDraft(
+            customDraft(additionalDnsQueryNamesText = "Trainer.Example\n\nbrowser.example\n"))
+    val policy =
+        assertIs<MobileAdapterNetworkPolicy.CustomServer>(
+            assertIs<MobileAdapterPolicyValidation.Valid>(valid).policy)
+    assertEquals(listOf("browser.example", "trainer.example"), policy.additionalDnsQueryNames)
+    assertEquals(
+        "browser.example\ntrainer.example",
+        MobileAdapterPolicyDraft.from(policy).additionalDnsQueryNamesText,
+    )
+
+    val primaryFirst =
+        validateMobileAdapterPolicyDraft(
+            customDraft(
+                dnsQueryName = "bad*primary.example",
+                additionalDnsQueryNamesText = "bad*alias.example",
+            ))
+    assertEquals(
+        MobileAdapterPolicyField.DNS_QUERY_NAME,
+        assertIs<MobileAdapterPolicyValidation.Invalid>(primaryFirst).field,
+    )
+    val resolverFirst =
+        validateMobileAdapterPolicyDraft(
+            customDraft(additionalDnsQueryNamesText = "bad*alias.example")
+                .copy(resolverIpv4Address = "999.0.2.53"))
+    assertEquals(
+        MobileAdapterPolicyField.RESOLVER_ADDRESS,
+        assertIs<MobileAdapterPolicyValidation.Invalid>(resolverFirst).field,
+    )
+
+    listOf(
+            "bad*alias.example",
+            " alias.example",
+            "ALIAS.example\nalias.example",
+            "service.example",
+        )
+        .forEach { aliases ->
+          val invalid =
+              assertIs<MobileAdapterPolicyValidation.Invalid>(
+                  validateMobileAdapterPolicyDraft(
+                      customDraft(additionalDnsQueryNamesText = aliases)))
+          assertEquals(MobileAdapterPolicyField.ADDITIONAL_DNS_QUERY_NAMES, invalid.field)
+        }
+  }
+
+  @Test
+  fun `additional DNS text parser bounds raw input lines and nonempty alias count`() {
+    val maximumAliases = (0 until 7).joinToString("\n") { "alias$it.example" }
+    assertEquals(7, parseMobileAdapterAdditionalDnsQueryNames(maximumAliases).size)
+    assertEquals(
+        listOf("first.example", "second.example"),
+        parseMobileAdapterAdditionalDnsQueryNames(
+            "first.example\r\n\r\nsecond.example\r\n"),
+    )
+    assertFailsWith<IllegalArgumentException> {
+      parseMobileAdapterAdditionalDnsQueryNames(maximumAliases + "\nalias7.example")
+    }
+    assertFailsWith<IllegalArgumentException> {
+      parseMobileAdapterAdditionalDnsQueryNames("a".repeat(254))
+    }
+    assertEquals(
+        emptyList(),
+        parseMobileAdapterAdditionalDnsQueryNames(
+            "\n".repeat(MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS)),
+    )
+    assertFailsWith<IllegalArgumentException> {
+      parseMobileAdapterAdditionalDnsQueryNames(
+          "\n".repeat(MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS + 1))
+    }
   }
 
   @Test
@@ -184,6 +263,24 @@ class MobileAdapterConfigurationWindowTest {
                     ),
             ))
 
+        assertTrue(edited.isEmpty(), "rendering a retained alias draft must not publish an edit")
+        assertEquals("browser.example\ntrainer.example", panel.additionalDnsQueryNames.text)
+        assertFalse(panel.additionalDnsQueryNames.lineWrap)
+        assertEquals(3, panel.additionalDnsQueryNames.rows)
+        assertEquals(28, panel.additionalDnsQueryNames.columns)
+        assertEquals(
+            panel.additionalDnsQueryNames,
+            descendants(panel)
+                .filterIsInstance<JLabel>()
+                .single { it.text == "Additional exact DNS names" }
+                .labelFor,
+        )
+        assertTrue(
+            descendants(panel)
+                .filterIsInstance<JTextArea>()
+                .single { it.accessibleContext.accessibleName == "Additional DNS names help" }
+                .text
+                .contains("one exact DNS name per line"))
         assertEquals(2, panel.mappingModel.rowCount)
         assertEquals(
             listOf("Transport", "Guest port", "Target port"),
@@ -208,6 +305,16 @@ class MobileAdapterConfigurationWindowTest {
         assertTrue(importExplanation.contains("host metadata is ignored"))
         panel.importImageButton.doClick()
         assertEquals(1, imports.get())
+
+        panel.additionalDnsQueryNames.text = "store.example\n"
+        assertEquals("store.example\n", edited.last().additionalDnsQueryNamesText)
+        val boundedDocument = panel.additionalDnsQueryNames.document as AbstractDocument
+        val retained = "x".repeat(MAX_MOBILE_ADAPTER_ADDITIONAL_DNS_QUERY_NAMES_TEXT_CHARS)
+        boundedDocument.replace(0, boundedDocument.length, retained, null)
+        assertEquals(retained, panel.additionalDnsQueryNames.text)
+        boundedDocument.replace(0, boundedDocument.length, retained + "x", null)
+        assertEquals(retained, panel.additionalDnsQueryNames.text)
+        panel.additionalDnsQueryNames.text = "store.example\n"
 
         panel.mappingModel.setValueAt("0", 0, 1)
         assertEquals("0", edited.last().portMappings.first().guestPort)
@@ -277,6 +384,8 @@ class MobileAdapterConfigurationWindowTest {
       assertEquals(2, summary.portMappingCount)
       assertTrue(summary.preferencesText().contains("private/LAN development allowed"))
       assertFalse(summary.preferencesText().contains("service.example"))
+      assertFalse(summary.preferencesText().contains("browser.example"))
+      assertFalse(summary.preferencesText().contains("trainer.example"))
       assertFalse(summary.preferencesText().contains("192.0.2.53"))
 
       onEdt { fixture.view.actions.setNetworkConsent(false) }
@@ -517,7 +626,11 @@ class MobileAdapterConfigurationWindowTest {
       flushEdt()
 
       val current = latest.get()
-      assertIs<MobileAdapterNetworkPolicy.CustomServer>(current.baselinePolicy)
+      val savedPolicy = assertIs<MobileAdapterNetworkPolicy.CustomServer>(current.baselinePolicy)
+      assertEquals(
+          listOf("browser.example", "trainer.example"), savedPolicy.additionalDnsQueryNames)
+      assertEquals(
+          "browser.example\ntrainer.example", current.draft.additionalDnsQueryNamesText)
       assertFalse(current.policyDirty)
       assertFalse(current.networkConsent)
       assertFalse(current.privateLocalDevelopment)
@@ -529,6 +642,44 @@ class MobileAdapterConfigurationWindowTest {
       coordinator.close()
       bus.close()
     }
+  }
+
+  @Test
+  fun `saved alias draft survives a fresh store load and draft reconstruction`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-window-alias-reopen")
+    val path = directory.resolve("adapter.bin")
+    val store = MobileAdapterConfigurationStore(path)
+    val coordinator = MobileAdapterConfigurationCoordinator(offlineConfiguration(), store)
+    val bus = EventBusImpl()
+    val saved = CountDownLatch(1)
+    val fixture =
+        onEdt {
+          HostFixture(coordinator, bus, RecordingDecisions()) { presentation ->
+            if (presentation.policyStatusTone == MobileAdapterStatusTone.SUCCESS) saved.countDown()
+          }
+        }
+    try {
+      onEdt {
+        fixture.host.show()
+        fixture.view.actions.draftChanged(
+            customDraft(additionalDnsQueryNamesText = "Trainer.Example\n\nbrowser.example\n"))
+        fixture.view.actions.savePolicy()
+      }
+      assertTrue(saved.await(5, TimeUnit.SECONDS))
+      flushEdt()
+    } finally {
+      onEdt { fixture.host.close() }
+      coordinator.close()
+      bus.close()
+    }
+
+    val loaded = MobileAdapterConfigurationStore(path).load().configuration
+    val policy = assertIs<MobileAdapterNetworkPolicy.CustomServer>(loaded.networkPolicy)
+    assertEquals(listOf("browser.example", "trainer.example"), policy.additionalDnsQueryNames)
+    assertEquals(
+        "browser.example\ntrainer.example",
+        MobileAdapterPolicyDraft.from(policy).additionalDnsQueryNamesText,
+    )
   }
 
   @Test
@@ -788,18 +939,22 @@ class MobileAdapterConfigurationWindowTest {
               MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080),
               MobileAdapterPortMapping(MobileAdapterTransport.UDP, 53, 15353),
           ),
+          listOf("trainer.example", "browser.example"),
       )
 
   private fun customDraft(
       mappings: List<MobileAdapterMappingDraft> =
-          listOf(MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "80", "18080"))
+          listOf(MobileAdapterMappingDraft(MobileAdapterTransport.TCP, "80", "18080")),
+      dnsQueryName: String = "service.example",
+      additionalDnsQueryNamesText: String = "Trainer.Example\nbrowser.example\n",
   ): MobileAdapterPolicyDraft =
       MobileAdapterPolicyDraft(
           MobileAdapterNetworkMode.CUSTOM_SERVER,
-          "service.example",
+          dnsQueryName,
           "192.0.2.53",
           "5353",
           mappings,
+          additionalDnsQueryNamesText,
       )
 
   private fun persistenceEvent(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationWindowTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationWindowTest.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.swing
 import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfiguration
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationError
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationSource
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationStore
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterNetworkMode
@@ -75,6 +76,85 @@ class MobileAdapterConfigurationWindowTest {
   }
 
   @Test
+  fun `guest image persistence presentation has literal actionable text and semantic tone`() {
+    val failure = MobileAdapterConfigurationError.STORAGE_WRITE_FAILED
+    val expected =
+        mapOf(
+            Controller.MobileAdapterConfigurationPersistencePhase.PENDING to
+                ("Changes received from the emulated Mobile Adapter are active and being saved. Keep Coffee GB open until saving finishes." to
+                    MobileAdapterStatusTone.WARNING),
+            Controller.MobileAdapterConfigurationPersistencePhase.SAVED to
+                ("Changes received from the emulated Mobile Adapter are active and saved. No action is needed." to
+                    MobileAdapterStatusTone.SUCCESS),
+            Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED to
+                ("Pending changes received from the emulated Mobile Adapter were replaced by the owner-selected adapter image. Review the imported image before continuing." to
+                    MobileAdapterStatusTone.NEUTRAL),
+            Controller.MobileAdapterConfigurationPersistencePhase.FAILED to
+                ("${failure.code}: ${failure.userMessage} Changes received from the emulated Mobile Adapter remain active for this session but could not be saved. Check private configuration storage, then retry by closing Coffee GB again." to
+                    MobileAdapterStatusTone.ERROR),
+        )
+
+    Controller.MobileAdapterConfigurationPersistencePhase.entries.forEach { phase ->
+      val presentation =
+          presentMobileAdapterGuestImagePersistence(
+              phase,
+              failure.takeIf {
+                phase == Controller.MobileAdapterConfigurationPersistencePhase.FAILED
+              },
+          )
+      assertEquals(expected.getValue(phase).first, presentation.status)
+      assertEquals(expected.getValue(phase).second, presentation.tone)
+    }
+  }
+
+  @Test
+  fun `guest image persistence ordering is global and accepts only later same-sequence phases`() {
+    val phases = Controller.MobileAdapterConfigurationPersistencePhase.entries
+    val order =
+        mapOf(
+            Controller.MobileAdapterConfigurationPersistencePhase.PENDING to 0,
+            Controller.MobileAdapterConfigurationPersistencePhase.FAILED to 1,
+            Controller.MobileAdapterConfigurationPersistencePhase.SAVED to 2,
+            Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED to 2,
+        )
+
+    phases.forEach { currentPhase ->
+      phases.forEach { nextPhase ->
+        assertEquals(
+            order.getValue(nextPhase) > order.getValue(currentPhase),
+            acceptsMobileAdapterGuestImagePersistence(
+                MobileAdapterGuestImagePersistenceCursor(7, currentPhase),
+                7,
+                nextPhase,
+            ),
+            "$currentPhase -> $nextPhase",
+        )
+      }
+    }
+    phases.forEach { phase ->
+      assertFalse(
+          acceptsMobileAdapterGuestImagePersistence(
+              MobileAdapterGuestImagePersistenceCursor(7, phase),
+              6,
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED,
+          ))
+      assertTrue(
+          acceptsMobileAdapterGuestImagePersistence(
+              MobileAdapterGuestImagePersistenceCursor(7, phase),
+              8,
+              Controller.MobileAdapterConfigurationPersistencePhase.PENDING,
+          ))
+    }
+    assertTrue(
+        acceptsMobileAdapterGuestImagePersistence(
+            MobileAdapterGuestImagePersistenceCursor(
+                7, Controller.MobileAdapterConfigurationPersistencePhase.FAILED),
+            7,
+            Controller.MobileAdapterConfigurationPersistencePhase.SAVED,
+        ))
+  }
+
+  @Test
   fun `panel uses a structured mapping table live inline validation literal text and semantic theme`() =
       onEdt {
         val edited = mutableListOf<MobileAdapterPolicyDraft>()
@@ -94,6 +174,8 @@ class MobileAdapterConfigurationWindowTest {
                 draft = draft,
                 policyStatus = "<html><b>literal policy status</b></html>",
                 policyTone = MobileAdapterStatusTone.ERROR,
+                guestImageStatus = "<html><b>literal guest image status</b></html>",
+                guestImageTone = MobileAdapterStatusTone.SUCCESS,
                 session =
                     MobileAdapterSessionPresentation(
                         "<html><b>literal session status</b></html>",
@@ -108,7 +190,10 @@ class MobileAdapterConfigurationWindowTest {
             (0 until panel.mappingModel.columnCount).map(panel.mappingModel::getColumnName),
         )
         assertEquals(true, panel.policyStatus.getClientProperty("html.disable"))
+        assertEquals(true, panel.guestImageStatus.getClientProperty("html.disable"))
         assertEquals("<html><b>literal policy status</b></html>", panel.policyStatus.text)
+        assertEquals(
+            "<html><b>literal guest image status</b></html>", panel.guestImageStatus.text)
         assertEquals("<html><b>literal session status</b></html>", panel.sessionStatus.text)
         assertTrue(
             descendants(panel)
@@ -133,6 +218,10 @@ class MobileAdapterConfigurationWindowTest {
                 draft = edited.last(),
                 validation = invalid,
                 dirty = true,
+                policyStatus = "<html><b>literal policy status</b></html>",
+                policyTone = MobileAdapterStatusTone.ERROR,
+                guestImageStatus = "<html><b>literal guest image status</b></html>",
+                guestImageTone = MobileAdapterStatusTone.SUCCESS,
             ))
         assertTrue(panel.validationStatus.isVisible)
         assertTrue(panel.validationStatus.text.contains("1..65535"))
@@ -149,6 +238,8 @@ class MobileAdapterConfigurationWindowTest {
         panel.desktopThemeChanged(dark)
         assertEquals(dark.surface, panel.background)
         assertEquals(dark.danger, panel.validationStatus.foreground)
+        assertEquals(dark.success, panel.guestImageStatus.foreground)
+        assertEquals(dark.danger, panel.policyStatus.foreground)
       }
 
   @Test
@@ -244,6 +335,119 @@ class MobileAdapterConfigurationWindowTest {
       assertTrue(current.session.summary.contains("REMOTE_CLOSED"))
       assertTrue(current.session.summary.contains("Connection slot 2"))
       assertTrue(current.session.cancelEnabled)
+    } finally {
+      onEdt { fixture.host.close() }
+      coordinator.close()
+      bus.close()
+    }
+  }
+
+  @Test
+  fun `hidden host folds persistence on EDT redacts correlations and warns only for accepted failure`() {
+    val bus = EventBusImpl()
+    val coordinator = coordinator(customConfiguration())
+    val failures = mutableListOf<String>()
+    val callbackOnEdt = mutableListOf<Boolean>()
+    val fixture =
+        onEdt {
+          HostFixture(
+              coordinator,
+              bus,
+              RecordingDecisions(),
+              onGuestImagePersistenceFailure = { message ->
+                callbackOnEdt += SwingUtilities.isEventDispatchThread()
+                failures += message
+              },
+          )
+        }
+    try {
+      assertEquals(0, fixture.factoryCalls, "the retained window remains hidden")
+
+      bus.post(persistenceEvent(20, Controller.MobileAdapterConfigurationPersistencePhase.PENDING))
+      flushEdt()
+      var current = onEdt { fixture.host.currentPresentation() }
+      assertEquals(MobileAdapterStatusTone.WARNING, current.guestImageStatusTone)
+      assertTrue(current.guestImageStatus.contains("being saved"))
+
+      bus.post(
+          persistenceEvent(
+              19,
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED,
+              MobileAdapterConfigurationError.STORAGE_WRITE_FAILED,
+          ))
+      flushEdt()
+      assertTrue(failures.isEmpty(), "an older global sequence is ignored")
+
+      bus.post(
+          persistenceEvent(
+              20,
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED,
+              MobileAdapterConfigurationError.STORAGE_WRITE_FAILED,
+          ))
+      flushEdt()
+      current = onEdt { fixture.host.currentPresentation() }
+      assertEquals(MobileAdapterStatusTone.ERROR, current.guestImageStatusTone)
+      val acceptedError = MobileAdapterConfigurationError.STORAGE_WRITE_FAILED
+      assertEquals(
+          presentMobileAdapterGuestImagePersistence(
+                  Controller.MobileAdapterConfigurationPersistencePhase.FAILED, acceptedError)
+              .status,
+          current.guestImageStatus,
+      )
+      assertTrue(
+          current.guestImageStatus.contains(
+              "${acceptedError.code}: ${acceptedError.userMessage}"))
+      assertEquals(listOf(true), callbackOnEdt)
+      assertEquals(listOf(current.guestImageStatus), failures)
+      assertEquals(0, fixture.factoryCalls, "a failure does not open a modal or utility window")
+
+      bus.post(persistenceEvent(20, Controller.MobileAdapterConfigurationPersistencePhase.PENDING))
+      bus.post(
+          persistenceEvent(
+              20,
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED,
+              MobileAdapterConfigurationError.PERMISSION_HARDENING_FAILED,
+          ))
+      flushEdt()
+      assertEquals(1, failures.size, "phase regressions and duplicate failures are ignored")
+
+      bus.post(persistenceEvent(20, Controller.MobileAdapterConfigurationPersistencePhase.SAVED))
+      flushEdt()
+      current = onEdt { fixture.host.currentPresentation() }
+      assertEquals(MobileAdapterStatusTone.SUCCESS, current.guestImageStatusTone)
+      assertTrue(current.guestImageStatus.contains("active and saved"))
+
+      bus.post(
+          persistenceEvent(
+              20,
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED,
+              MobileAdapterConfigurationError.NON_REGULAR_FILE,
+          ))
+      bus.post(
+          persistenceEvent(21, Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED))
+      bus.post(persistenceEvent(21, Controller.MobileAdapterConfigurationPersistencePhase.SAVED))
+      flushEdt()
+      current = onEdt { fixture.host.currentPresentation() }
+      assertEquals(MobileAdapterStatusTone.NEUTRAL, current.guestImageStatusTone)
+      assertTrue(current.guestImageStatus.contains("owner-selected adapter image"))
+      assertEquals(1, failures.size)
+
+      val renderedPersistenceText = listOf(current.guestImageStatus) + failures
+      listOf(
+              "20",
+              PERSISTENCE_ATTACHMENT_ID.toString(),
+              PERSISTENCE_MUTATION_REVISION.toString(),
+              "PERMISSION_HARDENING_FAILED",
+              "NON_REGULAR_FILE",
+              "Exception",
+              "/",
+          )
+          .forEach { forbidden ->
+            assertTrue(
+                renderedPersistenceText.none { it.contains(forbidden) },
+                "persistence presentation must redact $forbidden",
+            )
+          }
     } finally {
       onEdt { fixture.host.close() }
       coordinator.close()
@@ -470,6 +674,7 @@ class MobileAdapterConfigurationWindowTest {
       eventBus: EventBusImpl,
       decisions: RecordingDecisions,
       imageSelector: () -> Path? = { null },
+      onGuestImagePersistenceFailure: (String) -> Unit = {},
       onPresentation: (MobileAdapterConfigurationPresentation) -> Unit = {},
   ) {
     lateinit var view: RecordingView
@@ -490,6 +695,7 @@ class MobileAdapterConfigurationWindowTest {
             },
             decisions,
             onSummary = {},
+            onGuestImagePersistenceFailure = onGuestImagePersistenceFailure,
             imageSelector = MobileAdapterConfigurationImageSelector(imageSelector),
         )
   }
@@ -596,6 +802,19 @@ class MobileAdapterConfigurationWindowTest {
           mappings,
       )
 
+  private fun persistenceEvent(
+      sequence: Long,
+      phase: Controller.MobileAdapterConfigurationPersistencePhase,
+      error: MobileAdapterConfigurationError? = null,
+  ) =
+      Controller.MobileAdapterConfigurationPersistenceStatusEvent(
+          sequence = sequence,
+          attachmentId = PERSISTENCE_ATTACHMENT_ID,
+          mutationRevision = PERSISTENCE_MUTATION_REVISION,
+          phase = phase,
+          error = error,
+      )
+
   private fun presentation(
       policy: MobileAdapterNetworkPolicy,
       draft: MobileAdapterPolicyDraft,
@@ -603,6 +822,9 @@ class MobileAdapterConfigurationWindowTest {
       dirty: Boolean = false,
       policyStatus: String = "Ready.",
       policyTone: MobileAdapterStatusTone = MobileAdapterStatusTone.NEUTRAL,
+      guestImageStatus: String =
+          "No guest-authored adapter image changes have been received this session.",
+      guestImageTone: MobileAdapterStatusTone = MobileAdapterStatusTone.NEUTRAL,
       session: MobileAdapterSessionPresentation = MobileAdapterSessionPresentation("Ready.", false),
   ) =
       MobileAdapterConfigurationPresentation(
@@ -616,6 +838,8 @@ class MobileAdapterConfigurationWindowTest {
           savePhase = MobileAdapterSavePhase.IDLE,
           networkConsent = false,
           privateLocalDevelopment = false,
+          guestImageStatus = guestImageStatus,
+          guestImageStatusTone = guestImageTone,
           policyStatus = policyStatus,
           policyStatusTone = policyTone,
           session = session,
@@ -662,5 +886,10 @@ class MobileAdapterConfigurationWindowTest {
     val task = FutureTask(action)
     SwingUtilities.invokeAndWait(task)
     return task.get()
+  }
+
+  private companion object {
+    const val PERSISTENCE_ATTACHMENT_ID = 987_654_321L
+    const val PERSISTENCE_MUTATION_REVISION = 123_456_789L
   }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -39,6 +39,49 @@ import org.junit.Test
 class PreferencesDialogTest {
 
   @Test
+  fun `Mobile Adapter handoff preserves dirty Preferences until discard is confirmed`() {
+    val rejectedEvents = mutableListOf<String>()
+    val rejected =
+        requestMobileAdapterConfigurationHandoff(
+            isDirty = true,
+            confirmDiscard = {
+              rejectedEvents += "confirm"
+              false
+            },
+            stopBackgroundWork = { rejectedEvents += "stop" },
+            closePreferences = { rejectedEvents += "close" },
+            defer = { rejectedEvents += "defer" },
+            configureMobileAdapter = { rejectedEvents += "configure" },
+        )
+
+    assertFalse(rejected)
+    assertEquals(listOf("confirm"), rejectedEvents)
+
+    val acceptedEvents = mutableListOf<String>()
+    var deferred: (() -> Unit)? = null
+    val accepted =
+        requestMobileAdapterConfigurationHandoff(
+            isDirty = true,
+            confirmDiscard = {
+              acceptedEvents += "confirm"
+              true
+            },
+            stopBackgroundWork = { acceptedEvents += "stop" },
+            closePreferences = { acceptedEvents += "close" },
+            defer = {
+              acceptedEvents += "defer"
+              deferred = it
+            },
+            configureMobileAdapter = { acceptedEvents += "configure" },
+        )
+
+    assertTrue(accepted)
+    assertEquals(listOf("confirm", "stop", "close", "defer"), acceptedEvents)
+    deferred?.invoke()
+    assertEquals(listOf("confirm", "stop", "close", "defer", "configure"), acceptedEvents)
+  }
+
+  @Test
   fun `edit applies exposed fields to latest settings and preserves hidden settings`() {
     val defaultInput = ApplicationSettings.Input.defaults()
     val currentInput =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SerialPeripheralMenuBindingTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SerialPeripheralMenuBindingTest.kt
@@ -27,14 +27,14 @@ import org.junit.Test
 class SerialPeripheralMenuBindingTest {
 
   @Test
-  fun `mobile adapter is hidden when the desktop UI disables it`() {
+  fun `mobile adapter is always exposed as a link-port choice`() {
     val eventBus = EventBusImpl()
     try {
-      val binding = onEdtResult { SerialPeripheralMenuBinding(eventBus, mobileAdapterVisible = false) }
+      val binding = onEdtResult { SerialPeripheralMenuBinding(eventBus) }
 
-      assertFalse(binding.items.containsKey(SerialPeripheralSelection.MOBILE_ADAPTER_GB))
+      assertTrue(binding.items.containsKey(SerialPeripheralSelection.MOBILE_ADAPTER_GB))
       assertFalse(binding.isSelected(SerialPeripheralSelection.MOBILE_ADAPTER_GB))
-      assertFalse(
+      assertTrue(
           onEdtResult {
             binding.menu.menuComponents
                 .filterIsInstance<javax.swing.JMenuItem>()
@@ -46,7 +46,8 @@ class SerialPeripheralMenuBindingTest {
           Controller.SerialPeripheralSelectionChangedEvent(
               SerialPeripheralSelection.MOBILE_ADAPTER_GB))
       flushEdt()
-      assertEquals(SerialPeripheralSelection.PEER_TO_PEER, binding.snapshot().selection)
+      assertEquals(SerialPeripheralSelection.MOBILE_ADAPTER_GB, binding.snapshot().selection)
+      assertTrue(binding.isSelected(SerialPeripheralSelection.MOBILE_ADAPTER_GB))
     } finally {
       eventBus.close()
     }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingMenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingMenuTest.kt
@@ -1,0 +1,51 @@
+package eu.rekawek.coffeegb.swing
+
+import javax.swing.JMenu
+import javax.swing.JMenuBar
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SwingMenuTest {
+
+  @Test
+  fun `mobile adapter configuration action opens the retained window`() {
+    var opens = 0
+
+    SwingUtilities.invokeAndWait {
+      val item = mobileAdapterConfigurationMenuItem { opens++ }
+
+      assertEquals("Configure Mobile Adapter…", item.text)
+      assertTrue(item.accessibleContext.accessibleDescription.contains("session permissions"))
+      item.doClick()
+    }
+
+    assertEquals(1, opens)
+  }
+
+  @Test
+  fun `desktop startup contract requires both Mobile Adapter entry points`() {
+    val menuBar = JMenuBar()
+    val peripherals = JMenu("Peripherals")
+    val linkPort = JMenu("Link-port device")
+    linkPort.add("Mobile Adapter GB")
+    peripherals.add(linkPort)
+    menuBar.add(peripherals)
+
+    assertFalse(hasMobileAdapterDesktopControls(menuBar))
+
+    val configuration = mobileAdapterConfigurationMenuItem {}
+    peripherals.add(configuration)
+    assertTrue(hasMobileAdapterDesktopControls(menuBar))
+
+    configuration.isEnabled = false
+    assertFalse(hasMobileAdapterDesktopControls(menuBar))
+    configuration.isEnabled = true
+
+    val owner = linkPort.getItem(0)
+    owner.isVisible = false
+    assertFalse(hasMobileAdapterDesktopControls(menuBar))
+  }
+}


### PR DESCRIPTION
## Summary

- expose Mobile Adapter GB as an exclusive link-port choice under **Peripherals**
- expose the retained configuration/import workflow from **Peripherals** and **Preferences**
- preserve one primary exact DNS name plus up to seven exact aliases through the desktop editor
- present guest-image persistence progress and failures with redacted, sequenced UI state
- keep the final Mobile Trainer-to-REON acceptance evidence from #458 intact

The manual workflow is now available through **Peripherals → Link-port device → Mobile Adapter GB** and **Peripherals → Configure Mobile Adapter…**.

## Safety boundary

The adapter remains offline by default. Saving a custom-server policy performs no host I/O; session networking consent and the separate private/LAN consent remain runtime-only gates. Status and persistence surfaces omit configuration bytes, paths, endpoints, exceptions, and correlation identifiers.

The owner-authorized Mobile Trainer acceptance is documented in #458: one ROM-originated request reached the pinned loopback REON service, the declared 19-byte response was delivered and visibly rendered, remote close released backend ownership, and controlled shutdown cleanup passed.

Closes #399.

## Verification

- focused Swing/Mobile Adapter suite: 152 tests, 0 failures/errors/skips
- full `mvn -B -Dkotlin.compiler.daemon=false package --file pom.xml`: 2,754 tests, 0 failures/errors, 4 skipped
- `git diff --check`
- current head is rebased onto merged #458 and #459; the final intervening base change is limited to the separately CI-validated `.claude/skills/play-gb-rom` files

## AI assistance

This change, rebase conflict resolution, testing, and PR update were prepared with AI assistance and reviewed against the existing privacy, lifecycle, acceptance-evidence, and cleanup contracts.
