### PR TITLE
Add Android MBC7 tilt input

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ by the controller descriptor plus vendor/product identity; the mapping dialog ca
 replaces a conflicting mapping deterministically, and can reset one controller. Focus loss,
 surface teardown, stopping, and controller removal synchronously release their input source.
 
+MBC7 games use the Android accelerometer only while their session is active. The next reading
+establishes a neutral position, the optional-device settings can recalibrate it, and the axes follow
+the display rotation. Devices without an accelerometer safely retain neutral tilt input.
+
 Android audio shares the desktop's portable resampling, two-period mixing filter, and DC blocking.
 The service writes signed 16-bit stereo PCM to an `AudioTrack` on a dedicated consumer thread at
 the initialized track rate. Its six preallocated host-frame slots bound memory and latency: a late

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -79,6 +79,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private BasicController controller;
     private volatile AndroidAudioSink audio;
     private volatile AndroidRumbleSink rumble;
+    private volatile AndroidTiltSink tilt;
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
@@ -88,6 +89,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private StateRepository activeStates;
     private long nextOpenRequestId;
     private long activeOpenRequestId;
+    private long tiltOpenRequestId;
+    private boolean tiltRequiredForOpenRequest;
     private long nextFlushRequestId;
     private long pendingFlushRequestId;
     private ScheduledFuture<?> flushDeadline;
