### PR TITLE
[Android] Add SAF ROM loading and app-private persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ The Gradle build refuses any repository other than `build/android-m2`, so it can
 back to a stale copy from `~/.m2`. See the ADR for the supported toolchain and the full clean-checkout
 flow.
 
+The starter activity opens `.gb`, `.gbc`, `.rom`, and ZIP documents through Android's Storage
+Access Framework; it asks only for the selected document's read grant and retains it for Recents
+only when the provider offers a persistable grant. There are no broad storage permissions. Provider
+streams are bounded to 64 MiB per ROM, 128 MiB per ZIP container, 256 MiB after decompression, and
+4,096 archive entries. Pathless Android input deliberately supports ZIP rather than 7z because the
+bounded 7z decoder currently needs a desktop filesystem handle.
+
+Battery saves and portable StateFile saves are stored atomically under the app's no-backup private
+directory, keyed solely by the ROM's exact SHA-256 identity. This keeps duplicate document names
+separate, preserves crash recovery, and never turns a document URI into a filename. Battery and
+StateFile import/export use the Android document picker; import replacement and export destination
+replacement are confirmed explicitly. A revoked recent-document grant is removed without exposing
+the document URI in the error message.
+
 ## Download and play
 
 The portable Coffee GB download is a single executable JAR. It requires a desktop **Java 16 or

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomInput.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomInput.java
@@ -1,0 +1,84 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import eu.rekawek.coffeegb.core.memory.cart.RomInput;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/** Android Storage Access Framework adapter. It deliberately exposes no filesystem path. */
+final class AndroidRomInput implements RomInput {
+
+    private final ContentResolver resolver;
+    private final Uri uri;
+    private final String displayName;
+    private final long declaredSize;
+
+    AndroidRomInput(ContentResolver resolver, Uri uri) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.uri = Objects.requireNonNull(uri, "uri");
+        Metadata metadata = metadata(resolver, uri);
+        this.displayName = metadata.displayName;
+        this.declaredSize = metadata.size;
+    }
+
+    @Override
+    public String displayName() {
+        return displayName;
+    }
+
+    @Override
+    public InputStream openStream() throws IOException {
+        InputStream stream = resolver.openInputStream(uri);
+        if (stream == null) {
+            throw new FileNotFoundException("The selected document is no longer available");
+        }
+        return stream;
+    }
+
+    @Override
+    public long declaredSize() {
+        return declaredSize;
+    }
+
+    @Override
+    public String toString() {
+        return "AndroidRomInput(<redacted>)";
+    }
+
+    private static Metadata metadata(ContentResolver resolver, Uri uri) {
+        String fallback = uri.getLastPathSegment();
+        String name = fallback == null || fallback.isBlank() ? "selected-rom.gb" : fallback;
+        long size = -1L;
+        try (Cursor cursor = resolver.query(
+                uri,
+                new String[]{OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE},
+                null,
+                null,
+                null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                int nameColumn = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (nameColumn >= 0 && !cursor.isNull(nameColumn)) {
+                    String supplied = cursor.getString(nameColumn);
+                    if (supplied != null && !supplied.isBlank()) {
+                        name = supplied;
+                    }
+                }
+                int sizeColumn = cursor.getColumnIndex(OpenableColumns.SIZE);
+                if (sizeColumn >= 0 && !cursor.isNull(sizeColumn)) {
+                    size = cursor.getLong(sizeColumn);
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // Metadata is advisory. The bounded stream reader remains authoritative.
+        }
+        return new Metadata(name, size);
+    }
+
+    private record Metadata(String displayName, long size) {}
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomPersistenceStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomPersistenceStore.java
@@ -1,0 +1,66 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import eu.rekawek.coffeegb.controller.state.BatteryStore;
+import eu.rekawek.coffeegb.controller.state.FileStateStore;
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore;
+import eu.rekawek.coffeegb.controller.state.SessionPersistence;
+import eu.rekawek.coffeegb.controller.state.StateRomHashes;
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * App-private persistence for SAF-loaded ROMs.
+ *
+ * <p>Only the exact normalized ROM hash becomes a directory name. Document display names and
+ * content URIs are never used as storage paths, so duplicate filenames cannot collide and a
+ * revoked grant cannot make an app-private save escape its namespace.
+ */
+public final class AndroidRomPersistenceStore implements RomPersistenceStore {
+
+    private static final String ROOT_DIRECTORY = "coffee-gb";
+
+    private final Path root;
+
+    public AndroidRomPersistenceStore(Context context) throws IOException {
+        Objects.requireNonNull(context, "context");
+        root = context.getNoBackupFilesDir().toPath().resolve(ROOT_DIRECTORY)
+                .toAbsolutePath().normalize();
+        Files.createDirectories(root);
+    }
+
+    @Override
+    public SessionPersistence resolve(
+            Gameboy.GameboyConfiguration configuration,
+            StateRomHashes hashes) {
+        StateStorageLayout primaryLayout = layout(hashes.getPrimaryRom().hex());
+        BatteryStore primary = () -> battery(primaryLayout);
+        BatteryStore slot = hashes.getSlotRom() == null
+                ? null
+                : () -> battery(layout(hashes.getSlotRom().hex()));
+        return new SessionPersistence(new FileStateStore(primaryLayout), primary, slot);
+    }
+
+    StateStorageLayout layout(String romSha256) {
+        if (romSha256 == null || !romSha256.matches("[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("ROM storage identity must be a SHA-256 digest");
+        }
+        return new StateStorageLayout(root.resolve("games").resolve(romSha256));
+    }
+
+    Path root() {
+        return root;
+    }
+
+    private BatteryStorage battery(StateStorageLayout layout) {
+        return new BatteryStorage(
+                BatteryStorage.Source.managed(layout.getBatteryFile(), root),
+                java.util.List.of());
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1,28 +1,401 @@
 package eu.rekawek.coffeegb.android;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.Gravity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
-import eu.rekawek.coffeegb.controller.state.StateImage;
+import eu.rekawek.coffeegb.controller.state.StateRef;
+import eu.rekawek.coffeegb.controller.state.StateRepository;
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.RomImage;
+import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
- * Permission-free Phase 1 startup probe. It validates that the real portable controller runtime
- * reaches Android without introducing ROM, storage, or session behavior prematurely.
+ * Permission-free SAF ROM-opening probe. ROM decoding and app-private storage work run on the
+ * dedicated worker; the UI thread only launches documents and renders immutable results.
  */
 public final class MainActivity extends Activity {
+
+    private static final int OPEN_ROM_REQUEST = 1;
+    private static final int IMPORT_BATTERY_REQUEST = 2;
+    private static final int EXPORT_BATTERY_REQUEST = 3;
+    private static final int IMPORT_STATE_REQUEST = 4;
+    private static final int EXPORT_STATE_REQUEST = 5;
+
+    private final ExecutorService romWorker = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "coffee-gb-android-rom-open");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private TextView status;
+    private Button importBattery;
+    private Button exportBattery;
+    private Button importState;
+    private Button exportState;
+
+    private volatile StateStorageLayout activeLayout;
+    private volatile StateRepository activeStates;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        StateImage portableFrame = new StateImage(1, 1, new int[]{0x00_88_cc});
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setGravity(Gravity.CENTER);
+        int padding = (int) (24 * getResources().getDisplayMetrics().density);
+        content.setPadding(padding, padding, padding, padding);
 
-        TextView message = new TextView(this);
-        message.setGravity(Gravity.CENTER);
-        message.setContentDescription("Coffee GB Android portable runtime probe");
-        message.setText("Coffee GB Android portable runtime ready: " +
-                String.format("#%06X", portableFrame.copyRgb()[0]));
-        setContentView(message);
+        status = new TextView(this);
+        status.setGravity(Gravity.CENTER);
+        status.setContentDescription("Coffee GB Android ROM loading status");
+        status.setText("Coffee GB Android is ready. Choose a ROM or ZIP document.");
+        content.addView(status);
+
+        Button open = new Button(this);
+        open.setText("Open ROM");
+        open.setOnClickListener(this::openRomDocument);
+        content.addView(open);
+
+        Button recent = new Button(this);
+        recent.setText("Open recent ROM");
+        recent.setOnClickListener(this::openRecentRom);
+        content.addView(recent);
+
+        importBattery = transferButton("Import battery save", this::chooseBatteryImport);
+        exportBattery = transferButton("Export battery save", this::chooseBatteryExport);
+        importState = transferButton("Import state slot 0", this::chooseStateImport);
+        exportState = transferButton("Export state slot 0", this::chooseStateExport);
+        content.addView(importBattery);
+        content.addView(exportBattery);
+        content.addView(importState);
+        content.addView(exportState);
+        setContentView(content);
+    }
+
+    @Override
+    protected void onDestroy() {
+        romWorker.shutdownNow();
+        super.onDestroy();
+    }
+
+    private void openRomDocument(View ignored) {
+        Intent request = new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("application/octet-stream")
+                .putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
+                        "application/octet-stream",
+                        "application/x-gameboy-rom",
+                        "application/zip",
+                        "application/x-zip-compressed",
+                })
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        startActivityForResult(request, OPEN_ROM_REQUEST);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode != RESULT_OK || data == null || data.getData() == null) {
+            return;
+        }
+        Uri uri = data.getData();
+        if (requestCode == OPEN_ROM_REQUEST) {
+            retainReadPermission(uri, data.getFlags());
+            status.setText("Opening selected ROM…");
+            romWorker.execute(() -> inspect(uri));
+            return;
+        }
+        switch (requestCode) {
+            case IMPORT_BATTERY_REQUEST -> importBattery(uri);
+            case EXPORT_BATTERY_REQUEST -> confirmExport(
+                    "Export battery save?",
+                    "The chosen document will be replaced.",
+                    () -> exportBattery(uri));
+            case IMPORT_STATE_REQUEST -> importState(uri);
+            case EXPORT_STATE_REQUEST -> confirmExport(
+                    "Export state slot 0?",
+                    "The chosen document will be replaced.",
+                    () -> exportState(uri));
+            default -> { }
+        }
+    }
+
+    private void retainReadPermission(Uri uri, int resultFlags) {
+        int read = resultFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        int persistable = resultFlags & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION;
+        if (read == 0 || persistable == 0) {
+            return;
+        }
+        try {
+            getContentResolver().takePersistableUriPermission(uri, read);
+        } catch (SecurityException ignored) {
+            // Some providers lawfully grant only the activity-lifetime permission. The document
+            // can still be opened now but is not retained as a recent document.
+        }
+    }
+
+    private void openRecentRom(View ignored) {
+        status.setText("Checking recent ROM permissions…");
+        romWorker.execute(() -> {
+            List<Uri> recent = new RecentSafDocuments(getApplicationContext()).readable();
+            if (recent.isEmpty()) {
+                showFailure("No readable recent ROM document is available.");
+                return;
+            }
+            String[] labels = new String[recent.size()];
+            for (int index = 0; index < labels.length; index++) {
+                labels[index] = "Recent ROM " + (index + 1);
+            }
+            runOnUiThread(() -> new AlertDialog.Builder(this)
+                    .setTitle("Open recent ROM")
+                    .setItems(labels, (dialog, index) -> {
+                        status.setText("Opening recent ROM…");
+                        romWorker.execute(() -> inspect(recent.get(index)));
+                    })
+                    .show());
+        });
+    }
+
+    private Button transferButton(String label, View.OnClickListener listener) {
+        Button button = new Button(this);
+        button.setText(label);
+        button.setEnabled(false);
+        button.setOnClickListener(listener);
+        return button;
+    }
+
+    private void chooseBatteryImport(View ignored) {
+        confirmImport(
+                "Import battery save?",
+                "Importing can replace this ROM's app-private battery save.",
+                IMPORT_BATTERY_REQUEST,
+                "application/octet-stream");
+    }
+
+    private void chooseBatteryExport(View ignored) {
+        chooseExport(EXPORT_BATTERY_REQUEST, "battery.sav");
+    }
+
+    private void chooseStateImport(View ignored) {
+        confirmImport(
+                "Import state slot 0?",
+                "Importing can replace this ROM's app-private state slot 0.",
+                IMPORT_STATE_REQUEST,
+                "application/octet-stream");
+    }
+
+    private void chooseStateExport(View ignored) {
+        chooseExport(EXPORT_STATE_REQUEST, "slot-0.cgbstate");
+    }
+
+    private void confirmImport(String title, String message, int requestCode, String mimeType) {
+        if (!ensureLoaded()) {
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setMessage(message)
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton("Choose document", (dialog, ignored) -> startActivityForResult(
+                        new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                                .addCategory(Intent.CATEGORY_OPENABLE)
+                                .setType(mimeType)
+                                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION),
+                        requestCode))
+                .show();
+    }
+
+    private void chooseExport(int requestCode, String suggestedName) {
+        if (!ensureLoaded()) {
+            return;
+        }
+        startActivityForResult(
+                new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                        .addCategory(Intent.CATEGORY_OPENABLE)
+                        .setType("application/octet-stream")
+                        .putExtra(Intent.EXTRA_TITLE, suggestedName)
+                        .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
+                requestCode);
+    }
+
+    private boolean ensureLoaded() {
+        if (activeLayout != null && activeStates != null) {
+            return true;
+        }
+        showFailure("Open a ROM before importing or exporting its save data.");
+        return false;
+    }
+
+    private void importBattery(Uri source) {
+        StateStorageLayout layout = activeLayout;
+        if (layout == null) return;
+        status.setText("Importing battery save…");
+        romWorker.execute(() -> {
+            try {
+                SafPersistenceExchange.importBattery(
+                        getContentResolver(),
+                        source,
+                        layout,
+                        SafPersistenceExchange.CollisionDecision.REPLACE);
+                runOnUiThread(() -> status.setText("Battery save imported."));
+            } catch (Exception failure) {
+                showFailure("Coffee GB could not import that battery save.");
+            }
+        });
+    }
+
+    private void exportBattery(Uri destination) {
+        StateStorageLayout layout = activeLayout;
+        if (layout == null) return;
+        status.setText("Exporting battery save…");
+        romWorker.execute(() -> {
+            try {
+                SafPersistenceExchange.exportBattery(getContentResolver(), destination, layout, true);
+                runOnUiThread(() -> status.setText("Battery save exported."));
+            } catch (Exception failure) {
+                showFailure("Coffee GB could not export the battery save.");
+            }
+        });
+    }
+
+    private void importState(Uri source) {
+        StateRepository states = activeStates;
+        if (states == null) return;
+        status.setText("Importing state slot 0…");
+        romWorker.execute(() -> {
+            try {
+                SafPersistenceExchange.importState(
+                        getContentResolver(),
+                        source,
+                        states,
+                        new StateRef.Slot(0),
+                        SafPersistenceExchange.CollisionDecision.REPLACE);
+                runOnUiThread(() -> status.setText("State slot 0 imported."));
+            } catch (Exception failure) {
+                showFailure("Coffee GB could not import that state file.");
+            }
+        });
+    }
+
+    private void exportState(Uri destination) {
+        StateRepository states = activeStates;
+        if (states == null) return;
+        status.setText("Exporting state slot 0…");
+        romWorker.execute(() -> {
+            try {
+                SafPersistenceExchange.exportState(
+                        getContentResolver(), destination, states, new StateRef.Slot(0), true);
+                runOnUiThread(() -> status.setText("State slot 0 exported."));
+            } catch (Exception failure) {
+                showFailure("Coffee GB could not export state slot 0.");
+            }
+        });
+    }
+
+    private void confirmExport(String title, String message, Runnable action) {
+        new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setMessage(message)
+                .setNegativeButton("Cancel", null)
+                .setPositiveButton("Export", (dialog, ignored) -> action.run())
+                .show();
+    }
+
+    private void inspect(Uri uri) {
+        try {
+            AndroidRomInput input = new AndroidRomInput(getContentResolver(), uri);
+            RomSourceSnapshot snapshot = RomSourceSnapshot.open(input);
+            if (!snapshot.isArchive() || snapshot.candidates().size() == 1) {
+                load(snapshot, snapshot.isArchive()
+                        ? snapshot.candidates().get(0).token()
+                        : RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN, uri);
+                return;
+            }
+            List<RomSourceSnapshot.ArchiveCandidate> candidates = snapshot.candidates();
+            String[] names = candidates.stream()
+                    .map(RomSourceSnapshot.ArchiveCandidate::displayName)
+                    .toArray(String[]::new);
+            runOnUiThread(() -> new AlertDialog.Builder(this)
+                    .setTitle("Choose ROM from archive")
+                    .setItems(names, (dialog, index) -> romWorker.execute(
+                            () -> load(snapshot, candidates.get(index).token(), uri)))
+                    .setOnCancelListener(dialog -> closeQuietly(snapshot))
+                    .show());
+        } catch (Exception failure) {
+            // Deliberately do not expose content URIs or provider details in the UI.
+            forgetRevokedPermission(uri, failure);
+            showFailure("Coffee GB could not open this document. Check its permission and format.");
+        }
+    }
+
+    private void load(RomSourceSnapshot snapshot, long token, Uri sourceUri) {
+        try {
+            RomImage image = token == RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN
+                    ? snapshot.loadSingle()
+                    : snapshot.load(token);
+            Rom rom = new Rom(image);
+            AndroidRomPersistenceStore store = new AndroidRomPersistenceStore(getApplicationContext());
+            // Construct the hash-keyed layout now so a valid document never needs a path beside
+            // the provider's source. Controller session activation consumes this same store.
+            StateStorageLayout layout = store.layout(
+                    eu.rekawek.coffeegb.controller.state.StateIdentity.INSTANCE.hash(rom).hex());
+            StateRepository states = new StateRepository(
+                    layout,
+                    eu.rekawek.coffeegb.core.persistence.AtomicFileWriter.system());
+            new RecentSafDocuments(getApplicationContext()).recordIfPersisted(sourceUri);
+            runOnUiThread(() -> {
+                activeLayout = layout;
+                activeStates = states;
+                importBattery.setEnabled(true);
+                exportBattery.setEnabled(true);
+                importState.setEnabled(true);
+                exportState.setEnabled(true);
+                status.setText("Loaded " + rom.getTitle() + ". App-private saves are ready.");
+            });
+        } catch (Exception failure) {
+            forgetRevokedPermission(sourceUri, failure);
+            showFailure("Coffee GB could not load the selected ROM.");
+        } finally {
+            closeQuietly(snapshot);
+        }
+    }
+
+    private void forgetRevokedPermission(Uri uri, Exception failure) {
+        if (failure instanceof SecurityException || failure instanceof IOException) {
+            for (UriPermission permission : getContentResolver().getPersistedUriPermissions()) {
+                if (permission.getUri().equals(uri) && permission.isReadPermission()) {
+                    getContentResolver().releasePersistableUriPermission(
+                            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
+            }
+        }
+    }
+
+    private void showFailure(String message) {
+        runOnUiThread(() -> status.setText(message));
+    }
+
+    private static void closeQuietly(RomSourceSnapshot snapshot) {
+        try {
+            snapshot.close();
+        } catch (IOException ignored) {
+            // Stream snapshots have no path to unlink; a close failure is not user actionable.
+        }
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RecentSafDocuments.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RecentSafDocuments.java
@@ -1,0 +1,86 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.UriPermission;
+import android.net.Uri;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/** Small, permission-aware recent-document list. Stale SAF grants are removed eagerly. */
+final class RecentSafDocuments {
+
+    private static final String PREFERENCES = "coffee-gb-saf";
+    private static final String KEY_URIS = "recent-rom-uris";
+    private static final int CAPACITY = 10;
+
+    private final ContentResolver resolver;
+    private final SharedPreferences preferences;
+
+    RecentSafDocuments(Context context) {
+        resolver = context.getContentResolver();
+        preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    void recordIfPersisted(Uri uri) {
+        if (!hasPersistedReadPermission(uri)) {
+            remove(uri);
+            return;
+        }
+        LinkedHashSet<String> ordered = new LinkedHashSet<>();
+        ordered.add(uri.toString());
+        ordered.addAll(preferences.getStringSet(KEY_URIS, Collections.emptySet()));
+        while (ordered.size() > CAPACITY) {
+            String oldest = ordered.stream().skip(CAPACITY).findFirst().orElseThrow();
+            ordered.remove(oldest);
+        }
+        preferences.edit().putStringSet(KEY_URIS, ordered).apply();
+    }
+
+    List<Uri> readable() {
+        List<Uri> result = new ArrayList<>();
+        for (String encoded : preferences.getStringSet(KEY_URIS, Collections.emptySet())) {
+            Uri uri = Uri.parse(encoded);
+            if (hasPersistedReadPermission(uri)) {
+                result.add(uri);
+            }
+        }
+        save(result);
+        return result;
+    }
+
+    void remove(Uri uri) {
+        List<Uri> remaining = new ArrayList<>();
+        for (String encoded : preferences.getStringSet(KEY_URIS, Collections.emptySet())) {
+            Uri candidate = Uri.parse(encoded);
+            if (!candidate.equals(uri) && hasPersistedReadPermission(candidate)) {
+                remaining.add(candidate);
+            }
+        }
+        save(remaining);
+    }
+
+    private boolean hasPersistedReadPermission(Uri uri) {
+        for (UriPermission permission : resolver.getPersistedUriPermissions()) {
+            if (permission.getUri().equals(uri) && permission.isReadPermission()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void save(List<Uri> uris) {
+        LinkedHashSet<String> encoded = new LinkedHashSet<>();
+        for (Uri uri : uris) {
+            if (encoded.size() == CAPACITY) {
+                break;
+            }
+            encoded.add(uri.toString());
+        }
+        preferences.edit().putStringSet(KEY_URIS, encoded).apply();
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/SafPersistenceExchange.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/SafPersistenceExchange.java
@@ -1,0 +1,170 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+import eu.rekawek.coffeegb.controller.state.StateCodec;
+import eu.rekawek.coffeegb.controller.state.StateRef;
+import eu.rekawek.coffeegb.controller.state.StateRepository;
+import eu.rekawek.coffeegb.controller.state.StateSaveMetadata;
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Bounded raw-battery and portable-StateFile transfer through SAF streams.
+ *
+ * <p>Import replacement and destination overwrite choices are deliberately explicit. UI code
+ * should ask for confirmation, then pass {@link CollisionDecision#REPLACE}; this class never
+ * silently destroys an app-private save or a caller-selected document.
+ */
+public final class SafPersistenceExchange {
+
+    // Matches the controller's battery headroom and portable StateFile envelope limit.
+    private static final int MAX_BATTERY_BYTES = 2 * 1024 * 1024;
+    private static final int MAX_STATE_BYTES = 128 * 1024 * 1024 + 128 * 1024;
+
+    private SafPersistenceExchange() {}
+
+    public enum CollisionDecision {
+        CANCEL,
+        REPLACE
+    }
+
+    public static void importBattery(
+            ContentResolver resolver,
+            Uri source,
+            StateStorageLayout layout,
+            CollisionDecision decision) throws IOException {
+        Path target = layout.getBatteryFile();
+        requireReplacementDecision(target, decision);
+        byte[] bytes = readBounded(resolver, source, MAX_BATTERY_BYTES);
+        AtomicFileWriter.system().write(target, bytes);
+    }
+
+    public static void exportBattery(
+            ContentResolver resolver,
+            Uri destination,
+            StateStorageLayout layout,
+            boolean destinationConfirmed) throws IOException {
+        requireDestinationConfirmation(destinationConfirmed);
+        byte[] bytes = AtomicFileWriter.system().read(layout.getBatteryFile(), path -> {
+            if (!Files.exists(path)) {
+                throw new FileNotFoundException("No battery save is available");
+            }
+            return Files.readAllBytes(path);
+        });
+        writeDocument(resolver, destination, bytes);
+    }
+
+    public static void importState(
+            ContentResolver resolver,
+            Uri source,
+            StateRepository repository,
+            StateRef ref,
+            CollisionDecision decision) throws IOException {
+        Objects.requireNonNull(repository, "repository");
+        Objects.requireNonNull(ref, "ref");
+        requireStateReplacementDecision(repository, ref, decision);
+        byte[] bytes = readBounded(resolver, source, MAX_STATE_BYTES);
+        // Decode before replacing the destination. This rejects malformed or unsupported #314
+        // StateFiles while preserving the current app-private state.
+        StateCodec.INSTANCE.decode(bytes);
+        repository.save(ref, bytes, new StateSaveMetadata(null, Instant.now(), null, null));
+    }
+
+    public static void exportState(
+            ContentResolver resolver,
+            Uri destination,
+            StateRepository repository,
+            StateRef ref,
+            boolean destinationConfirmed) throws IOException {
+        requireDestinationConfirmation(destinationConfirmed);
+        writeDocument(resolver, destination, repository.exportBytes(ref));
+    }
+
+    private static void requireReplacementDecision(Path target, CollisionDecision decision)
+            throws IOException {
+        Objects.requireNonNull(decision, "decision");
+        if (Files.exists(target) && decision != CollisionDecision.REPLACE) {
+            throw new FileAlreadyExistsException(
+                    target.getFileName().toString(),
+                    null,
+                    "Existing save requires explicit replacement confirmation");
+        }
+    }
+
+    private static void requireStateReplacementDecision(
+            StateRepository repository,
+            StateRef ref,
+            CollisionDecision decision) throws IOException {
+        Objects.requireNonNull(decision, "decision");
+        // Catalog preserves a corrupt or unreadable entry as occupied, so an import cannot
+        // silently overwrite something the user may still be able to recover.
+        boolean exists = repository.catalog(null).getEntries().stream()
+                .anyMatch(entry -> entry.getRef().equals(ref));
+        if (exists && decision != CollisionDecision.REPLACE) {
+            throw new FileAlreadyExistsException(
+                    ref.storageKey(),
+                    null,
+                    "Existing state requires explicit replacement confirmation");
+        }
+    }
+
+    private static void requireDestinationConfirmation(boolean destinationConfirmed) {
+        if (!destinationConfirmed) {
+            throw new IllegalStateException(
+                    "SAF destination replacement requires explicit user confirmation");
+        }
+    }
+
+    private static byte[] readBounded(ContentResolver resolver, Uri source, int maximum)
+            throws IOException {
+        Objects.requireNonNull(resolver, "resolver");
+        Objects.requireNonNull(source, "source");
+        try (InputStream input = resolver.openInputStream(source)) {
+            if (input == null) {
+                throw new FileNotFoundException("Selected document is no longer available");
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(maximum, 32 * 1024));
+            byte[] buffer = new byte[32 * 1024];
+            int total = 0;
+            while (true) {
+                int read = input.read(buffer);
+                if (read < 0) {
+                    return output.toByteArray();
+                }
+                if (read == 0) {
+                    continue;
+                }
+                if (read > maximum - total) {
+                    throw new IOException("Selected document exceeds its import safety limit");
+                }
+                output.write(buffer, 0, read);
+                total += read;
+            }
+        }
+    }
+
+    private static void writeDocument(ContentResolver resolver, Uri destination, byte[] bytes)
+            throws IOException {
+        Objects.requireNonNull(resolver, "resolver");
+        Objects.requireNonNull(destination, "destination");
+        try (OutputStream output = resolver.openOutputStream(destination, "wt")) {
+            if (output == null) {
+                throw new FileNotFoundException("Selected destination is no longer available");
+            }
+            output.write(bytes);
+            output.flush();
+        }
+    }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.properties.SystemProperties
 import eu.rekawek.coffeegb.controller.state.MachineState
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.debug.DebugPort
@@ -51,6 +52,8 @@ interface Controller : AutoCloseable {
       val rom: File,
       val state: MachineState? = null,
       val image: RomImage? = null,
+      /** Host-provided storage for pathless ROM inputs. Null retains the desktop adapter. */
+      val persistenceStore: RomPersistenceStore? = null,
       val openRequestId: Long? = null,
       /**
        * Whether a completed ROM activation may consult the autosave-resume policy. A Reset is a
@@ -62,12 +65,14 @@ interface Controller : AutoCloseable {
     constructor(
         image: RomImage,
         state: MachineState? = null,
+        persistenceStore: RomPersistenceStore? = null,
         openRequestId: Long? = null,
         allowAutosaveResume: Boolean = true,
     ) : this(
         image.origin().containerPath().map { it.toFile() }.orElse(File(image.origin().displayName())),
         state,
         image,
+        persistenceStore,
         openRequestId,
         allowAutosaveResume,
     )

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -7,7 +7,7 @@ import eu.rekawek.coffeegb.core.Gameboy.BootState
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.Gameboy.GameboyConfiguration
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
-import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
+import eu.rekawek.coffeegb.controller.state.DesktopRomPersistenceStore
 import eu.rekawek.coffeegb.controller.state.MachineState
 import eu.rekawek.coffeegb.controller.state.StateIdentity
 import eu.rekawek.coffeegb.controller.state.StateRomHashes
@@ -39,7 +39,9 @@ internal class RomSessionPreparer(
     ensureActive()
     val romHashes = StateIdentity.hashes(config)
     ensureActive()
-    BatteryStorageResolver.configure(properties.applicationSettings.saves, config, romHashes)
+    (event.persistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
+        .resolve(config, romHashes)
+        .applyTo(config)
     ensureActive()
 
     event.state?.let { return PreparedSession.FromDetachedState(config, it, romHashes) }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/RomPersistenceStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/RomPersistenceStore.kt
@@ -1,0 +1,72 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage
+
+/**
+ * Host-owned persistence for one emulation session.
+ *
+ * The controller never derives a writable location from a pathless ROM. Desktop callers use
+ * [DesktopRomPersistenceStore], while hosts such as Android can supply an app-private,
+ * hash-keyed implementation before the machine is built.
+ */
+fun interface RomPersistenceStore {
+  fun resolve(
+      configuration: Gameboy.GameboyConfiguration,
+      hashes: StateRomHashes,
+  ): SessionPersistence
+}
+
+/** State and battery stores resolved atomically for the exact primary ROM identity. */
+data class SessionPersistence(
+    /** Null only for legacy in-memory desktop callers that supplied no writable host store. */
+    val stateStore: StateStore?,
+    val primaryBatteryStore: BatteryStore?,
+    val slotBatteryStore: BatteryStore?,
+) {
+  fun applyTo(configuration: Gameboy.GameboyConfiguration) {
+    configuration.setBatteryStorage(
+        primaryBatteryStore?.storage(),
+        slotBatteryStore?.storage(),
+    )
+  }
+}
+
+/** Portable state-store contract; concrete stores choose their own safe backing location. */
+interface StateStore {
+  val layout: StateStorageLayout
+
+  fun repository(): StateRepository
+}
+
+/** Portable battery-store contract retained independently from the state store. */
+fun interface BatteryStore {
+  fun storage(): BatteryStorage
+}
+
+/** Existing NIO/desktop state repository exposed through the portable state-store contract. */
+class FileStateStore(
+    override val layout: StateStorageLayout,
+) : StateStore {
+  override fun repository(): StateRepository = StateRepository(layout)
+}
+
+/** Existing desktop save policy retained as the default controller adapter. */
+class DesktopRomPersistenceStore(
+    private val saves: ApplicationSettings.Saves,
+) : RomPersistenceStore {
+  override fun resolve(
+      configuration: Gameboy.GameboyConfiguration,
+      hashes: StateRomHashes,
+  ): SessionPersistence {
+    val stateStore =
+        configuration.rom.file?.let { FileStateStore(StateStorageResolver.resolve(saves, configuration).layout) }
+    val batteries = BatteryStorageResolver.resolve(saves, configuration, hashes)
+    return SessionPersistence(
+        stateStore,
+        batteries.primary?.let { battery -> BatteryStore { battery } },
+        batteries.slot?.let { battery -> BatteryStore { battery } },
+    )
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
@@ -317,6 +317,13 @@ class StateRepository(
     )
   }
 
+  /** Returns a defensive copy of the authoritative portable StateFile for host stream exports. */
+  fun exportBytes(ref: StateRef): ByteArray =
+      lock(ref).withLock {
+        val raw = readRaw(ref) ?: throw NoSuchFileException(layout.stateFile(ref).toString())
+        raw.bytes.clone()
+      }
+
   /**
    * Builds a bounded deterministic catalog. Supplying [targetIdentity] additionally classifies
    * wrong-ROM and wrong-profile entries without live-state access.

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -3,15 +3,23 @@ package eu.rekawek.coffeegb.controller
 import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
+import eu.rekawek.coffeegb.controller.state.BatteryStore
+import eu.rekawek.coffeegb.controller.state.FileStateStore
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore
+import eu.rekawek.coffeegb.controller.state.SessionPersistence
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.memory.cart.RomImage
 import eu.rekawek.coffeegb.core.memory.cart.RomOrigin
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage
 import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class RomSessionPreparerTest {
@@ -79,6 +87,42 @@ class RomSessionPreparerTest {
       assertEquals(bytes.toList(), prepared.config.rom.image.bytes().toList())
     } finally {
       Files.deleteIfExists(container)
+    }
+  }
+
+  @Test
+  fun pathlessRomUsesItsProvidedHostPersistenceStore() {
+    val root = Files.createTempDirectory("coffee-gb-pathless-store")
+    try {
+      val image = RomImage.memory(ROM.readBytes(), "picked.gb")
+      val store =
+          RomPersistenceStore { _, hashes ->
+            val layout = StateStorageLayout(root.resolve("games").resolve(hashes.primaryRom.hex()))
+            val battery =
+                BatteryStorage(
+                    BatteryStorage.Source.managed(layout.batteryFile, root),
+                    emptyList(),
+                )
+            SessionPersistence(
+                FileStateStore(layout),
+                BatteryStore { battery },
+                null,
+            )
+          }
+
+      val prepared =
+          RomSessionPreparer(BootStateCache(2)).prepare(
+              PROPERTIES,
+              LoadRomEvent(image, persistenceStore = store),
+          )
+
+      assertNull(prepared.config.rom.file)
+      assertTrue(prepared.config.batteryStorage.targetPath().startsWith(root))
+      assertTrue(prepared.config.batteryStorage.targetPath().fileName.toString() == "battery.sav")
+    } finally {
+      Files.walk(root).use { paths ->
+        paths.sorted(java.util.Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+      }
     }
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomInput.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomInput.java
@@ -1,0 +1,55 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * One user-selected ROM input that can be opened without resolving it to a filesystem path.
+ *
+ * <p>The caller owns the host permission (for example, a desktop file handle or Android SAF
+ * grant). Coffee GB opens the stream once while creating a bounded {@link RomSourceSnapshot};
+ * implementations therefore need not support reopening the source after that call.
+ */
+public interface RomInput {
+
+    /** Human-readable source name used only for type selection and presentation. */
+    String displayName();
+
+    /** Opens the exact bytes selected by the user. */
+    InputStream openStream() throws IOException;
+
+    /**
+     * Declared byte length when the host can provide it, or {@code -1} when unknown.
+     *
+     * <p>The loader still enforces its own observed-byte bounds, so this value is advisory.
+     */
+    default long declaredSize() {
+        return -1L;
+    }
+
+    /** Simple one-shot adapter for hosts that already own a stream-opening function. */
+    static RomInput of(String displayName, StreamOpener opener) {
+        String name = Objects.requireNonNull(displayName, "displayName");
+        StreamOpener checkedOpener = Objects.requireNonNull(opener, "opener");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("displayName must not be blank");
+        }
+        return new RomInput() {
+            @Override
+            public String displayName() {
+                return name;
+            }
+
+            @Override
+            public InputStream openStream() throws IOException {
+                return checkedOpener.open();
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface StreamOpener {
+        InputStream open() throws IOException;
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomOrigin.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomOrigin.java
@@ -232,7 +232,7 @@ public final class RomOrigin {
         return normalized;
     }
 
-    private static String validateArchiveEntry(String entryName) {
+    static String validateArchiveEntry(String entryName) {
         String raw = requireText(entryName, "entryName");
         String pathForValidation = raw.replace('\\', '/');
         if (raw.indexOf('\0') >= 0

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomSourceSnapshot.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/RomSourceSnapshot.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.memory.cart;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 /**
  * Immutable, bounded snapshot of one untrusted desktop ROM source.
@@ -52,6 +54,9 @@ public final class RomSourceSnapshot implements Closeable {
 
     private final Path archiveSnapshot;
 
+    /** Bounded stream-only ZIP container. This is never a filesystem path. */
+    private final byte[] streamArchive;
+
     private final ArchiveFormat archiveFormat;
 
     private final List<ArchiveCandidate> candidates;
@@ -64,12 +69,14 @@ public final class RomSourceSnapshot implements Closeable {
             Path sourcePath,
             RomImage directImage,
             Path archiveSnapshot,
+            byte[] streamArchive,
             ArchiveFormat archiveFormat,
             List<ArchiveCandidate> candidates,
             int extensionCandidateCount) {
         this.sourcePath = sourcePath;
         this.directImage = directImage;
         this.archiveSnapshot = archiveSnapshot;
+        this.streamArchive = streamArchive;
         this.archiveFormat = archiveFormat;
         this.candidates = Collections.unmodifiableList(new ArrayList<>(candidates));
         this.extensionCandidateCount = extensionCandidateCount;
@@ -77,6 +84,83 @@ public final class RomSourceSnapshot implements Closeable {
 
     public static RomSourceSnapshot open(Path source) throws IOException {
         return open(source, () -> false, ignored -> {});
+    }
+
+    /**
+     * Opens a bounded, path-independent input. Raw ROMs and ZIP archives use the exact same
+     * selection model as desktop inputs; a path-only 7z decoder remains intentionally confined to
+     * the desktop compatibility overload above.
+     */
+    public static RomSourceSnapshot open(RomInput source) throws IOException {
+        return open(source, () -> false, ignored -> {});
+    }
+
+    public static RomSourceSnapshot open(
+            RomInput source,
+            BooleanSupplier cancelled,
+            LongConsumer copiedBytes) throws IOException {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(cancelled, "cancelled");
+        Objects.requireNonNull(copiedBytes, "copiedBytes");
+        String displayName = Objects.requireNonNull(source.displayName(), "source.displayName()");
+        String extension = FilenameUtils.getExtension(displayName).toLowerCase(Locale.ROOT);
+        boolean zip = "zip".equals(extension);
+        if ("7z".equals(extension)) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.UNSUPPORTED_TYPE,
+                    "7z ROM archives require a path-backed desktop input; use a ZIP or raw ROM");
+        }
+        if (!zip && !isRomExtension(extension)) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.UNSUPPORTED_TYPE,
+                    "Supported ROM inputs are .gb, .gbc, .rom, and .zip");
+        }
+        checkCancelled(cancelled);
+        if (zip && source.declaredSize() > Rom.MAX_ARCHIVE_CONTAINER_BYTES) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.CONTAINER_TOO_LARGE,
+                    "Archive exceeds the "
+                            + Rom.MAX_ARCHIVE_CONTAINER_BYTES
+                            + "-byte compressed-size safety limit");
+        }
+        try (InputStream input = source.openStream()) {
+            if (input == null) {
+                throw new IOException("The selected source returned no stream");
+            }
+            if (!zip) {
+                byte[] bytes = readRomBytes(input, source.declaredSize(), cancelled, copiedBytes);
+                return new RomSourceSnapshot(
+                        null,
+                        RomImage.memory(bytes, displayName),
+                        null,
+                        null,
+                        null,
+                        List.of(),
+                        0);
+            }
+            byte[] archive = readArchiveBytes(input, source.declaredSize(), cancelled, copiedBytes);
+            Inventory inventory = inventoryZipStream(archive, cancelled);
+            return new RomSourceSnapshot(
+                    null,
+                    null,
+                    null,
+                    archive,
+                    ArchiveFormat.ZIP,
+                    inventory.candidates,
+                    inventory.extensionCandidateCount);
+        } catch (RomSourceException e) {
+            throw e;
+        } catch (ZipException e) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.INVALID_ARCHIVE,
+                    "The ZIP archive is invalid or unsupported",
+                    e);
+        } catch (IOException e) {
+            throw new RomSourceException(
+                    zip ? classifyArchiveFailure(e) : RomSourceException.Reason.UNREADABLE,
+                    zip ? archiveMessage(e) : "The selected source cannot be read",
+                    e);
+        }
     }
 
     public static RomSourceSnapshot open(
@@ -113,7 +197,7 @@ public final class RomSourceSnapshot implements Closeable {
                                 readRomBytes(input, declaredSize, cancelled, copiedBytes));
                 checkCancelled(cancelled);
                 return new RomSourceSnapshot(
-                        normalized, image, null, null, List.of(), 0);
+                        normalized, image, null, null, null, List.of(), 0);
             } catch (RomSourceException e) {
                 throw e;
             } catch (NoSuchFileException | FileNotFoundException e) {
@@ -156,6 +240,7 @@ public final class RomSourceSnapshot implements Closeable {
                     normalized,
                     null,
                     temporary,
+                    null,
                     archiveFormat,
                     inventory.candidates,
                     inventory.extensionCandidateCount);
@@ -194,7 +279,7 @@ public final class RomSourceSnapshot implements Closeable {
     }
 
     public boolean isArchive() {
-        return archiveSnapshot != null;
+        return archiveSnapshot != null || streamArchive != null;
     }
 
     public List<ArchiveCandidate> candidates() {
@@ -242,6 +327,9 @@ public final class RomSourceSnapshot implements Closeable {
 
     private RomImage loadZip(ArchiveCandidate selected, BooleanSupplier cancelled)
             throws IOException {
+        if (streamArchive != null) {
+            return loadStreamZip(selected, cancelled);
+        }
         try (ZipFile zip = new ZipFile(archiveSnapshot.toFile())) {
             Enumeration<? extends ZipEntry> entries = zip.entries();
             long ordinal = 0;
@@ -267,6 +355,42 @@ public final class RomSourceSnapshot implements Closeable {
                                 selected.entryOccurrence(),
                                 extensionCandidateCount == 1);
                 return new RomImage(origin, bytes);
+            }
+            throw invalidSelection();
+        } catch (RomSourceException e) {
+            throw e;
+        } catch (ZipException e) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.INVALID_ARCHIVE,
+                    "The selected ZIP entry is corrupt",
+                    e);
+        } catch (IOException e) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.INVALID_ARCHIVE,
+                    "The selected ZIP entry is corrupt or unreadable",
+                    e);
+        }
+    }
+
+    private RomImage loadStreamZip(ArchiveCandidate selected, BooleanSupplier cancelled)
+            throws IOException {
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(streamArchive))) {
+            long ordinal = 0;
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                checkCancelled(cancelled);
+                if (ordinal++ != selected.token()) {
+                    drainEntry(zip, cancelled);
+                    continue;
+                }
+                if (!entry.getName().equals(selected.entryName())) {
+                    throw invalidSelection();
+                }
+                byte[] bytes = readRomBytes(zip, entry.getSize(), cancelled, ignored -> {});
+                // ZipInputStream validates the data descriptor and CRC as the entry is consumed.
+                zip.closeEntry();
+                checkCancelled(cancelled);
+                return RomImage.memory(bytes, selected.displayName());
             }
             throw invalidSelection();
         } catch (RomSourceException e) {
@@ -405,6 +529,61 @@ public final class RomSourceSnapshot implements Closeable {
         }
     }
 
+    private static byte[] readArchiveBytes(
+            InputStream input,
+            long declaredSize,
+            BooleanSupplier cancelled,
+            LongConsumer copiedBytes) throws IOException {
+        if (declaredSize > Rom.MAX_ARCHIVE_CONTAINER_BYTES) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.CONTAINER_TOO_LARGE,
+                    "Archive exceeds the "
+                            + Rom.MAX_ARCHIVE_CONTAINER_BYTES
+                            + "-byte compressed-size safety limit");
+        }
+        int initial = declaredSize > 0
+                ? (int) Math.min(declaredSize, COPY_BUFFER_BYTES * 4L)
+                : COPY_BUFFER_BYTES;
+        ByteArrayOutputStream output = new ByteArrayOutputStream(initial);
+        byte[] buffer = new byte[COPY_BUFFER_BYTES];
+        long total = 0;
+        while (true) {
+            checkCancelled(cancelled);
+            int read = input.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            if (read == 0) {
+                int value = input.read();
+                if (value < 0) {
+                    break;
+                }
+                if (total == Rom.MAX_ARCHIVE_CONTAINER_BYTES) {
+                    throw new RomSourceException(
+                            RomSourceException.Reason.CONTAINER_TOO_LARGE,
+                            "Archive exceeds the "
+                                    + Rom.MAX_ARCHIVE_CONTAINER_BYTES
+                                    + "-byte compressed-size safety limit");
+                }
+                output.write(value);
+                total++;
+            } else {
+                if (read > Rom.MAX_ARCHIVE_CONTAINER_BYTES - total) {
+                    throw new RomSourceException(
+                            RomSourceException.Reason.CONTAINER_TOO_LARGE,
+                            "Archive exceeds the "
+                                    + Rom.MAX_ARCHIVE_CONTAINER_BYTES
+                                    + "-byte compressed-size safety limit");
+                }
+                output.write(buffer, 0, read);
+                total += read;
+            }
+            copiedBytes.accept(total);
+        }
+        checkCancelled(cancelled);
+        return output.toByteArray();
+    }
+
     private static byte[] readRomBytes(
             InputStream input,
             long declaredSize,
@@ -539,6 +718,121 @@ public final class RomSourceSnapshot implements Closeable {
         return new Inventory(candidates, extensionCandidates);
     }
 
+    /**
+     * Streaming ZIP inventory. Every entry is drained with the same aggregate decompression
+     * bound used by desktop snapshots, which prevents a provider-backed archive from bypassing
+     * the ZIP central-directory preflight.
+     */
+    private static Inventory inventoryZipStream(byte[] archive, BooleanSupplier cancelled)
+            throws IOException {
+        List<ArchiveCandidate> candidates = new ArrayList<>();
+        Map<String, Integer> occurrences = new HashMap<>();
+        int entryCount = 0;
+        int extensionCandidates = 0;
+        int oversizedRomCandidates = 0;
+        long totalSize = 0;
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(archive))) {
+            ZipEntry entry;
+            long ordinal = 0;
+            while ((entry = zip.getNextEntry()) != null) {
+                checkCancelled(cancelled);
+                if (++entryCount > Rom.MAX_ARCHIVE_ENTRIES) {
+                    throw new IOException(
+                            "Archive exceeds the " + Rom.MAX_ARCHIVE_ENTRIES + "-entry safety limit");
+                }
+                validateStreamEntryName(entry.getName());
+                int occurrence = occurrences.merge(entry.getName(), 1, Integer::sum) - 1;
+                EntryScan scan = scanEntry(zip, cancelled, totalSize);
+                totalSize = scan.totalSize();
+                if (!entry.isDirectory() && isRomEntry(entry.getName())) {
+                    extensionCandidates++;
+                    if (scan.entrySize() > RomImage.MAX_ROM_BYTES) {
+                        oversizedRomCandidates++;
+                    } else if (scan.entrySize() >= RomHeaderInspector.HEADER_LENGTH) {
+                        RomHeaderInspector.Header header = RomHeaderInspector.inspect(scan.header());
+                        candidates.add(
+                                new ArchiveCandidate(
+                                        ordinal,
+                                        entry.getName(),
+                                        occurrence,
+                                        scan.entrySize(),
+                                        header.hasCartridgeShape() ? header.title() : ""));
+                    }
+                }
+                ordinal++;
+            }
+        }
+        if (extensionCandidates == 0) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.NO_ROM_CANDIDATES,
+                    "The ZIP archive contains no .gb, .gbc, or .rom entries");
+        }
+        if (candidates.isEmpty()) {
+            if (oversizedRomCandidates > 0) {
+                throw romTooLarge(RomImage.MAX_ROM_BYTES + 1L);
+            }
+            throw new RomSourceException(
+                    RomSourceException.Reason.INVALID_HEADER,
+                    "No ROM entry in the ZIP is large enough to contain a cartridge header");
+        }
+        return new Inventory(candidates, extensionCandidates);
+    }
+
+    private static EntryScan scanEntry(
+            ZipInputStream input, BooleanSupplier cancelled, long previousTotal) throws IOException {
+        byte[] buffer = new byte[COPY_BUFFER_BYTES];
+        byte[] header = new byte[RomHeaderInspector.HEADER_LENGTH];
+        int headerBytes = 0;
+        long entrySize = 0;
+        long totalSize = previousTotal;
+        while (true) {
+            checkCancelled(cancelled);
+            int read = input.read(buffer);
+            if (read < 0) {
+                break;
+            }
+            if (read == 0) {
+                continue;
+            }
+            if (read > Rom.MAX_ARCHIVE_UNCOMPRESSED_BYTES - totalSize) {
+                throw new IOException(
+                        "Archive exceeds the "
+                                + Rom.MAX_ARCHIVE_UNCOMPRESSED_BYTES
+                                + "-byte uncompressed-size safety limit");
+            }
+            totalSize += read;
+            entrySize += read;
+            int copied = Math.min(read, header.length - headerBytes);
+            if (copied > 0) {
+                System.arraycopy(buffer, 0, header, headerBytes, copied);
+                headerBytes += copied;
+            }
+        }
+        return new EntryScan(entrySize, totalSize, header);
+    }
+
+    private static void drainEntry(ZipInputStream input, BooleanSupplier cancelled) throws IOException {
+        byte[] buffer = new byte[COPY_BUFFER_BYTES];
+        while (true) {
+            checkCancelled(cancelled);
+            int read = input.read(buffer);
+            if (read < 0) {
+                return;
+            }
+        }
+    }
+
+    private static void validateStreamEntryName(String entryName) throws RomSourceException {
+        try {
+            RomOrigin.validateArchiveEntry(entryName);
+        } catch (IllegalArgumentException e) {
+            throw new RomSourceException(
+                    RomSourceException.Reason.UNSAFE_ARCHIVE_ENTRY,
+                    "The archive contains an unsafe entry path",
+                    e);
+        }
+    }
+
     private static boolean isRomExtension(String extension) {
         return "gb".equals(extension) || "gbc".equals(extension) || "rom".equals(extension);
     }
@@ -642,6 +936,8 @@ public final class RomSourceSnapshot implements Closeable {
             return entryName.substring(slash + 1);
         }
     }
+
+    private record EntryScan(long entrySize, long totalSize, byte[] header) {}
 
     private record Inventory(
             List<ArchiveCandidate> candidates,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RomSourceSnapshotTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RomSourceSnapshotTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import org.tukaani.xz.LZMA2Options;
 
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -53,6 +54,80 @@ public class RomSourceSnapshotTest {
             assertEquals(RomOrigin.Kind.DIRECT_FILE, image.origin().kind());
             assertArrayEquals(bytes, image.bytes());
         }
+    }
+
+    @Test
+    public void loadsRawRomFromPathlessInputWithContentIdentity() throws Exception {
+        byte[] bytes = syntheticRom("STREAM", 0x7a);
+        RomInput input = RomInput.of("picked.GBC", () -> new ByteArrayInputStream(bytes));
+
+        try (RomSourceSnapshot snapshot = RomSourceSnapshot.open(input)) {
+            RomImage image = snapshot.loadSingle();
+
+            assertEquals(null, snapshot.sourcePath());
+            assertEquals(RomOrigin.Kind.MEMORY, image.origin().kind());
+            assertFalse(image.origin().containerPath().isPresent());
+            assertEquals("picked.GBC", image.origin().displayName());
+            assertArrayEquals(bytes, image.bytes());
+        }
+    }
+
+    @Test
+    public void selectsExactZipEntryFromPathlessInput() throws Exception {
+        File archive = temporaryFolder.newFile("stream.zip");
+        byte[] first = syntheticRom("STREAM-ONE", 0x7b);
+        byte[] second = syntheticRom("STREAM-TWO", 0x7c);
+        writeZip(archive, new Entry("one/game.gb", first), new Entry("two/game.gbc", second));
+        byte[] archiveBytes = Files.readAllBytes(archive.toPath());
+
+        try (RomSourceSnapshot snapshot =
+                RomSourceSnapshot.open(RomInput.of("picked.zip", () -> new ByteArrayInputStream(archiveBytes)))) {
+            assertTrue(snapshot.isArchive());
+            assertEquals(2, snapshot.candidates().size());
+            RomImage image = snapshot.load(snapshot.candidates().get(1).token());
+
+            assertEquals(RomOrigin.Kind.MEMORY, image.origin().kind());
+            assertEquals("game.gbc", image.origin().displayName());
+            assertArrayEquals(second, image.bytes());
+        }
+    }
+
+    @Test
+    public void pathlessInputReportsLostPermissionAsUnreadable() {
+        RomInput input = RomInput.of("lost.gb", () -> {
+            throw new java.io.FileNotFoundException("permission revoked");
+        });
+
+        RomSourceException failure = assertThrows(
+                RomSourceException.class, () -> RomSourceSnapshot.open(input));
+
+        assertEquals(RomSourceException.Reason.UNREADABLE, failure.reason());
+        assertFalse(failure.getMessage().contains("permission revoked"));
+    }
+
+    @Test
+    public void pathlessArchiveChecksTheDeclaredContainerLimitBeforeReading() {
+        RomInput input = new RomInput() {
+            @Override
+            public String displayName() {
+                return "oversized.zip";
+            }
+
+            @Override
+            public java.io.InputStream openStream() {
+                throw new AssertionError("oversized input must not be opened");
+            }
+
+            @Override
+            public long declaredSize() {
+                return Rom.MAX_ARCHIVE_CONTAINER_BYTES + 1;
+            }
+        };
+
+        RomSourceException failure = assertThrows(
+                RomSourceException.class, () -> RomSourceSnapshot.open(input));
+
+        assertEquals(RomSourceException.Reason.CONTAINER_TOO_LARGE, failure.reason());
     }
 
     @Test


### PR DESCRIPTION
Closes #356

## What changed
- adds bounded, pathless ROM input for raw ROMs and ZIP archives, with typed/redacted failures and the existing archive safety limits
- adds shared controller persistence contracts, preserving desktop save behavior while allowing hosts to supply a hash-keyed app-private store
- adds Android SAF document opening, persistable recent-document cleanup, raw battery and portable StateFile import/export, and explicit replacement confirmations
- stores Android saves atomically below the app no-backup directory by exact ROM SHA-256, never by provider URI or display name
- documents Android SAF permissions, limits, recovery, and the intentional pathless-7z boundary

## Validation
- `mvn -B test`
- `mvn -B -pl core -am test -Dtest=RomSourceSnapshotTest`
- `mvn -B -pl controller -am test -Dtest=RomSessionPreparerTest`
- Android `:app:check :app:lintDebug :app:assembleDebug :app:assembleRelease` against same-checkout artifacts