### PR TITLE
Remove desktop APIs from Android runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ orchestration layer use Kotlin and Java.
 
 ### Android build groundwork
 
-The Android frontend is at its initial build-boundary stage; it is **not yet a playable
-emulator**. The `android/` Gradle project builds a permission-free starter activity and consumes a
-small Java/Kotlin portability artifact installed from this exact checkout. It deliberately does
-not yet consume `core` or `controller`, whose remaining desktop APIs are recorded in the
+The Android frontend is at its portable-runtime stage; it is **not yet a playable emulator**. The
+`android/` Gradle project builds a permission-free starter activity and consumes the real
+`controller` and `core` artifacts installed from this exact checkout. Desktop image, keyboard, and
+console adapters remain outside that runtime as recorded in the
 [Android build-boundary ADR](docs/adr/0003-android-build-boundary.md).
 
 With Android SDK Platform 36 and Build Tools 36.0.0 installed, prepare the isolated artifact
 repository and run the Android checks:
 
 ```bash
-mvn -B -pl android-portable -am install -DskipTests -Dmaven.repo.local="$PWD/build/android-m2"
+mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$PWD/build/android-m2"
 ./android/gradlew -p android -PcoffeeGbMavenRepository="$PWD/build/android-m2" \
   :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease
 ```

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -116,7 +116,7 @@ android {
 }
 
 dependencies {
-  implementation("eu.rekawek.coffeegb:android-portable:$coffeeGbVersion")
+  implementation("eu.rekawek.coffeegb:controller:$coffeeGbVersion")
   testImplementation("junit:junit:4.13.2")
 }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -4,12 +4,11 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.widget.TextView;
