### PR TITLE
[Android] Build accessible MVP session controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ changes, focus/visibility loss, and route changes clear queued PCM; focus loss s
 user to resume the game. The app declares no microphone, vibration, broad-storage, or network
 permission. See [Android audio operation and device validation](docs/android-audio.md).
 
+The Android MVP keeps its launch, game, pause, state, settings, and privacy flows in the bound
+Activity while the service remains the only emulator owner. The pause sheet offers explicit
+resume, reset, quick-state, state-slot, settings, and stop actions. State slots show only
+redacted portable metadata and require confirmation before deletion; unavailable video/profile/
+rewind changes explain why rather than silently doing nothing. Buttons carry text labels and
+standard Android keyboard/focus navigation, with status text that does not rely on color alone.
+
 ## Download and play
 
 The portable Coffee GB download is a single executable JAR. It requires a desktop **Java 16 or

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -124,6 +125,87 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeAudio != null) {
             activeAudio.setVolume(volume);
         }
+    }
+
+    /** Pauses one active session at its controller-owned safe point without ending it. */
+    public void pause() {
+        input.releaseAll();
+        AndroidAudioSink activeAudio = audio;
+        if (activeAudio != null) {
+            activeAudio.pause();
+        }
+        submit(() -> {
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.PauseEmulationEvent());
+            }
+        });
+    }
+
+    /** Resets only the active emulator session through its portable controller event. */
+    public void reset() {
+        submit(() -> {
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.ResetEmulationEvent());
+            }
+        });
+    }
+
+    /** Requests a portable quick-state save at the controller's safe point. */
+    public void saveSnapshot(int slot) {
+        checkStateSlot(slot);
+        submit(() -> {
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.SaveSnapshotEvent(slot));
+            }
+        });
+    }
+
+    /** Requests a portable quick-state restore; controller errors remain typed/redacted. */
+    public void restoreSnapshot(int slot) {
+        checkStateSlot(slot);
+        submit(() -> {
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.RestoreSnapshotEvent(slot));
+            }
+        });
+    }
+
+    /** Reads only redacted state metadata on the runtime owner, then delivers immutable rows on UI. */
+    void listStateSlots(Consumer<List<AndroidStateSlot>> callback) {
+        Consumer<List<AndroidStateSlot>> checked = Objects.requireNonNull(callback, "callback");
+        submit(() -> {
+            List<AndroidStateSlot> slots = new ArrayList<>();
+            if (activeStates != null) {
+                var entries = activeStates.catalog(null).getEntries();
+                for (int slot = StateRef.MIN_SLOT; slot <= StateRef.MAX_SLOT; slot++) {
+                    int index = slot;
+                    var entry = entries.stream()
+                            .filter(candidate -> candidate.getRef() instanceof StateRef.Slot
+                                    && ((StateRef.Slot) candidate.getRef()).getIndex() == index)
+                            .findFirst().orElse(null);
+                    slots.add(AndroidStateSlot.from(index, entry));
+                }
+            }
+            List<AndroidStateSlot> snapshot = List.copyOf(slots);
+            mainHandler.post(() -> checked.accept(snapshot));
+        });
+    }
+
+    void deleteSnapshot(int slot) {
+        checkStateSlot(slot);
+        submit(() -> {
+            if (activeStates == null) {
+                return;
+            }
+            try {
+                activeStates.delete(new StateRef.Slot(slot));
+                publish(state.phase(), "State slot " + slot + " deleted.", List.of(),
+                        state.transferReady(), state.paused(), state.flushPending());
+            } catch (Exception failure) {
+                publish(state.phase(), "Coffee GB could not delete that state slot.", List.of(),
+                        state.transferReady(), state.paused(), state.flushPending());
+            }
+        });
     }
 
     /** Registers one UI observer and immediately replays the latest immutable snapshot. */
@@ -588,6 +670,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             throw new IllegalStateException("No active ROM state storage");
         }
         return activeStates;
