### PR TITLE
Add persistent Game Boy play skill

### DIFF
--- a/.claude/skills/play-gb-rom/SKILL.md
+++ b/.claude/skills/play-gb-rom/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: play-gb-rom
+description: Run an authorized local Game Boy or Game Boy Color ROM in one persistent headless Coffee GB session, inspect captured frames, send controller input interactively, and retain a frame-accurate action trace for replay or test authoring. Use when asked to play, navigate, explore, reproduce, or automate gameplay without restarting the emulator between inputs.
+---
+
+# Play GB ROM
+
+Keep one emulator process alive, inspect its latest PNG, decide the next input, and append every
+action to a private trace. Use this loop for long playthroughs as well as short reproduction work.
+
+## Start one private session
+
+1. Work from a clean or task-specific Coffee GB checkout.
+2. Resolve exactly one user-authorized ROM. Honor local `AGENTS.md` instructions. Never guess among
+   ambiguous revisions, and never print, copy, hash, upload, or commit the ROM or save data.
+3. Start the bundled driver in a PTY so stdin stays open:
+
+   ```text
+   .claude/skills/play-gb-rom/scripts/play-gb-rom.sh <authorized-rom>
+   ```
+
+   Use a tool invocation with `tty: true` and a short initial yield. The wrapper builds Coffee GB,
+   creates a mode-700 directory under `/tmp`, compiles the driver there, and prints the private
+   session directory plus sanitized build progress. A cold build may take about a minute. It reads
+   the ROM in place and does not copy or symlink it.
+4. Keep the returned process/session ID. Do not relaunch the driver for each action.
+
+The current `Agent` backend intentionally disables battery writes and attaches a null serial
+endpoint. A session therefore starts from the ROM's normal initial state, retains progress only
+while the process lives, and cannot exercise link peripherals. Report this limitation when the
+requested playthrough depends on saves, RTC persistence, multiplayer, printer, or Mobile Adapter
+traffic.
+
+## Drive and inspect
+
+Send one newline-terminated command at a time:
+
+```text
+BUTTON A
+BUTTON RIGHT 12 60
+STEP 120
+CAPTURE map
+STATUS
+QUIT
+```
+
+- `BUTTON <RIGHT|LEFT|UP|DOWN|A|B|SELECT|START> [hold_frames] [dwell_frames]` presses, advances the
+  held frames, always releases, advances the dwell frames, and captures the resulting frame.
+  Defaults are 3 held frames and 30 dwell frames.
+- `STEP <frames>` advances without input and captures the resulting frame.
+- `CAPTURE [label]` records the current frame without advancing. Labels are optional safe tokens.
+- `STATUS` reports emulated tick/frame, CPU/PPU state, and the latest frame token without advancing.
+- `QUIT` releases input, closes the owner thread, and leaves the private trace and frames available.
+
+Counts are bounded per command. For long waits, issue several `STEP` commands so the user receives
+regular progress updates and tool calls do not block for more than 60 seconds.
+
+After each action, open the reported PNG from `<session>/frames/` with the local image-viewing tool.
+Use the visible screen—not guessed menu timing—to choose the next input. Keep commentary concise for
+long runs: report milestones, ambiguity, and blockers rather than narrating every button.
+The initial one-frame capture may legitimately be black during startup; issue `STEP` and inspect the
+next capture before classifying that as a failure. Use about a one-second stdin-tool yield for normal
+commands because the resident process remains alive after printing its result; poll again only when
+no action marker has arrived.
+
+## Preserve reproducibility
+
+`actions.tsv` records command order, starting and ending emulated positions, hold/dwell/step frame
+counts, and PNG basenames. It deliberately contains no ROM identity or filesystem path. Treat the
+trace as the source for a later deterministic input script or integration test; copy only generic
+button/timing facts into repository tests or documentation.
+
+When a destination is ambiguous, capture and inspect instead of restarting. If an action produces
+an unexpected screen, continue from the resident session when safe and record the correction. Do
+not claim a complete playthrough from transport or memory evidence alone; confirm the visible end
+state.
+
+## Finish safely
+
+Send `QUIT`, confirm `cleanup_buttons=true` and `session_closed=true`, then remove only the exact
+private session directory when its frames and trace are no longer needed. Prefer `QUIT` over a signal
+so the completion markers are observable; the shutdown hook still releases input and closes the
+Agent if the process is interrupted. Never commit or publish commercial screenshots, the action
+trace if it identifies private gameplay, generated class files, ROMs, saves, or local paths.

