### PR TITLE
Add Android touch and controller input

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ orchestration layer use Kotlin and Java.
 
 ### Android build groundwork
 
-The Android frontend is at its portable-runtime stage; it is **not yet a playable emulator**. The
-`android/` Gradle project builds a permission-free starter activity and consumes the real
-`controller` and `core` artifacts installed from this exact checkout. Desktop image, keyboard, and
-console adapters remain outside that runtime as recorded in the
+The Android frontend provides a focused playable emulator path. Its Gradle project consumes the
+real `controller` and `core` artifacts installed from this exact checkout. Desktop image, keyboard,
+and console adapters remain outside that runtime as recorded in the
 [Android build-boundary ADR](docs/adr/0003-android-build-boundary.md).
 
 With Android SDK Platform 36 and Build Tools 36.0.0 installed, prepare the isolated artifact
@@ -69,6 +68,14 @@ three reusable ARGB buffers before a frame callback returns; the renderer draws 
 frame with nearest-neighbor integer scaling (or aspect-preserving letterboxing where an integer
 fit is impossible). Losing or recreating a surface does not affect the emulation session. Native
 PNG screenshots are exported from that frame store, never from the Android UI or its overlays.
+
+Android input sources feed the portable player-input hub, so multi-touch controls, a keyboard,
+and a game controller can hold buttons at the same time without stuck releases. The translucent
+touch overlay supports adjustable opacity, size, raised position, handedness, and haptic feedback;
+its settings stay app-private. Controller key remaps and axis inversion are app-private too, keyed
+by the controller descriptor plus vendor/product identity; the mapping dialog captures a button,
+replaces a conflicting mapping deterministically, and can reset one controller. Focus loss,
+surface teardown, stopping, and controller removal synchronously release their input source.
 
 ## Download and play
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidControllerMappings.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidControllerMappings.java
@@ -1,0 +1,133 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.InputDevice;
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * App-private controller remaps keyed by the controller descriptor plus vendor and product ids.
+ *
+ * <p>The persisted key is a digest rather than the descriptor itself, so hardware identity never
+ * appears in a preference backup or diagnostic string. A remap replaces another key targeting the
+ * same logical button on that controller, making conflicts explicit and deterministic.
+ */
+final class AndroidControllerMappings {
+
+    private static final String PREFERENCES = "coffee-gb-controller-mappings";
+    private static final String KEYS = "keys.";
+    private static final String BINDING = "binding.";
+    private static final String INVERT_X = "invert-x.";
+    private static final String INVERT_Y = "invert-y.";
+
+    private final SharedPreferences preferences;
+
+    AndroidControllerMappings(Context context) {
+        preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    Button binding(InputDevice device, int keyCode, Button fallback) {
+        String encoded = preferences.getString(BINDING + identity(device) + "." + keyCode, null);
+        if (encoded == null) {
+            return fallback;
+        }
+        if ("NONE".equals(encoded)) {
+            return null;
+        }
+        try {
+            return Button.valueOf(encoded);
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+
+    void setBinding(InputDevice device, int keyCode, Button button,
+                    Map<Integer, Button> defaults) {
+        String identity = identity(device);
+        Set<String> keys = new HashSet<>(preferences.getStringSet(KEYS + identity,
+                Collections.emptySet()));
+        SharedPreferences.Editor edit = preferences.edit();
+        for (String existing : new HashSet<>(keys)) {
+            String key = BINDING + identity + "." + existing;
+            if (button.name().equals(preferences.getString(key, null))
+                    && !existing.equals(Integer.toString(keyCode))) {
+                edit.remove(key);
+                keys.remove(existing);
+            }
+        }
+        for (Map.Entry<Integer, Button> defaultBinding : defaults.entrySet()) {
+            int defaultKeyCode = defaultBinding.getKey();
+            if (defaultBinding.getValue() == button && defaultKeyCode != keyCode) {
+                keys.add(Integer.toString(defaultKeyCode));
+                edit.putString(BINDING + identity + "." + defaultKeyCode, "NONE");
+            }
+        }
+        keys.add(Integer.toString(keyCode));
+        edit.putString(BINDING + identity + "." + keyCode, button.name())
+                .putStringSet(KEYS + identity, keys)
+                .apply();
+    }
+
+    boolean invertedX(InputDevice device) {
+        return preferences.getBoolean(INVERT_X + identity(device), false);
+    }
+
+    boolean invertedY(InputDevice device) {
+        return preferences.getBoolean(INVERT_Y + identity(device), false);
+    }
+
+    void toggleInvertedX(InputDevice device) {
+        String key = INVERT_X + identity(device);
+        preferences.edit().putBoolean(key, !preferences.getBoolean(key, false)).apply();
+    }
+
+    void toggleInvertedY(InputDevice device) {
+        String key = INVERT_Y + identity(device);
+        preferences.edit().putBoolean(key, !preferences.getBoolean(key, false)).apply();
+    }
+
+    void reset(InputDevice device) {
+        String identity = identity(device);
+        SharedPreferences.Editor edit = preferences.edit()
+                .remove(KEYS + identity)
+                .remove(INVERT_X + identity)
+                .remove(INVERT_Y + identity);
+        for (String keyCode : preferences.getStringSet(KEYS + identity, Collections.emptySet())) {
+            edit.remove(BINDING + identity + "." + keyCode);
+        }
+        edit.apply();
+    }
+
+    private static String identity(InputDevice device) {
+        if (device == null) {
+            return "unknown";
+        }
+        String descriptor = device.getDescriptor();
+        String raw = (descriptor == null ? "" : descriptor) + "|"
+                + device.getVendorId() + "|" + device.getProductId();
+        return sha256(raw);
+    }
+
+    private static String sha256(String raw) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(raw.getBytes(StandardCharsets.UTF_8));
+            StringBuilder encoded = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                encoded.append(Character.forDigit((value >>> 4) & 0xf, 16));
+                encoded.append(Character.forDigit(value & 0xf, 16));
+            }
+            return encoded.toString();
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is unavailable", impossible);
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -68,6 +68,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final AtomicBoolean closed = new AtomicBoolean();
     private final RuntimeLifecycleGate lifecycle = new RuntimeLifecycleGate();
     private final NativeFrameStore frames = new NativeFrameStore();
+    private final EmulatorProperties properties = new EmulatorProperties();
+    private final AndroidInputRouter input;
 
     private volatile RuntimeState state = RuntimeState.stopped();
 
@@ -89,6 +91,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     public AndroidEmulationRuntime(Context context) {
         this.context = Objects.requireNonNull(context, "context").getApplicationContext();
+        input = new AndroidInputRouter(properties.getPlayerInputSource(),
+                new AndroidControllerMappings(this.context));
         submit(this::initialize);
     }
 
@@ -99,6 +103,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Service-owned native frames for a short-lived {@link CoffeeGbSurfaceView} attachment. */
     NativeFrameStore frames() {
         return frames;
+    }
+
+    /** Service-owned source merger for transient Android touch and controller devices. */
+    AndroidInputRouter input() {
+        return input;
     }
 
     /** Registers one UI observer and immediately replays the latest immutable snapshot. */
@@ -197,6 +206,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     /** Pauses at the controller safe point and asks for a bounded asynchronous battery flush. */
     public void onHostNotVisible() {
+        input.releaseAll();
         submit(() -> {
             if (controller == null) {
                 return;
@@ -228,6 +238,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     /** Stops one session and recreates its controller shell for a later load without leaks. */
     public void stop() {
+        input.releaseAll();
         submit(() -> {
             clearPendingSource();
             if (!closeController()) {
@@ -312,6 +323,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 activeLayout = null;
                 activeStates = null;
                 currentSource = null;
+                input.close();
                 frames.close();
             });
         } catch (RejectedExecutionException ignored) {
@@ -416,7 +428,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     }
                 }),
                 Controller.BatteryFlushCompletedEvent.class);
-        controller = new BasicController(eventBus, new EmulatorProperties(), null);
+        controller = new BasicController(eventBus, properties, null);
         controller.startController();
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidInputRouter.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidInputRouter.java
@@ -1,0 +1,322 @@
+package eu.rekawek.coffeegb.android;
+
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Android source adapter over the portable {@link PlayerInputHub}.
+ *
+ * <p>Each touch pointer and connected controller has its own releasable source handle. The hub
+ * unions these sources, so a cancellation or disconnect releases only that source and never
+ * creates duplicate or stuck logical transitions when touch, keyboard, and controllers overlap.
+ */
+final class AndroidInputRouter implements AutoCloseable {
+
+    private static final float DEAD_ZONE = 0.45f;
+
+    private static final Map<Integer, Button> DEFAULT_KEYS = Map.ofEntries(
+            Map.entry(KeyEvent.KEYCODE_DPAD_LEFT, Button.LEFT),
+            Map.entry(KeyEvent.KEYCODE_DPAD_RIGHT, Button.RIGHT),
+            Map.entry(KeyEvent.KEYCODE_DPAD_UP, Button.UP),
+            Map.entry(KeyEvent.KEYCODE_DPAD_DOWN, Button.DOWN),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_A, Button.A),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_B, Button.B),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_X, Button.A),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_Y, Button.B),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_START, Button.START),
+            Map.entry(KeyEvent.KEYCODE_BUTTON_SELECT, Button.SELECT),
+            Map.entry(KeyEvent.KEYCODE_ENTER, Button.START),
+            Map.entry(KeyEvent.KEYCODE_SPACE, Button.A));
+
+    private final PlayerInputHub hub;
+    private final AndroidControllerMappings mappings;
+    private final Map<Integer, PlayerInputHub.SourceHandle> touchPointers = new HashMap<>();
+    private final Map<String, DeviceSource> devices = new HashMap<>();
+    private final Map<Integer, String> deviceIds = new HashMap<>();
+    private final PlayerInputHub.SourceHandle keyboard;
+    private final EnumSet<Button> keyboardButtons = EnumSet.noneOf(Button.class);
+
+    private InputDevice activeController;
+    private Button captureTarget;
+    private boolean closed;
+
+    AndroidInputRouter(PlayerInputHub hub) {
+        this(hub, null);
+    }
+
+    AndroidInputRouter(PlayerInputHub hub, AndroidControllerMappings mappings) {
+        this.hub = Objects.requireNonNull(hub, "hub");
+        this.mappings = mappings;
+        keyboard = hub.openSource(0);
+    }
+
+    synchronized void updateTouchPointer(int pointerId, Collection<Button> buttons) {
+        if (closed) {
+            return;
+        }
+        PlayerInputHub.SourceHandle source = touchPointers.computeIfAbsent(
+                pointerId, ignored -> hub.openSource(0));
+        source.update(buttons);
+    }
+
+    synchronized void releaseTouchPointer(int pointerId) {
+        PlayerInputHub.SourceHandle source = touchPointers.remove(pointerId);
+        if (source != null) {
+            source.close();
+        }
+    }
+
+    synchronized void releaseAllTouch() {
+        touchPointers.values().forEach(PlayerInputHub.SourceHandle::close);
+        touchPointers.clear();
+    }
+
+    synchronized boolean onKeyEvent(KeyEvent event) {
+        if (closed || event.getAction() == KeyEvent.ACTION_MULTIPLE) {
+            return false;
+        }
+        if (isGameController(event.getSource())) {
+            InputDevice controller = event.getDevice();
+            activeController = controller;
+            if (event.getAction() == KeyEvent.ACTION_DOWN && captureTarget != null) {
+                if (mappings != null && controller != null) {
+                    mappings.setBinding(controller, event.getKeyCode(), captureTarget, DEFAULT_KEYS);
+                }
+                captureTarget = null;
+                return true;
+            }
+            Button button = DEFAULT_KEYS.get(event.getKeyCode());
+            if (mappings != null) {
+                button = mappings.binding(controller, event.getKeyCode(), button);
+            }
+            if (button == null) {
+                return false;
+            }
+            DeviceSource source = device(controller);
+            if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                source.keyButtons.add(button);
+            } else if (event.getAction() == KeyEvent.ACTION_UP) {
+                source.keyButtons.remove(button);
+            } else {
+                return false;
+            }
+            source.publish();
+            return true;
+        }
+        Button button = DEFAULT_KEYS.get(event.getKeyCode());
+        if (button == null) {
+            return false;
+        }
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            keyboardButtons.add(button);
+        } else if (event.getAction() == KeyEvent.ACTION_UP) {
+            keyboardButtons.remove(button);
+        } else {
+            return false;
+        }
+        keyboard.update(keyboardButtons);
+        return true;
+    }
+
+    synchronized boolean onMotionEvent(MotionEvent event) {
+        if (closed || !isGameController(event.getSource()) || event.getAction() != MotionEvent.ACTION_MOVE) {
+            return false;
+        }
+        InputDevice controller = event.getDevice();
+        activeController = controller;
+        DeviceSource source = device(controller);
+        float hatX = event.getAxisValue(MotionEvent.AXIS_HAT_X);
+        float hatY = event.getAxisValue(MotionEvent.AXIS_HAT_Y);
+        float x = Math.abs(hatX) >= DEAD_ZONE ? hatX : event.getAxisValue(MotionEvent.AXIS_X);
+        float y = Math.abs(hatY) >= DEAD_ZONE ? hatY : event.getAxisValue(MotionEvent.AXIS_Y);
+        if (mappings != null && mappings.invertedX(controller)) {
+            x = -x;
+        }
+        if (mappings != null && mappings.invertedY(controller)) {
+            y = -y;
+        }
+        applyAxis(source.axisButtons, x,
+                Button.LEFT, Button.RIGHT);
+        applyAxis(source.axisButtons, y,
+                Button.UP, Button.DOWN);
+        source.publish();
+        return true;
+    }
+
+    synchronized void disconnect(InputDevice device) {
+        if (device == null) {
+            return;
+        }
+        disconnect(device.getId());
+    }
+
+    synchronized void disconnect(int deviceId) {
+        String key = deviceIds.remove(deviceId);
+        if (key == null) {
+            return;
+        }
+        DeviceSource source = devices.remove(key);
+        if (source != null) {
+            source.close();
+        }
+        if (activeController != null && activeController.getId() == deviceId) {
+            activeController = null;
+            captureTarget = null;
+        }
+    }
+
+    synchronized boolean beginCapture(Button target) {
+        if (closed || configurationDevice() == null) {
+            return false;
+        }
+        captureTarget = Objects.requireNonNull(target, "target");
+        return true;
+    }
+
+    synchronized boolean toggleHorizontalInversion() {
+        InputDevice controller = configurationDevice();
+        if (controller == null || mappings == null) {
+            return false;
+        }
+        mappings.toggleInvertedX(controller);
+        return true;
+    }
+
+    synchronized boolean toggleVerticalInversion() {
+        InputDevice controller = configurationDevice();
+        if (controller == null || mappings == null) {
+            return false;
+        }
+        mappings.toggleInvertedY(controller);
+        return true;
+    }
+
+    synchronized boolean horizontalInverted() {
+        InputDevice controller = configurationDevice();
+        return controller != null && mappings != null && mappings.invertedX(controller);
+    }
+
+    synchronized boolean verticalInverted() {
+        InputDevice controller = configurationDevice();
+        return controller != null && mappings != null && mappings.invertedY(controller);
+    }
+
+    synchronized boolean resetActiveController() {
+        InputDevice controller = configurationDevice();
+        if (controller == null || mappings == null) {
+            return false;
+        }
+        mappings.reset(controller);
+        captureTarget = null;
+        return true;
+    }
+
+    synchronized String activeControllerName() {
+        InputDevice controller = configurationDevice();
+        return controller == null ? null : controller.getName();
+    }
+
+    synchronized void releaseAll() {
+        releaseAllTouch();
+        keyboardButtons.clear();
+        keyboard.update(keyboardButtons);
+        devices.values().forEach(DeviceSource::clear);
+        captureTarget = null;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        releaseAllTouch();
+        keyboard.close();
+        devices.values().forEach(DeviceSource::close);
+        devices.clear();
+        deviceIds.clear();
+        activeController = null;
+        captureTarget = null;
+        closed = true;
+    }
+
+    private DeviceSource device(InputDevice device) {
+        String key = device == null ? "unknown" : deviceKey(device);
+        if (device != null) {
+            deviceIds.put(device.getId(), key);
+        }
+        return devices.computeIfAbsent(key, ignored -> new DeviceSource(hub.openSource(0)));
+    }
+
+    private InputDevice configurationDevice() {
+        if (activeController != null) {
+            return activeController;
+        }
+        for (int id : InputDevice.getDeviceIds()) {
+            InputDevice device = InputDevice.getDevice(id);
+            if (device != null && isGameController(device.getSources())) {
+                activeController = device;
+                return device;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isGameController(int source) {
+        return (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD
+                || (source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK
+                || (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD;
+    }
+
+    private static String deviceKey(InputDevice device) {
+        String descriptor = device.getDescriptor();
+        if (descriptor != null && !descriptor.isBlank()) {
+            return descriptor;
+        }
+        return device.getVendorId() + ":" + device.getProductId() + ":" + device.getId();
+    }
+
+    private static void applyAxis(EnumSet<Button> buttons, float value, Button negative, Button positive) {
+        buttons.remove(negative);
+        buttons.remove(positive);
+        if (value <= -DEAD_ZONE) {
+            buttons.add(negative);
+        } else if (value >= DEAD_ZONE) {
+            buttons.add(positive);
+        }
+    }
+
+    private static final class DeviceSource {
+        private final PlayerInputHub.SourceHandle handle;
+        private final EnumSet<Button> keyButtons = EnumSet.noneOf(Button.class);
+        private final EnumSet<Button> axisButtons = EnumSet.noneOf(Button.class);
+
+        private DeviceSource(PlayerInputHub.SourceHandle handle) {
+            this.handle = handle;
+        }
+
+        private void publish() {
+            EnumSet<Button> pressed = EnumSet.copyOf(keyButtons);
+            pressed.addAll(axisButtons);
+            handle.update(pressed);
+        }
+
+        private void clear() {
+            keyButtons.clear();
+            axisButtons.clear();
+            publish();
+        }
+
+        private void close() {
+            handle.close();
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -6,8 +6,13 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.view.HapticFeedbackConstants;
+import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.util.List;
 
 /**
  * Dedicated nearest-neighbour native-frame surface.
@@ -21,29 +26,54 @@ public final class CoffeeGbSurfaceView extends SurfaceView
 
     private final Object renderLock = new Object();
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint controlPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Rect source = new Rect();
     private final Rect destination = new Rect();
     private final Bitmap bitmap = Bitmap.createBitmap(
             NativeFrameStore.MAX_WIDTH, NativeFrameStore.MAX_HEIGHT, Bitmap.Config.ARGB_8888);
 
     private volatile NativeFrameStore frames;
+    private final TouchControlsPreferences touchPreferences;
+    private volatile TouchControlsLayout touchLayout;
+    private AndroidInputRouter input;
     private RenderThread renderThread;
     private volatile boolean surfaceReady;
 
     public CoffeeGbSurfaceView(Context context) {
         super(context);
         paint.setFilterBitmap(false);
+        touchPreferences = new TouchControlsPreferences(context);
+        touchLayout = touchPreferences.load();
+        controlPaint.setTextAlign(Paint.Align.CENTER);
         getHolder().addCallback(this);
         setContentDescription("Coffee GB emulated video output");
     }
 
+    TouchControlsLayout touchLayout() {
+        return touchLayout;
+    }
+
+    void updateTouchLayout(TouchControlsLayout layout) {
+        touchLayout = layout;
+        touchPreferences.save(layout);
+        onFrameAvailable();
+    }
+
+    void resetTouchLayout() {
+        touchPreferences.reset();
+        touchLayout = touchPreferences.load();
+        onFrameAvailable();
+    }
+
     /** Attaches this transient Surface to the long-lived service frame store. */
-    public void attach(NativeFrameStore frameStore) {
+    public void attach(NativeFrameStore frameStore, AndroidInputRouter inputRouter) {
         if (frames == frameStore) {
+            input = inputRouter;
             return;
         }
         detach();
         frames = frameStore;
+        input = inputRouter;
         if (surfaceReady) {
             frames.addListener(this);
             startRenderer();
@@ -57,7 +87,43 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             active.removeListener(this);
         }
         frames = null;
+        if (input != null) {
+            input.releaseAllTouch();
+        }
+        input = null;
         stopRenderer();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        AndroidInputRouter router = input;
+        if (router == null) {
+            return false;
+        }
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_OUTSIDE) {
+            router.releaseAllTouch();
+            return true;
+        }
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
+            router.releaseTouchPointer(event.getPointerId(event.getActionIndex()));
+            return true;
+        }
+        if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN
+                || action == MotionEvent.ACTION_MOVE) {
+            TouchControlsLayout layout = touchLayout;
+            for (int index = 0; index < event.getPointerCount(); index++) {
+                List<Button> buttons = layout.buttonsAt(event.getX(index), event.getY(index),
+                        getWidth(), getHeight());
+                router.updateTouchPointer(event.getPointerId(index), buttons);
+                if (index == event.getActionIndex() && action != MotionEvent.ACTION_MOVE
+                        && !buttons.isEmpty() && layout.haptics()) {
+                    performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY);
+                }
+            }
+            return true;
+        }
+        return super.onTouchEvent(event);
     }
 
     @Override
@@ -80,6 +146,10 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         NativeFrameStore active = frames;
         if (active != null) {
             active.removeListener(this);
+        }
+        AndroidInputRouter router = input;
+        if (router != null) {
+            router.releaseAllTouch();
         }
         stopRenderer();
     }
@@ -182,21 +252,49 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                     return;
                 }
                 canvas.drawColor(Color.BLACK);
-                if (frame == null) {
-                    return;
+                if (frame != null) {
+                    bitmap.setPixels(frame.pixels(), 0, frame.width(), 0, 0,
+                            frame.width(), frame.height());
+                    source.set(0, 0, frame.width(), frame.height());
+                    VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(
+                            frame.width(), frame.height(), canvas.getWidth(), canvas.getHeight());
+                    destination.set(viewport.left(), viewport.top(),
+                            viewport.left() + viewport.width(), viewport.top() + viewport.height());
+                    canvas.drawBitmap(bitmap, source, destination, paint);
                 }
-                bitmap.setPixels(frame.pixels(), 0, frame.width(), 0, 0, frame.width(), frame.height());
-                source.set(0, 0, frame.width(), frame.height());
-                VideoGeometry.Viewport viewport = VideoGeometry.nearestFit(
-                        frame.width(), frame.height(), canvas.getWidth(), canvas.getHeight());
-                destination.set(viewport.left(), viewport.top(),
-                        viewport.left() + viewport.width(), viewport.top() + viewport.height());
-                canvas.drawBitmap(bitmap, source, destination, paint);
+                drawTouchControls(canvas, touchLayout);
             } finally {
                 if (canvas != null) {
                     getHolder().unlockCanvasAndPost(canvas);
                 }
             }
         }
+    }
+
+    private void drawTouchControls(Canvas canvas, TouchControlsLayout layout) {
+        float radius = layout.controlRadius(canvas.getWidth(), canvas.getHeight());
+        float y = layout.controlsCenterY(canvas.getHeight(), radius);
+        float dpadX = layout.dpadCenterX(canvas.getWidth());
+        float actionsX = layout.actionsCenterX(canvas.getWidth());
+        controlPaint.setColor(Color.argb(Math.round(layout.opacity() * 255), 230, 230, 230));
+        controlPaint.setStyle(Paint.Style.FILL);
+        canvas.drawCircle(dpadX, y, radius * 1.35f, controlPaint);
+        canvas.drawCircle(actionsX - radius * 0.70f, y, radius * 0.72f, controlPaint);
+        canvas.drawCircle(actionsX + radius * 0.70f, y, radius * 0.72f, controlPaint);
+        canvas.drawRoundRect(canvas.getWidth() * 0.38f, y - radius * 2.10f,
+                canvas.getWidth() * 0.50f, y - radius * 1.40f, radius * 0.22f,
+                radius * 0.22f, controlPaint);
+        canvas.drawRoundRect(canvas.getWidth() * 0.50f, y - radius * 2.10f,
+                canvas.getWidth() * 0.62f, y - radius * 1.40f, radius * 0.22f,
+                radius * 0.22f, controlPaint);
+
+        controlPaint.setColor(Color.argb(Math.round(layout.opacity() * 255), 20, 20, 20));
+        controlPaint.setTextSize(radius * 0.45f);
+        canvas.drawText("+", dpadX, y + radius * 0.16f, controlPaint);
+        canvas.drawText("B", actionsX - radius * 0.70f, y + radius * 0.16f, controlPaint);
+        canvas.drawText("A", actionsX + radius * 0.70f, y + radius * 0.16f, controlPaint);
+        controlPaint.setTextSize(radius * 0.20f);
+        canvas.drawText("SELECT", canvas.getWidth() * 0.44f, y - radius * 1.65f, controlPaint);
+        canvas.drawText("START", canvas.getWidth() * 0.56f, y - radius * 1.65f, controlPaint);
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -5,14 +5,20 @@ import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.hardware.input.InputManager;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.Switch;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.List;
 
@@ -43,10 +49,33 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private Button importState;
     private Button exportState;
     private Button exportScreenshot;
+    private Button touchControls;
+    private Button controllerMapping;
 
     private AndroidEmulationRuntime runtime;
     private boolean bound;
+    private InputManager inputManager;
     private long shownSelectionGeneration = -1L;
+
+    private final InputManager.InputDeviceListener inputDevices = new InputManager.InputDeviceListener() {
+        @Override
+        public void onInputDeviceAdded(int deviceId) {
+            // The first event selects the controller; no implicit mapping is created on connect.
+        }
+
+        @Override
+        public void onInputDeviceRemoved(int deviceId) {
+            AndroidEmulationRuntime active = runtime;
+            if (active != null) {
+                active.input().disconnect(deviceId);
+            }
+        }
+
+        @Override
+        public void onInputDeviceChanged(int deviceId) {
+            // Android delivers the new axes on the next motion event.
+        }
+    };
 
     private final ServiceConnection connection = new ServiceConnection() {
         @Override
@@ -54,7 +83,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             runtime = ((EmulationService.RuntimeBinder) service).runtime();
             bound = true;
             runtime.addObserver(MainActivity.this);
-            video.attach(runtime.frames());
+            video.attach(runtime.frames(), runtime.input());
             applyState(runtime.state());
         }
 
@@ -100,6 +129,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         importState = button("Import state slot 0", this::chooseStateImport);
         exportState = button("Export state slot 0", this::chooseStateExport);
         exportScreenshot = button("Export native screenshot", this::chooseScreenshotExport);
+        touchControls = button("Touch controls", ignored -> configureTouchControls());
+        controllerMapping = button("Controller mapping", ignored -> configureController());
         content.addView(open);
         content.addView(recent);
         content.addView(resume);
@@ -109,6 +140,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         content.addView(importState);
         content.addView(exportState);
         content.addView(exportScreenshot);
+        content.addView(touchControls);
+        content.addView(controllerMapping);
         setContentView(content);
         disableCommands();
     }
@@ -116,6 +149,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @Override
     protected void onStart() {
         super.onStart();
+        inputManager = getSystemService(InputManager.class);
+        inputManager.registerInputDeviceListener(inputDevices, null);
         EmulationService.start(this);
         if (!bound) {
             bindService(new Intent(this, EmulationService.class), connection, BIND_AUTO_CREATE);
@@ -124,7 +159,12 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     @Override
     protected void onStop() {
+        if (inputManager != null) {
+            inputManager.unregisterInputDeviceListener(inputDevices);
+            inputManager = null;
+        }
         if (bound) {
+            runtime.input().releaseAll();
             video.detach();
             runtime.removeObserver(this);
             unbindService(connection);
@@ -132,6 +172,32 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             runtime = null;
         }
         super.onStop();
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        AndroidEmulationRuntime active = runtime;
+        if (active != null && active.input().onKeyEvent(event)) {
+            return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean onGenericMotionEvent(MotionEvent event) {
+        AndroidEmulationRuntime active = runtime;
+        if (active != null && active.input().onMotionEvent(event)) {
+            return true;
+        }
+        return super.onGenericMotionEvent(event);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (!hasFocus && runtime != null) {
+            runtime.input().releaseAll();
+        }
     }
 
     @Override
@@ -222,6 +288,103 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 EXPORT_SCREENSHOT_REQUEST);
     }
 
+    private void configureTouchControls() {
+        TouchControlsLayout initial = video.touchLayout();
+        LinearLayout form = new LinearLayout(this);
+        form.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int) (20 * getResources().getDisplayMetrics().density);
+        form.setPadding(padding, padding, padding, padding);
+
+        SeekBar opacity = slider(form, "Opacity", 15, 100,
+                Math.round(initial.opacity() * 100));
+        SeekBar scale = slider(form, "Size", 60, 140,
+                Math.round(initial.scale() * 100));
+        SeekBar vertical = slider(form, "Raise controls", 0, 100,
+                Math.round(initial.verticalPosition() * 100));
+        Switch leftHanded = new Switch(this);
+        leftHanded.setText("Left-handed layout");
+        leftHanded.setChecked(initial.leftHanded());
+        form.addView(leftHanded);
+        Switch haptics = new Switch(this);
+        haptics.setText("Haptic feedback");
+        haptics.setChecked(initial.haptics());
+        form.addView(haptics);
+
+        new AlertDialog.Builder(this)
+                .setTitle("Touch controls")
+                .setView(form)
+                .setNegativeButton("Cancel", null)
+                .setNeutralButton("Reset", (dialog, ignored) -> video.resetTouchLayout())
+                .setPositiveButton("Save", (dialog, ignored) -> video.updateTouchLayout(
+                        new TouchControlsLayout(opacity.getProgress() / 100f,
+                                scale.getProgress() / 100f, vertical.getProgress() / 100f,
+                                leftHanded.isChecked(), haptics.isChecked())))
+                .show();
+    }
+
+    private SeekBar slider(LinearLayout form, String label, int min, int max, int value) {
+        TextView text = new TextView(this);
+        text.setText(label);
+        form.addView(text);
+        SeekBar slider = new SeekBar(this);
+        slider.setMin(min);
+        slider.setMax(max);
+        slider.setProgress(value);
+        form.addView(slider);
+        return slider;
+    }
+
+    private void configureController() {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null) {
+            return;
+        }
+        AndroidInputRouter input = active.input();
+        String name = input.activeControllerName();
+        if (name == null) {
+            Toast.makeText(this, "Connect or press a game controller first.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        eu.rekawek.coffeegb.core.joypad.Button[] targets = {
+                eu.rekawek.coffeegb.core.joypad.Button.A,
+                eu.rekawek.coffeegb.core.joypad.Button.B,
+                eu.rekawek.coffeegb.core.joypad.Button.START,
+                eu.rekawek.coffeegb.core.joypad.Button.SELECT,
+                eu.rekawek.coffeegb.core.joypad.Button.UP,
+                eu.rekawek.coffeegb.core.joypad.Button.DOWN,
+                eu.rekawek.coffeegb.core.joypad.Button.LEFT,
+                eu.rekawek.coffeegb.core.joypad.Button.RIGHT
+        };
+        String[] items = {
+                "Map A", "Map B", "Map Start", "Map Select", "Map Up", "Map Down",
+                "Map Left", "Map Right", "Horizontal axis: "
+                        + (input.horizontalInverted() ? "inverted" : "normal"),
+                "Vertical axis: " + (input.verticalInverted() ? "inverted" : "normal"),
+                "Reset this controller"
+        };
+        new AlertDialog.Builder(this)
+                .setTitle("Controller: " + name)
+                .setItems(items, (dialog, which) -> {
+                    if (which < targets.length) {
+                        if (input.beginCapture(targets[which])) {
+                            Toast.makeText(this, "Press the button to map. A conflicting mapping is replaced.",
+                                    Toast.LENGTH_LONG).show();
+                        }
+                    } else if (which == targets.length) {
+                        if (input.toggleHorizontalInversion()) {
+                            Toast.makeText(this, "Horizontal axis toggled.", Toast.LENGTH_SHORT).show();
+                        }
+                    } else if (which == targets.length + 1) {
+                        if (input.toggleVerticalInversion()) {
+                            Toast.makeText(this, "Vertical axis toggled.", Toast.LENGTH_SHORT).show();
+                        }
+                    } else if (input.resetActiveController()) {
+                        Toast.makeText(this, "Controller mappings reset.", Toast.LENGTH_SHORT).show();
+                    }
+                })
+                .show();
+    }
+
     private void confirmImport(String title, String message, int requestCode) {
         if (runtime == null || !importBattery.isEnabled()) {
             return;
@@ -273,6 +436,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         importState.setEnabled(ready && state.transferReady() && !state.flushPending());
         exportState.setEnabled(ready && state.transferReady() && !state.flushPending());
         exportScreenshot.setEnabled(ready && state.transferReady() && !state.flushPending());
+        touchControls.setEnabled(ready);
+        controllerMapping.setEnabled(ready);
         showSelectionIfNeeded(state);
     }
 
@@ -323,6 +488,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         importState.setEnabled(false);
         exportState.setEnabled(false);
         exportScreenshot.setEnabled(false);
+        touchControls.setEnabled(false);
+        controllerMapping.setEnabled(false);
     }
 
     @FunctionalInterface

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsLayout.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsLayout.java
@@ -1,0 +1,134 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * Persistable geometry for the translucent touch controls.
+ *
+ * <p>The layout deliberately turns every pointer into a snapshot of logical buttons instead of
+ * synthesising key events. That makes an Android touch chord equivalent to a physical controller
+ * chord and keeps the control geometry independently testable.
+ */
+final class TouchControlsLayout {
+
+    static final float DEFAULT_OPACITY = 0.38f;
+    static final float DEFAULT_SCALE = 1f;
+    static final float DEFAULT_VERTICAL_POSITION = 0f;
+
+    private final float opacity;
+    private final float scale;
+    private final float verticalPosition;
+    private final boolean leftHanded;
+    private final boolean haptics;
+
+    TouchControlsLayout(float opacity, float scale, float verticalPosition,
+                        boolean leftHanded, boolean haptics) {
+        this.opacity = clamp(opacity, 0.15f, 1f);
+        this.scale = clamp(scale, 0.60f, 1.40f);
+        this.verticalPosition = clamp(verticalPosition, 0f, 1f);
+        this.leftHanded = leftHanded;
+        this.haptics = haptics;
+    }
+
+    float opacity() {
+        return opacity;
+    }
+
+    float scale() {
+        return scale;
+    }
+
+    float verticalPosition() {
+        return verticalPosition;
+    }
+
+    boolean leftHanded() {
+        return leftHanded;
+    }
+
+    boolean haptics() {
+        return haptics;
+    }
+
+    List<Button> buttonsAt(float x, float y, int width, int height) {
+        if (width <= 0 || height <= 0) {
+            return List.of();
+        }
+        float radius = controlRadius(width, height);
+        float dpadX = dpadCenterX(width);
+        float actionsX = actionsCenterX(width);
+        float controlsY = controlsCenterY(height, radius);
+
+        if (inCircle(x, y, dpadX, controlsY, radius * 1.35f)) {
+            EnumSet<Button> pressed = EnumSet.noneOf(Button.class);
+            if (x < dpadX - radius * 0.30f) {
+                pressed.add(Button.LEFT);
+            } else if (x > dpadX + radius * 0.30f) {
+                pressed.add(Button.RIGHT);
+            }
+            if (y < controlsY - radius * 0.30f) {
+                pressed.add(Button.UP);
+            } else if (y > controlsY + radius * 0.30f) {
+                pressed.add(Button.DOWN);
+            }
+            return List.copyOf(pressed);
+        }
+
+        float bX = actionsX - radius * 0.70f;
+        float aX = actionsX + radius * 0.70f;
+        if (inCircle(x, y, bX, controlsY, radius * 0.72f)) {
+            return List.of(Button.B);
+        }
+        if (inCircle(x, y, aX, controlsY, radius * 0.72f)) {
+            return List.of(Button.A);
+        }
+
+        float utilityY = controlsY - radius * 1.75f;
+        if (inRect(x, y, width * 0.38f, utilityY - radius * 0.35f,
+                width * 0.12f, radius * 0.70f)) {
+            return List.of(Button.SELECT);
+        }
+        if (inRect(x, y, width * 0.50f, utilityY - radius * 0.35f,
+                width * 0.12f, radius * 0.70f)) {
+            return List.of(Button.START);
+        }
+        return List.of();
+    }
+
+    float controlRadius(int width, int height) {
+        return Math.max(22f, Math.min(width, height) * 0.13f * scale);
+    }
+
+    float dpadCenterX(int width) {
+        return width * (leftHanded ? 0.76f : 0.24f);
+    }
+
+    float actionsCenterX(int width) {
+        return width * (leftHanded ? 0.24f : 0.76f);
+    }
+
+    float controlsCenterY(int height, float radius) {
+        return Math.max(radius * 2.2f,
+                height - radius * 2.0f - verticalPosition * height * 0.38f);
+    }
+
+    private static boolean inCircle(float x, float y, float centerX, float centerY, float radius) {
+        float dx = x - centerX;
+        float dy = y - centerY;
+        return dx * dx + dy * dy <= radius * radius;
+    }
+
+    private static boolean inRect(float x, float y, float left, float top, float width, float height) {
+        return x >= left && x <= left + width && y >= top && y <= top + height;
+    }
+
+    private static float clamp(float value, float lower, float upper) {
+        if (!Float.isFinite(value)) {
+            return lower;
+        }
+        return Math.max(lower, Math.min(upper, value));
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsPreferences.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsPreferences.java
@@ -1,0 +1,44 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/** App-private preferences for touch controls; no external-storage permission is involved. */
+final class TouchControlsPreferences {
+
+    private static final String PREFERENCES = "coffee-gb-touch-controls";
+    private static final String OPACITY = "opacity";
+    private static final String SCALE = "scale";
+    private static final String VERTICAL_POSITION = "vertical-position";
+    private static final String LEFT_HANDED = "left-handed";
+    private static final String HAPTICS = "haptics";
+
+    private final SharedPreferences preferences;
+
+    TouchControlsPreferences(Context context) {
+        preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    TouchControlsLayout load() {
+        return new TouchControlsLayout(
+                preferences.getFloat(OPACITY, TouchControlsLayout.DEFAULT_OPACITY),
+                preferences.getFloat(SCALE, TouchControlsLayout.DEFAULT_SCALE),
+                preferences.getFloat(VERTICAL_POSITION, TouchControlsLayout.DEFAULT_VERTICAL_POSITION),
+                preferences.getBoolean(LEFT_HANDED, false),
+                preferences.getBoolean(HAPTICS, true));
+    }
+
+    void save(TouchControlsLayout layout) {
+        preferences.edit()
+                .putFloat(OPACITY, layout.opacity())
+                .putFloat(SCALE, layout.scale())
+                .putFloat(VERTICAL_POSITION, layout.verticalPosition())
+                .putBoolean(LEFT_HANDED, layout.leftHanded())
+                .putBoolean(HAPTICS, layout.haptics())
+                .apply();
+    }
+
+    void reset() {
+        preferences.edit().clear().apply();
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidInputRouterTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidInputRouterTest.java
@@ -1,0 +1,47 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AndroidInputRouterTest {
+
+    @Test
+    public void touchPointersMergeChordsAndReleasingOnePointerKeepsTheOtherHeld() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            router.updateTouchPointer(4, List.of(Button.LEFT, Button.UP));
+            router.updateTouchPointer(9, List.of(Button.A));
+
+            assertEquals(java.util.Set.of(Button.LEFT, Button.UP, Button.A), hub.sample().buttons(0));
+
+            router.releaseTouchPointer(4);
+
+            assertEquals(java.util.Set.of(Button.A), hub.sample().buttons(0));
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void releaseAllClearsEveryTouchAndControllerSourceWithoutStuckButtons() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            router.updateTouchPointer(1, List.of(Button.B, Button.START));
+            router.updateTouchPointer(2, List.of(Button.RIGHT));
+
+            router.releaseAll();
+
+            assertTrue(hub.sample().buttons(0).isEmpty());
+        } finally {
+            router.close();
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/TouchControlsLayoutTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/TouchControlsLayoutTest.java
@@ -1,0 +1,37 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.joypad.Button;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TouchControlsLayoutTest {
+
+    @Test
+    public void dpadAllowsDiagonalWhileSeparatePointersCanUseActionButtons() {
+        TouchControlsLayout layout = new TouchControlsLayout(.5f, 1f, 0f, false, true);
+        float radius = layout.controlRadius(1_000, 600);
+        float x = layout.dpadCenterX(1_000) - radius * .70f;
+        float y = layout.controlsCenterY(600, radius) - radius * .70f;
+
+        assertTrue(layout.buttonsAt(x, y, 1_000, 600).containsAll(List.of(Button.LEFT, Button.UP)));
+        assertEquals(List.of(Button.A), layout.buttonsAt(layout.actionsCenterX(1_000) + radius * .7f,
+                layout.controlsCenterY(600, radius), 1_000, 600));
+    }
+
+    @Test
+    public void handednessMovesDpadAndActionsWithoutChangingButtonMeaning() {
+        TouchControlsLayout layout = new TouchControlsLayout(.5f, 1f, .2f, true, false);
+        float radius = layout.controlRadius(1_000, 600);
+        float y = layout.controlsCenterY(600, radius);
+
+        assertTrue(layout.dpadCenterX(1_000) > layout.actionsCenterX(1_000));
+        assertEquals(List.of(Button.RIGHT), layout.buttonsAt(layout.dpadCenterX(1_000) + radius,
+                y, 1_000, 600));
+        assertEquals(List.of(Button.START), layout.buttonsAt(560, y - radius * 1.75f,
+                1_000, 600));
+    }
+}


### PR DESCRIPTION
## Summary

Completes Android roadmap Phase 5 / #359.

- Route independent touch-pointer, keyboard, DPAD, gamepad, hat, and analog-axis sources through the portable `PlayerInputHub`.
- Add a visible multi-touch overlay with D-pad diagonals, A/B, Start/Select, configurable opacity, size, raised position, handedness, and haptics.
- Add app-private per-controller key capture/remapping, conflict replacement, axis inversion, reset, and hot-unplug cleanup.
- Synchronously release held input on focus loss, view/surface teardown, stop, host backgrounding, and service shutdown.

## Verification

- `mvn -B test`
- `ANDROID_HOME=/tmp/coffee-gb-android-sdk ANDROID_SDK_ROOT=/tmp/coffee-gb-android-sdk ./android/gradlew -p android -PcoffeeGbMavenRepository=$PWD/build/android-m2 --no-daemon :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`
