### PR TITLE
Shard gbc-hw-tests in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,8 +72,6 @@ jobs:
             profiles: test-mealybug
           - name: GBMicrotest
             profiles: test-gbmicrotest
-          - name: gbc-hw-tests
-            profiles: test-gbc-hw
           - name: Misc.-GB-Tests
             profiles: test-misc-gb
 
@@ -87,3 +85,23 @@ jobs:
         cache: maven
     - name: Run integration tests
       run: mvn -B -pl core test -P"${{ matrix.profiles }}"
+
+  gbc-hw-tests:
+    name: gbc-hw-tests (shard ${{ matrix.shard }}/2)
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: Set up JDK 21
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run gbc-hw-tests shard
+      run: mvn -B -pl core test -Ptest-gbc-hw -Dgbc.hw.shard=${{ matrix.shard }}/2

--- a/core/src/test/java/eu/rekawek/coffeegb/core/integration/gbchw/GbcHwRomTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/integration/gbchw/GbcHwRomTest.java
@@ -30,6 +30,13 @@ public class GbcHwRomTest {
 
     private static final String ARCHIVE = "/roms/gbc-hw-tests/gbc-hw-tests-631e600.zip";
 
+    /**
+     * Optional one-based shard selection in the {@code shard/total} form. GitHub Actions runs
+     * the suite as {@code 1/2} and {@code 2/2}; local runs leave this unset and execute every
+     * verdict.
+     */
+    private static final String SHARD_PROPERTY = "gbc.hw.shard";
+
     private static final String TAC_GBC_DOCUMENTATION =
             "timers/tac_set_everything/GBC_1.txt";
 
@@ -188,7 +195,37 @@ public class GbcHwRomTest {
             throw new IOException("Expected 221 gbc-hw-tests strict verdicts, found "
                     + parameters.size());
         }
-        return parameters;
+        return selectShard(parameters, System.getProperty(SHARD_PROPERTY));
+    }
+
+    private static List<Object[]> selectShard(List<Object[]> parameters, String shard) {
+        if (shard == null || shard.isBlank()) {
+            return parameters;
+        }
+        String[] components = shard.split("/", -1);
+        if (components.length != 2) {
+            throw new IllegalArgumentException("Invalid " + SHARD_PROPERTY + ": " + shard
+                    + "; expected shard/total");
+        }
+        int shardNumber;
+        int shardCount;
+        try {
+            shardNumber = Integer.parseInt(components[0]);
+            shardCount = Integer.parseInt(components[1]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid " + SHARD_PROPERTY + ": " + shard
+                    + "; expected numeric shard/total", e);
+        }
+        if (shardCount < 1 || shardNumber < 1 || shardNumber > shardCount) {
+            throw new IllegalArgumentException("Invalid " + SHARD_PROPERTY + ": " + shard
+                    + "; shard must be between 1 and total");
+        }
+
+        List<Object[]> selected = new ArrayList<>();
+        for (int i = shardNumber - 1; i < parameters.size(); i += shardCount) {
+            selected.add(parameters.get(i));
+        }
+        return selected;
     }
 
     private static void addReference(List<Object[]> parameters, Map<String, byte[]> entries,


### PR DESCRIPTION
## Summary

- Run the GBC hardware test suite in two parallel GitHub Actions shards.
- Keep local runs unsharded while selecting stable, complementary CI subsets.

## Validation

- `mvn -B -pl core -DskipTests test-compile`
- `mvn -B -pl core test -Ptest-gbc-hw -Dgbc.hw.shard=1/2`
- `mvn -B -pl core test -Ptest-gbc-hw -Dgbc.hw.shard=2/2`