### PR TITLE
Add Android Game Boy Printer preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ MBC7 games use the Android accelerometer only while their session is active. The
 establishes a neutral position, the optional-device settings can recalibrate it, and the axes follow
 the display rotation. Devices without an accelerometer safely retain neutral tilt input.
 
+The optional Game Boy Printer connects through the existing portable serial endpoint. Printed
+paper stays in a bounded app-memory roll, can be previewed, and exports as PNG only through a
+user-selected SAF document; the export can then be shared with a temporary read grant.
+
 Android audio shares the desktop's portable resampling, two-period mixing filter, and DC blocking.
 The service writes signed 16-bit stereo PCM to an `AudioTrack` on a dedicated consumer thread at
 the initialized track rate. Its six preallocated host-frame slots bound memory and latency: a late

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -80,6 +80,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private volatile AndroidAudioSink audio;
     private volatile AndroidRumbleSink rumble;
     private volatile AndroidTiltSink tilt;
+    private AndroidPrinterStore printer;
+    private boolean printerEnabled;
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
@@ -145,6 +147,34 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeTilt != null) {
             activeTilt.calibrate();
         }
+    }
+
+    /** Connects or disconnects the portable Game Boy Printer at the controller-safe boundary. */
+    void setPrinterEnabled(boolean enabled) {
+        submit(() -> {
+            printerEnabled = enabled;
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.SetPrinterEvent(enabled));
+            }
+        });
+    }
+
+    /** Creates a preview bitmap away from the main thread, then returns it to the UI. */
+    void previewPrinter(Consumer<Bitmap> callback) {
+        Consumer<Bitmap> checked = Objects.requireNonNull(callback, "callback");
+        submit(() -> {
+            AndroidPrinterStore.Snapshot snapshot = printer == null ? null : printer.snapshot();
+            Bitmap bitmap = snapshot == null ? null : snapshot.toBitmap();
+            mainHandler.post(() -> checked.accept(bitmap));
+        });
+    }
+
+    void clearPrinter() {
+        submit(() -> {
+            if (printer != null) {
+                printer.clear();
+            }
+        });
     }
 
     /** Pauses one active session at its controller-owned safe point without ending it. */
@@ -435,6 +465,43 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         context.getContentResolver(), destination, requireStates(), new StateRef.Slot(0), true));
     }
 
+    /** Exports the retained Game Boy Printer paper as PNG through a user-selected SAF document. */
+    void exportPrinter(Uri destination, Runnable completed) {
+        Uri checked = Objects.requireNonNull(destination, "destination");
+        Runnable callback = Objects.requireNonNull(completed, "completed");
+        submit(() -> {
+            AndroidPrinterStore.Snapshot snapshot = printer == null ? null : printer.snapshot();
+            if (snapshot == null) {
+                publish(state.phase(), "Nothing has been printed yet.", List.of(),
+                        state.transferReady(), state.paused(), state.flushPending());
+                return;
+            }
+            RuntimeState before = state;
+            publish(before.phase(), "Exporting printer paper…", List.of(), before.transferReady(),
+                    before.paused(), before.flushPending());
+            Bitmap bitmap = null;
+            try {
+                bitmap = snapshot.toBitmap();
+                try (OutputStream output = context.getContentResolver().openOutputStream(checked, "wt")) {
+                    if (output == null || !bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                        throw new IOException("Printer paper could not be encoded");
+                    }
+                    output.flush();
+                }
+                publish(before.phase(), "Printer paper exported.", List.of(), before.transferReady(),
+                        before.paused(), before.flushPending());
+                mainHandler.post(callback);
+            } catch (IOException failure) {
+                publish(before.phase(), "Coffee GB could not export printer paper.", List.of(),
+                        before.transferReady(), before.paused(), before.flushPending());
+            } finally {
+                if (bitmap != null) {
+                    bitmap.recycle();
+                }
+            }
+        });
+    }
+
     /** Writes the latest native emulated frame as a PNG; it never captures Android UI overlays. */
     public void exportScreenshot(Uri destination) {
         Uri checked = Objects.requireNonNull(destination, "destination");
@@ -500,11 +567,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         audio.start();
         rumble = new AndroidRumbleSink(context, eventBus, false);
         tilt = new AndroidTiltSink(context, eventBus);
+        printer = new AndroidPrinterStore();
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
         eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
         eventBus.register(frames::publish, Display.GbcFrameReadyEvent.class);
         eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
+        eventBus.register(printer::append, Controller.PrinterPrintEvent.class);
         eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
@@ -527,6 +596,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                             new RecentSafDocuments(context).recordIfPersisted(currentSource);
                         }
                         lifecycle.activated(lifecycleCommands());
