### PR TITLE
Support bounded Mobile Adapter DNS aliases

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfiguration.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfiguration.kt
@@ -131,17 +131,50 @@ sealed interface MobileAdapterNetworkPolicy {
     override val mode = MobileAdapterNetworkMode.OFFLINE
   }
 
-  class CustomServer(
+  class CustomServer private constructor(
       dnsQueryName: String,
       resolverIpv4Address: String,
       val resolverPort: Int,
-      portMappings: Collection<MobileAdapterPortMapping> = emptyList(),
+      portMappings: Collection<MobileAdapterPortMapping>,
+      additionalDnsQueryNames: Collection<String>,
+      @Suppress("UNUSED_PARAMETER") constructorMarker: Unit,
   ) : MobileAdapterNetworkPolicy {
+    constructor(
+        dnsQueryName: String,
+        resolverIpv4Address: String,
+        resolverPort: Int,
+        portMappings: Collection<MobileAdapterPortMapping> = emptyList(),
+    ) : this(
+        dnsQueryName,
+        resolverIpv4Address,
+        resolverPort,
+        portMappings,
+        emptyList(),
+        Unit,
+    )
+
+    constructor(
+        dnsQueryName: String,
+        resolverIpv4Address: String,
+        resolverPort: Int,
+        portMappings: Collection<MobileAdapterPortMapping>,
+        additionalDnsQueryNames: Collection<String>,
+    ) : this(
+        dnsQueryName,
+        resolverIpv4Address,
+        resolverPort,
+        portMappings,
+        additionalDnsQueryNames,
+        Unit,
+    )
+
     override val mode = MobileAdapterNetworkMode.CUSTOM_SERVER
 
     val dnsQueryName: String = normalizeDnsQueryName(dnsQueryName)
 
     val resolverIpv4Address: String = normalizeIpv4Address(resolverIpv4Address)
+
+    val additionalDnsQueryNames: List<String>
 
     val portMappings: List<MobileAdapterPortMapping>
 
@@ -161,6 +194,24 @@ sealed interface MobileAdapterNetworkPolicy {
         "A transport and guest port may have only one target mapping"
       }
       this.portMappings = Collections.unmodifiableList(ArrayList(sorted))
+
+      val boundedAliases = ArrayList<String>(MAX_ADDITIONAL_DNS_QUERY_NAMES)
+      additionalDnsQueryNames.forEach { alias ->
+        require(boundedAliases.size < MAX_ADDITIONAL_DNS_QUERY_NAMES) {
+          "A Mobile Adapter custom server supports at most " +
+              "$MAX_ADDITIONAL_DNS_QUERY_NAMES additional DNS query names"
+        }
+        boundedAliases.add(normalizeDnsQueryName(alias))
+      }
+      val sortedAliases = boundedAliases.sorted()
+      require(sortedAliases.distinct().size == sortedAliases.size) {
+        "Additional DNS query names must be unique"
+      }
+      require(this.dnsQueryName !in sortedAliases) {
+        "An additional DNS query name must not duplicate the primary name"
+      }
+      this.additionalDnsQueryNames =
+          Collections.unmodifiableList(ArrayList(sortedAliases))
     }
 
     internal fun resolverAddressBytes(): ByteArray {
@@ -172,12 +223,14 @@ sealed interface MobileAdapterNetworkPolicy {
         this === other ||
             (other is CustomServer &&
                 dnsQueryName == other.dnsQueryName &&
+                additionalDnsQueryNames == other.additionalDnsQueryNames &&
                 resolverIpv4Address == other.resolverIpv4Address &&
                 resolverPort == other.resolverPort &&
                 portMappings == other.portMappings)
 
     override fun hashCode(): Int {
       var result = dnsQueryName.hashCode()
+      result = 31 * result + additionalDnsQueryNames.hashCode()
       result = 31 * result + resolverIpv4Address.hashCode()
       result = 31 * result + resolverPort
       result = 31 * result + portMappings.hashCode()
@@ -186,12 +239,15 @@ sealed interface MobileAdapterNetworkPolicy {
 
     override fun toString(): String =
         "MobileAdapterNetworkPolicy.CustomServer(" +
-            "dnsQueryName=[redacted], resolverIpv4Address=[redacted], " +
+            "dnsQueryName=[redacted], additionalDnsQueryNames=${additionalDnsQueryNames.size}, " +
+            "resolverIpv4Address=[redacted], " +
             "resolverPort=[redacted], portMappings=${portMappings.size})"
 
     companion object {
       const val MAX_DNS_QUERY_NAME_BYTES = 253
       const val MAX_DNS_LABEL_BYTES = 63
+      const val MAX_ADDITIONAL_DNS_QUERY_NAMES = 7
+      const val MAX_DNS_QUERY_NAMES = MAX_ADDITIONAL_DNS_QUERY_NAMES + 1
       const val MAX_PORT_MAPPINGS = 16
 
       private val DNS_LABEL = Regex("[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationCodec.kt
@@ -10,11 +10,17 @@ import java.security.NoSuchAlgorithmException
 /** Versioned, deterministic and allocation-bounded owner-only configuration representation. */
 internal object MobileAdapterConfigurationCodec {
   const val LEGACY_FORMAT_VERSION: Int = 1
-  const val FORMAT_VERSION: Int = 2
+  const val VERSION_2_FORMAT_VERSION: Int = 2
+  const val FORMAT_VERSION: Int = 3
 
   const val LEGACY_ENCODED_SIZE: Int = 300
   const val MIN_ENCODED_SIZE: Int = LEGACY_ENCODED_SIZE
-  const val MAX_ENCODED_SIZE: Int = 640
+  const val VERSION_2_MAX_ENCODED_SIZE: Int = 640
+  const val MAX_ENCODED_SIZE: Int =
+      VERSION_2_MAX_ENCODED_SIZE +
+          1 +
+          MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES *
+              (1 + MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES)
 
   private const val LEGACY_LENGTH_FIELD_SIZE = 2
   private const val DIGEST_SIZE = 32
@@ -33,21 +39,57 @@ internal object MobileAdapterConfigurationCodec {
   private const val V2_FIXED_BODY_SIZE =
       8 + 1 + 1 + MobileAdapterConfiguration.CONFIGURATION_SIZE + 1 + IPV4_BYTES + 2 + 1 + 1
   private const val V2_MIN_ENCODED_SIZE = V2_FIXED_BODY_SIZE + DIGEST_SIZE
+  private const val V3_FIXED_BODY_SIZE = V2_FIXED_BODY_SIZE + 1
+  private const val V3_MIN_ENCODED_SIZE = V3_FIXED_BODY_SIZE + DIGEST_SIZE
 
   /** Writes the current format. Runtime network consent and private/local gates are never encoded. */
-  fun encode(configuration: MobileAdapterConfiguration): ByteArray {
+  fun encode(configuration: MobileAdapterConfiguration): ByteArray =
+      encodeCustomFormat(configuration, FORMAT_VERSION, includeAdditionalAliases = true)
+
+  /** Exact version-2 fixture writer retained for migration and byte-compatibility tests. */
+  fun encodeVersion2(configuration: MobileAdapterConfiguration): ByteArray {
+    val custom = configuration.networkPolicy as? MobileAdapterNetworkPolicy.CustomServer
+    require(custom?.additionalDnsQueryNames.isNullOrEmpty()) {
+      "Version 2 cannot represent additional DNS query names"
+    }
+    return encodeCustomFormat(
+        configuration,
+        VERSION_2_FORMAT_VERSION,
+        includeAdditionalAliases = false,
+    )
+  }
+
+  private fun encodeCustomFormat(
+      configuration: MobileAdapterConfiguration,
+      version: Int,
+      includeAdditionalAliases: Boolean,
+  ): ByteArray {
     val custom = configuration.networkPolicy as? MobileAdapterNetworkPolicy.CustomServer
     val queryName =
         custom?.dnsQueryName?.toByteArray(StandardCharsets.US_ASCII) ?: EMPTY_BYTES
+    val additionalAliases =
+        if (includeAdditionalAliases) {
+          custom?.additionalDnsQueryNames
+              ?.map { it.toByteArray(StandardCharsets.US_ASCII) }
+              .orEmpty()
+        } else {
+          emptyList()
+        }
     val mappings = custom?.portMappings ?: emptyList()
     val mappingBytes = Math.multiplyExact(mappings.size, PORT_MAPPING_BYTES)
-    val bodySize = Math.addExact(V2_FIXED_BODY_SIZE, Math.addExact(queryName.size, mappingBytes))
+    val additionalAliasBytes = additionalAliases.sumOf { 1 + it.size }
+    val fixedBodySize = if (includeAdditionalAliases) V3_FIXED_BODY_SIZE else V2_FIXED_BODY_SIZE
+    val bodySize =
+        Math.addExact(
+            fixedBodySize,
+            Math.addExact(queryName.size, Math.addExact(additionalAliasBytes, mappingBytes)),
+        )
     val encoded = ByteArray(Math.addExact(bodySize, DIGEST_SIZE))
-    check(encoded.size <= MAX_ENCODED_SIZE)
+    check(encoded.size <= if (includeAdditionalAliases) MAX_ENCODED_SIZE else VERSION_2_MAX_ENCODED_SIZE)
 
     val output = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
     output.put(MAGIC)
-    output.put(FORMAT_VERSION.toByte())
+    output.put(version.toByte())
     output.put(configuration.deviceId.toByte())
     output.put(configuration.configurationBytes())
     output.put(if (custom == null) 0 else CUSTOM_SERVER_FLAG.toByte())
@@ -55,6 +97,13 @@ internal object MobileAdapterConfigurationCodec {
     output.putShort((custom?.resolverPort ?: 0).toShort())
     output.put(queryName.size.toByte())
     output.put(queryName)
+    if (includeAdditionalAliases) {
+      output.put(additionalAliases.size.toByte())
+      additionalAliases.forEach { alias ->
+        output.put(alias.size.toByte())
+        output.put(alias)
+      }
+    }
     output.put(mappings.size.toByte())
     mappings.forEach { mapping ->
       output.put(mapping.transport.wireId.toByte())
@@ -93,7 +142,8 @@ internal object MobileAdapterConfigurationCodec {
     requireMagic(encoded)
     return when (encoded[MAGIC.size].toInt() and 0xff) {
       LEGACY_FORMAT_VERSION -> decodeVersion1(encoded)
-      FORMAT_VERSION -> decodeVersion2(encoded)
+      VERSION_2_FORMAT_VERSION -> decodeVersion2(encoded)
+      FORMAT_VERSION -> decodeVersion3(encoded)
       else -> reject(MobileAdapterConfigurationError.UNSUPPORTED_VERSION)
     }
   }
@@ -121,9 +171,23 @@ internal object MobileAdapterConfigurationCodec {
   }
 
   private fun decodeVersion2(encoded: ByteArray): MobileAdapterConfiguration {
-    if (encoded.size < V2_MIN_ENCODED_SIZE) {
+    if (encoded.size !in V2_MIN_ENCODED_SIZE..VERSION_2_MAX_ENCODED_SIZE) {
       reject(MobileAdapterConfigurationError.MALFORMED_FILE)
     }
+    return decodeCustomFormat(encoded, includeAdditionalAliases = false)
+  }
+
+  private fun decodeVersion3(encoded: ByteArray): MobileAdapterConfiguration {
+    if (encoded.size !in V3_MIN_ENCODED_SIZE..MAX_ENCODED_SIZE) {
+      reject(MobileAdapterConfigurationError.MALFORMED_FILE)
+    }
+    return decodeCustomFormat(encoded, includeAdditionalAliases = true)
+  }
+
+  private fun decodeCustomFormat(
+      encoded: ByteArray,
+      includeAdditionalAliases: Boolean,
+  ): MobileAdapterConfiguration {
     val bodySize = encoded.size - DIGEST_SIZE
     verifyDigest(encoded, bodySize)
     val input = ByteBuffer.wrap(encoded, 0, bodySize).order(ByteOrder.BIG_ENDIAN)
@@ -141,7 +205,7 @@ internal object MobileAdapterConfigurationCodec {
     val resolverPort = input.short.toInt() and 0xffff
     val queryNameLength = input.get().toInt() and 0xff
     if (queryNameLength > MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES ||
-        input.remaining() < queryNameLength + 1) {
+        input.remaining() < queryNameLength + if (includeAdditionalAliases) 2 else 1) {
       reject(MobileAdapterConfigurationError.MALFORMED_FILE)
     }
     val queryNameBytes = ByteArray(queryNameLength)
@@ -150,6 +214,34 @@ internal object MobileAdapterConfigurationCodec {
       reject(MobileAdapterConfigurationError.MALFORMED_FILE)
     }
     val queryName = String(queryNameBytes, StandardCharsets.US_ASCII)
+
+    val additionalAliases =
+        if (includeAdditionalAliases) {
+          val aliasCount = input.get().toInt() and 0xff
+          if (aliasCount > MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES) {
+            reject(MobileAdapterConfigurationError.MALFORMED_FILE)
+          }
+          buildList(aliasCount) {
+            repeat(aliasCount) {
+              if (input.remaining() < 2) {
+                reject(MobileAdapterConfigurationError.MALFORMED_FILE)
+              }
+              val aliasLength = input.get().toInt() and 0xff
+              if (aliasLength !in 1..MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES ||
+                  input.remaining() < aliasLength + 1) {
+                reject(MobileAdapterConfigurationError.MALFORMED_FILE)
+              }
+              val aliasBytes = ByteArray(aliasLength)
+              input.get(aliasBytes)
+              if (aliasBytes.any { it.toInt() !in 0..0x7f }) {
+                reject(MobileAdapterConfigurationError.MALFORMED_FILE)
+              }
+              add(String(aliasBytes, StandardCharsets.US_ASCII))
+            }
+          }
+        } else {
+          emptyList()
+        }
 
     val mappingCount = input.get().toInt() and 0xff
     if (mappingCount > MobileAdapterNetworkPolicy.CustomServer.MAX_PORT_MAPPINGS ||
@@ -179,6 +271,7 @@ internal object MobileAdapterConfigurationCodec {
           if (resolver.any { it != 0.toByte() } ||
               resolverPort != 0 ||
               queryName.isNotEmpty() ||
+              additionalAliases.isNotEmpty() ||
               mappings.isNotEmpty()) {
             reject(MobileAdapterConfigurationError.MALFORMED_FILE)
           }
@@ -190,6 +283,7 @@ internal object MobileAdapterConfigurationCodec {
                 resolver.joinToString(".") { (it.toInt() and 0xff).toString() },
                 resolverPort,
                 mappings,
+                additionalAliases,
             )
           } catch (_: IllegalArgumentException) {
             reject(MobileAdapterConfigurationError.MALFORMED_FILE)
@@ -248,7 +342,13 @@ internal object MobileAdapterConfigurationCodec {
         V2_FIXED_BODY_SIZE +
             MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES +
             MobileAdapterNetworkPolicy.CustomServer.MAX_PORT_MAPPINGS * PORT_MAPPING_BYTES +
-            DIGEST_SIZE == MAX_ENCODED_SIZE)
+            DIGEST_SIZE == VERSION_2_MAX_ENCODED_SIZE)
+    check(
+        VERSION_2_MAX_ENCODED_SIZE +
+            1 +
+            MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES *
+                (1 + MobileAdapterNetworkPolicy.CustomServer.MAX_DNS_QUERY_NAME_BYTES) ==
+            MAX_ENCODED_SIZE)
   }
 
   private val EMPTY_BYTES = ByteArray(0)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterDestinationPolicy.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterDestinationPolicy.kt
@@ -163,32 +163,58 @@ class MobileAdapterTransportTarget private constructor(
   }
 }
 
-/** One exact guest alias/protocol/port capability mapped to one custom transport endpoint. */
+/** One bounded set of exact guest aliases/protocol/port capabilities mapped to one endpoint. */
 class MobileAdapterDestinationRule(
-    alias: String,
+    aliases: Collection<String>,
     val target: MobileAdapterTransportTarget,
     val protocol: MobileAdapterTransportProtocol,
     val guestPort: Int,
     val targetPort: Int = guestPort,
 ) {
-  internal val canonicalAlias: String = canonicalMobileAdapterHost(alias)
+  constructor(
+      alias: String,
+      target: MobileAdapterTransportTarget,
+      protocol: MobileAdapterTransportProtocol,
+      guestPort: Int,
+      targetPort: Int = guestPort,
+  ) : this(listOf(alias), target, protocol, guestPort, targetPort)
+
+  internal val canonicalAliases: List<String>
 
   init {
     require(guestPort in 1..65535) { "Guest port must be in 1..65535" }
     require(targetPort in 1..65535) { "Target port must be in 1..65535" }
+    val boundedAliases = ArrayList<String>(MAX_ALIASES)
+    aliases.forEach { alias ->
+      require(boundedAliases.size < MAX_ALIASES) {
+        "A destination rule supports at most $MAX_ALIASES exact aliases"
+      }
+      boundedAliases.add(canonicalMobileAdapterHost(alias))
+    }
+    require(boundedAliases.isNotEmpty()) { "A destination rule requires at least one exact alias" }
+    val sortedAliases = boundedAliases.sorted()
+    require(sortedAliases.distinct().size == sortedAliases.size) {
+      "A destination rule cannot contain duplicate aliases"
+    }
+    canonicalAliases = java.util.Collections.unmodifiableList(ArrayList(sortedAliases))
   }
+
+  internal val canonicalAlias: String
+    get() = canonicalAliases.first()
+
+  internal fun acceptsCanonicalAlias(alias: String): Boolean = alias in canonicalAliases
 
   override fun equals(other: Any?): Boolean =
       this === other ||
           other is MobileAdapterDestinationRule &&
-              canonicalAlias == other.canonicalAlias &&
+              canonicalAliases == other.canonicalAliases &&
               target == other.target &&
               protocol == other.protocol &&
               guestPort == other.guestPort &&
               targetPort == other.targetPort
 
   override fun hashCode(): Int {
-    var result = canonicalAlias.hashCode()
+    var result = canonicalAliases.hashCode()
     result = 31 * result + target.hashCode()
     result = 31 * result + protocol.hashCode()
     result = 31 * result + guestPort
@@ -196,8 +222,12 @@ class MobileAdapterDestinationRule(
   }
 
   override fun toString(): String =
-      "MobileAdapterDestinationRule(alias=[redacted], target=[redacted], protocol=$protocol, " +
+      "MobileAdapterDestinationRule(aliases=${canonicalAliases.size}, target=[redacted], protocol=$protocol, " +
           "guestPort=[redacted], targetPort=[redacted])"
+
+  companion object {
+    const val MAX_ALIASES: Int = 8
+  }
 }
 
 /**
@@ -218,13 +248,19 @@ class MobileAdapterDestinationPolicy(
     require(revision >= 0) { "Destination policy revision must not be negative" }
     require(rules.size <= MAX_RULES) { "Destination policy exceeds 16 rules" }
     ownedRules = rules.toList()
-    rulesByAlias = ownedRules.groupBy { it.canonicalAlias }
+    rulesByAlias =
+        ownedRules
+            .flatMap { rule -> rule.canonicalAliases.map { alias -> alias to rule } }
+            .groupBy({ it.first }, { it.second })
     require(ownedRules.distinct().size == ownedRules.size) { "Destination policy has duplicate rules" }
+    val aliasRuleCount = ownedRules.sumOf { it.canonicalAliases.size }
     require(
         ownedRules
-            .map { Triple(it.canonicalAlias, it.protocol, it.guestPort) }
+            .flatMap { rule ->
+              rule.canonicalAliases.map { alias -> Triple(alias, rule.protocol, rule.guestPort) }
+            }
             .distinct()
-            .size == ownedRules.size) {
+            .size == aliasRuleCount) {
       "Destination policy has an ambiguous alias, transport, and guest-port mapping"
     }
     require(ownedRules.none { it.target.requiresDns } || resolver != null) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterNetworkBackend.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterNetworkBackend.kt
@@ -532,7 +532,7 @@ class MobileAdapterNetworkBackend(
                     rule.target.literalAddress != null -> rule.target.literalAddress == requestedAddress
                     else ->
                         capabilities.any { capability ->
-                          capability.alias == rule.canonicalAlias &&
+                          rule.acceptsCanonicalAlias(capability.alias) &&
                               capability.target == rule.target &&
                               requestedAddress in capability.addresses
                         }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationStoreTest.kt
@@ -46,18 +46,29 @@ class MobileAdapterConfigurationStoreTest {
             MobileAdapterPortMapping(MobileAdapterTransport.UDP, 443, 8443),
             MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 8080),
         )
+    val suppliedAliases =
+        mutableListOf(
+            "Zeta.Example-Test.Org",
+            "Alt.Example-Test.Org",
+        )
     val policy =
         MobileAdapterNetworkPolicy.CustomServer(
             dnsQueryName = "Api.Example-Test.Org",
             resolverIpv4Address = "192.0.2.53",
             resolverPort = 53,
             portMappings = suppliedMappings,
+            additionalDnsQueryNames = suppliedAliases,
         )
     val configuration = MobileAdapterConfiguration(8, ByteArray(256), policy)
     suppliedMappings.clear()
+    suppliedAliases.clear()
 
     assertEquals(MobileAdapterNetworkMode.CUSTOM_SERVER, policy.mode)
     assertEquals("api.example-test.org", policy.dnsQueryName)
+    assertEquals(
+        listOf("alt.example-test.org", "zeta.example-test.org"),
+        policy.additionalDnsQueryNames,
+    )
     assertEquals("192.0.2.53", policy.resolverIpv4Address)
     assertEquals(MobileAdapterTransport.TCP, policy.portMappings[0].transport)
     assertEquals(MobileAdapterTransport.UDP, policy.portMappings[1].transport)
@@ -69,13 +80,20 @@ class MobileAdapterConfigurationStoreTest {
             "192.0.2.53",
             53,
             policy.portMappings.reversed(),
+            policy.additionalDnsQueryNames.reversed(),
         ),
     )
     assertEquals(policy.hashCode(), configuration.networkPolicy.hashCode())
     assertFalse(policy.toString().contains("api.example-test.org"))
+    assertFalse(policy.toString().contains("alt.example-test.org"))
+    assertTrue(policy.toString().contains("additionalDnsQueryNames=2"))
     assertFalse(policy.toString().contains("192.0.2.53"))
     assertFalse(policy.toString().contains("8080"))
     assertFalse(configuration.toString().contains("example-test"))
+    assertFailsWith<UnsupportedOperationException> {
+      @Suppress("UNCHECKED_CAST")
+      (policy.additionalDnsQueryNames as MutableList<String>).add("mutated.example-test.org")
+    }
     assertEquals("MobileAdapterPortMapping([redacted])", policy.portMappings.single { it.guestPort == 80 }.toString())
   }
 
@@ -144,15 +162,41 @@ class MobileAdapterConfigurationStoreTest {
             .portMappings
             .size,
     )
+    assertEquals(
+        MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES,
+        customPolicy(
+                additionalDnsQueryNames =
+                    (1..MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES)
+                        .map { "alias$it.example.test" })
+            .additionalDnsQueryNames
+            .size,
+    )
+    assertFailsWith<IllegalArgumentException> {
+      customPolicy(
+          additionalDnsQueryNames =
+              (0..MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES)
+                  .map { "alias$it.example.test" })
+    }
+    assertFailsWith<IllegalArgumentException> {
+      customPolicy(additionalDnsQueryNames = listOf("ALIAS.example.test", "alias.example.test"))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      customPolicy(additionalDnsQueryNames = listOf("RESOLVER.EXAMPLE.TEST"))
+    }
+    invalidDnsNames.forEach { dnsName ->
+      assertFailsWith<IllegalArgumentException>(dnsName) {
+        customPolicy(additionalDnsQueryNames = listOf(dnsName))
+      }
+    }
   }
 
   @Test
-  fun `codec deterministically writes bounded version two records`() {
+  fun `codec deterministically writes bounded version three records`() {
     val fallback = MobileAdapterConfiguration.syntheticFallback()
     val first = MobileAdapterConfigurationCodec.encode(fallback)
     val second = MobileAdapterConfigurationCodec.encode(fallback)
 
-    assertEquals(307, first.size)
+    assertEquals(308, first.size)
     assertContentEquals(first, second)
     assertContentEquals("CGBMACFG".toByteArray(StandardCharsets.US_ASCII), first.copyOfRange(0, 8))
     assertEquals(MobileAdapterConfigurationCodec.FORMAT_VERSION, first[8].toInt() and 0xff)
@@ -163,6 +207,35 @@ class MobileAdapterConfigurationStoreTest {
     assertEquals(0x4d, fallback.configurationBytes()[0].toInt() and 0xff)
     assertEquals(0x81, fallback.configurationBytes()[2].toInt() and 0xff)
     assertEquals(127, fallback.configurationBytes()[255].toInt() and 0xff)
+  }
+
+  @Test
+  fun `codec round trips sorted exact aliases and rejects version two alias loss`() {
+    val expected =
+        configuration(
+            8,
+            0x35,
+            customPolicy(
+                portMappings =
+                    listOf(MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080)),
+                additionalDnsQueryNames =
+                    listOf("Zeta.Example.Test", "Alternate.Example.Test"),
+            ),
+        )
+
+    val encoded = MobileAdapterConfigurationCodec.encode(expected)
+    val decoded = MobileAdapterConfigurationCodec.decode(encoded)
+    val policy = decoded.networkPolicy as MobileAdapterNetworkPolicy.CustomServer
+
+    assertEquals(MobileAdapterConfigurationCodec.FORMAT_VERSION, encoded[8].toInt() and 0xff)
+    assertEquals(expected, decoded)
+    assertEquals(
+        listOf("alternate.example.test", "zeta.example.test"),
+        policy.additionalDnsQueryNames,
+    )
+    assertFailsWith<IllegalArgumentException> {
+      MobileAdapterConfigurationCodec.encodeVersion2(expected)
+    }
   }
 
   @Test
@@ -189,10 +262,55 @@ class MobileAdapterConfigurationStoreTest {
   }
 
   @Test
+  fun `codec decodes exact version two custom records and migrates them without aliases`() {
+    val directory = Files.createTempDirectory("coffee-gb-mobile-config-v2")
+    val path = directory.resolve("adapter.bin")
+    val expected =
+        configuration(
+            17,
+            0x29,
+            customPolicy(
+                portMappings =
+                    listOf(MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080))),
+        )
+    val version2 = MobileAdapterConfigurationCodec.encodeVersion2(expected)
+
+    assertEquals(
+        MobileAdapterConfigurationCodec.VERSION_2_FORMAT_VERSION,
+        version2[8].toInt() and 0xff,
+    )
+    val decoded = MobileAdapterConfigurationCodec.decode(version2)
+    assertEquals(expected, decoded)
+    assertTrue(
+        (decoded.networkPolicy as MobileAdapterNetworkPolicy.CustomServer)
+            .additionalDnsQueryNames
+            .isEmpty())
+    Files.write(path, version2)
+
+    val store = MobileAdapterConfigurationStore(path)
+    val loaded = store.load()
+    assertEquals(MobileAdapterConfigurationSource.PERSISTED, loaded.source)
+    assertTrue(store.save(loaded.configuration).saved)
+    val migrated = Files.readAllBytes(path)
+    assertEquals(MobileAdapterConfigurationCodec.FORMAT_VERSION, migrated[8].toInt() and 0xff)
+    assertEquals(expected, MobileAdapterConfigurationCodec.decode(migrated))
+  }
+
+  @Test
   fun `codec accepts maximum DNS and mapping boundaries`() {
     val maximumDnsName =
         listOf("a".repeat(63), "b".repeat(63), "c".repeat(63), "d".repeat(61))
             .joinToString(".")
+    val maximumAliases =
+        ('e'..'k').map { character ->
+          listOf(
+                  character.toString().repeat(63),
+                  character.toString().repeat(63),
+                  character.toString().repeat(63),
+                  character.toString().repeat(61),
+              )
+              .joinToString(".")
+        }
     val mappings =
         (0 until MobileAdapterNetworkPolicy.CustomServer.MAX_PORT_MAPPINGS).map { index ->
           MobileAdapterPortMapping(
@@ -210,14 +328,41 @@ class MobileAdapterConfigurationStoreTest {
                 resolverIpv4Address = "255.255.255.255",
                 resolverPort = 65_535,
                 portMappings = mappings,
+                additionalDnsQueryNames = maximumAliases,
             ),
         )
 
     val encoded = MobileAdapterConfigurationCodec.encode(expected)
 
     assertEquals(253, maximumDnsName.length)
+    assertEquals(
+        MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES,
+        maximumAliases.size,
+    )
+    assertTrue(maximumAliases.all { it.length == 253 })
     assertEquals(MobileAdapterConfigurationCodec.MAX_ENCODED_SIZE, encoded.size)
     assertEquals(expected, MobileAdapterConfigurationCodec.decode(encoded))
+
+    val version2Maximum =
+        MobileAdapterConfigurationCodec.encodeVersion2(
+            configuration(
+                127,
+                0x43,
+                MobileAdapterNetworkPolicy.CustomServer(
+                    maximumDnsName,
+                    "255.255.255.255",
+                    65_535,
+                    mappings,
+                ),
+            ))
+    assertEquals(MobileAdapterConfigurationCodec.VERSION_2_MAX_ENCODED_SIZE, version2Maximum.size)
+    assertEquals(
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+        assertFailsWith<MobileAdapterConfigurationFormatException> {
+              MobileAdapterConfigurationCodec.decode(version2Maximum.copyOf(version2Maximum.size + 1))
+            }
+            .error,
+    )
   }
 
   @Test
@@ -233,10 +378,16 @@ class MobileAdapterConfigurationStoreTest {
                         listOf(
                             MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 8080),
                             MobileAdapterPortMapping(MobileAdapterTransport.UDP, 53, 5353),
-                        )),
+                        ),
+                    additionalDnsQueryNames = listOf("alternate.example.test"),
+                ),
             ))
     val queryNameLength = custom[273].toInt() and 0xff
-    val mappingCountOffset = 274 + queryNameLength
+    val aliasCountOffset = 274 + queryNameLength
+    val firstAliasLengthOffset = aliasCountOffset + 1
+    val firstAliasOffset = firstAliasLengthOffset + 1
+    val firstAliasLength = custom[firstAliasLengthOffset].toInt() and 0xff
+    val mappingCountOffset = firstAliasOffset + firstAliasLength
     val mappingsOffset = mappingCountOffset + 1
 
     assertDecodeError(
@@ -252,7 +403,9 @@ class MobileAdapterConfigurationStoreTest {
         MobileAdapterConfigurationError.MALFORMED_FILE,
     )
     assertDecodeError(
-        offline.clone().also { it[8] = 3 },
+        offline.clone().also {
+          it[8] = (MobileAdapterConfigurationCodec.FORMAT_VERSION + 1).toByte()
+        },
         MobileAdapterConfigurationError.UNSUPPORTED_VERSION,
     )
     assertDecodeError(
@@ -294,6 +447,26 @@ class MobileAdapterConfigurationStoreTest {
         MobileAdapterConfigurationError.MALFORMED_FILE,
     )
     assertDecodeError(
+        mutateAndResign(custom) {
+          it[aliasCountOffset] =
+              (MobileAdapterNetworkPolicy.CustomServer.MAX_ADDITIONAL_DNS_QUERY_NAMES + 1)
+                  .toByte()
+        },
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+    )
+    assertDecodeError(
+        mutateAndResign(custom) { it[firstAliasLengthOffset] = 0 },
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+    )
+    assertDecodeError(
+        mutateAndResign(custom) { it[firstAliasOffset] = 0x80.toByte() },
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+    )
+    assertDecodeError(
+        mutateAndResign(custom) { it[firstAliasOffset] = '_'.code.toByte() },
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+    )
+    assertDecodeError(
         mutateAndResign(custom) { it[mappingCountOffset] = 17 },
         MobileAdapterConfigurationError.MALFORMED_FILE,
     )
@@ -319,6 +492,33 @@ class MobileAdapterConfigurationStoreTest {
     )
     assertDecodeError(
         mutateAndResign(custom.copyOf(custom.size + 1)) {},
+        MobileAdapterConfigurationError.MALFORMED_FILE,
+    )
+
+    val duplicatePrimary =
+        MobileAdapterConfigurationCodec.encode(
+            configuration(
+                8,
+                0x24,
+                customPolicy(
+                    dnsQueryName = "primary.example.test",
+                    additionalDnsQueryNames = listOf("another.example.test"),
+                ),
+            ))
+    val duplicateQueryLength = duplicatePrimary[273].toInt() and 0xff
+    val duplicateAliasCountOffset = 274 + duplicateQueryLength
+    val duplicateAliasLengthOffset = duplicateAliasCountOffset + 1
+    val duplicateAliasOffset = duplicateAliasLengthOffset + 1
+    assertEquals(duplicateQueryLength, duplicatePrimary[duplicateAliasLengthOffset].toInt() and 0xff)
+    assertDecodeError(
+        mutateAndResign(duplicatePrimary) {
+          it.copyInto(
+              destination = it,
+              destinationOffset = duplicateAliasOffset,
+              startIndex = 274,
+              endIndex = 274 + duplicateQueryLength,
+          )
+        },
         MobileAdapterConfigurationError.MALFORMED_FILE,
     )
   }
@@ -673,12 +873,14 @@ class MobileAdapterConfigurationStoreTest {
       resolverIpv4Address: String = "192.0.2.53",
       resolverPort: Int = 53,
       portMappings: Collection<MobileAdapterPortMapping> = emptyList(),
+      additionalDnsQueryNames: Collection<String> = emptyList(),
   ): MobileAdapterNetworkPolicy.CustomServer =
       MobileAdapterNetworkPolicy.CustomServer(
           dnsQueryName,
           resolverIpv4Address,
           resolverPort,
           portMappings,
+          additionalDnsQueryNames,
       )
 
   private fun mutateAndResign(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterDestinationPolicyTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterDestinationPolicyTest.kt
@@ -96,10 +96,11 @@ class MobileAdapterDestinationPolicyTest {
   @Test
   fun `policy freezes exact rules rejects ambiguity and redacts every endpoint`() {
     val target = MobileAdapterTransportTarget.parse("Custom.Example")
+    val aliases = mutableListOf("Secondary.Game.Service", "Game.Service")
     val rules =
         mutableListOf(
             MobileAdapterDestinationRule(
-                "Game.Service",
+                aliases,
                 target,
                 MobileAdapterTransportProtocol.TCP,
                 80,
@@ -119,11 +120,23 @@ class MobileAdapterDestinationPolicyTest {
             MobileAdapterDnsResolver(MobileAdapterIpv4Address.parse("203.0.114.53")),
             rules,
         )
+    aliases.clear()
     rules.clear()
 
     assertEquals(2, policy.rules().size)
+    assertEquals(
+        listOf("game.service", "secondary.game.service"),
+        policy.rules().first { it.protocol == MobileAdapterTransportProtocol.TCP }.canonicalAliases,
+    )
+    assertEquals(2, policy.rulesForCanonicalAlias("game.service").size)
+    assertEquals(1, policy.rulesForCanonicalAlias("secondary.game.service").size)
+    assertFailsWith<UnsupportedOperationException> {
+      @Suppress("UNCHECKED_CAST")
+      (policy.rules().first().canonicalAliases as MutableList<String>).add("mutated.example")
+    }
     val rendered = policy.toString() + policy.rules().joinToString() + target
     assertFalse(rendered.contains("game.service", ignoreCase = true))
+    assertFalse(rendered.contains("secondary.game.service", ignoreCase = true))
     assertFalse(rendered.contains("custom.example", ignoreCase = true))
     assertFalse(rendered.contains("8080"))
     assertTrue(rendered.contains("[redacted]"))
@@ -147,14 +160,14 @@ class MobileAdapterDestinationPolicyTest {
           policy.resolver,
           listOf(
               MobileAdapterDestinationRule(
-                  "game.service",
+                  listOf("game.service", "alternate.service"),
                   target,
                   MobileAdapterTransportProtocol.TCP,
                   80,
                   8080,
               ),
               MobileAdapterDestinationRule(
-                  "game.service",
+                  "ALTERNATE.SERVICE",
                   target,
                   MobileAdapterTransportProtocol.TCP,
                   80,
@@ -175,6 +188,79 @@ class MobileAdapterDestinationPolicyTest {
                 it + 1,
             )
           },
+      )
+    }
+  }
+
+  @Test
+  fun `one rule admits eight immutable exact aliases and rejects empty duplicate or excessive sets`() {
+    val target = MobileAdapterTransportTarget.parse("203.0.114.9")
+    val aliases = (8 downTo 1).mapTo(mutableListOf()) { "Alias$it.Example" }
+    val rule =
+        MobileAdapterDestinationRule(
+            aliases,
+            target,
+            MobileAdapterTransportProtocol.TCP,
+            80,
+            8080,
+        )
+    aliases.clear()
+
+    assertEquals(MobileAdapterDestinationRule.MAX_ALIASES, rule.canonicalAliases.size)
+    assertEquals((1..8).map { "alias$it.example" }.sorted(), rule.canonicalAliases)
+    assertTrue(rule.acceptsCanonicalAlias("alias1.example"))
+    assertFalse(rule.acceptsCanonicalAlias("unconfigured.example"))
+    assertFalse(rule.toString().contains("alias1.example"))
+    assertTrue(rule.toString().contains("aliases=8"))
+    assertFailsWith<IllegalArgumentException> {
+      MobileAdapterDestinationRule(
+          emptyList(),
+          target,
+          MobileAdapterTransportProtocol.TCP,
+          80,
+      )
+    }
+    assertFailsWith<IllegalArgumentException> {
+      MobileAdapterDestinationRule(
+          listOf("Duplicate.Example", "duplicate.example"),
+          target,
+          MobileAdapterTransportProtocol.TCP,
+          80,
+      )
+    }
+    assertFailsWith<IllegalArgumentException> {
+      MobileAdapterDestinationRule(
+          (0..MobileAdapterDestinationRule.MAX_ALIASES).map { "alias$it.example" },
+          target,
+          MobileAdapterTransportProtocol.TCP,
+          80,
+      )
+    }
+  }
+
+  @Test
+  fun `overlapping aliases cannot select different targets even on different ports`() {
+    val firstTarget = MobileAdapterTransportTarget.parse("first-target.example")
+    val secondTarget = MobileAdapterTransportTarget.parse("second-target.example")
+
+    assertFailsWith<IllegalArgumentException> {
+      MobileAdapterDestinationPolicy(
+          1,
+          MobileAdapterDnsResolver(MobileAdapterIpv4Address.parse("203.0.114.53")),
+          listOf(
+              MobileAdapterDestinationRule(
+                  listOf("primary.example", "shared.example"),
+                  firstTarget,
+                  MobileAdapterTransportProtocol.TCP,
+                  80,
+              ),
+              MobileAdapterDestinationRule(
+                  listOf("SHARED.EXAMPLE", "secondary.example"),
+                  secondTarget,
+                  MobileAdapterTransportProtocol.UDP,
+                  53,
+              ),
+          ),
       )
     }
   }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterNetworkBackendTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/mobile/network/MobileAdapterNetworkBackendTest.kt
@@ -793,6 +793,71 @@ class MobileAdapterNetworkBackendTest {
   }
 
   @Test
+  fun `additional exact alias resolves and opens through one shared destination rule`() {
+    val loopback = byteArrayOf(127, 0, 0, 1)
+    ServerSocket(0, 1, InetAddress.getByAddress(loopback)).use { server ->
+      val accepted = CountDownLatch(1)
+      thread(isDaemon = true, name = "mobile-adapter-test-additional-alias") {
+        try {
+          server.accept().use { accepted.countDown() }
+        } catch (_: Exception) {
+          // Fixture close owns termination.
+        }
+      }
+      DnsFixture(listOf(listOf(loopback), listOf(loopback))).use { dns ->
+        val target = MobileAdapterTransportTarget.parse("custom-server.example")
+        val rule =
+            MobileAdapterDestinationRule(
+                listOf("game.service", "trainer.service"),
+                target,
+                MobileAdapterTransportProtocol.TCP,
+                80,
+                server.localPort,
+            )
+        val policy =
+            MobileAdapterDestinationPolicy(
+                1,
+                MobileAdapterDnsResolver(
+                    MobileAdapterIpv4Address.parse("127.0.0.1"),
+                    dns.port,
+                ),
+                listOf(rule),
+            )
+        val backend =
+            MobileAdapterNetworkBackend(
+                policy,
+                MobileAdapterRuntimeAuthorization(true, true),
+            )
+        try {
+          val lookup = submit(backend, 1, DNS_QUERY, alias("trainer.service"))
+          assertEquals(BackendStatus.SUCCESS, lookup.status())
+          assertContentEquals(loopback, lookup.payload())
+
+          val opened = submit(backend, 2, TCP_OPEN, openPayload(127, 0, 0, 1, 80))
+          assertEquals(BackendStatus.SUCCESS, opened.status())
+          assertContentEquals(byteArrayOf(0), opened.payload())
+          assertTrue(accepted.await(2, TimeUnit.SECONDS))
+          assertEquals(1, policy.rules().size)
+          assertEquals(
+              listOf("custom-server.example", "custom-server.example"),
+              listOf(
+                  dns.queries.poll(2, TimeUnit.SECONDS),
+                  dns.queries.poll(2, TimeUnit.SECONDS),
+              ),
+          )
+          assertEquals(
+              BackendStatus.SUCCESS,
+              submit(backend, 3, TCP_CLOSE, byteArrayOf(0)).status(),
+          )
+        } finally {
+          backend.close()
+          assertTrue(backend.awaitTermination(2_000))
+        }
+      }
+    }
+  }
+
+  @Test
   fun `fresh allowed DNS answer must still contain the requested address before socket open`() {
     DnsFixture(
             listOf(

--- a/docs/mobile-adapter-contract.md
+++ b/docs/mobile-adapter-contract.md
@@ -214,6 +214,7 @@ The core engine validates before allocating or indexing:
 | runtime logical connection identifiers | 2 (`0` and `1`), never serialized |
 | transfer packet | 1-byte ID plus `0..253` data bytes |
 | DNS packet/effective ASCII name | 254 / 253 bytes |
+| exact guest DNS aliases per custom server | 8 total: 1 primary plus at most 7 additional |
 | dial body | 1-byte adapter model plus at most 32 dial-string bytes |
 | ISP ID/password | 32 bytes each; never retained after command completion |
 
@@ -227,6 +228,7 @@ waits on NIO channels. The remaining host-side limits are:
 | prepared/terminating backend owner loops | 2 total |
 | backend command payload | 254 bytes |
 | status snapshots | 16, oldest replaced on overflow |
+| destination rules / alias-rule associations | 16 / 128 |
 | raw DNS datagram | 512 bytes |
 | DNS answer/authority/additional records | 32 total |
 | DNS compression pointer jumps / CNAME hops | 16 per decoded name / 4 per selected chain |
@@ -259,11 +261,13 @@ re-snapshots the still-tracked backends and waits under a new shared 2,000 ms de
 re-enables authority or starts a replacement worker.
 
 DNS is a bounded raw UDP A query sent only to the configured literal IPv4 resolver; the JVM system
-resolver is never called. A guest name is only an exact alias into the saved mapping table. A named
-target is freshly resolved immediately before every open, every returned address is reclassified,
-and the exact address requested by the guest must still be present. A changed or newly denied
-answer fails closed. TCP and UDP are outbound and connected to the selected peer; there is no
-listener, bind service, relay, proxy, discovery, unsolicited receive, or ambient DNS path.
+resolver is never called. A guest name is only one of at most eight exact aliases into the saved
+mapping table. Every alias on a rule selects the same configured target, and aliases never multiply
+the 16-rule port-mapping limit. A named target is freshly resolved immediately before every open,
+every returned address is reclassified, and the exact address requested by the guest must still be
+present. A changed or newly denied answer fails closed. TCP and UDP are outbound and connected to
+the selected peer; there is no listener, bind service, relay, proxy, discovery, unsolicited receive,
+wildcard alias, or ambient DNS path.
 
 The two logical IDs are a runtime validation view of controller-owned TCP/UDP resources. They are
 created only by a validated successful open completion, cleared only by matching close, remote
@@ -397,28 +401,33 @@ injected backend, and never captures that backend.
 
 Desktop startup loads configuration on the launcher thread, before entering Swing, and supplies a
 cached immutable value to the controller. The emulator and EDT therefore perform no filesystem
-work. The dedicated file is separate from general preferences. Current variable-length version 2
-is `307..640` bytes:
+work. The dedicated file is separate from general preferences. Current variable-length version 3
+is `308..2419` bytes. Let `n` be the primary-name length and `a` the total bytes occupied by the
+additional length-prefixed aliases:
 
 | Offset | Width | Field |
 |---:|---:|---|
 | 0 | 8 | ASCII magic `CGBMACFG` |
-| 8 | 1 | format version `2` |
+| 8 | 1 | format version `3` |
 | 9 | 1 | device ID `0..127` |
 | 10 | 256 | private configuration bytes |
 | 266 | 1 | known flags; bit 0 means custom-server policy |
 | 267 | 4 | literal resolver IPv4 bytes; zero only in offline mode |
 | 271 | 2 | big-endian resolver port; zero only in offline mode |
 | 273 | 1 | ASCII DNS query-name length `0..253` |
-| 274 | n | canonical DNS query name; empty only in offline mode |
-| 274+n | 1 | mapping count `0..16` |
-| 275+n | 5m | mappings: transport ID, guest port, target port |
+| 274 | n | canonical target and primary guest DNS name; empty only in offline mode |
+| 274+n | 1 | additional exact guest-alias count `0..7` |
+| 275+n | a | aliases, each as a one-byte length `1..253` plus canonical ASCII bytes |
+| 275+n+a | 1 | mapping count `0..16` |
+| 276+n+a | 5m | mappings: transport ID, guest port, target port |
 | final 32 | 32 | SHA-256 of every preceding byte |
 
 The exact 300-byte version-1 record remains readable and migrates to an offline policy; it retains
-its original two-byte configuration-length field and digest layout. Every new save uses version 2.
-Runtime network consent and the separate private/local development gate are deliberately absent
-from both formats and reset on every application start and every policy edit.
+its original two-byte configuration-length field and digest layout. Version 2 remains readable only
+within its original `307..640`-byte bound and migrates with no additional aliases. Every new save
+uses version 3. Older Coffee GB versions reject version 3 rather than misreading it. Runtime network
+consent and the separate private/local development gate are deliberately absent from every format
+and reset on every application start and every policy edit.
 
 ### Guest-authored configuration writes
 
@@ -500,9 +509,10 @@ never enter status text or logs.
 The configuration view reports whether the launcher selected a validated record, recovered backup,
 last-good value, or synthetic fallback, plus the safe device ID, network mode, mapping count, and
 stable diagnostic. Its summary never receives the private byte array or renders resolver/name/port
-values. The editor may show the user's own owner-only policy while it is open. It supports offline
-or custom-server mode, one literal resolver, one canonical DNS name, and exact TCP/UDP guest-to-
-target port mappings.
+values. The editor may show the user's own owner-only policy while it is open. The persisted model
+supports offline or custom-server mode, one literal resolver, one canonical target/primary guest
+name, up to seven additional exact guest aliases, and exact TCP/UDP guest-to-target port mappings.
+UI exposure must preserve all configured aliases rather than silently dropping them.
 
 Runtime authorization is fail-closed and independent of event delivery. Every gate or policy edit
 holds the coordinator authority lock and directly revokes every prepared backend before publishing
@@ -544,7 +554,7 @@ wire; payload redaction applies only to application logs, diagnostics, status ev
 Use only a service and network you trust, and do not put credentials, tokens, or other secrets in a
 custom-service flow.
 
-The owner-only configuration file necessarily contains the configured resolver, query name, port
+The owner-only configuration file necessarily contains the configured resolver, query names, port
 mappings, and the adapter's private 256-byte configuration region. Runtime consent flags are never
 stored. The configuration editor shows the values entered by its user, but summaries and runtime
 status expose only mode, counts, slot IDs, phases, and typed errors. The policy's special-range

--- a/docs/mobile-adapter-crystal-reon-validation.md
+++ b/docs/mobile-adapter-crystal-reon-validation.md
@@ -213,6 +213,7 @@ Until a real ROM completes the declared request/response, game-visible result, a
 against REON, the strict result remains partial, with no additional core protocol or
 production-backend conclusion inferred from the importer.
 
-The current custom-server policy admits one exact guest DNS alias. Any future ROM trace that needs
-additional mail, time, or content aliases requires an explicit bounded multi-alias policy rather
-than wildcard or ambient DNS access.
+The custom-server policy admits one primary and at most seven additional exact guest DNS aliases
+for the same configured target. This covers a bounded service family without multiplying port
+mapping rules or allowing wildcard or ambient DNS access. A fresh ROM-to-service trace is still
+required before this document can claim complete #399 acceptance.

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinator.kt
@@ -826,7 +826,7 @@ internal class MobileAdapterConfigurationCoordinator(
             val rules =
                 policy.portMappings.map { mapping ->
                   MobileAdapterDestinationRule(
-                      policy.dnsQueryName,
+                      listOf(policy.dnsQueryName) + policy.additionalDnsQueryNames,
                       target,
                       when (mapping.transport) {
                         MobileAdapterTransport.TCP -> MobileAdapterTransportProtocol.TCP

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinatorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MobileAdapterConfigurationCoordinatorTest.kt
@@ -368,15 +368,18 @@ class MobileAdapterConfigurationCoordinatorTest {
   }
 
   @Test
-  fun `policy conversion is exact bounded and redacted`() {
+  fun `policy conversion shares aliases without multiplying mappings and remains redacted`() {
     val configuration = customConfiguration()
     val custom = configuration.networkPolicy as MobileAdapterNetworkPolicy.CustomServer
     val policy = MobileAdapterConfigurationCoordinator.destinationPolicy(9, custom)
 
     assertEquals(9, policy.revision)
-    assertEquals(2, policy.rules().size)
+    assertEquals(custom.portMappings.size, policy.rules().size)
+    assertEquals(2, custom.additionalDnsQueryNames.size)
     assertEquals(setOf(80, 53), policy.rules().map { it.guestPort }.toSet())
+    assertTrue(policy.rules().all { it.toString().contains("aliases=3") })
     assertFalse(policy.toString().contains("service.example"))
+    assertFalse(policy.rules().joinToString().contains("trainer.example"))
     assertFalse(policy.toString().contains("127.0.0.1"))
     assertTrue(policy.toString().contains("rules=2"))
   }
@@ -1494,6 +1497,7 @@ class MobileAdapterConfigurationCoordinatorTest {
                   MobileAdapterPortMapping(MobileAdapterTransport.TCP, 80, 18080),
                   MobileAdapterPortMapping(MobileAdapterTransport.UDP, 53, 15353),
               ),
+              listOf("trainer.example", "browser.example"),
           ),
       )
 


### PR DESCRIPTION
## Summary

- allow one Mobile Adapter custom-server target to accept one primary and up to seven additional exact guest DNS aliases
- keep one destination rule per port mapping, with bounded alias indexing and fail-closed DNS capabilities
- write configuration format v3 while preserving exact v1/v2 reads and the original v2 size ceiling
- document the persistence schema, limits, privacy boundary, and UI sequencing requirement

## Why

The REON-backed Mobile Trainer flow can use more than one exact service alias before reaching its content endpoint. The existing single-alias policy rejects that flow before DNS resolution. This adds the bounded model needed for issue #399 without wildcard DNS, ambient resolver access, or multiplying the 16-rule port-mapping limit.

References #399.

## Validation

- focused Mobile Adapter configuration, destination-policy, backend, and coordinator suite: 82 tests, 0 failures
- `mvn -B -Dkotlin.compiler.daemon=false clean test`
  - core: 1,109 tests, 0 failures/errors, 2 skipped
  - controller: 917 tests, 0 failures/errors, 2 skipped
  - CLI: 46 tests, 0 failures/errors
  - Swing: 673 tests, 0 failures/errors
- two independent read-only reviews found no actionable correctness, compatibility, allocation, privacy, migration, documentation, or test-quality issues
