### PR TITLE
Add Android Pocket Camera capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ The optional Game Boy Printer connects through the existing portable serial endp
 paper stays in a bounded app-memory roll, can be previewed, and exports as PNG only through a
 user-selected SAF document; the export can then be shared with a temporary read grant.
 
+For Pocket Camera cartridges, choosing live capture requests Android camera access only at that
+point. CameraX supplies bounded latest-frame analysis while the compatible game is active and the
+app is visible; before permission, without a camera, or after capture stops, the portable core
+uses its deterministic synthetic camera pattern.
+
 Android audio shares the desktop's portable resampling, two-period mixing filter, and DC blocking.
 The service writes signed 16-bit stereo PCM to an `AudioTrack` on a dedicated consumer thread at
 the initialized track rate. Its six preallocated host-frame slots bound memory and latency: a late

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,7 +68,6 @@ private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Coll
 
 private val forbiddenPermissions = listOf(
     "android.permission.INTERNET",
-    "android.permission.CAMERA",
     "android.permission.RECORD_AUDIO",
     "android.permission.MANAGE_EXTERNAL_STORAGE",
     "android.permission.READ_EXTERNAL_STORAGE",
@@ -116,6 +115,10 @@ android {
 
 dependencies {
   implementation("eu.rekawek.coffeegb:controller:$coffeeGbVersion")
+  implementation("androidx.camera:camera-camera2:1.6.1")
+  implementation("androidx.camera:camera-core:1.6.1")
+  implementation("androidx.camera:camera-lifecycle:1.6.1")
+  implementation("androidx.lifecycle:lifecycle-process:2.11.0")
   testImplementation("junit:junit:4.13.2")
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="false"

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidCameraSource.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidCameraSource.java
@@ -1,7 +1,6 @@
 package eu.rekawek.coffeegb.android;
 
 import android.content.Context;
-import android.graphics.ImageFormat;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Size;
@@ -123,8 +122,10 @@ final class AndroidCameraSource implements CameraSource, AutoCloseable {
 
         private void onImage(ImageProxy image) {
             try {
-                if (!running || image.getFormat() != ImageFormat.RGBA_8888
-                        || image.getPlanes().length != 1) {
+                // OUTPUT_IMAGE_FORMAT_RGBA_8888 guarantees one RGBA plane. Do not inspect an
+                // Android framework format constant here: CameraX owns that compatibility layer
+                // across our API 26+ range.
+                if (!running || image.getPlanes().length != 1) {
                     return;
                 }
                 ImageProxy.PlaneProxy plane = image.getPlanes()[0];

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidCameraSource.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidCameraSource.java
@@ -1,0 +1,259 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.Context;
+import android.graphics.ImageFormat;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Size;
+import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageAnalysis;
+import androidx.camera.core.ImageProxy;
+import androidx.camera.lifecycle.ProcessCameraProvider;
+import androidx.lifecycle.ProcessLifecycleOwner;
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraFrame;
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraSource;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+/**
+ * Lifecycle-safe CameraX adapter for the portable Pocket Camera source.
+ *
+ * <p>The emulator only ever reads the latest immutable frame, so CameraX analysis is deliberately
+ * keep-only-latest. Capture starts only for an enabled Pocket Camera cartridge while the host is
+ * active; a missing frame remains the core's deterministic synthetic-camera fallback.
+ */
+final class AndroidCameraSource implements CameraSource, AutoCloseable {
+
+    interface Input extends AutoCloseable {
+        void start(Consumer<CameraFrame> listener);
+
+        void stop();
+
+        @Override
+        default void close() {
+            stop();
+        }
+    }
+
+    private static final class CameraXInput implements Input {
+        private static final Size TARGET_RESOLUTION = new Size(320, 240);
+
+        private final Context context;
+        private final Handler mainHandler = new Handler(Looper.getMainLooper());
+        private final ExecutorService analyzer = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "coffee-gb-android-camera");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        private volatile boolean running;
+        private volatile Consumer<CameraFrame> listener;
+        // Accessed on the main thread only.
+        private ProcessCameraProvider provider;
+        private ImageAnalysis analysis;
+
+        private CameraXInput(Context context) {
+            this.context = Objects.requireNonNull(context, "context").getApplicationContext();
+        }
+
+        @Override
+        public void start(Consumer<CameraFrame> listener) {
+            this.listener = Objects.requireNonNull(listener, "listener");
+            running = true;
+            mainHandler.post(this::bind);
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+            listener = null;
+            mainHandler.post(() -> {
+                if (provider != null && analysis != null) {
+                    provider.unbind(analysis);
+                    analysis = null;
+                }
+            });
+        }
+
+        @Override
+        public void close() {
+            stop();
+            analyzer.shutdownNow();
+        }
+
+        private void bind() {
+            if (!running) {
+                return;
+            }
+            var providerFuture = ProcessCameraProvider.getInstance(context);
+            providerFuture.addListener(() -> {
+                if (!running) {
+                    return;
+                }
+                try {
+                    ProcessCameraProvider nextProvider = providerFuture.get();
+                    if (!running) {
+                        return;
+                    }
+                    ImageAnalysis nextAnalysis = new ImageAnalysis.Builder()
+                            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                            .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
+                            .setTargetResolution(TARGET_RESOLUTION)
+                            .build();
+                    nextAnalysis.setAnalyzer(analyzer, this::onImage);
+                    if (analysis != null) {
+                        nextProvider.unbind(analysis);
+                    }
+                    nextProvider.bindToLifecycle(ProcessLifecycleOwner.get(),
+                            CameraSelector.DEFAULT_BACK_CAMERA, nextAnalysis);
+                    provider = nextProvider;
+                    analysis = nextAnalysis;
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException | RuntimeException ignored) {
+                    // The portable camera receives no frame and deterministically falls back.
+                }
+            }, mainHandler::post);
+        }
+
+        private void onImage(ImageProxy image) {
+            try {
+                if (!running || image.getFormat() != ImageFormat.RGBA_8888
+                        || image.getPlanes().length != 1) {
+                    return;
+                }
+                ImageProxy.PlaneProxy plane = image.getPlanes()[0];
+                CameraFrame frame = decodeRgba(plane.getBuffer(), image.getWidth(), image.getHeight(),
+                        plane.getRowStride(), plane.getPixelStride());
+                Consumer<CameraFrame> target = listener;
+                if (running && frame != null && target != null) {
+                    target.accept(frame);
+                }
+            } finally {
+                image.close();
+            }
+        }
+    }
+
+    private final Input input;
+    private final Consumer<CameraFrame> frames = this::accept;
+
+    private volatile CameraFrame latest;
+    private boolean enabled;
+    private boolean cartridgeActive;
+    private boolean hostActive = true;
+    private volatile boolean capturing;
+    private boolean closed;
+
+    AndroidCameraSource(Context context) {
+        this(new CameraXInput(context));
+    }
+
+    AndroidCameraSource(Input input) {
+        this.input = Objects.requireNonNull(input, "input");
+    }
+
+    synchronized void setEnabled(boolean enabled) {
+        if (closed) {
+            return;
+        }
+        this.enabled = enabled;
+        apply();
+    }
+
+    synchronized void setCartridgeActive(boolean active) {
+        if (closed || cartridgeActive == active) {
+            return;
+        }
+        cartridgeActive = active;
+        apply();
+    }
+
+    synchronized void pause() {
+        hostActive = false;
+        apply();
+    }
+
+    synchronized void resume() {
+        hostActive = true;
+        apply();
+    }
+
+    @Override
+    public CameraFrame getFrame() {
+        return capturing ? latest : null;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        enabled = false;
+        cartridgeActive = false;
+        latest = null;
+        if (capturing) {
+            capturing = false;
+        }
+        try {
+            input.close();
+        } catch (Exception ignored) {
+            // Camera teardown must never prevent the controller from releasing its own resources.
+        }
+    }
+
+    private synchronized void accept(CameraFrame frame) {
+        if (capturing) {
+            latest = frame;
+        }
+    }
+
+    private void apply() {
+        boolean shouldCapture = enabled && cartridgeActive && hostActive && !closed;
+        if (shouldCapture == capturing) {
+            return;
+        }
+        capturing = shouldCapture;
+        latest = null;
+        if (shouldCapture) {
+            input.start(frames);
+        } else {
+            input.stop();
+        }
+    }
+
+    static CameraFrame decodeRgba(ByteBuffer bytes, int width, int height, int rowStride,
+                                  int pixelStride) {
+        if (width < 1 || height < 1 || rowStride < 1 || pixelStride < 4) {
+            return null;
+        }
+        try {
+            ByteBuffer source = Objects.requireNonNull(bytes, "bytes").slice();
+            long finalOffset = Math.addExact(
+                    Math.addExact(Math.multiplyExact((long) height - 1L, rowStride),
+                            Math.multiplyExact((long) width - 1L, pixelStride)), 3L);
+            if (finalOffset >= source.remaining()) {
+                return null;
+            }
+            int[] rgb = new int[Math.multiplyExact(width, height)];
+            for (int y = 0; y < height; y++) {
+                int row = Math.multiplyExact(y, rowStride);
+                for (int x = 0; x < width; x++) {
+                    int offset = Math.addExact(row, Math.multiplyExact(x, pixelStride));
+                    rgb[y * width + x] = ((source.get(offset) & 0xff) << 16)
+                            | ((source.get(offset + 1) & 0xff) << 8)
+                            | (source.get(offset + 2) & 0xff);
+                }
+            }
+            return new CameraFrame(width, height, rgb);
+        } catch (ArithmeticException | IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -17,9 +17,11 @@ import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.RomImage;
 import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
+import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera;
 import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 
@@ -80,8 +82,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private volatile AndroidAudioSink audio;
     private volatile AndroidRumbleSink rumble;
     private volatile AndroidTiltSink tilt;
+    private volatile AndroidCameraSource camera;
     private AndroidPrinterStore printer;
     private boolean printerEnabled;
+    private boolean cameraEnabled;
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
@@ -93,6 +97,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private long activeOpenRequestId;
     private long tiltOpenRequestId;
     private boolean tiltRequiredForOpenRequest;
+    private long cameraOpenRequestId;
+    private boolean cameraRequiredForOpenRequest;
     private long nextFlushRequestId;
     private long pendingFlushRequestId;
     private ScheduledFuture<?> flushDeadline;
@@ -149,6 +155,17 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
+    /** Enables live Pocket Camera capture after the user grants the optional camera permission. */
+    void setCameraEnabled(boolean enabled) {
+        submit(() -> {
+            cameraEnabled = enabled;
+            AndroidCameraSource activeCamera = camera;
+            if (activeCamera != null) {
+                activeCamera.setEnabled(enabled);
+            }
+        });
+    }
+
     /** Connects or disconnects the portable Game Boy Printer at the controller-safe boundary. */
     void setPrinterEnabled(boolean enabled) {
         submit(() -> {
@@ -191,6 +208,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         AndroidTiltSink activeTilt = tilt;
         if (activeTilt != null) {
             activeTilt.pause();
+        }
+        AndroidCameraSource activeCamera = camera;
+        if (activeCamera != null) {
+            activeCamera.pause();
         }
         submit(() -> {
             if (controller != null && activeLayout != null) {
@@ -375,6 +396,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeTilt != null) {
             activeTilt.pause();
         }
+        AndroidCameraSource activeCamera = camera;
+        if (activeCamera != null) {
+            activeCamera.pause();
+        }
         submit(() -> {
             if (controller == null) {
                 return;
@@ -410,6 +435,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             AndroidTiltSink activeTilt = tilt;
             if (activeTilt != null) {
                 activeTilt.resume();
+            }
+            AndroidCameraSource activeCamera = camera;
+            if (activeCamera != null) {
+                activeCamera.resume();
             }
             lifecycle.resumedByUser();
             eventBus.post(new Controller.ResumeEmulationEvent());
@@ -567,6 +596,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         audio.start();
         rumble = new AndroidRumbleSink(context, eventBus, false);
         tilt = new AndroidTiltSink(context, eventBus);
+        camera = new AndroidCameraSource(context);
+        camera.setEnabled(cameraEnabled);
+        PocketCamera.setCameraSource(camera);
         printer = new AndroidPrinterStore();
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
@@ -591,6 +623,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         if (activeTilt != null) {
                             activeTilt.setCartridgeActive(tiltOpenRequestId
                                     == activeOpenRequestId && tiltRequiredForOpenRequest);
+                        }
+                        AndroidCameraSource activeCamera = camera;
+                        if (activeCamera != null) {
+                            activeCamera.setCartridgeActive(cameraOpenRequestId
+                                    == activeOpenRequestId && cameraRequiredForOpenRequest);
                         }
                         if (currentSource != null) {
                             new RecentSafDocuments(context).recordIfPersisted(currentSource);
@@ -707,6 +744,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeOpenRequestId = ++nextOpenRequestId;
             tiltOpenRequestId = activeOpenRequestId;
             tiltRequiredForOpenRequest = rom.getType().isMbc7();
+            cameraOpenRequestId = activeOpenRequestId;
+            cameraRequiredForOpenRequest = rom.getType().isPocketCamera()
+                    || rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.POCKET_CAMERA;
             publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
                     false, true, false);
             controllerEventBus().post(new Controller.LoadRomEvent(
@@ -819,12 +859,14 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         AndroidAudioSink activeAudio = audio;
         AndroidRumbleSink activeRumble = rumble;
         AndroidTiltSink activeTilt = tilt;
+        AndroidCameraSource activeCamera = camera;
         AndroidPrinterStore activePrinter = printer;
         controller = null;
         eventBus = null;
         audio = null;
         rumble = null;
         tilt = null;
+        camera = null;
         printer = null;
         if (active == null) {
             if (activeAudio != null) {
@@ -836,6 +878,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             if (activeTilt != null) {
                 activeTilt.close();
             }
+            if (activeCamera != null) {
+                activeCamera.close();
+            }
+            PocketCamera.setCameraSource(null);
             return true;
         }
         try {
@@ -849,6 +895,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             if (activeTilt != null) {
                 activeTilt.close();
             }
+            if (activeCamera != null) {
+                activeCamera.close();
+            }
+            PocketCamera.setCameraSource(null);
             lifecycle.released();
             return true;
         } catch (RuntimeException failure) {
@@ -858,6 +908,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             audio = activeAudio;
             rumble = activeRumble;
             tilt = activeTilt;
+            camera = activeCamera;
             printer = activePrinter;
             return false;
         }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1,11 +1,13 @@
 package eu.rekawek.coffeegb.android;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ClipData;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
 import android.hardware.input.InputManager;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -41,6 +43,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final int EXPORT_STATE_REQUEST = 5;
     private static final int EXPORT_SCREENSHOT_REQUEST = 6;
     private static final int EXPORT_PRINTER_REQUEST = 7;
+    private static final int CAMERA_PERMISSION_REQUEST = 8;
 
     private TextView status;
     private CoffeeGbSurfaceView video;
@@ -96,6 +99,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             runtime.setAudioVolume(getPreferences(MODE_PRIVATE).getInt("audio.volume", 100));
             runtime.setRumbleEnabled(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
             runtime.setPrinterEnabled(getPreferences(MODE_PRIVATE).getBoolean("devices.printer", false));
+            if (getPreferences(MODE_PRIVATE).getBoolean("devices.camera", false)
+                    && checkSelfPermission(Manifest.permission.CAMERA)
+                    == PackageManager.PERMISSION_GRANTED) {
+                runtime.setCameraEnabled(true);
+            }
             applyState(runtime.state());
         }
 
@@ -277,6 +285,21 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                     "Export printer paper?", "The chosen document will be replaced.",
                     () -> runtime.exportPrinter(data.getData(), () -> sharePrinter(data.getData())));
             default -> { }
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode != CAMERA_PERMISSION_REQUEST || runtime == null) {
+            return;
+        }
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            runtime.setCameraEnabled(true);
+        } else {
+            runtime.setCameraEnabled(false);
+            Toast.makeText(this, "Pocket Camera will use its test pattern until camera access is allowed.",
+                    Toast.LENGTH_LONG).show();
         }
     }
 
@@ -544,6 +567,10 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         rumble.setText("Rumble when supported by the game and device");
         rumble.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.rumble", false));
         options.addView(rumble);
+        Switch camera = new Switch(this);
+        camera.setText("Use live camera for Pocket Camera cartridges");
+        camera.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.camera", false));
+        options.addView(camera);
         Switch printer = new Switch(this);
         printer.setText("Emulate the Game Boy Printer");
         printer.setChecked(getPreferences(MODE_PRIVATE).getBoolean("devices.printer", false));
@@ -568,12 +595,30 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 .setMessage("Tilt, camera, and printer integrations require a compatible cartridge and are configured only when available.")
                 .setNegativeButton("Cancel", null).setPositiveButton("Save", (dialog, which) -> {
                     getPreferences(MODE_PRIVATE).edit().putBoolean("devices.rumble", rumble.isChecked()).apply();
+                    getPreferences(MODE_PRIVATE).edit().putBoolean("devices.camera", camera.isChecked()).apply();
                     getPreferences(MODE_PRIVATE).edit().putBoolean("devices.printer", printer.isChecked()).apply();
                     requireRuntime(active -> {
                         active.setRumbleEnabled(rumble.isChecked());
                         active.setPrinterEnabled(printer.isChecked());
                     });
+                    if (camera.isChecked()) {
+                        enableCameraIfPermitted();
+                    } else {
+                        requireRuntime(active -> active.setCameraEnabled(false));
+                    }
                 }).show();
+    }
+
+    private void enableCameraIfPermitted() {
+        if (runtime == null) {
+            return;
+        }
+        if (checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+            runtime.setCameraEnabled(true);
+            return;
+        }
+        runtime.setCameraEnabled(false);
+        requestPermissions(new String[]{Manifest.permission.CAMERA}, CAMERA_PERMISSION_REQUEST);
     }
 
     private void showPrinterPreview(AndroidEmulationRuntime active) {
@@ -610,7 +655,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     private void showAbout() {
         new AlertDialog.Builder(this).setTitle("About Coffee GB Android")
-                .setMessage("Coffee GB is GPL-3.0-or-later software. This MVP opens GB, GBC, and ZIP documents you select, stores saves privately by ROM identity, and exports only when you choose a document. It requests no network, broad storage, microphone, or camera permission. Optional rumble uses Android's normal vibration permission only when enabled.\n\nSource and third-party notices: github.com/trekawek/coffee-gb")
+                .setMessage("Coffee GB is GPL-3.0-or-later software. This MVP opens GB, GBC, and ZIP documents you select, stores saves privately by ROM identity, and exports only when you choose a document. It requests no network, broad storage, or microphone permission. Camera access is requested only after you enable live Pocket Camera capture; optional rumble uses Android's normal vibration permission only when enabled.\n\nSource and third-party notices: github.com/trekawek/coffee-gb")
                 .setPositiveButton("OK", null).show();
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidCameraSourceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidCameraSourceTest.java
@@ -1,0 +1,86 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.core.memory.cart.type.CameraFrame;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class AndroidCameraSourceTest {
+
+    @Test
+    public void capturesOnlyForAnEnabledForegroundPocketCameraCartridge() {
+        FakeInput input = new FakeInput();
+        AndroidCameraSource source = new AndroidCameraSource(input);
+        CameraFrame frame = new CameraFrame(1, 1, new int[]{0x00112233});
+
+        source.setEnabled(true);
+        assertEquals(0, input.starts);
+        source.setCartridgeActive(true);
+        assertEquals(1, input.starts);
+        input.publish(frame);
+        assertSame(frame, source.getFrame());
+
+        source.pause();
+        assertEquals(1, input.stops);
+        assertNull(source.getFrame());
+        source.resume();
+        assertEquals(2, input.starts);
+        input.publish(frame);
+        source.setEnabled(false);
+        assertEquals(2, input.stops);
+        assertNull(source.getFrame());
+
+        source.close();
+        assertEquals(1, input.closes);
+    }
+
+    @Test
+    public void decodesRgbaWithRowPaddingWithoutRetainingTheBuffer() {
+        ByteBuffer rgba = ByteBuffer.wrap(new byte[]{
+                0x11, 0x22, 0x33, 0x44, 0, 0, 0, 0,
+                0x55, 0x66, 0x77, (byte) 0x88, 0, 0, 0, 0,
+        });
+
+        CameraFrame frame = AndroidCameraSource.decodeRgba(rgba, 1, 2, 8, 4);
+
+        assertArrayEquals(new int[]{0x00112233, 0x00556677}, frame.copyRgb());
+        rgba.put(0, (byte) 0xff);
+        assertArrayEquals(new int[]{0x00112233, 0x00556677}, frame.copyRgb());
+        assertNull(AndroidCameraSource.decodeRgba(ByteBuffer.wrap(new byte[3]), 1, 1, 4, 4));
+    }
+
+    private static final class FakeInput implements AndroidCameraSource.Input {
+        private Consumer<CameraFrame> listener;
+        private int starts;
+        private int stops;
+        private int closes;
+
+        @Override
+        public void start(Consumer<CameraFrame> listener) {
+            starts++;
+            this.listener = listener;
+        }
+
+        @Override
+        public void stop() {
+            stops++;
+            listener = null;
+        }
+
+        @Override
+        public void close() {
+            closes++;
+            listener = null;
+        }
+
+        private void publish(CameraFrame frame) {
+            listener.accept(frame);
+        }
+    }
+}


### PR DESCRIPTION
Completes the Pocket Camera part of #319 phase 8.

- requests CAMERA only when the user enables optional live capture
- uses CameraX latest-frame analysis while a compatible cartridge and the app are active
- falls back to Coffee GB portable synthetic camera when live capture is unavailable
- covers lifecycle gating, padded RGBA extraction, and immutable frames with a fakeable adapter

Validation:
- git diff --check
- Android debug and instrumentation dependency configurations resolve successfully
- Android unit tests require an SDK unavailable in this local environment; PR CI covers the full Android build