### PR TITLE
Fix About dialog layout overflow

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
@@ -269,7 +269,12 @@ internal class DesktopAboutPanel(
       readOnlyHelpText(
           "Pocket Brew desktop emulator for Game Boy and Game Boy Color.",
           "Coffee GB description",
-      )
+      ).apply {
+        // The description wraps at the About dialog's reading width. Reserve both lines while
+        // packing so the copy control cannot be laid out underneath the dialog action bar.
+        columns = ABOUT_DESCRIPTION_COLUMNS
+        rows = ABOUT_DESCRIPTION_ROWS
+      }
   private val versionLabel =
       JLabel("Version: $version").apply {
         alignmentX = Component.LEFT_ALIGNMENT
@@ -426,3 +431,5 @@ private fun systemHelpUriOpener(): DesktopUriOpener =
 
 private const val COFFEE_GB_SOURCE_URL = "https://github.com/trekawek/coffee-gb"
 private val COFFEE_GB_SOURCE_URI = URI.create(COFFEE_GB_SOURCE_URL)
+private const val ABOUT_DESCRIPTION_COLUMNS = 48
+private const val ABOUT_DESCRIPTION_ROWS = 2

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogsTest.kt
@@ -104,6 +104,28 @@ class DesktopHelpDialogsTest {
         assertEquals(left, about.copyButton.x)
       }
 
+  @Test
+  fun `about content fits above its dialog actions at packed size`() =
+      onEdt {
+        val about = DesktopAboutPanel("1.2.3")
+        val panel =
+            DesktopDialogFactory(tokenProvider = ::tokens)
+                .createContentPanel(
+                    DesktopContentSpec(
+                        title = "About Coffee GB",
+                        accessibleDescription = "Application information.",
+                        contentAccessibleName = "Application information",
+                        buttons = DesktopDialogButtons(cancel = DesktopDialogAction("Close", Unit)),
+                    ),
+                    about,
+                ) {}
+
+        panel.size = panel.preferredSize
+        layoutTree(panel)
+
+        assertTrue(about.copyButton.y + about.copyButton.height <= panel.buttonBar.y)
+      }
+
   private fun actionRegistry(): DesktopActionRegistry =
       DesktopActionRegistry(
           DesktopCommandHandlers(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/RomOpenServiceTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/RomOpenServiceTest.kt
@@ -85,6 +85,7 @@ class RomOpenServiceTest {
     SwingUtilities.invokeAndWait { emulatorRef.set(SwingEmulator(eventBus, null, properties)) }
     val emulator = emulatorRef.get()
     val started = LinkedBlockingQueue<String>()
+    val opened = LinkedBlockingQueue<RomOpenUpdate.Opened>()
     val updates = CopyOnWriteArrayList<RomOpenUpdate>()
     val worker = Executors.newSingleThreadExecutor()
     val service =
@@ -97,7 +98,10 @@ class RomOpenServiceTest {
 
               override fun remove(path: Path) = Unit
             },
-            updates::add,
+            { update ->
+              updates += update
+              (update as? RomOpenUpdate.Opened)?.let(opened::add)
+            },
             worker,
             Executor { task -> task.run() },
         )
@@ -106,12 +110,13 @@ class RomOpenServiceTest {
     try {
       service.open(RomOpenRequest(romFile("swing-first.gb", "SWING_FIRST"), RomOpenSource.RECENT))
       assertEquals("SWING_FIRST", started.poll(5, TimeUnit.SECONDS))
+      assertEquals("SWING_FIRST", opened.poll(5, TimeUnit.SECONDS)?.title)
 
       service.open(RomOpenRequest(romFile("swing-next.gb", "SWING_NEXT"), RomOpenSource.RECENT))
 
       assertEquals("SWING_NEXT", started.poll(5, TimeUnit.SECONDS))
+      assertEquals("SWING_NEXT", opened.poll(5, TimeUnit.SECONDS)?.title)
       assertTrue(updates.any { it is RomOpenUpdate.Progress && it.stage == RomOpenStage.PREPARING_CORE })
-      assertTrue(updates.any { it is RomOpenUpdate.Opened })
     } finally {
       service.close()
       emulator.stop()


### PR DESCRIPTION
## Summary
- reserve the wrapped About description height during packing
- prevent Copy version info from extending into the dialog action bar
- cover the packed layout with a regression test

## Test
- mvn -pl swing -Dtest=DesktopHelpDialogsTest test