+    }
+
+    private static void checkStateSlot(int slot) {
+        if (slot < StateRef.MIN_SLOT || slot > StateRef.MAX_SLOT) {
+            throw new IllegalArgumentException("State slot must be between " + StateRef.MIN_SLOT
+                    + " and " + StateRef.MAX_SLOT);
+        }
     }
 
     private EventBus controllerEventBus() {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidStateSlot.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidStateSlot.java
@@ -1,0 +1,28 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.controller.state.StateCatalogEntry;
+import eu.rekawek.coffeegb.controller.state.StateCatalogStatus;
+
+/** Immutable, path-free state-slot row for Android UI presentation. */
+record AndroidStateSlot(int index, String detail, boolean loadable) {
+
+    static AndroidStateSlot from(int index, StateCatalogEntry entry) {
+        if (entry == null) {
+            return new AndroidStateSlot(index, "Empty", false);
+        }
+        StateCatalogStatus status = entry.getStatus();
+        if (status != StateCatalogStatus.AVAILABLE) {
+            String reason = entry.getDetail();
+            return new AndroidStateSlot(index,
+                    reason == null || reason.isBlank() ? "Unavailable: " + status : reason, false);
+        }
+        String saved = entry.getMetadata() == null
+                ? "Saved state"
+                : "Saved " + entry.getMetadata().getSavedAt();
+        return new AndroidStateSlot(index, saved, true);
+    }
+
+    String label() {
+        return "Slot " + index + ": " + detail;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
+import android.widget.ScrollView;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -42,8 +43,12 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private CoffeeGbSurfaceView video;
     private Button open;
     private Button recent;
+    private Button pauseMenu;
     private Button resume;
     private Button stop;
+    private Button states;
+    private Button settings;
+    private Button about;
     private Button importBattery;
     private Button exportBattery;
     private Button importState;
@@ -84,6 +89,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             bound = true;
             runtime.addObserver(MainActivity.this);
             video.attach(runtime.frames(), runtime.input());
+            runtime.setAudioMuted(getPreferences(MODE_PRIVATE).getBoolean("audio.muted", false));
+            runtime.setAudioVolume(getPreferences(MODE_PRIVATE).getInt("audio.volume", 100));
             applyState(runtime.state());
         }
 
@@ -117,13 +124,18 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         content.addView(status);
 
         video = new CoffeeGbSurfaceView(this);
+        int videoHeight = (int) (240 * getResources().getDisplayMetrics().density);
         content.addView(video, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f));
+                ViewGroup.LayoutParams.MATCH_PARENT, videoHeight));
 
         open = button("Open ROM", this::openRomDocument);
         recent = button("Open recent ROM", ignored -> requireRuntime(AndroidEmulationRuntime::requestRecentDocuments));
+        pauseMenu = button("Pause and menu", ignored -> showPauseMenu());
         resume = button("Resume", ignored -> requireRuntime(AndroidEmulationRuntime::resume));
         stop = button("Stop game", ignored -> requireRuntime(AndroidEmulationRuntime::stop));
+        states = button("Save states", ignored -> showStateSlots());
+        settings = button("Settings", ignored -> showSettings());
+        about = button("About, licenses, and privacy", ignored -> showAbout());
         importBattery = button("Import battery save", this::chooseBatteryImport);
         exportBattery = button("Export battery save", this::chooseBatteryExport);
         importState = button("Import state slot 0", this::chooseStateImport);
@@ -133,8 +145,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         controllerMapping = button("Controller mapping", ignored -> configureController());
         content.addView(open);
         content.addView(recent);
+        content.addView(pauseMenu);
         content.addView(resume);
         content.addView(stop);
+        content.addView(states);
+        content.addView(settings);
         content.addView(importBattery);
         content.addView(exportBattery);
         content.addView(importState);
@@ -142,7 +157,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         content.addView(exportScreenshot);
         content.addView(touchControls);
         content.addView(controllerMapping);
-        setContentView(content);
+        content.addView(about);
+        ScrollView scroll = new ScrollView(this);
+        scroll.setFillViewport(true);
+        scroll.addView(content);
+        setContentView(scroll);
         disableCommands();
     }
 
@@ -385,6 +404,127 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 .show();
     }
 
