### PR TITLE
Add Android lifecycle runtime service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ StateFile import/export use the Android document picker; import replacement and 
 replacement are confirmed explicitly. A revoked recent-document grant is removed without exposing
 the document URI in the error message.
 
+The app's same-process, non-foreground `EmulationService` is the single owner of the controller,
+event bus, selected ROM, and app-private save handles. Activities only bind to immutable redacted
+runtime state and issue asynchronous commands, so a rotation cannot duplicate a session. Losing
+visibility or audio focus pauses at the controller's safe point and requests a bounded battery
+flush; returning to the app requires an explicit Resume action. The service is non-sticky, so a
+process recreation truthfully starts stopped and offers only persisted recent-document metadata.
+There is no background playback, no foreground-service notification, and no extra permission.
+
 ## Download and play
 
 The portable Coffee GB download is a single executable JAR. It requires a desktop **Java 16 or

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,2 +1,6 @@
-# Phase 0 has no reflection, serialization schema, or emulator API in the APK. Keep rules belong
-# beside the feature that needs them; the release build remains intentionally strict as an R8 probe.
+# The Android runtime now owns BasicController. Its desktop-only historical Java-serialization
+# migration is intentionally not exposed by the Android service or UI, but R8 visits its JDK 9
+# ObjectInputFilter signature while tracing the controller's public event surface. Android has no
+# equivalent class; suppress only this unreachable legacy-import warning, not arbitrary missing
+# desktop APIs.
+-dontwarn java.io.ObjectInputFilter

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     <application
         android:allowBackup="false"
         android:label="Coffee GB">
