### PR TITLE
Add Android rumble adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ The service writes signed 16-bit stereo PCM to an `AudioTrack` on a dedicated co
 the initialized track rate. Its six preallocated host-frame slots bound memory and latency: a late
 producer discards old PCM rather than blocking emulation or accumulating delay. Muting, volume
 changes, focus/visibility loss, and route changes clear queued PCM; focus loss still requires the
-user to resume the game. The app declares no microphone, vibration, broad-storage, or network
-permission. See [Android audio operation and device validation](docs/android-audio.md).
+user to resume the game. The app declares no microphone, broad-storage, or network permission.
+It declares Android's normal vibration permission solely for the optional rumble setting: a
+supported cartridge event reaches the platform vibrator (through Android 12+'s `VibratorManager`,
+with an API 26–30 fallback) only while that setting and the app session are active. See
+[Android audio operation and device validation](docs/android-audio.md).
 
 The Android MVP keeps its launch, game, pause, state, settings, and privacy flows in the bound
 Activity while the service remains the only emulator owner. The pause sheet offers explicit

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -76,7 +76,6 @@ private val forbiddenPermissions = listOf(
     "android.permission.READ_MEDIA_AUDIO",
     "android.permission.READ_MEDIA_IMAGES",
     "android.permission.READ_MEDIA_VIDEO",
-    "android.permission.VIBRATE",
 )
 
 private fun sensitivePermissions(contents: String): List<String> = forbiddenPermissions.filter { permission ->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application
         android:allowBackup="false"
         android:label="Coffee GB">

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -78,6 +78,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private EventBus eventBus;
     private BasicController controller;
     private volatile AndroidAudioSink audio;
+    private volatile AndroidRumbleSink rumble;
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
@@ -127,12 +128,24 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
+    /** Applies the user’s host-only rumble preference without changing the portable cartridge. */
+    void setRumbleEnabled(boolean enabled) {
+        AndroidRumbleSink activeRumble = rumble;
+        if (activeRumble != null) {
+            activeRumble.setEnabled(enabled);
+        }
+    }
+
     /** Pauses one active session at its controller-owned safe point without ending it. */
     public void pause() {
         input.releaseAll();
         AndroidAudioSink activeAudio = audio;
         if (activeAudio != null) {
             activeAudio.pause();
+        }
+        AndroidRumbleSink activeRumble = rumble;
+        if (activeRumble != null) {
+            activeRumble.pause();
         }
         submit(() -> {
             if (controller != null && activeLayout != null) {
@@ -309,6 +322,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeAudio != null) {
             activeAudio.pause();
         }
+        AndroidRumbleSink activeRumble = rumble;
+        if (activeRumble != null) {
+            activeRumble.pause();
+        }
         submit(() -> {
             if (controller == null) {
                 return;
@@ -336,6 +353,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             AndroidAudioSink activeAudio = audio;
             if (activeAudio != null) {
                 activeAudio.resume();
+            }
+            AndroidRumbleSink activeRumble = rumble;
+            if (activeRumble != null) {
+                activeRumble.resume();
             }
             lifecycle.resumedByUser();
             eventBus.post(new Controller.ResumeEmulationEvent());
@@ -454,6 +475,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus = new EventBusImpl();
         audio = new AndroidAudioSink(context, eventBus);
         audio.start();
+        rumble = new AndroidRumbleSink(context, eventBus, false);
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
         eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
@@ -692,12 +714,17 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         BasicController active = controller;
         EventBus activeBus = eventBus;
         AndroidAudioSink activeAudio = audio;
+        AndroidRumbleSink activeRumble = rumble;
         controller = null;
         eventBus = null;
         audio = null;
+        rumble = null;
         if (active == null) {
             if (activeAudio != null) {
                 activeAudio.close();
+            }
+            if (activeRumble != null) {
+                activeRumble.close();
             }
             return true;
         }
@@ -706,6 +733,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             if (activeAudio != null) {
                 activeAudio.close();
             }
+            if (activeRumble != null) {
+                activeRumble.close();
+            }
             lifecycle.released();
             return true;
         } catch (RuntimeException failure) {
@@ -713,6 +743,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             controller = active;
             eventBus = activeBus;
             audio = activeAudio;
+            rumble = activeRumble;
             return false;
         }
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumbleSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumbleSink.java
@@ -1,0 +1,135 @@
+package eu.rekawek.coffeegb.android;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.os.VibratorManager;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
+
+import java.util.Objects;
+
+/**
+ * Android host adapter for the portable rumble event. It never changes emulation state and can be
+ * disabled without suppressing the event stream needed by other frontend adapters.
+ */
+final class AndroidRumbleSink implements AutoCloseable {
+
+    interface Output {
+        boolean supported();
+
+        void start();
+
+        void cancel();
+    }
+
+    private static final class VibratorOutput implements Output {
+        private final Vibrator vibrator;
+
+        private VibratorOutput(Context context) {
+            Context applicationContext = Objects.requireNonNull(context, "context")
+                    .getApplicationContext();
+            vibrator = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                    ? Api31Vibrator.defaultVibrator(applicationContext)
+                    : applicationContext.getSystemService(Vibrator.class);
+        }
+
+        @Override
+        public boolean supported() {
+            return vibrator != null && vibrator.hasVibrator();
+        }
+
+        @Override
+        public void start() {
+            if (supported()) {
+                vibrator.vibrate(VibrationEffect.createWaveform(new long[]{0L, 50L}, 0));
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (vibrator != null) {
+                vibrator.cancel();
+            }
+        }
+    }
+
+    /** Keeps the Android 12 API reference out of verification on older devices. */
+    private static final class Api31Vibrator {
+        @TargetApi(Build.VERSION_CODES.S)
+        private static Vibrator defaultVibrator(Context context) {
+            VibratorManager manager = context.getSystemService(VibratorManager.class);
+            return manager == null ? null : manager.getDefaultVibrator();
+        }
+    }
+
+    private final Output output;
+    private boolean enabled;
+    private boolean active;
+    private boolean hostActive = true;
+    private boolean outputActive;
+    private boolean closed;
+
+    AndroidRumbleSink(Context context, EventBus eventBus, boolean enabled) {
+        this(new VibratorOutput(context), eventBus, enabled);
+    }
+
+    AndroidRumbleSink(Output output, EventBus eventBus, boolean enabled) {
+        this.output = Objects.requireNonNull(output, "output");
+        this.enabled = enabled;
+        Objects.requireNonNull(eventBus, "eventBus").register(this::onRumble, RumbleEvent.class);
+    }
+
+    synchronized void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        apply();
+    }
+
+    synchronized void pause() {
+        hostActive = false;
+        apply();
+    }
+
+    synchronized void resume() {
+        hostActive = true;
+        apply();
+    }
+
+    synchronized boolean supported() {
+        return !closed && output.supported();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        active = false;
+        outputActive = false;
+        output.cancel();
+    }
+
+    private synchronized void onRumble(RumbleEvent event) {
+        if (closed) {
+            return;
+        }
+        active = event.on();
+        apply();
+    }
+
+    private void apply() {
+        boolean shouldRun = enabled && active && hostActive && output.supported();
+        if (shouldRun == outputActive) {
+            return;
+        }
+        outputActive = shouldRun;
+        if (shouldRun) {
+            output.start();
+        } else {
+            output.cancel();
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -91,6 +91,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             video.attach(runtime.frames(), runtime.input());
             runtime.setAudioMuted(getPreferences(MODE_PRIVATE).getBoolean("audio.muted", false));
             runtime.setAudioVolume(getPreferences(MODE_PRIVATE).getInt("audio.volume", 100));
+            runtime.setRumbleEnabled(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
             applyState(runtime.state());
         }
 
@@ -478,16 +479,17 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void showSettings() {
-        String[] choices = {"Audio", "Touch controls", "Controller mapping", "Video", "System profile",
+        String[] choices = {"Audio", "Touch controls", "Controller mapping", "Optional devices", "Video", "System profile",
                 "Rewind and save behavior"};
         new AlertDialog.Builder(this).setTitle("Settings").setItems(choices, (dialog, which) -> {
             switch (which) {
                 case 0 -> configureAudio();
                 case 1 -> configureTouchControls();
                 case 2 -> configureController();
-                case 3 -> showUnavailable("Video", "Video uses native nearest-neighbor rendering with aspect-preserving fit.");
-                case 4 -> showUnavailable("System profile", "Profile selection is determined safely when the ROM opens; changing it during a session is unavailable.");
-                case 5 -> showUnavailable("Rewind and save behavior", "Rewind and battery-save behavior use the portable session defaults. Live changes are unavailable during a session.");
+                case 3 -> configureOptionalDevices();
+                case 4 -> showUnavailable("Video", "Video uses native nearest-neighbor rendering with aspect-preserving fit.");
+                case 5 -> showUnavailable("System profile", "Profile selection is determined safely when the ROM opens; changing it during a session is unavailable.");
+                case 6 -> showUnavailable("Rewind and save behavior", "Rewind and battery-save behavior use the portable session defaults. Live changes are unavailable during a session.");
                 default -> { }
             }
         }).show();
@@ -511,6 +513,18 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                         active.setAudioVolume(slider.getProgress());
                         active.setAudioMuted(mute.isChecked());
                     });
+                }).show();
+    }
+
+    private void configureOptionalDevices() {
+        Switch rumble = new Switch(this);
+        rumble.setText("Rumble when supported by the game and device");
+        rumble.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
+        new AlertDialog.Builder(this).setTitle("Optional devices").setView(rumble)
+                .setMessage("Tilt, camera, and printer integrations require a compatible cartridge and are configured only when available.")
+                .setNegativeButton("Cancel", null).setPositiveButton("Save", (dialog, which) -> {
+                    getPreferences(MODE_PRIVATE).edit().putBoolean("devices.rumble", rumble.isChecked()).apply();
+                    requireRuntime(active -> active.setRumbleEnabled(rumble.isChecked()));
                 }).show();
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidRumbleSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidRumbleSinkTest.java
@@ -1,0 +1,86 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class AndroidRumbleSinkTest {
+
+    @Test
+    public void toggleAndCloseCancelWithoutChangingPortableRumbleEvents() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeOutput output = new FakeOutput(true);
+        AndroidRumbleSink sink = new AndroidRumbleSink(output, events, true);
+
+        events.post(new RumbleEvent(true));
+        assertEquals(1, output.starts.get());
+        sink.setEnabled(false);
+        assertEquals(1, output.cancels.get());
+        sink.setEnabled(true);
+        assertEquals(2, output.starts.get());
+        events.post(new RumbleEvent(false));
+        assertEquals(2, output.cancels.get());
+        sink.close();
+        assertEquals(3, output.cancels.get());
+    }
+
+    @Test
+    public void pauseStopsRumbleAndUserResumeRestoresOnlyAnActiveMotor() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeOutput output = new FakeOutput(true);
+        AndroidRumbleSink sink = new AndroidRumbleSink(output, events, true);
+
+        events.post(new RumbleEvent(true));
+        sink.pause();
+        sink.resume();
+        events.post(new RumbleEvent(false));
+        sink.pause();
+        sink.resume();
+
+        assertEquals(2, output.starts.get());
+        assertEquals(2, output.cancels.get());
+    }
+
+    @Test
+    public void unsupportedOutputNeverStarts() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeOutput output = new FakeOutput(false);
+        AndroidRumbleSink sink = new AndroidRumbleSink(output, events, true);
+
+        events.post(new RumbleEvent(true));
+        sink.pause();
+        sink.resume();
+
+        assertEquals(0, output.starts.get());
+        assertEquals(0, output.cancels.get());
+    }
+
+    private static final class FakeOutput implements AndroidRumbleSink.Output {
+        private final boolean supported;
+        private final AtomicInteger starts = new AtomicInteger();
+        private final AtomicInteger cancels = new AtomicInteger();
+
+        private FakeOutput(boolean supported) {
+            this.supported = supported;
+        }
+
+        @Override
+        public boolean supported() {
+            return supported;
+        }
+
+        @Override
+        public void start() {
+            starts.incrementAndGet();
+        }
+
+        @Override
+        public void cancel() {
+            cancels.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Route portable `RumbleEvent` updates to an Android vibration adapter behind a persisted, opt-in setting.
- Use Android 12+ `VibratorManager` with an API 26–30 vibrator fallback and capability checks.
- Stop haptics while paused/backgrounded and reapply them only after explicit resume.

## Verification

- `git diff --check`
- `mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$PWD/build/android-m2"`
- Android Gradle unit/lint/APK checks are blocked locally because this environment has no Android SDK path configured; required GitHub CI is pending.

## Scope

Phase 8 rumble slice for #319; this does not close the Android roadmap epic.