### PR TITLE
Add Android native frame renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ flush; returning to the app requires an explicit Resume action. The service is n
 process recreation truthfully starts stopped and offers only persisted recent-document metadata.
 There is no background playback, no foreground-service notification, and no extra permission.
 
+Android video uses a dedicated `SurfaceView` which attaches to the service-owned native-frame
+store only while its surface exists. The controller copies DMG, CGB, or SGB pixels into one of
+three reusable ARGB buffers before a frame callback returns; the renderer draws only the newest
+frame with nearest-neighbor integer scaling (or aspect-preserving letterboxing where an integer
+fit is impossible). Losing or recreating a surface does not affect the emulation session. Native
+PNG screenshots are exported from that frame store, never from the Android UI or its overlays.
+
 ## Download and play
 
 The portable Coffee GB download is a single executable JAR. It requires a desktop **Java 16 or

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.android;
 import android.content.Context;
 import android.content.Intent;
 import android.content.UriPermission;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
@@ -15,12 +16,15 @@ import eu.rekawek.coffeegb.controller.state.StateRepository;
 import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.RomImage;
 import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
 import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -63,6 +67,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final CopyOnWriteArraySet<RuntimeObserver> observers = new CopyOnWriteArraySet<>();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final RuntimeLifecycleGate lifecycle = new RuntimeLifecycleGate();
+    private final NativeFrameStore frames = new NativeFrameStore();
 
     private volatile RuntimeState state = RuntimeState.stopped();
 
@@ -89,6 +94,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     public RuntimeState state() {
         return state;
+    }
+
+    /** Service-owned native frames for a short-lived {@link CoffeeGbSurfaceView} attachment. */
+    NativeFrameStore frames() {
+        return frames;
     }
 
     /** Registers one UI observer and immediately replays the latest immutable snapshot. */
@@ -229,6 +239,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeLayout = null;
             activeStates = null;
             currentSource = null;
+            frames.clear();
             lifecycle.released();
             createController();
             publish(RuntimeState.Phase.STOPPED,
@@ -263,6 +274,31 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         context.getContentResolver(), destination, requireStates(), new StateRef.Slot(0), true));
     }
 
