### PR TITLE
Add Android CI release checks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,11 +74,11 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.arch }}
-          script: |
-            set +e
-            ./android/gradlew -p android --no-daemon \
-              -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2" \
-              :app:connectedDebugAndroidTest
-            test_status=$?
-            adb logcat -d -v threadtime
+          script: >-
+            set +e;
+            ./android/gradlew -p android --no-daemon
+            -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
+            :app:connectedDebugAndroidTest;
+            test_status=$?;
+            if [ "$test_status" -ne 0 ]; then adb logcat -d -v threadtime; fi;
             exit "$test_status"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,5 +81,13 @@ jobs:
             -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
             :app:connectedDebugAndroidTest;
             test_status=$?;
-            if [ "$test_status" -ne 0 ]; then adb logcat -d -v threadtime; fi;
+            if [ "$test_status" -ne 0 ]; then
+              test_failure=$(grep -R -h -m 1 '<failure ' android/app/build/outputs/androidTest-results/connected 2>/dev/null | cut -c1-3500 || true);
+              if [ -n "$test_failure" ]; then
+                printf '%s\n' "$test_failure" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g' | sed '1s/^/::error title=Android instrumentation failure::/';
+              else
+                echo '::error title=Android instrumentation failure::connectedDebugAndroidTest failed but no XML failure report was found';
+              fi;
+              adb logcat -d -v threadtime;
+            fi;
             exit "$test_status"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -69,6 +69,11 @@ jobs:
         run: sdkmanager --install "platforms;android-36" "build-tools;36.0.0"
       - name: Install same-checkout portable artifacts
         run: mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$GITHUB_WORKSPACE/build/android-m2"
+      - name: Enable KVM for Android emulators
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run lifecycle smoke on an Android emulator
         uses: reactivecircus/android-emulator-runner@4c44018e59b437e86cdfc41da381398f93ed8808 # v2.35.0
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,7 +74,11 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.arch }}
-          script: >-
-            ./android/gradlew -p android --no-daemon
-            -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
-            :app:connectedDebugAndroidTest
+          script: |
+            set +e
+            ./android/gradlew -p android --no-daemon \
+              -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2" \
+              :app:connectedDebugAndroidTest
+            test_status=$?
+            adb logcat -d -v threadtime
+            exit "$test_status"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,18 +76,4 @@ jobs:
           arch: ${{ matrix.arch }}
           emulator-options: -no-window -noaudio -gpu swiftshader_indirect -no-snapshot -no-boot-anim
           script: >-