+                        if (printerEnabled) {
+                            eventBus.post(new Controller.SetPrinterEvent(true));
+                        }
                         publish(RuntimeState.Phase.RUNNING,
                                 "Loaded " + event.getRomName() + ". App-private saves are ready.",
                                 List.of(), true, false, false);
@@ -747,11 +819,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         AndroidAudioSink activeAudio = audio;
         AndroidRumbleSink activeRumble = rumble;
         AndroidTiltSink activeTilt = tilt;
+        AndroidPrinterStore activePrinter = printer;
         controller = null;
         eventBus = null;
         audio = null;
         rumble = null;
         tilt = null;
+        printer = null;
         if (active == null) {
             if (activeAudio != null) {
                 activeAudio.close();
@@ -784,6 +858,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             audio = activeAudio;
             rumble = activeRumble;
             tilt = activeTilt;
+            printer = activePrinter;
             return false;
         }
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPrinterStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPrinterStore.java
@@ -1,0 +1,113 @@
+package eu.rekawek.coffeegb.android;
+
+import android.graphics.Bitmap;
+import eu.rekawek.coffeegb.controller.Controller;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Bounded, immutable Android-side retention for Game Boy Printer strips. The controller thread
+ * copies every producer-owned print buffer before returning, so preview and SAF export never hold
+ * live emulation memory.
+ */
+final class AndroidPrinterStore {
+
+    static final int WIDTH = 160;
+    private static final int MARGIN_PIXELS_PER_UNIT = 3;
+    private static final long MAX_DECODED_PIXELS = 2L * 1024L * 1024L;
+    private static final int PAPER_WHITE = 0xffffffff;
+
+    private final List<Segment> segments = new ArrayList<>();
+    private long decodedPixels;
+    private long omittedStrips;
+
+    synchronized boolean append(Controller.PrinterPrintEvent event) {
+        if (event.getWidth() != WIDTH || event.getHeight() < 0 || event.getTopMargin() < 0
+                || event.getBottomMargin() < 0) {
+            omit();
+            return false;
+        }
+        try {
+            int sourcePixels = Math.multiplyExact(event.getWidth(), event.getHeight());
+            if (event.getArgb().length != sourcePixels) {
+                omit();
+                return false;
+            }
+            int top = Math.multiplyExact(event.getTopMargin(), MARGIN_PIXELS_PER_UNIT);
+            int bottom = Math.multiplyExact(event.getBottomMargin(), MARGIN_PIXELS_PER_UNIT);
+            int height = Math.addExact(Math.addExact(top, event.getHeight()), bottom);
+            if (height <= 0) {
+                omit();
+                return false;
+            }
+            long pixels = Math.multiplyExact((long) WIDTH, height);
+            if (pixels > MAX_DECODED_PIXELS - decodedPixels) {
+                omit();
+                return false;
+            }
+            int[] copy = new int[(int) pixels];
+            Arrays.fill(copy, PAPER_WHITE);
+            System.arraycopy(event.getArgb(), 0, copy, top * WIDTH, sourcePixels);
+            segments.add(new Segment(height, copy));
+            decodedPixels += pixels;
+            return true;
+        } catch (ArithmeticException ignored) {
+            omit();
+            return false;
+        }
+    }
+
+    synchronized Snapshot snapshot() {
+        if (segments.isEmpty()) {
+            return null;
+        }
+        int height = 0;
+        for (Segment segment : segments) {
+            height = Math.addExact(height, segment.height());
+        }
+        return new Snapshot(height, List.copyOf(segments));
+    }
+
+    synchronized void clear() {
+        segments.clear();
+        decodedPixels = 0;
+        omittedStrips = 0;
+    }
+
+    synchronized long omittedStrips() {
+        return omittedStrips;
+    }
+
+    private void omit() {
+        if (omittedStrips < Long.MAX_VALUE) {
+            omittedStrips++;
+        }
+    }
+
+    record Snapshot(int height, List<Segment> segments) {
+        int[] copyArgb() {
+            int[] copy = new int[Math.multiplyExact(WIDTH, height)];
+            int offset = 0;
+            for (Segment segment : segments) {
+                System.arraycopy(segment.argb(), 0, copy, offset, segment.argb().length);
+                offset += segment.argb().length;
+            }
+            return copy;
+        }
+
+        Bitmap toBitmap() {
+            Bitmap bitmap = Bitmap.createBitmap(WIDTH, height, Bitmap.Config.ARGB_8888);
+            int top = 0;
+            for (Segment segment : segments) {
+                bitmap.setPixels(segment.argb(), 0, WIDTH, 0, top, WIDTH, segment.height());
+                top += segment.height();
+            }
+            return bitmap;
+        }
+    }
+
+    private record Segment(int height, int[] argb) {
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.android;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ClipData;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
@@ -14,6 +15,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.ScrollView;
@@ -38,6 +40,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final int IMPORT_STATE_REQUEST = 4;
     private static final int EXPORT_STATE_REQUEST = 5;
     private static final int EXPORT_SCREENSHOT_REQUEST = 6;
+    private static final int EXPORT_PRINTER_REQUEST = 7;
 
     private TextView status;
     private CoffeeGbSurfaceView video;
@@ -92,6 +95,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             runtime.setAudioMuted(getPreferences(MODE_PRIVATE).getBoolean("audio.muted", false));
             runtime.setAudioVolume(getPreferences(MODE_PRIVATE).getInt("audio.volume", 100));
             runtime.setRumbleEnabled(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
+            runtime.setPrinterEnabled(getPreferences(MODE_PRIVATE).getBoolean("devices.printer", false));
             applyState(runtime.state());
         }
 
@@ -269,6 +273,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             case EXPORT_SCREENSHOT_REQUEST -> confirmExport(
                     "Export native screenshot?", "The chosen document will be replaced.",
                     () -> runtime.exportScreenshot(data.getData()));
+            case EXPORT_PRINTER_REQUEST -> confirmExport(
+                    "Export printer paper?", "The chosen document will be replaced.",
+                    () -> runtime.exportPrinter(data.getData(), () -> sharePrinter(data.getData())));
             default -> { }
         }
     }
@@ -306,6 +313,20 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                         .putExtra(Intent.EXTRA_TITLE, "coffee-gb.png")
                         .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
                 EXPORT_SCREENSHOT_REQUEST);