@@ -136,6 +139,14 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
+    /** Calibrates an active MBC7 cartridge to the device's current resting position. */
+    void calibrateTilt() {
+        AndroidTiltSink activeTilt = tilt;
+        if (activeTilt != null) {
+            activeTilt.calibrate();
+        }
+    }
+
     /** Pauses one active session at its controller-owned safe point without ending it. */
     public void pause() {
         input.releaseAll();
@@ -146,6 +157,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         AndroidRumbleSink activeRumble = rumble;
         if (activeRumble != null) {
             activeRumble.pause();
+        }
+        AndroidTiltSink activeTilt = tilt;
+        if (activeTilt != null) {
+            activeTilt.pause();
         }
         submit(() -> {
             if (controller != null && activeLayout != null) {
@@ -326,6 +341,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeRumble != null) {
             activeRumble.pause();
         }
+        AndroidTiltSink activeTilt = tilt;
+        if (activeTilt != null) {
+            activeTilt.pause();
+        }
         submit(() -> {
             if (controller == null) {
                 return;
@@ -357,6 +376,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             AndroidRumbleSink activeRumble = rumble;
             if (activeRumble != null) {
                 activeRumble.resume();
+            }
+            AndroidTiltSink activeTilt = tilt;
+            if (activeTilt != null) {
+                activeTilt.resume();
             }
             lifecycle.resumedByUser();
             eventBus.post(new Controller.ResumeEmulationEvent());
@@ -476,6 +499,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         audio = new AndroidAudioSink(context, eventBus);
         audio.start();
         rumble = new AndroidRumbleSink(context, eventBus, false);
+        tilt = new AndroidTiltSink(context, eventBus);
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
         eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
@@ -494,6 +518,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 (Controller.EmulationStartedEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId) {
+                        AndroidTiltSink activeTilt = tilt;
+                        if (activeTilt != null) {
+                            activeTilt.setCartridgeActive(tiltOpenRequestId
+                                    == activeOpenRequestId && tiltRequiredForOpenRequest);
+                        }
                         if (currentSource != null) {
                             new RecentSafDocuments(context).recordIfPersisted(currentSource);
                         }
@@ -604,6 +633,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeStates = new StateRepository(layout, AtomicFileWriter.system());
             currentSource = source;
             activeOpenRequestId = ++nextOpenRequestId;
+            tiltOpenRequestId = activeOpenRequestId;
+            tiltRequiredForOpenRequest = rom.getType().isMbc7();
             publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
                     false, true, false);
             controllerEventBus().post(new Controller.LoadRomEvent(
@@ -715,16 +746,21 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         EventBus activeBus = eventBus;
         AndroidAudioSink activeAudio = audio;
         AndroidRumbleSink activeRumble = rumble;
+        AndroidTiltSink activeTilt = tilt;
         controller = null;
         eventBus = null;
         audio = null;
         rumble = null;
+        tilt = null;
         if (active == null) {
             if (activeAudio != null) {
                 activeAudio.close();
             }
             if (activeRumble != null) {
                 activeRumble.close();
+            }
+            if (activeTilt != null) {
+                activeTilt.close();
             }
             return true;
         }
@@ -736,6 +772,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             if (activeRumble != null) {
                 activeRumble.close();
             }
+            if (activeTilt != null) {
+                activeTilt.close();
+            }
             lifecycle.released();
             return true;
         } catch (RuntimeException failure) {
@@ -744,6 +783,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             eventBus = activeBus;
             audio = activeAudio;
             rumble = activeRumble;
+            tilt = activeTilt;
             return false;
         }
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
@@ -1,0 +1,226 @@
+package eu.rekawek.coffeegb.android;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.view.Surface;
+import android.view.WindowManager;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.cart.type.AccelerometerEvent;
+
+import java.util.Objects;
+
+/**
+ * Android host adapter for MBC7 tilt input. Neutral calibration and display rotation stay host
+ * state: the portable mapper continues to receive only normalized accelerometer events.
+ */
+final class AndroidTiltSink implements AutoCloseable {
+
+    interface SampleListener {
+        void onAcceleration(float x, float y);
+    }
+
+    interface Input {
+        boolean start(SampleListener listener);
+
+        void stop(SampleListener listener);
+    }
+
+    interface Orientation {
+        int rotation();
+    }
+
+    private static final class AndroidSensorInput implements Input, SensorEventListener {
+        private final SensorManager sensorManager;
+        private final Sensor accelerometer;
+        private SampleListener listener;
+
+        private AndroidSensorInput(Context context) {
+            sensorManager = Objects.requireNonNull(context, "context")
+                    .getApplicationContext().getSystemService(SensorManager.class);
+            accelerometer = sensorManager == null
+                    ? null : sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+        }
+
+        @Override
+        public synchronized boolean start(SampleListener listener) {
+            if (accelerometer == null || this.listener != null) {
+                return false;
+            }
+            this.listener = listener;
+            if (!sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_GAME)) {
+                this.listener = null;
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public synchronized void stop(SampleListener listener) {
+            if (this.listener != listener) {
+                return;
+            }
+            sensorManager.unregisterListener(this);
+            this.listener = null;
+        }
+
+        @Override
+        public void onSensorChanged(SensorEvent event) {
+            if (event.sensor.getType() != Sensor.TYPE_ACCELEROMETER || event.values.length < 2) {
+                return;
+            }
+            SampleListener target;
+            synchronized (this) {
+                target = listener;
+            }
+            if (target != null) {
+                target.onAcceleration(event.values[0], event.values[1]);
+            }
+        }
+
+        @Override
+        public void onAccuracyChanged(Sensor sensor, int accuracy) {
+            // The current sample is used directly; no accuracy threshold can safely invent input.
+        }
+    }
+
+    private static final class DisplayOrientation implements Orientation {
+        private final WindowManager windowManager;
+
+        private DisplayOrientation(Context context) {
+            windowManager = Objects.requireNonNull(context, "context")
+                    .getApplicationContext().getSystemService(WindowManager.class);
+        }
+
+        @Override
+        @SuppressLint("deprecation")
+        public int rotation() {
+            return windowManager == null ? Surface.ROTATION_0 : windowManager.getDefaultDisplay()
+                    .getRotation();
+        }
+    }
+
+    private final EventBus eventBus;
+    private final Input input;
+    private final Orientation orientation;
+    private final SampleListener samples = this::onAcceleration;
+
+    private boolean cartridgeActive;
+    private boolean hostActive = true;
+    private boolean sensorRegistered;
+    private boolean calibrated;
+    private boolean closed;
+    private int calibrationRotation = -1;
+    private float neutralX;
+    private float neutralY;
+
+    AndroidTiltSink(Context context, EventBus eventBus) {
+        this(eventBus, new AndroidSensorInput(context), new DisplayOrientation(context));
+    }
+
+    AndroidTiltSink(EventBus eventBus, Input input, Orientation orientation) {
+        this.eventBus = Objects.requireNonNull(eventBus, "eventBus");
+        this.input = Objects.requireNonNull(input, "input");
+        this.orientation = Objects.requireNonNull(orientation, "orientation");
+    }
+
+    synchronized void setCartridgeActive(boolean active) {
+        if (closed || cartridgeActive == active) {
+            return;
+        }
+        cartridgeActive = active;
+        resetCalibration();
+        if (active) {
+            startIfNeeded();
+        } else {
+            stopIfNeeded();
+        }
+    }
+
+    synchronized void pause() {
+        hostActive = false;
+        stopIfNeeded();
+    }
+
+    synchronized void resume() {
+        hostActive = true;
+        startIfNeeded();
+    }
+
+    /** Uses the next rotation-corrected sample as the neutral MBC7 position. */
+    synchronized void calibrate() {
+        resetCalibration();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        cartridgeActive = false;
+        stopIfNeeded();
+    }
+
+    private synchronized void onAcceleration(float rawX, float rawY) {
+        if (closed || !cartridgeActive || !hostActive || !sensorRegistered) {
+            return;
+        }
+        int rotation = orientation.rotation();
+        float x;
+        float y;
+        switch (rotation) {
+            case Surface.ROTATION_90 -> {
+                x = -rawY;
+                y = rawX;
+            }
+            case Surface.ROTATION_180 -> {
+                x = -rawX;
+                y = -rawY;
+            }
+            case Surface.ROTATION_270 -> {
+                x = rawY;
+                y = -rawX;
+            }
+            default -> {
+                x = rawX;
+                y = rawY;
+            }
+        }
+        if (!calibrated || calibrationRotation != rotation) {
+            neutralX = x;
+            neutralY = y;
+            calibrationRotation = rotation;
+            calibrated = true;
+        }
+        eventBus.post(new AccelerometerEvent(x - neutralX, y - neutralY));
+    }
+
+    private void startIfNeeded() {
+        if (closed || !cartridgeActive || !hostActive || sensorRegistered) {
+            return;
+        }
+        sensorRegistered = input.start(samples);
+        if (!sensorRegistered) {
+            eventBus.post(new AccelerometerEvent(0, 0));
+        }
+    }
+
+    private void stopIfNeeded() {
+        if (!sensorRegistered) {
+            return;
+        }
+        input.stop(samples);
+        sensorRegistered = false;
+    }
+
+    private void resetCalibration() {
+        calibrated = false;
+        calibrationRotation = -1;
+        neutralX = 0;
+        neutralY = 0;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -517,10 +517,21 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void configureOptionalDevices() {
+        LinearLayout options = new LinearLayout(this);
+        options.setOrientation(LinearLayout.VERTICAL);
         Switch rumble = new Switch(this);
         rumble.setText("Rumble when supported by the game and device");
         rumble.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
-        new AlertDialog.Builder(this).setTitle("Optional devices").setView(rumble)
+        options.addView(rumble);
+        Button calibrateTilt = new Button(this);
+        calibrateTilt.setText("Set current position as tilt neutral");
+        calibrateTilt.setOnClickListener(ignored -> {
+            requireRuntime(AndroidEmulationRuntime::calibrateTilt);
+            Toast.makeText(this, "Tilt will calibrate using the next sensor sample.",
+                    Toast.LENGTH_SHORT).show();
+        });
+        options.addView(calibrateTilt);
+        new AlertDialog.Builder(this).setTitle("Optional devices").setView(options)
                 .setMessage("Tilt, camera, and printer integrations require a compatible cartridge and are configured only when available.")
                 .setNegativeButton("Cancel", null).setPositiveButton("Save", (dialog, which) -> {
                     getPreferences(MODE_PRIVATE).edit().putBoolean("devices.rumble", rumble.isChecked()).apply();
@@ -535,7 +546,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     private void showAbout() {
         new AlertDialog.Builder(this).setTitle("About Coffee GB Android")
-                .setMessage("Coffee GB is GPL-3.0-or-later software. This MVP opens GB, GBC, and ZIP documents you select, stores saves privately by ROM identity, and exports only when you choose a document. It requests no network, broad storage, microphone, camera, or vibration permission.\n\nSource and third-party notices: github.com/trekawek/coffee-gb")
+                .setMessage("Coffee GB is GPL-3.0-or-later software. This MVP opens GB, GBC, and ZIP documents you select, stores saves privately by ROM identity, and exports only when you choose a document. It requests no network, broad storage, microphone, or camera permission. Optional rumble uses Android's normal vibration permission only when enabled.\n\nSource and third-party notices: github.com/trekawek/coffee-gb")
                 .setPositiveButton("OK", null).show();
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
@@ -1,0 +1,142 @@
+package eu.rekawek.coffeegb.android;
+
+import android.view.Surface;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.memory.cart.type.AccelerometerEvent;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AndroidTiltSinkTest {
+
+    @Test
+    public void calibratesNeutralAndMapsAxesForEachDisplayRotation() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        List<AccelerometerEvent> samples = new ArrayList<>();
+        events.register(samples::add, AccelerometerEvent.class);
+        FakeInput input = new FakeInput(true);
+        FakeOrientation orientation = new FakeOrientation(Surface.ROTATION_0);
+        AndroidTiltSink sink = new AndroidTiltSink(events, input, orientation);
+
+        sink.setCartridgeActive(true);
+        input.sample(5, 10);
+        input.sample(7, 13);
+        assertSample(samples.get(0), 0, 0);
+        assertSample(samples.get(1), 2, 3);
+
+        orientation.rotation = Surface.ROTATION_90;
+        input.sample(7, 13);
+        input.sample(8, 14);
+        assertSample(samples.get(2), 0, 0);
+        assertSample(samples.get(3), -1, 1);
+    }
+
+    @Test
+    public void pauseAndMissingSensorSafelyFallBackToNeutralInput() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        List<AccelerometerEvent> samples = new ArrayList<>();
+        events.register(samples::add, AccelerometerEvent.class);
+        FakeInput input = new FakeInput(true);
+        AndroidTiltSink sink = new AndroidTiltSink(events, input,
+                () -> Surface.ROTATION_0);
+
+        sink.setCartridgeActive(true);
+        input.sample(4, 9);
+        sink.pause();
+        input.sample(9, 12);
+        sink.resume();
+        input.sample(9, 12);
+
+        assertEquals(2, input.starts);
+        assertEquals(1, input.stops);
+        assertEquals(2, samples.size());
+        assertSample(samples.get(0), 0, 0);
+        assertSample(samples.get(1), 5, 3);
+        sink.close();
+        assertEquals(2, input.stops);
+
+        FakeInput unavailable = new FakeInput(false);
+        AndroidTiltSink fallback = new AndroidTiltSink(events, unavailable,
+                () -> Surface.ROTATION_0);
+        fallback.setCartridgeActive(true);
+        assertEquals(1, unavailable.starts);
+        assertSample(samples.get(2), 0, 0);
+    }
+
+    @Test
+    public void explicitCalibrationRebasesTheNextSensorSample() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        List<AccelerometerEvent> samples = new ArrayList<>();
+        events.register(samples::add, AccelerometerEvent.class);
+        FakeInput input = new FakeInput(true);
+        AndroidTiltSink sink = new AndroidTiltSink(events, input,
+                () -> Surface.ROTATION_0);
+
+        sink.setCartridgeActive(true);
+        input.sample(2, 4);
+        input.sample(4, 7);
+        sink.calibrate();
+        input.sample(4, 7);
+        input.sample(5, 9);
+
+        assertSample(samples.get(1), 2, 3);
+        assertSample(samples.get(2), 0, 0);
+        assertSample(samples.get(3), 1, 2);
+    }
+
+    private static void assertSample(AccelerometerEvent sample, double x, double y) {
+        assertEquals(x, sample.x(), 0.0001);
+        assertEquals(y, sample.y(), 0.0001);
+    }
+
+    private static final class FakeInput implements AndroidTiltSink.Input {
+        private final boolean available;
+        private AndroidTiltSink.SampleListener listener;
+        private int starts;
+        private int stops;
+
+        private FakeInput(boolean available) {
+            this.available = available;
+        }
+
+        @Override
+        public boolean start(AndroidTiltSink.SampleListener listener) {
+            starts++;
+            if (!available) {
+                return false;
+            }
+            this.listener = listener;
+            return true;
+        }
+
+        @Override
+        public void stop(AndroidTiltSink.SampleListener listener) {
+            stops++;
+            if (this.listener == listener) {
+                this.listener = null;
+            }
+        }
+
+        private void sample(float x, float y) {
+            if (listener != null) {
+                listener.onAcceleration(x, y);
+            }
+        }
+    }
+
+    private static final class FakeOrientation implements AndroidTiltSink.Orientation {
+        private int rotation;
+
+        private FakeOrientation(int rotation) {
+            this.rotation = rotation;
+        }
+
+        @Override
+        public int rotation() {
+            return rotation;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Route Android accelerometer samples to portable MBC7 `AccelerometerEvent`s only while an MBC7 cartridge is running.
- Calibrate a neutral device position, remap axes for display rotation, and stop sensor registration for pause, background, and shutdown.
- Preserve neutral input on devices without an accelerometer and expose a user recalibration action.

## Verification

- `git diff --check`
- Android Gradle unit/lint/APK checks remain blocked locally because this environment has no Android SDK path configured; required GitHub CI is pending.

## Scope

Phase 8 tilt slice for #319; this does not close the Android roadmap epic.