-import eu.rekawek.coffeegb.androidportable.AndroidPortabilityProbe;
-import eu.rekawek.coffeegb.androidportable.KotlinPortabilityProbe;
+import eu.rekawek.coffeegb.controller.state.StateImage;
 
 /**
- * Permission-free Phase 0 startup probe. It intentionally contains no ROM, storage, or emulator
- * session behavior; later phases replace this with the lifecycle-owned frontend.
+ * Permission-free Phase 1 startup probe. It validates that the real portable controller runtime
+ * reaches Android without introducing ROM, storage, or session behavior prematurely.
  */
 public final class MainActivity extends Activity {
 
@@ -17,16 +16,13 @@ public final class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        AndroidPortabilityProbe javaProbe = new AndroidPortabilityProbe(
-                "Coffee GB Android groundwork",
-                AndroidPortabilityProbe.BytecodeFlavor.JAVA_RECORD_AND_SWITCH
-        );
-        KotlinPortabilityProbe kotlinProbe = new KotlinPortabilityProbe("Coffee GB Android groundwork");
+        StateImage portableFrame = new StateImage(1, 1, new int[]{0x00_88_cc});
 
         TextView message = new TextView(this);
         message.setGravity(Gravity.CENTER);
-        message.setContentDescription("Coffee GB Android build groundwork");
-        message.setText(javaProbe.description() + "\n" + kotlinProbe.description());
+        message.setContentDescription("Coffee GB Android portable runtime probe");
+        message.setText("Coffee GB Android portable runtime ready: " +
+                String.format("#%06X", portableFrame.copyRgb()[0]));
         setContentView(message);
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/PortabilityArtifactTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/PortabilityArtifactTest.java
@@ -1,7 +1,7 @@
 package eu.rekawek.coffeegb.android;
 
-import eu.rekawek.coffeegb.androidportable.AndroidPortabilityProbe;
-import eu.rekawek.coffeegb.androidportable.KotlinPortabilityProbe;
+import eu.rekawek.coffeegb.controller.state.StateImage;
+import eu.rekawek.coffeegb.controller.state.StatePngCodec;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -9,13 +9,8 @@ import static org.junit.Assert.assertEquals;
 public class PortabilityArtifactTest {
 
     @Test
-    public void consumesJavaRecordSwitchAndKotlinBytecodeFromTheMavenArtifact() {
-        AndroidPortabilityProbe javaProbe = new AndroidPortabilityProbe(
-                "Coffee GB",
-                AndroidPortabilityProbe.BytecodeFlavor.JAVA_RECORD_AND_SWITCH
-        );
-
-        assertEquals("Coffee GB uses Java records and switch expressions", javaProbe.description());
-        assertEquals("Coffee GB includes Kotlin metadata", new KotlinPortabilityProbe("Coffee GB").description());
+    public void consumesThePortableControllerRuntimeFromTheMavenArtifact() throws Exception {
+        StateImage image = new StateImage(2, 1, new int[]{0x112233, 0xaabbcc});
+        assertEquals(image, StatePngCodec.INSTANCE.decode(StatePngCodec.INSTANCE.encode(image)));
     }
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -30,7 +30,7 @@ val expectedMavenRepository = checkoutRoot.resolve("build/android-m2").canonical
 val suppliedMavenRepository = providers.gradleProperty("coffeeGbMavenRepository").orNull
     ?: error(
         "Set -PcoffeeGbMavenRepository=${expectedMavenRepository.path} after installing " +
-            "android-portable from this checkout."
+            "core and controller from this checkout."
     )
 val coffeeGbMavenRepository = file(suppliedMavenRepository).canonicalFile
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Agent.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Agent.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.controller.agent.AgentDisassembler
 import eu.rekawek.coffeegb.controller.agent.HeadlessAgentSession
+import eu.rekawek.coffeegb.controller.state.StateImage
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
 import eu.rekawek.coffeegb.core.debug.DebugButton
 import eu.rekawek.coffeegb.core.debug.DebugCpuState
@@ -13,7 +14,6 @@ import eu.rekawek.coffeegb.core.debug.DebugResult
 import eu.rekawek.coffeegb.core.debug.DebugSnapshot
 import eu.rekawek.coffeegb.core.debug.DebugStepKind
 import eu.rekawek.coffeegb.core.joypad.Button
-import java.awt.image.BufferedImage
 import java.io.File
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ExecutionException
@@ -22,7 +22,7 @@ import java.util.concurrent.ExecutionException
  * Synchronous headless convenience adapter over a bounded, asynchronous [DebugPort].
  *
  * Each instance owns one named emulation thread. Call [close] when finished; Kotlin callers can use
- * `Agent(file).use { ... }`. The temporary [BufferedImage] adapter remains outside the debug API.
+ * `Agent(file).use { ... }`. Frame output is an immutable, toolkit-neutral pixel value.
  */
 class Agent(romFile: File) : AutoCloseable {
 
@@ -55,12 +55,10 @@ class Agent(romFile: File) : AutoCloseable {
 
   fun getLY(): Int = snapshot().ppu().line()
 
-  /** Returns a caller-owned frame without introducing AWT into [DebugPort]. */
-  fun getFrame(): BufferedImage? {
+  /** Returns a caller-owned immutable RGB frame, or null when no frame is queued. */
+  fun getFrameImage(): StateImage? {
     val pixels = getFramePixels() ?: return null
-    return BufferedImage(DISPLAY_WIDTH, DISPLAY_HEIGHT, BufferedImage.TYPE_INT_RGB).apply {
-      setRGB(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT, pixels, 0, DISPLAY_WIDTH)
-    }
+    return StateImage(DISPLAY_WIDTH, DISPLAY_HEIGHT, pixels)
   }
 
   /** Returns a caller-owned RGB frame buffer, or null when no frame is queued. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -4,8 +4,6 @@ import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import eu.rekawek.coffeegb.core.joypad.Button
-import java.awt.event.KeyEvent
-import java.lang.reflect.Modifier
 import java.nio.file.Path
 import java.util.Collections
 import java.util.EnumMap
@@ -242,14 +240,14 @@ data class ApplicationSettings(
     }
 
     fun toPlayerMapping(): ControllerProperties.PlayerMapping {
-      val byKey = linkedMapOf<Int, ControllerProperties.PlayerButton>()
+      val byKey = linkedMapOf<KeyboardKey, ControllerProperties.PlayerButton>()
       keyboard.entries.sortedWith(
               compareBy<Map.Entry<ControllerProperties.PlayerButton, KeyboardKey>>(
                   { it.key.player }, { it.key.button.ordinal }))
           .forEach { (binding, key) ->
-            val previous = byKey.put(key.code, binding)
+            val previous = byKey.put(key, binding)
             require(previous == null) {
-              "Key ${KeyEvent.getKeyText(key.code)} is assigned to both " +
+              "Key ${key.propertyName} is assigned to both " +
                   "P${previous!!.player + 1} ${previous.button} and " +
                   "P${binding.player + 1} ${binding.button}"
             }
@@ -305,72 +303,76 @@ data class ApplicationSettings(
 
       internal fun defaultPrimaryKeyboard(): Map<Button, KeyboardKey> =
           EnumMap<Button, KeyboardKey>(Button::class.java).apply {
-            put(Button.LEFT, KeyboardKey.of("VK_LEFT", KeyEvent.VK_LEFT))
-            put(Button.RIGHT, KeyboardKey.of("VK_RIGHT", KeyEvent.VK_RIGHT))
-            put(Button.UP, KeyboardKey.of("VK_UP", KeyEvent.VK_UP))
-            put(Button.DOWN, KeyboardKey.of("VK_DOWN", KeyEvent.VK_DOWN))
-            put(Button.A, KeyboardKey.of("VK_Z", KeyEvent.VK_Z))
-            put(Button.B, KeyboardKey.of("VK_X", KeyEvent.VK_X))
-            put(Button.START, KeyboardKey.of("VK_ENTER", KeyEvent.VK_ENTER))
-            put(Button.SELECT, KeyboardKey.of("VK_SHIFT", KeyEvent.VK_SHIFT))
+            put(Button.LEFT, KeyboardKey.parse("VK_LEFT", "default left button"))
+            put(Button.RIGHT, KeyboardKey.parse("VK_RIGHT", "default right button"))
+            put(Button.UP, KeyboardKey.parse("VK_UP", "default up button"))
+            put(Button.DOWN, KeyboardKey.parse("VK_DOWN", "default down button"))
+            put(Button.A, KeyboardKey.parse("VK_Z", "default A button"))
+            put(Button.B, KeyboardKey.parse("VK_X", "default B button"))
+            put(Button.START, KeyboardKey.parse("VK_ENTER", "default start button"))
+            put(Button.SELECT, KeyboardKey.parse("VK_SHIFT", "default select button"))
           }
     }
   }
 
-  class KeyboardKey private constructor(val propertyName: String, val code: Int) {
+  /** A portable persisted keyboard token. Each frontend resolves it to its own host key code. */
+  class KeyboardKey private constructor(val propertyName: String) {
     override fun equals(other: Any?): Boolean =
-        other is KeyboardKey && propertyName == other.propertyName && code == other.code
+        other is KeyboardKey && propertyName == other.propertyName
 
-    override fun hashCode(): Int = 31 * propertyName.hashCode() + code
+    override fun hashCode(): Int = propertyName.hashCode()
 
     override fun toString(): String = propertyName
 
     companion object {
-      /**
-       * Resolves a captured AWT key code to the canonical persisted VK_* name. Some JDK constants
-       * are aliases, so lexicographic ordering makes the serialized result stable across reflection
-       * order and runs.
-       */
-      fun fromKeyCode(keyCode: Int): KeyboardKey {
-        require(keyCode != KeyEvent.VK_UNDEFINED) {
-          "VK_UNDEFINED cannot be used as a keyboard binding"
-        }
-        val propertyName =
-            canonicalPropertyNamesByCode[keyCode]
-                ?: throw IllegalArgumentException(
-                    "Key code $keyCode does not name a java.awt.event.KeyEvent VK_* constant")
-        return KeyboardKey(propertyName, keyCode)
-      }
-
       fun parse(propertyName: String, property: String): KeyboardKey {
-        require(propertyName.startsWith("VK_")) {
-          "$property must name a java.awt.event.KeyEvent VK_* constant"
-        }
-        val field =
-            try {
-              KeyEvent::class.java.getField(propertyName)
-            } catch (_: ReflectiveOperationException) {
-              throw IllegalArgumentException("Unknown keyboard key in $property: $propertyName")
+        val canonicalName =
+            when (propertyName) {
+              // The JDK exposes both spellings for the same key code. Keep the historical
+              // lexicographic canonical form so duplicate bindings remain invalid everywhere.
+              "VK_SEPARATOR" -> "VK_SEPARATER"
+              else -> propertyName
             }
-        require(field.type == Int::class.javaPrimitiveType) {
-          "Invalid keyboard key in $property: $propertyName"
+        require(canonicalName in KEY_NAMES) {
+          "$property must use a known VK_* keyboard token"
         }
-        return KeyboardKey(propertyName, field.getInt(null))
+        return KeyboardKey(canonicalName)
       }
 
-      internal fun of(propertyName: String, code: Int) = KeyboardKey(propertyName, code)
-
-      private val canonicalPropertyNamesByCode: Map<Int, String> by lazy {
-        KeyEvent::class.java.fields
-            .asSequence()
-            .filter {
-              it.name.startsWith("VK_") &&
-                  it.type == Int::class.javaPrimitiveType &&
-                  Modifier.isStatic(it.modifiers)
-            }
-            .groupBy { it.getInt(null) }
-            .mapValues { (_, fields) -> fields.minOf { it.name } }
-      }
+      /**
+       * Stable names copied from the desktop key-code contract, rather than resolving a desktop
+       * class at runtime. The desktop shell performs its own token-to-key-code resolution.
+       */
+      private val KEY_NAMES =
+          """
+          VK_ENTER VK_BACK_SPACE VK_TAB VK_CANCEL VK_CLEAR VK_SHIFT VK_CONTROL VK_ALT VK_PAUSE
+          VK_CAPS_LOCK VK_ESCAPE VK_SPACE VK_PAGE_UP VK_PAGE_DOWN VK_END VK_HOME VK_LEFT VK_UP
+          VK_RIGHT VK_DOWN VK_COMMA VK_MINUS VK_PERIOD VK_SLASH VK_0 VK_1 VK_2 VK_3 VK_4 VK_5
+          VK_6 VK_7 VK_8 VK_9 VK_SEMICOLON VK_EQUALS VK_A VK_B VK_C VK_D VK_E VK_F VK_G VK_H
+          VK_I VK_J VK_K VK_L VK_M VK_N VK_O VK_P VK_Q VK_R VK_S VK_T VK_U VK_V VK_W VK_X VK_Y
+          VK_Z VK_OPEN_BRACKET VK_BACK_SLASH VK_CLOSE_BRACKET VK_NUMPAD0 VK_NUMPAD1 VK_NUMPAD2
+          VK_NUMPAD3 VK_NUMPAD4 VK_NUMPAD5 VK_NUMPAD6 VK_NUMPAD7 VK_NUMPAD8 VK_NUMPAD9
+          VK_MULTIPLY VK_ADD VK_SEPARATER VK_SEPARATOR VK_SUBTRACT VK_DECIMAL VK_DIVIDE VK_DELETE
+          VK_NUM_LOCK VK_SCROLL_LOCK VK_F1 VK_F2 VK_F3 VK_F4 VK_F5 VK_F6 VK_F7 VK_F8 VK_F9 VK_F10
+          VK_F11 VK_F12 VK_F13 VK_F14 VK_F15 VK_F16 VK_F17 VK_F18 VK_F19 VK_F20 VK_F21 VK_F22
+          VK_F23 VK_F24 VK_PRINTSCREEN VK_INSERT VK_HELP VK_META VK_BACK_QUOTE VK_QUOTE VK_KP_UP
+          VK_KP_DOWN VK_KP_LEFT VK_KP_RIGHT VK_DEAD_GRAVE VK_DEAD_ACUTE VK_DEAD_CIRCUMFLEX
+          VK_DEAD_TILDE VK_DEAD_MACRON VK_DEAD_BREVE VK_DEAD_ABOVEDOT VK_DEAD_DIAERESIS
+          VK_DEAD_ABOVERING VK_DEAD_DOUBLEACUTE VK_DEAD_CARON VK_DEAD_CEDILLA VK_DEAD_OGONEK
+          VK_DEAD_IOTA VK_DEAD_VOICED_SOUND VK_DEAD_SEMIVOICED_SOUND VK_AMPERSAND VK_ASTERISK
+          VK_QUOTEDBL VK_LESS VK_GREATER VK_BRACELEFT VK_BRACERIGHT VK_AT VK_COLON VK_CIRCUMFLEX
+          VK_DOLLAR VK_EURO_SIGN VK_EXCLAMATION_MARK VK_INVERTED_EXCLAMATION_MARK
+          VK_LEFT_PARENTHESIS VK_NUMBER_SIGN VK_PLUS VK_RIGHT_PARENTHESIS VK_UNDERSCORE VK_WINDOWS
+          VK_CONTEXT_MENU VK_FINAL VK_CONVERT VK_NONCONVERT VK_ACCEPT VK_MODECHANGE VK_KANA VK_KANJI
+          VK_ALPHANUMERIC VK_KATAKANA VK_HIRAGANA VK_FULL_WIDTH VK_HALF_WIDTH VK_ROMAN_CHARACTERS
+          VK_ALL_CANDIDATES VK_PREVIOUS_CANDIDATE VK_CODE_INPUT VK_JAPANESE_KATAKANA
+          VK_JAPANESE_HIRAGANA VK_JAPANESE_ROMAN VK_KANA_LOCK VK_INPUT_METHOD_ON_OFF VK_CUT VK_COPY
+          VK_PASTE VK_UNDO VK_AGAIN VK_FIND VK_PROPS VK_STOP VK_COMPOSE VK_ALT_GRAPH VK_BEGIN
+          VK_UNDEFINED
+          """
+              .trimIndent()
+              .split(Regex("\\s+"))
+              .toSet()
     }
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ControllerProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ControllerProperties.kt
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.controller.properties
 
 import eu.rekawek.coffeegb.core.joypad.Button
-import java.awt.event.KeyEvent
 import java.util.EnumMap
 import java.util.Locale
 import java.util.Properties
@@ -34,11 +33,11 @@ object ControllerProperties {
   }
 
   data class PlayerMapping(
-      val keyboard: Map<Int, PlayerButton>,
+      val keyboard: Map<ApplicationSettings.KeyboardKey, PlayerButton>,
       val gamepads: List<GamepadAssignment>,
   ) {
     /** Historical P1 view retained for source compatibility with existing callers. */
-    fun legacyPrimaryKeyboard(): Map<Int, Button> =
+    fun legacyPrimaryKeyboard(): Map<ApplicationSettings.KeyboardKey, Button> =
         keyboard.filterValues { it.player == 0 }.mapValues { it.value.button }
   }
 
@@ -108,13 +107,13 @@ object ControllerProperties {
     }
 
     val keyboard = linkedMapOf<PlayerButton, ApplicationSettings.KeyboardKey>()
-    val usedKeys = linkedMapOf<Int, PlayerButton>()
+    val usedKeys = linkedMapOf<ApplicationSettings.KeyboardKey, PlayerButton>()
     perPlayer.forEachIndexed { player, bindings ->
       bindings.forEach { (button, key) ->
         val binding = PlayerButton(player, button)
-        val previous = usedKeys.put(key.code, binding)
+        val previous = usedKeys.put(key, binding)
         require(previous == null) {
-          "Key ${KeyEvent.getKeyText(key.code)} is assigned to both P${previous!!.player + 1} " +
+          "Key ${key.propertyName} is assigned to both P${previous!!.player + 1} " +
               "${previous.button} and P${player + 1} $button"
         }
         keyboard[binding] = key
@@ -124,7 +123,7 @@ object ControllerProperties {
     return ApplicationSettings.Input(keyboard.toMap(), gamepads.toMap()).also { it.toPlayerMapping() }
   }
 
-  fun getControllerMapping(properties: Properties): Map<Int, Button> =
+  fun getControllerMapping(properties: Properties): Map<ApplicationSettings.KeyboardKey, Button> =
       getPlayerMapping(properties).legacyPrimaryKeyboard()
 
   private fun parsePlayer(value: String, property: String): Int {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/EmulatorProperties.kt
@@ -108,7 +108,7 @@ internal constructor(
   /** Shared live-input service copied into each active machine configuration. */
   val playerInputSource = PlayerInputHub()
 
-  val controllerMapping: Map<Int, eu.rekawek.coffeegb.core.joypad.Button>
+  val controllerMapping: Map<ApplicationSettings.KeyboardKey, eu.rekawek.coffeegb.core.joypad.Button>
     get() = playerInputMapping.legacyPrimaryKeyboard()
 
   init {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StatePngCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StatePngCodec.kt
@@ -1,17 +1,19 @@
 package eu.rekawek.coffeegb.controller.state
 
-import java.awt.image.BufferedImage
-import java.awt.image.DataBufferInt
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import javax.imageio.IIOImage
-import javax.imageio.ImageIO
-import javax.imageio.metadata.IIOMetadataNode
-import javax.imageio.stream.MemoryCacheImageInputStream
+import java.util.zip.CRC32
+import java.util.zip.DataFormatException
+import java.util.zip.Deflater
+import java.util.zip.Inflater
 
-/** Bounded deterministic PNG encoding shared by thumbnails and screenshots. */
+/**
+ * Bounded deterministic RGB PNG codec shared by thumbnails and screenshots.
+ *
+ * It deliberately supports the RGB, 8-bit PNGs Coffee GB writes (including prior desktop
+ * releases) rather than relying on a desktop image toolkit in the controller runtime.
+ */
 object StatePngCodec {
   const val MAX_PNG_BYTES = 2 * 1024 * 1024
   const val MAX_METADATA_ENTRIES = 8
@@ -19,6 +21,11 @@ object StatePngCodec {
 
   private val KEY = Regex("[A-Za-z][A-Za-z0-9 ]{0,31}")
   private val VALUE = Regex("[\\x20-\\x7e]{1,128}")
+  private val SIGNATURE = byteArrayOf(137.toByte(), 80, 78, 71, 13, 10, 26, 10)
+  private val IHDR = "IHDR".toByteArray(StandardCharsets.US_ASCII)
+  private val IDAT = "IDAT".toByteArray(StandardCharsets.US_ASCII)
+  private val IEND = "IEND".toByteArray(StandardCharsets.US_ASCII)
+  private val TEXT = "tEXt".toByteArray(StandardCharsets.US_ASCII)
 
   @JvmOverloads
   fun encode(
@@ -26,85 +33,255 @@ object StatePngCodec {
       metadata: Map<String, String> = emptyMap(),
   ): ByteArray {
     validateMetadata(metadata)
-    val buffered = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB)
-    val target = (buffered.raster.dataBuffer as DataBufferInt).data
-    image.copyRgb().copyInto(target)
+    val raw = ByteArray(Math.multiplyExact(image.height, Math.addExact(Math.multiplyExact(image.width, 3), 1)))
+    val pixels = image.copyRgb()
+    var offset = 0
+    var pixel = 0
+    repeat(image.height) {
+      raw[offset++] = 0 // PNG filter: None. Stable across hosts and inexpensive at Coffee GB sizes.
+      repeat(image.width) {
+        val rgb = pixels[pixel++]
+        raw[offset++] = (rgb shr 16).toByte()
+        raw[offset++] = (rgb shr 8).toByte()
+        raw[offset++] = rgb.toByte()
+      }
+    }
 
-    val writer =
-        ImageIO.getImageWritersByFormatName("png").asSequence().firstOrNull()
-            ?: throw IOException("The Java runtime has no PNG writer")
-    try {
-      val output = ByteArrayOutputStream()
-      ImageIO.createImageOutputStream(output).use { imageOutput ->
-        writer.output = imageOutput
-        val parameters = writer.defaultWriteParam
-        if (parameters.canWriteCompressed()) {
-          parameters.compressionMode = javax.imageio.ImageWriteParam.MODE_EXPLICIT
-          parameters.compressionQuality = 0.9f
-        }
-        val pngMetadata = writer.getDefaultImageMetadata(
-            javax.imageio.ImageTypeSpecifier.createFromRenderedImage(buffered),
-            parameters,
-        )
-        if (metadata.isNotEmpty()) {
-          val root = IIOMetadataNode(PNG_METADATA_FORMAT)
-          val text = IIOMetadataNode("tEXt")
-          metadata.toSortedMap().forEach { (key, value) ->
-            val entry = IIOMetadataNode("tEXtEntry")
-            entry.setAttribute("keyword", key)
-            entry.setAttribute("value", value)
-            text.appendChild(entry)
-          }
-          root.appendChild(text)
-          pngMetadata.mergeTree(PNG_METADATA_FORMAT, root)
-        }
-        writer.write(null, IIOImage(buffered, null, pngMetadata), parameters)
-        imageOutput.flush()
+    val output = ByteArrayOutputStream()
+    output.write(SIGNATURE)
+    writeChunk(
+        output,
+        IHDR,
+        ByteArray(13).also { header ->
+          writeInt(header, 0, image.width)
+          writeInt(header, 4, image.height)
+          header[8] = 8 // bit depth
+          header[9] = 2 // truecolour RGB
+        },
+    )
+    metadata.toSortedMap().forEach { (key, value) ->
+      writeChunk(
+          output,
+          TEXT,
+          (key + '\u0000' + value).toByteArray(StandardCharsets.ISO_8859_1),
+      )
+    }
+    writeChunk(output, IDAT, deflate(raw))
+    writeChunk(output, IEND, ByteArray(0))
+    return output.toByteArray().also {
+      if (it.size > MAX_PNG_BYTES) {
+        throw IOException("PNG exceeds the $MAX_PNG_BYTES-byte limit")
       }
-      return output.toByteArray().also {
-        if (it.size > MAX_PNG_BYTES) {
-          throw IOException("PNG exceeds the $MAX_PNG_BYTES-byte limit")
-        }
-      }
-    } finally {
-      writer.dispose()
     }
   }
 
   /**
-   * Decodes only a bounded image after checking dimensions through ImageIO's header reader. This
-   * prevents a small hostile PNG from allocating an arbitrary raster.
+   * Decodes bounded, non-interlaced 8-bit RGB PNGs after validating the full envelope and every
+   * chunk checksum. Dimensions are checked before any raster allocation.
    */
   fun decode(bytes: ByteArray): StateImage {
     if (bytes.isEmpty() || bytes.size > MAX_PNG_BYTES) {
       throw IOException("PNG byte count must be between 1 and $MAX_PNG_BYTES")
     }
-    val reader =
-        ImageIO.getImageReadersByFormatName("png").asSequence().firstOrNull()
-            ?: throw IOException("The Java runtime has no PNG reader")
-    try {
-      MemoryCacheImageInputStream(ByteArrayInputStream(bytes)).use { input ->
-        reader.input = input
-        val width = reader.getWidth(0)
-        val height = reader.getHeight(0)
-        if (width !in 1..StateImage.MAX_WIDTH || height !in 1..StateImage.MAX_HEIGHT) {
-          throw IOException(
-              "PNG dimensions $width x $height exceed " +
-                  "${StateImage.MAX_WIDTH} x ${StateImage.MAX_HEIGHT}")
-        }
-        val buffered = reader.read(0)
-            ?: throw IOException("PNG has no readable first image")
-        val rgb = IntArray(Math.multiplyExact(width, height))
-        buffered.getRGB(0, 0, width, height, rgb, 0, width)
-        return StateImage(width, height, rgb)
-      }
-    } catch (failure: IOException) {
-      throw failure
-    } catch (failure: RuntimeException) {
-      throw IOException("PNG is malformed", failure)
-    } finally {
-      reader.dispose()
+    if (bytes.size < SIGNATURE.size || !bytes.copyOfRange(0, SIGNATURE.size).contentEquals(SIGNATURE)) {
+      throw IOException("PNG signature is invalid")
     }
+
+    var offset = SIGNATURE.size
+    var width = 0
+    var height = 0
+    var sawHeader = false
+    var sawData = false
+    val compressed = ByteArrayOutputStream()
+    while (offset < bytes.size) {
+      if (bytes.size - offset < 12) throw IOException("PNG chunk is truncated")
+      val length = readLength(bytes, offset)
+      val typeOffset = offset + 4
+      val dataOffset = typeOffset + 4
+      if (length > bytes.size - dataOffset - 4) throw IOException("PNG chunk exceeds input")
+      val checksumOffset = dataOffset + length
+      val type = bytes.copyOfRange(typeOffset, dataOffset)
+      verifyCrc(bytes, typeOffset, type, dataOffset, length, checksumOffset)
+
+      when {
+        type.contentEquals(IHDR) -> {
+          if (sawHeader || sawData || length != 13) throw IOException("PNG header is invalid")
+          width = readLength(bytes, dataOffset)
+          height = readLength(bytes, dataOffset + 4)
+          if (width !in 1..StateImage.MAX_WIDTH || height !in 1..StateImage.MAX_HEIGHT) {
+            throw IOException(
+                "PNG dimensions $width x $height exceed " +
+                    "${StateImage.MAX_WIDTH} x ${StateImage.MAX_HEIGHT}")
+          }
+          if (
+              bytes[dataOffset + 8].toInt() != 8 ||
+                  bytes[dataOffset + 9].toInt() != 2 ||
+                  bytes[dataOffset + 10].toInt() != 0 ||
+                  bytes[dataOffset + 11].toInt() != 0 ||
+                  bytes[dataOffset + 12].toInt() != 0
+          ) {
+            throw IOException("PNG must be a non-interlaced 8-bit RGB image")
+          }
+          sawHeader = true
+        }
+        type.contentEquals(IDAT) -> {
+          if (!sawHeader) throw IOException("PNG data appears before its header")
+          sawData = true
+          compressed.write(bytes, dataOffset, length)
+        }
+        type.contentEquals(IEND) -> {
+          if (!sawHeader || !sawData || length != 0 || checksumOffset + 4 != bytes.size) {
+            throw IOException("PNG end chunk is invalid")
+          }
+          return decodeRgb(width, height, compressed.toByteArray())
+        }
+        (type[0].toInt() and 0x20) == 0 -> throw IOException("PNG has an unsupported critical chunk")
+      }
+      offset = checksumOffset + 4
+    }
+    throw IOException("PNG has no end chunk")
+  }
+
+  private fun decodeRgb(width: Int, height: Int, compressed: ByteArray): StateImage {
+    val stride = Math.multiplyExact(width, 3)
+    val expected = Math.multiplyExact(height, Math.addExact(stride, 1))
+    val filtered = inflate(compressed, expected)
+    val pixels = IntArray(Math.multiplyExact(width, height))
+    val previous = ByteArray(stride)
+    val current = ByteArray(stride)
+    var offset = 0
+    var pixel = 0
+    repeat(height) {
+      val filter = filtered[offset++].toInt() and 0xff
+      if (filter !in 0..4) throw IOException("PNG has an unsupported scanline filter")
+      repeat(stride) { index ->
+        val encoded = filtered[offset++].toInt() and 0xff
+        val left = if (index >= 3) current[index - 3].toInt() and 0xff else 0
+        val up = previous[index].toInt() and 0xff
+        val upperLeft = if (index >= 3) previous[index - 3].toInt() and 0xff else 0
+        current[index] =
+            when (filter) {
+              0 -> encoded
+              1 -> encoded + left
+              2 -> encoded + up
+              3 -> encoded + ((left + up) ushr 1)
+              else -> encoded + paeth(left, up, upperLeft)
+            }.toByte()
+      }
+      repeat(width) { x ->
+        val component = x * 3
+        pixels[pixel++] =
+            ((current[component].toInt() and 0xff) shl 16) or
+                ((current[component + 1].toInt() and 0xff) shl 8) or
+                (current[component + 2].toInt() and 0xff)
+      }
+      current.copyInto(previous)
+    }
+    return StateImage(width, height, pixels)
+  }
+
+  private fun deflate(raw: ByteArray): ByteArray {
+    val compressor = Deflater(Deflater.DEFAULT_COMPRESSION)
+    return try {
+      compressor.setInput(raw)
+      compressor.finish()
+      ByteArrayOutputStream().also { output ->
+        val buffer = ByteArray(4096)
+        while (!compressor.finished()) {
+          output.write(buffer, 0, compressor.deflate(buffer))
+        }
+      }.toByteArray()
+    } finally {
+      compressor.end()
+    }
+  }
+
+  private fun inflate(compressed: ByteArray, expected: Int): ByteArray {
+    val inflater = Inflater()
+    return try {
+      inflater.setInput(compressed)
+      val output = ByteArray(expected)
+      var written = 0
+      while (!inflater.finished() && written < output.size) {
+        val count = inflater.inflate(output, written, output.size - written)
+        if (count == 0 && (inflater.needsInput() || inflater.needsDictionary())) {
+          throw IOException("PNG image data is malformed")
+        }
+        written += count
+      }
+      if (!inflater.finished() || inflater.remaining != 0 || written != output.size) {
+        throw IOException("PNG image data has an invalid size")
+      }
+      output
+    } catch (failure: DataFormatException) {
+      throw IOException("PNG image data is malformed", failure)
+    } finally {
+      inflater.end()
+    }
+  }
+
+  private fun paeth(left: Int, up: Int, upperLeft: Int): Int {
+    val estimate = left + up - upperLeft
+    val leftDistance = kotlin.math.abs(estimate - left)
+    val upDistance = kotlin.math.abs(estimate - up)
+    val upperLeftDistance = kotlin.math.abs(estimate - upperLeft)
+    return when {
+      leftDistance <= upDistance && leftDistance <= upperLeftDistance -> left
+      upDistance <= upperLeftDistance -> up
+      else -> upperLeft
+    }
+  }
+
+  private fun writeChunk(output: ByteArrayOutputStream, type: ByteArray, data: ByteArray) {
+    writeInt(output, data.size)
+    output.write(type)
+    output.write(data)
+    val crc = CRC32()
+    crc.update(type)
+    crc.update(data)
+    writeInt(output, crc.value.toInt())
+  }
+
+  private fun verifyCrc(
+      bytes: ByteArray,
+      typeOffset: Int,
+      type: ByteArray,
+      dataOffset: Int,
+      length: Int,
+      checksumOffset: Int,
+  ) {
+    val crc = CRC32()
+    crc.update(bytes, typeOffset, type.size)
+    crc.update(bytes, dataOffset, length)
+    if (crc.value.toInt() != readRawInt(bytes, checksumOffset)) {
+      throw IOException("PNG chunk checksum is invalid")
+    }
+  }
+
+  private fun readLength(bytes: ByteArray, offset: Int): Int {
+    val value = readRawInt(bytes, offset).toLong() and 0xffffffffL
+    if (value > Int.MAX_VALUE) throw IOException("PNG chunk is too large")
+    return value.toInt()
+  }
+
+  private fun readRawInt(bytes: ByteArray, offset: Int): Int =
+      ((bytes[offset].toInt() and 0xff) shl 24) or
+          ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+          ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+          (bytes[offset + 3].toInt() and 0xff)
+
+  private fun writeInt(output: ByteArrayOutputStream, value: Int) {
+    output.write(value ushr 24)
+    output.write(value ushr 16)
+    output.write(value ushr 8)
+    output.write(value)
+  }
+
+  private fun writeInt(target: ByteArray, offset: Int, value: Int) {
+    target[offset] = (value ushr 24).toByte()
+    target[offset + 1] = (value ushr 16).toByte()
+    target[offset + 2] = (value ushr 8).toByte()
+    target[offset + 3] = value.toByte()
   }
 
   private fun validateMetadata(metadata: Map<String, String>) {
@@ -125,6 +302,4 @@ object StatePngCodec {
       "PNG metadata exceeds $MAX_METADATA_UTF8_BYTES UTF-8 bytes"
     }
   }
-
-  private const val PNG_METADATA_FORMAT = "javax_imageio_png_1.0"
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/TestAgent.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/TestAgent.kt
@@ -1,7 +1,8 @@
 package eu.rekawek.coffeegb.controller
 
 import java.io.File
-import javax.imageio.ImageIO
+import eu.rekawek.coffeegb.controller.state.StatePngCodec
+import java.nio.file.Files
 
 fun main() {
     val romFile = File("core/src/test/resources/roms/blargg/cpu_instrs.gb")
@@ -23,10 +24,10 @@ fun main() {
             }
         }
 
-        val frame = agent.getFrame()
+        val frame = agent.getFrameImage()
         if (frame != null) {
             val outputFile = File("screenshot.png")
-            ImageIO.write(frame, "png", outputFile)
+            Files.write(outputFile.toPath(), StatePngCodec.encode(frame))
             println("Screenshot saved to ${outputFile.absolutePath}")
         } else {
             println("No frame captured")

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsGeneralTest.kt
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.controller.properties
 
 import eu.rekawek.coffeegb.core.joypad.Button
-import java.awt.event.KeyEvent
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
@@ -66,21 +65,19 @@ class ApplicationSettingsGeneralTest {
   }
 
   @Test
-  fun `captured key codes resolve to stable persisted VK names`() {
-    val ordinary = ApplicationSettings.KeyboardKey.fromKeyCode(KeyEvent.VK_A)
+  fun `portable keyboard tokens preserve stable persisted names`() {
+    val ordinary = ApplicationSettings.KeyboardKey.parse("VK_A", "test")
     assertEquals("VK_A", ordinary.propertyName)
-    assertEquals(KeyEvent.VK_A, ordinary.code)
 
-    val aliased = ApplicationSettings.KeyboardKey.fromKeyCode(KeyEvent.VK_SEPARATOR)
+    val aliased = ApplicationSettings.KeyboardKey.parse("VK_SEPARATER", "test")
     assertEquals("VK_SEPARATER", aliased.propertyName)
-    assertEquals(KeyEvent.VK_SEPARATOR, aliased.code)
   }
 
   @Test
-  fun `undefined and unknown captured key codes are rejected`() {
-    listOf(KeyEvent.VK_UNDEFINED, Int.MAX_VALUE).forEach { invalid ->
+  fun `malformed portable keyboard tokens are rejected`() {
+    listOf("VK_lower", "KEY_A", "VK_").forEach { invalid ->
       assertFailsWith<IllegalArgumentException> {
-        ApplicationSettings.KeyboardKey.fromKeyCode(invalid)
+        ApplicationSettings.KeyboardKey.parse(invalid, "test")
       }
     }
   }
@@ -494,7 +491,7 @@ class ApplicationSettingsGeneralTest {
       )
       assertEquals(
           Button.A,
-          properties.controllerMapping[KeyEvent.VK_Q],
+          properties.controllerMapping[ApplicationSettings.KeyboardKey.parse("VK_Q", "test")],
       )
       properties.flush()
     }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
@@ -7,7 +7,6 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memory.cart.Rom
-import java.awt.event.KeyEvent
 import java.util.Properties
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -25,13 +24,13 @@ class ControllerPropertiesTest {
     assertEquals(8, mapping.keyboard.size)
     assertEquals(
         ControllerProperties.PlayerButton(0, Button.A),
-        mapping.keyboard[KeyEvent.VK_Z],
+        mapping.keyboard[key("VK_Z")],
     )
     assertEquals(
         listOf(ControllerProperties.GamepadAssignment(0, "auto")),
         mapping.gamepads,
     )
-    assertEquals(Button.B, mapping.legacyPrimaryKeyboard()[KeyEvent.VK_X])
+    assertEquals(Button.B, mapping.legacyPrimaryKeyboard()[key("VK_X")])
   }
 
   @Test
@@ -48,10 +47,10 @@ class ControllerPropertiesTest {
         }
 
     val mapping = ControllerProperties.getPlayerMapping(properties)
-    assertEquals(ControllerProperties.PlayerButton(0, Button.A), mapping.keyboard[KeyEvent.VK_Q])
-    assertEquals(ControllerProperties.PlayerButton(1, Button.A), mapping.keyboard[KeyEvent.VK_W])
-    assertEquals(ControllerProperties.PlayerButton(2, Button.START), mapping.keyboard[KeyEvent.VK_E])
-    assertEquals(ControllerProperties.PlayerButton(3, Button.SELECT), mapping.keyboard[KeyEvent.VK_R])
+    assertEquals(ControllerProperties.PlayerButton(0, Button.A), mapping.keyboard[key("VK_Q")])
+    assertEquals(ControllerProperties.PlayerButton(1, Button.A), mapping.keyboard[key("VK_W")])
+    assertEquals(ControllerProperties.PlayerButton(2, Button.START), mapping.keyboard[key("VK_E")])
+    assertEquals(ControllerProperties.PlayerButton(3, Button.SELECT), mapping.keyboard[key("VK_R")])
     assertEquals(listOf(ControllerProperties.GamepadAssignment(3, id)), mapping.gamepads)
   }
 
@@ -76,6 +75,13 @@ class ControllerPropertiesTest {
     assertFailsWith<IllegalArgumentException>("duplicate key") {
       ControllerProperties.getPlayerMapping(
           Properties().apply { setProperty("input.p2.btn_a", "VK_Z") })
+    }
+    assertFailsWith<IllegalArgumentException>("duplicate keyboard aliases") {
+      ControllerProperties.getPlayerMapping(
+          Properties().apply {
+            setProperty("input.p1.btn_a", "VK_SEPARATOR")
+            setProperty("input.p2.btn_a", "VK_SEPARATER")
+          })
     }
     assertFailsWith<IllegalArgumentException>("legacy/new duplicate") {
       ControllerProperties.getPlayerMapping(
@@ -147,4 +153,7 @@ class ControllerPropertiesTest {
       assertFalse(StateIdentity.from(config).profile.displaySgbBorder)
     }
   }
+
+  private fun key(value: String): ApplicationSettings.KeyboardKey =
+      ApplicationSettings.KeyboardKey.parse(value, "test")
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,11 +29,6 @@
             <groupId>org.tukaani</groupId>
             <artifactId>xz</artifactId>
         </dependency>
-        <!-- The interactive debugger is still a desktop boundary. Phase 1 moves it out of core. -->
-        <dependency>
-            <groupId>org.jline</groupId>
-            <artifactId>jline</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -41,11 +36,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/core/src/main/java/eu/rekawek/coffeegb/core/debug/Console.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/debug/Console.java
@@ -10,31 +10,29 @@ import eu.rekawek.coffeegb.core.debug.command.ShowState;
 import eu.rekawek.coffeegb.core.debug.command.Step;
 import eu.rekawek.coffeegb.core.debug.command.cpu.ShowOpcode;
 import eu.rekawek.coffeegb.core.debug.command.cpu.ShowOpcodes;
-import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
-import org.jline.reader.UserInterruptException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-public class Console implements Runnable {
-
-    private static final Logger LOG = LoggerFactory.getLogger(Console.class);
+/**
+ * Platform-neutral command processor for the debugger.
+ *
+ * <p>Presentation owns line editing and input blocking. Desktop front ends use their JLine
+ * adapter, while other hosts may feed complete lines directly through {@link #executeLine}.
+ */
+public class Console {
 
     private static final long DEFAULT_COMMAND_TIMEOUT_MILLIS = 5_000;
 
-    private volatile boolean doStop;
+    private volatile boolean stopped;
 
     private volatile DebugPort debugPort;
 
     private final List<Command> commands;
 
-    private final PrintStream error;
+    protected final PrintStream error;
 
     public Console() {
         this(System.out, System.err, DEFAULT_COMMAND_TIMEOUT_MILLIS);
@@ -70,27 +68,8 @@ public class Console implements Runnable {
         return debugPort;
     }
 
-    @Override
-    public void run() {
-        LineReader lineReader = LineReaderBuilder.builder().build();
-
-        while (!doStop) {
-            try {
-                String line = lineReader.readLine("coffee-gb> ");
-                executeLine(line);
-            } catch (IllegalArgumentException e) {
-                error.println(e.getMessage());
-            } catch (UserInterruptException e) {
-                stop();
-            } catch (RuntimeException e) {
-                LOG.warn("Console command failed", e);
-                error.println("Command failed.");
-            }
-        }
-    }
-
     /** Executes one parsed command on the caller thread. Machine commands still use DebugPort. */
-    void executeLine(String line) {
+    public void executeLine(String line) {
         Objects.requireNonNull(line, "line");
         for (Command cmd : commands) {
             if (cmd.getPattern().matches(line)) {
@@ -105,6 +84,11 @@ public class Console implements Runnable {
     }
 
     public void stop() {
-        doStop = true;
+        stopped = true;
+    }
+
+    /** Returns whether the host-facing command loop should stop. */
+    protected final boolean isStopped() {
+        return stopped;
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/CameraFrame.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/CameraFrame.java
@@ -1,0 +1,51 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import java.util.Arrays;
+
+/**
+ * An immutable, caller-owned RGB camera frame.
+ *
+ * <p>This deliberately has no toolkit image type. Hosts may capture with Android, desktop, or
+ * test APIs, then hand the camera a bounded RGB snapshot without retaining a mutable raster.
+ */
+public final class CameraFrame {
+
+    public static final int MAX_DIMENSION = 4096;
+
+    public static final int MAX_PIXELS = 16 * 1024 * 1024;
+
+    private final int width;
+
+    private final int height;
+
+    private final int[] rgb;
+
+    public CameraFrame(int width, int height, int[] rgb) {
+        if (width < 1 || width > MAX_DIMENSION || height < 1 || height > MAX_DIMENSION) {
+            throw new IllegalArgumentException("Camera frame dimensions must be within 1.." + MAX_DIMENSION);
+        }
+        int pixels = Math.multiplyExact(width, height);
+        if (pixels > MAX_PIXELS || rgb == null || rgb.length != pixels) {
+            throw new IllegalArgumentException("Camera frame must contain one bounded RGB value per pixel");
+        }
+        this.width = width;
+        this.height = height;
+        this.rgb = Arrays.copyOf(rgb, rgb.length);
+        for (int i = 0; i < this.rgb.length; i++) {
+            this.rgb[i] &= 0x00ffffff;
+        }
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    /** Returns a fresh, caller-owned RGB copy in row-major order. */
+    public int[] copyRgb() {
+        return Arrays.copyOf(rgb, rgb.length);
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/CameraSource.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/CameraSource.java
@@ -1,18 +1,16 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
-import java.awt.image.BufferedImage;
-
 /**
- * A live source of frames for the Pocket Camera sensor. A front end (e.g. the Swing UI
- * with a real webcam) registers one through {@link PocketCamera#setCameraSource}; the
- * camera scales each returned frame to the sensor's 128x112 and dithers it like the real
- * ASIC. Keeping this out of the core means the core stays free of any capture dependency.
+ * A live source of immutable RGB frames for the Pocket Camera sensor. A front end registers one
+ * through {@link PocketCamera#setCameraSource}; the camera scales each returned frame to the
+ * sensor's 128x112 and dithers it like the real ASIC. Capture, files, and image decoding belong
+ * to the host adapter rather than the emulation core.
  */
 public interface CameraSource {
 
     /**
-     * @return the most recent camera frame, or {@code null} if none is available yet
-     * (the camera then falls back to the image file / test pattern)
+     * @return the most recent caller-owned camera frame, or {@code null} if none is available yet
+     * (the camera then falls back to its synthetic test pattern)
      */
-    BufferedImage getFrame();
+    CameraFrame getFrame();
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCamera.java
@@ -8,20 +8,13 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 
-import javax.imageio.ImageIO;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-
 /**
  * The Pocket Camera cartridge (type 0xFC): MBC5-like ROM banking, 128 KB of banked RAM,
  * and the camera's register file mapped in place of RAM when RAM-bank bit 4 is set.
  * A capture completes instantly (the busy bit always reads 0). The sensor image comes,
  * in priority order, from a live {@link CameraSource} registered by the front end (the
- * Swing UI wires a real webcam through it), then the file named by the
- * {@code coffeegb.camera.image} system property (re-read on every capture, e.g. one kept
- * fresh by {@code ffmpeg -f v4l2 -i /dev/video0 -update 1 cam.jpg}), and finally a
- * synthetic test pattern. The image is scaled to the
+ * Swing UI wires a real webcam through it), and finally a synthetic test pattern. File and image
+ * decoding are desktop adapter responsibilities. The image is scaled to the
  * sensor's 128x112, converted to luminance and dithered through the game-supplied
  * threshold matrix (registers 0x06-0x35), and the result is written as 2bpp tiles to the
  * capture buffer at RAM offset 0x100 like the real ASIC does.
@@ -54,13 +47,8 @@ public class PocketCamera implements MemoryController {
 
     private boolean cameraMapped;
 
-    private transient long sourceTimestamp;
-
-    private transient int[] sourceLuma;
-
-    // a live capture source (e.g. a webcam) registered by the front end; when present it
-    // takes priority over the image file. Static because the cartridge is created deep in
-    // the emulator and there is only ever one camera.
+    // A live capture source is registered by the front end. It is static because the cartridge is
+    // constructed beneath the front-end session boundary and only one active machine owns it.
     private static volatile CameraSource cameraSource;
 
     /** Registers (or clears, with {@code null}) the live sensor source. */
@@ -162,36 +150,16 @@ public class PocketCamera implements MemoryController {
     }
 
     private int[] sensorImage() {
-        // a registered live source (webcam) wins over the file; it is re-read every capture
+        // A registered live source is re-read for every capture and must never block the machine.
         CameraSource source = cameraSource;
         if (source != null) {
             try {
-                BufferedImage frame = source.getFrame();
+                CameraFrame frame = source.getFrame();
                 if (frame != null) {
                     return toLuma(frame);
                 }
             } catch (Exception e) {
-                // fall through to the file / test pattern
-            }
-        }
-        String path = System.getProperty("coffeegb.camera.image");
-        if (path != null) {
-            File f = new File(path);
-            if (f.isFile()) {
-                try {
-                    if (sourceLuma == null || f.lastModified() != sourceTimestamp) {
-                        BufferedImage src = ImageIO.read(f);
-                        if (src != null) {
-                            sourceLuma = toLuma(src);
-                            sourceTimestamp = f.lastModified();
-                        }
-                    }
-                    if (sourceLuma != null) {
-                        return sourceLuma;
-                    }
-                } catch (Exception e) {
-                    // fall through to the test pattern
-                }
+                // Fall through to the test pattern. Host capture failures must not affect emulation.
             }
         }
         // synthetic test pattern: diagonal gradient with circles
@@ -206,17 +174,22 @@ public class PocketCamera implements MemoryController {
         return luma;
     }
 
-    /** Scales a frame to the sensor's 128x112 and converts it to per-pixel luminance. */
-    private static int[] toLuma(BufferedImage src) {
-        BufferedImage scaled = new BufferedImage(128, 112, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = scaled.createGraphics();
-        g.drawImage(src, 0, 0, 128, 112, null);
-        g.dispose();
+    /**
+     * Scales an RGB frame to the sensor's 128x112 with deterministic nearest-neighbour sampling,
+     * then converts it to per-pixel luminance. The integer mapping is the established desktop
+     * default and avoids host-specific image interpolation.
+     */
+    private static int[] toLuma(CameraFrame src) {
+        int sourceWidth = src.getWidth();
+        int sourceHeight = src.getHeight();
+        int[] rgb = src.copyRgb();
         int[] luma = new int[128 * 112];
         for (int y = 0; y < 112; y++) {
+            int sourceY = y * sourceHeight / 112;
             for (int x = 0; x < 128; x++) {
-                int rgb = scaled.getRGB(x, y);
-                luma[y * 128 + x] = ((rgb >> 16 & 0xff) * 77 + (rgb >> 8 & 0xff) * 151 + (rgb & 0xff) * 28) >> 8;
+                int sourceX = x * sourceWidth / 128;
+                int pixel = rgb[sourceY * sourceWidth + sourceX];
+                luma[y * 128 + x] = ((pixel >> 16 & 0xff) * 77 + (pixel >> 8 & 0xff) * 151 + (pixel & 0xff) * 28) >> 8;
             }
         }
         return luma;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCameraFrameTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/PocketCameraFrameTest.java
@@ -1,0 +1,63 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Golden sensor-pixel baseline for the platform-neutral Pocket Camera source contract. */
+public class PocketCameraFrameTest {
+
+    @Test
+    public void nearestNeighbourCameraFrameProducesTheApprovedSensorQuadrants() throws Exception {
+        PocketCamera.setCameraSource(() -> new CameraFrame(
+                2,
+                2,
+                new int[]{0x000000, 0x808080, 0x404040, 0xffffff}));
+        try {
+            PocketCamera camera = new PocketCamera(new Rom(new byte[0x8000]), Battery.NULL_BATTERY);
+            camera.setByte(0x4000, 0x10);
+            camera.setByte(0xa001, 4); // gain 1.0
+            camera.setByte(0xa002, 0x10); // exposure 0x1000
+            camera.setByte(0xa003, 0x00);
+            for (int threshold = 0; threshold < 16; threshold++) {
+                int register = 6 + threshold * 3;
+                camera.setByte(0xa000 + register, 64);
+                camera.setByte(0xa000 + register + 1, 128);
+                camera.setByte(0xa000 + register + 2, 192);
+            }
+            camera.setByte(0xa000, 1);
+            camera.setByte(0x4000, 0);
+
+            assertEquals(3, colorAt(camera, 0, 0));
+            assertEquals(1, colorAt(camera, 64, 0));
+            assertEquals(2, colorAt(camera, 0, 56));
+            assertEquals(0, colorAt(camera, 64, 56));
+        } finally {
+            PocketCamera.setCameraSource(null);
+        }
+    }
+
+    @Test
+    public void frameOwnsAndBoundsItsRgbPixels() {
+        int[] pixels = {0xff112233};
+        CameraFrame frame = new CameraFrame(1, 1, pixels);
+        pixels[0] = 0;
+
+        assertArrayEquals(new int[]{0x112233}, frame.copyRgb());
+        assertThrows(IllegalArgumentException.class, () -> new CameraFrame(0, 1, new int[0]));
+        assertThrows(IllegalArgumentException.class, () -> new CameraFrame(1, 1, new int[2]));
+    }
+
+    private static int colorAt(PocketCamera camera, int x, int y) {
+        int tile = (y / 8) * 16 + (x / 8);
+        int address = 0xa100 + tile * 16 + (y & 7) * 2;
+        int bit = 7 - (x & 7);
+        int low = (camera.getByte(address) >> bit) & 1;
+        int high = (camera.getByte(address + 1) >> bit) & 1;
+        return low | (high << 1);
+    }
+}

--- a/docs/adr/0003-android-build-boundary.md
+++ b/docs/adr/0003-android-build-boundary.md
@@ -21,22 +21,21 @@ would make a new Android-facing artifact unsafe by default.
 
 1. `android/` is a standalone Gradle project with an `app` module. Maven remains the source of
    truth for Coffee GB artifacts; Gradle does not include, compile, or copy emulator sources.
-2. Phase 0 consumes only Maven module `android-portable`. It contains one Java record/switch probe
-   and one Kotlin class. It proves that the Android D8/R8 pipeline consumes Coffee GB's current
-   Java and Kotlin bytecode shape without falsely declaring `core` or `controller` portable.
-3. Dependencies are managed in the parent POM but declared by each child. The temporary portable
-   artifact therefore has only Kotlin's standard library in its runtime graph, rather than
-   inheriting JLine or a desktop logging binding.
+2. Phase 0 consumed only Maven module `android-portable`. Phase 1 replaces that probe with the
+   real `controller` and transitive `core` artifacts after their desktop-only image, keyboard, and
+   console contracts moved behind Swing adapters.
+3. Dependencies are managed in the parent POM but declared by each child. `core` and `controller`
+   therefore have no JLine, desktop logging binding, image toolkit, or native desktop runtime in
+   their Android graph.
 4. The Android build accepts `coffeeGbMavenRepository` only when it resolves exactly to
    `<checkout>/build/android-m2`. It has no Maven-local fallback. The documented Maven command
-   installs the parent POM and `android-portable` into that directory before Gradle resolves.
+   installs the parent POM, `core`, and `controller` into that directory before Gradle resolves.
    A clean checkout has no such directory, so Gradle fails rather than accepting stale artifacts.
-5. The Android app is Java-only in Phase 0 and has no emulator feature. It is a minimal Activity
-   that exercises both classes from the same-checkout artifact. It requests no permission.
+5. The Android app is Java-only in Phase 1 and has no emulator feature. It is a minimal Activity
+   that exercises a portable controller pixel value. It requests no permission.
 
-This boundary is intentionally temporary. Phase 1 must make real reusable contracts portable. It
-must not bypass the work by adding `core` or `controller` to `android/app` while the forbidden
-surfaces above remain.
+This boundary remains intentionally narrow. Later phases add lifecycle-owned sessions and Android
+presentation without copying emulator logic or reintroducing desktop dependencies.
 
 ## Toolchain
 
@@ -69,21 +68,21 @@ From a clean checkout:
 
 ```bash
 mvn -B test
-mvn -B -pl android-portable -am install -DskipTests -Dmaven.repo.local="$PWD/build/android-m2"
+mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$PWD/build/android-m2"
 ./android/gradlew -p android -PcoffeeGbMavenRepository="$PWD/build/android-m2" \
   :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease
 ```
 
 `assembleRelease` keeps code and resource shrinking enabled, exercising R8. Device instrumentation
-and Android 26/36 emulator coverage are Phase 9 work; no Phase-0 feature needs a device runner.
+and Android 26/36 emulator coverage are Phase 9 work; no Phase-1 feature needs a device runner.
 
 ## Consequences
 
 - Desktop Maven behavior remains unchanged at runtime, but modules now declare the libraries they
   actually use instead of inheriting them from the parent.
-- The Android APK contains no Coffee GB emulator implementation yet. That is an honest portability
-  boundary, not a second emulator or a claim of playable support.
-- Phase 1 owns migration of the documented AWT/JLine APIs. Later phases own URI storage, session
+- The Android APK now validates the real portable Coffee GB runtime, but still has no emulation
+  session or playable frontend. It remains one shared implementation rather than a second emulator.
+- Phase 1 owns migration of the documented desktop APIs. Later phases own URI storage, session
   lifecycle, renderer, input, audio, UI, device integrations, and CI instrumentation.
 - No Internet, broad storage, camera, microphone, analytics, or ROM/service integration is
   introduced. ROM and persistent-data ownership remain unchanged until their dedicated phases.

--- a/swing/pom.xml
+++ b/swing/pom.xml
@@ -180,6 +180,15 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
             <version>9.0.5</version>

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyAdapter.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyAdapter.java
@@ -1,0 +1,91 @@
+package eu.rekawek.coffeegb.swing;
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings;
+import eu.rekawek.coffeegb.controller.properties.ControllerProperties;
+
+import java.awt.event.KeyEvent;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Resolves portable persisted keyboard tokens at the desktop boundary. */
+public final class DesktopKeyboardKeyAdapter {
+
+    private static final Map<Integer, String> CANONICAL_NAMES_BY_CODE =
+            java.util.Arrays.stream(KeyEvent.class.getFields())
+                    .filter(field -> field.getName().startsWith("VK_"))
+                    .filter(field -> field.getType() == int.class)
+                    .filter(field -> Modifier.isStatic(field.getModifiers()))
+                    .collect(Collectors.groupingBy(
+                            field -> getInt(field),
+                            Collectors.collectingAndThen(
+                                    Collectors.toList(),
+                                    fields -> fields.stream()
+                                            .map(Field::getName)
+                                            .min(String::compareTo)
+                                            .orElseThrow())));
+
+    private DesktopKeyboardKeyAdapter() {
+    }
+
+    public static ApplicationSettings.KeyboardKey fromKeyCode(int keyCode) {
+        if (keyCode == KeyEvent.VK_UNDEFINED) {
+            throw new IllegalArgumentException("Undefined desktop keys cannot be bound");
+        }
+        String name = CANONICAL_NAMES_BY_CODE.get(keyCode);
+        if (name == null) {
+            throw new IllegalArgumentException("Unsupported desktop key code " + keyCode);
+        }
+        return ApplicationSettings.KeyboardKey.Companion.parse(name, "desktop keyboard capture");
+    }
+
+    public static int keyCode(ApplicationSettings.KeyboardKey key) {
+        Field field;
+        try {
+            field = KeyEvent.class.getField(key.getPropertyName());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("Unknown desktop keyboard key " + key.getPropertyName());
+        }
+        if (field.getType() != int.class || !Modifier.isStatic(field.getModifiers())) {
+            throw new IllegalArgumentException("Invalid desktop keyboard key " + key.getPropertyName());
+        }
+        int keyCode = getInt(field);
+        if (keyCode == KeyEvent.VK_UNDEFINED) {
+            throw new IllegalArgumentException("Undefined desktop keys cannot be bound");
+        }
+        return keyCode;
+    }
+
+    public static List<Integer> keyCodes(Collection<ApplicationSettings.KeyboardKey> keys) {
+        return keys.stream().map(DesktopKeyboardKeyAdapter::keyCode).collect(Collectors.toList());
+    }
+
+    /** Converts the portable mapping just before Swing receives host key events. */
+    public static Map<Integer, ControllerProperties.PlayerButton> resolveMapping(
+            Map<ApplicationSettings.KeyboardKey, ControllerProperties.PlayerButton> mapping) {
+        Map<Integer, ControllerProperties.PlayerButton> resolved = new LinkedHashMap<>();
+        mapping.forEach((key, binding) -> {
+            int keyCode = keyCode(key);
+            ControllerProperties.PlayerButton previous = resolved.put(keyCode, binding);
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "Desktop key " + KeyEvent.getKeyText(keyCode) + " is assigned to both P"
+                                + (previous.getPlayer() + 1) + " " + previous.getButton() + " and P"
+                                + (binding.getPlayer() + 1) + " " + binding.getButton());
+            }
+        });
+        return resolved;
+    }
+
+    private static int getInt(Field field) {
+        try {
+            return field.getInt(null);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Unable to read desktop keyboard constant", e);
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyExtensions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyExtensions.kt
@@ -1,0 +1,7 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+
+/** Desktop-only convenience view used by Swing widgets and their tests. */
+internal val ApplicationSettings.KeyboardKey.code: Int
+  get() = DesktopKeyboardKeyAdapter.keyCode(this)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
@@ -211,7 +211,7 @@ class KeyboardMappingEditor private constructor(
     }
     val key =
         try {
-          ApplicationSettings.KeyboardKey.fromKeyCode(keyCode)
+          DesktopKeyboardKeyAdapter.fromKeyCode(keyCode)
         } catch (_: IllegalArgumentException) {
           return EditResult.Unsupported(binding, keyCode).also {
             showStatus("That key cannot be stored as a keyboard binding.")
@@ -221,7 +221,7 @@ class KeyboardMappingEditor private constructor(
     val previousTargetKey = keyboard[target]
     val conflict =
         keyboard.entries.firstOrNull { (candidate, candidateKey) ->
-          candidate != target && candidateKey.code == key.code
+          candidate != target && candidateKey == key
         }
     if (conflict != null) {
       val existing = conflict.key.toBinding()
@@ -500,7 +500,8 @@ class KeyboardMappingEditor private constructor(
 
   private fun ControllerProperties.PlayerButton.toBinding() = Binding(player, button)
 
-  private fun ApplicationSettings.KeyboardKey.displayName(): String = KeyEvent.getKeyText(code)
+  private fun ApplicationSettings.KeyboardKey.displayName(): String =
+      KeyEvent.getKeyText(DesktopKeyboardKeyAdapter.keyCode(this))
 
   private companion object {
     const val PLAYER_COUNT = 4

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -13,9 +13,12 @@ import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
 import eu.rekawek.coffeegb.core.debug.Console
+import eu.rekawek.coffeegb.swing.debug.JlineConsole
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera
 import eu.rekawek.coffeegb.core.sound.Sound
+import eu.rekawek.coffeegb.swing.io.DesktopCameraSource
 import eu.rekawek.coffeegb.swing.packaging.NativeRuntimeBootstrap
 import java.awt.Cursor
 import java.awt.Dimension
@@ -92,7 +95,7 @@ class SwingGui private constructor(
 
   private val emulator: SwingEmulator
 
-  private val console: Console? = if (debug) Console() else null
+  private val console: JlineConsole? = if (debug) JlineConsole() else null
 
   private lateinit var mainWindow: JFrame
 
@@ -172,6 +175,7 @@ class SwingGui private constructor(
   }
 
   init {
+    PocketCamera.setCameraSource(DesktopCameraSource.INSTANCE)
     eventBus = EventBusImpl()
     emulator =
         SwingEmulator(
@@ -390,7 +394,7 @@ class SwingGui private constructor(
             ))
     desktopActions.applyShortcuts(
         DesktopShortcutRegistry(
-            properties.applicationSettings.input.keyboard.values.map { it.code }))
+            DesktopKeyboardKeyAdapter.keyCodes(properties.applicationSettings.input.keyboard.values)))
     menu =
         SwingMenu(
             properties,
@@ -1000,7 +1004,7 @@ class SwingGui private constructor(
     applyEffect("controls") {
       emulator.applyKeyboardMapping(applied.input.toPlayerMapping())
       desktopActions.applyShortcuts(
-          DesktopShortcutRegistry(applied.input.keyboard.values.map { it.code }))
+          DesktopShortcutRegistry(DesktopKeyboardKeyAdapter.keyCodes(applied.input.keyboard.values)))
     }
     applyEffect("audio and game controllers") { emulator.applyDeviceSettings(applied) }
     applyEffect("camera") { menu.applyCameraSettings(applied.peripherals) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -15,7 +15,7 @@ import eu.rekawek.coffeegb.core.genie.AddPatches
 import eu.rekawek.coffeegb.core.genie.CheatDatabase
 import eu.rekawek.coffeegb.core.genie.PatchFactory
 import eu.rekawek.coffeegb.core.ir.FullChanger
-import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera
+import eu.rekawek.coffeegb.swing.io.DesktopCameraSource
 import eu.rekawek.coffeegb.swing.io.WebcamCameraSource
 import java.awt.Component
 import java.awt.event.KeyEvent
@@ -426,7 +426,7 @@ internal class SwingMenu(
             opener = WebcamCameraSource::open,
             initialDeviceIndex = cameraDeviceIndex,
             sourceCloser = WebcamCameraSource::close,
-            publisher = PocketCamera::setCameraSource,
+            publisher = DesktopCameraSource.INSTANCE::setLiveSource,
             stateConsumer = { state ->
               camera.text =
                   if (state == CameraPeripheralUiState.Opening) {
@@ -798,7 +798,7 @@ internal fun createScreenMenu(
    * delivering one physical press to two owners.
    */
   fun fullscreenAccelerator(): KeyStroke? =
-      if (keyboardBindings().none { it.code == KeyEvent.VK_F11 }) {
+      if (keyboardBindings().none { DesktopKeyboardKeyAdapter.keyCode(it) == KeyEvent.VK_F11 }) {
         KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0)
       } else {
         null

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/debug/JlineConsole.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/debug/JlineConsole.java
@@ -1,0 +1,31 @@
+package eu.rekawek.coffeegb.swing.debug;
+
+import eu.rekawek.coffeegb.core.debug.Console;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Desktop JLine presentation for the platform-neutral debugger command processor. */
+public final class JlineConsole extends Console implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JlineConsole.class);
+
+    @Override
+    public void run() {
+        LineReader lineReader = LineReaderBuilder.builder().build();
+        while (!isStopped()) {
+            try {
+                executeLine(lineReader.readLine("coffee-gb> "));
+            } catch (IllegalArgumentException e) {
+                error.println(e.getMessage());
+            } catch (UserInterruptException e) {
+                stop();
+            } catch (RuntimeException e) {
+                LOG.warn("Console command failed", e);
+                error.println("Command failed.");
+            }
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopCameraSource.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopCameraSource.java
@@ -1,0 +1,70 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraFrame;
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraSource;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+/**
+ * Desktop-only camera adapter that preserves the historical webcam-then-image-file behavior.
+ *
+ * <p>The static system-property and ImageIO details intentionally stay on this side of the core
+ * boundary. Every returned frame is immutable and the emulator only sees {@link CameraFrame}.
+ */
+public final class DesktopCameraSource implements CameraSource {
+
+    public static final DesktopCameraSource INSTANCE = new DesktopCameraSource();
+
+    private volatile CameraSource liveSource;
+
+    private long sourceTimestamp;
+
+    private CameraFrame sourceFrame;
+
+    private DesktopCameraSource() {
+    }
+
+    public void setLiveSource(CameraSource source) {
+        liveSource = source;
+    }
+
+    @Override
+    public CameraFrame getFrame() {
+        CameraSource live = liveSource;
+        if (live != null) {
+            CameraFrame frame = live.getFrame();
+            if (frame != null) {
+                return frame;
+            }
+        }
+        return imageFileFrame();
+    }
+
+    private synchronized CameraFrame imageFileFrame() {
+        String path = System.getProperty("coffeegb.camera.image");
+        if (path == null) {
+            return null;
+        }
+        File file = new File(path);
+        if (!file.isFile()) {
+            return null;
+        }
+        try {
+            if (sourceFrame == null || file.lastModified() != sourceTimestamp) {
+                BufferedImage image = ImageIO.read(file);
+                if (image != null) {
+                    int width = image.getWidth();
+                    int height = image.getHeight();
+                    int[] rgb = image.getRGB(0, 0, width, height, null, 0, width);
+                    sourceFrame = new CameraFrame(width, height, rgb);
+                    sourceTimestamp = file.lastModified();
+                }
+            }
+            return sourceFrame;
+        } catch (RuntimeException | java.io.IOException ignored) {
+            return sourceFrame;
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.ControllerProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.swing.DesktopKeyboardKeyAdapter;
 
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -28,7 +29,7 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
     @SuppressWarnings("unchecked")
     public SwingJoypad(ControllerProperties.PlayerMapping mapping, EventBus eventBus,
                        DesktopPlayerInput input) {
-        this.mapping = Map.copyOf(mapping.getKeyboard());
+        this.mapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveMapping(mapping.getKeyboard()));
         this.eventBus = eventBus;
         this.input = input;
         this.pressed = new EnumSet[4];
@@ -113,7 +114,7 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
         releaseKeyboard();
         releaseRewind();
         input.releaseAll();
-        this.mapping = Map.copyOf(mapping.getKeyboard());
+        this.mapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveMapping(mapping.getKeyboard()));
     }
 
     private void update(int player) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/WebcamCameraSource.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/WebcamCameraSource.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.core.memory.cart.type.CameraSource;
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraFrame;
 import eu.rekawek.coffeegb.swing.packaging.NativeRuntimeBootstrap;
 import nu.pattern.OpenCV;
 import org.opencv.core.Mat;
@@ -8,8 +9,6 @@ import org.opencv.videoio.VideoCapture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -37,7 +36,7 @@ public class WebcamCameraSource implements CameraSource, AutoCloseable {
 
     private volatile boolean running = true;
 
-    private volatile BufferedImage latest;
+    private volatile CameraFrame latest;
 
     private WebcamCameraSource(VideoCapture capture) {
         this.capture = capture;
@@ -101,7 +100,7 @@ public class WebcamCameraSource implements CameraSource, AutoCloseable {
         while (running) {
             try {
                 if (capture.read(mat) && !mat.empty()) {
-                    latest = matToBufferedImage(mat);
+                    latest = matToCameraFrame(mat);
                 } else {
                     Thread.sleep(50);
                 }
@@ -119,21 +118,30 @@ public class WebcamCameraSource implements CameraSource, AutoCloseable {
     }
 
     @Override
-    public BufferedImage getFrame() {
+    public CameraFrame getFrame() {
         return latest;
     }
 
-    private static BufferedImage matToBufferedImage(Mat mat) {
+    private static CameraFrame matToCameraFrame(Mat mat) {
         int width = mat.cols();
         int height = mat.rows();
         int channels = mat.channels();
-        byte[] data = new byte[width * height * channels];
+        byte[] data = new byte[Math.multiplyExact(Math.multiplyExact(width, height), channels)];
         mat.get(0, 0, data);
-        int type = channels == 1 ? BufferedImage.TYPE_BYTE_GRAY : BufferedImage.TYPE_3BYTE_BGR;
-        BufferedImage image = new BufferedImage(width, height, type);
-        byte[] target = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
-        System.arraycopy(data, 0, target, 0, Math.min(data.length, target.length));
-        return image;
+        int[] rgb = new int[Math.multiplyExact(width, height)];
+        for (int pixel = 0; pixel < rgb.length; pixel++) {
+            int offset = pixel * channels;
+            if (channels == 1) {
+                int grey = data[offset] & 0xff;
+                rgb[pixel] = (grey << 16) | (grey << 8) | grey;
+            } else {
+                int blue = data[offset] & 0xff;
+                int green = data[offset + 1] & 0xff;
+                int red = data[offset + 2] & 0xff;
+                rgb[pixel] = (red << 16) | (green << 8) | blue;
+            }
+        }
+        return new CameraFrame(width, height, rgb);
     }
 
     @Override

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/CameraPeripheralControllerTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/CameraPeripheralControllerTest.kt
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.core.memory.cart.type.CameraSource
-import java.awt.image.BufferedImage
 import java.io.IOException
 import java.util.Collections
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -356,7 +355,7 @@ class CameraPeripheralControllerTest {
   }
 
   private class TestSource : CameraSource {
-    override fun getFrame(): BufferedImage? = null
+    override fun getFrame() = null
   }
 
   private fun awaitIgnoringInterrupt(latch: CountDownLatch) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -300,7 +300,7 @@ class PreferencesDialogTest {
         val changedKeyboard =
             defaults.input.keyboard +
                 (ControllerProperties.PlayerButton(0, Button.A) to
-                    ApplicationSettings.KeyboardKey.fromKeyCode(KeyEvent.VK_A))
+                    DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_A))
         val initial =
             defaults.copy(
                 general =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
@@ -184,7 +184,7 @@ class ScreenMenuTest {
       assertEquals(1, fixture.settings.replacements)
 
       fixture.keyboardBindings +=
-          ApplicationSettings.KeyboardKey.fromKeyCode(KeyEvent.VK_F11)
+          DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_F11)
       onScreenMenuEdt {
         fixture.eventBus.post(DisplaySettingsChangedEvent(fixture.settings.display))
       }


### PR DESCRIPTION
Closes #355.

## What changed
- Makes Android consume the real controller and transitive core runtime from the isolated Maven repository.
- Replaces desktop image values with portable RGB camera/state-image contracts and a deterministic PNG codec.
- Moves JLine, desktop keyboard resolution, image-file loading, webcam conversion, and the desktop logging binding to Swing/CLI adapters.
- Keeps persisted keyboard tokens portable and canonical, including the historical separator alias.
- Adds camera-frame and Android artifact coverage; documents the Phase 1 boundary.

## Why
The Android runtime graph previously stopped at a probe artifact because desktop APIs leaked through reusable modules. This removes those leaks without duplicating emulator logic or adding Android permissions.

## Validation
- mvn -B test (all modules)
- focused controller settings tests
- Android check, lint, debug assembly, and R8 release assembly