+    }
+
+    private void choosePrinterExport() {
+        if (runtime == null) {
+            return;
+        }
+        startActivityForResult(
+                new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                        .addCategory(Intent.CATEGORY_OPENABLE)
+                        .setType("image/png")
+                        .putExtra(Intent.EXTRA_TITLE, "coffee-gb-printer.png")
+                        .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION),
+                EXPORT_PRINTER_REQUEST);
     }
 
     private void configureTouchControls() {
@@ -523,6 +544,10 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         rumble.setText("Rumble when supported by the game and device");
         rumble.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
         options.addView(rumble);
+        Switch printer = new Switch(this);
+        printer.setText("Emulate the Game Boy Printer");
+        printer.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.printer", false));
+        options.addView(printer);
         Button calibrateTilt = new Button(this);
         calibrateTilt.setText("Set current position as tilt neutral");
         calibrateTilt.setOnClickListener(ignored -> {
@@ -531,12 +556,51 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                     Toast.LENGTH_SHORT).show();
         });
         options.addView(calibrateTilt);
+        Button previewPrinter = new Button(this);
+        previewPrinter.setText("Preview printer paper");
+        previewPrinter.setOnClickListener(ignored -> requireRuntime(this::showPrinterPreview));
+        options.addView(previewPrinter);
+        Button exportPrinter = new Button(this);
+        exportPrinter.setText("Export and share printer paper");
+        exportPrinter.setOnClickListener(ignored -> choosePrinterExport());
+        options.addView(exportPrinter);
         new AlertDialog.Builder(this).setTitle("Optional devices").setView(options)
                 .setMessage("Tilt, camera, and printer integrations require a compatible cartridge and are configured only when available.")
                 .setNegativeButton("Cancel", null).setPositiveButton("Save", (dialog, which) -> {
                     getPreferences(MODE_PRIVATE).edit().putBoolean("devices.rumble", rumble.isChecked()).apply();
-                    requireRuntime(active -> active.setRumbleEnabled(rumble.isChecked()));
+                    getPreferences(MODE_PRIVATE).edit().putBoolean("devices.printer", printer.isChecked()).apply();
+                    requireRuntime(active -> {
+                        active.setRumbleEnabled(rumble.isChecked());
+                        active.setPrinterEnabled(printer.isChecked());
+                    });
                 }).show();