+    private void showPauseMenu() {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null || !pauseMenu.isEnabled()) {
+            return;
+        }
+        active.pause();
+        String[] choices = {"Resume", "Reset game", "Save state (slot 0)", "Load state (slot 0)",
+                "Save states", "Settings", "Stop game"};
+        new AlertDialog.Builder(this)
+                .setTitle("Game paused")
+                .setItems(choices, (dialog, which) -> {
+                    switch (which) {
+                        case 0 -> active.resume();
+                        case 1 -> new AlertDialog.Builder(this).setTitle("Reset game?")
+                                .setMessage("Unsaved progress in the running game may be lost.")
+                                .setNegativeButton("Cancel", null)
+                                .setPositiveButton("Reset", (ignored, button) -> active.reset()).show();
+                        case 2 -> active.saveSnapshot(0);
+                        case 3 -> active.restoreSnapshot(0);
+                        case 4 -> showStateSlots();
+                        case 5 -> showSettings();
+                        case 6 -> new AlertDialog.Builder(this).setTitle("Stop game?")
+                                .setMessage("The running session will end after its safe cleanup.")
+                                .setNegativeButton("Cancel", null)
+                                .setPositiveButton("Stop", (ignored, button) -> active.stop()).show();
+                        default -> { }
+                    }
+                }).show();
+    }
+
+    private void showStateSlots() {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null || !states.isEnabled()) {
+            return;
+        }
+        active.listStateSlots(slots -> {
+            if (slots.isEmpty()) {
+                Toast.makeText(this, "Open a ROM before managing save states.", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            String[] labels = slots.stream().map(AndroidStateSlot::label).toArray(String[]::new);
+            new AlertDialog.Builder(this).setTitle("Save states")
+                    .setItems(labels, (dialog, which) -> showStateSlotActions(slots.get(which))).show();
+        });
+    }
+
+    private void showStateSlotActions(AndroidStateSlot slot) {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null) {
+            return;
+        }
+        List<String> choices = new java.util.ArrayList<>();
+        choices.add("Save or overwrite");
+        if (slot.loadable()) {
+            choices.add("Load");
+            choices.add("Delete");
+        }
+        new AlertDialog.Builder(this).setTitle("State slot " + slot.index())
+                .setMessage(slot.detail()).setItems(choices.toArray(new String[0]), (dialog, which) -> {
+                    String choice = choices.get(which);
+                    if (choice.equals("Save or overwrite")) {
+                        active.saveSnapshot(slot.index());
+                    } else if (choice.equals("Load")) {
+                        active.restoreSnapshot(slot.index());
+                    } else {
+                        new AlertDialog.Builder(this).setTitle("Delete state slot?")
+                                .setMessage("This cannot be undone.").setNegativeButton("Cancel", null)
+                                .setPositiveButton("Delete", (ignored, button) -> active.deleteSnapshot(slot.index()))
+                                .show();
+                    }
+                }).show();
+    }
+
+    private void showSettings() {
+        String[] choices = {"Audio", "Touch controls", "Controller mapping", "Video", "System profile",
+                "Rewind and save behavior"};
+        new AlertDialog.Builder(this).setTitle("Settings").setItems(choices, (dialog, which) -> {
+            switch (which) {
+                case 0 -> configureAudio();
+                case 1 -> configureTouchControls();
+                case 2 -> configureController();
+                case 3 -> showUnavailable("Video", "Video uses native nearest-neighbor rendering with aspect-preserving fit.");
+                case 4 -> showUnavailable("System profile", "Profile selection is determined safely when the ROM opens; changing it during a session is unavailable.");
+                case 5 -> showUnavailable("Rewind and save behavior", "Rewind and battery-save behavior use the portable session defaults. Live changes are unavailable during a session.");
+                default -> { }
+            }
+        }).show();
+    }
+
+    private void configureAudio() {
+        LinearLayout form = new LinearLayout(this);
+        form.setOrientation(LinearLayout.VERTICAL);
+        int volume = getPreferences(MODE_PRIVATE).getInt("audio.volume", 100);
+        boolean muted = getPreferences(MODE_PRIVATE).getBoolean("audio.muted", false);
+        SeekBar slider = slider(form, "Volume", 0, 100, volume);
+        Switch mute = new Switch(this);
+        mute.setText("Mute audio");
+        mute.setChecked(muted);
+        form.addView(mute);
+        new AlertDialog.Builder(this).setTitle("Audio").setView(form).setNegativeButton("Cancel", null)
+                .setPositiveButton("Save", (dialog, which) -> {
+                    getPreferences(MODE_PRIVATE).edit().putInt("audio.volume", slider.getProgress())
+                            .putBoolean("audio.muted", mute.isChecked()).apply();
+                    requireRuntime(active -> {
+                        active.setAudioVolume(slider.getProgress());
+                        active.setAudioMuted(mute.isChecked());
+                    });
+                }).show();
+    }
+
+    private void showUnavailable(String title, String reason) {
+        new AlertDialog.Builder(this).setTitle(title).setMessage(reason)
+                .setPositiveButton("OK", null).show();
+    }
+
+    private void showAbout() {
+        new AlertDialog.Builder(this).setTitle("About Coffee GB Android")
+                .setMessage("Coffee GB is GPL-3.0-or-later software. This MVP opens GB, GBC, and ZIP documents you select, stores saves privately by ROM identity, and exports only when you choose a document. It requests no network, broad storage, microphone, camera, or vibration permission.\n\nSource and third-party notices: github.com/trekawek/coffee-gb")
+                .setPositiveButton("OK", null).show();
+    }
+
     private void confirmImport(String title, String message, int requestCode) {
         if (runtime == null || !importBattery.isEnabled()) {
             return;
@@ -429,8 +569,12 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         boolean ready = runtime != null;
         open.setEnabled(ready);
         recent.setEnabled(ready);
+        pauseMenu.setEnabled(ready && state.transferReady() && !state.paused());
         resume.setEnabled(ready && state.paused() && state.transferReady());
         stop.setEnabled(ready && state.transferReady());
+        states.setEnabled(ready && state.transferReady() && !state.flushPending());
+        settings.setEnabled(ready);
+        about.setEnabled(true);
         importBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
         exportBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
         importState.setEnabled(ready && state.transferReady() && !state.flushPending());
@@ -481,8 +625,12 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
         open.setEnabled(false);
         recent.setEnabled(false);
+        pauseMenu.setEnabled(false);
         resume.setEnabled(false);
         stop.setEnabled(false);
+        states.setEnabled(false);
+        settings.setEnabled(false);
+        about.setEnabled(true);
         importBattery.setEnabled(false);
         exportBattery.setEnabled(false);
         importState.setEnabled(false);

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
@@ -1,0 +1,17 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class AndroidStateSlotTest {
+
+    @Test
+    public void missingPortableEntryIsPresentedAsAnEmptyNonLoadableSlot() {
+        AndroidStateSlot slot = AndroidStateSlot.from(3, null);
+
+        assertEquals("Slot 3: Empty", slot.label());
+        assertFalse(slot.loadable());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the accessible Android MVP UI flow for roadmap Phase 7.

- Adds a text-labelled, scrollable launch/game screen with explicit Pause and menu, Resume, Stop, state, settings, and About/privacy paths that remain reachable with large fonts and standard Android keyboard/focus navigation.
- Adds a pause sheet with safe Resume, reset confirmation, quick save/load, state-browser, settings, and stop actions. All commands remain service/runtime mediated; UI never owns the controller or mutable emulator state.
- Adds redacted portable state-slot rows, with safe save/overwrite, load only when the catalog reports a loadable entry, and explicit delete confirmation. The runtime reads catalog metadata only on its owner thread and returns immutable path-free presentation values to main UI.
- Persists host-only audio mute/volume in app-private preferences, wires them to the Phase 6 sink, documents permissions/privacy/data behavior, and gives clear reasons for settings intentionally unavailable during a running session.

Closes #361. Part of #319; consumes the session/audio contracts from #317 and #360.

## Validation

- `ANDROID_HOME=/tmp/coffee-gb-android-sdk ./android/gradlew -p android -PcoffeeGbMavenRepository=$PWD/build/android-m2 --no-daemon :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`
- Android unit tests cover the state-slot presentation model; the existing runtime, touch, renderer, input, audio, and portability tests remain green.

## Device evidence

No physical device or emulator is attached in this workspace. The layout uses standard Android controls, scroll behavior, text labels, and non-color status text; final TalkBack/device verification remains a release validation step.