+        <service
+            android:name=".EmulationService"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -1,0 +1,630 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import eu.rekawek.coffeegb.controller.BasicController;
+import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.controller.state.StateIdentity;
+import eu.rekawek.coffeegb.controller.state.StateRef;
+import eu.rekawek.coffeegb.controller.state.StateRepository;
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.RomImage;
+import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
+import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * The one same-process owner of Coffee GB's Android controller, event bus, selected ROM bytes,
+ * persistence handles, and lifecycle operations.
+ *
+ * <p>Every mutable operation is serialized on {@code coffee-gb-android-runtime}. Observers receive
+ * immutable, redacted state snapshots on the main thread and never retain the service or an
+ * Activity. The controller remains the sole owner of the emulation timing thread; this runtime
+ * only posts its documented commands and observes its documented events.
+ */
+public final class AndroidEmulationRuntime implements AutoCloseable {
+
+    private static final long BACKGROUND_FLUSH_TIMEOUT_MILLIS = 5_000L;
+
+    private final Context context;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final ExecutorService owner = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "coffee-gb-android-runtime");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final ScheduledExecutorService deadlines = Executors.newSingleThreadScheduledExecutor(
+            runnable -> {
+                Thread thread = new Thread(runnable, "coffee-gb-android-runtime-deadline");
+                thread.setDaemon(true);
+                return thread;
+            });
+    private final CopyOnWriteArraySet<RuntimeObserver> observers = new CopyOnWriteArraySet<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final RuntimeLifecycleGate lifecycle = new RuntimeLifecycleGate();
+
+    private volatile RuntimeState state = RuntimeState.stopped();
+
+    // Everything below is accessed only on the owner executor.
+    private EventBus eventBus;
+    private BasicController controller;
+    private AndroidRomPersistenceStore persistenceStore;
+    private RomSourceSnapshot pendingSnapshot;
+    private Uri pendingSource;
+    private List<Uri> pendingRecents = List.of();
+    private Uri currentSource;
+    private StateStorageLayout activeLayout;
+    private StateRepository activeStates;
+    private long nextOpenRequestId;
+    private long activeOpenRequestId;
+    private long nextFlushRequestId;
+    private long pendingFlushRequestId;
+    private ScheduledFuture<?> flushDeadline;
+
+    public AndroidEmulationRuntime(Context context) {
+        this.context = Objects.requireNonNull(context, "context").getApplicationContext();
+        submit(this::initialize);
+    }
+
+    public RuntimeState state() {
+        return state;
+    }
+
+    /** Registers one UI observer and immediately replays the latest immutable snapshot. */
+    public void addObserver(RuntimeObserver observer) {
+        RuntimeObserver checked = Objects.requireNonNull(observer, "observer");
+        observers.add(checked);
+        RuntimeState replay = state;
+        mainHandler.post(() -> {
+            if (observers.contains(checked)) {
+                checked.onStateChanged(replay);
+            }
+        });
+    }
+
+    /** Must be paired with {@link #addObserver(RuntimeObserver)} from Activity/service teardown. */
+    public void removeObserver(RuntimeObserver observer) {
+        observers.remove(observer);
+    }
+
+    /** Opens the user-selected SAF document; all metadata, archive and ROM work stays off-main. */
+    public void openRom(Uri uri, int resultFlags) {
+        Uri checked = Objects.requireNonNull(uri, "uri");
+        submit(() -> {
+            retainReadPermission(checked, resultFlags);
+            openRom(checked);
+        });
+    }
+
+    /** Selects an opaque archive token published through {@link RuntimeState#selections()}. */
+    public void selectArchiveCandidate(long token) {
+        submit(() -> {
+            RomSourceSnapshot snapshot = pendingSnapshot;
+            Uri source = pendingSource;
+            if (snapshot == null || source == null) {
+                publish(RuntimeState.Phase.FAILED,
+                        "That ROM selection is no longer available. Choose the document again.",
+                        List.of(), false, false, false);
+                return;
+            }
+            pendingSnapshot = null;
+            pendingSource = null;
+            activateSnapshot(snapshot, token, source);
+        });
+    }
+
+    /** Reads persisted recent grants on the runtime owner and publishes redacted choices. */
+    public void requestRecentDocuments() {
+        submit(() -> {
+            List<Uri> recent = new RecentSafDocuments(context).readable();
+            if (recent.isEmpty()) {
+                publish(RuntimeState.Phase.FAILED,
+                        "No readable recent ROM document is available.",
+                        List.of(), activeLayout != null, state.paused(), false);
+                return;
+            }
+            pendingRecents = List.copyOf(recent);
+            List<RuntimeState.Selection> choices = new ArrayList<>();
+            for (int index = 0; index < recent.size(); index++) {
+                choices.add(new RuntimeState.Selection(index, "Recent ROM " + (index + 1)));
+            }
+            publish(RuntimeState.Phase.AWAITING_RECENT_SELECTION,
+                    "Choose a recent ROM document.", choices, false, true, false);
+        });
+    }
+
+    /** Opens a redacted recent-document token published by {@link #requestRecentDocuments()}. */
+    public void selectRecentDocument(long token) {
+        submit(() -> {
+            if (token < 0 || token >= pendingRecents.size()) {
+                publish(RuntimeState.Phase.FAILED,
+                        "That recent ROM selection is no longer available.",
+                        List.of(), activeLayout != null, state.paused(), false);
+                return;
+            }
+            Uri uri = pendingRecents.get((int) token);
+            pendingRecents = List.of();
+            openRom(uri);
+        });
+    }
+
+    /** Releases an unselected archive snapshot or recent-choice list without changing a live game. */
+    public void cancelPendingSelection() {
+        submit(() -> {
+            clearPendingSource();
+            if (activeLayout == null) {
+                publish(RuntimeState.Phase.STOPPED,
+                        "Coffee GB Android is ready. Choose a ROM or ZIP document.",
+                        List.of(), false, false, false);
+            } else {
+                publish(state.paused() ? RuntimeState.Phase.PAUSED : RuntimeState.Phase.RUNNING,
+                        state.paused() ? "Game paused." : "Game running.",
+                        List.of(), true, state.paused(), state.flushPending());
+            }
+        });
+    }
+
+    /** Pauses at the controller safe point and asks for a bounded asynchronous battery flush. */
+    public void onHostNotVisible() {
+        submit(() -> {
+            if (controller == null) {
+                return;
+            }
+            lifecycle.background(lifecycleCommands());
+        });
+    }
+
+    /** Records visibility for a future load without automatically resuming an already paused game. */
+    public void onHostVisible() {
+        submit(lifecycle::foregrounded);
+    }
+
+    /** Audio loss follows the same conservative policy: pause, flush, and require user resume. */
+    public void onAudioFocusLost() {
+        onHostNotVisible();
+    }
+
+    /** Audio focus gain intentionally does not resume emulation without an explicit user command. */
+    public void resume() {
+        submit(() -> {
+            if (controller == null || activeLayout == null) {
+                return;
+            }
+            lifecycle.resumedByUser();
+            eventBus.post(new Controller.ResumeEmulationEvent());
+        });
+    }
+
+    /** Stops one session and recreates its controller shell for a later load without leaks. */
+    public void stop() {
+        submit(() -> {
+            clearPendingSource();
+            if (!closeController()) {
+                publish(RuntimeState.Phase.FAILED,
+                        "Coffee GB could not safely stop the current game. Retry stopping it.",
+                        List.of(), activeLayout != null, true, false);
+                return;
+            }
+            activeLayout = null;
+            activeStates = null;
+            currentSource = null;
+            lifecycle.released();
+            createController();
+            publish(RuntimeState.Phase.STOPPED,
+                    "Game stopped. Choose a ROM or ZIP document.",
+                    List.of(), false, false, false);
+        });
+    }
+
+    public void importBattery(Uri source) {
+        transfer("Importing battery save…", "Battery save imported.", () ->
+                SafPersistenceExchange.importBattery(
+                        context.getContentResolver(), source, requireLayout(),
+                        SafPersistenceExchange.CollisionDecision.REPLACE));
+    }
+
+    public void exportBattery(Uri destination) {
+        transfer("Exporting battery save…", "Battery save exported.", () ->
+                SafPersistenceExchange.exportBattery(
+                        context.getContentResolver(), destination, requireLayout(), true));
+    }
+
+    public void importState(Uri source) {
+        transfer("Importing state slot 0…", "State slot 0 imported.", () ->
+                SafPersistenceExchange.importState(
+                        context.getContentResolver(), source, requireStates(), new StateRef.Slot(0),
+                        SafPersistenceExchange.CollisionDecision.REPLACE));
+    }
+
+    public void exportState(Uri destination) {
+        transfer("Exporting state slot 0…", "State slot 0 exported.", () ->
+                SafPersistenceExchange.exportState(
+                        context.getContentResolver(), destination, requireStates(), new StateRef.Slot(0), true));
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        deadlines.shutdownNow();
+        try {
+            owner.execute(() -> {
+                clearPendingSource();
+                closeController();
+                activeLayout = null;
+                activeStates = null;
+                currentSource = null;
+            });
+        } catch (RejectedExecutionException ignored) {
+            // The owner is already tearing down; no new resource can have been admitted.
+        } finally {
+            owner.shutdown();
+        }
+    }
+
+    private void initialize() {
+        try {
+            persistenceStore = new AndroidRomPersistenceStore(context);
+            createController();
+        } catch (Exception failure) {
+            publish(RuntimeState.Phase.FAILED,
+                    "Coffee GB could not initialize its private game storage.",
+                    List.of(), false, false, false);
+        }
+    }
+
+    private void createController() {
+        eventBus = new EventBusImpl();
+        eventBus.register(
+                (Controller.RomLoadingEvent event) -> submit(() -> {
+                    if (event.getOpenRequestId() != null
+                            && event.getOpenRequestId() == activeOpenRequestId) {
+                        publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
+                                false, true, state.flushPending());
+                    }
+                }),
+                Controller.RomLoadingEvent.class);
+        eventBus.register(
+                (Controller.EmulationStartedEvent event) -> submit(() -> {
+                    if (event.getOpenRequestId() != null
+                            && event.getOpenRequestId() == activeOpenRequestId) {
+                        if (currentSource != null) {
+                            new RecentSafDocuments(context).recordIfPersisted(currentSource);
+                        }
+                        lifecycle.activated(lifecycleCommands());
+                        publish(RuntimeState.Phase.RUNNING,
+                                "Loaded " + event.getRomName() + ". App-private saves are ready.",
+                                List.of(), true, false, false);
+                    }
+                }),
+                Controller.EmulationStartedEvent.class);
+        eventBus.register(
+                (Controller.EmulationStoppedEvent event) -> submit(() -> {
+                    if (!closed.get()) {
+                        publish(RuntimeState.Phase.STOPPED,
+                                "Game stopped. Choose a ROM or ZIP document.",
+                                List.of(), false, false, false);
+                    }
+                }),
+                Controller.EmulationStoppedEvent.class);
+        eventBus.register(
+                (Controller.LoadRomFailedEvent event) -> submit(() -> {
+                    if (event.getOpenRequestId() != null
+                            && event.getOpenRequestId() == activeOpenRequestId) {
+                        forgetRevokedPermission(currentSource);
+                        publish(RuntimeState.Phase.FAILED,
+                                "Coffee GB could not load the selected ROM.",
+                                List.of(), false, true, false);
+                    }
+                }),
+                Controller.LoadRomFailedEvent.class);
+        eventBus.register(
+                (Controller.SessionPlaybackStateEvent event) -> submit(() -> {
+                    if (activeLayout == null || state.phase() == RuntimeState.Phase.LOADING) {
+                        return;
+                    }
+                    if (event.getPaused()) {
+                        publish(RuntimeState.Phase.PAUSED,
+                                state.flushPending()
+                                        ? "Game paused. Saving battery data…"
+                                        : "Game paused.",
+                                List.of(), true, true, state.flushPending());
+                    } else {
+                        publish(RuntimeState.Phase.RUNNING, "Game running.", List.of(),
+                                true, false, state.flushPending());
+                    }
+                }),
+                Controller.SessionPlaybackStateEvent.class);
+        eventBus.register(
+                (Controller.BatteryFlushCompletedEvent event) -> submit(() -> {
+                    if (event.getRequestId() != pendingFlushRequestId) {
+                        return;
+                    }
+                    cancelFlushDeadline();
+                    pendingFlushRequestId = 0;
+                    lifecycle.flushCompleted();
+                    if (event.getSucceeded()) {
+                        publish(RuntimeState.Phase.PAUSED,
+                                "Game paused. Battery data saved.", List.of(), true, true, false);
+                    } else {
+                        publish(RuntimeState.Phase.PAUSED,
+                                "Game paused. Battery save needs retrying.", List.of(), true, true, false);
+                    }
+                }),
+                Controller.BatteryFlushCompletedEvent.class);
+        controller = new BasicController(eventBus, new EmulatorProperties(), null);
+        controller.startController();
+    }
+
+    private void openRom(Uri uri) {
+        clearPendingSource();
+        publish(RuntimeState.Phase.OPENING, "Opening selected ROM…", List.of(), false, true, false);
+        try {
+            AndroidRomInput input = new AndroidRomInput(context.getContentResolver(), uri);
+            RomSourceSnapshot snapshot = RomSourceSnapshot.open(input);
+            if (!snapshot.isArchive() || snapshot.candidates().size() == 1) {
+                activateSnapshot(snapshot,
+                        snapshot.isArchive()
+                                ? snapshot.candidates().get(0).token()
+                                : RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN,
+                        uri);
+                return;
+            }
+            pendingSnapshot = snapshot;
+            pendingSource = uri;
+            List<RuntimeState.Selection> choices = snapshot.candidates().stream()
+                    .map(candidate -> new RuntimeState.Selection(candidate.token(), candidate.displayName()))
+                    .collect(Collectors.toList());
+            publish(RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION,
+                    "Choose ROM from archive.", choices, false, true, false);
+        } catch (Exception failure) {
+            forgetRevokedPermission(uri);
+            publish(RuntimeState.Phase.FAILED,
+                    "Coffee GB could not open this document. Check its permission and format.",
+                    List.of(), activeLayout != null, state.paused(), false);
+        }
+    }
+
+    private void activateSnapshot(RomSourceSnapshot snapshot, long token, Uri source) {
+        try {
+            RomImage image = token == RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN
+                    ? snapshot.loadSingle()
+                    : snapshot.load(token);
+            Rom rom = new Rom(image);
+            String hash = StateIdentity.INSTANCE.hash(rom).hex();
+            StateStorageLayout layout = persistenceStore.layout(hash);
+            activeLayout = layout;
+            activeStates = new StateRepository(layout, AtomicFileWriter.system());
+            currentSource = source;
+            activeOpenRequestId = ++nextOpenRequestId;
+            publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
+                    false, true, false);
+            controllerEventBus().post(new Controller.LoadRomEvent(
+                    image, null, persistenceStore, activeOpenRequestId, true));
+        } catch (Exception failure) {
+            forgetRevokedPermission(source);
+            activeLayout = null;
+            activeStates = null;
+            currentSource = null;
+            publish(RuntimeState.Phase.FAILED,
+                    "Coffee GB could not load the selected ROM.", List.of(), false, true, false);
+        } finally {
+            closeQuietly(snapshot);
+        }
+    }
+
+    private void requestBackgroundFlush() {
+        if (pendingFlushRequestId != 0) {
+            return;
+        }
+        long requestId = ++nextFlushRequestId;
+        pendingFlushRequestId = requestId;
+        publish(RuntimeState.Phase.PAUSED, "Game paused. Saving battery data…", List.of(),
+                true, true, true);
+        eventBus.post(new Controller.FlushBatteryEvent(requestId));
+        flushDeadline = deadlines.schedule(
+                () -> submit(() -> onFlushDeadline(requestId)),
+                BACKGROUND_FLUSH_TIMEOUT_MILLIS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private RuntimeLifecycleGate.SessionCommands lifecycleCommands() {
+        return new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                eventBus.post(new Controller.PauseEmulationEvent());
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                requestBackgroundFlush();
+            }
+        };
+    }
+
+    private void onFlushDeadline(long requestId) {
+        if (pendingFlushRequestId != requestId) {
+            return;
+        }
+        // The controller keeps the single writer alive; this only bounds the lifecycle caller's
+        // wait. A late completion still clears this truthful retryable warning.
+        publish(RuntimeState.Phase.PAUSED,
+                "Game paused. Battery save is still completing; retry if it fails.",
+                List.of(), true, true, true);
+    }
+
+    private void transfer(String working, String success, CheckedIoAction action) {
+        submit(() -> {
+            if (activeLayout == null || activeStates == null) {
+                publish(RuntimeState.Phase.FAILED,
+                        "Open a ROM before importing or exporting its save data.",
+                        List.of(), false, false, false);
+                return;
+            }
+            RuntimeState before = state;
+            publish(before.phase(), working, List.of(), true, before.paused(), before.flushPending());
+            try {
+                action.run();
+                publish(before.phase(), success, List.of(), true, before.paused(), before.flushPending());
+            } catch (Exception failure) {
+                publish(before.phase(), "Coffee GB could not complete that save-data transfer.",
+                        List.of(), true, before.paused(), before.flushPending());
+            }
+        });
+    }
+
+    private StateStorageLayout requireLayout() {
+        if (activeLayout == null) {
+            throw new IllegalStateException("No active ROM storage");
+        }
+        return activeLayout;
+    }
+
+    private StateRepository requireStates() {
+        if (activeStates == null) {
+            throw new IllegalStateException("No active ROM state storage");
+        }
+        return activeStates;
+    }
+
+    private EventBus controllerEventBus() {
+        if (eventBus == null || controller == null) {
+            throw new IllegalStateException("Android emulator runtime is not available");
+        }
+        return eventBus;
+    }
+
+    private boolean closeController() {
+        cancelFlushDeadline();
+        pendingFlushRequestId = 0;
+        BasicController active = controller;
+        EventBus activeBus = eventBus;
+        controller = null;
+        eventBus = null;
+        if (active == null) {
+            return true;
+        }
+        try {
+            active.close();
+            lifecycle.released();
+            return true;
+        } catch (RuntimeException failure) {
+            // Retain the controller for an explicit retry; it may still own an unflushed battery.
+            controller = active;
+            eventBus = activeBus;
+            return false;
+        }
+    }
+
+    private void retainReadPermission(Uri uri, int resultFlags) {
+        int read = resultFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        int persistable = resultFlags & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION;
+        if (read == 0 || persistable == 0) {
+            return;
+        }
+        try {
+            context.getContentResolver().takePersistableUriPermission(uri, read);
+        } catch (SecurityException ignored) {
+            // A one-shot provider grant remains usable for this open but is not retained in Recents.
+        }
+    }
+
+    private void forgetRevokedPermission(Uri uri) {
+        if (uri == null) {
+            return;
+        }
+        new RecentSafDocuments(context).remove(uri);
+        for (UriPermission permission : context.getContentResolver().getPersistedUriPermissions()) {
+            if (permission.getUri().equals(uri) && permission.isReadPermission()) {
+                try {
+                    context.getContentResolver().releasePersistableUriPermission(
+                            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                } catch (SecurityException ignored) {
+                    // The provider already revoked it. The recent-list cleanup above is enough.
+                }
+            }
+        }
+    }
+
+    private void clearPendingSource() {
+        RomSourceSnapshot snapshot = pendingSnapshot;
+        pendingSnapshot = null;
+        pendingSource = null;
+        pendingRecents = List.of();
+        closeQuietly(snapshot);
+    }
+
+    private void cancelFlushDeadline() {
+        if (flushDeadline != null) {
+            flushDeadline.cancel(false);
+            flushDeadline = null;
+        }
+    }
+
+    private void publish(
+            RuntimeState.Phase phase,
+            String message,
+            List<RuntimeState.Selection> selections,
+            boolean transferReady,
+            boolean paused,
+            boolean flushPending) {
+        RuntimeState next = new RuntimeState(
+                phase, message, selections, transferReady, paused, flushPending,
+                Math.addExact(state.generation(), 1));
+        state = next;
+        mainHandler.post(() -> {
+            for (RuntimeObserver observer : observers) {
+                observer.onStateChanged(next);
+            }
+        });
+    }
+
+    private void submit(Runnable action) {
+        if (closed.get()) {
+            return;
+        }
+        try {
+            owner.execute(action);
+        } catch (RejectedExecutionException ignored) {
+            // Runtime teardown already owns the resource boundary.
+        }
+    }
+
+    private static void closeQuietly(RomSourceSnapshot snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        try {
+            snapshot.close();
+        } catch (IOException ignored) {
+            // Stream snapshots own no visible path. The next process startup cannot reopen one.
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedIoAction {
+        void run() throws IOException;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -1,0 +1,109 @@
+package eu.rekawek.coffeegb.android;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.os.Binder;
+import android.os.IBinder;
+
+/**
+ * Same-process, non-foreground owner for the Android emulation runtime.
+ *
+ * <p>Activities bind only to observe/command the runtime. This service owns the controller and
+ * its event tree across Activity recreation; it is {@link #START_NOT_STICKY}, does not enter the
+ * foreground, and never claims that a process-recreated game is still running.
+ */
+public final class EmulationService extends Service implements AudioManager.OnAudioFocusChangeListener {
+
+    private final RuntimeBinder binder = new RuntimeBinder();
+
+    private AndroidEmulationRuntime runtime;
+    private AudioManager audioManager;
+
+    public static void start(Context context) {
+        context.startService(new Intent(context, EmulationService.class));
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        audioManager = getSystemService(AudioManager.class);
+        runtime = new AndroidEmulationRuntime(this);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // The system must not recreate a stopped process and imply that its in-memory game lived.
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        runtime.onHostVisible();
+        requestAudioFocus();
+        return binder;
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        abandonAudioFocus();
+        runtime.onHostNotVisible();
+        return true;
+    }
+
+    @Override
+    public void onRebind(Intent intent) {
+        runtime.onHostVisible();
+        requestAudioFocus();
+        super.onRebind(intent);
+    }
+
+    @Override
+    public void onTaskRemoved(Intent rootIntent) {
+        // This pauses at a controller safe point and starts a bounded flush without background
+        // playback. The non-sticky service may be reclaimed; a later process starts truthfully
+        // stopped and offers only the persisted recent-document metadata.
+        abandonAudioFocus();
+        runtime.onHostNotVisible();
+        super.onTaskRemoved(rootIntent);
+    }
+
+    @Override
+    public void onDestroy() {
+        abandonAudioFocus();
+        if (runtime != null) {
+            runtime.close();
+        }
+        super.onDestroy();
+    }
+
+    @Override
+    public void onAudioFocusChange(int focusChange) {
+        if (focusChange == AudioManager.AUDIOFOCUS_LOSS
+                || focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT
+                || focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
+            runtime.onAudioFocusLost();
+        }
+        // On gain, runtime deliberately remains paused until the user resumes. Phase 6 installs
+        // AudioTrack here; this lifecycle policy already prevents an unexpected restart/route race.
+    }
+
+    private void requestAudioFocus() {
+        if (audioManager != null) {
+            audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+        }
+    }
+
+    private void abandonAudioFocus() {
+        if (audioManager != null) {
+            audioManager.abandonAudioFocus(this);
+        }
+    }
+
+    public final class RuntimeBinder extends Binder {
+        public AndroidEmulationRuntime runtime() {
+            return runtime;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -2,32 +2,27 @@ package eu.rekawek.coffeegb.android;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ComponentName;
 import android.content.Intent;
-import android.content.UriPermission;
-import android.net.Uri;
+import android.content.ServiceConnection;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import eu.rekawek.coffeegb.controller.state.StateRef;
-import eu.rekawek.coffeegb.controller.state.StateRepository;
-import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
-import eu.rekawek.coffeegb.core.memory.cart.Rom;
-import eu.rekawek.coffeegb.core.memory.cart.RomImage;
-import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
- * Permission-free SAF ROM-opening probe. ROM decoding and app-private storage work run on the
- * dedicated worker; the UI thread only launches documents and renders immutable results.
+ * Thin SAF/UI client for {@link EmulationService}.
+ *
+ * <p>The Activity owns only document-picker and dialog interactions. Its bound service owns every
+ * emulator, controller, event-bus, persistence, and lifecycle resource, so rotation never creates
+ * a second session and unbinding never directly stops the active game.
  */
-public final class MainActivity extends Activity {
+public final class MainActivity extends Activity implements RuntimeObserver {
 
     private static final int OPEN_ROM_REQUEST = 1;
     private static final int IMPORT_BATTERY_REQUEST = 2;
@@ -35,20 +30,40 @@ public final class MainActivity extends Activity {
     private static final int IMPORT_STATE_REQUEST = 4;
     private static final int EXPORT_STATE_REQUEST = 5;
 
-    private final ExecutorService romWorker = Executors.newSingleThreadExecutor(runnable -> {
-        Thread thread = new Thread(runnable, "coffee-gb-android-rom-open");
-        thread.setDaemon(true);
-        return thread;
-    });
-
     private TextView status;
+    private Button open;
+    private Button recent;
+    private Button resume;
+    private Button stop;
     private Button importBattery;
     private Button exportBattery;
     private Button importState;
     private Button exportState;
 
-    private volatile StateStorageLayout activeLayout;
-    private volatile StateRepository activeStates;
+    private AndroidEmulationRuntime runtime;
+    private boolean bound;
+    private long shownSelectionGeneration = -1L;
+
+    private final ServiceConnection connection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            runtime = ((EmulationService.RuntimeBinder) service).runtime();
+            bound = true;
+            runtime.addObserver(MainActivity.this);
+            applyState(runtime.state());
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            if (runtime != null) {
+                runtime.removeObserver(MainActivity.this);
+            }
+            runtime = null;
+            bound = false;
+            disableCommands();
+            status.setText("Coffee GB runtime stopped. Reopen the app to choose a ROM.");
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,38 +77,66 @@ public final class MainActivity extends Activity {
 
         status = new TextView(this);
         status.setGravity(Gravity.CENTER);
-        status.setContentDescription("Coffee GB Android ROM loading status");
-        status.setText("Coffee GB Android is ready. Choose a ROM or ZIP document.");
+        status.setContentDescription("Coffee GB Android runtime status");
+        status.setText("Starting Coffee GB Android runtime…");
         content.addView(status);
 
-        Button open = new Button(this);
-        open.setText("Open ROM");
-        open.setOnClickListener(this::openRomDocument);
+        open = button("Open ROM", this::openRomDocument);
+        recent = button("Open recent ROM", ignored -> requireRuntime(AndroidEmulationRuntime::requestRecentDocuments));
+        resume = button("Resume", ignored -> requireRuntime(AndroidEmulationRuntime::resume));
+        stop = button("Stop game", ignored -> requireRuntime(AndroidEmulationRuntime::stop));
+        importBattery = button("Import battery save", this::chooseBatteryImport);
+        exportBattery = button("Export battery save", this::chooseBatteryExport);
+        importState = button("Import state slot 0", this::chooseStateImport);
+        exportState = button("Export state slot 0", this::chooseStateExport);
         content.addView(open);
-
-        Button recent = new Button(this);
-        recent.setText("Open recent ROM");
-        recent.setOnClickListener(this::openRecentRom);
         content.addView(recent);
-
-        importBattery = transferButton("Import battery save", this::chooseBatteryImport);
-        exportBattery = transferButton("Export battery save", this::chooseBatteryExport);
-        importState = transferButton("Import state slot 0", this::chooseStateImport);
-        exportState = transferButton("Export state slot 0", this::chooseStateExport);
+        content.addView(resume);
+        content.addView(stop);
         content.addView(importBattery);
         content.addView(exportBattery);
         content.addView(importState);
         content.addView(exportState);
         setContentView(content);
+        disableCommands();
     }
 
     @Override
-    protected void onDestroy() {
-        romWorker.shutdownNow();
-        super.onDestroy();
+    protected void onStart() {
+        super.onStart();
+        EmulationService.start(this);
+        if (!bound) {
+            bindService(new Intent(this, EmulationService.class), connection, BIND_AUTO_CREATE);
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        if (bound) {
+            runtime.removeObserver(this);
+            unbindService(connection);
+            bound = false;
+            runtime = null;
+        }
+        super.onStop();
+    }
+
+    @Override
+    public void onStateChanged(RuntimeState state) {
+        applyState(state);
+    }
+
+    private Button button(String label, View.OnClickListener listener) {
+        Button button = new Button(this);
+        button.setText(label);
+        button.setOnClickListener(listener);
+        return button;
     }
 
     private void openRomDocument(View ignored) {
+        if (runtime == null) {
+            return;
+        }
         Intent request = new Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
                 .setType("application/octet-stream")
@@ -111,81 +154,28 @@ public final class MainActivity extends Activity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (resultCode != RESULT_OK || data == null || data.getData() == null) {
-            return;
-        }
-        Uri uri = data.getData();
-        if (requestCode == OPEN_ROM_REQUEST) {
-            retainReadPermission(uri, data.getFlags());
-            status.setText("Opening selected ROM…");
-            romWorker.execute(() -> inspect(uri));
+        if (resultCode != RESULT_OK || data == null || data.getData() == null || runtime == null) {
             return;
         }
         switch (requestCode) {
-            case IMPORT_BATTERY_REQUEST -> importBattery(uri);
+            case OPEN_ROM_REQUEST -> runtime.openRom(data.getData(), data.getFlags());
+            case IMPORT_BATTERY_REQUEST -> runtime.importBattery(data.getData());
             case EXPORT_BATTERY_REQUEST -> confirmExport(
-                    "Export battery save?",
-                    "The chosen document will be replaced.",
-                    () -> exportBattery(uri));
-            case IMPORT_STATE_REQUEST -> importState(uri);
+                    "Export battery save?", "The chosen document will be replaced.",
+                    () -> runtime.exportBattery(data.getData()));
+            case IMPORT_STATE_REQUEST -> runtime.importState(data.getData());
             case EXPORT_STATE_REQUEST -> confirmExport(
-                    "Export state slot 0?",
-                    "The chosen document will be replaced.",
-                    () -> exportState(uri));
+                    "Export state slot 0?", "The chosen document will be replaced.",
+                    () -> runtime.exportState(data.getData()));
             default -> { }
         }
-    }
-
-    private void retainReadPermission(Uri uri, int resultFlags) {
-        int read = resultFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION;
-        int persistable = resultFlags & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION;
-        if (read == 0 || persistable == 0) {
-            return;
-        }
-        try {
-            getContentResolver().takePersistableUriPermission(uri, read);
-        } catch (SecurityException ignored) {
-            // Some providers lawfully grant only the activity-lifetime permission. The document
-            // can still be opened now but is not retained as a recent document.
-        }
-    }
-
-    private void openRecentRom(View ignored) {
-        status.setText("Checking recent ROM permissions…");
-        romWorker.execute(() -> {
-            List<Uri> recent = new RecentSafDocuments(getApplicationContext()).readable();
-            if (recent.isEmpty()) {
-                showFailure("No readable recent ROM document is available.");
-                return;
-            }
-            String[] labels = new String[recent.size()];
-            for (int index = 0; index < labels.length; index++) {
-                labels[index] = "Recent ROM " + (index + 1);
-            }
-            runOnUiThread(() -> new AlertDialog.Builder(this)
-                    .setTitle("Open recent ROM")
-                    .setItems(labels, (dialog, index) -> {
-                        status.setText("Opening recent ROM…");
-                        romWorker.execute(() -> inspect(recent.get(index)));
-                    })
-                    .show());
-        });
-    }
-
-    private Button transferButton(String label, View.OnClickListener listener) {
-        Button button = new Button(this);
-        button.setText(label);
-        button.setEnabled(false);
-        button.setOnClickListener(listener);
-        return button;
     }
 
     private void chooseBatteryImport(View ignored) {
         confirmImport(
                 "Import battery save?",
                 "Importing can replace this ROM's app-private battery save.",
-                IMPORT_BATTERY_REQUEST,
-                "application/octet-stream");
+                IMPORT_BATTERY_REQUEST);
     }
 
     private void chooseBatteryExport(View ignored) {
@@ -196,16 +186,15 @@ public final class MainActivity extends Activity {
         confirmImport(
                 "Import state slot 0?",
                 "Importing can replace this ROM's app-private state slot 0.",
-                IMPORT_STATE_REQUEST,
-                "application/octet-stream");
+                IMPORT_STATE_REQUEST);
     }
 
     private void chooseStateExport(View ignored) {
         chooseExport(EXPORT_STATE_REQUEST, "slot-0.cgbstate");
     }
 
-    private void confirmImport(String title, String message, int requestCode, String mimeType) {
-        if (!ensureLoaded()) {
+    private void confirmImport(String title, String message, int requestCode) {
+        if (runtime == null || !importBattery.isEnabled()) {
             return;
         }
         new AlertDialog.Builder(this)
@@ -215,14 +204,14 @@ public final class MainActivity extends Activity {
                 .setPositiveButton("Choose document", (dialog, ignored) -> startActivityForResult(
                         new Intent(Intent.ACTION_OPEN_DOCUMENT)
                                 .addCategory(Intent.CATEGORY_OPENABLE)
-                                .setType(mimeType)
+                                .setType("application/octet-stream")
                                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION),
                         requestCode))
                 .show();
     }
 
     private void chooseExport(int requestCode, String suggestedName) {
-        if (!ensureLoaded()) {
+        if (runtime == null || !exportBattery.isEnabled()) {
             return;
         }
         startActivityForResult(
@@ -234,80 +223,6 @@ public final class MainActivity extends Activity {
                 requestCode);
     }
 
-    private boolean ensureLoaded() {
-        if (activeLayout != null && activeStates != null) {
-            return true;
-        }
-        showFailure("Open a ROM before importing or exporting its save data.");
-        return false;
-    }
-
-    private void importBattery(Uri source) {
-        StateStorageLayout layout = activeLayout;
-        if (layout == null) return;
-        status.setText("Importing battery save…");
-        romWorker.execute(() -> {
-            try {
-                SafPersistenceExchange.importBattery(
-                        getContentResolver(),
-                        source,
-                        layout,
-                        SafPersistenceExchange.CollisionDecision.REPLACE);
-                runOnUiThread(() -> status.setText("Battery save imported."));
-            } catch (Exception failure) {
-                showFailure("Coffee GB could not import that battery save.");
-            }
-        });
-    }
-
-    private void exportBattery(Uri destination) {
-        StateStorageLayout layout = activeLayout;
-        if (layout == null) return;
-        status.setText("Exporting battery save…");
-        romWorker.execute(() -> {
-            try {
-                SafPersistenceExchange.exportBattery(getContentResolver(), destination, layout, true);
-                runOnUiThread(() -> status.setText("Battery save exported."));
-            } catch (Exception failure) {
-                showFailure("Coffee GB could not export the battery save.");
-            }
-        });
-    }
-
-    private void importState(Uri source) {
-        StateRepository states = activeStates;
-        if (states == null) return;
-        status.setText("Importing state slot 0…");
-        romWorker.execute(() -> {
-            try {
-                SafPersistenceExchange.importState(
-                        getContentResolver(),
-                        source,
-                        states,
-                        new StateRef.Slot(0),
-                        SafPersistenceExchange.CollisionDecision.REPLACE);
-                runOnUiThread(() -> status.setText("State slot 0 imported."));
-            } catch (Exception failure) {
-                showFailure("Coffee GB could not import that state file.");
-            }
-        });
-    }
-
-    private void exportState(Uri destination) {
-        StateRepository states = activeStates;
-        if (states == null) return;
-        status.setText("Exporting state slot 0…");
-        romWorker.execute(() -> {
-            try {
-                SafPersistenceExchange.exportState(
-                        getContentResolver(), destination, states, new StateRef.Slot(0), true);
-                runOnUiThread(() -> status.setText("State slot 0 exported."));
-            } catch (Exception failure) {
-                showFailure("Coffee GB could not export state slot 0.");
-            }
-        });
-    }
-
     private void confirmExport(String title, String message, Runnable action) {
         new AlertDialog.Builder(this)
                 .setTitle(title)
@@ -317,85 +232,70 @@ public final class MainActivity extends Activity {
                 .show();
     }
 
-    private void inspect(Uri uri) {
-        try {
-            AndroidRomInput input = new AndroidRomInput(getContentResolver(), uri);
-            RomSourceSnapshot snapshot = RomSourceSnapshot.open(input);
-            if (!snapshot.isArchive() || snapshot.candidates().size() == 1) {
-                load(snapshot, snapshot.isArchive()
-                        ? snapshot.candidates().get(0).token()
-                        : RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN, uri);
-                return;
-            }
-            List<RomSourceSnapshot.ArchiveCandidate> candidates = snapshot.candidates();
-            String[] names = candidates.stream()
-                    .map(RomSourceSnapshot.ArchiveCandidate::displayName)
-                    .toArray(String[]::new);
-            runOnUiThread(() -> new AlertDialog.Builder(this)
-                    .setTitle("Choose ROM from archive")
-                    .setItems(names, (dialog, index) -> romWorker.execute(
-                            () -> load(snapshot, candidates.get(index).token(), uri)))
-                    .setOnCancelListener(dialog -> closeQuietly(snapshot))
-                    .show());
-        } catch (Exception failure) {
-            // Deliberately do not expose content URIs or provider details in the UI.
-            forgetRevokedPermission(uri, failure);
-            showFailure("Coffee GB could not open this document. Check its permission and format.");
+    private void applyState(RuntimeState state) {
+        status.setText(state.message());
+        boolean ready = runtime != null;
+        open.setEnabled(ready);
+        recent.setEnabled(ready);
+        resume.setEnabled(ready && state.paused() && state.transferReady());
+        stop.setEnabled(ready && state.transferReady());
+        importBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
+        exportBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
+        importState.setEnabled(ready && state.transferReady() && !state.flushPending());
+        exportState.setEnabled(ready && state.transferReady() && !state.flushPending());
+        showSelectionIfNeeded(state);
+    }
+
+    private void showSelectionIfNeeded(RuntimeState state) {
+        if (runtime == null || state.selections().isEmpty()
+                || state.generation() == shownSelectionGeneration) {
+            return;
+        }
+        boolean archive = state.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION;
+        boolean recentSelection = state.phase() == RuntimeState.Phase.AWAITING_RECENT_SELECTION;
+        if (!archive && !recentSelection) {
+            return;
+        }
+        shownSelectionGeneration = state.generation();
+        List<RuntimeState.Selection> selections = state.selections();
+        String[] labels = selections.stream().map(RuntimeState.Selection::label).toArray(String[]::new);
+        new AlertDialog.Builder(this)
+                .setTitle(archive ? "Choose ROM from archive" : "Open recent ROM")
+                .setItems(labels, (dialog, index) -> {
+                    RuntimeState.Selection selection = selections.get(index);
+                    if (archive) {
+                        runtime.selectArchiveCandidate(selection.token());
+                    } else {
+                        runtime.selectRecentDocument(selection.token());
+                    }
+                })
+                .setOnCancelListener(dialog -> runtime.cancelPendingSelection())
+                .show();
+    }
+
+    private void requireRuntime(RuntimeAction action) {
+        AndroidEmulationRuntime active = runtime;
+        if (active != null) {
+            action.run(active);
         }
     }
 
-    private void load(RomSourceSnapshot snapshot, long token, Uri sourceUri) {
-        try {
-            RomImage image = token == RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN
-                    ? snapshot.loadSingle()
-                    : snapshot.load(token);
-            Rom rom = new Rom(image);
-            AndroidRomPersistenceStore store = new AndroidRomPersistenceStore(getApplicationContext());
-            // Construct the hash-keyed layout now so a valid document never needs a path beside
-            // the provider's source. Controller session activation consumes this same store.
-            StateStorageLayout layout = store.layout(
-                    eu.rekawek.coffeegb.controller.state.StateIdentity.INSTANCE.hash(rom).hex());
-            StateRepository states = new StateRepository(
-                    layout,
-                    eu.rekawek.coffeegb.core.persistence.AtomicFileWriter.system());
-            new RecentSafDocuments(getApplicationContext()).recordIfPersisted(sourceUri);
-            runOnUiThread(() -> {
-                activeLayout = layout;
-                activeStates = states;
-                importBattery.setEnabled(true);
-                exportBattery.setEnabled(true);
-                importState.setEnabled(true);
-                exportState.setEnabled(true);
-                status.setText("Loaded " + rom.getTitle() + ". App-private saves are ready.");
-            });
-        } catch (Exception failure) {
-            forgetRevokedPermission(sourceUri, failure);
-            showFailure("Coffee GB could not load the selected ROM.");
-        } finally {
-            closeQuietly(snapshot);
+    private void disableCommands() {
+        if (open == null) {
+            return;
         }
+        open.setEnabled(false);
+        recent.setEnabled(false);
+        resume.setEnabled(false);
+        stop.setEnabled(false);
+        importBattery.setEnabled(false);
+        exportBattery.setEnabled(false);
+        importState.setEnabled(false);
+        exportState.setEnabled(false);
     }
 
-    private void forgetRevokedPermission(Uri uri, Exception failure) {
-        if (failure instanceof SecurityException || failure instanceof IOException) {
-            for (UriPermission permission : getContentResolver().getPersistedUriPermissions()) {
-                if (permission.getUri().equals(uri) && permission.isReadPermission()) {
-                    getContentResolver().releasePersistableUriPermission(
-                            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
-            }
-        }
-    }
-
-    private void showFailure(String message) {
-        runOnUiThread(() -> status.setText(message));
-    }
-
-    private static void closeQuietly(RomSourceSnapshot snapshot) {
-        try {
-            snapshot.close();
-        } catch (IOException ignored) {
-            // Stream snapshots have no path to unlink; a close failure is not user actionable.
-        }
+    @FunctionalInterface
+    private interface RuntimeAction {
+        void run(AndroidEmulationRuntime runtime);
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGate.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGate.java
@@ -1,0 +1,73 @@
+package eu.rekawek.coffeegb.android;
+
+/**
+ * Serial lifecycle policy used by {@link AndroidEmulationRuntime}.
+ *
+ * <p>The runtime invokes this only from its single owner executor. Keeping the policy free of
+ * Android and emulator types lets focused JVM tests model rapid Activity/audio/service races with
+ * a fake session and prove that one live session receives at most one background flush at a time.
+ */
+final class RuntimeLifecycleGate {
+
+    interface SessionCommands {
+        void pause();
+
+        void requestBatteryFlush();
+    }
+
+    private boolean active;
+    private boolean background;
+    private boolean hostPauseRequested;
+    private boolean flushRequested;
+
+    void activated(SessionCommands commands) {
+        active = true;
+        hostPauseRequested = false;
+        flushRequested = false;
+        if (background) {
+            background(commands);
+        }
+    }
+
+    void background(SessionCommands commands) {
+        background = true;
+        if (!active) {
+            return;
+        }
+        if (!hostPauseRequested) {
+            hostPauseRequested = true;
+            commands.pause();
+        }
+        if (!flushRequested) {
+            flushRequested = true;
+            commands.requestBatteryFlush();
+        }
+    }
+
+    void resumedByUser() {
+        background = false;
+        if (active) {
+            hostPauseRequested = false;
+        }
+    }
+
+    /** A bound Activity is visible again; it still must call {@link #resumedByUser()} to play. */
+    void foregrounded() {
+        background = false;
+    }
+
+    void flushCompleted() {
+        flushRequested = false;
+    }
+
+    void released() {
+        active = false;
+        background = false;
+        hostPauseRequested = false;
+        flushRequested = false;
+    }
+
+    boolean active() {
+        return active;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeObserver.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeObserver.java
@@ -1,0 +1,8 @@
+package eu.rekawek.coffeegb.android;
+
+/** Receives immutable {@link RuntimeState} snapshots on Android's main thread. */
+@FunctionalInterface
+public interface RuntimeObserver {
+
+    void onStateChanged(RuntimeState state);
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeState.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeState.java
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.android;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable, redacted presentation state owned by {@link AndroidEmulationRuntime}.
+ *
+ * <p>The Android UI observes snapshots only. It never receives a live controller, a document URI,
+ * a filesystem path, or a mutable emulator object.
+ */
+public record RuntimeState(
+        Phase phase,
+        String message,
+        List<Selection> selections,
+        boolean transferReady,
+        boolean paused,
+        boolean flushPending,
+        long generation) {
+
+    public RuntimeState {
+        Objects.requireNonNull(phase, "phase");
+        Objects.requireNonNull(message, "message");
+        selections = List.copyOf(selections);
+        if (generation < 0) {
+            throw new IllegalArgumentException("generation must not be negative");
+        }
+    }
+
+    public static RuntimeState stopped() {
+        return new RuntimeState(
+                Phase.STOPPED,
+                "Coffee GB Android is ready. Choose a ROM or ZIP document.",
+                List.of(),
+                false,
+                false,
+                false,
+                0);
+    }
+
+    public enum Phase {
+        STOPPED,
+        OPENING,
+        AWAITING_ARCHIVE_SELECTION,
+        AWAITING_RECENT_SELECTION,
+        LOADING,
+        RUNNING,
+        PAUSED,
+        FAILED
+    }
+
+    /** A user-visible, opaque selection token. It intentionally contains no provider identity. */
+    public record Selection(long token, String label) {
+        public Selection {
+            Objects.requireNonNull(label, "label");
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGateTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGateTest.java
@@ -1,0 +1,101 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RuntimeLifecycleGateTest {
+
+    @Test
+    public void rapidBackgroundSignalsCoalesceUntilTheFakeSessionFlushCompletes() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger pauses = new AtomicInteger();
+        AtomicInteger flushes = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                pauses.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                flushes.incrementAndGet();
+            }
+        };
+
+        gate.activated(session);
+        for (int index = 0; index < 10; index++) {
+            gate.background(session);
+        }
+
+        assertTrue(gate.active());
+        assertEquals(1, pauses.get());
+        assertEquals(1, flushes.get());
+
+        gate.flushCompleted();
+        gate.resumedByUser();
+        gate.background(session);
+
+        assertEquals(2, pauses.get());
+        assertEquals(2, flushes.get());
+    }
+
+    @Test
+    public void releasedRuntimeNeverCallsTheFakeSessionAgain() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger calls = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                calls.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                calls.incrementAndGet();
+            }
+        };
+
+        gate.activated(session);
+        gate.released();
+        gate.background(session);
+
+        assertFalse(gate.active());
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    public void tenRapidFakeSessionLifecycleCyclesLeaveNoCommandsAfterEachRelease() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger pauses = new AtomicInteger();
+        AtomicInteger flushes = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                pauses.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                flushes.incrementAndGet();
+            }
+        };
+
+        for (int cycle = 0; cycle < 10; cycle++) {
+            gate.activated(session);
+            gate.background(session);
+            gate.background(session);
+            gate.flushCompleted();
+            gate.released();
+            gate.background(session);
+        }
+
+        assertFalse(gate.active());
+        assertEquals(10, pauses.get());
+        assertEquals(10, flushes.get());
+    }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -406,6 +406,9 @@ class BasicController private constructor(
 
   private var pendingRomSwitch: PendingRomSwitch? = null
 
+  /** One explicit non-terminal battery persistence barrier, if any. */
+  private var batteryFlushJob: BatteryFlushJob? = null
+
   private var pendingCloseRequestId: Long? = null
 
   private var sessionStartedNanos: Long? = null
@@ -548,6 +551,7 @@ class BasicController private constructor(
         releaseInteractivePauseOwners(releaseApplicationPause = true, releaseDebuggerPause = true)
       }
     }
+    eventQueue.register<Controller.FlushBatteryEvent> { requestBatteryFlush(it) }
     eventQueue.register<Controller.RewindEvent> {
       // Disabled rewind is a real no-work mode: the key cannot freeze forward emulation and
       // runFrame never reaches a machine capture.
@@ -662,6 +666,7 @@ class BasicController private constructor(
     finishPreparedLoad()
     finishReplacement()
     finishStop()
+    finishBatteryFlush()
 
     // rewinding restores one recorded state and then emulates a single frame from it,
     // so the display and audio play backwards at RewindManager.RECORD_INTERVAL speed
@@ -3069,6 +3074,48 @@ class BasicController private constructor(
     }
   }
 
+  private fun requestBatteryFlush(event: Controller.FlushBatteryEvent) {
+    if (batteryFlushJob != null) {
+      // A host owns request correlation, so it can retry after the current completion instead of
+      // racing a second writer against the same cartridge capture.
+      eventBus.post(Controller.BatteryFlushCompletedEvent(event.requestId, 0, false))
+      return
+    }
+    val capture = session?.gameboy?.prepareCartridgeFlush() ?: BatteryFlush.none()
+    val attempt = PersistenceTask(capture)
+    batteryFlushJob = BatteryFlushJob(event.requestId, capture, attempt)
+    persistenceExecutor.execute(attempt)
+  }
+
+  private fun finishBatteryFlush() {
+    val job = batteryFlushJob ?: return
+    if (!job.attempt.isDone) {
+      return
+    }
+    batteryFlushJob = null
+    val result =
+        try {
+          job.attempt.get()
+        } catch (_: CancellationException) {
+          return
+        } catch (failure: Exception) {
+          unexpectedPersistenceFailure(failure)
+        }
+    job.capture.complete(result)
+    when (result) {
+      is BatteryPersistenceResult.Success ->
+          eventBus.post(Controller.BatteryFlushCompletedEvent(job.requestId, result.filesWritten(), true))
+      is BatteryPersistenceResult.Failure ->
+          eventBus.post(Controller.BatteryFlushCompletedEvent(job.requestId, 0, false))
+    }
+  }
+
+  private fun discardBatteryFlush() {
+    val job = batteryFlushJob ?: return
+    batteryFlushJob = null
+    job.attempt.cancel(true)
+  }
+
   private fun postPersistenceFailure(
       requestId: Long,
       operation: Controller.PersistenceBarrierOperation,
@@ -4357,6 +4404,7 @@ class BasicController private constructor(
     cancelPendingRomSwitch(notifyCancellation = false, restorePause = false)
     discardReplacement(restorePause = false, notifyCancellation = false)
     discardStop(restorePause = false)
+    discardBatteryFlush()
     pauseStateBeforeLoading = null
     pauseStateBeforeResume = null
     setPaused(true)
@@ -4965,6 +5013,12 @@ class BasicController private constructor(
       var attempt: PersistenceTask?,
       var awaitingGuestConfiguration: Boolean = false,
       var completedPersistence: BatteryPersistenceResult.Success? = null,
+  )
+
+  private data class BatteryFlushJob(
+      val requestId: Long,
+      val capture: BatteryFlush,
+      val attempt: PersistenceTask,
   )
 
   private class PersistenceTask(capture: BatteryFlush) :

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -153,6 +153,20 @@ interface Controller : AutoCloseable {
 
   class ResumeEmulationEvent : Event
 
+  /**
+   * Captures the active cartridge at the controller's frame-safe point and persists it on the
+   * controller-owned worker. Hosts can request a bounded background flush without observing a
+   * live machine or blocking their UI thread.
+   */
+  data class FlushBatteryEvent(val requestId: Long) : Event
+
+  /** Terminal result for one [FlushBatteryEvent]. A failed request remains safe to retry. */
+  data class BatteryFlushCompletedEvent(
+      val requestId: Long,
+      val filesWritten: Int,
+      val succeeded: Boolean,
+  ) : Event
+
   class ResetEmulationEvent : Event
 
   class StopEmulationEvent : Event

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1475,6 +1475,27 @@ class BasicControllerTest {
     }
   }
 
+  @Test
+  fun batteryFlushRequestCompletesAtTheControllerSafePointWithoutBlockingCaller() {
+    val eventBus = EventBusImpl()
+    val completions = LinkedBlockingQueue<Controller.BatteryFlushCompletedEvent>()
+    eventBus.register<Controller.BatteryFlushCompletedEvent> { completions.add(it) }
+    val controller = BasicController(eventBus, testProperties(), null)
+
+    controller.startController()
+    try {
+      eventBus.post(Controller.FlushBatteryEvent(73))
+
+      val completion = assertNotNull(completions.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(73, completion.requestId)
+      assertTrue(completion.succeeded)
+      assertEquals(0, completion.filesWritten)
+    } finally {
+      controller.close()
+      eventBus.close()
+    }
+  }
+
   private fun namedRom(title: String): File {
     val bytes = ROM.readBytes()
     for (address in 0x0134 until 0x0143) {


### PR DESCRIPTION
Closes #357

## Summary

- Move Android controller, event bus, ROM ownership, and lifecycle work into one same-process non-foreground `EmulationService`.
- Expose immutable, redacted runtime state and asynchronous UI commands so Activity recreation cannot duplicate a session.
- Pause safely on visibility or audio-focus loss, request a bounded/retryable battery flush, and require explicit resume.
- Add controller flush events and fake-session lifecycle tests, including ten rapid activation/background/release cycles.

## Invariants and impact

The Activity only binds, observes snapshots, and launches SAF dialogs. It never owns the emulator or stops it during rotation. The service is `START_NOT_STICKY`; process recreation starts truthfully stopped. The app adds no permissions or background-play/foreground-service behavior, and SAF details remain redacted.

## Validation

- `mvn -B test`
- `ANDROID_HOME=/tmp/coffee-gb-android-sdk ANDROID_SDK_ROOT=/tmp/coffee-gb-android-sdk ./android/gradlew -p android -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 --no-daemon :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`

Unblocks the Android rendering phase.