--- a/.claude/skills/play-gb-rom/agents/openai.yaml
+++ b/.claude/skills/play-gb-rom/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Play GB ROM"
+  short_description: "Interactively play and record Coffee GB ROMs"
+  default_prompt: "Use $play-gb-rom to play an authorized local Game Boy ROM interactively and record a reproducible input trace."

--- a/.claude/skills/play-gb-rom/scripts/PlayGbRom.java
+++ b/.claude/skills/play-gb-rom/scripts/PlayGbRom.java
@@ -1,0 +1,353 @@
+import eu.rekawek.coffeegb.controller.Agent;
+import eu.rekawek.coffeegb.core.debug.DebugResult;
+import eu.rekawek.coffeegb.core.debug.DebugSnapshot;
+import eu.rekawek.coffeegb.core.debug.DebugStepKind;
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import javax.imageio.ImageIO;
+
+/** Private, persistent stdin driver for the Coffee GB headless Agent. */
+public final class PlayGbRom {
+
+  private static final int MAX_FRAMES_PER_COMMAND = 3_600;
+  private static final Set<Button> BUTTONS = EnumSet.allOf(Button.class);
+
+  private final Agent agent;
+  private final Path framesDirectory;
+  private final BufferedWriter actionLog;
+  private final EnumSet<Button> heldButtons = EnumSet.noneOf(Button.class);
+  private BufferedImage latestFrame;
+  private String latestFrameToken = "none";
+  private long sequence;
+
+  private PlayGbRom(Agent agent, Path sessionDirectory) throws IOException {
+    this.agent = agent;
+    this.framesDirectory = sessionDirectory.resolve("frames");
+    Files.createDirectory(framesDirectory);
+    this.actionLog =
+        Files.newBufferedWriter(
+            sessionDirectory.resolve("actions.tsv"),
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE_NEW,
+            StandardOpenOption.WRITE);
+    actionLog.write(
+        "sequence\taction\tstart_tick\tstart_frame\thold_frames\tdwell_frames"
+            + "\tstep_frames\tend_tick\tend_frame\tframe\n");
+    actionLog.flush();
+  }
+
+  public static void main(String[] args) {
+    if (args.length != 2) {
+      fail("INVALID_ARGUMENTS");
+      System.exit(2);
+      return;
+    }
+    Path rom = Path.of(args[0]);
+    Path session = Path.of(args[1]);
+    if (!Files.isRegularFile(rom) || !Files.isReadable(rom)) {
+      fail("ROM_UNREADABLE");
+      System.exit(2);
+      return;
+    }
+    if (!Files.isDirectory(session, LinkOption.NOFOLLOW_LINKS)) {
+      fail("SESSION_INVALID");
+      System.exit(2);
+      return;
+    }
+
+    try (Agent agent = new Agent(rom.toFile())) {
+      PlayGbRom driver = new PlayGbRom(agent, session);
+      Thread hook = new Thread(driver::closeOnShutdown, "play-gb-rom-cleanup");
+      Runtime.getRuntime().addShutdownHook(hook);
+      try {
+        driver.run();
+      } finally {
+        try {
+          driver.releaseAll();
+        } finally {
+          driver.actionLog.close();
+          try {
+            Runtime.getRuntime().removeShutdownHook(hook);
+          } catch (IllegalStateException ignored) {
+            // The hook is already running during VM shutdown.
+          }
+        }
+      }
+    } catch (Throwable failure) {
+      fail("SESSION_FAILED");
+      System.exit(6);
+    }
+    System.out.println("session_closed=true");
+    System.out.flush();
+  }
+
+  private void run() throws Exception {
+    DebugSnapshot start = agent.snapshot();
+    stepFrames(1);
+    updateLatestFrame();
+    DebugSnapshot end = agent.snapshot();
+    writeAction("INITIAL", start, 0, 0, 1, end, "initial");
+    System.out.println("session_ready=true");
+    System.out.println("action_log_token=actions.tsv");
+    System.out.println(
+        "commands=BUTTON_name_hold_dwell,STEP_frames,CAPTURE_label,STATUS,QUIT");
+    emitStatus();
+    System.out.flush();
+
+    try (BufferedReader input =
+        new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = input.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.isEmpty()) {
+          commandError("EMPTY_COMMAND");
+          continue;
+        }
+        try {
+          if (!execute(trimmed)) {
+            System.out.println("session_quit=true");
+            System.out.flush();
+            break;
+          }
+        } catch (CommandSyntaxException syntax) {
+          commandError(syntax.code);
+        }
+      }
+    }
+    System.out.println("cleanup_buttons=true");
+  }
+
+  private boolean execute(String line) throws Exception {
+    String[] words = line.split("\\s+");
+    String command = words[0].toUpperCase(Locale.ROOT);
+    switch (command) {
+      case "BUTTON" -> executeButton(words);
+      case "STEP" -> executeStep(words);
+      case "CAPTURE" -> executeCapture(words);
+      case "STATUS" -> {
+        requireLength(words, 1);
+        emitStatus();
+      }
+      case "QUIT" -> {
+        requireLength(words, 1);
+        return false;
+      }
+      default -> throw new CommandSyntaxException("UNKNOWN_COMMAND");
+    }
+    System.out.flush();
+    return true;
+  }
+
+  private void executeButton(String[] words) throws Exception {
+    if (words.length < 2 || words.length > 4) {
+      throw new CommandSyntaxException("INVALID_BUTTON_COMMAND");
+    }
+    Button button;
+    try {
+      button = Button.valueOf(words[1].toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException invalid) {
+      throw new CommandSyntaxException("INVALID_BUTTON");
+    }
+    if (!BUTTONS.contains(button)) {
+      throw new CommandSyntaxException("INVALID_BUTTON");
+    }
+    int holdFrames = words.length >= 3 ? frames(words[2], 1) : 3;
+    int dwellFrames = words.length == 4 ? frames(words[3], 0) : 30;
+    DebugSnapshot start = agent.snapshot();
+    boolean pressed = false;
+    try {
+      agent.pressButton(button);
+      heldButtons.add(button);
+      pressed = true;
+      stepFrames(holdFrames);
+    } finally {
+      if (pressed) {
+        agent.releaseButton(button);
+        heldButtons.remove(button);
+      }
+    }
+    stepFrames(dwellFrames);
+    updateLatestFrame();
+    DebugSnapshot end = agent.snapshot();
+    writeAction(
+        "BUTTON_" + button.name(), start, holdFrames, dwellFrames,
+        holdFrames + dwellFrames, end, button.name().toLowerCase(Locale.ROOT));
+    emitAction(end, "BUTTON_" + button.name());
+  }
+
+  private void executeStep(String[] words) throws Exception {
+    requireLength(words, 2);
+    int frameCount = frames(words[1], 1);
+    DebugSnapshot start = agent.snapshot();
+    stepFrames(frameCount);
+    updateLatestFrame();
+    DebugSnapshot end = agent.snapshot();
+    writeAction("STEP", start, 0, 0, frameCount, end, "step");
+    emitAction(end, "STEP");
+  }
+
+  private void executeCapture(String[] words) throws Exception {
+    if (words.length < 1 || words.length > 2) {
+      throw new CommandSyntaxException("INVALID_CAPTURE_COMMAND");
+    }
+    String label = words.length == 2 ? safeLabel(words[1]) : "capture";
+    updateLatestFrame();
+    DebugSnapshot snapshot = agent.snapshot();
+    writeAction("CAPTURE", snapshot, 0, 0, 0, snapshot, label);
+    emitAction(snapshot, "CAPTURE");
+  }
+
+  private void stepFrames(int count) throws Exception {
+    for (int i = 0; i < count; i++) {
+      requireSuccess(agent.getDebugPort().step(DebugStepKind.FRAME));
+    }
+  }
+
+  private void updateLatestFrame() {
+    BufferedImage candidate;
+    while ((candidate = agent.getFrame()) != null) {
+      latestFrame = candidate;
+    }
+  }
+
+  private void writeAction(
+      String action,
+      DebugSnapshot start,
+      int holdFrames,
+      int dwellFrames,
+      int stepFrames,
+      DebugSnapshot end,
+      String label)
+      throws IOException {
+    if (latestFrame == null) {
+      throw new IOException("frame unavailable");
+    }
+    long currentSequence = sequence++;
+    String token = String.format("%06d-%s.png", currentSequence, label);
+    Path target = framesDirectory.resolve(token);
+    if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+        || !ImageIO.write(latestFrame, "png", target.toFile())) {
+      throw new IOException("frame publication failed");
+    }
+    latestFrameToken = token;
+    actionLog.write(
+        currentSequence + "\t" + action + "\t" + start.masterTick() + "\t" + start.frame()
+            + "\t" + holdFrames + "\t" + dwellFrames + "\t" + stepFrames + "\t"
+            + end.masterTick() + "\t" + end.frame() + "\t" + token + "\n");
+    actionLog.flush();
+  }
+
+  private void emitAction(DebugSnapshot snapshot, String action) {
+    System.out.println("sequence=" + (sequence - 1));
+    System.out.println("action=" + action);
+    System.out.println("frame_token=" + latestFrameToken);
+    System.out.println("emulated_tick=" + snapshot.masterTick());
+    System.out.println("emulated_frame=" + snapshot.frame());
+  }
+
+  private void emitStatus() {
+    DebugSnapshot snapshot = agent.snapshot();
+    System.out.println("status_tick=" + snapshot.masterTick());
+    System.out.println("status_frame=" + snapshot.frame());
+    System.out.println("status_frame_position=" + snapshot.framePosition());
+    System.out.println("status_cpu=" + snapshot.execution().cpuState().name());
+    System.out.println("status_lcd=" + (snapshot.ppu().lcdEnabled() ? "ENABLED" : "DISABLED"));
+    System.out.println("status_ppu_mode=" + snapshot.ppu().mode().name());
+    System.out.println("status_ppu_line=" + snapshot.ppu().line());
+    System.out.println("status_frame_token=" + latestFrameToken);
+  }
+
+  private synchronized void releaseAll() {
+    for (Button button : EnumSet.copyOf(heldButtons)) {
+      try {
+        agent.releaseButton(button);
+      } finally {
+        heldButtons.remove(button);
+      }
+    }
+  }
+
+  private void releaseAllSilently() {
+    try {
+      releaseAll();
+    } catch (Throwable ignored) {
+      // Shutdown remains best-effort; Agent.close owns final machine cleanup.
+    }
+  }
+
+  private void closeOnShutdown() {
+    releaseAllSilently();
+    try {
+      agent.close();
+    } catch (Throwable ignored) {
+      // The owner may already be closing; process shutdown remains best-effort.
+    }
+  }
+
+  private static int frames(String value, int minimum) throws CommandSyntaxException {
+    try {
+      int parsed = Integer.parseInt(value);
+      if (parsed < minimum || parsed > MAX_FRAMES_PER_COMMAND) {
+        throw new CommandSyntaxException("FRAME_COUNT_OUT_OF_RANGE");
+      }
+      return parsed;
+    } catch (NumberFormatException invalid) {
+      throw new CommandSyntaxException("INVALID_FRAME_COUNT");
+    }
+  }
+
+  private static String safeLabel(String value) throws CommandSyntaxException {
+    if (!value.matches("[A-Za-z0-9_-]{1,32}")) {
+      throw new CommandSyntaxException("INVALID_LABEL");
+    }
+    return value.toLowerCase(Locale.ROOT);
+  }
+
+  private static void requireLength(String[] words, int length) throws CommandSyntaxException {
+    if (words.length != length) {
+      throw new CommandSyntaxException("INVALID_COMMAND_ARITY");
+    }
+  }
+
+  private static <T> T requireSuccess(CompletionStage<DebugResult<T>> stage) throws Exception {
+    DebugResult<T> result = stage.toCompletableFuture().get();
+    if (result.isFailure()) {
+      throw new IllegalStateException("debug command failed");
+    }
+    return result.value();
+  }
+
+  private static void commandError(String code) {
+    System.out.println("command_error=" + code);
+    System.out.flush();
+  }
+
+  private static void fail(String code) {
+    System.err.println("session_error=" + code);
+    System.err.flush();
+  }
+
+  private static final class CommandSyntaxException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    private final String code;
+
+    private CommandSyntaxException(String code) {
+      this.code = code;
+    }
+  }
+}

