### PR TITLE
Poll Mobile Adapter completions at byte boundaries

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -869,8 +869,15 @@ class BasicController private constructor(
     val currentSession = session ?: return
     drainMobileAdapterGuestConfiguration(currentSession)
     pollMobileAdapterGuestConfigurationPersistence()
-    if (hasMobileAdapterExternalIo()) {
+    // A CGB can admit and finish a backend request between two controller frame boundaries. The
+    // endpoint's one-shot fence prevents rewind history from bridging that nondeterministic host
+    // effect even when no request or logical connection remains live at the end of this frame.
+    val mobileExternalIoObserved = consumeMobileAdapterExternalIoActivity()
+    if (mobileExternalIoObserved || hasMobileAdapterExternalIo()) {
       rewindManager.clear()
+      if (mobileExternalIoObserved) {
+        debugCheckpointHistory.clear(DebugHistoryTruncationReason.NONDETERMINISTIC_IO)
+      }
     } else {
       rewindManager.record(currentSession)
     }
@@ -3874,6 +3881,9 @@ class BasicController private constructor(
     val lifecycle = mobileAdapterLifecycle(currentSession)
     return endpoint.hasExternalIo() || lifecycle?.backend?.hasExternalWork() == true
   }
+
+  private fun consumeMobileAdapterExternalIoActivity(): Boolean =
+      (session?.serialEndpoint as? MobileAdapterSerialEndpoint)?.consumeExternalIoActivity() == true
 
   /** Exact predicate serialized by MobileAdapterSerialEndpoint capture normalization. */
   private fun mobileAdapterEndpointHasExternalIo(): Boolean =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/MobileAdapterControllerLifecycleTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/MobileAdapterControllerLifecycleTest.kt
@@ -403,6 +403,55 @@ class MobileAdapterControllerLifecycleTest {
   }
 
   @Test
+  fun `backend request completed within one owner frame clears prior rewind history`() {
+    udpFixture().use { server ->
+      val backend = backend(server.localPort, 1)
+      val rewind = RewindManager(enabled = true)
+      fixture(
+              Controller.MobileAdapterConfigurationProvider { configuration(1, backend) },
+              rewind,
+          )
+          .use { fixture ->
+            fixture.awaitCondition { rewind.historySize > 0 }
+            val completed = AtomicBoolean()
+            val failure = AtomicReference<Throwable>()
+            fixture.gameboy.get().onNextTick.set {
+              try {
+                val endpoint = assertNotNull(fixture.endpoint.get())
+                completeMobileTransaction(
+                    endpoint,
+                    packet(BEGIN_SESSION, "NINTENDO".encodeToByteArray()),
+                )
+                completeMobileTransaction(
+                    endpoint,
+                    packet(DNS_QUERY, "game.service".encodeToByteArray()),
+                )
+                assertEquals(
+                    MobileAdapterEngine.Outcome.BACKEND_RESPONSE,
+                    endpoint.snapshot().outcome(),
+                )
+                assertFalse(endpoint.hasExternalIo())
+                fixture.awaitCondition { !backend.hasExternalWork() }
+              } catch (caught: Throwable) {
+                failure.set(caught)
+              } finally {
+                // The next controller boundary pauses before another frame can record a new state.
+                fixture.eventBus.post(Controller.PauseEmulationEvent())
+                completed.set(true)
+              }
+            }
+
+            fixture.eventBus.post(Controller.ResumeEmulationEvent())
+
+            fixture.awaitCondition { completed.get() }
+            failure.get()?.let { throw AssertionError("in-frame Mobile transaction failed", it) }
+            fixture.awaitCondition { rewind.historySize == 0 }
+          }
+      assertTrue(backend.awaitTermination(2_000))
+    }
+  }
+
+  @Test
   fun `reset cancels and joins the old backend before the replacement session owns Mobile`() {
     udpFixture().use { server ->
       val oldBackend = backend(server.localPort, 1)
@@ -887,7 +936,6 @@ class MobileAdapterControllerLifecycleTest {
     val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
     var first = 0xd2
     while (first == 0xd2 && System.nanoTime() < deadline) {
-      endpoint.pollBackendCompletion()
       first = exchangeMobileByte(endpoint, 0x4b)
       if (first == 0xd2) Thread.sleep(2)
     }
@@ -1037,6 +1085,12 @@ class MobileAdapterControllerLifecycleTest {
   ) : Gameboy(configuration) {
     val rejectNextMobileHandoff = AtomicBoolean()
     val failAfterNextPressedButtonMutation = AtomicBoolean()
+    val onNextTick = AtomicReference<(() -> Unit)?>(null)
+
+    override fun tick(): Boolean {
+      onNextTick.getAndSet(null)?.invoke()
+      return super.tick()
+    }
 
     override fun init(
         eventBus: EventBus,

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterCrystalWireIntegrationTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterCrystalWireIntegrationTest.kt
@@ -171,7 +171,6 @@ class MobileAdapterCrystalWireIntegrationTest {
     val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(8)
     var first = IDLE_BYTE
     while (first == IDLE_BYTE && System.nanoTime() < deadline) {
-      endpoint.pollBackendCompletion()
       first = exchange(endpoint, POLL_BYTE)
       if (first == IDLE_BYTE) Thread.sleep(2)
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngine.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterEngine.java
@@ -320,7 +320,8 @@ public final class MobileAdapterEngine implements StatefulComponent<MobileAdapte
      * Atomically polls and applies at most one controller completion without waiting.
      *
      * <p>The completion's generation and request identity are checked again immediately before any
-     * deterministic state changes. A controller calls this at an emulator safe point; it is not a
+     * deterministic state changes. The controller calls this at a frame safe point, and the serial
+     * endpoint may call it at a new-byte boundary while a backend response is pending. It is not a
      * host-I/O callback and never blocks.
      */
     public EngineResult pollBackendCompletion() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpoint.java
@@ -55,6 +55,9 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
     /** Number of response retransmissions already scheduled for this transaction. */
     private int responseRetryCount;
 
+    /** Runtime-only history fence set when a backend request crosses the host-I/O boundary. */
+    private transient boolean externalIoActivityObserved;
+
     public MobileAdapterSerialEndpoint(ClockSpec clockSpec, int deviceId, byte[] configuration) {
         this(clockSpec, deviceId, configuration, MobileAdapterBackendPort.DISCONNECTED);
     }
@@ -96,6 +99,13 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
             byteTransferActive = false;
             legacyReplyLatched = false;
             if (wirePhase == WirePhase.NORMALIZED_DISCONNECT) resetWireState();
+        }
+        // CGB fast serial can clock hundreds of bytes before the controller's next frame safe
+        // point. Once the validated response gate is pending, consume one already-published
+        // completion at this byte boundary so the guest cannot outrun a DNS/socket reply. This
+        // atomic port poll performs no host I/O and cannot replace a reply byte already in flight.
+        if (wirePhase == WirePhase.RESPONSE_PENDING && responsePacket.length == 0) {
+            pollBackendCompletion();
         }
         sendBitIndex = 0;
         byteTransferActive = true;
@@ -159,6 +169,18 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
     /** Runtime-only ownership hint for controller warnings; it is never captured as a host handle. */
     public boolean hasExternalIo() {
         return engine.hasExternalIo();
+    }
+
+    /**
+     * Consumes the owner-thread history fence for backend work admitted since the previous
+     * controller boundary. The fence is deliberately distinct from {@link #hasExternalIo()}:
+     * a fast request can complete before the frame ends, but its host interaction cannot be
+     * replayed from a portable or rewind snapshot.
+     */
+    public boolean consumeExternalIoActivity() {
+        boolean observed = externalIoActivityObserved;
+        externalIoActivityObserved = false;
+        return observed;
     }
 
     public byte[] configurationCopy() {
@@ -271,6 +293,9 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
             }
         }
         MobileAdapterEngine.EngineResult result = engine.acceptByte(sb);
+        if (result.outcome() == MobileAdapterEngine.Outcome.BACKEND_PENDING) {
+            externalIoActivityObserved = true;
+        }
         byte[] acknowledgement = result.acknowledgement();
         if (acknowledgement.length != 2) {
             return;
@@ -394,6 +419,7 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
             resetWireState();
             currentReply = 0xff;
             legacyReplyLatched = true;
+            externalIoActivityObserved = false;
         } else if (state instanceof MobileAdapterSerialEndpointState legacyState) {
             validateLegacyEndpointState(legacyState.sb, legacyState.sendBitIndex);
             engine.restoreState(legacyState.engineState);
@@ -406,6 +432,7 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
             resetWireState();
             currentReply = 0xff;
             legacyReplyLatched = true;
+            externalIoActivityObserved = false;
         } else {
             throw new IllegalArgumentException("Invalid Mobile Adapter serial endpoint state type");
         }
@@ -428,6 +455,7 @@ public final class MobileAdapterSerialEndpoint implements SerialEndpoint {
         responseByteIndex = state.responseByteIndex;
         awaitingResponse = state.awaitingResponse;
         responseRetryCount = state.responseRetryCount;
+        externalIoActivityObserved = false;
     }
 
     private static void validateLegacyEndpointState(int restoredSb, int restoredSendBitIndex) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpointTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/mobile/MobileAdapterSerialEndpointTest.java
@@ -677,7 +677,7 @@ public class MobileAdapterSerialEndpointTest {
     }
 
     @Test
-    public void crystalServiceFlowPollsUntilAnAsynchronousDnsReplyIsPublished() {
+    public void pendingWirePollConsumesAnAsynchronousDnsReplyAtTheNextByteBoundary() {
         DeterministicMobileAdapterBackend backend = new DeterministicMobileAdapterBackend();
         MobileAdapterSerialEndpoint endpoint = new MobileAdapterSerialEndpoint(
                 ClockSpec.LEGACY, DEVICE_ID, configuration(), backend);
@@ -711,11 +711,11 @@ public class MobileAdapterSerialEndpointTest {
                         0,
                         MobileAdapterBackendPort.BackendStatus.SUCCESS,
                         new byte[]{127, 0, 0, 1}));
-        assertEquals(MobileAdapterEngine.Outcome.BACKEND_RESPONSE,
-                endpoint.pollBackendCompletion().outcome());
+        assertEquals(1, backend.completedResults());
         assertArrayEquals(
                 packet(0xa8, new byte[]{127, 0, 0, 1}),
                 readResponse(endpoint));
+        assertEquals(0, backend.completedResults());
     }
 
     @Test
@@ -741,25 +741,100 @@ public class MobileAdapterSerialEndpointTest {
                         0,
                         MobileAdapterBackendPort.BackendStatus.SUCCESS,
                         new byte[]{127, 0, 0, 1}));
-        assertEquals(MobileAdapterEngine.Outcome.BACKEND_RESPONSE,
-                endpoint.pollBackendCompletion().outcome());
+        assertEquals(MobileAdapterEngine.Outcome.BACKEND_PENDING,
+                endpoint.snapshot().outcome());
         for (int bit = 3; bit < 8; bit++) {
             pendingReply = pendingReply << 1 | endpoint.sendBit();
         }
         assertEquals(0xd2, pendingReply);
-        assertEquals(MobileAdapterEngine.Outcome.BACKEND_RESPONSE,
-                endpoint.pollBackendCompletion().outcome());
-        assertEquals(9,
-                ((MobileAdapterSerialEndpoint.MobileAdapterSerialEndpointWireState)
-                        endpoint.captureState()).wirePhaseId());
+        assertEquals(MobileAdapterEngine.Outcome.BACKEND_PENDING,
+                endpoint.snapshot().outcome());
 
+        // The next byte boundary, rather than a test-only controller poll, consumes the result.
         byte[] expected = packet(0xa8, new byte[]{127, 0, 0, 1});
         assertEquals(expected[0] & 0xff, exchange(endpoint, 0x4b));
+        assertEquals(MobileAdapterEngine.Outcome.BACKEND_RESPONSE,
+                endpoint.snapshot().outcome());
+        MobileAdapterSerialEndpoint.MobileAdapterSerialEndpointWireState streaming =
+                (MobileAdapterSerialEndpoint.MobileAdapterSerialEndpointWireState)
+                        endpoint.captureState();
+        assertEquals(6, streaming.wirePhaseId());
+        assertEquals(1, streaming.responseByteIndex());
+
         for (int index = 1; index < expected.length; index++) {
             assertEquals(expected[index] & 0xff, exchange(endpoint, 0x4b));
         }
         assertEquals(DEVICE_ID | 0x80, exchange(endpoint, 0x80));
         assertEquals(0, exchange(endpoint, 0x28));
+    }
+
+    @Test
+    public void completedBackendRequestLeavesOneRuntimeOnlyHistoryFence() {
+        DeterministicMobileAdapterBackend backend = new DeterministicMobileAdapterBackend();
+        MobileAdapterSerialEndpoint endpoint = new MobileAdapterSerialEndpoint(
+                ClockSpec.LEGACY, DEVICE_ID, configuration(), backend);
+        assertArrayEquals(BEGIN_RESPONSE, transaction(endpoint, BEGIN));
+        assertTrue(!endpoint.consumeExternalIoActivity());
+
+        sendRequestAndReadAcknowledgement(
+                endpoint, packet(0x28, "service.test".getBytes(StandardCharsets.US_ASCII)));
+        assertTrue(endpoint.hasExternalIo());
+        assertEquals(MobileAdapterBackendPort.CompletionResult.COMPLETED,
+                backend.complete(
+                        backend.generation(),
+                        0,
+                        MobileAdapterBackendPort.BackendStatus.SUCCESS,
+                        new byte[]{127, 0, 0, 1}));
+        assertArrayEquals(
+                packet(0xa8, new byte[]{127, 0, 0, 1}),
+                readResponse(endpoint));
+        assertTrue(!endpoint.hasExternalIo());
+        assertEquals(0, backend.completedResults());
+        assertTrue(endpoint.consumeExternalIoActivity());
+        assertTrue(!endpoint.consumeExternalIoActivity());
+
+        sendRequestAndReadAcknowledgement(
+                endpoint, packet(0x28, "service.test".getBytes(StandardCharsets.US_ASCII)));
+        endpoint.disconnect();
+        assertTrue(!endpoint.hasExternalIo());
+        assertTrue(endpoint.consumeExternalIoActivity());
+        assertTrue(!endpoint.consumeExternalIoActivity());
+    }
+
+    @Test
+    public void successfulRestoreStartsWithNoRuntimeOnlyHistoryFence() {
+        DeterministicMobileAdapterBackend backend = new DeterministicMobileAdapterBackend();
+        MobileAdapterSerialEndpoint endpoint = new MobileAdapterSerialEndpoint(
+                ClockSpec.LEGACY, DEVICE_ID, configuration(), backend);
+        assertArrayEquals(BEGIN_RESPONSE, transaction(endpoint, BEGIN));
+        sendRequestAndReadAcknowledgement(
+                endpoint, packet(0x28, "service.test".getBytes(StandardCharsets.US_ASCII)));
+
+        MobileAdapterSerialEndpoint restored = new MobileAdapterSerialEndpoint(
+                ClockSpec.LEGACY, DEVICE_ID, configuration(), backend);
+        restored.restoreState(endpoint.captureState());
+
+        assertTrue(!restored.consumeExternalIoActivity());
+        assertTrue(endpoint.consumeExternalIoActivity());
+    }
+
+    @Test
+    public void revokedPendingGenerationAutoPollsToIdleAndAcceptsFreshMagic() {
+        DeterministicMobileAdapterBackend backend = new DeterministicMobileAdapterBackend();
+        MobileAdapterSerialEndpoint endpoint = new MobileAdapterSerialEndpoint(
+                ClockSpec.LEGACY, DEVICE_ID, configuration(), backend);
+        assertArrayEquals(BEGIN_RESPONSE, transaction(endpoint, BEGIN));
+        sendRequestAndReadAcknowledgement(
+                endpoint, packet(0x28, "service.test".getBytes(StandardCharsets.US_ASCII)));
+        assertEquals(0xd2, exchange(endpoint, 0));
+        assertEquals(0xd2, exchange(endpoint, 0x4b));
+
+        backend.cancelAll();
+
+        assertEquals(0xd2, exchange(endpoint, 0x99));
+        assertEquals(MobileAdapterEngine.Outcome.NEED_MORE, endpoint.snapshot().outcome());
+        assertEquals(1, endpoint.snapshot().retainedBytes());
+        assertEquals(0, backend.completedResults());
     }
 
     @Test

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -47,6 +47,15 @@ The deterministic fake linearizes this bounded ownership with an immutable snaps
 lock-free atomic reference. It creates no worker, task, future, executor, callback, or blocking
 wait; host jobs remain controller-owned and publish only at controller safe points.
 
+The controller polls an already-published backend completion at each frame boundary. While the
+serial wire is specifically waiting for that response, the endpoint also performs the same
+constant-time, nonblocking poll before latching each new reply byte. CGB fast serial can clock
+hundreds of bytes within one frame, so this byte-boundary safe point prevents a game from outrunning
+a completed DNS or socket operation. A completion never changes a reply byte already in flight.
+The endpoint also raises a runtime-only history fence whenever it admits backend work. The
+controller consumes that fence after the frame and clears rewind history even if the request and
+its logical connection both completed within that same frame; the fence is never serialized.
+
 Phase #353 supplies only a synthetic service flow for reaching a custom server. Blue-adapter dial command
 `12` accepts model prefix `00` plus the exact Mobile System GB ISP number `#9677`; it never places a
 host telephone call. Status command `17` reports disconnected `00 4d 00` before dial and connected


### PR DESCRIPTION
## Summary

- poll already-published Mobile Adapter backend completions at a safe serial-byte boundary while the endpoint is waiting for a response
- fence rewind and debugger history whenever backend work crosses the host-I/O boundary, including requests that finish within one controller frame
- keep the fence runtime-only and preserve the existing deterministic restore/disconnect semantics

## Why

A CGB fast-serial guest can clock hundreds of bytes before the controller reaches its next frame boundary. A DNS or socket completion could therefore already be published while the guest continued receiving idle bytes and timed out before the next controller poll.

The added byte-boundary poll is constant-time and nonblocking, and it never replaces a reply byte already in flight.

## Verification

- focused core/controller Mobile Adapter suites: 101 tests passed
- `mvn -B -Dkotlin.compiler.daemon=false clean test`: full reactor passed
- two independent read-only implementation audits found no blocking issue
- sanitized user-authorized Mobile Trainer/loopback-REON replay advanced a formerly unanswered DNS operation to a checksum-valid, deterministic destination-policy result; full service acceptance remains tracked by #353

Closes no issue. Advances #399 and #353.

AI assistance was used to implement, test, audit, and prepare this pull request.