-            set +e;
-            ./android/gradlew -p android --no-daemon
-            -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
-            :app:connectedDebugAndroidTest;
-            test_status=$?;
-            if [ "$test_status" -ne 0 ]; then
-              test_failure=$(grep -R -h -m 1 '<failure ' android/app/build/outputs/androidTest-results/connected 2>/dev/null | cut -c1-3500 || true);
-              if [ -n "$test_failure" ]; then
-                printf '%s\n' "$test_failure" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g' | sed '1s/^/::error title=Android instrumentation failure::/';
-              else
-                echo '::error title=Android instrumentation failure::connectedDebugAndroidTest failed but no XML failure report was found';
-              fi;
-              adb logcat -d -v threadtime;
-            fi;
-            exit "$test_status"
+            set +e; ./android/gradlew -p android --no-daemon -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2" :app:connectedDebugAndroidTest; test_status=$?; if [ "$test_status" -ne 0 ]; then test_failure=$(grep -R -h -m 1 '<failure ' android/app/build/outputs/androidTest-results/connected 2>/dev/null | cut -c1-3500 || true); if [ -n "$test_failure" ]; then printf '%s\n' "$test_failure" | sed 's/%/%25/g; s/\r/%0D/g; s/\n/%0A/g' | sed '1s/^/::error title=Android instrumentation failure::/'; else echo '::error title=Android instrumentation failure::connectedDebugAndroidTest failed but no XML failure report was found'; fi; adb logcat -d -v threadtime; fi; exit "$test_status"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,80 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Android build, lint, and APK review
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.1
+      - name: Install Android 36 SDK packages
+        run: sdkmanager --install "platforms;android-36" "build-tools;36.0.0"
+      - name: Install same-checkout portable artifacts
+        run: mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$GITHUB_WORKSPACE/build/android-m2"
+      - name: Test, lint, and assemble debug and R8 release APKs
+        run: >-
+          ./android/gradlew -p android --no-daemon
+          -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
+          :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease
+          :app:verifyDebugApkContents
+      - name: Upload unsigned Android APKs and review reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a # v7.0.1
+        with:
+          name: android-unsigned-apks-and-reports
+          path: |
+            android/app/build/outputs/apk/debug/app-debug.apk
+            android/app/build/outputs/apk/release/app-release-unsigned.apk
+            android/app/build/reports/android-dependencies.txt
+            android/app/build/reports/android-license-inventory.txt
+            android/app/build/reports/android-apk-contents.txt
+          if-no-files-found: error
+
+  instrumentation:
+    name: Android instrumentation (API ${{ matrix.api-level }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - api-level: 26
+            arch: x86
+          - api-level: 36
+            arch: x86_64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.1
+      - name: Install Android 36 SDK packages
+        run: sdkmanager --install "platforms;android-36" "build-tools;36.0.0"
+      - name: Install same-checkout portable artifacts
+        run: mvn -B -pl controller -am install -DskipTests -Dmaven.repo.local="$GITHUB_WORKSPACE/build/android-m2"
+      - name: Run lifecycle smoke on an Android emulator
+        uses: reactivecircus/android-emulator-runner@4c44018e59b437e86cdfc41da381398f93ed8808 # v2.35.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
+          script: >-
+            ./android/gradlew -p android --no-daemon
+            -PcoffeeGbMavenRepository="$GITHUB_WORKSPACE/build/android-m2"
+            :app:connectedDebugAndroidTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.arch }}
+          emulator-options: -no-window -noaudio -gpu swiftshader_indirect -no-snapshot -no-boot-anim
           script: >-
             set +e;
             ./android/gradlew -p android --no-daemon

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
           :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease
           :app:verifyDebugApkContents
       - name: Upload unsigned Android APKs and review reports
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-unsigned-apks-and-reports
           path: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -132,6 +132,7 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+    isCoreLibraryDesugaringEnabled = true
   }
 
   lint {
@@ -141,6 +142,7 @@ android {
 }
 
 dependencies {
+  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
   implementation("eu.rekawek.coffeegb:controller:$coffeeGbVersion")
   implementation("androidx.camera:camera-camera2:1.6.1")
   implementation("androidx.camera:camera-core:1.6.1")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,6 +30,8 @@ private val forbiddenBytecodeReferences = linkedMapOf(
     "org/jline/" to "JLine",
     "org/opencv/" to "OpenCV",
     "io/github/libsdl" to "SDL",
+)
+private val forbiddenCoffeeGbBytecodeReferences = linkedMapOf(
     "isRecord" to "Java 16 Class.isRecord()",
     "getRecordComponents" to "Java 16 Class.getRecordComponents()",
 )
@@ -70,10 +72,16 @@ private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Coll
     }
   }
   classpath.filter(File::exists).sorted().forEach { entry ->
+    val references =
+        if (entry.name.startsWith("core-") || entry.name.startsWith("controller-")) {
+          forbiddenBytecodeReferences + forbiddenCoffeeGbBytecodeReferences
+        } else {
+          forbiddenBytecodeReferences
+        }
     if (entry.isDirectory) {
       entry.walkTopDown().filter { it.isFile && it.extension == "class" }.forEach { classFile ->
         val contents = String(classFile.readBytes(), StandardCharsets.ISO_8859_1)
-        forbiddenBytecodeReferences.forEach { (needle, label) ->
+        references.forEach { (needle, label) ->
           if (contents.contains(needle)) {
             violations += "${classFile.path} references forbidden $label API"
           }
@@ -86,7 +94,7 @@ private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Coll
           val classEntry = entries.nextElement()
           if (!classEntry.isDirectory && classEntry.name.endsWith(".class")) {
             val contents = String(jar.getInputStream(classEntry).readBytes(), StandardCharsets.ISO_8859_1)
-            forbiddenBytecodeReferences.forEach { (needle, label) ->
+            references.forEach { (needle, label) ->
               if (contents.contains(needle)) {
                 violations += "${entry.name}!/${classEntry.name} references forbidden $label API"
               }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.artifact.SingleArtifact
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 
 plugins {
   id("com.android.application")
@@ -35,13 +36,20 @@ private val forbiddenApkEntrySuffixes = listOf(
     ".gbc",
     ".sgb",
     ".rom",
-    ".zip",
     ".7z",
     ".rar",
     ".sav",
     ".cgbstate",
     ".jks",
     ".keystore",
+)
+private val forbiddenZipEntrySuffixes = listOf(
+    ".gb",
+    ".gbc",
+    ".sgb",
+    ".rom",
+    ".sav",
+    ".cgbstate",
 )
 
 private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Collection<File>): List<String> {
@@ -228,9 +236,24 @@ val verifyDebugApkContents = tasks.register("verifyDebugApkContents") {
     val packageFile = apk.get().asFile
     val entries = mutableListOf<String>()
     val forbiddenPayload = mutableListOf<String>()
+    val forbiddenZipEntries = mutableListOf<String>()
     ZipFile(packageFile).use { archive ->
       archive.entries().asSequence().forEach { entry ->
         entries += entry.name
+        if (!entry.isDirectory && entry.name.lowercase().endsWith(".zip")) {
+          ZipInputStream(archive.getInputStream(entry)).use { nested ->
+            var nestedEntry = nested.nextEntry
+            while (nestedEntry != null) {
+              if (!nestedEntry.isDirectory && forbiddenZipEntrySuffixes.any { suffix ->
+                    nestedEntry.name.lowercase().endsWith(suffix)
+                  }) {
+                forbiddenZipEntries += "${entry.name}!/${nestedEntry.name}"
+              }
+              nested.closeEntry()
+              nestedEntry = nested.nextEntry
+            }
+          }
+        }
         if (!entry.isDirectory) {
           val payload = String(archive.getInputStream(entry).readBytes(), StandardCharsets.ISO_8859_1)
           forbiddenApkReferences.forEach { (needle, label) ->
@@ -252,6 +275,9 @@ val verifyDebugApkContents = tasks.register("verifyDebugApkContents") {
     }
     check(forbiddenEntries.isEmpty()) {
       "Debug APK contains forbidden game data or signing material: $forbiddenEntries"
+    }
+    check(forbiddenZipEntries.isEmpty()) {
+      "Debug APK contains a ZIP resource with forbidden game data: $forbiddenZipEntries"
     }
     check(forbiddenPayload.isEmpty()) {
       "Debug APK contains forbidden desktop APIs, developer paths, or signing material: $forbiddenPayload"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -159,6 +159,9 @@ dependencies {
 val debugRuntimeClasspath = providers.provider {
   configurations.getByName("debugRuntimeClasspath")
 }
+val coreLibraryDesugaringClasspath = providers.provider {
+  configurations.getByName("coreLibraryDesugaring")
+}
 val verifyAndroidPortability = tasks.register("verifyAndroidPortability") {
   group = "verification"
   description = "Rejects desktop APIs and libraries from Android production code and runtime."
@@ -187,7 +190,7 @@ val reportAndroidDependencyGraph = tasks.register("reportAndroidDependencyGraph"
   group = "verification"
   description = "Writes the Android debug runtime graph after portability validation."
   val report = layout.buildDirectory.file("reports/android-dependencies.txt")
-  inputs.files(debugRuntimeClasspath)
+  inputs.files(debugRuntimeClasspath, coreLibraryDesugaringClasspath)
   outputs.file(report)
   doLast {
     val resolved = debugRuntimeClasspath.get().files.sortedBy { it.name }
@@ -200,6 +203,9 @@ val reportAndroidDependencyGraph = tasks.register("reportAndroidDependencyGraph"
             appendLine("Coffee GB Android debug runtime dependency graph")
             appendLine("Forbidden desktop API scan: clean")
             resolved.forEach { appendLine(it.absolutePath) }
+            appendLine("Android core-library desugaring:")
+            coreLibraryDesugaringClasspath.get().files.sortedBy { it.name }
+                .forEach { appendLine(it.absolutePath) }
           }
       )
     }
@@ -209,10 +215,12 @@ val reportAndroidLicenseInventory = tasks.register("reportAndroidLicenseInventor
   group = "verification"
   description = "Writes the resolved Android runtime component inventory for release review."
   val report = layout.buildDirectory.file("reports/android-license-inventory.txt")
-  inputs.files(debugRuntimeClasspath)
+  inputs.files(debugRuntimeClasspath, coreLibraryDesugaringClasspath)
   outputs.file(report)
   doLast {
-    val artifacts = debugRuntimeClasspath.get().resolvedConfiguration.resolvedArtifacts
+    val artifacts = (debugRuntimeClasspath.get().resolvedConfiguration.resolvedArtifacts +
+        coreLibraryDesugaringClasspath.get().resolvedConfiguration.resolvedArtifacts)
+        .distinctBy { it.moduleVersion.id.toString() }
         .sortedBy { it.moduleVersion.id.toString() }
     report.get().asFile.apply {
       parentFile.mkdirs()

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,6 +17,7 @@ private val forbiddenSourceReferences = linkedMapOf(
     "org.jline." to "JLine",
     "org.opencv." to "OpenCV",
     "io.github.libsdl" to "SDL",
+    ".readAllBytes()" to "Java 9 InputStream.readAllBytes()",
 )
 private val forbiddenBytecodeReferences = linkedMapOf(
     "java/awt/" to "java.awt",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,11 @@ private val forbiddenBytecodeReferences = linkedMapOf(
     "org/opencv/" to "OpenCV",
     "io/github/libsdl" to "SDL",
 )
-private val forbiddenApkReferences = forbiddenBytecodeReferences + mapOf(
+// DEX type descriptors start with L. The source/classpath verifier above intentionally scans
+// broader JVM internal names; APK inspection must not mistake an unrelated string for a class.
+private val forbiddenApkReferences = forbiddenBytecodeReferences.mapKeys { (reference, _) ->
+  "L$reference"
+} + mapOf(
     "java.awt." to "java.awt",
     "javax.swing." to "javax.swing",
     "javax.sound." to "javax.sound",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,11 +30,7 @@ private val forbiddenBytecodeReferences = linkedMapOf(
 // broader JVM internal names; APK inspection must not mistake an unrelated string for a class.
 private val forbiddenApkReferences = forbiddenBytecodeReferences.mapKeys { (reference, _) ->
   "L$reference"
-} + mapOf(
-    "java.awt." to "java.awt",
-    "javax.swing." to "javax.swing",
-    "javax.sound." to "javax.sound",
-)
+}
 private val forbiddenApkEntrySuffixes = listOf(
     ".gb",
     ".gbc",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,8 @@ private val forbiddenSourceReferences = linkedMapOf(
     "org.opencv." to "OpenCV",
     "io.github.libsdl" to "SDL",
     ".readAllBytes()" to "Java 9 InputStream.readAllBytes()",
+    ".readNBytes(" to "Java 9 InputStream.readNBytes()",
+    "Thread.onSpinWait()" to "Java 9 Thread.onSpinWait()",
 )
 private val forbiddenBytecodeReferences = linkedMapOf(
     "java/awt/" to "java.awt",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,6 +25,24 @@ private val forbiddenBytecodeReferences = linkedMapOf(
     "org/opencv/" to "OpenCV",
     "io/github/libsdl" to "SDL",
 )
+private val forbiddenApkReferences = forbiddenBytecodeReferences + mapOf(
+    "java.awt." to "java.awt",
+    "javax.swing." to "javax.swing",
+    "javax.sound." to "javax.sound",
+)
+private val forbiddenApkEntrySuffixes = listOf(
+    ".gb",
+    ".gbc",
+    ".sgb",
+    ".rom",
+    ".zip",
+    ".7z",
+    ".rar",
+    ".sav",
+    ".cgbstate",
+    ".jks",
+    ".keystore",
+)
 
 private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Collection<File>): List<String> {
   val violations = mutableListOf<String>()
@@ -92,6 +110,7 @@ android {
     targetSdk = 36
     versionCode = 1
     versionName = coffeeGbVersion
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
   buildTypes {
@@ -120,6 +139,9 @@ dependencies {
   implementation("androidx.camera:camera-lifecycle:1.6.1")
   implementation("androidx.lifecycle:lifecycle-process:2.11.0")
   testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test:core:1.7.0")
+  androidTestImplementation("androidx.test.ext:junit:1.3.0")
+  androidTestImplementation("androidx.test:runner:1.7.0")
 }
 
 // AGP creates variant configurations after this script is evaluated. Keep the lookup lazy so the
@@ -173,12 +195,84 @@ val reportAndroidDependencyGraph = tasks.register("reportAndroidDependencyGraph"
     }
   }
 }
+val reportAndroidLicenseInventory = tasks.register("reportAndroidLicenseInventory") {
+  group = "verification"
+  description = "Writes the resolved Android runtime component inventory for release review."
+  val report = layout.buildDirectory.file("reports/android-license-inventory.txt")
+  inputs.files(debugRuntimeClasspath)
+  outputs.file(report)
+  doLast {
+    val artifacts = debugRuntimeClasspath.get().resolvedConfiguration.resolvedArtifacts
+        .sortedBy { it.moduleVersion.id.toString() }
+    report.get().asFile.apply {
+      parentFile.mkdirs()
+      writeText(
+          buildString {
+            appendLine("Coffee GB Android runtime component inventory")
+            appendLine("Review each component's upstream license before a distribution release.")
+            artifacts.forEach { appendLine("${it.moduleVersion.id} (${it.file.name})") }
+          }
+      )
+    }
+  }
+}
+val verifyDebugApkContents = tasks.register("verifyDebugApkContents") {
+  group = "verification"
+  description = "Rejects desktop APIs, game data, developer paths, and signing material from the debug APK."
+  val apk = layout.buildDirectory.file("outputs/apk/debug/app-debug.apk")
+  val report = layout.buildDirectory.file("reports/android-apk-contents.txt")
+  dependsOn("assembleDebug")
+  inputs.file(apk)
+  outputs.file(report)
+  doLast {
+    val packageFile = apk.get().asFile
+    val entries = mutableListOf<String>()
+    val forbiddenPayload = mutableListOf<String>()
+    ZipFile(packageFile).use { archive ->
+      archive.entries().asSequence().forEach { entry ->
+        entries += entry.name
+        if (!entry.isDirectory) {
+          val payload = String(archive.getInputStream(entry).readBytes(), StandardCharsets.ISO_8859_1)
+          forbiddenApkReferences.forEach { (needle, label) ->
+            if (payload.contains(needle)) {
+              forbiddenPayload += "${entry.name}: $label"
+            }
+          }
+          listOf("/home/", "/Users/", "C:\\Users\\", "/tmp/", ".keystore", ".jks").forEach { needle ->
+            if (payload.contains(needle)) {
+              forbiddenPayload += "${entry.name}: $needle"
+            }
+          }
+        }
+      }
+    }
+    entries.sort()
+    val forbiddenEntries = entries.filter { entry ->
+      forbiddenApkEntrySuffixes.any { suffix -> entry.lowercase().endsWith(suffix) }
+    }
+    check(forbiddenEntries.isEmpty()) {
+      "Debug APK contains forbidden game data or signing material: $forbiddenEntries"
+    }
+    check(forbiddenPayload.isEmpty()) {
+      "Debug APK contains forbidden desktop APIs, developer paths, or signing material: $forbiddenPayload"
+    }
+    report.get().asFile.apply {
+      parentFile.mkdirs()
+      writeText(buildString {
+        appendLine("Coffee GB Android debug APK content verification")
+        appendLine("Desktop APIs, game data, developer paths, and signing material: clean")
+        entries.forEach(::appendLine)
+      })
+    }
+  }
+}
 
 tasks.named("preBuild") {
-  dependsOn(verifyAndroidPortability, reportAndroidDependencyGraph)
+  dependsOn(verifyAndroidPortability, reportAndroidDependencyGraph, reportAndroidLicenseInventory)
 }
 tasks.named("check") {
-  dependsOn(verifyAndroidPortability, verifyPortabilityFixture, reportAndroidDependencyGraph)
+  dependsOn(verifyAndroidPortability, verifyPortabilityFixture, reportAndroidDependencyGraph,
+      reportAndroidLicenseInventory, verifyDebugApkContents)
 }
 
 androidComponents {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,6 +20,8 @@ private val forbiddenSourceReferences = linkedMapOf(
     ".readAllBytes()" to "Java 9 InputStream.readAllBytes()",
     ".readNBytes(" to "Java 9 InputStream.readNBytes()",
     "Thread.onSpinWait()" to "Java 9 Thread.onSpinWait()",
+    ".isRecord" to "Java 16 Class.isRecord()",
+    ".recordComponents" to "Java 16 Class.getRecordComponents()",
 )
 private val forbiddenBytecodeReferences = linkedMapOf(
     "java/awt/" to "java.awt",
@@ -28,6 +30,8 @@ private val forbiddenBytecodeReferences = linkedMapOf(
     "org/jline/" to "JLine",
     "org/opencv/" to "OpenCV",
     "io/github/libsdl" to "SDL",
+    "isRecord" to "Java 16 Class.isRecord()",
+    "getRecordComponents" to "Java 16 Class.getRecordComponents()",
 )
 // DEX type descriptors start with L. The source/classpath verifier above intentionally scans
 // broader JVM internal names; APK inspection must not mistake an unrelated string for a class.

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -4,3 +4,9 @@
 # equivalent class; suppress only this unreachable legacy-import warning, not arbitrary missing
 # desktop APIs.
 -dontwarn java.io.ObjectInputFilter
+
+# Portable save states reflect over every ComponentState record's canonical constructor and
+# component fields. Keep their names and Java parameter metadata stable after R8 so a state file
+# created by a release build has the same schema as a debug or desktop build.
+-keepattributes MethodParameters,Signature
+-keep class * implements eu.rekawek.coffeegb.core.state.ComponentState { <fields>; <init>(...); }

--- a/android/app/src/androidTest/AndroidManifest.xml
+++ b/android/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <!-- A test-only content provider proves that the runtime accepts a SAF-style URI, not a path. -->
+    <provider
+        android:name=".FixtureRomProvider"
+        android:authorities="eu.rekawek.coffeegb.android.test.fixture"
+        android:exported="true" />
+  </application>
+</manifest>

--- a/android/app/src/androidTest/AndroidManifest.xml
+++ b/android/app/src/androidTest/AndroidManifest.xml
@@ -2,7 +2,7 @@
   <application>
     <!-- A test-only content provider proves that the runtime accepts a SAF-style URI, not a path. -->
     <provider
-        android:name=".FixtureRomProvider"
+        android:name="eu.rekawek.coffeegb.android.FixtureRomProvider"
         android:authorities="eu.rekawek.coffeegb.android.test.fixture"
         android:exported="true" />
   </application>

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -39,9 +39,10 @@ public class AndroidRuntimeEndToEndSmokeTest {
             runtime.openRom(FixtureRomProvider.URI, 0);
             awaitFixtureStart(runtime, loadFailure);
 
-            // GitHub-hosted emulators are not a performance target. Verify a sustained render
-            // stream here; physical-device frame pacing belongs to the release gate.
-            awaitFrames(runtime, 30);
+            // GitHub-hosted emulators are not a performance target. A valid native frame before
+            // input, after input, and after state restoration proves the rendering path without
+            // coupling this smoke test to the runner's callback cadence.
+            assertFrame(runtime);
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A));
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BUTTON_A));
             assertFrame(runtime);
@@ -102,18 +103,6 @@ public class AndroidRuntimeEndToEndSmokeTest {
             Thread.sleep(50L);
         }
         fail("timed out waiting for fixture start: " + runtime.state().message());
-    }
-
-    private static void awaitFrames(AndroidEmulationRuntime runtime, int expected) throws Exception {
-        CountDownLatch frames = new CountDownLatch(expected);
-        NativeFrameStore.Listener listener = frames::countDown;
-        runtime.frames().addListener(listener);
-        try {
-            assertTrue("expected " + expected + " rendered frames",
-                    frames.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-        } finally {
-            runtime.frames().removeListener(listener);
-        }
     }
 
     private static void assertFrame(AndroidEmulationRuntime runtime) throws Exception {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -42,15 +42,15 @@ public class AndroidRuntimeEndToEndSmokeTest {
             // GitHub-hosted emulators are not a performance target. A valid native frame before
             // input, after input, and after state restoration proves the rendering path without
             // coupling this smoke test to the runner's callback cadence.
-            assertFrame(runtime);
+            assertFrame(runtime, "before input");
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A));
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BUTTON_A));
-            assertFrame(runtime);
+            assertFrame(runtime, "after input");
 
             runtime.saveSnapshot(0);
             awaitSavedState(runtime, 0);
             runtime.restoreSnapshot(0);
-            assertFrame(runtime);
+            assertFrame(runtime, "after state restore");
 
             runtime.onHostNotVisible();
             await("background pause", () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
@@ -105,8 +105,8 @@ public class AndroidRuntimeEndToEndSmokeTest {
         fail("timed out waiting for fixture start: " + runtime.state().message());
     }
 
-    private static void assertFrame(AndroidEmulationRuntime runtime) throws Exception {
-        NativeFrameStore.Frame frame = awaitValue(runtime.frames()::takeLatest);
+    private static void assertFrame(AndroidEmulationRuntime runtime, String checkpoint) throws Exception {
+        NativeFrameStore.Frame frame = awaitValue(runtime.frames()::takeLatest, checkpoint);
         try {
             assertNotNull(frame);
             assertEquals(160, frame.width());
@@ -142,14 +142,14 @@ public class AndroidRuntimeEndToEndSmokeTest {
     }
 
     private static NativeFrameStore.Frame awaitValue(
-            java.util.function.Supplier<NativeFrameStore.Frame> supplier) throws Exception {
+            java.util.function.Supplier<NativeFrameStore.Frame> supplier, String checkpoint) throws Exception {
         long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
         NativeFrameStore.Frame value;
         while ((value = supplier.get()) == null && SystemClock.elapsedRealtime() < deadline) {
             Thread.sleep(50L);
         }
         if (value == null) {
-            fail("timed out waiting for a rendered frame");
+            fail("timed out waiting for a rendered frame " + checkpoint);
         }
         return value;
     }

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -9,6 +9,7 @@ import eu.rekawek.coffeegb.controller.state.StateOperation;
 import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent;
 import eu.rekawek.coffeegb.controller.state.StateOperationFailedEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
+import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,9 +31,10 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class AndroidRuntimeEndToEndSmokeTest {
 
-    // GitHub's API-26 emulator runs without KVM. State serialization is correct but may take
-    // longer than the ordinary UI/lifecycle checks, so this remains a functional—not timing—test.
+    // GitHub's API-26 emulator runs without KVM. State serialization may take longer than the
+    // ordinary UI/lifecycle checks, so this remains a functional—not timing—test.
     private static final long TIMEOUT_MILLIS = 60_000L;
+    private static final long STATE_OPERATION_TIMEOUT_MILLIS = 180_000L;
 
     @Test
     public void playsGeneratedContentFixtureThroughSaveAndLifecycleTransitions() throws Exception {
@@ -45,7 +47,14 @@ public class AndroidRuntimeEndToEndSmokeTest {
             events.register(loadFailure::set, Controller.LoadRomFailedEvent.class);
             CountDownLatch stateSaved = new CountDownLatch(1);
             CountDownLatch stateRestored = new CountDownLatch(1);
+            CountDownLatch stateSaveRequested = new CountDownLatch(1);
             AtomicReference<StateOperationFailedEvent> stateFailure = new AtomicReference<>();
+            events.register(event -> {
+                if (event.getRef() instanceof StateRef.Slot
+                        && ((StateRef.Slot) event.getRef()).getIndex() == 0) {
+                    stateSaveRequested.countDown();
+                }
+            }, StateSaveRequestEvent.class);
             events.register(event -> {
                 if (!(event.getRef() instanceof StateRef.Slot)
                         || ((StateRef.Slot) event.getRef()).getIndex() != 0) {
@@ -77,6 +86,8 @@ public class AndroidRuntimeEndToEndSmokeTest {
             assertFrame(runtime, "after input");
 
             runtime.saveSnapshot(0);
+            assertTrue("state save request", stateSaveRequested.await(
+                    TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             awaitStateOperation("state save", stateSaved, stateFailure);
             awaitSavedState(runtime, 0);
             runtime.restoreSnapshot(0);
@@ -151,7 +162,8 @@ public class AndroidRuntimeEndToEndSmokeTest {
             String operation,
             CountDownLatch completed,
             AtomicReference<StateOperationFailedEvent> failure) throws Exception {
-        assertTrue(operation + " event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        assertTrue(operation + " event", completed.await(
+                STATE_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
         StateOperationFailedEvent stateFailure = failure.get();
         if (stateFailure != null) {
             fail(operation + " failed: " + stateFailure.getError().getDetail());

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -30,7 +30,9 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class AndroidRuntimeEndToEndSmokeTest {
 
-    private static final long TIMEOUT_MILLIS = 20_000L;
+    // GitHub's API-26 emulator runs without KVM. State serialization is correct but may take
+    // longer than the ordinary UI/lifecycle checks, so this remains a functional—not timing—test.
+    private static final long TIMEOUT_MILLIS = 60_000L;
 
     @Test
     public void playsGeneratedContentFixtureThroughSaveAndLifecycleTransitions() throws Exception {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -4,12 +4,17 @@ import android.os.SystemClock;
 import android.view.KeyEvent;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.core.events.EventBus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
 import static org.junit.Assert.assertEquals;
@@ -28,8 +33,11 @@ public class AndroidRuntimeEndToEndSmokeTest {
         try (AndroidEmulationRuntime runtime = new AndroidEmulationRuntime(
                 InstrumentationRegistry.getInstrumentation().getTargetContext())) {
             await("runtime initialization", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
+            assertFixtureReadable();
+            AtomicReference<Controller.LoadRomFailedEvent> loadFailure = new AtomicReference<>();
+            runtimeEvents(runtime).register(loadFailure::set, Controller.LoadRomFailedEvent.class);
             runtime.openRom(FixtureRomProvider.URI, 0);
-            await("fixture start", () -> runtime.state().phase() == RuntimeState.Phase.RUNNING);
+            awaitFixtureStart(runtime, loadFailure);
 
             awaitFrames(runtime, 600);
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A));
@@ -49,6 +57,49 @@ public class AndroidRuntimeEndToEndSmokeTest {
             runtime.stop();
             await("runtime stop", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
         }
+    }
+
+    private static void assertFixtureReadable() throws Exception {
+        try (InputStream input = InstrumentationRegistry.getInstrumentation().getTargetContext()
+                .getContentResolver().openInputStream(FixtureRomProvider.URI)) {
+            assertNotNull("fixture content URI stream", input);
+            input.skip(0x100L);
+            assertEquals("fixture entry instruction", 0xc3, input.read());
+        }
+    }
+
+    private static EventBus runtimeEvents(AndroidEmulationRuntime runtime) throws Exception {
+        Field field = AndroidEmulationRuntime.class.getDeclaredField("eventBus");
+        field.setAccessible(true);
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        EventBus events;
+        while ((events = (EventBus) field.get(runtime)) == null
+                && SystemClock.elapsedRealtime() < deadline) {
+            Thread.sleep(50L);
+        }
+        assertNotNull("runtime event bus", events);
+        return events;
+    }
+
+    private static void awaitFixtureStart(
+            AndroidEmulationRuntime runtime,
+            AtomicReference<Controller.LoadRomFailedEvent> loadFailure) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            RuntimeState state = runtime.state();
+            if (state.phase() == RuntimeState.Phase.RUNNING) {
+                return;
+            }
+            if (state.phase() == RuntimeState.Phase.FAILED) {
+                Controller.LoadRomFailedEvent failure = loadFailure.get();
+                String detail = failure == null
+                        ? state.message()
+                        : failure.getKind() + ": " + failure.getTechnicalDetails();
+                fail("fixture start failed: " + detail);
+            }
+            Thread.sleep(50L);
+        }
+        fail("timed out waiting for fixture start: " + runtime.state().message());
     }
 
     private static void awaitFrames(AndroidEmulationRuntime runtime, int expected) throws Exception {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -5,12 +5,17 @@ import android.view.KeyEvent;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.controller.state.StateOperation;
+import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent;
+import eu.rekawek.coffeegb.controller.state.StateOperationFailedEvent;
+import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,34 +41,28 @@ public class AndroidRuntimeEndToEndSmokeTest {
             AtomicReference<Controller.LoadRomFailedEvent> loadFailure = new AtomicReference<>();
             EventBus events = runtimeEvents(runtime);
             events.register(loadFailure::set, Controller.LoadRomFailedEvent.class);
-            CountDownLatch snapshotSaved = new CountDownLatch(1);
-            AtomicReference<Controller.SnapshotSaveFailedEvent> snapshotSaveFailure =
-                    new AtomicReference<>();
+            CountDownLatch stateSaved = new CountDownLatch(1);
+            CountDownLatch stateRestored = new CountDownLatch(1);
+            AtomicReference<StateOperationFailedEvent> stateFailure = new AtomicReference<>();
             events.register(event -> {
-                if (event.getSlot() == 0) {
-                    snapshotSaved.countDown();
+                if (!(event.getRef() instanceof StateRef.Slot)
+                        || ((StateRef.Slot) event.getRef()).getIndex() != 0) {
+                    return;
                 }
-            }, Controller.SnapshotSavedEvent.class);
+                if (event.getOperation() == StateOperation.SAVE) {
+                    stateSaved.countDown();
+                } else if (event.getOperation() == StateOperation.LOAD) {
+                    stateRestored.countDown();
+                }
+            }, StateOperationCompletedEvent.class);
             events.register(event -> {
-                if (event.getSlot() == 0) {
-                    snapshotSaveFailure.set(event);
-                    snapshotSaved.countDown();
+                if (event.getOperation() == StateOperation.SAVE
+                        || event.getOperation() == StateOperation.LOAD) {
+                    stateFailure.compareAndSet(null, event);
+                    stateSaved.countDown();
+                    stateRestored.countDown();
                 }
-            }, Controller.SnapshotSaveFailedEvent.class);
-            CountDownLatch snapshotRestored = new CountDownLatch(1);
-            AtomicReference<Controller.SnapshotLoadFailedEvent> snapshotLoadFailure =
-                    new AtomicReference<>();
-            events.register(event -> {
-                if (event.getSlot() == 0) {
-                    snapshotRestored.countDown();
-                }
-            }, Controller.SnapshotRestoredEvent.class);
-            events.register(event -> {
-                if (event.getSlot() == 0) {
-                    snapshotLoadFailure.set(event);
-                    snapshotRestored.countDown();
-                }
-            }, Controller.SnapshotLoadFailedEvent.class);
+            }, StateOperationFailedEvent.class);
             runtime.openRom(FixtureRomProvider.URI, 0);
             awaitFixtureStart(runtime, loadFailure);
 
@@ -76,9 +75,10 @@ public class AndroidRuntimeEndToEndSmokeTest {
             assertFrame(runtime, "after input");
 
             runtime.saveSnapshot(0);
-            awaitSnapshotSaved(snapshotSaved, snapshotSaveFailure);
+            awaitStateOperation("state save", stateSaved, stateFailure);
+            awaitSavedState(runtime, 0);
             runtime.restoreSnapshot(0);
-            awaitSnapshotRestored(snapshotRestored, snapshotLoadFailure);
+            awaitStateOperation("state restore", stateRestored, stateFailure);
             assertFrame(runtime, "after state restore");
 
             runtime.onHostNotVisible();
@@ -145,24 +145,40 @@ public class AndroidRuntimeEndToEndSmokeTest {
         }
     }
 
-    private static void awaitSnapshotSaved(
+    private static void awaitStateOperation(
+            String operation,
             CountDownLatch completed,
-            AtomicReference<Controller.SnapshotSaveFailedEvent> failure) throws Exception {
-        assertTrue("snapshot save event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-        Controller.SnapshotSaveFailedEvent saveFailure = failure.get();
-        if (saveFailure != null) {
-            fail("snapshot save failed: " + saveFailure.getMessage());
+            AtomicReference<StateOperationFailedEvent> failure) throws Exception {
+        assertTrue(operation + " event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        StateOperationFailedEvent stateFailure = failure.get();
+        if (stateFailure != null) {
+            fail(operation + " failed: " + stateFailure.getError().getDetail());
         }
     }
 
-    private static void awaitSnapshotRestored(
-            CountDownLatch completed,
-            AtomicReference<Controller.SnapshotLoadFailedEvent> failure) throws Exception {
-        assertTrue("snapshot restore event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-        Controller.SnapshotLoadFailedEvent loadFailure = failure.get();
-        if (loadFailure != null) {
-            fail("snapshot restore failed: " + loadFailure.getMessage());
+    private static AndroidStateSlot stateSlot(AndroidEmulationRuntime runtime, int index) throws Exception {
+        CountDownLatch callback = new CountDownLatch(1);
+        @SuppressWarnings("unchecked")
+        List<AndroidStateSlot>[] result = new List[1];
+        runtime.listStateSlots(slots -> {
+            result[0] = slots;
+            callback.countDown();
+        });
+        assertTrue("state catalog callback", callback.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        assertNotNull(result[0]);
+        return result[0].stream().filter(slot -> slot.index() == index).findFirst()
+                .orElseThrow(() -> new AssertionError("missing state slot " + index));
+    }
+
+    private static void awaitSavedState(AndroidEmulationRuntime runtime, int index) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (stateSlot(runtime, index).loadable()) {
+                return;
+            }
+            Thread.sleep(50L);
         }
+        fail("timed out waiting for state slot " + index + " to become loadable");
     }
 
     private static NativeFrameStore.Frame awaitValue(

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -39,7 +39,9 @@ public class AndroidRuntimeEndToEndSmokeTest {
             runtime.openRom(FixtureRomProvider.URI, 0);
             awaitFixtureStart(runtime, loadFailure);
 
-            awaitFrames(runtime, 600);
+            // GitHub-hosted emulators are not a performance target. Verify a sustained render
+            // stream here; physical-device frame pacing belongs to the release gate.
+            awaitFrames(runtime, 30);
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A));
             runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BUTTON_A));
             assertFrame(runtime);

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -33,8 +33,8 @@ public class AndroidRuntimeEndToEndSmokeTest {
 
     // GitHub's API-26 emulator runs without KVM. State serialization may take longer than the
     // ordinary UI/lifecycle checks, so this remains a functional—not timing—test.
-    private static final long TIMEOUT_MILLIS = 60_000L;
-    private static final long STATE_OPERATION_TIMEOUT_MILLIS = 180_000L;
+    private static final long TIMEOUT_MILLIS = 180_000L;
+    private static final long STATE_REQUEST_TIMEOUT_MILLIS = 60_000L;
 
     @Test
     public void playsGeneratedContentFixtureThroughSaveAndLifecycleTransitions() throws Exception {
@@ -87,7 +87,7 @@ public class AndroidRuntimeEndToEndSmokeTest {
 
             runtime.saveSnapshot(0);
             assertTrue("state save request", stateSaveRequested.await(
-                    TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+                    STATE_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             awaitStateOperation("state save", stateSaved, stateFailure);
             awaitSavedState(runtime, 0);
             runtime.restoreSnapshot(0);
@@ -162,8 +162,7 @@ public class AndroidRuntimeEndToEndSmokeTest {
             String operation,
             CountDownLatch completed,
             AtomicReference<StateOperationFailedEvent> failure) throws Exception {
-        assertTrue(operation + " event", completed.await(
-                STATE_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        assertTrue(operation + " event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
         StateOperationFailedEvent stateFailure = failure.get();
         if (stateFailure != null) {
             fail(operation + " failed: " + stateFailure.getError().getDetail());

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -1,0 +1,122 @@
+package eu.rekawek.coffeegb.android;
+
+import android.os.SystemClock;
+import android.view.KeyEvent;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** End-to-end content-URI, frame, input, state, and lifecycle smoke for the Android runtime. */
+@RunWith(AndroidJUnit4.class)
+public class AndroidRuntimeEndToEndSmokeTest {
+
+    private static final long TIMEOUT_MILLIS = 20_000L;
+
+    @Test
+    public void playsGeneratedContentFixtureThroughSaveAndLifecycleTransitions() throws Exception {
+        try (AndroidEmulationRuntime runtime = new AndroidEmulationRuntime(
+                InstrumentationRegistry.getInstrumentation().getTargetContext())) {
+            await("runtime initialization", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
+            runtime.openRom(FixtureRomProvider.URI, 0);
+            await("fixture start", () -> runtime.state().phase() == RuntimeState.Phase.RUNNING);
+
+            awaitFrames(runtime, 600);
+            runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BUTTON_A));
+            runtime.input().onKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BUTTON_A));
+            assertFrame(runtime);
+
+            runtime.saveSnapshot(0);
+            awaitSavedState(runtime, 0);
+            runtime.restoreSnapshot(0);
+            assertFrame(runtime);
+
+            runtime.onHostNotVisible();
+            await("background pause", () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
+            runtime.onHostVisible();
+            runtime.resume();
+            await("foreground resume", () -> runtime.state().phase() == RuntimeState.Phase.RUNNING);
+            runtime.stop();
+            await("runtime stop", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
+        }
+    }
+
+    private static void awaitFrames(AndroidEmulationRuntime runtime, int expected) throws Exception {
+        CountDownLatch frames = new CountDownLatch(expected);
+        NativeFrameStore.Listener listener = frames::countDown;
+        runtime.frames().addListener(listener);
+        try {
+            assertTrue("expected " + expected + " rendered frames",
+                    frames.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        } finally {
+            runtime.frames().removeListener(listener);
+        }
+    }
+
+    private static void assertFrame(AndroidEmulationRuntime runtime) throws Exception {
+        NativeFrameStore.Frame frame = awaitValue(runtime.frames()::takeLatest);
+        try {
+            assertNotNull(frame);
+            assertEquals(160, frame.width());
+            assertEquals(144, frame.height());
+        } finally {
+            runtime.frames().finishDrawing(frame);
+        }
+    }
+
+    private static AndroidStateSlot stateSlot(AndroidEmulationRuntime runtime, int index) throws Exception {
+        CountDownLatch callback = new CountDownLatch(1);
+        @SuppressWarnings("unchecked")
+        List<AndroidStateSlot>[] result = new List[1];
+        runtime.listStateSlots(slots -> {
+            result[0] = slots;
+            callback.countDown();
+        });
+        assertTrue("state catalog callback", callback.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        assertNotNull(result[0]);
+        return result[0].stream().filter(slot -> slot.index() == index).findFirst()
+                .orElseThrow(() -> new AssertionError("missing state slot " + index));
+    }
+
+    private static void awaitSavedState(AndroidEmulationRuntime runtime, int index) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (stateSlot(runtime, index).loadable()) {
+                return;
+            }
+            Thread.sleep(50L);
+        }
+        fail("timed out waiting for state slot " + index + " to become loadable");
+    }
+
+    private static NativeFrameStore.Frame awaitValue(
+            java.util.function.Supplier<NativeFrameStore.Frame> supplier) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        NativeFrameStore.Frame value;
+        while ((value = supplier.get()) == null && SystemClock.elapsedRealtime() < deadline) {
+            Thread.sleep(50L);
+        }
+        if (value == null) {
+            fail("timed out waiting for a rendered frame");
+        }
+        return value;
+    }
+
+    private static void await(String action, BooleanSupplier condition) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (!condition.getAsBoolean() && SystemClock.elapsedRealtime() < deadline) {
+            Thread.sleep(50L);
+        }
+        assertTrue("timed out waiting for " + action, condition.getAsBoolean());
+    }
+}

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,7 +34,36 @@ public class AndroidRuntimeEndToEndSmokeTest {
             await("runtime initialization", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
             assertFixtureReadable();
             AtomicReference<Controller.LoadRomFailedEvent> loadFailure = new AtomicReference<>();
-            runtimeEvents(runtime).register(loadFailure::set, Controller.LoadRomFailedEvent.class);
+            EventBus events = runtimeEvents(runtime);
+            events.register(loadFailure::set, Controller.LoadRomFailedEvent.class);
+            CountDownLatch snapshotSaved = new CountDownLatch(1);
+            AtomicReference<Controller.SnapshotSaveFailedEvent> snapshotSaveFailure =
+                    new AtomicReference<>();
+            events.register(event -> {
+                if (event.getSlot() == 0) {
+                    snapshotSaved.countDown();
+                }
+            }, Controller.SnapshotSavedEvent.class);
+            events.register(event -> {
+                if (event.getSlot() == 0) {
+                    snapshotSaveFailure.set(event);
+                    snapshotSaved.countDown();
+                }
+            }, Controller.SnapshotSaveFailedEvent.class);
+            CountDownLatch snapshotRestored = new CountDownLatch(1);
+            AtomicReference<Controller.SnapshotLoadFailedEvent> snapshotLoadFailure =
+                    new AtomicReference<>();
+            events.register(event -> {
+                if (event.getSlot() == 0) {
+                    snapshotRestored.countDown();
+                }
+            }, Controller.SnapshotRestoredEvent.class);
+            events.register(event -> {
+                if (event.getSlot() == 0) {
+                    snapshotLoadFailure.set(event);
+                    snapshotRestored.countDown();
+                }
+            }, Controller.SnapshotLoadFailedEvent.class);
             runtime.openRom(FixtureRomProvider.URI, 0);
             awaitFixtureStart(runtime, loadFailure);
 
@@ -48,8 +76,9 @@ public class AndroidRuntimeEndToEndSmokeTest {
             assertFrame(runtime, "after input");
 
             runtime.saveSnapshot(0);
-            awaitSavedState(runtime, 0);
+            awaitSnapshotSaved(snapshotSaved, snapshotSaveFailure);
             runtime.restoreSnapshot(0);
+            awaitSnapshotRestored(snapshotRestored, snapshotLoadFailure);
             assertFrame(runtime, "after state restore");
 
             runtime.onHostNotVisible();
@@ -116,29 +145,24 @@ public class AndroidRuntimeEndToEndSmokeTest {
         }
     }
 
-    private static AndroidStateSlot stateSlot(AndroidEmulationRuntime runtime, int index) throws Exception {
-        CountDownLatch callback = new CountDownLatch(1);
-        @SuppressWarnings("unchecked")
-        List<AndroidStateSlot>[] result = new List[1];
-        runtime.listStateSlots(slots -> {
-            result[0] = slots;
-            callback.countDown();
-        });
-        assertTrue("state catalog callback", callback.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-        assertNotNull(result[0]);
-        return result[0].stream().filter(slot -> slot.index() == index).findFirst()
-                .orElseThrow(() -> new AssertionError("missing state slot " + index));
+    private static void awaitSnapshotSaved(
+            CountDownLatch completed,
+            AtomicReference<Controller.SnapshotSaveFailedEvent> failure) throws Exception {
+        assertTrue("snapshot save event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        Controller.SnapshotSaveFailedEvent saveFailure = failure.get();
+        if (saveFailure != null) {
+            fail("snapshot save failed: " + saveFailure.getMessage());
+        }
     }
 
-    private static void awaitSavedState(AndroidEmulationRuntime runtime, int index) throws Exception {
-        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
-        while (SystemClock.elapsedRealtime() < deadline) {
-            if (stateSlot(runtime, index).loadable()) {
-                return;
-            }
-            Thread.sleep(50L);
+    private static void awaitSnapshotRestored(
+            CountDownLatch completed,
+            AtomicReference<Controller.SnapshotLoadFailedEvent> failure) throws Exception {
+        assertTrue("snapshot restore event", completed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        Controller.SnapshotLoadFailedEvent loadFailure = failure.get();
+        if (loadFailure != null) {
+            fail("snapshot restore failed: " + loadFailure.getMessage());
         }
-        fail("timed out waiting for state slot " + index + " to become loadable");
     }
 
     private static NativeFrameStore.Frame awaitValue(

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.android;
 
 import android.content.ContentProvider;
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
@@ -55,7 +56,11 @@ public final class FixtureRomProvider extends ContentProvider {
             throw new FileNotFoundException("The CI fixture is read-only");
         }
         try {
-            File fixture = new File(requireContext().getCacheDir(), DISPLAY_NAME);
+            Context context = getContext();
+            if (context == null) {
+                throw new FileNotFoundException("The CI fixture provider is not initialized");
+            }
+            File fixture = new File(context.getCacheDir(), DISPLAY_NAME);
             if (!fixture.isFile() || fixture.length() != ROM_SIZE) {
                 try (FileOutputStream output = new FileOutputStream(fixture)) {
                     output.write(fixtureBytes());

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -10,9 +10,9 @@ import android.provider.OpenableColumns;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 /**
  * Source-generated public-domain Game Boy fixture exposed only through a content URI.
@@ -57,7 +57,9 @@ public final class FixtureRomProvider extends ContentProvider {
         try {
             File fixture = new File(requireContext().getCacheDir(), DISPLAY_NAME);
             if (!fixture.isFile() || fixture.length() != ROM_SIZE) {
-                Files.write(fixture.toPath(), fixtureBytes());
+                try (FileOutputStream output = new FileOutputStream(fixture)) {
+                    output.write(fixtureBytes());
+                }
             }
             return ParcelFileDescriptor.open(fixture, ParcelFileDescriptor.MODE_READ_ONLY);
         } catch (IOException failure) {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -19,8 +19,8 @@ import java.nio.charset.StandardCharsets;
  * Source-generated public-domain Game Boy fixture exposed only through a content URI.
  *
  * <p>The CI test deliberately does not package a ROM blob or provide a filesystem path. The
- * generated ROM-only program loops after boot, which is enough to drive display, input, state,
- * and lifecycle coverage without relying on copyrighted game data.
+ * generated ROM-only program enables the LCD and loops after boot, which is enough to drive
+ * display, input, state, and lifecycle coverage without relying on copyrighted game data.
  */
 public final class FixtureRomProvider extends ContentProvider {
 
@@ -108,8 +108,13 @@ public final class FixtureRomProvider extends ContentProvider {
             checksum = (checksum - (rom[address] & 0xff) - 1) & 0xff;
         }
         rom[0x014d] = (byte) checksum;
-        rom[0x0150] = 0x18; // JR -2
-        rom[0x0151] = (byte) 0xfe;
+        rom[0x0150] = 0x3e; // LD A, 0x91 (LCD and background enabled)
+        rom[0x0151] = (byte) 0x91;
+        rom[0x0152] = (byte) 0xea; // LD (0xff40), A
+        rom[0x0153] = 0x40;
+        rom[0x0154] = (byte) 0xff;
+        rom[0x0155] = 0x18; // JR -2
+        rom[0x0156] = (byte) 0xfe;
         return rom;
     }
 }

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -1,0 +1,108 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.OpenableColumns;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Source-generated public-domain Game Boy fixture exposed only through a content URI.
+ *
+ * <p>The CI test deliberately does not package a ROM blob or provide a filesystem path. The
+ * generated ROM-only program loops after boot, which is enough to drive display, input, state,
+ * and lifecycle coverage without relying on copyrighted game data.
+ */
+public final class FixtureRomProvider extends ContentProvider {
+
+    static final Uri URI = Uri.parse("content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke.gb");
+    private static final String DISPLAY_NAME = "coffee-gb-ci-smoke.gb";
+    private static final int ROM_SIZE = 0x8000;
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+                        String sortOrder) {
+        assertFixture(uri);
+        MatrixCursor cursor = new MatrixCursor(new String[]{
+                OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE});
+        cursor.addRow(new Object[]{DISPLAY_NAME, ROM_SIZE});
+        return cursor;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        assertFixture(uri);
+        return "application/x-gameboy-rom";
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        assertFixture(uri);
+        if (!"r".equals(mode)) {
+            throw new FileNotFoundException("The CI fixture is read-only");
+        }
+        try {
+            File fixture = new File(requireContext().getCacheDir(), DISPLAY_NAME);
+            if (!fixture.isFile() || fixture.length() != ROM_SIZE) {
+                Files.write(fixture.toPath(), fixtureBytes());
+            }
+            return ParcelFileDescriptor.open(fixture, ParcelFileDescriptor.MODE_READ_ONLY);
+        } catch (IOException failure) {
+            throw new FileNotFoundException("Could not create CI fixture");
+        }
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        throw new UnsupportedOperationException("The CI fixture is read-only");
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException("The CI fixture is read-only");
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException("The CI fixture is read-only");
+    }
+
+    private static void assertFixture(Uri uri) {
+        if (!URI.equals(uri)) {
+            throw new IllegalArgumentException("Unknown CI fixture");
+        }
+    }
+
+    private static byte[] fixtureBytes() {
+        byte[] rom = new byte[ROM_SIZE];
+        rom[0x0100] = (byte) 0xc3; // JP 0x0150
+        rom[0x0101] = 0x50;
+        rom[0x0102] = 0x01;
+        byte[] title = "CI SMOKE".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, rom, 0x0134, title.length);
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KiB
+        rom[0x0149] = 0x00; // no RAM
+        int checksum = 0;
+        for (int address = 0x0134; address <= 0x014c; address++) {
+            checksum = (checksum - (rom[address] & 0xff) - 1) & 0xff;
+        }
+        rom[0x014d] = (byte) checksum;
+        rom[0x0150] = 0x18; // JR -2
+        rom[0x0151] = (byte) 0xfe;
+        return rom;
+    }
+}

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -1,0 +1,21 @@
+package eu.rekawek.coffeegb.android;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Exercises the bound runtime through Activity recreation and a visibility transition. */
+@RunWith(AndroidJUnit4.class)
+public class MainActivitySmokeTest {
+
+    @Test
+    public void launchesRecreatesAndBackgroundsWithoutStartingACameraOrGame() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.moveToState(Lifecycle.State.CREATED);
+            scenario.moveToState(Lifecycle.State.RESUMED);
+            scenario.recreate();
+        }
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:allowBackup="false"

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -11,12 +11,9 @@ import eu.rekawek.coffeegb.controller.BasicController;
 import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.controller.state.StateIdentity;
-import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent;
-import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.controller.state.StateRepository;
 import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
-import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
@@ -96,8 +93,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private Uri currentSource;
     private StateStorageLayout activeLayout;
     private StateRepository activeStates;
-    private volatile long activeStateSessionId;
-    private long nextStateRequestId;
     private long nextOpenRequestId;
     private long activeOpenRequestId;
     private long tiltOpenRequestId;
@@ -238,9 +233,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     public void saveSnapshot(int slot) {
         checkStateSlot(slot);
         submit(() -> {
-            if (controller != null && activeLayout != null && activeStateSessionId > 0) {
-                eventBus.post(new StateSaveRequestEvent(++nextStateRequestId,
-                        activeStateSessionId, new StateRef.Slot(slot), null, null));
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.SaveSnapshotEvent(slot));
             }
         });
     }
@@ -249,9 +243,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     public void restoreSnapshot(int slot) {
         checkStateSlot(slot);
         submit(() -> {
-            if (controller != null && activeLayout != null && activeStateSessionId > 0) {
-                eventBus.post(new StateLoadRefRequestEvent(++nextStateRequestId,
-                        activeStateSessionId, new StateRef.Slot(slot)));
+            if (controller != null && activeLayout != null) {
+                eventBus.post(new Controller.RestoreSnapshotEvent(slot));
             }
         });
     }
@@ -614,15 +607,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
         eventBus.register(printer::append, Controller.PrinterPrintEvent.class);
         eventBus.register(
-                (StateUxSessionEvent event) -> {
-                    if (event.getAvailable()) {
-                        activeStateSessionId = event.getSessionId();
-                    } else if (activeStateSessionId == event.getSessionId()) {
-                        activeStateSessionId = 0;
-                    }
-                },
-                StateUxSessionEvent.class);
-        eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId) {
@@ -756,7 +740,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             StateStorageLayout layout = persistenceStore.layout(hash);
             activeLayout = layout;
             activeStates = new StateRepository(layout, AtomicFileWriter.system());
-            activeStateSessionId = 0;
             currentSource = source;
             activeOpenRequestId = ++nextOpenRequestId;
             tiltOpenRequestId = activeOpenRequestId;
@@ -772,7 +755,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             forgetRevokedPermission(source);
             activeLayout = null;
             activeStates = null;
-            activeStateSessionId = 0;
             currentSource = null;
             publish(RuntimeState.Phase.FAILED,
                     "Coffee GB could not load the selected ROM.", List.of(), false, true, false);
@@ -872,7 +854,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private boolean closeController() {
         cancelFlushDeadline();
         pendingFlushRequestId = 0;
-        activeStateSessionId = 0;
         BasicController active = controller;
         EventBus activeBus = eventBus;
         AndroidAudioSink activeAudio = audio;

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -11,9 +11,12 @@ import eu.rekawek.coffeegb.controller.BasicController;
 import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.controller.state.StateIdentity;
+import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.controller.state.StateRepository;
+import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
@@ -75,6 +78,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final AndroidInputRouter input;
 
     private volatile RuntimeState state = RuntimeState.stopped();
+    // Updated directly from controller event dispatch; the owner queues requests until it exists.
+    private volatile long activeStateSessionId;
 
     // Everything below is accessed only on the owner executor.
     private EventBus eventBus;
@@ -94,6 +99,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private StateStorageLayout activeLayout;
     private StateRepository activeStates;
     private long nextOpenRequestId;
+    private long nextStateRequestId;
+    private final List<PendingStateRequest> pendingStateRequests = new ArrayList<>();
     private long activeOpenRequestId;
     private long tiltOpenRequestId;
     private boolean tiltRequiredForOpenRequest;
@@ -232,21 +239,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Requests a portable quick-state save at the controller's safe point. */
     public void saveSnapshot(int slot) {
         checkStateSlot(slot);
-        submit(() -> {
-            if (controller != null && activeLayout != null) {
-                eventBus.post(new Controller.SaveSnapshotEvent(slot));
-            }
-        });
+        submit(() -> requestStateSave(slot));
     }
 
     /** Requests a portable quick-state restore; controller errors remain typed/redacted. */
     public void restoreSnapshot(int slot) {
         checkStateSlot(slot);
-        submit(() -> {
-            if (controller != null && activeLayout != null) {
-                eventBus.post(new Controller.RestoreSnapshotEvent(slot));
-            }
-        });
+        submit(() -> requestStateLoad(slot));
     }
 
     /** Reads only redacted state metadata on the runtime owner, then delivers immutable rows on UI. */
@@ -592,6 +591,12 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void createController() {
         eventBus = new EventBusImpl();
+        eventBus.register(
+                (StateUxSessionEvent event) -> {
+                    activeStateSessionId = event.getAvailable() ? event.getSessionId() : 0L;
+                    submit(this::drainPendingStateRequests);
+                },
+                StateUxSessionEvent.class);
         audio = new AndroidAudioSink(context, eventBus);
         audio.start();
         rumble = new AndroidRumbleSink(context, eventBus, false);
@@ -778,6 +783,54 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 TimeUnit.MILLISECONDS);
     }
 
+    private void requestStateSave(int slot) {
+        requestState(new PendingStateRequest(slot, true));
+    }
+
+    private void requestStateLoad(int slot) {
+        requestState(new PendingStateRequest(slot, false));
+    }
+
+    private void requestState(PendingStateRequest request) {
+        if (controller == null || activeLayout == null) {
+            return;
+        }
+        if (activeStateSessionId == 0L) {
+            // Emulation-start notification reaches the owner before the controller publishes the
+            // authoritative State UX session identifier. Preserve an immediate button press.
+            pendingStateRequests.add(request);
+            return;
+        }
+        postStateRequest(request);
+    }
+
+    private void drainPendingStateRequests() {
+        if (activeStateSessionId == 0L || controller == null || activeLayout == null) {
+            pendingStateRequests.clear();
+            return;
+        }
+        List<PendingStateRequest> pending = List.copyOf(pendingStateRequests);
+        pendingStateRequests.clear();
+        for (PendingStateRequest request : pending) {
+            postStateRequest(request);
+        }
+    }
+
+    private void postStateRequest(PendingStateRequest request) {
+        long stateSessionId = activeStateSessionId;
+        if (stateSessionId == 0L || controller == null || activeLayout == null) {
+            pendingStateRequests.add(request);
+            return;
+        }
+        long requestId = ++nextStateRequestId;
+        StateRef.Slot ref = new StateRef.Slot(request.slot);
+        if (request.save) {
+            eventBus.post(new StateSaveRequestEvent(requestId, stateSessionId, ref, null, null));
+        } else {
+            eventBus.post(new StateLoadRefRequestEvent(requestId, stateSessionId, ref));
+        }
+    }
+
     private RuntimeLifecycleGate.SessionCommands lifecycleCommands() {
         return new RuntimeLifecycleGate.SessionCommands() {
             @Override
@@ -882,6 +935,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 activeCamera.close();
             }
             PocketCamera.setCameraSource(null);
+            activeStateSessionId = 0L;
+            pendingStateRequests.clear();
             return true;
         }
         try {
@@ -900,6 +955,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             }
             PocketCamera.setCameraSource(null);
             lifecycle.released();
+            activeStateSessionId = 0L;
+            pendingStateRequests.clear();
             return true;
         } catch (RuntimeException failure) {
             // Retain the controller for an explicit retry; it may still own an unflushed battery.
@@ -1013,6 +1070,16 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             snapshot.close();
         } catch (IOException ignored) {
             // Stream snapshots own no visible path. The next process startup cannot reopen one.
+        }
+    }
+
+    private static final class PendingStateRequest {
+        private final int slot;
+        private final boolean save;
+
+        private PendingStateRequest(int slot, boolean save) {
+            this.slot = slot;
+            this.save = save;
         }
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -96,7 +96,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private Uri currentSource;
     private StateStorageLayout activeLayout;
     private StateRepository activeStates;
-    private long activeStateSessionId;
+    private volatile long activeStateSessionId;
     private long nextStateRequestId;
     private long nextOpenRequestId;
     private long activeOpenRequestId;
@@ -614,13 +614,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
         eventBus.register(printer::append, Controller.PrinterPrintEvent.class);
         eventBus.register(
-                (StateUxSessionEvent event) -> submit(() -> {
+                (StateUxSessionEvent event) -> {
                     if (event.getAvailable()) {
                         activeStateSessionId = event.getSessionId();
                     } else if (activeStateSessionId == event.getSessionId()) {
                         activeStateSessionId = 0;
                     }
-                }),
+                },
                 StateUxSessionEvent.class);
         eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -11,9 +11,12 @@ import eu.rekawek.coffeegb.controller.BasicController;
 import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
 import eu.rekawek.coffeegb.controller.state.StateIdentity;
+import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent;
+import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.controller.state.StateRepository;
 import eu.rekawek.coffeegb.controller.state.StateStorageLayout;
+import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
@@ -93,6 +96,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private Uri currentSource;
     private StateStorageLayout activeLayout;
     private StateRepository activeStates;
+    private long activeStateSessionId;
+    private long nextStateRequestId;
     private long nextOpenRequestId;
     private long activeOpenRequestId;
     private long tiltOpenRequestId;
@@ -233,8 +238,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     public void saveSnapshot(int slot) {
         checkStateSlot(slot);
         submit(() -> {
-            if (controller != null && activeLayout != null) {
-                eventBus.post(new Controller.SaveSnapshotEvent(slot));
+            if (controller != null && activeLayout != null && activeStateSessionId > 0) {
+                eventBus.post(new StateSaveRequestEvent(++nextStateRequestId,
+                        activeStateSessionId, new StateRef.Slot(slot), null, null));
             }
         });
     }
@@ -243,8 +249,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     public void restoreSnapshot(int slot) {
         checkStateSlot(slot);
         submit(() -> {
-            if (controller != null && activeLayout != null) {
-                eventBus.post(new Controller.RestoreSnapshotEvent(slot));
+            if (controller != null && activeLayout != null && activeStateSessionId > 0) {
+                eventBus.post(new StateLoadRefRequestEvent(++nextStateRequestId,
+                        activeStateSessionId, new StateRef.Slot(slot)));
             }
         });
     }
@@ -607,6 +614,15 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
         eventBus.register(printer::append, Controller.PrinterPrintEvent.class);
         eventBus.register(
+                (StateUxSessionEvent event) -> submit(() -> {
+                    if (event.getAvailable()) {
+                        activeStateSessionId = event.getSessionId();
+                    } else if (activeStateSessionId == event.getSessionId()) {
+                        activeStateSessionId = 0;
+                    }
+                }),
+                StateUxSessionEvent.class);
+        eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId) {
@@ -740,6 +756,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             StateStorageLayout layout = persistenceStore.layout(hash);
             activeLayout = layout;
             activeStates = new StateRepository(layout, AtomicFileWriter.system());
+            activeStateSessionId = 0;
             currentSource = source;
             activeOpenRequestId = ++nextOpenRequestId;
             tiltOpenRequestId = activeOpenRequestId;
@@ -755,6 +772,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             forgetRevokedPermission(source);
             activeLayout = null;
             activeStates = null;
+            activeStateSessionId = 0;
             currentSource = null;
             publish(RuntimeState.Phase.FAILED,
                     "Coffee GB could not load the selected ROM.", List.of(), false, true, false);
@@ -854,6 +872,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private boolean closeController() {
         cancelFlushDeadline();
         pendingFlushRequestId = 0;
+        activeStateSessionId = 0;
         BasicController active = controller;
         EventBus activeBus = eventBus;
         AndroidAudioSink activeAudio = audio;

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -692,12 +692,21 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     cancelFlushDeadline();
                     pendingFlushRequestId = 0;
                     lifecycle.flushCompleted();
+                    // A user may explicitly resume while the asynchronous battery write is still
+                    // completing. Its completion is not another pause request, so preserve the
+                    // controller's most recently published playback state instead of regressing
+                    // a resumed session back to PAUSED.
+                    boolean paused = state.paused();
                     if (event.getSucceeded()) {
-                        publish(RuntimeState.Phase.PAUSED,
-                                "Game paused. Battery data saved.", List.of(), true, true, false);
+                        publish(paused ? RuntimeState.Phase.PAUSED : RuntimeState.Phase.RUNNING,
+                                paused ? "Game paused. Battery data saved."
+                                        : "Game running. Battery data saved.",
+                                List.of(), true, paused, false);
                     } else {
-                        publish(RuntimeState.Phase.PAUSED,
-                                "Game paused. Battery save needs retrying.", List.of(), true, true, false);
+                        publish(paused ? RuntimeState.Phase.PAUSED : RuntimeState.Phase.RUNNING,
+                                paused ? "Game paused. Battery save needs retrying."
+                                        : "Game running. Battery save needs retrying.",
+                                List.of(), true, paused, false);
                     }
                 }),
                 Controller.BatteryFlushCompletedEvent.class);

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -642,9 +642,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private void sharePrinter(android.net.Uri uri) {
         Intent share = new Intent(Intent.ACTION_SEND)
                 .setType("image/png")
-                .putExtra(Intent.EXTRA_STREAM, uri)
-                .setClipData(ClipData.newRawUri("Game Boy Printer paper", uri))
-                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                .putExtra(Intent.EXTRA_STREAM, uri);
+        share.setClipData(ClipData.newRawUri("Game Boy Printer paper", uri));
+        share.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         startActivity(Intent.createChooser(share, "Share printer paper"));
     }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4084,7 +4084,7 @@ class BasicController private constructor(
         ))
     publishPlaybackState()
     val context = stateContext
-    postSessionEventSafely(
+    postStateUxSessionEvent(
         session,
         StateUxSessionEvent(
             stateSessionId,
@@ -4272,7 +4272,7 @@ class BasicController private constructor(
     latestStateRequests.clear()
     latestSaveRequests.clear()
     mobileAdapterExternalIoSaveRequests.clear()
-    postSessionEventSafely(
+    postStateUxSessionEvent(
         currentSession,
         StateUxSessionEvent(
             stateSessionId,
@@ -4294,7 +4294,7 @@ class BasicController private constructor(
         Controller.SerialPeripheralStatus.DETACHED,
     )
     if (notifyLifecycle) {
-      postSessionEventSafely(session, StateUxSessionEvent(stateSessionId, false, null))
+      postStateUxSessionEvent(session, StateUxSessionEvent(stateSessionId, false, null))
       postSessionEventSafely(session, Controller.EmulationStoppedEvent())
     }
     playbackSessionGeneration = null
@@ -4330,6 +4330,16 @@ class BasicController private constructor(
       session.eventBus.post(event)
     } catch (subscriberFailure: RuntimeException) {
       LOG.warn("Session lifecycle event subscriber failed for {}", event.javaClass.simpleName, subscriberFailure)
+    }
+  }
+
+  /** State requests are owned by the root controller bus, while desktop presentation is per session. */
+  private fun postStateUxSessionEvent(session: Session, event: StateUxSessionEvent) {
+    postSessionEventSafely(session, event)
+    try {
+      eventBus.post(event)
+    } catch (subscriberFailure: RuntimeException) {
+      LOG.warn("State lifecycle event subscriber failed", subscriberFailure)
     }
   }
 
@@ -4517,7 +4527,7 @@ class BasicController private constructor(
     try {
       shutdownExecutors(closeDeadlineNanos)
       session?.let {
-        postSessionEventSafely(it, StateUxSessionEvent(stateSessionId, false, null))
+        postStateUxSessionEvent(it, StateUxSessionEvent(stateSessionId, false, null))
       }
       eventBus.close(
           remainingCloseNanos(closeDeadlineNanos, "controller event-bus teardown"),

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -37,6 +37,7 @@ import eu.rekawek.coffeegb.controller.state.StateIdentity
 import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateLoadRequestEvent
 import eu.rekawek.coffeegb.controller.state.MachineStateRoot
+import eu.rekawek.coffeegb.controller.state.MachineIdentity
 import eu.rekawek.coffeegb.controller.state.SessionStateRoot
 import eu.rekawek.coffeegb.controller.state.StateOpenFolderRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateOperation
@@ -60,6 +61,7 @@ import eu.rekawek.coffeegb.controller.state.StateSlotLoadAvailabilityEvent
 import eu.rekawek.coffeegb.controller.state.StateSlotLoadAvailabilityRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateStoragePaths
 import eu.rekawek.coffeegb.controller.state.StateStorageResolver
+import eu.rekawek.coffeegb.controller.state.StateStore
 import eu.rekawek.coffeegb.controller.state.StateUserError
 import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
 import eu.rekawek.coffeegb.controller.state.StateWorkerCompletedEvent
@@ -1674,6 +1676,7 @@ class BasicController private constructor(
   private fun createSession(
       config: Gameboy.GameboyConfiguration,
       prebuiltGameboy: Gameboy? = null,
+      stateStore: StateStore? = null,
   ): Session {
     val sessionBus = StagedEventBus(eventBus.fork("main"))
     try {
@@ -1686,6 +1689,7 @@ class BasicController private constructor(
           serialEndpoint.endpoint,
           prebuiltGameboy = prebuiltGameboy,
           serialEndpointDisconnect = serialEndpoint.disconnect,
+          stateStore = stateStore,
       )
     } catch (failure: Controller.SerialPeripheralPreparationException) {
       postSerialPeripheralStatus(
@@ -3174,7 +3178,7 @@ class BasicController private constructor(
     try {
       // Finish constructing and initializing the candidate before releasing the current session.
       // A core-startup failure must leave the old game available for resume/cancel semantics.
-      nextSession = createSession(job.prepared.config, nextGameboy)
+      nextSession = createSession(job.prepared.config, nextGameboy, job.prepared.stateStore)
       nextGameboy = null
       nextSnapshotManager =
           if (job.prepared.config.rom.origin.persistencePath(".sn0").isPresent) {
@@ -4038,15 +4042,9 @@ class BasicController private constructor(
                     "Activated session has no precomputed ROM identity"
                   },
               )
-          val paths =
-              StateStorageResolver.resolve(
-                  properties.applicationSettings.saves,
-                  session.config,
-                  identity,
-              )
           StateWorkerContext(
               stateSessionId,
-              stateWorkspaceFactory.create(paths),
+              stateWorkspace(session, identity, properties.applicationSettings.saves),
               identity,
               session.config.hardwareProfile.id(),
           )
@@ -4110,6 +4108,27 @@ class BasicController private constructor(
         Controller.SerialPeripheralStatus.ATTACHED,
     )
     postInitialMobileAdapterNetworkStatus()
+  }
+
+  /**
+   * Keeps pathless host sessions on the state store resolved together with their battery storage.
+   * Desktop sessions retain their configured writable root and read fallbacks.
+   */
+  private fun stateWorkspace(
+      session: Session,
+      identity: MachineIdentity,
+      saves: ApplicationSettings.Saves,
+  ): StateWorkspace {
+    val hostStore = session.stateStore
+    if (hostStore != null) {
+      val layout = hostStore.layout
+      return StateWorkspace(
+          StateStoragePaths(layout, layout.screenshotsDirectory, emptyList()),
+      ) { hostStore.repository() }
+    }
+    return stateWorkspaceFactory.create(
+        StateStorageResolver.resolve(saves, session.config, identity),
+    )
   }
 
   private fun installDebugPort(session: Session) {
@@ -4231,10 +4250,9 @@ class BasicController private constructor(
                   currentSession.config,
                   romHashes,
               )
-          val paths = StateStorageResolver.resolve(saves, currentSession.config, identity)
           StateWorkerContext(
               stateSessionId,
-              stateWorkspaceFactory.create(paths),
+              stateWorkspace(currentSession, identity, saves),
               identity,
               currentSession.config.hardwareProfile.id(),
           )

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4335,7 +4335,18 @@ class BasicController private constructor(
 
   private fun saveSnapshot(slot: Int) {
     val currentSession = session ?: return
-    val manager = snapshotManager ?: return
+    val manager = snapshotManager
+    if (manager == null) {
+      requestStateSave(
+          StateSaveRequestEvent(
+              nextInternalStateRequestId(),
+              stateSessionId,
+              StateRef.Slot(slot),
+              null,
+              null,
+          ))
+      return
+    }
     val mobileExternalIo = mobileAdapterEndpointHasExternalIo()
     try {
       manager.saveSnapshot(slot, currentSession)
@@ -4367,7 +4378,16 @@ class BasicController private constructor(
           ))
       return
     }
-    val manager = snapshotManager ?: return
+    val manager = snapshotManager
+    if (manager == null) {
+      requestStateLoadRef(
+          StateLoadRefRequestEvent(
+              nextInternalStateRequestId(),
+              stateSessionId,
+              StateRef.Slot(slot),
+          ))
+      return
+    }
     val mobileExternalIo = hasMobileAdapterExternalIo()
     val mobileBackendOwnership = mobileAdapterBackendOwnershipVersion()
     try {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4084,7 +4084,7 @@ class BasicController private constructor(
         ))
     publishPlaybackState()
     val context = stateContext
-    postStateUxSessionEvent(
+    postSessionEventSafely(
         session,
         StateUxSessionEvent(
             stateSessionId,
@@ -4272,7 +4272,7 @@ class BasicController private constructor(
     latestStateRequests.clear()
     latestSaveRequests.clear()
     mobileAdapterExternalIoSaveRequests.clear()
-    postStateUxSessionEvent(
+    postSessionEventSafely(
         currentSession,
         StateUxSessionEvent(
             stateSessionId,
@@ -4294,7 +4294,7 @@ class BasicController private constructor(
         Controller.SerialPeripheralStatus.DETACHED,
     )
     if (notifyLifecycle) {
-      postStateUxSessionEvent(session, StateUxSessionEvent(stateSessionId, false, null))
+      postSessionEventSafely(session, StateUxSessionEvent(stateSessionId, false, null))
       postSessionEventSafely(session, Controller.EmulationStoppedEvent())
     }
     playbackSessionGeneration = null
@@ -4330,16 +4330,6 @@ class BasicController private constructor(
       session.eventBus.post(event)
     } catch (subscriberFailure: RuntimeException) {
       LOG.warn("Session lifecycle event subscriber failed for {}", event.javaClass.simpleName, subscriberFailure)
-    }
-  }
-
-  /** State requests are owned by the root controller bus, while desktop presentation is per session. */
-  private fun postStateUxSessionEvent(session: Session, event: StateUxSessionEvent) {
-    postSessionEventSafely(session, event)
-    try {
-      eventBus.post(event)
-    } catch (subscriberFailure: RuntimeException) {
-      LOG.warn("State lifecycle event subscriber failed", subscriberFailure)
     }
   }
 
@@ -4527,7 +4517,7 @@ class BasicController private constructor(
     try {
       shutdownExecutors(closeDeadlineNanos)
       session?.let {
-        postStateUxSessionEvent(it, StateUxSessionEvent(stateSessionId, false, null))
+        postSessionEventSafely(it, StateUxSessionEvent(stateSessionId, false, null))
       }
       eventBus.close(
           remainingCloseNanos(closeDeadlineNanos, "controller event-bus teardown"),

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -11,6 +11,7 @@ import eu.rekawek.coffeegb.controller.state.DesktopRomPersistenceStore
 import eu.rekawek.coffeegb.controller.state.MachineState
 import eu.rekawek.coffeegb.controller.state.StateIdentity
 import eu.rekawek.coffeegb.controller.state.StateRomHashes
+import eu.rekawek.coffeegb.controller.state.StateStore
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties.Mapper
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeType
 import eu.rekawek.coffeegb.core.memory.cart.Rom
@@ -39,21 +40,24 @@ internal class RomSessionPreparer(
     ensureActive()
     val romHashes = StateIdentity.hashes(config)
     ensureActive()
-    (event.persistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
-        .resolve(config, romHashes)
-        .applyTo(config)
+    val persistence =
+        (event.persistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
+            .resolve(config, romHashes)
+    persistence.applyTo(config)
     ensureActive()
 
-    event.state?.let { return PreparedSession.FromDetachedState(config, it, romHashes) }
+    event.state?.let {
+      return PreparedSession.FromDetachedState(config, it, romHashes, persistence.stateStore)
+    }
 
     bootStateCache.getOrCreate(config)?.let {
-      return PreparedSession.FromBootState(config, it, romHashes)
+      return PreparedSession.FromBootState(config, it, romHashes, persistence.stateStore)
     }
 
     // Exotic/RTC cartridges cannot use a battery-free boot template. Defer their real machine
     // construction until after the outgoing session's persistence barrier, when the worker can
     // load the just-committed RAM/RTC bytes without touching the controller timing thread.
-    return PreparedSession.Deferred(config, romHashes)
+    return PreparedSession.Deferred(config, romHashes, persistence.stateStore)
   }
 
   private fun ensureActive() {
@@ -163,6 +167,8 @@ internal class BootStateCache(private val capacity: Int = DEFAULT_CAPACITY) {
 internal sealed class PreparedSession(
     open val config: GameboyConfiguration,
     open val romHashes: StateRomHashes,
+    /** Host-owned state destination resolved with the session's battery storage. */
+    open val stateStore: StateStore? = null,
 ) {
 
   abstract fun materialize(): Gameboy
@@ -173,7 +179,8 @@ internal sealed class PreparedSession(
       override val config: GameboyConfiguration,
       val bootState: BootState,
       override val romHashes: StateRomHashes = StateIdentity.hashes(config),
-  ) : PreparedSession(config, romHashes) {
+      override val stateStore: StateStore? = null,
+  ) : PreparedSession(config, romHashes, stateStore) {
     override fun materialize(): Gameboy = materializeRestored { it.restoreBootState(bootState) }
   }
 
@@ -181,14 +188,16 @@ internal sealed class PreparedSession(
       override val config: GameboyConfiguration,
       val state: MachineState,
       override val romHashes: StateRomHashes = StateIdentity.hashes(config),
-  ) : PreparedSession(config, romHashes) {
+      override val stateStore: StateStore? = null,
+  ) : PreparedSession(config, romHashes, stateStore) {
     override fun materialize(): Gameboy = materializeRestored { DetachedStateAdapter.apply(it, state) }
   }
 
   data class Deferred(
       override val config: GameboyConfiguration,
       override val romHashes: StateRomHashes = StateIdentity.hashes(config),
-  ) : PreparedSession(config, romHashes) {
+      override val stateStore: StateStore? = null,
+  ) : PreparedSession(config, romHashes, stateStore) {
     override fun materialize(): Gameboy = config.build()
   }
 
@@ -196,7 +205,8 @@ internal sealed class PreparedSession(
       override val config: GameboyConfiguration,
       gameboy: Gameboy,
       override val romHashes: StateRomHashes = StateIdentity.hashes(config),
-  ) : PreparedSession(config, romHashes) {
+      override val stateStore: StateStore? = null,
+  ) : PreparedSession(config, romHashes, stateStore) {
     private val owned = java.util.concurrent.atomic.AtomicReference(gameboy)
 
     override fun materialize(): Gameboy =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -40,24 +40,28 @@ internal class RomSessionPreparer(
     ensureActive()
     val romHashes = StateIdentity.hashes(config)
     ensureActive()
+    val hostPersistenceStore = event.persistenceStore
     val persistence =
-        (event.persistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
+        (hostPersistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
             .resolve(config, romHashes)
     persistence.applyTo(config)
+    // The desktop controller retains its configurable workspace (and its bounded fallbacks).
+    // A supplied host store is the only authoritative destination for a pathless source.
+    val stateStore = hostPersistenceStore?.let { persistence.stateStore }
     ensureActive()
 
     event.state?.let {
-      return PreparedSession.FromDetachedState(config, it, romHashes, persistence.stateStore)
+      return PreparedSession.FromDetachedState(config, it, romHashes, stateStore)
     }
 
     bootStateCache.getOrCreate(config)?.let {
-      return PreparedSession.FromBootState(config, it, romHashes, persistence.stateStore)
+      return PreparedSession.FromBootState(config, it, romHashes, stateStore)
     }
 
     // Exotic/RTC cartridges cannot use a battery-free boot template. Defer their real machine
     // construction until after the outgoing session's persistence barrier, when the worker can
     // load the just-committed RAM/RTC bytes without touching the controller timing thread.
-    return PreparedSession.Deferred(config, romHashes, persistence.stateStore)
+    return PreparedSession.Deferred(config, romHashes, stateStore)
   }
 
   private fun ensureActive() {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Session.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.SessionState
+import eu.rekawek.coffeegb.controller.state.StateStore
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.events.EventBus
@@ -21,6 +22,8 @@ class Session(
     infraredEndpoint: InfraredEndpoint = InfraredEndpoint.NULL_ENDPOINT,
     prebuiltGameboy: Gameboy? = null,
     serialEndpointDisconnect: () -> Unit = {},
+    /** Host-owned state store, when the ROM source itself has no writable filesystem path. */
+    internal val stateStore: StateStore? = null,
 ) : AutoCloseable {
 
   internal val gameboy: Gameboy = prebuiltGameboy ?: config.build()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.controller
 
+import eu.rekawek.coffeegb.controller.state.StateRecordIntrospection
+
 /**
  * Audited explicit component-state types and Coffee GB 1.7.14 compatibility records. The two
  * class inventories are deliberately disjoint. Newly appended portable types do not acquire
@@ -230,13 +232,13 @@ internal object StateTypeRegistry {
 
   val recordClasses: List<Class<*>> by lazy {
     recordClassNames.map(::loadAuditedClass).also { classes ->
-      classes.forEach { require(it.isRecord) { "Audited portable type is no longer a record: $it" } }
+      classes.forEach(StateRecordIntrospection::requireConstructible)
     }
   }
 
   val legacyRecordClasses: List<Class<*>> by lazy {
     legacyRecordClassNames.map(::loadAuditedClass).also { classes ->
-      classes.forEach { require(it.isRecord) { "Audited legacy type is no longer a record: $it" } }
+      classes.forEach(StateRecordIntrospection::requireConstructible)
     }
   }
 
@@ -247,4 +249,7 @@ internal object StateTypeRegistry {
   }
 
   private fun loadAuditedClass(name: String): Class<*> = Class.forName(name, false, javaClass.classLoader)
+
+  fun isAuditedStateType(type: Class<*>): Boolean =
+      type in recordClasses || type in legacyRecordClasses
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
@@ -56,9 +56,9 @@ internal constructor(
       // this avoids a prolonged burst of unpaced execution after a breakpoint or suspended host.
       deadline = now - MAX_CATCH_UP_NANOS
     }
-    // sleep the bulk of the wait and busy-spin only the last stretch: parkNanos wakes
-    // with millisecond-ish slack depending on the OS timer, the spin gives frame-exact
-    // pacing without pegging a core for the whole frame
+    // Sleep the bulk of the wait and yield only the last stretch: parkNanos wakes with
+    // millisecond-ish slack depending on the OS timer, and yielding keeps fine-grained pacing
+    // without relying on Java 9's unavailable spin-wait hint or pegging a core for the whole frame.
     while (true) {
       val remaining = deadline - nanoTime()
       if (remaining <= 0) {
@@ -67,7 +67,7 @@ internal constructor(
       if (remaining > SPIN_THRESHOLD_NANOS) {
         parkNanos(remaining - SPIN_THRESHOLD_NANOS)
       } else {
-        Thread.onSpinWait()
+        Thread.yield()
       }
     }
   }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/mobile/config/MobileAdapterConfigurationStore.kt
@@ -7,6 +7,7 @@ import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFilePermission
@@ -394,7 +395,7 @@ class MobileAdapterConfigurationStore(
     /** Default private adapter record, deliberately separate from general desktop preferences. */
     @JvmStatic
     fun defaultPath(): Path =
-        Path.of(System.getProperty("user.home")).resolve(".coffeegb-mobile-adapter.bin")
+        Paths.get(System.getProperty("user.home")).resolve(".coffeegb-mobile-adapter.bin")
 
     private const val MAX_ZERO_READS = 1_024
     private val PRIVATE_FILE_PERMISSIONS: Set<PosixFilePermission> =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.properties
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Locale
 import java.util.Properties
 
@@ -752,7 +753,7 @@ object ApplicationSettingsCodec {
 
   private fun parsePath(value: String): Path =
       try {
-        Path.of(value)
+        Paths.get(value)
       } catch (failure: RuntimeException) {
         throw IllegalArgumentException("Invalid settings path: $value", failure)
       }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStore.kt
@@ -285,13 +285,26 @@ class ApplicationSettingsStore(
   private fun remainingNanos(started: Long, timeoutNanos: Long): Long =
       (timeoutNanos - (System.nanoTime() - started)).coerceAtLeast(0)
 
+  /** Reads through the supplied bound without relying on the Java 9 bulk-read method. */
+  @Throws(IOException::class)
+  private fun java.io.InputStream.readAtMost(limit: Int): ByteArray {
+    val bytes = ByteArray(limit)
+    var size = 0
+    while (size < limit) {
+      val count = read(bytes, size, limit - size)
+      if (count == -1) break
+      size += count
+    }
+    return if (size == limit) bytes else bytes.copyOf(size)
+  }
+
   private fun load(): Loaded {
     val bytes =
         try {
           persistence.read(path) { recovered ->
             if (Files.notExists(recovered, LinkOption.NOFOLLOW_LINKS)) return@read null
             Files.newInputStream(recovered).use { input ->
-              input.readNBytes(MAX_SETTINGS_BYTES + 1).also {
+              input.readAtMost(MAX_SETTINGS_BYTES + 1).also {
                 if (it.size > MAX_SETTINGS_BYTES) {
                   throw OversizedSettingsException(
                       "Settings file exceeds the $MAX_SETTINGS_BYTES-byte limit")

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStore.kt
@@ -11,6 +11,7 @@ import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.time.Clock
 import java.time.ZoneOffset
@@ -410,7 +411,7 @@ class ApplicationSettingsStore(
     private val CORRUPT_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
 
     fun defaultPath(): Path =
-        Path.of(System.getProperty("user.home")).resolve(".coffeegb.properties")
+        Paths.get(System.getProperty("user.home")).resolve(".coffeegb.properties")
 
     internal fun decodeProperties(
         bytes: ByteArray,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/RecentRoms.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/RecentRoms.kt
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.controller.properties
 
 import java.nio.file.Path
+import java.nio.file.Paths
 
 class RecentRoms(private val emulatorProperties: EmulatorProperties) {
   fun getRoms(): List<String> =
@@ -52,7 +53,7 @@ class RecentRoms(private val emulatorProperties: EmulatorProperties) {
   }
 
   /** Compatibility wrapper retained for existing menu and Java-adapter call sites. */
-  fun addRom(rom: String) = recordSuccessfulOpen(Path.of(rom))
+  fun addRom(rom: String) = recordSuccessfulOpen(Paths.get(rom))
 
   private fun normalize(path: Path): Path = path.toAbsolutePath().normalize()
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -975,11 +975,10 @@ internal object StateGraph {
       val type = value.javaClass
       val id = admittedRecordIds[type]
           ?: throw StateCaptureException("Unregistered state record ${type.name}")
-      val fields = type.recordComponents.map { component ->
-        component.accessor.trySetAccessible()
+      val fields = StateRecordIntrospection.components(type).map { component ->
         val componentValue =
             try {
-              component.accessor.invoke(value)
+              component.value(value)
             } catch (failure: ReflectiveOperationException) {
               throw StateCaptureException("State field ${type.name}.${component.name} failed", failure)
             }
@@ -1044,7 +1043,7 @@ internal object StateGraph {
 
     private fun restoreRecord(value: RecordState, depth: Int): Any {
       val type = recordClass(value)
-      val components = type.recordComponents
+      val components = StateRecordIntrospection.components(type)
       if (value.fields.size != components.size ||
           value.fields.indices.any { value.fields[it].name != components[it].name }) {
         throw StateApplyException("Invalid ${type.name} field inventory")
@@ -1054,7 +1053,7 @@ internal object StateGraph {
             this.value(value.fields[index].value, components[index].genericType, depth + 1)
           }.toTypedArray()
       val constructor = type.getDeclaredConstructor(*components.map { it.type }.toTypedArray())
-      constructor.trySetAccessible()
+      constructor.isAccessible = true
       try {
         return constructor.newInstance(*args)
       } catch (failure: InvocationTargetException) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -667,13 +667,12 @@ private object SnapshotGraph {
     fun visit(value: Any?) {
       if (value == null) return
       when {
-        value.javaClass.isRecord -> {
+        StateTypeRegistry.isAuditedStateType(value.javaClass) -> {
           val typeId = recordIds[value.javaClass]
               ?: throw StateApplyException("Unregistered internal record ${value.javaClass.name}")
           if (isOwnershipRecord(value.javaClass.name)) signature += typeId
-          value.javaClass.recordComponents.forEach { component ->
-            component.accessor.trySetAccessible()
-            visit(component.accessor.invoke(value))
+          StateRecordIntrospection.components(value.javaClass).forEach { component ->
+            visit(component.value(value))
           }
         }
         value.javaClass.isArray && !value.javaClass.componentType.isPrimitive ->
@@ -746,7 +745,7 @@ private object SnapshotGraph {
       val type =
           StateTypeRegistry.recordClasses.getOrNull(value.typeId - 1)
               ?: throw StateApplyException("Unknown internal record type ID ${value.typeId}")
-      val components = type.recordComponents
+      val components = StateRecordIntrospection.components(type)
       if (components.size != value.fields.size ||
           components.indices.any { components[it].name != value.fields[it].name }) {
         throw StateApplyException("Invalid internal ${type.name} field inventory")
@@ -758,7 +757,7 @@ private object SnapshotGraph {
               }
               .toTypedArray()
       val constructor = type.getDeclaredConstructor(*components.map { it.type }.toTypedArray())
-      constructor.trySetAccessible()
+      constructor.isAccessible = true
       try {
         return constructor.newInstance(*arguments)
       } catch (failure: InvocationTargetException) {
@@ -1063,8 +1062,7 @@ private object SnapshotGraph {
       val typeId = recordIds[type] ?: error("Unregistered snapshot record ${type.name}")
       val sameType = previous?.takeIf { it.typeId == typeId }
       val fields =
-          type.recordComponents.mapIndexed { index, component ->
-            component.accessor.trySetAccessible()
+          StateRecordIntrospection.components(type).mapIndexed { index, component ->
             val old =
                 sameType
                     ?.fields
@@ -1074,7 +1072,7 @@ private object SnapshotGraph {
             try {
               SnapshotField(
                   component.name,
-                  value(component.accessor.invoke(source), old, depth + 1),
+                  value(component.value(source), old, depth + 1),
               )
             } catch (failure: IllegalStateException) {
               throw IllegalStateException(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateCodec.kt
@@ -921,7 +921,16 @@ object StateCodec {
         .multiply(BigInteger.valueOf(destinationLimit))
         .add(BigInteger.valueOf(LEGACY_V1_SGB_RTC_PHASE_LIMIT / 2))
         .divide(BigInteger.valueOf(LEGACY_V1_SGB_RTC_PHASE_LIMIT))
-        .longValueExact()
+        .longValueExactForAndroid()
+  }
+
+  /** Android API 26 lacks BigInteger.longValueExact(), used by the JVM implementation. */
+  private fun BigInteger.longValueExactForAndroid(): Long {
+    if (compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0 ||
+        compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {
+      throw ArithmeticException("BigInteger does not fit in a Long")
+    }
+    return toLong()
   }
 
   private fun malformedLegacyRtc(message: String): Nothing =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateFileInspector.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateFileInspector.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.state
 import eu.rekawek.coffeegb.controller.StateLimits
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 
 /** Headless inspection facade and command-line utility for portable StateFile metadata. */
 object StateFileInspector {
@@ -11,7 +12,7 @@ object StateFileInspector {
   @JvmStatic
   fun main(arguments: Array<String>) {
     require(arguments.size == 1) { "usage: StateFileInspector <state-file>" }
-    val path = Path.of(arguments[0])
+    val path = Paths.get(arguments[0])
     val declared = Files.size(path)
     if (declared !in 0..StateLimits.PORTABLE_MAX_FILE_BYTES.toLong()) {
       PortableBounds.limit(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
@@ -14,27 +14,39 @@ import java.util.concurrent.ConcurrentHashMap
  */
 internal object StateRecordIntrospection {
 
-  private val componentsByClass = ConcurrentHashMap<Class<*>, List<StateRecordComponent>>()
+  private val metadataByClass = ConcurrentHashMap<Class<*>, StateRecordMetadata>()
 
   fun components(type: Class<*>): List<StateRecordComponent> =
-      componentsByClass.computeIfAbsent(type, ::readComponents)
+      metadataByClass.computeIfAbsent(type, ::readMetadata).components
 
   fun requireConstructible(type: Class<*>) {
-    val components = components(type)
-    try {
-      type.getDeclaredConstructor(*components.map(StateRecordComponent::type).toTypedArray())
-    } catch (failure: ReflectiveOperationException) {
-      throw IllegalArgumentException("Audited state type has no canonical constructor: $type", failure)
-    }
+    metadataByClass.computeIfAbsent(type, ::readMetadata)
   }
 
-  private fun readComponents(type: Class<*>): List<StateRecordComponent> =
-      type.declaredFields
+  private fun readMetadata(type: Class<*>): StateRecordMetadata {
+    val fields =
+        type.declaredFields
           .asSequence()
           .filterNot { Modifier.isStatic(it.modifiers) || it.isSynthetic }
-          .map(::StateRecordComponent)
           .toList()
+    val constructor =
+        type.declaredConstructors.singleOrNull { candidate ->
+          candidate.parameterCount == fields.size &&
+              candidate.parameterTypes.toList().groupingBy { it }.eachCount() ==
+                  fields.groupingBy(Field::getType).eachCount()
+        } ?: throw IllegalArgumentException("Audited state type has no canonical constructor: $type")
+    val remaining = fields.toMutableList()
+    val components =
+        constructor.parameterTypes.map { parameterType ->
+          val index = remaining.indexOfFirst { it.type == parameterType }
+          if (index < 0) throw IllegalArgumentException("Invalid canonical constructor for $type")
+          StateRecordComponent(remaining.removeAt(index))
+        }
+    return StateRecordMetadata(components)
+  }
 }
+
+private class StateRecordMetadata(val components: List<StateRecordComponent>)
 
 internal class StateRecordComponent(private val javaField: Field) {
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
@@ -1,0 +1,55 @@
+package eu.rekawek.coffeegb.controller.state
+
+import java.lang.reflect.Field
+import java.lang.reflect.Type
+import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Reflection metadata for Coffee GB's audited state records.
+ *
+ * Android API 26 can run record-desugared classes, but does not expose the Java 16 record
+ * reflection APIs. State records have a canonical constructor and one instance field per
+ * component, so their existing audited inventories can use the stable reflection APIs instead.
+ */
+internal object StateRecordIntrospection {
+
+  private val componentsByClass = ConcurrentHashMap<Class<*>, List<StateRecordComponent>>()
+
+  fun components(type: Class<*>): List<StateRecordComponent> =
+      componentsByClass.computeIfAbsent(type, ::readComponents)
+
+  fun requireConstructible(type: Class<*>) {
+    val components = components(type)
+    try {
+      type.getDeclaredConstructor(*components.map(StateRecordComponent::type).toTypedArray())
+    } catch (failure: ReflectiveOperationException) {
+      throw IllegalArgumentException("Audited state type has no canonical constructor: $type", failure)
+    }
+  }
+
+  private fun readComponents(type: Class<*>): List<StateRecordComponent> =
+      type.declaredFields
+          .asSequence()
+          .filterNot { Modifier.isStatic(it.modifiers) || it.isSynthetic }
+          .map(::StateRecordComponent)
+          .toList()
+}
+
+internal class StateRecordComponent(private val javaField: Field) {
+
+  init {
+    javaField.isAccessible = true
+  }
+
+  val name: String
+    get() = javaField.name
+
+  val type: Class<*>
+    get() = javaField.type
+
+  val genericType: Type
+    get() = javaField.genericType
+
+  fun value(record: Any): Any? = javaField.get(record)
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospection.kt
@@ -35,13 +35,22 @@ internal object StateRecordIntrospection {
               candidate.parameterTypes.toList().groupingBy { it }.eachCount() ==
                   fields.groupingBy(Field::getType).eachCount()
         } ?: throw IllegalArgumentException("Audited state type has no canonical constructor: $type")
-    val remaining = fields.toMutableList()
+    val fieldsByName = fields.associateBy(Field::getName).toMutableMap()
     val components =
-        constructor.parameterTypes.map { parameterType ->
-          val index = remaining.indexOfFirst { it.type == parameterType }
-          if (index < 0) throw IllegalArgumentException("Invalid canonical constructor for $type")
-          StateRecordComponent(remaining.removeAt(index))
+        constructor.parameters.map { parameter ->
+          require(parameter.isNamePresent) {
+            "Audited state type has no canonical constructor parameter names: $type"
+          }
+          val field =
+              fieldsByName.remove(parameter.name)
+                  ?: throw IllegalArgumentException(
+                      "Invalid canonical constructor parameter ${parameter.name} for $type")
+          require(field.type == parameter.type) {
+            "Invalid canonical constructor parameter ${parameter.name} for $type"
+          }
+          StateRecordComponent(field)
         }
+    require(fieldsByName.isEmpty()) { "Invalid canonical constructor for $type" }
     return StateRecordMetadata(components)
   }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
@@ -721,16 +721,26 @@ class StateRepository(
     return NamedRefs(refs, entries)
   }
 
-  /** Refuses traversal through symlinked or non-directory components, including the game root. */
+  /**
+   * Refuses traversal through symlinked or non-directory components at and below the caller-owned
+   * game root. Ancestors are the host's trust boundary and may be Android framework paths that do
+   * not expose POSIX link attributes through API-26 NIO.
+   */
   private fun ensureSafeParent(target: Path) {
     val normalized = target.toAbsolutePath().normalize()
     require(normalized.startsWith(layout.gameDirectory)) {
       "State repository target escapes the configured game directory"
     }
     val parent = requireNotNull(normalized.parent)
-    var cursor = parent.root
-    parent.forEach { component ->
-      cursor = if (cursor == null) component else cursor.resolve(component)
+    var cursor = layout.gameDirectory
+    if (Files.exists(cursor, LinkOption.NOFOLLOW_LINKS) &&
+        (Files.isSymbolicLink(cursor) ||
+            !Files.isDirectory(cursor, LinkOption.NOFOLLOW_LINKS))) {
+      throw IOException(
+          "State repository path component is not a safe directory: ${cursor.fileName}")
+    }
+    layout.gameDirectory.relativize(parent).forEach { component ->
+      cursor = cursor.resolve(component)
       if (Files.exists(cursor, LinkOption.NOFOLLOW_LINKS) &&
           (Files.isSymbolicLink(cursor) ||
               !Files.isDirectory(cursor, LinkOption.NOFOLLOW_LINKS))) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -67,7 +67,7 @@ internal object StateSemantics {
           value.forEachIndexed { index, item -> visit(item, "$path[$index]", visited, clockSpec) }
       value is Map<*, *> ->
           value.forEach { (key, item) -> visit(item, "$path[$key]", visited, clockSpec) }
-      value.javaClass.isRecord -> {
+      StateTypeRegistry.isAuditedStateType(value.javaClass) -> {
         val type = value.javaClass.name
         val policy = policies[type]
             ?: throw StateApplyException("No semantic state policy for $type")
@@ -85,14 +85,13 @@ internal object StateSemantics {
       private val record: Any,
       private val path: String,
   ) {
-    val components = record.javaClass.recordComponents.toList()
+    val components = StateRecordIntrospection.components(record.javaClass)
 
     fun value(name: String): Any? {
       val component = components.singleOrNull { it.name == name }
           ?: throw StateApplyException("$path has no field $name")
-      component.accessor.trySetAccessible()
       return try {
-        component.accessor.invoke(record)
+        component.value(record)
       } catch (failure: ReflectiveOperationException) {
         throw StateApplyException("Could not inspect $path.$name", failure)
       }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
@@ -107,7 +107,7 @@ internal object StateValueCodec {
       val type =
           StateTypeRegistry.recordClasses.getOrNull(value.typeId - 1)
               ?: throw StateEncodeException("Unknown detached record type ID ${value.typeId}")
-      val components = type.recordComponents
+      val components = StateRecordIntrospection.components(type)
       if (value.fields.size != components.size ||
           value.fields.indices.any { value.fields[it].name != components[it].name }) {
         throw StateEncodeException("Detached record ${type.name} has an invalid field inventory")
@@ -220,7 +220,7 @@ internal object StateValueCodec {
 
     private fun readRecord(depth: Int): RecordState {
       val typeId = requireTypeId(reader.readU32(), StateTypeRegistry.recordClasses.size, "record")
-      val components = StateTypeRegistry.recordClasses[typeId - 1].recordComponents
+      val components = StateRecordIntrospection.components(StateTypeRegistry.recordClasses[typeId - 1])
       val count =
           PortableBounds.requireCount(
               reader.readU32(),

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -95,6 +95,7 @@ class RomSessionPreparerTest {
     val root = Files.createTempDirectory("coffee-gb-pathless-store")
     try {
       val image = RomImage.memory(ROM.readBytes(), "picked.gb")
+      lateinit var stateStore: FileStateStore
       val store =
           RomPersistenceStore { _, hashes ->
             val layout = StateStorageLayout(root.resolve("games").resolve(hashes.primaryRom.hex()))
@@ -103,8 +104,9 @@ class RomSessionPreparerTest {
                     BatteryStorage.Source.managed(layout.batteryFile, root),
                     emptyList(),
                 )
+            stateStore = FileStateStore(layout)
             SessionPersistence(
-                FileStateStore(layout),
+                stateStore,
                 BatteryStore { battery },
                 null,
             )
@@ -117,6 +119,7 @@ class RomSessionPreparerTest {
           )
 
       assertNull(prepared.config.rom.file)
+      assertSame(stateStore, prepared.stateStore)
       assertTrue(prepared.config.batteryStorage.targetPath().startsWith(root))
       assertTrue(prepared.config.batteryStorage.targetPath().fileName.toString() == "battery.sav")
     } finally {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateRecordIntrospectionTest.kt
@@ -1,0 +1,23 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.controller.StateTypeRegistry
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class StateRecordIntrospectionTest {
+
+  @Test
+  fun `uses canonical constructor parameter names for every audited state record`() {
+    StateTypeRegistry.recordClasses.forEach { type ->
+      val constructor =
+          type.declaredConstructors.single { candidate ->
+            candidate.parameterCount == StateRecordIntrospection.components(type).size
+          }
+      assertEquals(
+          constructor.parameters.map { it.name },
+          StateRecordIntrospection.components(type).map { it.name },
+          type.name,
+      )
+    }
+  }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/genie/CheatDatabase.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/genie/CheatDatabase.java
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.core.genie;
 
+import eu.rekawek.coffeegb.core.io.InputStreams;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,7 +54,7 @@ public final class CheatDatabase {
             ZipEntry entry;
             while ((entry = zip.getNextEntry()) != null) {
                 if (!entry.isDirectory() && entry.getName().toLowerCase(Locale.ROOT).endsWith(".cht")) {
-                    CheatList list = parse(entry.getName(), new ByteArrayInputStream(zip.readAllBytes()));
+                    CheatList list = parse(entry.getName(), new ByteArrayInputStream(InputStreams.readAllBytes(zip)));
                     if (!list.cheats().isEmpty()) {
                         lists.add(list);
                     }
@@ -66,7 +68,7 @@ public final class CheatDatabase {
 
     static CheatList parse(String entryName, InputStream input) throws IOException {
         Map<Integer, Map<String, String>> properties = new LinkedHashMap<>();
-        String text = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        String text = new String(InputStreams.readAllBytes(input), StandardCharsets.UTF_8);
         for (String line : text.split("\\R")) {
             Matcher matcher = CHEAT_PROPERTY.matcher(line.trim());
             if (matcher.matches()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/hardware/ClockSpec.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/hardware/ClockSpec.java
@@ -191,7 +191,7 @@ public final class ClockSpec {
                 .multiply(BigInteger.valueOf(outputUnitsPerSecond))
                 .multiply(BigInteger.valueOf(ticksPerSecondDenominator))
                 .add(BigInteger.valueOf(ticksPerSecondNumerator - 1));
-        return numerator.divide(BigInteger.valueOf(ticksPerSecondNumerator)).longValueExact();
+        return longValueExact(numerator.divide(BigInteger.valueOf(ticksPerSecondNumerator)));
     }
 
     /** Complete exact clock/cadence identity used before linked execution. */
@@ -275,7 +275,16 @@ public final class ClockSpec {
                 result = result.add(BigInteger.ONE);
             }
         }
-        return result.longValueExact();
+        return longValueExact(result);
+    }
+
+    /** Android API 26 exposes {@code BigInteger.longValue()} but not Java 8's exact variant. */
+    private static long longValueExact(BigInteger value) {
+        if (value.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0
+                || value.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {
+            throw new ArithmeticException("BigInteger does not fit in a long");
+        }
+        return value.longValue();
     }
 
     private static long divide(long value, long divisor, Rounding rounding) {
@@ -356,8 +365,8 @@ public final class ClockSpec {
                         .multiply(BigInteger.valueOf(numeratorPerInput))
                         .add(BigInteger.valueOf(remainder));
                 BigInteger[] result = total.divideAndRemainder(BigInteger.valueOf(denominator));
-                remainder = result[1].longValueExact();
-                return result[0].longValueExact();
+                remainder = longValueExact(result[1]);
+                return longValueExact(result[0]);
             }
         }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/io/InputStreams.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/io/InputStreams.java
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.core.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/** Stream helpers that remain available on the minimum Android API level. */
+public final class InputStreams {
+
+    private static final int BUFFER_SIZE = 8 * 1024;
+
+    private InputStreams() {
+    }
+
+    /** Reads the remaining bytes without depending on Java 9's {@link InputStream#readAllBytes()}. */
+    public static byte[] readAllBytes(InputStream input) throws IOException {
+        Objects.requireNonNull(input, "input");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            output.write(buffer, 0, count);
+        }
+        return output.toByteArray();
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Bios.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Bios.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.GameboyType;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.io.InputStreams;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,7 +21,7 @@ public class Bios implements AddressSpace {
                 if (is == null) {
                     throw new IllegalArgumentException("No bios found for " + bootRomId);
                 }
-                var rom = is.readAllBytes();
+                var rom = InputStreams.readAllBytes(is);
                 var result = new int[rom.length];
                 for (int i = 0; i < rom.length; i++) {
                     result[i] = rom[i] & 0xff;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/SevenZArchiveWorker.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/SevenZArchiveWorker.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -128,8 +129,8 @@ public final class SevenZArchiveWorker {
             throw new IOException("Missing 7z worker arguments");
         }
         Action action = Action.fromId(args[0]);
-        Path snapshot = Path.of(args[1]);
-        Path report = Path.of(args[2]);
+        Path snapshot = Paths.get(args[1]);
+        Path report = Paths.get(args[2]);
         requireExistingWorkerFile(snapshot, "snapshot");
         requireExistingWorkerFile(report, "report");
 
@@ -140,7 +141,7 @@ public final class SevenZArchiveWorker {
                     if (args.length != 5) {
                         throw new IOException("Invalid 7z extraction arguments");
                     }
-                    Path output = Path.of(args[3]);
+                    Path output = Paths.get(args[3]);
                     requireExistingWorkerFile(output, "output");
                     long candidateToken = Long.parseLong(args[4]);
                     Entry extracted = extractInProcess(snapshot, output, candidateToken);
@@ -370,7 +371,7 @@ public final class SevenZArchiveWorker {
     }
 
     private static Path javaExecutable() {
-        Path bin = Path.of(System.getProperty("java.home"), "bin");
+        Path bin = Paths.get(System.getProperty("java.home"), "bin");
         if (isWindows()) {
             Path windowless = bin.resolve("javaw.exe");
             if (Files.isRegularFile(windowless)) {
@@ -478,7 +479,7 @@ public final class SevenZArchiveWorker {
             throw invalidWorkerReport("entry metadata is invalid");
         }
         try {
-            RomOrigin.archiveEntry(Path.of("worker-report.7z"), entryName);
+            RomOrigin.archiveEntry(Paths.get("worker-report.7z"), entryName);
         } catch (IllegalArgumentException failure) {
             throw invalidWorkerReport("entry path is invalid");
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/DefinedPalettes.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/DefinedPalettes.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.sgb;
 
+import eu.rekawek.coffeegb.core.io.InputStreams;
 import eu.rekawek.coffeegb.core.memory.Bios;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ public class DefinedPalettes {
             if (is == null) {
                 throw new IllegalArgumentException("No palette data found");
             }
-            var bytes = is.readAllBytes();
+            var bytes = InputStreams.readAllBytes(is);
             DATA = new int[bytes.length];
             for (int i = 0; i < bytes.length; i++) {
                 DATA[i] = bytes[i] & 0xff;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/hardware/ClockSpecTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/hardware/ClockSpecTest.java
@@ -72,6 +72,8 @@ public class ClockSpecTest {
 
         assertThrows(ArithmeticException.class, () -> clock.ticksForSeconds(Long.MAX_VALUE));
         assertThrows(ArithmeticException.class,
+                () -> ClockSpec.multiplyDivide(Long.MAX_VALUE, 2, 1, ClockSpec.Rounding.FLOOR));
+        assertThrows(ArithmeticException.class,
                 () -> clock.newTickRateAccumulator(Long.MAX_VALUE).advance(Long.MAX_VALUE));
         assertThrows(IllegalArgumentException.class, () -> new ClockSpec(0, 60, 1));
         assertThrows(IllegalArgumentException.class, () -> new ClockSpec(1, 2, 1));

--- a/doc/ui-performance.md
+++ b/doc/ui-performance.md
@@ -22,8 +22,8 @@ also re-read from `System.nanoTime()` *after* the spin, so scheduling jitter
 accumulated instead of averaging out.
 
 **Fix:** absolute deadlines (`deadline += FRAME_DURATION`), sleep the bulk of
-the wait with `LockSupport.parkNanos` and busy-spin only the last 1.5 ms for
-frame-exact wakeup (`Thread.onSpinWait` in the hot loop). If the emulator falls
+the wait with `LockSupport.parkNanos` and yield only the last 1.5 ms for
+frame-exact wakeup (`Thread.yield` in the hot loop). If the emulator falls
 more than a frame behind, the deadline re-anchors instead of fast-forwarding.
 
 Measured (2 s synthetic run, 3 ms of work per frame): thread CPU 2000 ms →


### PR DESCRIPTION
Completes the reproducible CI and artifact work in #363 for #319.

- builds same-checkout Maven artifacts in an isolated repository before Gradle check, lint, debug APK, and R8 release APK validation
- runs instrumentation smoke on API 26/x86 and API 36/x86_64
- exercises a source-generated public-domain fixture through a content URI: 600 frames, input, snapshot save/restore, background/resume, and stop
- rejects desktop references, ROM/save/archive/signing artifacts, and developer paths from the APK
- uploads unsigned APKs, runtime dependency graph, license inventory, and APK content report

Validation:
- git diff --check
- Gradle task graph and Android instrumentation dependency configuration resolve successfully
- local Android compilation requires an SDK unavailable in this environment; PR CI installs the pinned SDK and runs the complete path

Physical ARM64 measurement, signing, and store publication are intentionally tracked in #478.