### PR TITLE
Persist guest Mobile Adapter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ telephone call; there is no listener, relay, real dial-up, Nintendo
 production-service preset, automatic endpoint selection, or bundled service data. The public-IP
 policy cannot identify who operates an address, so users must configure only a trusted non-Nintendo
 custom service; DNS names, network metadata, and guest payloads are sent without TLS. Deterministic
-tests cover the Crystal command path and acknowledgement/response schedule without bundling a ROM;
-end-to-end gameplay validation still requires a user-supplied ROM and selected custom service. See
+tests cover the Crystal command path and acknowledgement/response schedule without bundling a ROM.
+Changed configuration bytes written by the guest are coalesced into the private owner-only adapter
+record and participate in the desktop's retryable shutdown barrier; state restore does not replay a
+filesystem write. End-to-end gameplay validation still requires a user-supplied ROM and selected
+custom service. See
 [the Mobile Adapter contract](docs/mobile-adapter-contract.md) and the
 [Japanese Crystal/REON validation record](docs/mobile-adapter-crystal-reon-validation.md).
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -7,6 +7,11 @@ import eu.rekawek.coffeegb.controller.debug.DebugHistorySessionBusyException
 import eu.rekawek.coffeegb.controller.debug.DebugInstructionReplayer
 import eu.rekawek.coffeegb.controller.debug.QueuedDebugCommand
 import eu.rekawek.coffeegb.controller.debug.QueuedDebugPort
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationError
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationOfferResult
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistencePhase
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationSink
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationWrite
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkBackend
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkError as BackendNetworkError
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkPhase as BackendNetworkPhase
@@ -148,6 +153,8 @@ class BasicController private constructor(
      * an image, but the desktop injects this for the Home recent-game previews.
      */
     private val autosaveThumbnailProvider: () -> StateImage? = { null },
+    private val mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
+        MobileAdapterGuestConfigurationSink.NO_OP,
 ) : Controller, SnapshotSupport {
 
   constructor(
@@ -194,6 +201,8 @@ class BasicController private constructor(
       externalActions: StateExternalActions,
       mobileAdapterConfigurationProvider: Controller.MobileAdapterConfigurationProvider,
       autosaveThumbnailProvider: () -> StateImage? = { null },
+      mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
+          MobileAdapterGuestConfigurationSink.NO_OP,
   ) : this(
       parentEventBus,
       properties,
@@ -209,6 +218,7 @@ class BasicController private constructor(
       CONTROLLER_CLOSE_TIMEOUT_MILLIS,
       mobileAdapterConfigurationProvider = mobileAdapterConfigurationProvider,
       autosaveThumbnailProvider = autosaveThumbnailProvider,
+      mobileAdapterGuestConfigurationSink = mobileAdapterGuestConfigurationSink,
   )
 
   internal constructor(
@@ -219,6 +229,8 @@ class BasicController private constructor(
       mobileAdapterConfigurationProvider: Controller.MobileAdapterConfigurationProvider =
           SYNTHETIC_OFFLINE_MOBILE_CONFIGURATION,
       autosaveThumbnailProvider: () -> StateImage? = { null },
+      mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
+          MobileAdapterGuestConfigurationSink.NO_OP,
   ) : this(
       parentEventBus,
       properties,
@@ -232,6 +244,7 @@ class BasicController private constructor(
       CONTROLLER_CLOSE_TIMEOUT_MILLIS,
       mobileAdapterConfigurationProvider = mobileAdapterConfigurationProvider,
       autosaveThumbnailProvider = autosaveThumbnailProvider,
+      mobileAdapterGuestConfigurationSink = mobileAdapterGuestConfigurationSink,
   )
 
   internal constructor(
@@ -307,6 +320,8 @@ class BasicController private constructor(
       mobileAdapterConfigurationProvider: Controller.MobileAdapterConfigurationProvider =
           SYNTHETIC_OFFLINE_MOBILE_CONFIGURATION,
       autosaveThumbnailProvider: () -> StateImage? = { null },
+      mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
+          MobileAdapterGuestConfigurationSink.NO_OP,
   ) : this(
       parentEventBus,
       properties,
@@ -321,6 +336,7 @@ class BasicController private constructor(
       liveBatteryStorageResolver,
       mobileAdapterConfigurationProvider,
       autosaveThumbnailProvider,
+      mobileAdapterGuestConfigurationSink,
   )
 
   private val timingTicker = TimingTicker()
@@ -635,6 +651,7 @@ class BasicController private constructor(
     eventQueue.dispatch()
     drainMobileAdapterControlLane()
     pollMobileAdapterBackend()
+    pollMobileAdapterGuestConfigurationPersistence()
     // A live request or logical connection makes every earlier rewind entry discontinuous.
     // Clear even while paused; after ownership ends, recording starts a fresh history instead of
     // appending post-I/O captures to states from before the unrepresentable host interaction.
@@ -850,6 +867,8 @@ class BasicController private constructor(
 
   private fun recordCompletedFrame() {
     val currentSession = session ?: return
+    drainMobileAdapterGuestConfiguration(currentSession)
+    pollMobileAdapterGuestConfigurationPersistence()
     if (hasMobileAdapterExternalIo()) {
       rewindManager.clear()
     } else {
@@ -1610,15 +1629,31 @@ class BasicController private constructor(
     when {
       controls.hasCancel && controls.hasRefresh && controls.cancelOrder < controls.refreshOrder -> {
         disconnectMobileAdapter(Controller.MobileAdapterDisconnectReason.USER_CANCELLED)
-        refreshMobileAdapterConfiguration(controls.refreshRevision)
+        if (refreshMobileAdapterConfiguration(controls.refreshRevision) ==
+            MobileAdapterRefreshResult.BLOCKED) {
+          // Cancellation preceded refresh, so retrying only the refresh preserves the requested
+          // final ordering once the guest configuration has been retained by its durable owner.
+          mobileAdapterControlLane.restoreDeferred(
+              controls.copy(cancelOrder = MobileAdapterControlLane.Pending.EMPTY.cancelOrder))
+        }
       }
       controls.hasCancel && controls.hasRefresh -> {
-        refreshMobileAdapterConfiguration(controls.refreshRevision)
+        val refreshResult = refreshMobileAdapterConfiguration(controls.refreshRevision)
         disconnectMobileAdapter(Controller.MobileAdapterDisconnectReason.USER_CANCELLED)
+        if (refreshResult == MobileAdapterRefreshResult.BLOCKED) {
+          // Refresh preceded cancellation. Requeue both in that order so a deferred refresh can
+          // never make the later user cancellation appear to have been undone.
+          mobileAdapterControlLane.restoreDeferred(controls)
+        }
       }
       controls.hasCancel ->
           disconnectMobileAdapter(Controller.MobileAdapterDisconnectReason.USER_CANCELLED)
-      controls.hasRefresh -> refreshMobileAdapterConfiguration(controls.refreshRevision)
+      controls.hasRefresh -> {
+        if (refreshMobileAdapterConfiguration(controls.refreshRevision) ==
+            MobileAdapterRefreshResult.BLOCKED) {
+          mobileAdapterControlLane.restoreDeferred(controls)
+        }
+      }
     }
   }
 
@@ -2758,7 +2793,26 @@ class BasicController private constructor(
     }
 
     outcome as ReplacementAttemptResult.Ready
+    job.ready = outcome
+    continueReplacementAfterGuestConfiguration(job)
+  }
+
+  private fun continueReplacementAfterGuestConfiguration(job: ReplacementJob) {
+    val outcome = job.ready ?: return
+    val drainResult =
+        session?.let(::drainMobileAdapterGuestConfiguration)
+            ?: MobileAdapterGuestConfigurationDrainResult.SAFE
+    if (drainResult == MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      postMobileAdapterGuestConfigurationBarrierFailure(
+          job.requestId,
+          Controller.PersistenceBarrierOperation.ROM_REPLACEMENT,
+          job.event.openRequestId,
+      )
+      return
+    }
+
     job.capture.complete(outcome.persistence)
+    job.ready = null
     replacementJob = null
     activatePreparedLoad(job, outcome.gameboy)
   }
@@ -2771,16 +2825,22 @@ class BasicController private constructor(
       return
     }
     replacementJob?.let { job ->
-      if (job.requestId == requestId && job.attempt == null) {
-        val attempt = ReplacementTask(job.capture, job.prepared)
-        job.attempt = attempt
-        persistenceExecutor.execute(attempt)
+      if (job.requestId == requestId) {
+        if (job.ready != null) {
+          continueReplacementAfterGuestConfiguration(job)
+        } else if (job.attempt == null) {
+          val attempt = ReplacementTask(job.capture, job.prepared)
+          job.attempt = attempt
+          persistenceExecutor.execute(attempt)
+        }
       }
       return
     }
     stopJob?.let { job ->
       if (job.requestId == requestId && job.attempt == null) {
-        if (job.awaitingAutosaveDecision) {
+        if (job.awaitingGuestConfiguration) {
+          continueStopAfterGuestConfiguration(job)
+        } else if (job.awaitingAutosaveDecision) {
           submitStopAutosave(job)
         } else {
           beginStopPersistence(job)
@@ -2811,6 +2871,8 @@ class BasicController private constructor(
     val job = replacementJob ?: return
     replacementJob = null
     job.attempt?.cancelAndDiscard()
+    job.ready?.gameboy?.discardUnstarted()
+    job.ready = null
     job.prepared.discard()
     if (notifyCancellation) {
       eventBus.post(
@@ -2836,6 +2898,7 @@ class BasicController private constructor(
       return
     }
 
+    val guestConfigurationDrain = drainMobileAdapterGuestConfiguration(currentSession)
     setPaused(true)
     val capture = currentSession.gameboy.prepareCartridgeFlush()
     val job =
@@ -2846,7 +2909,42 @@ class BasicController private constructor(
             attempt = null,
         )
     stopJob = job
+    if (guestConfigurationDrain == MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      job.awaitingGuestConfiguration = true
+      postMobileAdapterGuestConfigurationBarrierFailure(
+          job.requestId,
+          Controller.PersistenceBarrierOperation.STOP,
+      )
+      return
+    }
     submitStopAutosave(job)
+  }
+
+  private fun continueStopAfterGuestConfiguration(job: StopJob) {
+    val currentSession = session
+    val drainResult =
+        currentSession?.let(::drainMobileAdapterGuestConfiguration)
+            ?: MobileAdapterGuestConfigurationDrainResult.SAFE
+    if (drainResult == MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      job.awaitingGuestConfiguration = true
+      postMobileAdapterGuestConfigurationBarrierFailure(
+          job.requestId,
+          Controller.PersistenceBarrierOperation.STOP,
+      )
+      return
+    }
+
+    job.awaitingGuestConfiguration = false
+    val persistence = job.completedPersistence
+    if (persistence != null) {
+      job.capture.complete(persistence)
+      job.completedPersistence = null
+      stopJob = null
+      stop(afterCartridgeFlush = true)
+      isPaused = false
+    } else {
+      submitStopAutosave(job)
+    }
   }
 
   /** Writes the terminal autosave before battery persistence can release the current machine. */
@@ -2948,10 +3046,9 @@ class BasicController private constructor(
       return
     }
 
-    job.capture.complete(result)
-    stopJob = null
-    stop(afterCartridgeFlush = true)
-    isPaused = false
+    result as BatteryPersistenceResult.Success
+    job.completedPersistence = result
+    continueStopAfterGuestConfiguration(job)
   }
 
   private fun discardStop(restorePause: Boolean) {
@@ -3058,6 +3155,7 @@ class BasicController private constructor(
     // This assignment is the ownership commit. From here on the old session is never resumed:
     // its bus may need deferred cleanup, but it cannot invalidate the fully staged candidate.
     session = committedSession
+    commitMobileAdapterAttachment(committedSession)
     currentRomHashes = job.prepared.romHashes
     snapshotManager = nextSnapshotManager
     nextSession = null
@@ -3364,6 +3462,16 @@ class BasicController private constructor(
       return
     }
 
+    if (drainMobileAdapterGuestConfiguration(currentSession) ==
+        MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      postSerialPeripheralStatus(
+          selection,
+          Controller.SerialPeripheralStatus.UNAVAILABLE,
+          Controller.SerialPeripheralError.STORAGE_FAILED,
+      )
+      return
+    }
+
     val endpoint =
         try {
           createLinkDevice(selection, currentSession.eventBus, currentSession.config.clockSpec)
@@ -3389,6 +3497,7 @@ class BasicController private constructor(
       )
       return
     }
+    commitMobileAdapterAttachment(currentSession)
     val previousSelection = serialPeripheralSelection
     // The session handoff is the ownership commit. Update the controller's internal selection
     // before invoking any presentation subscriber, because EventBus dispatch is synchronous and
@@ -3410,11 +3519,27 @@ class BasicController private constructor(
   }
 
   /** Re-prepares the same selected endpoint so a policy change is an atomic ownership handoff. */
-  private fun refreshMobileAdapterConfiguration(requestedRevision: Long) {
-    if (serialPeripheralSelection != Controller.SerialPeripheralSelection.MOBILE_ADAPTER_GB) return
-    val currentSession = session ?: return
+  private fun refreshMobileAdapterConfiguration(
+      requestedRevision: Long
+  ): MobileAdapterRefreshResult {
+    if (serialPeripheralSelection != Controller.SerialPeripheralSelection.MOBILE_ADAPTER_GB) {
+      return MobileAdapterRefreshResult.NOT_APPLICABLE
+    }
+    val currentSession = session ?: return MobileAdapterRefreshResult.NOT_APPLICABLE
     val currentLifecycle = mobileAdapterLifecycle(currentSession)
-    if (currentLifecycle != null && requestedRevision <= currentLifecycle.policyRevision) return
+    if (currentLifecycle != null && requestedRevision <= currentLifecycle.policyRevision) {
+      return MobileAdapterRefreshResult.COMPLETED
+    }
+
+    if (drainMobileAdapterGuestConfiguration(currentSession) ==
+        MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      postSerialPeripheralStatus(
+          Controller.SerialPeripheralSelection.MOBILE_ADAPTER_GB,
+          Controller.SerialPeripheralStatus.UNAVAILABLE,
+          Controller.SerialPeripheralError.STORAGE_FAILED,
+      )
+      return MobileAdapterRefreshResult.BLOCKED
+    }
 
     // A newer policy request is an authority boundary, not merely a presentation refresh. Revoke
     // the live host capability before provider/core preparation so every failure is fail-closed.
@@ -3434,7 +3559,7 @@ class BasicController private constructor(
               Controller.SerialPeripheralStatus.UNAVAILABLE,
               failure.error,
           )
-          return
+          return MobileAdapterRefreshResult.COMPLETED
         }
     val replacementLifecycle = replacement.disconnect as? MobileAdapterEndpointLifecycle
     if (replacementLifecycle == null || replacementLifecycle.policyRevision < requestedRevision) {
@@ -3444,7 +3569,7 @@ class BasicController private constructor(
           Controller.SerialPeripheralStatus.UNAVAILABLE,
           Controller.SerialPeripheralError.CONFIGURATION_INVALID,
       )
-      return
+      return MobileAdapterRefreshResult.COMPLETED
     }
     try {
       currentSession.setSerialEndpoint(replacement.endpoint, replacement.disconnect)
@@ -3454,8 +3579,9 @@ class BasicController private constructor(
           Controller.SerialPeripheralStatus.UNAVAILABLE,
           Controller.SerialPeripheralError.ENDPOINT_UNAVAILABLE,
       )
-      return
+      return MobileAdapterRefreshResult.COMPLETED
     }
+    commitMobileAdapterAttachment(currentSession)
     rewindManager.clear()
     debugCheckpointHistory.clear(DebugHistoryTruncationReason.TOPOLOGY_CHANGED)
     debugInstructionReplayer.close()
@@ -3464,6 +3590,7 @@ class BasicController private constructor(
         Controller.SerialPeripheralStatus.ATTACHED,
     )
     postInitialMobileAdapterNetworkStatus()
+    return MobileAdapterRefreshResult.COMPLETED
   }
 
   private fun pollMobileAdapterBackend() {
@@ -3475,6 +3602,107 @@ class BasicController private constructor(
     while (true) {
       val status = backend.pollStatus() ?: break
       postMobileAdapterBackendStatus(lifecycle, status)
+    }
+  }
+
+  /** Publishes the newest complete guest image at the frame owner's deterministic safe point. */
+  private fun drainMobileAdapterGuestConfiguration(
+      currentSession: Session
+  ): MobileAdapterGuestConfigurationDrainResult {
+    val endpoint =
+        currentSession.serialEndpoint as? MobileAdapterSerialEndpoint
+            ?: return MobileAdapterGuestConfigurationDrainResult.SAFE
+    val lifecycle =
+        mobileAdapterLifecycle(currentSession)
+            ?: return MobileAdapterGuestConfigurationDrainResult.SAFE
+    val mutation =
+        endpoint.latestGuestConfigurationMutation()
+            ?: return MobileAdapterGuestConfigurationDrainResult.SAFE
+
+    if (mutation.revision() > lifecycle.guestConfigurationHistoryObservedRevision) {
+      lifecycle.guestConfigurationHistoryObservedRevision = mutation.revision()
+      // History invalidation follows the emulated side effect, independently of whether private
+      // desktop persistence is currently able to retain the corresponding full image.
+      rewindManager.clear()
+      debugCheckpointHistory.clear(DebugHistoryTruncationReason.CONFIGURATION_CHANGED)
+    }
+    if (mutation.revision() <= lifecycle.guestConfigurationPersistenceAcceptedRevision) {
+      return MobileAdapterGuestConfigurationDrainResult.SAFE
+    }
+
+    val offer =
+        try {
+          mobileAdapterGuestConfigurationSink.offer(
+              MobileAdapterGuestConfigurationWrite(
+                  lifecycle.attachmentId,
+                  mutation.revision(),
+                  mutation.configuration(),
+              ))
+        } catch (_: RuntimeException) {
+          // A privileged sink is required to reject through its typed result. Contain an
+          // implementation failure without logging private configuration or attachment details.
+          LOG.warn("Mobile Adapter guest configuration sink failed")
+          MobileAdapterGuestConfigurationOfferResult.CLOSED
+        }
+    if (offer != MobileAdapterGuestConfigurationOfferResult.ACCEPTED) {
+      return MobileAdapterGuestConfigurationDrainResult.BLOCKED
+    }
+    lifecycle.guestConfigurationPersistenceAcceptedRevision = mutation.revision()
+    return MobileAdapterGuestConfigurationDrainResult.ACCEPTED
+  }
+
+  private fun postMobileAdapterGuestConfigurationBarrierFailure(
+      requestId: Long,
+      operation: Controller.PersistenceBarrierOperation,
+      openRequestId: Long? = null,
+  ) {
+    postPersistenceFailure(
+        requestId,
+        operation,
+        MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+        MOBILE_ADAPTER_CONFIGURATION_PENDING_MESSAGE,
+        openRequestId,
+    )
+  }
+
+  /** Only stable typed metadata crosses the application event tree; the image remains private. */
+  private fun pollMobileAdapterGuestConfigurationPersistence() {
+    val status =
+        try {
+          mobileAdapterGuestConfigurationSink.pollStatus()
+        } catch (_: RuntimeException) {
+          LOG.warn("Mobile Adapter guest configuration status provider failed")
+          null
+        } ?: return
+    val phase =
+        when (status.phase) {
+          MobileAdapterGuestConfigurationPersistencePhase.PENDING ->
+              Controller.MobileAdapterConfigurationPersistencePhase.PENDING
+          MobileAdapterGuestConfigurationPersistencePhase.SAVED ->
+              Controller.MobileAdapterConfigurationPersistencePhase.SAVED
+          MobileAdapterGuestConfigurationPersistencePhase.SUPERSEDED ->
+              Controller.MobileAdapterConfigurationPersistencePhase.SUPERSEDED
+          MobileAdapterGuestConfigurationPersistencePhase.FAILED ->
+              Controller.MobileAdapterConfigurationPersistencePhase.FAILED
+        }
+    postSerialPeripheralEventSafely(
+        Controller.MobileAdapterConfigurationPersistenceStatusEvent(
+            status.sequence,
+            status.attachmentId,
+            status.mutationRevision,
+            phase,
+            status.error,
+        ))
+  }
+
+  /** Fences late work only after endpoint ownership has actually committed. */
+  private fun commitMobileAdapterAttachment(currentSession: Session) {
+    val lifecycle = mobileAdapterLifecycle(currentSession) ?: return
+    try {
+      mobileAdapterGuestConfigurationSink.attachmentCommitted(lifecycle.attachmentId)
+    } catch (_: RuntimeException) {
+      // Endpoint ownership is already committed and cannot be rolled back by a persistence seam.
+      LOG.warn("Mobile Adapter guest configuration attachment fence failed")
     }
   }
 
@@ -4121,6 +4349,17 @@ class BasicController private constructor(
     pauseStateBeforeResume = null
     setPaused(true)
     releaseClosedDebugPortIfNeeded(notifyLifecycle = false)
+    val guestConfigurationDrain =
+        session?.let(::drainMobileAdapterGuestConfiguration)
+            ?: MobileAdapterGuestConfigurationDrainResult.SAFE
+    if (guestConfigurationDrain == MobileAdapterGuestConfigurationDrainResult.BLOCKED) {
+      throw closeBarrierFailure(
+          "$MOBILE_ADAPTER_CONFIGURATION_PENDING_MESSAGE Close can be retried.",
+          java.io.IOException("Mobile Adapter configuration write was not accepted"),
+          MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+      )
+    }
+    flushMobileAdapterGuestConfiguration(closeDeadlineNanos)
 
     try {
       if (closeState == null) {
@@ -4453,6 +4692,50 @@ class BasicController private constructor(
     )
   }
 
+  private fun flushMobileAdapterGuestConfiguration(closeDeadlineNanos: Long) {
+    val result =
+        try {
+          mobileAdapterGuestConfigurationSink.flush(
+              remainingCloseNanos(
+                  closeDeadlineNanos,
+                  "Mobile Adapter configuration persistence",
+              ),
+              TimeUnit.NANOSECONDS,
+          )
+        } catch (_: TimeoutException) {
+          throw closeBarrierFailure(
+              "Mobile Adapter configuration persistence timed out. " +
+                  "The session remains retained and close can be retried.",
+              TimeoutException("Mobile Adapter configuration persistence timed out"),
+              MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+          )
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw closeBarrierFailure(
+              "Mobile Adapter configuration persistence was interrupted. " +
+                  "The session remains retained and close can be retried.",
+              InterruptedException("Mobile Adapter configuration persistence was interrupted"),
+              MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+          )
+        } catch (_: RuntimeException) {
+          throw closeBarrierFailure(
+              "Mobile Adapter configuration could not be saved. " +
+                  "The session remains retained and close can be retried.",
+              // A privileged sink has seen private adapter bytes. Do not retain its arbitrary
+              // exception text or cause graph in the public controller failure.
+              java.io.IOException("Mobile Adapter configuration writer failed"),
+              MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+          )
+        }
+    if (result.saved) return
+    val error = result.error ?: MobileAdapterConfigurationError.STORAGE_WRITE_FAILED
+    throw closeBarrierFailure(
+        "${error.userMessage} The session remains retained and close can be retried.",
+        java.io.IOException(error.code),
+        MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL,
+    )
+  }
+
   @Synchronized
   override fun waiveCloseAutosave(requestId: Long): Boolean {
     if (closed ||
@@ -4505,6 +4788,23 @@ class BasicController private constructor(
       val disconnect: () -> Unit = {},
   )
 
+  private enum class MobileAdapterGuestConfigurationDrainResult {
+    /** No unaccepted guest image remains for the committed attachment. */
+    SAFE,
+
+    /** The newest complete guest image was retained by the privileged sink. */
+    ACCEPTED,
+
+    /** The current image remains private in core memory and must be retried before teardown. */
+    BLOCKED,
+  }
+
+  private enum class MobileAdapterRefreshResult {
+    NOT_APPLICABLE,
+    COMPLETED,
+    BLOCKED,
+  }
+
   /** Final backend owner; endpoint.disconnect() itself remains a reusable cancellation boundary. */
   private class MobileAdapterEndpointLifecycle(
       val attachmentId: Long,
@@ -4515,6 +4815,8 @@ class BasicController private constructor(
   ) : () -> Unit {
     var disconnectReason: Controller.MobileAdapterDisconnectReason? = null
     var backendOwnershipVersion: Long = backend?.ownershipVersion() ?: 0
+    var guestConfigurationHistoryObservedRevision: Long = 0
+    var guestConfigurationPersistenceAcceptedRevision: Long = 0
 
     override fun invoke() {
       backend?.close()
@@ -4525,6 +4827,12 @@ class BasicController private constructor(
     val LOG: Logger = LoggerFactory.getLogger(BasicController::class.java)
 
     const val CONTROLLER_CLOSE_TIMEOUT_MILLIS = 8_000L
+
+    const val MOBILE_ADAPTER_CONFIGURATION_FILE_LABEL = "Mobile Adapter configuration"
+
+    const val MOBILE_ADAPTER_CONFIGURATION_PENDING_MESSAGE =
+        "Mobile Adapter configuration changes could not be queued for storage. " +
+            "The active session was preserved; retry after configuration storage is available."
 
     val STATE_SESSION_IDS = AtomicLong()
 
@@ -4630,6 +4938,7 @@ class BasicController private constructor(
       val prepared: PreparedSession,
       val capture: BatteryFlush,
       var attempt: ReplacementTask?,
+      var ready: ReplacementAttemptResult.Ready? = null,
   )
 
   private data class StopJob(
@@ -4642,6 +4951,8 @@ class BasicController private constructor(
       var thumbnail: StateImage? = null,
       var awaitingAutosaveDecision: Boolean = false,
       var attempt: PersistenceTask?,
+      var awaitingGuestConfiguration: Boolean = false,
+      var completedPersistence: BatteryPersistenceResult.Success? = null,
   )
 
   private class PersistenceTask(capture: BatteryFlush) :
@@ -4815,6 +5126,25 @@ internal class MobileAdapterControlLane {
       synchronized(lock) {
         pending.also { pending = Pending.EMPTY }
       }
+
+  /** Merges unfinished controls without moving them after controls offered while work was blocked. */
+  fun restoreDeferred(deferred: Pending) {
+    synchronized(lock) {
+      val refresh =
+          when {
+            deferred.refreshRevision > pending.refreshRevision -> deferred
+            deferred.refreshRevision < pending.refreshRevision -> pending
+            deferred.refreshOrder > pending.refreshOrder -> deferred
+            else -> pending
+          }
+      pending =
+          Pending(
+              cancelOrder = maxOf(pending.cancelOrder, deferred.cancelOrder),
+              refreshOrder = refresh.refreshOrder,
+              refreshRevision = refresh.refreshRevision,
+          )
+    }
+  }
 
   internal fun snapshot(): Pending = synchronized(lock) { pending }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -1,9 +1,10 @@
 package eu.rekawek.coffeegb.controller
 
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationError
+import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkBackend
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.properties.SystemProperties
-import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkBackend
 import eu.rekawek.coffeegb.controller.state.MachineState
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
@@ -292,6 +293,31 @@ interface Controller : AutoCloseable {
     init {
       require(revision >= 0) { "Mobile Adapter configuration revision must not be negative" }
     }
+  }
+
+  /** Sanitized durability status for configuration bytes accepted from the emulated adapter. */
+  data class MobileAdapterConfigurationPersistenceStatusEvent(
+      val sequence: Long,
+      val attachmentId: Long,
+      val mutationRevision: Long,
+      val phase: MobileAdapterConfigurationPersistencePhase,
+      val error: MobileAdapterConfigurationError? = null,
+  ) : Event {
+    init {
+      require(sequence > 0) { "Mobile Adapter persistence sequence must be positive" }
+      require(attachmentId > 0) { "Mobile Adapter attachment ID must be positive" }
+      require(mutationRevision > 0) { "Mobile Adapter mutation revision must be positive" }
+      require((phase == MobileAdapterConfigurationPersistencePhase.FAILED) == (error != null)) {
+        "Only a failed Mobile Adapter persistence event carries an error"
+      }
+    }
+  }
+
+  enum class MobileAdapterConfigurationPersistencePhase {
+    PENDING,
+    SAVED,
+    SUPERSEDED,
+    FAILED,
   }
 
   /** Cancels current Mobile Adapter host work without detaching its serial endpoint. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterGuestConfigurationSink.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterGuestConfigurationSink.kt
@@ -1,0 +1,119 @@
+package eu.rekawek.coffeegb.controller.mobile.config
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * One complete configuration image accepted from a committed Mobile Adapter attachment.
+ *
+ * The 256-byte image may contain account or dial data. It is detached at both API boundaries and
+ * deliberately omitted from diagnostics.
+ */
+class MobileAdapterGuestConfigurationWrite(
+    val attachmentId: Long,
+    val mutationRevision: Long,
+    configuration: ByteArray,
+) {
+  private val ownedConfiguration: ByteArray
+
+  init {
+    require(attachmentId > 0) { "Mobile Adapter attachment ID must be positive" }
+    require(mutationRevision > 0) { "Mobile Adapter mutation revision must be positive" }
+    require(configuration.size == MobileAdapterConfiguration.CONFIGURATION_SIZE) {
+      "Mobile Adapter guest configuration must contain exactly 256 bytes"
+    }
+    ownedConfiguration = configuration.clone()
+  }
+
+  fun configurationCopy(): ByteArray = ownedConfiguration.clone()
+
+  override fun toString(): String =
+      "MobileAdapterGuestConfigurationWrite(" +
+          "attachmentId=$attachmentId, mutationRevision=$mutationRevision, " +
+          "configuration=[redacted])"
+}
+
+enum class MobileAdapterGuestConfigurationOfferResult {
+  ACCEPTED,
+  STALE_ATTACHMENT,
+  CLOSED,
+}
+
+enum class MobileAdapterGuestConfigurationPersistencePhase {
+  PENDING,
+  SAVED,
+  SUPERSEDED,
+  FAILED,
+}
+
+/** Presentation-safe result from the bounded configuration writer. */
+data class MobileAdapterGuestConfigurationPersistenceStatus(
+    val sequence: Long,
+    val attachmentId: Long,
+    val mutationRevision: Long,
+    val phase: MobileAdapterGuestConfigurationPersistencePhase,
+    val error: MobileAdapterConfigurationError? = null,
+) {
+  init {
+    require(sequence > 0) { "Mobile Adapter persistence sequence must be positive" }
+    require(attachmentId > 0) { "Mobile Adapter attachment ID must be positive" }
+    require(mutationRevision > 0) { "Mobile Adapter mutation revision must be positive" }
+    require((phase == MobileAdapterGuestConfigurationPersistencePhase.FAILED) == (error != null)) {
+      "Only a failed Mobile Adapter persistence status carries an error"
+    }
+    require(
+        error == null ||
+            error == MobileAdapterConfigurationError.NON_REGULAR_FILE ||
+            error == MobileAdapterConfigurationError.STORAGE_WRITE_FAILED ||
+            error == MobileAdapterConfigurationError.PERMISSION_HARDENING_FAILED) {
+          "A guest Mobile Adapter persistence status must carry a storage error"
+        }
+  }
+}
+
+/**
+ * Privileged nonblocking bridge from the emulation owner to private desktop persistence.
+ *
+ * [offer] must retain or reject a detached write without blocking on filesystem work. [flush] is
+ * called only after the controller timing thread is frozen and participates in its retryable close
+ * barrier. Raw configuration bytes never cross the application event tree.
+ */
+interface MobileAdapterGuestConfigurationSink {
+  fun attachmentCommitted(attachmentId: Long)
+
+  fun offer(
+      write: MobileAdapterGuestConfigurationWrite
+  ): MobileAdapterGuestConfigurationOfferResult
+
+  fun pollStatus(): MobileAdapterGuestConfigurationPersistenceStatus?
+
+  fun flush(timeout: Long, unit: TimeUnit): MobileAdapterConfigurationSaveResult
+
+  companion object {
+    @JvmField
+    val NO_OP: MobileAdapterGuestConfigurationSink =
+        object : MobileAdapterGuestConfigurationSink {
+          override fun attachmentCommitted(attachmentId: Long) {
+            require(attachmentId > 0) { "Mobile Adapter attachment ID must be positive" }
+          }
+
+          override fun offer(
+              write: MobileAdapterGuestConfigurationWrite
+          ): MobileAdapterGuestConfigurationOfferResult =
+              // A controller without a privileged owner must not acknowledge durability it does
+              // not provide. The live endpoint keeps the image and the controller retries or
+              // exposes its normal persistence barrier.
+              MobileAdapterGuestConfigurationOfferResult.CLOSED
+
+          override fun pollStatus(): MobileAdapterGuestConfigurationPersistenceStatus? = null
+
+          override fun flush(
+              timeout: Long,
+              unit: TimeUnit,
+          ): MobileAdapterConfigurationSaveResult {
+            require(timeout >= 0) { "Mobile Adapter flush timeout must not be negative" }
+            unit.toNanos(timeout)
+            return MobileAdapterConfigurationSaveResult(saved = true)
+          }
+        }
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/MobileAdapterControllerLifecycleTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/MobileAdapterControllerLifecycleTest.kt
@@ -12,6 +12,12 @@ import eu.rekawek.coffeegb.controller.Controller.SerialPeripheralSelection
 import eu.rekawek.coffeegb.controller.Controller.SerialPeripheralStatus
 import eu.rekawek.coffeegb.controller.Controller.SerialPeripheralStatusEvent
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationError
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationSaveResult
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationOfferResult
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistenceStatus
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationSink
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationWrite
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterDestinationPolicy
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterDestinationRule
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkBackend
@@ -74,7 +80,13 @@ class MobileAdapterControllerLifecycleTest {
       val oldBackend = backend(server.localPort, 1)
       val candidateBackend = backend(server.localPort, 2)
       val supplied = AtomicReference(configuration(1, oldBackend))
-      fixture(Controller.MobileAdapterConfigurationProvider { supplied.get() }).use { fixture ->
+      val sink = RecordingGuestConfigurationSink()
+      fixture(
+              Controller.MobileAdapterConfigurationProvider { supplied.get() },
+              guestConfigurationSink = sink,
+          )
+          .use { fixture ->
+        assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
         val oldEndpoint = fixture.openLiveUdp(oldBackend)
         val oldGeneration = oldBackend.generation()
         fixture.gameboy.get().rejectNextMobileHandoff.set(true)
@@ -110,6 +122,10 @@ class MobileAdapterControllerLifecycleTest {
         fixture.awaitCondition { !oldBackend.hasExternalWork() }
         assertTrue(candidateBackend.awaitTermination(2_000))
         assertFalse(oldBackend.isClosed(), "the rolled-back endpoint remains the session owner")
+        assertNull(
+            sink.committedAttachments.poll(100, TimeUnit.MILLISECONDS),
+            "a rejected candidate must not fence the committed attachment",
+        )
       }
       assertTrue(oldBackend.awaitTermination(2_000))
     }
@@ -458,6 +474,258 @@ class MobileAdapterControllerLifecycleTest {
   }
 
   @Test
+  fun `guest configuration is drained before an immediate endpoint handoff`() {
+    val sink = RecordingGuestConfigurationSink()
+    val offline = MobileAdapterConfiguration.syntheticOffline()
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { offline },
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          val endpoint = assertNotNull(fixture.endpoint.get())
+          val attachmentId =
+              assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          feedMobile(endpoint, packet(CONFIG_WRITE, byteArrayOf(3, 0x55)))
+          assertNull(
+              sink.writes.poll(100, TimeUnit.MILLISECONDS),
+              "paused emulation must publish only at a controller safe point",
+          )
+
+          fixture.eventBus.post(
+              Controller.SetSerialPeripheralEvent(SerialPeripheralSelection.NONE))
+          fixture.await(fixture.serialStatuses) {
+            it.selection == SerialPeripheralSelection.NONE &&
+                it.status == SerialPeripheralStatus.ATTACHED
+          }
+
+          val write = assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(attachmentId, write.attachmentId)
+          assertEquals(1, write.mutationRevision)
+          assertEquals(0x55, write.configurationCopy()[3].toInt() and 0xff)
+          assertTrue(write.toString().contains("configuration=[redacted]"))
+        }
+  }
+
+  @Test
+  fun `closed guest configuration sink clears history and blocks handoff until retry`() {
+    val sink = RecordingGuestConfigurationSink()
+    sink.offerResults.add(MobileAdapterGuestConfigurationOfferResult.CLOSED)
+    val rewind = RewindManager(enabled = true)
+    val offline = MobileAdapterConfiguration.syntheticOffline()
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { offline },
+            rewind = rewind,
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          val endpoint = assertNotNull(fixture.endpoint.get())
+          val attachmentId =
+              assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          fixture.awaitCondition { rewind.historySize > 0 }
+          feedMobile(endpoint, packet(CONFIG_WRITE, byteArrayOf(5, 0x77)))
+
+          fixture.eventBus.post(
+              Controller.SetSerialPeripheralEvent(SerialPeripheralSelection.NONE))
+          val blocked =
+              fixture.await(fixture.serialStatuses) {
+                it.selection == SerialPeripheralSelection.NONE &&
+                    it.status == SerialPeripheralStatus.UNAVAILABLE
+              }
+          assertEquals(SerialPeripheralError.STORAGE_FAILED, blocked.error)
+          assertEquals(0, rewind.historySize)
+          assertNull(
+              fixture.selections.poll(100, TimeUnit.MILLISECONDS),
+              "a rejected write must preserve Mobile Adapter endpoint ownership",
+          )
+
+          val rejected = assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(attachmentId, rejected.attachmentId)
+          assertEquals(1, rejected.mutationRevision)
+          assertEquals(0x77, rejected.configurationCopy()[5].toInt() and 0xff)
+
+          fixture.eventBus.post(
+              Controller.SetSerialPeripheralEvent(SerialPeripheralSelection.NONE))
+          fixture.await(fixture.serialStatuses) {
+            it.selection == SerialPeripheralSelection.NONE &&
+                it.status == SerialPeripheralStatus.ATTACHED
+          }
+          val accepted = assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(attachmentId, accepted.attachmentId)
+          assertEquals(1, accepted.mutationRevision)
+          assertEquals(0x77, accepted.configurationCopy()[5].toInt() and 0xff)
+        }
+  }
+
+  @Test
+  fun `blocked refresh keeps a later concurrent cancellation after retry`() {
+    val sink = RecordingGuestConfigurationSink()
+    val initial = MobileAdapterConfiguration.syntheticOffline()
+    val supplied = AtomicReference(initial)
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { supplied.get() },
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          val originalEndpoint = assertNotNull(fixture.endpoint.get())
+          assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          feedMobile(originalEndpoint, packet(CONFIG_WRITE, byteArrayOf(7, 0x66)))
+          sink.offerResults.add(MobileAdapterGuestConfigurationOfferResult.CLOSED)
+          sink.offerCallbacks.add {
+            val producer =
+                Thread {
+                      fixture.eventBus.post(Controller.CancelMobileAdapterNetworkEvent)
+                    }
+                    .apply {
+                      name = "mobile-adapter-later-cancel-test"
+                      start()
+                    }
+            producer.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+            check(!producer.isAlive) { "concurrent cancellation producer did not finish" }
+          }
+          supplied.set(
+              MobileAdapterConfiguration(
+                  initial.deviceId,
+                  initial.copyBytes(),
+                  policyRevision = 1,
+              ))
+
+          fixture.eventBus.post(Controller.RefreshMobileAdapterConfigurationEvent(1))
+
+          val blocked =
+              fixture.await(fixture.serialStatuses) {
+                it.selection == SerialPeripheralSelection.MOBILE_ADAPTER_GB &&
+                    it.status == SerialPeripheralStatus.UNAVAILABLE
+              }
+          assertEquals(SerialPeripheralError.STORAGE_FAILED, blocked.error)
+          val replacementAttachment =
+              assertNotNull(
+                  sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+              )
+          val cancelled =
+              fixture.await(fixture.networkStatuses) {
+                it.phase == MobileAdapterNetworkPhase.DISCONNECTED &&
+                    it.disconnectReason == MobileAdapterDisconnectReason.USER_CANCELLED
+              }
+          assertEquals(replacementAttachment, cancelled.attachmentId)
+          fixture.awaitCondition {
+            fixture.endpoint.get() !== originalEndpoint &&
+                fixture.endpoint.get().snapshot().outcome() == MobileAdapterEngine.Outcome.CANCELLED
+          }
+        }
+  }
+
+  @Test
+  fun `throwing guest configuration sink blocks close and retries the private snapshot`() {
+    val sink = RecordingGuestConfigurationSink()
+    sink.offerFailures.add(IllegalStateException("private-config-marker"))
+    val offline = MobileAdapterConfiguration.syntheticOffline()
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { offline },
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          val endpoint = assertNotNull(fixture.endpoint.get())
+          val attachmentId =
+              assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          feedMobile(endpoint, packet(CONFIG_WRITE, byteArrayOf(6, 0x44)))
+
+          val failure =
+              kotlin.test.assertFailsWith<Controller.PersistenceBarrierException> {
+                fixture.controller.closeWithState()
+              }
+          assertEquals(Controller.PersistenceBarrierOperation.CLOSE, failure.operation)
+          assertEquals("Mobile Adapter configuration", failure.fileName)
+          assertFalse(failure.message.orEmpty().contains("private-config-marker"))
+          assertEquals(0, sink.flushCalls)
+
+          val rejected = assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(attachmentId, rejected.attachmentId)
+          assertEquals(1, rejected.mutationRevision)
+          assertEquals(0x44, rejected.configurationCopy()[6].toInt() and 0xff)
+
+          assertNotNull(fixture.controller.closeWithState())
+          fixture.controllerClosed = true
+          val accepted = assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(attachmentId, accepted.attachmentId)
+          assertEquals(1, accepted.mutationRevision)
+          assertEquals(0x44, accepted.configurationCopy()[6].toInt() and 0xff)
+          assertEquals(1, sink.flushCalls)
+        }
+  }
+
+  @Test
+  fun `close retries a failed guest configuration durability barrier`() {
+    val sink = RecordingGuestConfigurationSink()
+    val offline = MobileAdapterConfiguration.syntheticOffline()
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { offline },
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          val endpoint = assertNotNull(fixture.endpoint.get())
+          assertNotNull(sink.committedAttachments.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          feedMobile(endpoint, packet(CONFIG_WRITE, byteArrayOf(4, 0x66)))
+          sink.flushResult =
+              MobileAdapterConfigurationSaveResult(
+                  saved = false,
+                  error = MobileAdapterConfigurationError.STORAGE_WRITE_FAILED,
+              )
+
+          val failure =
+              kotlin.test.assertFailsWith<Controller.PersistenceBarrierException> {
+                fixture.controller.closeWithState()
+              }
+          assertEquals(Controller.PersistenceBarrierOperation.CLOSE, failure.operation)
+          assertEquals("Mobile Adapter configuration", failure.fileName)
+          assertNotNull(sink.writes.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+          assertEquals(1, sink.flushCalls)
+
+          sink.flushResult = MobileAdapterConfigurationSaveResult(saved = true)
+          assertNotNull(fixture.controller.closeWithState())
+          fixture.controllerClosed = true
+          assertEquals(2, sink.flushCalls)
+        }
+  }
+
+  @Test
+  fun `close strips all private guest configuration flush failure details`() {
+    val sink = RecordingGuestConfigurationSink()
+    val offline = MobileAdapterConfiguration.syntheticOffline()
+    fixture(
+            Controller.MobileAdapterConfigurationProvider { offline },
+            guestConfigurationSink = sink,
+        )
+        .use { fixture ->
+          listOf<Throwable>(
+                  java.util.concurrent.TimeoutException("private-timeout-marker"),
+                  InterruptedException("private-interrupted-marker"),
+                  IllegalStateException("private-runtime-marker"),
+              )
+              .forEach { privateFailure ->
+                sink.flushFailure = privateFailure
+                val failure =
+                    kotlin.test.assertFailsWith<Controller.PersistenceBarrierException> {
+                      fixture.controller.closeWithState()
+                    }
+                assertEquals(Controller.PersistenceBarrierOperation.CLOSE, failure.operation)
+                assertEquals("Mobile Adapter configuration", failure.fileName)
+                val publicFailureChain =
+                    generateSequence<Throwable>(failure) { it.cause }
+                        .joinToString("\n") { "${it.javaClass.name}: ${it.message}" }
+                assertFalse(publicFailureChain.contains("private-"))
+                if (privateFailure is InterruptedException) {
+                  assertTrue(Thread.interrupted(), "the controller must preserve interruption")
+                }
+              }
+
+          sink.flushFailure = null
+          assertNotNull(fixture.controller.closeWithState())
+          fixture.controllerClosed = true
+          assertEquals(4, sink.flushCalls)
+        }
+  }
+
+  @Test
   fun `shutdown publishes its terminal reason and joins live host work`() {
     udpFixture().use { server ->
       val backend = backend(server.localPort, 1)
@@ -488,6 +756,8 @@ class MobileAdapterControllerLifecycleTest {
       stateWorkspaceFactory: StateWorkspaceFactory = StateWorkspaceFactory.DEFAULT,
       stateOperationWorkerFactory: StateOperationWorkerFactory =
           StateOperationWorkerFactory.DEFAULT,
+      guestConfigurationSink: MobileAdapterGuestConfigurationSink =
+          MobileAdapterGuestConfigurationSink.NO_OP,
   ): Fixture {
     val directory = Files.createTempDirectory("coffee-gb-mobile-controller-lifecycle")
     val rom = directory.resolve("game.gb").toFile().also { it.writeBytes(ROM.readBytes()) }
@@ -525,6 +795,7 @@ class MobileAdapterControllerLifecycleTest {
             stateWorkspaceFactory,
             stateOperationWorkerFactory,
             mobileAdapterConfigurationProvider = provider,
+            mobileAdapterGuestConfigurationSink = guestConfigurationSink,
         )
     val fixture =
         Fixture(directory, properties, eventBus, controller, gameboy, endpoint)
@@ -838,6 +1109,47 @@ class MobileAdapterControllerLifecycleTest {
     override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean = isTerminated
   }
 
+  private class RecordingGuestConfigurationSink : MobileAdapterGuestConfigurationSink {
+    val committedAttachments = LinkedBlockingQueue<Long>()
+    val writes = LinkedBlockingQueue<MobileAdapterGuestConfigurationWrite>()
+    val offerCallbacks = LinkedBlockingQueue<() -> Unit>()
+    val offerResults = LinkedBlockingQueue<MobileAdapterGuestConfigurationOfferResult>()
+    val offerFailures = LinkedBlockingQueue<RuntimeException>()
+    @Volatile var flushResult = MobileAdapterConfigurationSaveResult(saved = true)
+    @Volatile var flushFailure: Throwable? = null
+    @Volatile var flushCalls = 0
+
+    override fun attachmentCommitted(attachmentId: Long) {
+      committedAttachments.add(attachmentId)
+    }
+
+    override fun offer(
+        write: MobileAdapterGuestConfigurationWrite
+    ): MobileAdapterGuestConfigurationOfferResult {
+      writes.add(
+          MobileAdapterGuestConfigurationWrite(
+              write.attachmentId,
+              write.mutationRevision,
+              write.configurationCopy(),
+          ))
+      offerCallbacks.poll()?.invoke()
+      offerFailures.poll()?.let { throw it }
+      return offerResults.poll() ?: MobileAdapterGuestConfigurationOfferResult.ACCEPTED
+    }
+
+    override fun pollStatus(): MobileAdapterGuestConfigurationPersistenceStatus? = null
+
+    override fun flush(
+        timeout: Long,
+        unit: TimeUnit,
+    ): MobileAdapterConfigurationSaveResult {
+      unit.toNanos(timeout)
+      flushCalls++
+      flushFailure?.let { throw it }
+      return flushResult
+    }
+  }
+
   private companion object {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
     const val TIMEOUT_SECONDS = 10L
@@ -845,5 +1157,6 @@ class MobileAdapterControllerLifecycleTest {
     const val UDP_OPEN = 0x25
     const val UDP_CLOSE = 0x26
     const val DNS_QUERY = 0x28
+    const val CONFIG_WRITE = 0x1a
   }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngine.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngine.java
@@ -119,6 +119,14 @@ public final class MobileAdapterEngine implements StatefulComponent<MobileAdapte
 
     private byte[] configuration;
 
+    /**
+     * Attachment-local guest-write sequence; runtime ownership deliberately excludes mementos.
+     */
+    private long guestConfigurationRevision;
+
+    /** Detached bytes from the latest changed guest write, retained across later state restores. */
+    private byte[] latestGuestConfiguration = EMPTY_BYTES;
+
     private int deviceId;
 
     private Phase phase = Phase.SLEEP;
@@ -371,6 +379,19 @@ public final class MobileAdapterEngine implements StatefulComponent<MobileAdapte
 
     public byte[] configurationCopy() {
         return configuration.clone();
+    }
+
+    /**
+     * Returns the latest changed configuration written by the guest, or {@code null} before one.
+     *
+     * <p>This runtime-only signal is attachment-local and is deliberately not captured in emulator
+     * state. Restoring a memento therefore neither publishes a guest write nor replaces an
+     * already-retained write that the controller has not observed yet.
+     */
+    public GuestConfigurationMutation latestGuestConfigurationMutation() {
+        if (guestConfigurationRevision == 0) return null;
+        return new GuestConfigurationMutation(
+                guestConfigurationRevision, latestGuestConfiguration);
     }
 
     /** Clears all deterministic request/response ownership for detach or session replacement. */
@@ -718,7 +739,12 @@ public final class MobileAdapterEngine implements StatefulComponent<MobileAdapte
 
         byte[] replacement = configuration.clone();
         System.arraycopy(data, 1, replacement, offset, writeLength);
+        boolean changed = !Arrays.equals(configuration, replacement);
         configuration = replacement;
+        if (changed) {
+            guestConfigurationRevision = Math.incrementExact(guestConfigurationRevision);
+            latestGuestConfiguration = replacement.clone();
+        }
         outcome = Outcome.CONFIG_WRITE;
         responsePacket = packet(COMMAND_CONFIG_WRITE | 0x80, new byte[]{(byte) offset});
         acknowledgement = acknowledgement(COMMAND_CONFIG_WRITE ^ 0x80);
@@ -1680,6 +1706,28 @@ public final class MobileAdapterEngine implements StatefulComponent<MobileAdapte
         @Override
         public byte[] acknowledgement() {
             return acknowledgement.clone();
+        }
+    }
+
+    /** Immutable runtime notification for one attachment's latest changed guest write. */
+    public record GuestConfigurationMutation(long revision, byte[] configuration) {
+
+        public GuestConfigurationMutation {
+            if (revision <= 0) {
+                throw new IllegalArgumentException("Guest configuration revision must be positive");
+            }
+            configuration = requireConfiguration(configuration);
+        }
+
+        @Override
+        public byte[] configuration() {
+            return configuration.clone();
+        }
+
+        @Override
+        public String toString() {
+            return "GuestConfigurationMutation[revision=" + revision
+                    + ", configuration=[redacted]]";
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpoint.java
@@ -165,6 +165,11 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
         return engine.configurationCopy();
     }
 
+    /** Returns the latest runtime-only changed guest write as a defensive snapshot, if any. */
+    public MobileAdapterEngine.GuestConfigurationMutation latestGuestConfigurationMutation() {
+        return engine.latestGuestConfigurationMutation();
+    }
+
     public void replaceConfiguration(byte[] replacement) {
         engine.replaceConfiguration(replacement);
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngineTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngineTest.java
@@ -570,8 +570,23 @@ public class MobileAdapterEngineTest {
         assertEquals(MobileAdapterEngine.Outcome.CONFIG_WRITE, write.outcome());
         assertEquals(1, engine.configurationCopy()[0]);
         assertEquals(0x55, engine.configurationCopy()[1] & 0xff);
+        MobileAdapterEngine.GuestConfigurationMutation firstMutation =
+                engine.latestGuestConfigurationMutation();
+        assertNotNull(firstMutation);
+        assertEquals(1, firstMutation.revision());
+        assertArrayEquals(engine.configurationCopy(), firstMutation.configuration());
+        assertEquals(
+                "GuestConfigurationMutation[revision=1, configuration=[redacted]]",
+                firstMutation.toString());
+        byte[] detachedMutation = firstMutation.configuration();
+        detachedMutation[0] = 0;
+        assertEquals(1, engine.latestGuestConfigurationMutation().configuration()[0]);
         assertArrayEquals(new byte[]{(byte) 0x88, (byte) 0x9a}, write.acknowledgement());
         assertEquals(0x9a, write.responsePacket()[2] & 0xff);
+
+        assertEquals(MobileAdapterEngine.Outcome.CONFIG_WRITE,
+                feed(engine, packet(0x1a, new byte[]{0, 1, 0x55})).outcome());
+        assertEquals(1, engine.latestGuestConfigurationMutation().revision());
 
         byte[] maximumWrite = new byte[MobileAdapterEngine.MAX_CONFIGURATION_OPERATION_BYTES + 1];
         maximumWrite[0] = (byte) 128;
@@ -581,14 +596,26 @@ public class MobileAdapterEngineTest {
         for (int i = 128; i < 256; i++) {
             assertEquals(0x6a, engine.configurationCopy()[i] & 0xff);
         }
+        assertEquals(2, engine.latestGuestConfigurationMutation().revision());
+        assertArrayEquals(engine.configurationCopy(),
+                engine.latestGuestConfigurationMutation().configuration());
         assertEquals(MobileAdapterEngine.Outcome.CONFIG_WRITE,
                 feed(engine, packet(0x1a, new byte[]{(byte) 255})).outcome());
+        assertEquals(2, engine.latestGuestConfigurationMutation().revision());
 
         byte[] afterWrite = engine.configurationCopy();
         assertUnsupported(feed(engine,
                 packet(0x1a, new byte[]{(byte) 255, 1, 2})));
         byte[] oversizedWrite = new byte[MobileAdapterEngine.MAX_CONFIGURATION_OPERATION_BYTES + 2];
         assertUnsupported(feed(engine, packet(0x1a, oversizedWrite)));
+        assertArrayEquals(afterWrite, engine.configurationCopy());
+        assertEquals(2, engine.latestGuestConfigurationMutation().revision());
+
+        byte[] invalidWriteChecksum = packet(0x1a, new byte[]{2, 0x44});
+        invalidWriteChecksum[invalidWriteChecksum.length - 1] ^= 1;
+        assertEquals(MobileAdapterEngine.Outcome.CHECKSUM_ERROR,
+                feed(engine, invalidWriteChecksum).outcome());
+        assertEquals(2, engine.latestGuestConfigurationMutation().revision());
         assertArrayEquals(afterWrite, engine.configurationCopy());
 
         assertUnsupported(feed(engine, packet(0x19, new byte[]{(byte) 200, 57})));
@@ -629,9 +656,11 @@ public class MobileAdapterEngineTest {
     public void configurationReplacementIsAtomicAndDeviceAcknowledgementIsNotFixtureSpecific() {
         MobileAdapterEngine engine = new MobileAdapterEngine(
                 ClockSpec.LEGACY, 0x21, configuration());
+        assertNull(engine.latestGuestConfigurationMutation());
         byte[] replacement = new byte[256];
         Arrays.fill(replacement, (byte) 0x5a);
         engine.replaceConfiguration(replacement);
+        assertNull(engine.latestGuestConfigurationMutation());
         replacement[0] = 0;
         assertEquals(0x5a, engine.configurationCopy()[0] & 0xff);
         assertThrows(IllegalArgumentException.class,
@@ -652,6 +681,35 @@ public class MobileAdapterEngineTest {
         restored.restoreState(engine.captureState());
         assertResultsEqual(historical, restored.snapshot());
         assertArrayEquals(newer, restored.configurationCopy());
+        assertNull(restored.latestGuestConfigurationMutation());
+    }
+
+    @Test
+    public void guestMutationSignalIsRuntimeOnlyAndSurvivesHostReplacementAndRestorePendingDrain() {
+        MobileAdapterEngine engine = engine(ClockSpec.LEGACY);
+        feed(engine, packet(0x1a, new byte[]{7, 0x55}));
+        MobileAdapterEngine.GuestConfigurationMutation mutation =
+                engine.latestGuestConfigurationMutation();
+        assertNotNull(mutation);
+        assertEquals(1, mutation.revision());
+
+        MobileAdapterEngine.MobileAdapterEngineState guestState = state(engine);
+        byte[] hostReplacement = new byte[MobileAdapterEngine.CONFIGURATION_BYTES];
+        Arrays.fill(hostReplacement, (byte) 0x33);
+        engine.replaceConfiguration(hostReplacement);
+        assertEquals(1, engine.latestGuestConfigurationMutation().revision());
+        assertArrayEquals(mutation.configuration(),
+                engine.latestGuestConfigurationMutation().configuration());
+
+        engine.restoreState(guestState);
+        assertEquals(1, engine.latestGuestConfigurationMutation().revision());
+        assertArrayEquals(mutation.configuration(),
+                engine.latestGuestConfigurationMutation().configuration());
+
+        MobileAdapterEngine restored = engine(ClockSpec.LEGACY);
+        restored.restoreState(guestState);
+        assertArrayEquals(guestState.configuration(), restored.configurationCopy());
+        assertNull(restored.latestGuestConfigurationMutation());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpointTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpointTest.java
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -53,6 +55,49 @@ public class MobileAdapterSerialEndpointTest {
 
         assertEquals(0xd2, exchange(endpoint, 0x99));
         assertEquals(1, endpoint.snapshot().retainedBytes());
+    }
+
+    @Test
+    public void changedGuestWriteIsVisibleAtPacketCommitAndIsNotCapturedOrUndoneByWireAbort() {
+        MobileAdapterSerialEndpoint endpoint = endpoint();
+        byte[] writeRequest = packet(0x1a, new byte[]{7, 0x55});
+
+        assertNull(endpoint.latestGuestConfigurationMutation());
+        for (int i = 0; i < writeRequest.length - 1; i++) {
+            assertEquals(0xd2, exchange(endpoint, writeRequest[i] & 0xff));
+            assertNull(endpoint.latestGuestConfigurationMutation());
+        }
+        assertEquals(0xd2, exchange(endpoint, writeRequest[writeRequest.length - 1] & 0xff));
+
+        MobileAdapterEngine.GuestConfigurationMutation mutation =
+                endpoint.latestGuestConfigurationMutation();
+        assertNotNull(mutation);
+        assertEquals(1, mutation.revision());
+        assertArrayEquals(endpoint.configurationCopy(), mutation.configuration());
+        byte[] detached = mutation.configuration();
+        detached[7] = 0;
+        assertEquals(0x55,
+                endpoint.latestGuestConfigurationMutation().configuration()[7] & 0xff);
+
+        ComponentState<eu.rekawek.coffeegb.core.serial.SerialEndpoint> captured =
+                endpoint.captureState();
+        MobileAdapterSerialEndpoint restored = endpoint();
+        restored.restoreState(captured);
+        assertEquals(0x55, restored.configurationCopy()[7] & 0xff);
+        assertNull(restored.latestGuestConfigurationMutation());
+
+        assertEquals(DEVICE_ID | 0x80, exchange(endpoint, 0x80));
+        assertEquals(0x9a, exchange(endpoint, 0));
+        assertEquals(0xd2, exchange(endpoint, 0));
+        assertEquals(0xd2, exchange(endpoint, 0));
+        assertEquals(1, endpoint.latestGuestConfigurationMutation().revision());
+        assertArrayEquals(mutation.configuration(),
+                endpoint.latestGuestConfigurationMutation().configuration());
+
+        endpoint.disconnect();
+        assertEquals(1, endpoint.latestGuestConfigurationMutation().revision());
+        assertArrayEquals(mutation.configuration(),
+                endpoint.latestGuestConfigurationMutation().configuration());
     }
 
     @Test

--- a/docs/adr/0002-mobile-adapter-clean-room.md
+++ b/docs/adr/0002-mobile-adapter-clean-room.md
@@ -47,9 +47,14 @@ development gate are process-local. Editing either gate or the policy directly a
 revokes every prepared backend under the coordinator authority lock before requesting an endpoint
 refresh through event delivery. First revocation rotates the generation; an already-revoked backend
 stays unavailable, and the owner loop closes its DNS capabilities and sockets. The event bus is
-therefore presentation and handoff, not the fail-closed authorization boundary. Configuration
-persistence has one active write and one queued write; shutdown and a retry each use their own
-2,000 ms deadline shared across the writer and all still-tracked backends.
+therefore presentation and handoff, not the fail-closed authorization boundary. Explicit
+configuration persistence has one active write and one queued write. Changed guest writes use a
+separate replaceable latest-image slot on that same writer, become the in-memory endpoint source
+immediately, and are merged with the latest durable device ID and policy. Failure retains the
+acknowledged dirty image without an automatic retry loop. The controller drains it at frame and
+ownership boundaries, and final close includes a bounded retry in its persistence barrier. Shutdown
+and a retry each use their own 2,000 ms deadline shared across the writer and all still-tracked
+backends.
 
 The retained Mobile Adapter configuration dialog has a bounded owner-selected image import, while
 the current desktop continues to hide Mobile Adapter controls. Its controller reader runs off the

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -233,14 +233,21 @@ Cancel and refresh delivery uses one coherent constant-space controller lane: on
 order and one latest accepted policy revision/order. Bursts cannot grow the general event queue,
 and relative order determines whether cancellation applies to the old or replacement endpoint.
 
-Configuration persistence has one daemon writer. At most one write may execute and one additional
-write may wait in its bounded queue; another request is rejected without enqueueing as
-`CONFIGURATION_BUSY`. Coordinator shutdown uses one 2,000 ms deadline shared by that writer and all
-prepared network backends. The writer receives at most 1,000 ms to stop gracefully, then an
-interrupt request and only the time still remaining; backend termination checks consume that same
-remaining deadline rather than receiving a fresh timeout each. If a shutdown attempt times out, a
-later close retry re-snapshots the still-tracked backends and waits under a new shared 2,000 ms
-deadline; it never re-enables authority or starts a replacement worker.
+Configuration persistence has one daemon writer. At most one explicit owner write may execute and
+one may wait in its bounded queue; another policy/import request is rejected without enqueueing as
+`CONFIGURATION_BUSY`. Changed guest configuration writes use a separate constant-space latest-image
+slot. Accepting that slot immediately updates the coordinator's detached in-memory image, then the
+same writer merges it with the latest durable device ID and policy. A newer guest image replaces an
+unscheduled older one. A failed write leaves the acknowledged image active and dirty without
+spinning; a later guest write, explicit configuration operation, or controller-close retry attempts
+it again. A later successful owner import explicitly supersedes an older dirty guest image and
+publishes a redacted terminal status. Coordinator shutdown uses one 2,000 ms deadline shared by
+that writer and all prepared network backends. The writer receives at most 1,000 ms to stop
+gracefully, then an interrupt request
+and only the time still remaining; backend termination checks consume that same remaining deadline
+rather than receiving a fresh timeout each. If a shutdown attempt times out, a later close retry
+re-snapshots the still-tracked backends and waits under a new shared 2,000 ms deadline; it never
+re-enables authority or starts a replacement worker.
 
 DNS is a bounded raw UDP A query sent only to the configured literal IPv4 resolver; the JVM system
 resolver is never called. A guest name is only an exact alias into the saved mapping table. A named
@@ -325,14 +332,18 @@ output, records `externalIoAtCapture`, and substitutes the stable disconnected o
 load, current backend ownership is cancelled before that deterministic disconnected image is
 installed; no socket or request is restored. Backend completion is queued and at most one result is
 applied at a controller safe point; late completion from a cancelled generation is discarded.
-Configuration writes validate a detached copy and commit atomically in core memory. Filesystem
-persistence, if requested, is a separate controller operation and cannot run on the emulator
-thread. Rewind history is cleared as soon as external ownership is observed, including while the
-machine is paused, so later host-free captures cannot bridge an unrepresentable DNS/socket
-interval after that ownership ends. The desktop reports an informational notice when a capture
-receives the marker. Loading a marked capture reports the disconnected warning even if the
-currently attached endpoint is idle; loading any state while current host work is live reports the
-same non-restoration boundary.
+Configuration writes validate a detached copy and commit atomically in core memory. A changed write
+retains one runtime-only complete image and attachment-local revision; same-value, zero-length, and
+rejected packets publish no mutation. The controller pulls that image at the completed-frame safe
+point and before endpoint handoff/teardown, then offers it to the private bounded writer. Filesystem
+work never runs on the emulator thread. State capture and restore do not serialize or replay this
+runtime notification. A later real guest write after state restore publishes the complete restored
+image plus that change. Rewind history is cleared at every accepted guest write and as soon as
+external ownership is observed, including while the machine is paused, so history cannot bridge
+either a durable configuration side effect or an unrepresentable DNS/socket interval. The desktop
+reports an informational notice when a capture receives the external-I/O marker. Loading a marked
+capture reports the disconnected warning even if the currently attached endpoint is idle; loading
+any state while current host work is live reports the same non-restoration boundary.
 
 The stable engine IDs serialized by Phase 1 are append-only:
 
@@ -397,6 +408,24 @@ The exact 300-byte version-1 record remains readable and migrates to an offline 
 its original two-byte configuration-length field and digest layout. Every new save uses version 2.
 Runtime network consent and the separate private/local development gate are deliberately absent
 from both formats and reset on every application start and every policy edit.
+
+### Guest-authored configuration writes
+
+The adapter's configuration-write command changes the live 256-byte image synchronously at the
+documented wire commit point. Coffee GB durably stores only writes that actually change at least one
+byte. The controller identifies each endpoint attachment before accepting its writes, drains the old
+attachment before replacement ownership commits, and fences a late detached attachment from replacing
+the committed one. Bursts retain only their latest complete image; raw bytes never enter the event
+bus, status text, logs, exception messages, or diagnostics.
+
+The in-memory image becomes authoritative as soon as the controller accepts it, so reset, policy
+refresh, detach/reattach, and ROM replacement construct a new endpoint from the guest's latest
+configuration even while disk persistence is pending. Policy saves modify only policy; guest writes
+modify only the image. A storage failure does not roll back a command already acknowledged to the
+game. It emits only a typed redacted failure and retains the dirty image for retry. Final desktop
+close freezes the timing thread, drains the endpoint, and includes this writer in the existing
+retryable persistence barrier; failed or timed-out durability retains the session instead of
+silently discarding the guest setup.
 
 ### Bounded adapter-image import
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinator.kt
@@ -6,6 +6,11 @@ import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationEr
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationImageReader
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationSaveResult
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationStore
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationOfferResult
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistencePhase
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistenceStatus
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationSink
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationWrite
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterNetworkPolicy
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterTransport
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterDestinationPolicy
@@ -24,6 +29,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -46,11 +52,12 @@ internal class MobileAdapterConfigurationCoordinator(
     private val store: MobileAdapterConfigurationStore,
     private val imageReader: MobileAdapterConfigurationImageReader =
         MobileAdapterConfigurationImageReader(),
-) : AutoCloseable {
+) : AutoCloseable, MobileAdapterGuestConfigurationSink {
   /** Orders each runtime mutation with its synchronous cancel/refresh publication. */
   private val transitionPublicationLock = Any()
   private val authorityLock = Any()
-  private var coordinatorClosed = false
+  private val guestPersistenceLock = Object()
+  @Volatile private var coordinatorClosed = false
   private val revision = AtomicLong(1)
   private val current =
       AtomicReference(
@@ -61,6 +68,16 @@ internal class MobileAdapterConfigurationCoordinator(
               privateLocalDevelopment = false,
           ))
   private val durableConfiguration = AtomicReference(initialConfiguration)
+  private var committedAttachmentId = 0L
+  private var acceptedMutationRevision = 0L
+  private var guestImageGeneration = 0L
+  private var guestPersistenceSequence = 0L
+  private var completedGuestAttempt = 0L
+  private var guestTaskScheduled = false
+  private var pendingGuestWrite: PendingGuestWrite? = null
+  private var lastGuestAttempt: CompletedGuestAttempt? = null
+  private val guestStatuses = ArrayBlockingQueue<MobileAdapterGuestConfigurationPersistenceStatus>(
+      MAX_PENDING_GUEST_STATUSES)
   private val activeBackends = ConcurrentHashMap.newKeySet<MobileAdapterNetworkBackend>()
   private val writer: ExecutorService =
       ThreadPoolExecutor(
@@ -72,6 +89,134 @@ internal class MobileAdapterConfigurationCoordinator(
           { task -> Thread(task, "mobile-adapter-configuration").apply { isDaemon = true } },
           ThreadPoolExecutor.AbortPolicy(),
       )
+
+  /**
+   * Commits the controller-owned attachment generation used to fence delayed old-endpoint writes.
+   * Attachment IDs are monotonic for one controller lifetime, so an older delayed notification
+   * cannot reopen a retired attachment.
+   */
+  override fun attachmentCommitted(attachmentId: Long) {
+    require(attachmentId > 0) { "Mobile Adapter attachment ID must be positive" }
+    synchronized(guestPersistenceLock) {
+      if (coordinatorClosed || attachmentId <= committedAttachmentId) return
+      committedAttachmentId = attachmentId
+      acceptedMutationRevision = 0
+    }
+  }
+
+  /**
+   * Retains a detached latest image without waiting for filesystem or executor capacity.
+   *
+   * The live configuration changes synchronously because the guest has already acknowledged the
+   * write. Device identity, owner policy, and both runtime authorization gates remain unchanged.
+   */
+  override fun offer(
+      write: MobileAdapterGuestConfigurationWrite
+  ): MobileAdapterGuestConfigurationOfferResult =
+      synchronized(transitionPublicationLock) {
+        if (coordinatorClosed) {
+          MobileAdapterGuestConfigurationOfferResult.CLOSED
+        } else {
+          val disposition =
+              synchronized(guestPersistenceLock) {
+                when {
+                  coordinatorClosed -> GuestOfferDisposition.CLOSED
+                  write.attachmentId != committedAttachmentId -> GuestOfferDisposition.STALE
+                  write.mutationRevision <= acceptedMutationRevision ->
+                      GuestOfferDisposition.DUPLICATE
+                  else -> {
+                    val configuration = write.configurationCopy()
+                    acceptedMutationRevision = write.mutationRevision
+                    guestImageGeneration = incrementExact(guestImageGeneration)
+                    guestPersistenceSequence = incrementExact(guestPersistenceSequence)
+                    val retained =
+                        PendingGuestWrite(
+                            sequence = guestPersistenceSequence,
+                            attachmentId = write.attachmentId,
+                            mutationRevision = write.mutationRevision,
+                            imageGeneration = guestImageGeneration,
+                            configuration = configuration,
+                        )
+                    pendingGuestWrite = retained
+                    publishGuestStatusLocked(
+                        retained,
+                        MobileAdapterGuestConfigurationPersistencePhase.PENDING,
+                    )
+                    GuestOfferDisposition.Accepted(configuration)
+                  }
+                }
+              }
+          when (disposition) {
+            GuestOfferDisposition.CLOSED -> MobileAdapterGuestConfigurationOfferResult.CLOSED
+            GuestOfferDisposition.STALE ->
+                MobileAdapterGuestConfigurationOfferResult.STALE_ATTACHMENT
+            GuestOfferDisposition.DUPLICATE -> {
+              MobileAdapterGuestConfigurationOfferResult.ACCEPTED
+            }
+            is GuestOfferDisposition.Accepted -> {
+              val configuration = disposition.configuration
+              synchronized(authorityLock) {
+                val before = current.get()
+                current.set(
+                    before.copy(
+                        configuration =
+                            MobileAdapterConfiguration(
+                                before.configuration.deviceId,
+                                configuration,
+                                before.configuration.networkPolicy,
+                            ),
+                    ))
+              }
+              kickPendingGuestWrite()
+              MobileAdapterGuestConfigurationOfferResult.ACCEPTED
+            }
+          }
+        }
+      }
+
+  override fun pollStatus(): MobileAdapterGuestConfigurationPersistenceStatus? =
+      guestStatuses.poll()
+
+  /**
+   * Waits for one retained dirty image to commit, retrying one earlier failed attempt. The caller
+   * freezes emulation before entering this close barrier, so no newer guest mutation can race its
+   * target.
+   */
+  override fun flush(
+      timeout: Long,
+      unit: TimeUnit,
+  ): MobileAdapterConfigurationSaveResult {
+    require(timeout >= 0) { "Mobile Adapter flush timeout must not be negative" }
+    val timeoutNanos = unit.toNanos(timeout)
+    val deadline = saturatedDeadline(timeoutNanos)
+    val (targetSequence, completedBeforeFlush) =
+        synchronized(guestPersistenceLock) {
+          val pending = pendingGuestWrite
+              ?: return MobileAdapterConfigurationSaveResult(saved = true)
+          pending.sequence to completedGuestAttempt
+        }
+
+    kickPendingGuestWrite()
+    synchronized(guestPersistenceLock) {
+      while (true) {
+        val pending = pendingGuestWrite
+        if (pending == null || pending.sequence != targetSequence) {
+          return MobileAdapterConfigurationSaveResult(saved = true)
+        }
+        val completed = lastGuestAttempt
+        if (!guestTaskScheduled &&
+            completedGuestAttempt > completedBeforeFlush &&
+            completed?.sequence == targetSequence) {
+          return completed.result
+        }
+        val remaining = deadline - System.nanoTime()
+        if (remaining <= 0) {
+          throw TimeoutException("Mobile Adapter configuration flush timed out")
+        }
+        TimeUnit.NANOSECONDS.timedWait(guestPersistenceLock, remaining)
+      }
+    }
+  }
 
   val provider =
       Controller.MobileAdapterConfigurationProvider {
@@ -212,10 +357,16 @@ internal class MobileAdapterConfigurationCoordinator(
                     if (coordinatorClosed) {
                       null
                     } else {
+                      val before = current.get()
                       val value =
-                          MobileAdapterRuntimeUiState(
+                          before.copy(
                               revision = nextRevision(),
-                              configuration = committedConfiguration,
+                              configuration =
+                                  MobileAdapterConfiguration(
+                                      committedConfiguration.deviceId,
+                                      before.configuration.configurationBytes(),
+                                      committedConfiguration.networkPolicy,
+                                  ),
                               networkConsent = false,
                               privateLocalDevelopment = false,
                           )
@@ -226,6 +377,7 @@ internal class MobileAdapterConfigurationCoordinator(
                   }
               reconciled?.let { postRevocationAndRefresh(eventBus, it.revision) }
             }
+            kickPendingGuestWrite()
             completeSafely(completed, result)
           }
         } catch (_: RejectedExecutionException) {
@@ -237,7 +389,10 @@ internal class MobileAdapterConfigurationCoordinator(
         }
       }
     }
-    immediateResult?.let { completeSafely(completed, it) }
+    immediateResult?.let {
+      kickPendingGuestWrite()
+      completeSafely(completed, it)
+    }
   }
 
   /**
@@ -279,6 +434,7 @@ internal class MobileAdapterConfigurationCoordinator(
                 error = MobileAdapterConfigurationError.CONFIGURATION_STALE,
             )
       } else {
+        val importImageGeneration = synchronized(guestPersistenceLock) { guestImageGeneration }
         try {
           writer.execute {
             val sourceError = store.validateImportSource(source)
@@ -317,15 +473,44 @@ internal class MobileAdapterConfigurationCoordinator(
                   durableConfiguration.get()
                 }
             synchronized(transitionPublicationLock) {
+              val importedImageWins =
+                  synchronized(guestPersistenceLock) {
+                    val wins = result.saved && guestImageGeneration <= importImageGeneration
+                    if (wins) {
+                      pendingGuestWrite?.let { pending ->
+                        if (pending.imageGeneration <= importImageGeneration) {
+                          publishGuestStatusLocked(
+                              pending,
+                              MobileAdapterGuestConfigurationPersistencePhase.SUPERSEDED,
+                          )
+                          pendingGuestWrite = null
+                        }
+                      }
+                      guestPersistenceLock.notifyAll()
+                    }
+                    wins
+                  }
               val reconciled =
                   synchronized(authorityLock) {
                     if (coordinatorClosed) {
                       null
                     } else {
+                      val before = current.get()
+                      val visibleImage =
+                          if (importedImageWins) {
+                            checkNotNull(candidate).configurationBytes()
+                          } else {
+                            before.configuration.configurationBytes()
+                          }
                       val value =
-                          MobileAdapterRuntimeUiState(
+                          before.copy(
                               revision = nextRevision(),
-                              configuration = committedConfiguration,
+                              configuration =
+                                  MobileAdapterConfiguration(
+                                      committedConfiguration.deviceId,
+                                      visibleImage,
+                                      committedConfiguration.networkPolicy,
+                                  ),
                               networkConsent = false,
                               privateLocalDevelopment = false,
                           )
@@ -336,6 +521,7 @@ internal class MobileAdapterConfigurationCoordinator(
                   }
               reconciled?.let { postRevocationAndRefresh(eventBus, it.revision) }
             }
+            kickPendingGuestWrite()
             completeSafely(completed, result)
           }
         } catch (_: RejectedExecutionException) {
@@ -347,19 +533,29 @@ internal class MobileAdapterConfigurationCoordinator(
         }
       }
     }
-    immediateResult?.let { completeSafely(completed, it) }
+    immediateResult?.let {
+      kickPendingGuestWrite()
+      completeSafely(completed, it)
+    }
   }
 
   override fun close() {
     val closeDeadlineNanos =
         System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(SHUTDOWN_TIMEOUT_MILLIS)
     val closingBackends =
-        synchronized(authorityLock) {
-          if (!coordinatorClosed) {
-            coordinatorClosed = true
-            revokePreparedBackends()
+        synchronized(transitionPublicationLock) {
+          val backends =
+              synchronized(authorityLock) {
+                if (!coordinatorClosed) {
+                  coordinatorClosed = true
+                  revokePreparedBackends()
+                }
+                activeBackends.toList()
+              }
+          synchronized(guestPersistenceLock) {
+            guestPersistenceLock.notifyAll()
           }
-          activeBackends.toList()
+          backends
         }
     closingBackends.forEach(MobileAdapterNetworkBackend::close)
     writer.shutdown()
@@ -395,6 +591,107 @@ internal class MobileAdapterConfigurationCoordinator(
     }
   }
 
+  /** Attempts to place one constant-space dirty slot on the existing bounded writer. */
+  private fun kickPendingGuestWrite() {
+    val submit =
+        synchronized(guestPersistenceLock) {
+          if (coordinatorClosed || pendingGuestWrite == null || guestTaskScheduled) {
+            false
+          } else {
+            guestTaskScheduled = true
+            true
+          }
+        }
+    if (!submit) return
+
+    try {
+      writer.execute { persistPendingGuestWrite() }
+    } catch (_: RejectedExecutionException) {
+      synchronized(guestPersistenceLock) {
+        guestTaskScheduled = false
+        guestPersistenceLock.notifyAll()
+      }
+      // Executor pressure never rejects the already acknowledged guest image. The next guest
+      // offer, explicit-operation completion, or flush barrier supplies a bounded retry trigger.
+    }
+  }
+
+  private fun persistPendingGuestWrite() {
+    val attempted =
+        synchronized(guestPersistenceLock) {
+          pendingGuestWrite
+              ?: run {
+                guestTaskScheduled = false
+                guestPersistenceLock.notifyAll()
+                return
+              }
+        }
+    val durable = durableConfiguration.get()
+    val candidate =
+        MobileAdapterConfiguration(
+            durable.deviceId,
+            attempted.configurationCopy(),
+            durable.networkPolicy,
+        )
+    val result = store.save(candidate)
+    if (result.saved) durableConfiguration.set(candidate)
+
+    var retryNewerGuest = false
+    synchronized(transitionPublicationLock) {
+      // A guest save changes only the image. If an owner operation changed metadata while the
+      // save was running, preserve the newest live image and reconcile that metadata separately
+      // when the serialized owner operation completes.
+      synchronized(guestPersistenceLock) {
+        completedGuestAttempt = incrementExact(completedGuestAttempt)
+        lastGuestAttempt = CompletedGuestAttempt(attempted.sequence, result)
+        guestTaskScheduled = false
+        publishGuestStatusLocked(
+            attempted,
+            if (result.saved) {
+              MobileAdapterGuestConfigurationPersistencePhase.SAVED
+            } else {
+              MobileAdapterGuestConfigurationPersistencePhase.FAILED
+            },
+            result.error,
+        )
+        val latest = pendingGuestWrite
+        if (result.saved && latest?.sequence == attempted.sequence) {
+          pendingGuestWrite = null
+        } else if (latest != null && latest.sequence != attempted.sequence) {
+          // A later write is itself a retry trigger even when this older attempt failed.
+          retryNewerGuest = true
+        }
+        guestPersistenceLock.notifyAll()
+      }
+    }
+    if (retryNewerGuest) kickPendingGuestWrite()
+  }
+
+  private fun publishGuestStatusLocked(
+      pending: PendingGuestWrite,
+      phase: MobileAdapterGuestConfigurationPersistencePhase,
+      error: MobileAdapterConfigurationError? = null,
+  ) {
+    val status =
+        MobileAdapterGuestConfigurationPersistenceStatus(
+            sequence = pending.sequence,
+            attachmentId = pending.attachmentId,
+            mutationRevision = pending.mutationRevision,
+            phase = phase,
+            error = error,
+        )
+    while (!guestStatuses.offer(status)) guestStatuses.poll()
+  }
+
+  private fun saturatedDeadline(timeoutNanos: Long): Long {
+    val now = System.nanoTime()
+    return try {
+      Math.addExact(now, timeoutNanos)
+    } catch (_: ArithmeticException) {
+      Long.MAX_VALUE
+    }
+  }
+
   private fun remainingShutdownMillis(deadlineNanos: Long): Long {
     val remaining = deadlineNanos - System.nanoTime()
     return if (remaining <= 0) 0 else maxOf(1, TimeUnit.NANOSECONDS.toMillis(remaining))
@@ -402,6 +699,8 @@ internal class MobileAdapterConfigurationCoordinator(
 
   private fun nextRevision(): Long =
       revision.updateAndGet { value -> Math.addExact(value, 1) }
+
+  private fun incrementExact(value: Long): Long = Math.addExact(value, 1)
 
   private fun createBackend(
       snapshot: MobileAdapterRuntimeUiState,
@@ -470,10 +769,50 @@ internal class MobileAdapterConfigurationCoordinator(
     }
   }
 
+  private sealed interface GuestOfferDisposition {
+    data object CLOSED : GuestOfferDisposition
+
+    data object STALE : GuestOfferDisposition
+
+    data object DUPLICATE : GuestOfferDisposition
+
+    class Accepted(configuration: ByteArray) : GuestOfferDisposition {
+      private val ownedConfiguration = configuration.clone()
+
+      val configuration: ByteArray
+        get() = ownedConfiguration.clone()
+
+      override fun toString(): String = "GuestOfferDisposition.Accepted(configuration=[redacted])"
+    }
+  }
+
+  private class PendingGuestWrite(
+      val sequence: Long,
+      val attachmentId: Long,
+      val mutationRevision: Long,
+      val imageGeneration: Long,
+      configuration: ByteArray,
+  ) {
+    private val ownedConfiguration = configuration.clone()
+
+    fun configurationCopy(): ByteArray = ownedConfiguration.clone()
+
+    override fun toString(): String =
+        "PendingGuestWrite(sequence=$sequence, attachmentId=$attachmentId, " +
+            "mutationRevision=$mutationRevision, imageGeneration=$imageGeneration, " +
+            "configuration=[redacted])"
+  }
+
+  private data class CompletedGuestAttempt(
+      val sequence: Long,
+      val result: MobileAdapterConfigurationSaveResult,
+  )
+
   companion object {
     const val SHUTDOWN_TIMEOUT_MILLIS = 2_000L
     const val MAX_PENDING_POLICY_WRITES = 1
     const val MAX_TRACKED_NETWORK_BACKENDS = 2
+    private const val MAX_PENDING_GUEST_STATUSES = 32
     private const val SHUTDOWN_GRACE_MILLIS = SHUTDOWN_TIMEOUT_MILLIS / 2
 
     internal fun destinationPolicy(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.link.LinkedController
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationSink
 import eu.rekawek.coffeegb.controller.network.ConnectionController
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.ControllerProperties
@@ -51,6 +52,8 @@ class SwingEmulator(
         Controller.MobileAdapterConfigurationProvider {
           Controller.MobileAdapterConfiguration.syntheticOffline()
         },
+    private val mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
+        MobileAdapterGuestConfigurationSink.NO_OP,
 ) {
   private val display: SwingDisplay
   private val joypad: SwingJoypad
@@ -112,6 +115,7 @@ class SwingEmulator(
                 DesktopStateExternalActions(),
                 mobileAdapterConfigurationProvider,
                 ::captureDisplayImage,
+                mobileAdapterGuestConfigurationSink,
             )
             .also { it.startController() }
 
@@ -149,6 +153,7 @@ class SwingEmulator(
                 DesktopStateExternalActions(),
                 mobileAdapterConfigurationProvider,
                 ::captureDisplayImage,
+                mobileAdapterGuestConfigurationSink,
             )
             .also { it.startController() }
     linkedControllerActive = false

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -179,6 +179,7 @@ class SwingGui private constructor(
             console,
             properties,
             mobileAdapterConfiguration.provider,
+            mobileAdapterConfiguration,
         )
   }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinatorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinatorTest.kt
@@ -6,6 +6,10 @@ import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfiguration
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationError
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationSaveResult
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationStore
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationOfferResult
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistencePhase
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationPersistenceStatus
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationWrite
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterNetworkPolicy
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterPortMapping
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterTransport
@@ -32,6 +36,267 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class MobileAdapterConfigurationCoordinatorTest {
+
+  @Test
+  fun `guest offer is defensively retained behind the committed attachment fence`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-coordinator-guest-fence")
+    val persistence = CountingOwnerOnlyWriter()
+    val initial = customConfiguration()
+    val coordinator =
+        MobileAdapterConfigurationCoordinator(
+            initial,
+            MobileAdapterConfigurationStore(directory.resolve("adapter.bin"), persistence),
+        )
+    val eventBus = EventBusImpl()
+    try {
+      assertTrue(
+          coordinator.applyRuntimeAuthorization(
+              coordinator.snapshot().revision,
+              networkConsent = true,
+              privateLocalDevelopment = true,
+              eventBus = eventBus,
+          ))
+      val authorityRevision = coordinator.snapshot().revision
+      coordinator.attachmentCommitted(2)
+      coordinator.attachmentCommitted(1) // A delayed older commit cannot reopen attachment 1.
+      assertEquals(
+          MobileAdapterGuestConfigurationOfferResult.STALE_ATTACHMENT,
+          coordinator.offer(
+              MobileAdapterGuestConfigurationWrite(
+                  1,
+                  1,
+                  generatedConfigurationBytes(0x20),
+              )),
+      )
+
+      val source = generatedConfigurationBytes(0x61)
+      val expected = source.clone()
+      val write = MobileAdapterGuestConfigurationWrite(2, 1, source)
+      source.fill(0)
+      assertEquals(MobileAdapterGuestConfigurationOfferResult.ACCEPTED, coordinator.offer(write))
+
+      val visible = coordinator.snapshot()
+      assertEquals(authorityRevision, visible.revision)
+      assertEquals(initial.deviceId, visible.configuration.deviceId)
+      assertEquals(initial.networkPolicy, visible.configuration.networkPolicy)
+      assertTrue(visible.networkConsent)
+      assertTrue(visible.privateLocalDevelopment)
+      assertContentEquals(expected, visible.configuration.configurationBytes())
+      assertEquals(
+          MobileAdapterGuestConfigurationPersistencePhase.PENDING,
+          assertNotNull(coordinator.pollStatus()).phase,
+      )
+
+      assertTrue(coordinator.flush(5, TimeUnit.SECONDS).saved)
+      val saved = awaitGuestStatus(
+          coordinator,
+          MobileAdapterGuestConfigurationPersistencePhase.SAVED,
+      )
+      assertEquals(2, saved.attachmentId)
+      assertEquals(1, saved.mutationRevision)
+      assertFalse(saved.toString().contains(expected.copyOfRange(0, 16).decodeToString()))
+      assertContentEquals(expected, coordinator.snapshot().configuration.configurationBytes())
+      assertContentEquals(
+          expected,
+          MobileAdapterConfigurationStore(directory.resolve("adapter.bin"))
+              .load()
+              .configuration
+              .configurationBytes(),
+      )
+    } finally {
+      coordinator.close()
+      eventBus.close()
+    }
+  }
+
+  @Test
+  fun `guest bursts coalesce to the latest constant-space image`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-coordinator-guest-coalesce")
+    val persistence = BlockingOwnerOnlyWriter()
+    val store = MobileAdapterConfigurationStore(directory.resolve("adapter.bin"), persistence)
+    val coordinator = MobileAdapterConfigurationCoordinator(customConfiguration(), store)
+    try {
+      coordinator.attachmentCommitted(7)
+      val first = generatedConfigurationBytes(0x11)
+      val middle = generatedConfigurationBytes(0x22)
+      val latest = generatedConfigurationBytes(0x33)
+      assertEquals(
+          MobileAdapterGuestConfigurationOfferResult.ACCEPTED,
+          coordinator.offer(MobileAdapterGuestConfigurationWrite(7, 1, first)),
+      )
+      assertTrue(persistence.started.await(5, TimeUnit.SECONDS))
+      assertEquals(
+          MobileAdapterGuestConfigurationOfferResult.ACCEPTED,
+          coordinator.offer(MobileAdapterGuestConfigurationWrite(7, 2, middle)),
+      )
+      assertEquals(
+          MobileAdapterGuestConfigurationOfferResult.ACCEPTED,
+          coordinator.offer(MobileAdapterGuestConfigurationWrite(7, 3, latest)),
+      )
+      assertContentEquals(latest, coordinator.snapshot().configuration.configurationBytes())
+
+      persistence.release.countDown()
+      assertTrue(coordinator.flush(5, TimeUnit.SECONDS).saved)
+      assertEquals(2, persistence.writes.get())
+      assertContentEquals(latest, store.current().configurationBytes())
+      val terminalRevisions =
+          drainGuestStatuses(coordinator)
+              .filter { it.phase == MobileAdapterGuestConfigurationPersistencePhase.SAVED }
+              .map { it.mutationRevision }
+      assertEquals(listOf(1L, 3L), terminalRevisions)
+    } finally {
+      persistence.release.countDown()
+      coordinator.close()
+    }
+  }
+
+  @Test
+  fun `failed guest image remains live and flush performs one bounded retry`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-coordinator-guest-flush")
+    val persistence = FailThenSucceedOwnerOnlyWriter(failures = 1)
+    val store = MobileAdapterConfigurationStore(directory.resolve("adapter.bin"), persistence)
+    val coordinator = MobileAdapterConfigurationCoordinator(customConfiguration(), store)
+    try {
+      coordinator.attachmentCommitted(3)
+      val image = generatedConfigurationBytes(0x44)
+      coordinator.offer(MobileAdapterGuestConfigurationWrite(3, 1, image))
+      val failed = awaitGuestStatus(
+          coordinator,
+          MobileAdapterGuestConfigurationPersistencePhase.FAILED,
+      )
+      assertEquals(MobileAdapterConfigurationError.STORAGE_WRITE_FAILED, failed.error)
+      assertEquals(1, persistence.writes.get())
+      assertContentEquals(image, coordinator.snapshot().configuration.configurationBytes())
+
+      assertTrue(coordinator.flush(5, TimeUnit.SECONDS).saved)
+      assertEquals(2, persistence.writes.get())
+      assertContentEquals(image, store.current().configurationBytes())
+      assertEquals(
+          MobileAdapterGuestConfigurationPersistencePhase.SAVED,
+          awaitGuestStatus(
+                  coordinator,
+                  MobileAdapterGuestConfigurationPersistencePhase.SAVED,
+              )
+              .phase,
+      )
+    } finally {
+      coordinator.close()
+    }
+  }
+
+  @Test
+  fun `policy completion composes durable metadata without rolling back a live guest image`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-coordinator-guest-policy")
+    val persistence = BlockingOwnerOnlyWriter()
+    val store = MobileAdapterConfigurationStore(directory.resolve("adapter.bin"), persistence)
+    val initial = customConfiguration()
+    val coordinator = MobileAdapterConfigurationCoordinator(initial, store)
+    val eventBus = EventBusImpl()
+    try {
+      val policyCompleted = CountDownLatch(1)
+      val imageAtPolicyCompletion = AtomicReference<ByteArray>()
+      coordinator.savePolicy(
+          coordinator.snapshot().revision,
+          MobileAdapterNetworkPolicy.Offline,
+          eventBus,
+      ) {
+        imageAtPolicyCompletion.set(coordinator.snapshot().configuration.configurationBytes())
+        policyCompleted.countDown()
+      }
+      assertTrue(persistence.started.await(5, TimeUnit.SECONDS))
+
+      coordinator.attachmentCommitted(4)
+      val guestImage = generatedConfigurationBytes(0x55)
+      coordinator.offer(MobileAdapterGuestConfigurationWrite(4, 1, guestImage))
+      persistence.release.countDown()
+      assertTrue(policyCompleted.await(5, TimeUnit.SECONDS))
+      assertContentEquals(guestImage, imageAtPolicyCompletion.get())
+      assertTrue(coordinator.flush(5, TimeUnit.SECONDS).saved)
+
+      val expected = MobileAdapterConfiguration(initial.deviceId, guestImage, MobileAdapterNetworkPolicy.Offline)
+      assertEquals(expected, coordinator.snapshot().configuration)
+      assertEquals(expected, store.current())
+    } finally {
+      persistence.release.countDown()
+      coordinator.close()
+      eventBus.close()
+    }
+  }
+
+  @Test
+  fun `successful import orders against guest images in both directions`() {
+    val firstDirectory = Files.createTempDirectory("coffee-gb-mobile-coordinator-import-after-guest")
+    val firstSource = firstDirectory.resolve("import.bin")
+    val importedAfterGuest = generatedConfigurationBytes(0x66)
+    Files.write(firstSource, importedAfterGuest)
+    val firstPersistence = FailThenSucceedOwnerOnlyWriter(failures = 1)
+    val firstStore = MobileAdapterConfigurationStore(firstDirectory.resolve("adapter.bin"), firstPersistence)
+    val firstCoordinator = MobileAdapterConfigurationCoordinator(customConfiguration(), firstStore)
+    val firstBus = EventBusImpl()
+    try {
+      firstCoordinator.attachmentCommitted(5)
+      firstCoordinator.offer(
+          MobileAdapterGuestConfigurationWrite(5, 1, generatedConfigurationBytes(0x65)))
+      awaitGuestStatus(firstCoordinator, MobileAdapterGuestConfigurationPersistencePhase.FAILED)
+      val imported = CountDownLatch(1)
+      firstCoordinator.importConfigurationImage(
+          firstCoordinator.snapshot().revision,
+          firstSource,
+          firstBus,
+      ) { result ->
+        assertTrue(result.saved)
+        imported.countDown()
+      }
+      assertTrue(imported.await(5, TimeUnit.SECONDS))
+      assertTrue(firstCoordinator.flush(1, TimeUnit.SECONDS).saved)
+      assertEquals(2, firstPersistence.writes.get())
+      assertEquals(
+          MobileAdapterGuestConfigurationPersistencePhase.SUPERSEDED,
+          awaitGuestStatus(
+                  firstCoordinator,
+                  MobileAdapterGuestConfigurationPersistencePhase.SUPERSEDED,
+              )
+              .phase,
+      )
+      assertContentEquals(importedAfterGuest, firstCoordinator.snapshot().configuration.configurationBytes())
+      assertContentEquals(importedAfterGuest, firstStore.current().configurationBytes())
+    } finally {
+      firstCoordinator.close()
+      firstBus.close()
+    }
+
+    val secondDirectory = Files.createTempDirectory("coffee-gb-mobile-coordinator-guest-after-import")
+    val secondSource = secondDirectory.resolve("import.bin")
+    Files.write(secondSource, generatedConfigurationBytes(0x70))
+    val secondPersistence = BlockingOwnerOnlyWriter()
+    val secondStore = MobileAdapterConfigurationStore(secondDirectory.resolve("adapter.bin"), secondPersistence)
+    val secondCoordinator = MobileAdapterConfigurationCoordinator(customConfiguration(), secondStore)
+    val secondBus = EventBusImpl()
+    try {
+      val imported = CountDownLatch(1)
+      secondCoordinator.importConfigurationImage(
+          secondCoordinator.snapshot().revision,
+          secondSource,
+          secondBus,
+      ) { result ->
+        assertTrue(result.saved)
+        imported.countDown()
+      }
+      assertTrue(secondPersistence.started.await(5, TimeUnit.SECONDS))
+      secondCoordinator.attachmentCommitted(6)
+      val guestAfterImport = generatedConfigurationBytes(0x71)
+      secondCoordinator.offer(MobileAdapterGuestConfigurationWrite(6, 1, guestAfterImport))
+      secondPersistence.release.countDown()
+      assertTrue(imported.await(5, TimeUnit.SECONDS))
+      assertContentEquals(guestAfterImport, secondCoordinator.snapshot().configuration.configurationBytes())
+      assertTrue(secondCoordinator.flush(5, TimeUnit.SECONDS).saved)
+      assertContentEquals(guestAfterImport, secondStore.current().configurationBytes())
+    } finally {
+      secondPersistence.release.countDown()
+      secondCoordinator.close()
+      secondBus.close()
+    }
+  }
 
   @Test
   fun `runtime authorization starts disabled and every policy edit revokes it before commit`() {
@@ -1196,6 +1461,27 @@ class MobileAdapterConfigurationCoordinatorTest {
     assertEquals("valid", document.getText(0, document.length))
   }
 
+  private fun awaitGuestStatus(
+      coordinator: MobileAdapterConfigurationCoordinator,
+      phase: MobileAdapterGuestConfigurationPersistencePhase,
+  ): MobileAdapterGuestConfigurationPersistenceStatus {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (System.nanoTime() < deadline) {
+      val status = coordinator.pollStatus()
+      if (status?.phase == phase) return status
+      Thread.yield()
+    }
+    throw AssertionError("Timed out waiting for redacted Mobile Adapter guest status $phase")
+  }
+
+  private fun drainGuestStatuses(
+      coordinator: MobileAdapterConfigurationCoordinator
+  ): List<MobileAdapterGuestConfigurationPersistenceStatus> {
+    val statuses = mutableListOf<MobileAdapterGuestConfigurationPersistenceStatus>()
+    while (true) statuses += coordinator.pollStatus() ?: break
+    return statuses
+  }
+
   private fun customConfiguration(): MobileAdapterConfiguration =
       MobileAdapterConfiguration(
           0x08,
@@ -1273,6 +1559,19 @@ class MobileAdapterConfigurationCoordinatorTest {
 
     override fun writeOwnerOnly(target: Path, intendedBytes: ByteArray) {
       writes.incrementAndGet()
+      AtomicFileWriter.system().writeOwnerOnly(target, intendedBytes)
+    }
+  }
+
+  private class FailThenSucceedOwnerOnlyWriter(
+      private val failures: Int,
+  ) : AtomicFileWriter() {
+    val writes = AtomicInteger()
+
+    override fun writeOwnerOnly(target: Path, intendedBytes: ByteArray) {
+      if (writes.incrementAndGet() <= failures) {
+        throw IOException("injected bounded Mobile Adapter guest write failure")
+      }
       AtomicFileWriter.system().writeOwnerOnly(target, intendedBytes)
     }
   }


### PR DESCRIPTION
## Summary

- expose the latest changed guest `CONFIG_WRITE` as a detached, runtime-only core notification
- drain guest configuration at controller safe points and before endpoint/session ownership changes
- fence writes by committed attachment and preserve retryable replacement, stop, and close barriers
- coalesce the latest complete image through the desktop coordinator's existing bounded writer
- preserve durable device/policy ownership while making acknowledged guest bytes immediately authoritative
- publish only typed, redacted persistence metadata and document state/rewind/privacy semantics

## Safety and ordering

- filesystem work stays off the emulation thread and Swing EDT
- raw 256-byte images never enter the event tree, logs, dialogs, diagnostics, or exception cause chains
- changed guest writes invalidate rewind/debug history even when private persistence is temporarily unavailable
- state restore neither creates nor replays a guest persistence notification
- policy saves, image imports, guest bursts, attachment changes, and blocked refresh/cancel races retain deterministic ordering
- final close freezes timing, drains the endpoint, and uses the existing bounded retryable persistence barrier

## Validation

- `mvn -B -pl controller -am -Dtest=MobileAdapterControllerLifecycleTest -Dsurefire.failIfNoSpecifiedTests=false test` — 16 passed
- `mvn -B clean test` — full core/controller/CLI/Swing reactor passed from clean output
- `git diff --check`

Progresses #399 and the persistence/cleanup requirements of #353. This intentionally does not close either issue; user-supplied-ROM custom-service evidence and final desktop exposure remain separate follow-up work.