--- a/.claude/skills/play-gb-rom/scripts/play-gb-rom.sh
+++ b/.claude/skills/play-gb-rom/scripts/play-gb-rom.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+if [[ $# -ne 1 ]]; then
+  echo 'error=usage' >&2
+  exit 2
+fi
+
+rom_path=$1
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+
+if [[ ! -f $rom_path || ! -r $rom_path ]]; then
+  echo 'error=rom_unreadable' >&2
+  exit 2
+fi
+
+session_dir=$(mktemp -d /tmp/coffee-gb-play.XXXXXX)
+echo "session_dir=$session_dir"
+echo 'build_started=true'
+
+cleanup_failed_setup() {
+  local status=$?
+  if [[ $status -ne 0 ]]; then
+    rm -rf -- "$session_dir"
+  fi
+  return "$status"
+}
+trap cleanup_failed_setup EXIT
+
+mvn -q -DskipTests -Dkotlin.compiler.daemon=false -pl cli -am package -f "$repo_root/pom.xml"
+echo 'build_finished=true'
+
+mkdir -m 700 -- "$session_dir/classes"
+javac --release 16 \
+  -cp "$repo_root/cli/target/coffee-gb-cli.jar" \
+  -d "$session_dir/classes" \
+  "$script_dir/PlayGbRom.java"
+
+trap - EXIT
+exec java \
+  -Djava.awt.headless=true \
+  -Dorg.slf4j.simpleLogger.defaultLogLevel=error \
+  -cp "$session_dir/classes:$repo_root/cli/target/coffee-gb-cli.jar" \
+  PlayGbRom "$rom_path" "$session_dir"


### PR DESCRIPTION
## Summary

- add a repository-local `$play-gb-rom` skill for long-lived, screen-driven Game Boy sessions
- provide a PTY-friendly Java driver with `BUTTON`, `STEP`, `CAPTURE`, `STATUS`, and `QUIT` commands
- capture every action as a private PNG plus a frame/tick-accurate sanitized TSV trace
- keep ROMs in place, disable battery writes, use a null serial endpoint, and cleanly release input/Agent ownership

The intent is to let a future agent navigate a game from the visible screen without restarting the emulator for each input, then convert the recorded generic button/timing sequence into a focused integration test.

## Validation

- skill schema validator: passed
- `bash -n` and `javac --release 16 -Xlint:all`: passed without warnings
- independent forward test used one resident PTY session with a repository-owned test ROM: initial capture, button input, frame step, status, visible PNG inspection, and clean quit all passed
- trace/privacy audit: only generic actions, timing, and PNG basenames; directories are mode 700 and files are mode 600
- malformed-command recovery, build-failure cleanup, and interrupted-process Agent shutdown: passed

## AI assistance

AI assistance was used to design, implement, and forward-test the skill. Validation used only a repository-owned test fixture; no commercial ROM, save, screenshot, identity, path, or checksum is included.
