### PR TITLE
[Android] Add bounded AudioTrack output

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ by the controller descriptor plus vendor/product identity; the mapping dialog ca
 replaces a conflicting mapping deterministically, and can reset one controller. Focus loss,
 surface teardown, stopping, and controller removal synchronously release their input source.
 
+Android audio shares the desktop's portable resampling, two-period mixing filter, and DC blocking.
+The service writes signed 16-bit stereo PCM to an `AudioTrack` on a dedicated consumer thread at
+the initialized track rate. Its six preallocated host-frame slots bound memory and latency: a late
+producer discards old PCM rather than blocking emulation or accumulating delay. Muting, volume
+changes, focus/visibility loss, and route changes clear queued PCM; focus loss still requires the
+user to resume the game. The app declares no microphone, vibration, broad-storage, or network
+permission. See [Android audio operation and device validation](docs/android-audio.md).
+
 ## Download and play
 
 The portable Coffee GB download is a single executable JAR. It requires a desktop **Java 16 or

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
@@ -1,0 +1,312 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.sound.Sound;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Bounded Android host-audio adapter. Emulator events only fill preallocated PCM slots; all
+ * {@code AudioTrack} opening, writes, flushes, and release work on this adapter's consumer thread.
+ */
+final class AndroidAudioSink implements AutoCloseable {
+
+    interface OutputFactory {
+        Output open();
+    }
+
+    interface Output {
+        int sampleRate();
+
+        void play();
+
+        void pause();
+
+        void flush();
+
+        /** Returns the bytes written, or a non-positive error code. */
+        int write(byte[] bytes, int offset, int length);
+
+        void release();
+    }
+
+    record Stats(int sampleRate, long overruns, long underruns, long restarts, boolean paused,
+                 boolean active) {
+    }
+
+    private static final long POLL_MILLIS = 20L;
+    private static final long CLOSE_TIMEOUT_MILLIS = 750L;
+
+    private final OutputFactory outputFactory;
+    private final AudioManager audioManager;
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final AtomicBoolean reopenRequested = new AtomicBoolean();
+    private final AtomicLong underruns = new AtomicLong();
+    private final AtomicLong restarts = new AtomicLong();
+    private final Object wakeLock = new Object();
+    private final AudioDeviceCallback deviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+            requestRouteReopen();
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+            requestRouteReopen();
+        }
+    };
+
+    private volatile BoundedPcmQueue queue;
+    private volatile boolean paused;
+    private volatile boolean muted;
+    private volatile int volume = 100;
+    private volatile boolean hasProducedPcm;
+    private volatile int sampleRate;
+    private volatile Thread worker;
+
+    AndroidAudioSink(Context context, EventBus eventBus) {
+        this(eventBus, new AndroidAudioTrackOutput.Factory(),
+                Objects.requireNonNull(context, "context").getSystemService(AudioManager.class));
+    }
+
+    AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory) {
+        this(eventBus, outputFactory, null);
+    }
+
+    private AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory, AudioManager audioManager) {
+        this.outputFactory = Objects.requireNonNull(outputFactory, "outputFactory");
+        this.audioManager = audioManager;
+        EventBus bus = Objects.requireNonNull(eventBus, "eventBus");
+        bus.register(this::onSoundSample, Sound.SoundSampleEvent.class);
+        bus.register(event -> setMuted(!event.enabled()), Sound.SoundEnabledEvent.class);
+    }
+
+    void start() {
+        if (!running.compareAndSet(false, true)) {
+            throw new IllegalStateException("Android audio sink can only be started once");
+        }
+        if (audioManager != null) {
+            audioManager.registerAudioDeviceCallback(deviceCallback, null);
+        }
+        Thread next = new Thread(this::runConsumer, "coffee-gb-android-audio");
+        next.setDaemon(true);
+        worker = next;
+        next.start();
+    }
+
+    void pause() {
+        paused = true;
+        clearQueuedPcm();
+        wakeConsumer();
+    }
+
+    void resume() {
+        paused = false;
+        wakeConsumer();
+    }
+
+    void setMuted(boolean nextMuted) {
+        muted = nextMuted;
+        clearQueuedPcm();
+        wakeConsumer();
+    }
+
+    void setVolume(int nextVolume) {
+        if (nextVolume < 0 || nextVolume > 100) {
+            throw new IllegalArgumentException("Audio volume must be between 0 and 100");
+        }
+        volume = nextVolume;
+        clearQueuedPcm();
+        wakeConsumer();
+    }
+
+    Stats stats() {
+        BoundedPcmQueue active = queue;
+        return new Stats(sampleRate, active == null ? 0 : active.overruns(), underruns.get(),
+                restarts.get(), paused, running.get());
+    }
+
+    void requestRouteReopen() {
+        reopenRequested.set(true);
+        clearQueuedPcm();
+        wakeConsumer();
+    }
+
+    Thread workerThreadForTesting() {
+        return worker;
+    }
+
+    @Override
+    public void close() {
+        if (!running.getAndSet(false)) {
+            return;
+        }
+        if (audioManager != null) {
+            audioManager.unregisterAudioDeviceCallback(deviceCallback);
+        }
+        clearQueuedPcm();
+        wakeConsumer();
+        Thread active = worker;
+        if (active != null && active != Thread.currentThread()) {
+            try {
+                active.join(CLOSE_TIMEOUT_MILLIS);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void onSoundSample(Sound.SoundSampleEvent event) {
+        BoundedPcmQueue active = queue;
+        if (!running.get() || active == null || paused) {
+            return;
+        }
+        active.offer(event, volume, muted);
+        hasProducedPcm = true;
+        wakeConsumer();
+    }
+
+    private void runConsumer() {
+        Output output = null;
+        BoundedPcmQueue activeQueue = null;
+        boolean outputPaused = false;
+        boolean outputOpenedOnce = false;
+        try {
+            while (running.get()) {
+                if (output == null || reopenRequested.getAndSet(false)) {
+                    release(output);
+                    output = openOutput();
+                    outputPaused = false;
+                    if (output == null) {
+                        awaitWake(POLL_MILLIS);
+                        continue;
+                    }
+                    if (outputOpenedOnce) {
+                        restarts.incrementAndGet();
+                    } else {
+                        outputOpenedOnce = true;
+                    }
+                    if (activeQueue == null || sampleRate != output.sampleRate()) {
+                        activeQueue = new BoundedPcmQueue(output.sampleRate());
+                        queue = activeQueue;
+                    } else {
+                        activeQueue.clear();
+                    }
+                    sampleRate = output.sampleRate();
+                    hasProducedPcm = false;
+                    if (!paused) {
+                        output.play();
+                    }
+                    continue;
+                }
+
+                if (paused) {
+                    if (!outputPaused) {
+                        output.pause();
+                        output.flush();
+                        outputPaused = true;
+                    }
+                    awaitWake(POLL_MILLIS);
+                    continue;
+                }
+                if (outputPaused) {
+                    output.play();
+                    outputPaused = false;
+                }
+
+                BoundedPcmQueue.Frame frame = activeQueue.poll(POLL_MILLIS, TimeUnit.MILLISECONDS);
+                if (frame == null) {
+                    if (hasProducedPcm) {
+                        underruns.incrementAndGet();
+                    }
+                    continue;
+                }
+                try {
+                    if (!writeFully(output, frame)) {
+                        reopenRequested.set(true);
+                    }
+                } finally {
+                    activeQueue.release(frame);
+                }
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        } finally {
+            queue = null;
+            sampleRate = 0;
+            release(output);
+        }
+    }
+
+    private Output openOutput() {
+        try {
+            return outputFactory.open();
+        } catch (RuntimeException unavailable) {
+            return null;
+        }
+    }
+
+    private boolean writeFully(Output output, BoundedPcmQueue.Frame frame) {
+        int offset = 0;
+        while (offset < frame.length() && running.get() && !paused) {
+            int written = output.write(frame.bytes(), offset, frame.length() - offset);
+            if (written <= 0) {
+                return false;
+            }
+            offset += written;
+        }
+        return offset == frame.length();
+    }
+
+    private void clearQueuedPcm() {
+        BoundedPcmQueue active = queue;
+        if (active != null) {
+            active.clear();
+        }
+        hasProducedPcm = false;
+    }
+
+    private void awaitWake(long timeoutMillis) {
+        synchronized (wakeLock) {
+            try {
+                wakeLock.wait(timeoutMillis);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void wakeConsumer() {
+        synchronized (wakeLock) {
+            wakeLock.notifyAll();
+        }
+    }
+
+    private static void release(Output output) {
+        if (output == null) {
+            return;
+        }
+        try {
+            output.pause();
+        } catch (RuntimeException ignored) {
+            // A disconnected output may already be unusable.
+        }
+        try {
+            output.flush();
+        } catch (RuntimeException ignored) {
+            // A disconnected output may already be unusable.
+        }
+        try {
+            output.release();
+        } catch (RuntimeException ignored) {
+            // Release must not retain the service because a route vanished during teardown.
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutput.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutput.java
@@ -1,0 +1,102 @@
+package eu.rekawek.coffeegb.android;
+
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+
+/** Android framework bridge kept outside the portable DSP and fixed PCM queue. */
+final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
+
+    static final class Factory implements AndroidAudioSink.OutputFactory {
+        @Override
+        public AndroidAudioSink.Output open() {
+            int nativeRate = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC);
+            for (int sampleRate : new int[]{nativeRate, 48_000, 44_100}) {
+                AndroidAudioTrackOutput output = tryOpen(sampleRate);
+                if (output != null) {
+                    return output;
+                }
+            }
+            throw new IllegalStateException("No supported Android stereo PCM output rate");
+        }
+
+        private static AndroidAudioTrackOutput tryOpen(int sampleRate) {
+            if (sampleRate <= 0) {
+                return null;
+            }
+            int minimum = AudioTrack.getMinBufferSize(sampleRate, AudioFormat.CHANNEL_OUT_STEREO,
+                    AudioFormat.ENCODING_PCM_16BIT);
+            if (minimum <= 0) {
+                return null;
+            }
+            AudioTrack track = null;
+            try {
+                track = new AudioTrack.Builder()
+                        .setAudioAttributes(new AudioAttributes.Builder()
+                                .setUsage(AudioAttributes.USAGE_GAME)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                                .build())
+                        .setAudioFormat(new AudioFormat.Builder()
+                                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                                .setSampleRate(sampleRate)
+                                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                                .build())
+                        .setBufferSizeInBytes(Math.max(minimum, sampleRate * 4 / 100))
+                        .setTransferMode(AudioTrack.MODE_STREAM)
+                        .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+                        .build();
+                if (track.getState() != AudioTrack.STATE_INITIALIZED) {
+                    track.release();
+                    return null;
+                }
+                int actualRate = track.getSampleRate();
+                return new AndroidAudioTrackOutput(track,
+                        actualRate > 0 ? actualRate : sampleRate);
+            } catch (RuntimeException unavailable) {
+                if (track != null) {
+                    track.release();
+                }
+                return null;
+            }
+        }
+    }
+
+    private final AudioTrack track;
+    private final int sampleRate;
+
+    private AndroidAudioTrackOutput(AudioTrack track, int sampleRate) {
+        this.track = track;
+        this.sampleRate = sampleRate;
+    }
+
+    @Override
+    public int sampleRate() {
+        return sampleRate;
+    }
+
+    @Override
+    public void play() {
+        track.play();
+    }
+
+    @Override
+    public void pause() {
+        track.pause();
+    }
+
+    @Override
+    public void flush() {
+        track.flush();
+    }
+
+    @Override
+    public int write(byte[] bytes, int offset, int length) {
+        return track.write(bytes, offset, length, AudioTrack.WRITE_BLOCKING);
+    }
+
+    @Override
+    public void release() {
+        track.release();
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -76,6 +76,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     // Everything below is accessed only on the owner executor.
     private EventBus eventBus;
     private BasicController controller;
+    private volatile AndroidAudioSink audio;
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
@@ -108,6 +109,21 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Service-owned source merger for transient Android touch and controller devices. */
     AndroidInputRouter input() {
         return input;
+    }
+
+    /** Applies host-only audio controls without changing emulation timing or save state. */
+    void setAudioMuted(boolean muted) {
+        AndroidAudioSink activeAudio = audio;
+        if (activeAudio != null) {
+            activeAudio.setMuted(muted);
+        }
+    }
+
+    void setAudioVolume(int volume) {
+        AndroidAudioSink activeAudio = audio;
+        if (activeAudio != null) {
+            activeAudio.setVolume(volume);
+        }
     }
 
     /** Registers one UI observer and immediately replays the latest immutable snapshot. */
@@ -207,6 +223,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Pauses at the controller safe point and asks for a bounded asynchronous battery flush. */
     public void onHostNotVisible() {
         input.releaseAll();
+        AndroidAudioSink activeAudio = audio;
+        if (activeAudio != null) {
+            activeAudio.pause();
+        }
         submit(() -> {
             if (controller == null) {
                 return;
@@ -230,6 +250,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         submit(() -> {
             if (controller == null || activeLayout == null) {
                 return;
+            }
+            AndroidAudioSink activeAudio = audio;
+            if (activeAudio != null) {
+                activeAudio.resume();
             }
             lifecycle.resumedByUser();
             eventBus.post(new Controller.ResumeEmulationEvent());
@@ -346,6 +370,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void createController() {
         eventBus = new EventBusImpl();
+        audio = new AndroidAudioSink(context, eventBus);
+        audio.start();
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
         eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
@@ -576,19 +602,28 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         pendingFlushRequestId = 0;
         BasicController active = controller;
         EventBus activeBus = eventBus;
+        AndroidAudioSink activeAudio = audio;
         controller = null;
         eventBus = null;
+        audio = null;
         if (active == null) {
+            if (activeAudio != null) {
+                activeAudio.close();
+            }
             return true;
         }
         try {
             active.close();
+            if (activeAudio != null) {
+                activeAudio.close();
+            }
             lifecycle.released();
             return true;
         } catch (RuntimeException failure) {
             // Retain the controller for an explicit retry; it may still own an unflushed battery.
             controller = active;
             eventBus = activeBus;
+            audio = activeAudio;
             return false;
         }
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/BoundedPcmQueue.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/BoundedPcmQueue.java
@@ -1,0 +1,128 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.sound.Sound;
+import eu.rekawek.coffeegb.core.sound.StereoPcmConverter;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Fixed-storage hand-off from the emulation event thread to one host-audio consumer.
+ *
+ * <p>Every slot and PCM byte array is allocated at construction. A producer that falls behind
+ * discards the oldest queued host frame, never waits for the consumer and never grows latency.
+ */
+final class BoundedPcmQueue {
+
+    static final int DEFAULT_CAPACITY = 6;
+
+    private final StereoPcmConverter converter;
+    private final ArrayBlockingQueue<Frame> available;
+    private final ArrayBlockingQueue<Frame> queued;
+    private final AtomicLong overruns = new AtomicLong();
+
+    BoundedPcmQueue(int sampleRate) {
+        this(sampleRate, DEFAULT_CAPACITY, maximumFrameBytes(sampleRate));
+    }
+
+    BoundedPcmQueue(int sampleRate, int capacity, int frameBytes) {
+        if (capacity < 2) {
+            throw new IllegalArgumentException("PCM queue needs at least two frames");
+        }
+        if (frameBytes <= 0) {
+            throw new IllegalArgumentException("PCM frames must have positive capacity");
+        }
+        converter = new StereoPcmConverter(sampleRate);
+        available = new ArrayBlockingQueue<>(capacity);
+        queued = new ArrayBlockingQueue<>(capacity);
+        for (int index = 0; index < capacity; index++) {
+            available.add(new Frame(new byte[frameBytes]));
+        }
+    }
+
+    /** Called synchronously by the emulation event bus; it never waits for host audio. */
+    void offer(Sound.SoundSampleEvent event, int volume, boolean muted) {
+        Frame frame = available.poll();
+        if (frame == null) {
+            frame = queued.poll();
+            if (frame == null) {
+                // One consumer can own at most one frame, so this is a defensive last resort.
+                overruns.incrementAndGet();
+                return;
+            }
+            overruns.incrementAndGet();
+        }
+        try {
+            frame.length = converter.render(event.buffer(), event.clockSpec(), volume, muted,
+                    frame.bytes);
+            if (!queued.offer(frame)) {
+                throw new IllegalStateException("PCM queue lost its reserved frame slot");
+            }
+        } catch (RuntimeException failure) {
+            frame.length = 0;
+            available.offer(frame);
+            throw failure;
+        }
+    }
+
+    Frame poll(long timeout, TimeUnit unit) throws InterruptedException {
+        return queued.poll(timeout, unit);
+    }
+
+    void release(Frame frame) {
+        if (frame == null) {
+            return;
+        }
+        frame.length = 0;
+        if (!available.offer(frame)) {
+            throw new IllegalStateException("PCM queue released a frame twice");
+        }
+    }
+
+    void clear() {
+        Frame frame;
+        while ((frame = queued.poll()) != null) {
+            release(frame);
+        }
+    }
+
+    long overruns() {
+        return overruns.get();
+    }
+
+    int queuedFrames() {
+        return queued.size();
+    }
+
+    long samplePhase() {
+        return converter.samplePhase();
+    }
+
+    private static int maximumFrameBytes(int sampleRate) {
+        long maximum = 0;
+        for (ClockSpec clock : new ClockSpec[]{ClockSpec.LEGACY, ClockSpec.SGB, ClockSpec.SGB2}) {
+            maximum = Math.max(maximum, clock.maximumOutputUnits(
+                    clock.controllerTicksPerFrame(), sampleRate));
+        }
+        return Math.toIntExact(Math.multiplyExact(maximum, 4));
+    }
+
+    static final class Frame {
+        private final byte[] bytes;
+        private int length;
+
+        private Frame(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        byte[] bytes() {
+            return bytes;
+        }
+
+        int length() {
+            return length;
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
@@ -1,0 +1,144 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.sound.Sound;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AndroidAudioSinkTest {
+
+    @Test
+    public void writesOnlyOnDedicatedConsumerAndRecoversAfterUnderrunAndRouteChange() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            Thread owner = sink.workerThreadForTesting();
+            assertNotNull(owner);
+            assertTrue(owner.getName().contains("android-audio"));
+
+            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
+            await("first PCM write", () -> factory.current().writes.size() == 1);
+            assertTrue(factory.current().writeThreads.stream().allMatch(name -> name.equals(owner.getName())));
+
+            await("underrun", () -> sink.stats().underruns() > 0);
+            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
+            await("underrun recovery", () -> factory.current().writes.size() == 2);
+
+            FakeOutput first = factory.current();
+            sink.requestRouteReopen();
+            await("route reopen", () -> factory.opens.get() == 2 && first.released);
+            assertEquals(1, sink.stats().restarts());
+        } finally {
+            sink.close();
+        }
+        assertTrue(factory.current().released);
+        assertFalse(sink.stats().active());
+        assertFalse(sink.workerThreadForTesting().isAlive());
+    }
+
+    @Test
+    public void pauseClearsQueuedFramesUntilExplicitResume() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            sink.pause();
+            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
+            Thread.sleep(60);
+            assertEquals(0, factory.current().writes.size());
+
+            sink.resume();
+            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
+            await("resumed PCM write", () -> factory.current().writes.size() == 1);
+        } finally {
+            sink.close();
+        }
+    }
+
+    private static int[] audibleSamples() {
+        int ticks = ClockSpec.LEGACY.controllerTicksPerFrame();
+        int[] samples = new int[ticks * 2];
+        for (int tick = 0; tick < ticks; tick++) {
+            samples[tick * 2] = 480;
+            samples[tick * 2 + 1] = -480;
+        }
+        return samples;
+    }
+
+    private static void await(String description, BooleanSupplier condition) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertTrue("Timed out waiting for " + description, condition.getAsBoolean());
+    }
+
+    private static final class FakeFactory implements AndroidAudioSink.OutputFactory {
+        private final AtomicInteger opens = new AtomicInteger();
+        private final List<FakeOutput> outputs = new CopyOnWriteArrayList<>();
+
+        @Override
+        public AndroidAudioSink.Output open() {
+            FakeOutput output = new FakeOutput();
+            outputs.add(output);
+            opens.incrementAndGet();
+            return output;
+        }
+
+        private FakeOutput current() {
+            return outputs.get(outputs.size() - 1);
+        }
+    }
+
+    private static final class FakeOutput implements AndroidAudioSink.Output {
+        private final List<byte[]> writes = new CopyOnWriteArrayList<>();
+        private final List<String> writeThreads = new CopyOnWriteArrayList<>();
+        private volatile boolean released;
+
+        @Override
+        public int sampleRate() {
+            return 44_100;
+        }
+
+        @Override
+        public void play() {
+        }
+
+        @Override
+        public void pause() {
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            writes.add(Arrays.copyOfRange(bytes, offset, offset + length));
+            writeThreads.add(Thread.currentThread().getName());
+            return length;
+        }
+
+        @Override
+        public void release() {
+            released = true;
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BoundedPcmQueueTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BoundedPcmQueueTest.java
@@ -1,0 +1,89 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.sound.Sound;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class BoundedPcmQueueTest {
+
+    @Test
+    public void fullQueueDropsOldestFramesInsteadOfGrowingOrBlockingProducer() throws Exception {
+        BoundedPcmQueue queue = new BoundedPcmQueue(44_100, 2, 4_096);
+        Sound.SoundSampleEvent event = new Sound.SoundSampleEvent(samples(2_000), ClockSpec.LEGACY);
+
+        queue.offer(event, 100, false);
+        queue.offer(event, 100, false);
+        queue.offer(event, 100, false);
+
+        assertEquals(2, queue.queuedFrames());
+        assertEquals(1, queue.overruns());
+        BoundedPcmQueue.Frame first = queue.poll(1, TimeUnit.SECONDS);
+        BoundedPcmQueue.Frame second = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(first);
+        assertNotNull(second);
+        assertTrue(first.length() > 0);
+        assertTrue(second.length() > 0);
+        queue.release(first);
+        queue.release(second);
+    }
+
+    @Test
+    public void clearingQueuedHostFramesKeepsFractionalResamplerContinuity() {
+        BoundedPcmQueue queue = new BoundedPcmQueue(44_100, 3, 4_096);
+        queue.offer(new Sound.SoundSampleEvent(samples(43), ClockSpec.SGB2), 100, false);
+        long phase = queue.samplePhase();
+
+        queue.clear();
+        queue.offer(new Sound.SoundSampleEvent(samples(67), ClockSpec.SGB2), 100, false);
+
+        assertTrue(phase != 0);
+        assertEquals(1, queue.queuedFrames());
+        assertTrue(queue.samplePhase() != 0);
+    }
+
+    @Test
+    public void releasedFrameAndPcmStorageAreReusedForTheNextEvent() throws Exception {
+        BoundedPcmQueue queue = new BoundedPcmQueue(44_100, 2, 4_096);
+        Sound.SoundSampleEvent event = new Sound.SoundSampleEvent(samples(2_000), ClockSpec.LEGACY);
+
+        queue.offer(event, 100, false);
+        queue.offer(event, 100, false);
+        BoundedPcmQueue.Frame first = queue.poll(1, TimeUnit.SECONDS);
+        BoundedPcmQueue.Frame second = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(first);
+        assertNotNull(second);
+        byte[] firstBytes = first.bytes();
+        byte[] secondBytes = second.bytes();
+        queue.release(first);
+        queue.release(second);
+
+        queue.offer(event, 100, false);
+        queue.offer(event, 100, false);
+        BoundedPcmQueue.Frame reusedFirst = queue.poll(1, TimeUnit.SECONDS);
+        BoundedPcmQueue.Frame reusedSecond = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(reusedFirst);
+        assertNotNull(reusedSecond);
+        assertSame(first, reusedFirst);
+        assertSame(second, reusedSecond);
+        assertSame(firstBytes, reusedFirst.bytes());
+        assertSame(secondBytes, reusedSecond.bytes());
+        queue.release(reusedFirst);
+        queue.release(reusedSecond);
+    }
+
+    private static int[] samples(int ticks) {
+        int[] result = new int[ticks * 2];
+        for (int tick = 0; tick < ticks; tick++) {
+            result[tick * 2] = 480;
+            result[tick * 2 + 1] = -480;
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/DcBlocker.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/DcBlocker.java
@@ -1,11 +1,13 @@
-package eu.rekawek.coffeegb.swing.io;
+package eu.rekawek.coffeegb.core.sound;
 
+/**
+ * First-order high-pass filter modelling the Game Boy output capacitor. Kept separate so desktop
+ * and Android conversion share both its stateful behavior and direct regression coverage.
+ */
 final class DcBlocker {
 
     private final double pole;
-
     private double previousInput;
-
     private double previousOutput;
 
     DcBlocker(double sampleRate, double cutoff) {
@@ -17,5 +19,10 @@ final class DcBlocker {
         previousInput = input;
         previousOutput = output;
         return output;
+    }
+
+    void reset() {
+        previousInput = 0;
+        previousOutput = 0;
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/StereoPcmConverter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/StereoPcmConverter.java
@@ -1,0 +1,153 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+
+import java.util.Objects;
+
+/**
+ * Stateful, platform-neutral conversion from Coffee GB's per-master-tick stereo mix to signed
+ * little-endian 16-bit host PCM.
+ *
+ * <p>The converter owns fractional resampling, the two-period box filter, and DC blockers. It
+ * writes into a caller-provided byte array, allowing a host sink to preallocate its bounded queue
+ * rather than allocate work proportional to emulated master ticks. One instance has one producer
+ * thread; callers must serialize a converter if their event delivery is not single-threaded.
+ */
+public final class StereoPcmConverter {
+
+    /** The mixer maximum is four channels times ±15 at volume 8, per stereo side. */
+    private static final int VOLUME_SCALE = 62;
+    private static final double HIGHPASS_CUTOFF = 28.0;
+    private static final int BYTES_PER_STEREO_FRAME = 4;
+
+    private final int sampleRate;
+    private final DcBlocker dcBlockerL;
+    private final DcBlocker dcBlockerR;
+
+    private ClockSpec activeClock = ClockSpec.LEGACY;
+    private ClockSpec.RateAccumulator sampleAccumulator;
+    private long sumL;
+    private long sumR;
+    private long previousSumL;
+    private long previousSumR;
+    private int count;
+    private int previousCount;
+
+    public StereoPcmConverter(int sampleRate) {
+        if (sampleRate <= 0) {
+            throw new IllegalArgumentException("Sample rate must be positive");
+        }
+        this.sampleRate = sampleRate;
+        sampleAccumulator = activeClock.newTickRateAccumulator(sampleRate);
+        dcBlockerL = new DcBlocker(sampleRate, HIGHPASS_CUTOFF);
+        dcBlockerR = new DcBlocker(sampleRate, HIGHPASS_CUTOFF);
+    }
+
+    /** Returns enough bytes for {@link #render} for this clock and source tick count. */
+    public int maximumPcmBytes(int ticks, ClockSpec clockSpec) {
+        if (ticks < 0) {
+            throw new IllegalArgumentException("Tick count must not be negative");
+        }
+        ClockSpec clock = Objects.requireNonNull(clockSpec, "clockSpec");
+        return Math.toIntExact(Math.multiplyExact(
+                clock.maximumOutputUnits(ticks, sampleRate), BYTES_PER_STEREO_FRAME));
+    }
+
+    /**
+     * Converts interleaved left/right mixer values into {@code target} and returns written bytes.
+     * The target must have at least {@link #maximumPcmBytes(int, ClockSpec)} bytes available.
+     */
+    public int render(int[] source, ClockSpec clockSpec, int masterVolume, boolean muted,
+                      byte[] target) {
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(target, "target");
+        if (masterVolume < 0 || masterVolume > 100) {
+            throw new IllegalArgumentException("Master volume must be between 0 and 100");
+        }
+        selectClock(Objects.requireNonNull(clockSpec, "clockSpec"));
+        int ticks = source.length / 2;
+        int required = maximumPcmBytes(ticks, activeClock);
+        if (target.length < required) {
+            throw new IllegalArgumentException("PCM target is smaller than the maximum output");
+        }
+
+        int offset = 0;
+        for (int tick = 0; tick < ticks; tick++) {
+            sumL += source[tick * 2];
+            sumR += source[tick * 2 + 1];
+            count++;
+            long produced = sampleAccumulator.advanceOne();
+            if (produced > 1) {
+                throw new IllegalStateException("Audio output rate exceeds the emulated tick rate");
+            }
+            if (produced == 1) {
+                int total = previousCount + count;
+                double rawL = (double) (previousSumL + sumL) / total;
+                double rawR = (double) (previousSumR + sumR) / total;
+                int left = outputSample(dcBlockerL.filter(rawL), masterVolume, muted);
+                int right = outputSample(dcBlockerR.filter(rawR), masterVolume, muted);
+                target[offset++] = (byte) left;
+                target[offset++] = (byte) (left >> 8);
+                target[offset++] = (byte) right;
+                target[offset++] = (byte) (right >> 8);
+                previousSumL = sumL;
+                previousSumR = sumR;
+                previousCount = count;
+                sumL = 0;
+                sumR = 0;
+                count = 0;
+            }
+        }
+        return offset;
+    }
+
+    /** Clears all filter and fractional-resampling phase. Use only for a deliberate new stream. */
+    public void reset() {
+        resetRateState();
+        dcBlockerL.reset();
+        dcBlockerR.reset();
+    }
+
+    /** Exposes only fractional phase for deterministic continuity tests. */
+    public long samplePhase() {
+        return sampleAccumulator.remainder();
+    }
+
+    private void selectClock(ClockSpec clockSpec) {
+        if (activeClock.equals(clockSpec)) {
+            return;
+        }
+        activeClock = clockSpec;
+        // Desktop output has always retained capacitor/DC state across a hardware-clock change;
+        // only the fractional clock accumulator and its pending box-filter period restart.
+        resetRateState();
+    }
+
+    private void resetRateState() {
+        sampleAccumulator = activeClock.newTickRateAccumulator(sampleRate);
+        sumL = 0;
+        sumR = 0;
+        previousSumL = 0;
+        previousSumR = 0;
+        count = 0;
+        previousCount = 0;
+    }
+
+    private static int outputSample(double filtered, int masterVolume, boolean muted) {
+        if (muted || masterVolume == 0) {
+            return 0;
+        }
+        double scaled = filtered * VOLUME_SCALE;
+        if (masterVolume != 100) {
+            scaled = scaled * masterVolume / 100.0;
+        }
+        if (scaled >= Short.MAX_VALUE) {
+            return Short.MAX_VALUE;
+        }
+        if (scaled <= Short.MIN_VALUE) {
+            return Short.MIN_VALUE;
+        }
+        return (int) scaled;
+    }
+
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/DcBlockerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/DcBlockerTest.java
@@ -1,4 +1,4 @@
-package eu.rekawek.coffeegb.swing.io;
+package eu.rekawek.coffeegb.core.sound;
 
 import org.junit.Test;
 
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertEquals;
 public class DcBlockerTest {
 
     private static final int SAMPLE_RATE = 44_100;
-
     private static final double CUTOFF = 28.0;
 
     @Test
@@ -16,7 +15,7 @@ public class DcBlockerTest {
         int timeConstantSamples = (int) Math.round(SAMPLE_RATE / (2.0 * Math.PI * CUTOFF));
 
         double output = 0;
-        for (int i = 0; i < timeConstantSamples; i++) {
+        for (int index = 0; index < timeConstantSamples; index++) {
             output = filter.filter(1.0);
         }
 
@@ -30,10 +29,10 @@ public class DcBlockerTest {
         double outputEnergy = 0;
         int warmup = SAMPLE_RATE / 10;
 
-        for (int i = 0; i < SAMPLE_RATE; i++) {
-            double input = Math.sin(2.0 * Math.PI * 200.0 * i / SAMPLE_RATE);
+        for (int index = 0; index < SAMPLE_RATE; index++) {
+            double input = Math.sin(2.0 * Math.PI * 200.0 * index / SAMPLE_RATE);
             double output = filter.filter(input);
-            if (i >= warmup) {
+            if (index >= warmup) {
                 inputEnergy += input * input;
                 outputEnergy += output * output;
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/StereoPcmConverterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/StereoPcmConverterTest.java
@@ -1,0 +1,89 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StereoPcmConverterTest {
+
+    private static final int SAMPLE_RATE = 44_100;
+
+    @Test
+    public void legacyDesktopPcmParityKeepsSampleOrderAndEndian() {
+        StereoPcmConverter converter = new StereoPcmConverter(SAMPLE_RATE);
+        int[] source = constantStereo(ClockSpec.LEGACY.controllerTicksPerFrame(), 480, -480);
+        byte[] output = new byte[converter.maximumPcmBytes(source.length / 2, ClockSpec.LEGACY)];
+
+        int written = converter.render(source, ClockSpec.LEGACY, 100, false, output);
+
+        assertEquals(4 * 734, written);
+        assertEquals(0x40, output[0] & 0xff);
+        assertEquals(0x74, output[1] & 0xff);
+        assertEquals(0xc0, output[2] & 0xff);
+        assertEquals(0x8b, output[3] & 0xff);
+    }
+
+    @Test
+    public void muteClippingAndDcBlockingAreStable() {
+        StereoPcmConverter converter = new StereoPcmConverter(SAMPLE_RATE);
+        int[] loud = constantStereo(ClockSpec.LEGACY.controllerTicksPerFrame(), 1_000_000, -1_000_000);
+        byte[] pcm = new byte[converter.maximumPcmBytes(loud.length / 2, ClockSpec.LEGACY)];
+
+        int written = converter.render(loud, ClockSpec.LEGACY, 100, false, pcm);
+        assertEquals(Short.MAX_VALUE, littleEndianShort(pcm, 0));
+        assertEquals(Short.MIN_VALUE, littleEndianShort(pcm, 2));
+
+        Arrays.fill(pcm, (byte) 0x7f);
+        converter.render(loud, ClockSpec.LEGACY, 0, true, pcm);
+        for (int offset = 0; offset < written; offset++) {
+            assertEquals(0, pcm[offset]);
+        }
+
+        StereoPcmConverter dc = new StereoPcmConverter(SAMPLE_RATE);
+        int[] constant = constantStereo(ClockSpec.LEGACY.controllerTicksPerFrame(), 480, 480);
+        byte[] settled = new byte[dc.maximumPcmBytes(constant.length / 2, ClockSpec.LEGACY)];
+        for (int i = 0; i < 8; i++) {
+            dc.render(constant, ClockSpec.LEGACY, 100, false, settled);
+        }
+        assertTrue(Math.abs(littleEndianShort(settled, settled.length - 4)) < 1_500);
+    }
+
+    @Test
+    public void fractionalResamplerPhaseContinuesAcrossEventBuffers() {
+        StereoPcmConverter converter = new StereoPcmConverter(SAMPLE_RATE);
+        ClockSpec clock = ClockSpec.SGB2;
+        int[] first = constantStereo(43, 480, 480);
+        byte[] firstPcm = new byte[converter.maximumPcmBytes(43, clock)];
+        converter.render(first, clock, 100, false, firstPcm);
+        long phaseBefore = converter.samplePhase();
+
+        int[] second = constantStereo(67, 480, 480);
+        byte[] secondPcm = new byte[converter.maximumPcmBytes(67, clock)];
+        int written = converter.render(second, clock, 100, false, secondPcm);
+
+        BigInteger numerator = BigInteger.valueOf(110L).multiply(BigInteger.valueOf(SAMPLE_RATE));
+        BigInteger[] expected = numerator.divideAndRemainder(
+                BigInteger.valueOf(clock.ticksPerSecondNumerator()));
+        assertTrue(phaseBefore != 0);
+        assertEquals(expected[0].longValueExact() * 4, written);
+        assertEquals(expected[1].longValueExact(), converter.samplePhase());
+    }
+
+    private static int[] constantStereo(int ticks, int left, int right) {
+        int[] samples = new int[ticks * 2];
+        for (int tick = 0; tick < ticks; tick++) {
+            samples[tick * 2] = left;
+            samples[tick * 2 + 1] = right;
+        }
+        return samples;
+    }
+
+    private static short littleEndianShort(byte[] bytes, int offset) {
+        return (short) ((bytes[offset] & 0xff) | (bytes[offset + 1] << 8));
+    }
+}

--- a/docs/android-audio.md
+++ b/docs/android-audio.md
@@ -1,0 +1,43 @@
+# Android audio operation and device validation
+
+The Android frontend consumes the portable `StereoPcmConverter` used by the Swing adapter. It
+performs fractional resampling, a two-period box filter, DC blocking, volume, muting, clipping,
+and interleaved little-endian signed 16-bit stereo PCM conversion without Android dependencies.
+The Android adapter constructs that converter with the initialized `AudioTrack` rate.
+
+`AndroidAudioSink` is one producer/one consumer hand-off. Controller audio events run only the
+producer path, which fills one of six preallocated PCM slots. If all available slots are busy, it
+discards the oldest queued slot and increments the overrun counter. The only code that opens,
+plays, pauses, flushes, writes, or releases an `AudioTrack` is the named
+`coffee-gb-android-audio` consumer thread. This keeps UI and emulation ownership separate and
+prevents a slow route from increasing host-audio latency indefinitely.
+
+On visibility or focus loss, the runtime pauses at its controller safe point, clears queued PCM,
+and asks the existing battery-save lifecycle to flush. It never resumes automatically on focus
+gain. A user Resume deliberately resumes the session and audio output. An audio-device callback releases
+and reopens the track on the consumer thread; PCM queued for the old route is cleared. Statistics
+include producer overruns, consumer underruns, and successful output restarts for diagnostics and
+test probes. Closing the session unregisters the route callback and releases the output on that
+same consumer thread.
+
+No audio permission is needed for playback. The frontend requests neither microphone access nor
+Internet, and no audio payload, ROM path, URI, or persistent game content is logged or exported.
+
+## Device validation procedure
+
+Automated JVM and Android unit tests prove converter parity, bounded slots, consumer-thread-only
+writes, underrun recovery, route reopen, pause/resume, and release. They do not claim physical
+latency measurements. Before a release, run the following on the current Android emulator and at
+least one physical mid-range device, then record the model, Android version, active route/rate,
+and observed overrun/underrun/restart counts in the release or issue evidence:
+
+1. Install the debug APK, load an owner-authorized game, and let audio warm up for one minute.
+2. Use wired and, when available, Bluetooth or speaker routes; connect and disconnect each while
+   the game is running, then confirm the next user Resume produces clean audio with no growing lag.
+3. Background the app and trigger a transient audio-focus loss. Confirm it pauses, flushes, saves,
+   and remains paused until the explicit Resume action.
+4. Play for ten minutes after warm-up on each route. Capture the sink counters and note audible
+   glitches and estimated end-to-end latency.
+
+Device measurements are intentionally not fabricated by the repository: they require an attached
+emulator/device and an owner-authorized game run.

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -2,8 +2,8 @@ package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.controller.properties.SoundProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
-import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.sound.Sound;
+import eu.rekawek.coffeegb.core.sound.StereoPcmConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,18 +54,6 @@ public class AudioSystemSound implements Runnable {
                     SAMPLE_RATE,
                     false);
 
-    /**
-     * The mixer outputs signed DAC-modelled samples of at most 4 channels * ±15 * volume 8
-     * = ±480 per side; scale to leave a little 16-bit headroom.
-     */
-    private static final int VOLUME_SCALE = 62;
-
-    /**
-     * The console's output capacitor has a cutoff of about 28 Hz. It removes baseline steps caused
-     * by channel routing while preserving master-volume PCM.
-     */
-    private static final double HIGHPASS_CUTOFF = 28.0;
-
     private static final long RETRY_UNAVAILABLE_MILLIS = 1000;
     private static final long STOP_TIMEOUT_MILLIS = 2000;
     private static final long FORCED_CLOSE_TIMEOUT_MILLIS = 250;
@@ -94,15 +82,7 @@ public class AudioSystemSound implements Runnable {
     private volatile Thread workerThread;
     private volatile AudioBackend.AudioLine activeLine;
 
-    private ClockSpec activeClock = ClockSpec.LEGACY;
-    private ClockSpec.RateAccumulator sampleAccumulator =
-            activeClock.newTickRateAccumulator(SAMPLE_RATE);
-
-    private long sumL, sumR, prevSumL, prevSumR;
-    private int cnt, prevCnt;
-
-    private final DcBlocker dcBlockerL = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
-    private final DcBlocker dcBlockerR = new DcBlocker(SAMPLE_RATE, HIGHPASS_CUTOFF);
+    private final StereoPcmConverter pcmConverter = new StereoPcmConverter(SAMPLE_RATE);
 
     /** Existing desktop constructor; preserves the old enabled/default-device behavior. */
     public AudioSystemSound(SoundProperties properties, EventBus eventBus, String callerId) {
@@ -643,68 +623,14 @@ public class AudioSystemSound implements Runnable {
         AudioRuntimeConfiguration configuration = desiredConfiguration.get();
         int[] source = event.buffer();
         int ticks = source.length / 2;
-        selectClock(event.clockSpec());
-
-        int maximumSamples = Math.toIntExact(activeClock.maximumOutputUnits(ticks, SAMPLE_RATE));
-        byte[] out = new byte[Math.multiplyExact(maximumSamples, BYTES_PER_STEREO_FRAME)];
-        int j = 0;
-        // moving average over two output periods (a width-2 box filter): near-Nyquist
-        // content is attenuated ~38 dB, so games parking a channel on an ultrasonic
-        // frequency stay inaudible like on hardware instead of aliasing into a buzz
-        // (Pit-Fighter, issue #59), at the cost of ~3 dB roll-off at 10 kHz
-        for (int t = 0; t < ticks; t++) {
-            sumL += source[t * 2];
-            sumR += source[t * 2 + 1];
-            cnt++;
-            long produced = sampleAccumulator.advanceOne();
-            if (produced > 1) {
-                throw new IllegalStateException("Audio output rate exceeds the emulated tick rate");
-            }
-            if (produced == 1) {
-                int total = prevCnt + cnt;
-                double rawL = (double) (prevSumL + sumL) / total;
-                double rawR = (double) (prevSumR + sumR) / total;
-                double filteredL = dcBlockerL.filter(rawL);
-                double filteredR = dcBlockerR.filter(rawR);
-                int left = outputSample(filteredL, configuration);
-                int right = outputSample(filteredR, configuration);
-                out[j++] = (byte) left;
-                out[j++] = (byte) (left >> 8);
-                out[j++] = (byte) right;
-                out[j++] = (byte) (right >> 8);
-                prevSumL = sumL;
-                prevSumR = sumR;
-                prevCnt = cnt;
-                sumL = 0;
-                sumR = 0;
-                cnt = 0;
-            }
-        }
-
-        byte[] trimmed = new byte[j];
-        System.arraycopy(out, 0, trimmed, 0, j);
+        byte[] out = new byte[pcmConverter.maximumPcmBytes(ticks, event.clockSpec())];
+        int written = pcmConverter.render(source, event.clockSpec(),
+                configuration.masterVolume(), configuration.muted(), out);
+        byte[] trimmed = new byte[written];
+        System.arraycopy(out, 0, trimmed, 0, written);
         if (generation == configurationGeneration.get()) {
             enqueuePcm(trimmed, configuration.latencyPreset().queuedFrames());
         }
-    }
-
-    private static int outputSample(
-            double filtered, AudioRuntimeConfiguration configuration) {
-        if (configuration.muted() || configuration.masterVolume() == 0) {
-            return 0;
-        }
-        double scaled = filtered * VOLUME_SCALE;
-        if (configuration.masterVolume() != 100) {
-            scaled = scaled * configuration.masterVolume() / 100.0;
-        }
-        if (scaled >= Short.MAX_VALUE) {
-            return Short.MAX_VALUE;
-        }
-        if (scaled <= Short.MIN_VALUE) {
-            return Short.MIN_VALUE;
-        }
-        // Preserve the historical truncation at 100% volume.
-        return (int) scaled;
     }
 
     private void enqueuePcm(byte[] bytes, int maximumFrames) {
@@ -719,27 +645,13 @@ public class AudioSystemSound implements Runnable {
         }
     }
 
-    private void selectClock(ClockSpec clockSpec) {
-        if (activeClock.equals(clockSpec)) {
-            return;
-        }
-        activeClock = clockSpec;
-        sampleAccumulator = clockSpec.newTickRateAccumulator(SAMPLE_RATE);
-        sumL = 0;
-        sumR = 0;
-        prevSumL = 0;
-        prevSumR = 0;
-        cnt = 0;
-        prevCnt = 0;
-    }
-
     static AudioFormat outputFormat() {
         return FORMAT;
     }
 
     /** Package-private deterministic probe; exposes only the scalar conversion phase. */
     long samplePhaseForTesting() {
-        return sampleAccumulator.remainder();
+        return pcmConverter.samplePhase();
     }
 
     Thread workerThreadForTesting() {


### PR DESCRIPTION
## Summary

Implements Android roadmap Phase 6: shared DSP and a bounded `AudioTrack` sink.

- Moves the desktop DC blocker into `core` and adds `StereoPcmConverter`, preserving desktop PCM semantics while sharing fractional resampling, two-period filtering, DC blocking, mute/volume, clipping, and little-endian signed stereo conversion.
- Adds a fixed six-slot Android PCM hand-off. The event producer never waits or allocates PCM proportional to master ticks; it drops the oldest queued host frame on overload. A dedicated `coffee-gb-android-audio` consumer owns all `AudioTrack` open/play/pause/flush/write/release work.
- Reopens safely on route changes, uses the initialized track rate, clears stale PCM on mute/volume/pause/focus/route transitions, and tracks overrun, underrun, and output-restart counts.
- Connects the sink to the service-owned runtime lifecycle, ports the direct DC-filter regression tests into core, and documents privacy, ownership, lifecycle, and device-validation procedure.

Closes #360. Part of #319; preserves the Android build boundary from #314 and the service/runtime contract from #317.

## Validation

- `mvn -B test`
- `ANDROID_HOME=/tmp/coffee-gb-android-sdk ./android/gradlew -p android -PcoffeeGbMavenRepository=$PWD/build/android-m2 --no-daemon :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`
- Android unit coverage includes PCM order/clipping/DC/resampler continuity, fixed-pool reuse and overflow, consumer-thread writes, underrun recovery, route reopen/restart, pause/resume, and release.

## Device evidence

No Android emulator or physical device was attached to this workspace, so no latency or underrun measurement is claimed. `docs/android-audio.md` records the exact warm-up, route, focus, and ten-minute device-validation procedure; this must be run and recorded before a release.