+    }
+
+    private void showPrinterPreview(AndroidEmulationRuntime active) {
+        active.previewPrinter(bitmap -> {
+            if (bitmap == null) {
+                Toast.makeText(this, "Nothing has been printed yet.", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            ImageView image = new ImageView(this);
+            image.setImageBitmap(bitmap);
+            image.setAdjustViewBounds(true);
+            ScrollView scroll = new ScrollView(this);
+            scroll.addView(image);
+            new AlertDialog.Builder(this).setTitle("Game Boy Printer paper").setView(scroll)
+                    .setNegativeButton("Close", null)
+                    .setNeutralButton("Clear", (dialog, which) -> active.clearPrinter())
+                    .setPositiveButton("Export", (dialog, which) -> choosePrinterExport()).show();
+        });
+    }
+
+    private void sharePrinter(android.net.Uri uri) {
+        Intent share = new Intent(Intent.ACTION_SEND)
+                .setType("image/png")
+                .putExtra(Intent.EXTRA_STREAM, uri)
+                .setClipData(ClipData.newRawUri("Game Boy Printer paper", uri))
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(Intent.createChooser(share, "Share printer paper"));
     }
 
     private void showUnavailable(String title, String reason) {

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPrinterStoreTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPrinterStoreTest.java
@@ -1,0 +1,48 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.controller.Controller;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class AndroidPrinterStoreTest {
+
+    @Test
+    public void copiesPrinterPixelsAndAddsPaperMargins() {
+        AndroidPrinterStore store = new AndroidPrinterStore();
+        int[] source = new int[AndroidPrinterStore.WIDTH * 2];
+        source[0] = 0xff112233;
+        source[source.length - 1] = 0xffabcdef;
+
+        assertTrue(store.append(new Controller.PrinterPrintEvent(source, AndroidPrinterStore.WIDTH,
+                2, 1, 2, 0)));
+        source[0] = 0;
+
+        AndroidPrinterStore.Snapshot snapshot = store.snapshot();
+        assertNotNull(snapshot);
+        assertEquals(11, snapshot.height());
+        int[] paper = snapshot.copyArgb();
+        assertEquals(0xffffffff, paper[0]);
+        assertEquals(0xff112233, paper[AndroidPrinterStore.WIDTH * 3]);
+        assertEquals(0xffabcdef, paper[AndroidPrinterStore.WIDTH * 5 - 1]);
+        assertEquals(0xffffffff, paper[paper.length - 1]);
+
+        store.clear();
+        assertNull(store.snapshot());
+    }
+
+    @Test
+    public void rejectsMalformedAndOversizedStripsWithoutRetainingThem() {
+        AndroidPrinterStore store = new AndroidPrinterStore();
+        assertFalse(store.append(new Controller.PrinterPrintEvent(new int[1], 159, 1, 0, 0, 0)));
+        assertFalse(store.append(new Controller.PrinterPrintEvent(new int[AndroidPrinterStore.WIDTH],
+                AndroidPrinterStore.WIDTH, 1, Integer.MAX_VALUE, 0, 0)));
+
+        assertEquals(2, store.omittedStrips());
+        assertNull(store.snapshot());
+    }
+}


### PR DESCRIPTION
Completes the Android printer part of #319 phase 8.

- connects the existing portable Game Boy Printer endpoint at the controller-safe boundary
- retains copied, bounded printer strips for preview and PNG export through a user-selected SAF document
- shares the exported document with a temporary read grant
- adds focused strip-copy, paper-margin, and malformed-input tests

Validation:
- `git diff --check`
- SDK-independent `AndroidPrinterStoreTest` (2 tests)
- Android Gradle build remains unavailable locally because this environment has no Android SDK; CI will run the Android build.