### PR TITLE
Prevent Gambatte cold-boot test timeouts

### DIFF
--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gambatte/GambatteHwRomTest.java
@@ -104,6 +104,13 @@ public class GambatteHwRomTest {
             parameters.add(new Object[]{test.rom(), bytes, test.gameboyType(), test.expected(),
                     currentBaseline.getOrDefault(test.key(), test.expected())});
         }
+        // A cold authentic-BIOS boot can exceed this test's per-case deadline on a
+        // busy CI runner. Prime each distinct cache entry during parameter discovery,
+        // before those deadlines begin; subsequent test instances restore its memento.
+        for (Object[] parameter : parameters) {
+            GambatteHwTestRunner.primePostBootState(
+                    (byte[]) parameter[1], (GameboyType) parameter[2]);
+        }
         return parameters;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/GambatteHwTestRunner.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/support/GambatteHwTestRunner.java
@@ -43,14 +43,38 @@ public final class GambatteHwTestRunner {
 
     public GambatteHwTestRunner(byte[] rom, GameboyType gameboyType) throws IOException {
         Rom parsedRom = new Rom(rom);
-        Gameboy.GameboyConfiguration configuration = new Gameboy.GameboyConfiguration(parsedRom)
-                .setGameboyType(gameboyType)
-                .setSupportBatterySave(false);
+        Gameboy.GameboyConfiguration configuration = configuration(parsedRom, gameboyType);
         gameboy = buildAtPostBoot(configuration, bootHeader(parsedRom));
         // The runner is fully synchronous. The default EventBusImpl starts a polling
         // thread; using one per parameterized ROM would retain every completed emulator
         // until JVM exit and make an exhaustive run grow without bound.
         gameboy.init(new EventBusImpl(null, null, false), SerialEndpoint.NULL_ENDPOINT, null);
+    }
+
+    /**
+     * Populates the post-boot cache outside JUnit's per-ROM deadline. A first boot can
+     * take several seconds on a contended CI runner, while restoring its memento is
+     * fast and deterministic.
+     */
+    public static void primePostBootState(byte[] rom, GameboyType gameboyType)
+            throws IOException {
+        Rom parsedRom = new Rom(rom);
+        Gameboy.GameboyConfiguration configuration = configuration(parsedRom, gameboyType);
+        BootStateKey key = new BootStateKey(configuration.getGameboyType(), bootHeader(parsedRom));
+        synchronized (POST_BOOT_STATES) {
+            if (!POST_BOOT_STATES.containsKey(key)) {
+                Gameboy booted = configuration
+                        .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                        .build();
+                POST_BOOT_STATES.put(key, booted.captureState());
+            }
+        }
+    }
+
+    private static Gameboy.GameboyConfiguration configuration(Rom rom, GameboyType gameboyType) {
+        return new Gameboy.GameboyConfiguration(rom)
+                .setGameboyType(gameboyType)
+                .setSupportBatterySave(false);
     }
 
     private static Gameboy buildAtPostBoot(


### PR DESCRIPTION
## Summary

Prime Gambatte HWTest post-BIOS snapshots while JUnit discovers parameters, before each parameterized case starts its 10-second deadline.

## Root cause

The test runner populated its post-BIOS cache from the first test case for each ROM-header and hardware combination. On contended GitHub runners, an authentic cold boot could use the full per-case JUnit deadline, causing false timeouts even though the ROM test itself was not stalled.

## Validation

- `mvn -B -pl core test -Ptest-gambatte-hw` — 4,674 tests passed in 125.0 seconds
- `mvn -B -pl core -Dtest=GambatteHwTestRunnerTest test` — passed