+    /** Writes the latest native emulated frame as a PNG; it never captures Android UI overlays. */
+    public void exportScreenshot(Uri destination) {
+        Uri checked = Objects.requireNonNull(destination, "destination");
+        submit(() -> {
+            NativeFrameStore.Snapshot snapshot = frames.snapshot();
+            if (snapshot == null) {
+                publish(RuntimeState.Phase.FAILED,
+                        "Render one game frame before exporting a screenshot.",
+                        List.of(), activeLayout != null, state.paused(), state.flushPending());
+                return;
+            }
+            RuntimeState before = state;
+            publish(before.phase(), "Exporting native screenshot…", List.of(),
+                    before.transferReady(), before.paused(), before.flushPending());
+            try {
+                writePng(checked, snapshot);
+                publish(before.phase(), "Native screenshot exported.", List.of(),
+                        before.transferReady(), before.paused(), before.flushPending());
+            } catch (IOException failure) {
+                publish(before.phase(), "Coffee GB could not export that screenshot.", List.of(),
+                        before.transferReady(), before.paused(), before.flushPending());
+            }
+        });
+    }
+
     @Override
     public void close() {
         if (!closed.compareAndSet(false, true)) {
@@ -276,6 +312,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 activeLayout = null;
                 activeStates = null;
                 currentSource = null;
+                frames.close();
             });
         } catch (RejectedExecutionException ignored) {
             // The owner is already tearing down; no new resource can have been admitted.
@@ -297,6 +334,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void createController() {
         eventBus = new EventBusImpl();
+        // Display events run synchronously on the controller thread. The bounded store must copy
+        // their producer-owned arrays before this callback returns; it never touches Android UI.
+        eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
+        eventBus.register(frames::publish, Display.GbcFrameReadyEvent.class);
+        eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
         eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
@@ -380,6 +422,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void openRom(Uri uri) {
         clearPendingSource();
+        frames.clear();
         publish(RuntimeState.Phase.OPENING, "Opening selected ROM…", List.of(), false, true, false);
         try {
             AndroidRomInput input = new AndroidRomInput(context.getContentResolver(), uri);
@@ -580,6 +623,23 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (flushDeadline != null) {
             flushDeadline.cancel(false);
             flushDeadline = null;
+        }
+    }
+
+    private void writePng(Uri destination, NativeFrameStore.Snapshot snapshot) throws IOException {
+        try (OutputStream output = context.getContentResolver().openOutputStream(destination, "wt")) {
+            if (output == null) {
+                throw new IOException("The selected screenshot document is unavailable");
+            }
+            Bitmap bitmap = Bitmap.createBitmap(
+                    snapshot.pixels(), snapshot.width(), snapshot.height(), Bitmap.Config.ARGB_8888);
+            try {
+                if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    throw new IOException("Android could not encode the native screenshot");
+                }
+            } finally {
+                bitmap.recycle();
+            }
         }
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -1,0 +1,202 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+
+/**
+ * Dedicated nearest-neighbour native-frame surface.
+ *
+ * <p>This view owns only a short-lived Surface renderer. It attaches to the service-owned
+ * {@link NativeFrameStore} while its Surface exists and never owns the controller or its frame
+ * producer, so a Surface loss during rotation cannot stop the emulation session.
+ */
+public final class CoffeeGbSurfaceView extends SurfaceView
+        implements SurfaceHolder.Callback, NativeFrameStore.Listener {
+
+    private final Object renderLock = new Object();
+    private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Rect source = new Rect();
+    private final Rect destination = new Rect();
+    private final Bitmap bitmap = Bitmap.createBitmap(
+            NativeFrameStore.MAX_WIDTH, NativeFrameStore.MAX_HEIGHT, Bitmap.Config.ARGB_8888);
+
+    private volatile NativeFrameStore frames;
+    private RenderThread renderThread;
+    private volatile boolean surfaceReady;
+
+    public CoffeeGbSurfaceView(Context context) {
+        super(context);
+        paint.setFilterBitmap(false);
+        getHolder().addCallback(this);
+        setContentDescription("Coffee GB emulated video output");
+    }
+
+    /** Attaches this transient Surface to the long-lived service frame store. */
+    public void attach(NativeFrameStore frameStore) {
+        if (frames == frameStore) {
+            return;
+        }
+        detach();
+        frames = frameStore;
+        if (surfaceReady) {
+            frames.addListener(this);
+            startRenderer();
+        }
+    }
+
+    /** Releases only the Surface subscription; the active emulator keeps running in its service. */
+    public void detach() {
+        NativeFrameStore active = frames;
+        if (active != null) {
+            active.removeListener(this);
+        }
+        frames = null;
+        stopRenderer();
+    }
+
+    @Override
+    public void surfaceCreated(SurfaceHolder holder) {
+        surfaceReady = true;
+        if (frames != null) {
+            frames.addListener(this);
+            startRenderer();
+        }
+    }
+
+    @Override
+    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+        onFrameAvailable();
+    }
+
+    @Override
+    public void surfaceDestroyed(SurfaceHolder holder) {
+        surfaceReady = false;
+        NativeFrameStore active = frames;
+        if (active != null) {
+            active.removeListener(this);
+        }
+        stopRenderer();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        detach();
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public void onFrameAvailable() {
+        synchronized (renderLock) {
+            if (renderThread != null) {
+                renderThread.frameAvailable = true;
+                renderLock.notifyAll();
+            }
+        }
+    }
+
+    private void startRenderer() {
+        synchronized (renderLock) {
+            if (renderThread != null || !surfaceReady || frames == null) {
+                return;
+            }
+            renderThread = new RenderThread();
+            renderThread.start();
+            renderThread.frameAvailable = true;
+            renderLock.notifyAll();
+        }
+    }
+
+    private void stopRenderer() {
+        RenderThread retiring;
+        synchronized (renderLock) {
+            retiring = renderThread;
+            renderThread = null;
+            if (retiring != null) {
+                retiring.running = false;
+                renderLock.notifyAll();
+            }
+        }
+        if (retiring != null && Thread.currentThread() != retiring) {
+            try {
+                retiring.join(500L);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private final class RenderThread extends Thread {
+        private boolean running = true;
+        private boolean frameAvailable;
+
+        private RenderThread() {
+            super("coffee-gb-android-video");
+            setDaemon(true);
+        }
+
+        @Override
+        public void run() {
+            while (awaitFrame()) {
+                NativeFrameStore active = frames;
+                if (active == null || !surfaceReady) {
+                    continue;
+                }
+                NativeFrameStore.Frame frame = active.takeLatest();
+                try {
+                    draw(frame);
+                } finally {
+                    active.finishDrawing(frame);
+                }
+            }
+        }
+
+        private boolean awaitFrame() {
+            synchronized (renderLock) {
+                while (running && !frameAvailable) {
+                    try {
+                        renderLock.wait();
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        return false;
+                    }
+                }
+                if (!running) {
+                    return false;
+                }
+                frameAvailable = false;
+                return true;
+            }
+        }
+
+        private void draw(NativeFrameStore.Frame frame) {
+            Canvas canvas = null;
+            try {
+                canvas = getHolder().lockCanvas();
+                if (canvas == null) {
+                    return;
+                }
+                canvas.drawColor(Color.BLACK);
+                if (frame == null) {
+                    return;
+                }
+                bitmap.setPixels(frame.pixels(), 0, frame.width(), 0, 0, frame.width(), frame.height());
+                source.set(0, 0, frame.width(), frame.height());
+                VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(
+                        frame.width(), frame.height(), canvas.getWidth(), canvas.getHeight());
+                destination.set(viewport.left(), viewport.top(),
+                        viewport.left() + viewport.width(), viewport.top() + viewport.height());
+                canvas.drawBitmap(bitmap, source, destination, paint);
+            } finally {
+                if (canvas != null) {
+                    getHolder().unlockCanvasAndPost(canvas);
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -29,8 +30,10 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final int EXPORT_BATTERY_REQUEST = 3;
     private static final int IMPORT_STATE_REQUEST = 4;
     private static final int EXPORT_STATE_REQUEST = 5;
+    private static final int EXPORT_SCREENSHOT_REQUEST = 6;
 
     private TextView status;
+    private CoffeeGbSurfaceView video;
     private Button open;
     private Button recent;
     private Button resume;
@@ -39,6 +42,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private Button exportBattery;
     private Button importState;
     private Button exportState;
+    private Button exportScreenshot;
 
     private AndroidEmulationRuntime runtime;
     private boolean bound;
@@ -50,12 +54,14 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             runtime = ((EmulationService.RuntimeBinder) service).runtime();
             bound = true;
             runtime.addObserver(MainActivity.this);
+            video.attach(runtime.frames());
             applyState(runtime.state());
         }
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
             if (runtime != null) {
+                video.detach();
                 runtime.removeObserver(MainActivity.this);
             }
             runtime = null;
@@ -81,6 +87,10 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         status.setText("Starting Coffee GB Android runtime…");
         content.addView(status);
 
+        video = new CoffeeGbSurfaceView(this);
+        content.addView(video, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+
         open = button("Open ROM", this::openRomDocument);
         recent = button("Open recent ROM", ignored -> requireRuntime(AndroidEmulationRuntime::requestRecentDocuments));
         resume = button("Resume", ignored -> requireRuntime(AndroidEmulationRuntime::resume));
@@ -89,6 +99,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         exportBattery = button("Export battery save", this::chooseBatteryExport);
         importState = button("Import state slot 0", this::chooseStateImport);
         exportState = button("Export state slot 0", this::chooseStateExport);
+        exportScreenshot = button("Export native screenshot", this::chooseScreenshotExport);
         content.addView(open);
         content.addView(recent);
         content.addView(resume);
@@ -97,6 +108,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         content.addView(exportBattery);
         content.addView(importState);
         content.addView(exportState);
+        content.addView(exportScreenshot);
         setContentView(content);
         disableCommands();
     }
@@ -113,6 +125,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @Override
     protected void onStop() {
         if (bound) {
+            video.detach();
             runtime.removeObserver(this);
             unbindService(connection);
             bound = false;
@@ -167,6 +180,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             case EXPORT_STATE_REQUEST -> confirmExport(
                     "Export state slot 0?", "The chosen document will be replaced.",
                     () -> runtime.exportState(data.getData()));
+            case EXPORT_SCREENSHOT_REQUEST -> confirmExport(
+                    "Export native screenshot?", "The chosen document will be replaced.",
+                    () -> runtime.exportScreenshot(data.getData()));
             default -> { }
         }
     }
@@ -191,6 +207,19 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     private void chooseStateExport(View ignored) {
         chooseExport(EXPORT_STATE_REQUEST, "slot-0.cgbstate");
+    }
+
+    private void chooseScreenshotExport(View ignored) {
+        if (runtime == null || !exportScreenshot.isEnabled()) {
+            return;
+        }
+        startActivityForResult(
+                new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                        .addCategory(Intent.CATEGORY_OPENABLE)
+                        .setType("image/png")
+                        .putExtra(Intent.EXTRA_TITLE, "coffee-gb.png")
+                        .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
+                EXPORT_SCREENSHOT_REQUEST);
     }
 
     private void confirmImport(String title, String message, int requestCode) {
@@ -243,6 +272,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         exportBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
         importState.setEnabled(ready && state.transferReady() && !state.flushPending());
         exportState.setEnabled(ready && state.transferReady() && !state.flushPending());
+        exportScreenshot.setEnabled(ready && state.transferReady() && !state.flushPending());
         showSelectionIfNeeded(state);
     }
 
@@ -292,6 +322,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         exportBattery.setEnabled(false);
         importState.setEnabled(false);
         exportState.setEnabled(false);
+        exportScreenshot.setEnabled(false);
     }
 
     @FunctionalInterface

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/NativeFrameStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/NativeFrameStore.java
@@ -1,0 +1,298 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.core.sgb.SuperGameboy;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * Bounded native-frame hand-off between the controller event thread and an Android renderer.
+ *
+ * <p>Core display events expose producer-owned arrays. This store converts and copies each event
+ * into one of three fixed ARGB buffers before the event callback returns. A consumer then claims
+ * only the newest complete frame; older queued frames are discarded. This gives the renderer a
+ * stable frame without retaining a core buffer, allocating a Bitmap, or allowing an unbounded
+ * frame queue to accumulate behind a slow Surface.
+ */
+final class NativeFrameStore implements AutoCloseable {
+
+    static final int MAX_WIDTH = SuperGameboy.SGB_DISPLAY_WIDTH;
+    static final int MAX_HEIGHT = SuperGameboy.SGB_DISPLAY_HEIGHT;
+    private static final int SLOT_COUNT = 3;
+
+    interface Listener {
+        /** Signals availability only; consumers must call {@link #takeLatest()} themselves. */
+        void onFrameAvailable();
+    }
+
+    private enum SlotState {
+        FREE,
+        WRITING,
+        PUBLISHED,
+        DRAWING
+    }
+
+    private final Slot[] slots = new Slot[SLOT_COUNT];
+    private final CopyOnWriteArraySet<Listener> listeners = new CopyOnWriteArraySet<>();
+
+    private long nextSequence;
+    private long droppedFrames;
+    private boolean closed;
+
+    NativeFrameStore() {
+        for (int index = 0; index < slots.length; index++) {
+            slots[index] = new Slot();
+        }
+    }
+
+    void addListener(Listener listener) {
+        listeners.add(listener);
+        if (hasFrame()) {
+            listener.onFrameAvailable();
+        }
+    }
+
+    void removeListener(Listener listener) {
+        listeners.remove(listener);
+    }
+
+    void publish(Display.DmgFrameReadyEvent event) {
+        Slot slot = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+        if (slot == null) {
+            return;
+        }
+        event.toRgb(slot.pixels, false);
+        makeOpaque(slot.pixels, Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT);
+        publish(slot);
+    }
+
+    void publish(Display.GbcFrameReadyEvent event) {
+        Slot slot = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+        if (slot == null) {
+            return;
+        }
+        event.toRgb(slot.pixels, false);
+        makeOpaque(slot.pixels, Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT);
+        publish(slot);
+    }
+
+    void publish(SgbDisplay.SgbFrameReadyEvent event) {
+        int width = event.includeBorder() ? SuperGameboy.SGB_DISPLAY_WIDTH : Display.DISPLAY_WIDTH;
+        int height = event.includeBorder() ? SuperGameboy.SGB_DISPLAY_HEIGHT : Display.DISPLAY_HEIGHT;
+        Slot slot = reserve(width, height);
+        if (slot == null) {
+            return;
+        }
+        event.toRgb(slot.pixels, false);
+        makeOpaque(slot.pixels, Math.multiplyExact(width, height));
+        publish(slot);
+    }
+
+    /**
+     * Claims the latest complete frame for drawing, releasing any older queued frames. The caller
+     * must later pair a non-null result with {@link #finishDrawing(Frame)}.
+     */
+    synchronized Frame takeLatest() {
+        Slot newest = null;
+        for (Slot slot : slots) {
+            if (slot.state == SlotState.PUBLISHED
+                    && (newest == null || slot.sequence > newest.sequence)) {
+                newest = slot;
+            }
+        }
+        if (newest == null) {
+            return null;
+        }
+        for (Slot slot : slots) {
+            if (slot != newest && slot.state == SlotState.PUBLISHED) {
+                slot.state = SlotState.FREE;
+            }
+        }
+        newest.state = SlotState.DRAWING;
+        return new Frame(newest);
+    }
+
+    /**
+     * Releases a frame after drawing. The most recent frame remains published for screenshot and
+     * Surface recreation; a stale frame is immediately made reusable.
+     */
+    synchronized void finishDrawing(Frame frame) {
+        if (frame == null || frame.slot.state != SlotState.DRAWING) {
+            return;
+        }
+        frame.slot.state = frame.slot.sequence == nextSequence ? SlotState.PUBLISHED : SlotState.FREE;
+    }
+
+    /** Returns a caller-owned native-frame copy for an explicit screenshot request. */
+    synchronized Snapshot snapshot() {
+        Slot newest = null;
+        for (Slot slot : slots) {
+            if ((slot.state == SlotState.PUBLISHED || slot.state == SlotState.DRAWING)
+                    && slot.sequence == nextSequence
+                    && (newest == null || slot.sequence > newest.sequence)) {
+                newest = slot;
+            }
+        }
+        if (newest == null) {
+            return null;
+        }
+        int length = Math.multiplyExact(newest.width, newest.height);
+        return new Snapshot(newest.width, newest.height, Arrays.copyOf(newest.pixels, length));
+    }
+
+    synchronized void clear() {
+        nextSequence++;
+        for (Slot slot : slots) {
+            if (slot.state == SlotState.PUBLISHED) {
+                slot.state = SlotState.FREE;
+            }
+        }
+        notifyListeners();
+    }
+
+    synchronized long droppedFrames() {
+        return droppedFrames;
+    }
+
+    synchronized int bufferCount() {
+        return slots.length;
+    }
+
+    synchronized int[] bufferAt(int index) {
+        return slots[index].pixels;
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        listeners.clear();
+        for (Slot slot : slots) {
+            slot.state = SlotState.FREE;
+        }
+    }
+
+    private synchronized boolean hasFrame() {
+        for (Slot slot : slots) {
+            if (slot.state == SlotState.PUBLISHED) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private synchronized Slot reserve(int width, int height) {
+        if (closed || width < 1 || height < 1 || width > MAX_WIDTH || height > MAX_HEIGHT) {
+            droppedFrames++;
+            return null;
+        }
+        Slot chosen = null;
+        for (Slot slot : slots) {
+            if (slot.state == SlotState.FREE) {
+                chosen = slot;
+                break;
+            }
+        }
+        if (chosen == null) {
+            for (Slot slot : slots) {
+                if (slot.state == SlotState.PUBLISHED
+                        && (chosen == null || slot.sequence < chosen.sequence)) {
+                    chosen = slot;
+                }
+            }
+        }
+        if (chosen == null) {
+            // Rendering owns every fixed buffer. Dropping one arriving frame is preferable to
+            // blocking the controller thread or allocating a fourth frame.
+            droppedFrames++;
+            return null;
+        }
+        chosen.state = SlotState.WRITING;
+        chosen.width = width;
+        chosen.height = height;
+        return chosen;
+    }
+
+    private void publish(Slot slot) {
+        synchronized (this) {
+            if (closed || slot.state != SlotState.WRITING) {
+                return;
+            }
+            slot.sequence = ++nextSequence;
+            slot.state = SlotState.PUBLISHED;
+        }
+        notifyListeners();
+    }
+
+    private void notifyListeners() {
+        for (Listener listener : listeners) {
+            listener.onFrameAvailable();
+        }
+    }
+
+    private static void makeOpaque(int[] pixels, int length) {
+        for (int index = 0; index < length; index++) {
+            pixels[index] |= 0xff000000;
+        }
+    }
+
+    static final class Frame {
+        private final Slot slot;
+
+        private Frame(Slot slot) {
+            this.slot = slot;
+        }
+
+        int[] pixels() {
+            return slot.pixels;
+        }
+
+        int width() {
+            return slot.width;
+        }
+
+        int height() {
+            return slot.height;
+        }
+    }
+
+    record Snapshot(int width, int height, int[] pixels) {
+
+        String sha256() {
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                updateInt(digest, width);
+                updateInt(digest, height);
+                for (int pixel : pixels) {
+                    updateInt(digest, pixel);
+                }
+                byte[] hash = digest.digest();
+                StringBuilder text = new StringBuilder(hash.length * 2);
+                for (byte value : hash) {
+                    text.append(String.format("%02x", value));
+                }
+                return text.toString();
+            } catch (NoSuchAlgorithmException failure) {
+                throw new IllegalStateException("SHA-256 is unavailable", failure);
+            }
+        }
+
+        private static void updateInt(MessageDigest digest, int value) {
+            digest.update((byte) (value >>> 24));
+            digest.update((byte) (value >>> 16));
+            digest.update((byte) (value >>> 8));
+            digest.update((byte) value);
+        }
+    }
+
+    private static final class Slot {
+        private final int[] pixels = new int[MAX_WIDTH * MAX_HEIGHT];
+        private SlotState state = SlotState.FREE;
+        private int width;
+        private int height;
+        private long sequence;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/VideoGeometry.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/VideoGeometry.java
@@ -1,0 +1,31 @@
+package eu.rekawek.coffeegb.android;
+
+/** Pure nearest-neighbour viewport math, deliberately independent of Android UI classes. */
+final class VideoGeometry {
+
+    private VideoGeometry() {
+    }
+
+    static Viewport nearestFit(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight) {
+        if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+            return new Viewport(0, 0, 0, 0);
+        }
+        int integerScale = Math.min(targetWidth / sourceWidth, targetHeight / sourceHeight);
+        int width;
+        int height;
+        if (integerScale >= 1) {
+            width = sourceWidth * integerScale;
+            height = sourceHeight * integerScale;
+        } else {
+            double fitScale = Math.min(
+                    (double) targetWidth / sourceWidth,
+                    (double) targetHeight / sourceHeight);
+            width = Math.max(1, (int) Math.floor(sourceWidth * fitScale));
+            height = Math.max(1, (int) Math.floor(sourceHeight * fitScale));
+        }
+        return new Viewport((targetWidth - width) / 2, (targetHeight - height) / 2, width, height);
+    }
+
+    record Viewport(int left, int top, int width, int height) {
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/NativeFrameStoreTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/NativeFrameStoreTest.java
@@ -1,0 +1,111 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.core.sgb.SuperGameboy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+public class NativeFrameStoreTest {
+
+    @Test
+    public void approvedDmgCgbAndSgbNativeFixturesHaveStablePixelHashes() {
+        NativeFrameStore store = new NativeFrameStore();
+        try {
+            int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            for (int index = 0; index < dmg.length; index++) {
+                dmg[index] = index & 3;
+            }
+            store.publish(new Display.DmgFrameReadyEvent(dmg));
+            NativeFrameStore.Snapshot dmgFrame = requireSnapshot(store);
+            assertEquals(Display.DISPLAY_WIDTH, dmgFrame.width());
+            assertEquals(Display.DISPLAY_HEIGHT, dmgFrame.height());
+            assertEquals("2c1db295273711ddd25d81e7efc83de6ea6f25232a119e6a67cf8da947ca684e", dmgFrame.sha256());
+
+            int[] cgb = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            for (int index = 0; index < cgb.length; index++) {
+                cgb[index] = (index * 73) & 0x7fff;
+            }
+            store.publish(new Display.GbcFrameReadyEvent(cgb));
+            assertEquals("a81ffd277afc629be08883743bb5b96e13849e2074271cbf40f3d69fe23d230b", requireSnapshot(store).sha256());
+
+            int[] sgb = new int[SuperGameboy.SGB_DISPLAY_WIDTH * SuperGameboy.SGB_DISPLAY_HEIGHT];
+            for (int index = 0; index < sgb.length; index++) {
+                sgb[index] = ((index * 17) & 0xff) << 16 | ((index * 29) & 0xff) << 8 | (index & 0xff);
+            }
+            store.publish(new SgbDisplay.SgbFrameReadyEvent(sgb, true));
+            NativeFrameStore.Snapshot sgbFrame = requireSnapshot(store);
+            assertEquals(SuperGameboy.SGB_DISPLAY_WIDTH, sgbFrame.width());
+            assertEquals(SuperGameboy.SGB_DISPLAY_HEIGHT, sgbFrame.height());
+            assertEquals("c543b47d4b32eaed8f82c4678e0c2e143bea1bdae7d29d1ee352743510d86438", sgbFrame.sha256());
+
+            int[] sgbCenter = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            store.publish(new SgbDisplay.SgbFrameReadyEvent(sgbCenter, false));
+            NativeFrameStore.Snapshot centerFrame = requireSnapshot(store);
+            assertEquals(Display.DISPLAY_WIDTH, centerFrame.width());
+            assertEquals(Display.DISPLAY_HEIGHT, centerFrame.height());
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void sixHundredFramesReuseThreeFixedBuffersAndKeepOnlyTheNewestFrame() {
+        NativeFrameStore store = new NativeFrameStore();
+        try {
+            int[][] fixedBuffers = new int[store.bufferCount()][];
+            for (int index = 0; index < fixedBuffers.length; index++) {
+                fixedBuffers[index] = store.bufferAt(index);
+            }
+            int[] source = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            for (int frame = 0; frame < 600; frame++) {
+                source[0] = frame & 3;
+                store.publish(new Display.DmgFrameReadyEvent(source));
+                NativeFrameStore.Frame rendered = store.takeLatest();
+                assertNotNull(rendered);
+                store.finishDrawing(rendered);
+            }
+
+            assertEquals(3, store.bufferCount());
+            for (int index = 0; index < fixedBuffers.length; index++) {
+                assertSame(fixedBuffers[index], store.bufferAt(index));
+            }
+            assertEquals(0, store.droppedFrames());
+            assertEquals(0xff051f2a, requireSnapshot(store).pixels()[0]);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void claimingTheNewestFrameDropsStaleQueuedFramesWithoutRetainingCorePixels() {
+        NativeFrameStore store = new NativeFrameStore();
+        try {
+            int[] first = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            int[] second = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            first[0] = 1;
+            second[0] = 3;
+            store.publish(new Display.DmgFrameReadyEvent(first));
+            store.publish(new Display.DmgFrameReadyEvent(second));
+            first[0] = 0;
+            second[0] = 0;
+
+            NativeFrameStore.Frame frame = store.takeLatest();
+            assertNotNull(frame);
+            assertEquals(0xff051f2a, frame.pixels()[0]);
+            store.finishDrawing(frame);
+            assertEquals(0xff051f2a, requireSnapshot(store).pixels()[0]);
+        } finally {
+            store.close();
+        }
+    }
+
+    private static NativeFrameStore.Snapshot requireSnapshot(NativeFrameStore store) {
+        NativeFrameStore.Snapshot frame = store.snapshot();
+        assertNotNull(frame);
+        return frame;
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/VideoGeometryTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/VideoGeometryTest.java
@@ -1,0 +1,36 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VideoGeometryTest {
+
+    @Test
+    public void nearestFitUsesTheLargestIntegerScaleAndLetterboxesIt() {
+        VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(160, 144, 1080, 1920);
+
+        assertEquals(60, viewport.left());
+        assertEquals(528, viewport.top());
+        assertEquals(960, viewport.width());
+        assertEquals(864, viewport.height());
+    }
+
+    @Test
+    public void nearestFitFallsBackToAspectFitWhenTheSurfaceIsSmallerThanTheFrame() {
+        VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(256, 224, 200, 100);
+
+        assertEquals(43, viewport.left());
+        assertEquals(0, viewport.top());
+        assertEquals(114, viewport.width());
+        assertEquals(100, viewport.height());
+    }
+
+    @Test
+    public void invalidDimensionsProduceNoDrawableViewport() {
+        VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(160, 144, 0, 1080);
+
+        assertEquals(0, viewport.width());
+        assertEquals(0, viewport.height());
+    }
+}


### PR DESCRIPTION
Closes #358

## Summary

- add a dedicated `SurfaceView` that attaches only to the service-owned native frame stream
- synchronously copy DMG, CGB, and SGB frame events into three reusable ARGB buffers, retaining only the newest complete frame
- draw nearest-neighbour integer-fit output with aspect-preserving letterboxing, including SGB dimension transitions
- export PNG screenshots from native emulated pixels rather than Android UI

## Invariants and impact

The controller retains producer-owned pixels only for the frame callback; the bounded bridge copies them before returning and has no unbounded queue. Surface destruction removes only the renderer subscription and cannot stop the emulation service. There are no new permissions, foreground-service behavior, or desktop dependencies.

## Validation

- `mvn -B test`
- `ANDROID_HOME=/tmp/coffee-gb-android-sdk ANDROID_SDK_ROOT=/tmp/coffee-gb-android-sdk ./android/gradlew -p android -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 --no-daemon :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`

The Android unit fixtures lock approved DMG/CGB/SGB native-frame SHA-256 hashes and cover 600 rendered frame hand-offs, buffer reuse, stale-frame dropping, SGB dimensions, and viewport geometry.

Unblocks the Android input phase.
