### PR TITLE
Publish Windows portable EXE

### DIFF
--- a/.github/workflows/native-packages.yml
+++ b/.github/workflows/native-packages.yml
@@ -137,18 +137,20 @@ jobs:
               ;;
           esac
 
-      - name: Prove Windows target runner architecture and WiX
+      - name: Prove Windows target runner architecture and portable-EXE tooling
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
             throw "windows-x86-64 requires an X64 runner"
           }
-          if (-not (Get-Command candle.exe -ErrorAction SilentlyContinue)) {
-            throw "The Windows runner has no WiX candle.exe required by JDK 21 jpackage"
+          $SevenZip = Get-Command 7z.exe -ErrorAction SilentlyContinue
+          if (-not $SevenZip) {
+            throw "windows-x86-64 requires 7z.exe to build the portable EXE"
           }
-          if (-not (Get-Command light.exe -ErrorAction SilentlyContinue)) {
-            throw "The Windows runner has no WiX light.exe required by JDK 21 jpackage"
+          $SfxModule = Join-Path (Split-Path -Parent $SevenZip.Source) "7z.sfx"
+          if (-not (Test-Path -LiteralPath $SfxModule -PathType Leaf)) {
+            throw "windows-x86-64 requires the 7-Zip SFX module: $SfxModule"
           }
 
       - name: Install Linux package validation prerequisites
@@ -207,7 +209,7 @@ jobs:
               "swing/target/native-package-${PACKAGE_TARGET}-${PACKAGE_TYPE}"
           fi
 
-      - name: Install final package and repeat strict launch smokes
+      - name: Run the portable EXE and repeat strict launch smokes
         if: runner.os == 'Windows'
         shell: pwsh
         env:

--- a/android/app/src/main/res/values-v27/styles.xml
+++ b/android/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.CoffeeGb" parent="Theme.CoffeeGb.Base">
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.CoffeeGb" parent="android:style/Theme.Material.Light.NoActionBar">
+    <style name="Theme.CoffeeGb.Base" parent="android:style/Theme.Material.Light.NoActionBar">
         <item name="android:colorAccent">#61693F</item>
         <item name="android:statusBarColor">#EFE8D8</item>
         <item name="android:navigationBarColor">#EFE8D8</item>
         <item name="android:windowLightStatusBar">true</item>
-        <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowActionModeOverlay">true</item>
     </style>
+
+    <style name="Theme.CoffeeGb" parent="Theme.CoffeeGb.Base" />
 </resources>

--- a/docs/native-package-ci.md
+++ b/docs/native-package-ci.md
@@ -6,32 +6,32 @@ Linux. Each jpackage invocation runs on its target architecture:
 | Target | GitHub-hosted runner | Deliverable | Final-package check |
 | --- | --- | --- | --- |
 | Linux x64 | `ubuntu-24.04` | DEB | `dpkg-deb --extract` |
-| Windows x64 | `windows-2025` | EXE | silent install into an isolated verification directory |
+| Windows x64 | `windows-2025` | Portable EXE | run the EXE, then extract into an isolated verification directory |
 | macOS x64 | `macos-15-intel` | DMG | read-only `hdiutil` mount |
 | macOS arm64 | `macos-15` | DMG | read-only `hdiutil` mount |
 
-JDK 21 supplies `jdeps`, `jlink`, and `jpackage`. The Windows image must also expose WiX
-`candle.exe` and `light.exe`; each job fails before building if its architecture or required host
+JDK 21 supplies `jdeps`, `jlink`, and `jpackage`. The Windows image must also expose 7-Zip's
+`7z.exe` and `7z.sfx` module; each job fails before building if its architecture or required host
 tool is wrong. Oracle jpackage cannot cross-build these formats, so a missing target runner is a
 release blocker rather than permission to relabel another architecture.
 
 ## What CI proves
 
 The wrapper runs the Maven-authoritative `clean verify` reactor, including unit tests and the
-target-neutral staging integration tests, before building one unsigned installer. The package tool
+target-neutral staging integration tests, before building one unsigned target package. The package tool
 then:
 
 1. verifies the minimized runtime module closure and launches the neutral JAR with that runtime;
 2. validates the canonical NFC UTF-8 license and exact `Tomasz Rękawek` author name, generates the
-   platform-safe installer license, and builds the host installer without a signing request;
+   platform-safe installer license where needed, and builds the host package without a signing request;
 3. inspects jpackage's exact payload image and runs packaged `--version`, `--package-smoke`, and
    production desktop launches both normally and with `--debug`;
 4. writes `PACKAGE-RESULT.properties`, one canonical byte-identical Maven dependency CycloneDX
    SBOM, one exact target-native CycloneDX SBOM generated from the locked inventory, and exhaustive
    `SHA256SUMS`;
-5. unpacks or mounts the final installer and repeats strict inspection and both launch smokes from
+5. unpacks, extracts, or mounts the final package and repeats strict inspection and both launch smokes from
    an isolated temporary home; and
-6. proves the final DEB desktop entry, installed EXE registry state, and DMG application metadata
+6. proves the final DEB desktop entry, portable-EXE registry state, and DMG application metadata
    do not register `.gb`, `.gbc`, or `.rom` with Coffee GB; and
 7. uploads the short-lived target validation inputs, including both SBOMs, checksums, result
    manifest, and (once, from Linux) the unchanged portable Maven JAR. The final gated release
@@ -57,9 +57,9 @@ Windows keeps the primary `Coffee GB.exe` GUI launcher console-free and uses the
 The no-registration gate inspects the exact final artifacts. Linux rejects any `MimeType` in the
 packaged Coffee GB desktop entry. macOS rejects `CFBundleDocumentTypes`,
 `UTExportedTypeDeclarations`, and `UTImportedTypeDeclarations` in the mounted application. Windows
-silently installs the EXE into an isolated directory and rejects any `.gb`, `.gbc`, or `.rom`
-extension class, `OpenWithProgids`, or `OpenWithList` entry that resolves to Coffee GB. These checks
-run again for protected signed builds.
+runs the portable EXE, extracts it into an isolated directory, and rejects any `.gb`, `.gbc`, or
+`.rom` extension class, `OpenWithProgids`, or `OpenWithList` entry that resolves to Coffee GB.
+These checks run again for protected signed builds.
 
 The content verifier bounds traversal and rejects symlinks in application input, a second runtime,
 foreign or altered target natives, ROM-like files, signing-store exports, private-key/token-shaped
@@ -102,7 +102,7 @@ commit ID; every matrix and gate checkout uses that ID and verifies `HEAD`, and 
 re-fetched and re-peeled before each promotion. A moved tag therefore fails closed. The release
 matrix records the bound source commit.
 
-Publication waits for the unsigned build, installer inspection, desktop/debug launch, and
+Publication waits for the unsigned build, package inspection, desktop/debug launch, and
 no-registration gates on all four targets. A Linux release-gate job independently downloads the
 results, requires one default package, one canonical byte-identical Maven dependency SBOM, and
 one exact target-native SBOM per target, renames packages with explicit architecture, records the
@@ -133,9 +133,9 @@ the release notes together; never silently omit it.
 Normal and pull-request artifacts are unsigned and the matrix records that fact. The release
 dispatch can request `sign_native_packages`; only then, after the unsigned four-target gate, does
 the protected `native-release` matrix import ephemeral credentials and invoke `--release-sign`.
-The Windows path signs and verifies every visible executable/DLL in a prebuilt app image, creates
-an EXE from that signed image, signs and verifies the EXE, then verifies the installed executable
-payload. Digest-locked third-party native-source bytes live in a deterministic stored ZIP, so
+The Windows path signs and verifies every visible executable/DLL in a prebuilt app image, wraps
+that signed image in a portable self-extracting EXE, signs and verifies the outer EXE, then
+verifies the extracted executable payload. Digest-locked third-party native-source bytes live in a deterministic stored ZIP, so
 platform signing seals the archive without changing the upstream sizes or SHA-256 values that the
 runtime verifies while extracting.
 The macOS path signs and verifies the app image, explicitly requires the JDK default
@@ -169,8 +169,8 @@ must update the adjacent version comment and revalidate all workflow tests befor
 
 - Linux: verify `SHA256SUMS`, install the DEB with the distribution package tool, and remove the
   `coffee-gb` package with that same tool.
-- Windows: verify `SHA256SUMS`, open the EXE, and remove Coffee GB through Installed Apps or the
-  same EXE product identity.
+- Windows: verify `SHA256SUMS`, open the EXE, and close Coffee GB when finished. It extracts only
+  to its temporary run directory and creates no Installed Apps entry.
 - macOS: verify the checksum, open the DMG, copy Coffee GB to Applications, eject the image, and
   remove the application by moving it to Trash.
 

--- a/docs/native-packaging.md
+++ b/docs/native-packaging.md
@@ -3,7 +3,8 @@
 This document defines the native packaging and release-validation contract. Maven remains the
 authoritative application build. Target staging, minimized runtimes, application images, and native
 installers consume Maven outputs; they never compile a second application copy or resolve a second
-dependency graph.
+dependency graph. Windows release EXEs are self-extracting portable application images, not
+installers.
 
 ## Desktop artifacts
 
@@ -126,7 +127,7 @@ neutral JAR, universal JAR, and CycloneDX SBOM, and then invoke the same Java pa
 ```
 
 ```powershell
-# Windows x86-64 EXE (the target's default package)
+# Windows x86-64 portable EXE (the target's default package)
 .\packaging\package-native.ps1 windows-x86-64 exe
 ```
 
@@ -137,10 +138,10 @@ dependencies, JDKs, native libraries, or signing tools themselves.
 `jpackage` cannot generate a foreign platform image. The selected target is never inferred from
 the host; after selection, the tool rejects a mismatched host OS or architecture:
 
-| Target | Host | Default installer | Other validated type | Host prerequisites |
+| Target | Host | Default package | Other validated type | Host prerequisites |
 | --- | --- | --- | --- | --- |
 | `linux-x86-64` | Linux x86-64 | DEB | RPM, app-image | JDK 21+, `dpkg-deb` and `desktop-file-validate` for DEB, or `rpmbuild` for RPM |
-| `windows-x86-64` | Windows x86-64 | EXE | MSI, app-image | JDK 21+, WiX supported by that JDK |
+| `windows-x86-64` | Windows x86-64 | Portable EXE | MSI, app-image | JDK 21+, 7-Zip with `7z.sfx` |
 | `macos-x86-64` | macOS x86-64 | DMG | PKG, app-image | JDK 21+, Xcode command-line packaging tools |
 | `macos-aarch64` | macOS arm64 | DMG | PKG, app-image | arm64 JDK 21+, Xcode command-line packaging tools |
 
@@ -220,7 +221,7 @@ code unit; the macOS resource override uses an RTF resource rather than the lega
 This keeps the installed legal copy byte-identical while avoiding locale-dependent installer
 decoding.
 
-Installers do not register `.gb`, `.gbc`, or `.rom` with Coffee GB and do not request default- or
+Packages do not register `.gb`, `.gbc`, or `.rom` with Coffee GB and do not request default- or
 optional-handler status. Staging creates no jpackage association files, Linux desktop metadata has
 no `MimeType`, macOS bundles declare no document or exported/imported type keys, and Windows
 installation must not add Coffee GB to extension class or `OpenWith` registrations. Users can
@@ -230,9 +231,9 @@ type. Linux packages install a freedesktop `Game;` menu shortcut while retaining
 section `games`. A DEB build extracts the package-owned
 `/opt/coffee-gb/lib/coffee-gb-Coffee_GB.desktop` payload, runs `desktop-file-validate`, and proves
 the bounded `postinst` script registers that exact file. It also verifies the section and expected
-`libasound2t64` dependency; Windows packages request
-Start-menu and desktop shortcuts, retain a fixed upgrade UUID for upgrade/uninstall identity,
-expose help/update URLs, and provide an install-directory chooser. macOS packages set the Games
+`libasound2t64` dependency. The Windows portable EXE extracts to a temporary directory, launches
+Coffee GB, and creates no shortcut, uninstall identity, or registry entry; the optional MSI retains
+the fixed upgrade UUID, help/update URLs, and install-directory chooser. macOS packages set the Games
 application category and bundle identifier. The desktop ROM-open service remains available for
 explicit application-directed open-file events; packaging never claims those file types.
 
@@ -295,16 +296,16 @@ Protected release signing uses a two-stage image flow before any digest is final
 
 1. build and structurally inspect a prebuilt application image;
 2. sign and verify its executable content;
-3. build the default installer from that exact signed image;
-4. sign and independently verify the outer installer;
-5. inspect the installer payload and reverify the copied/installed executable content; and
+3. build the default package from that exact signed image;
+4. sign and independently verify the outer package;
+5. inspect the package payload and reverify the extracted executable content; and
 6. only then copy the verified Maven dependency SBOM and target-native SBOM and write the result
    manifest and checksums.
 
 On Windows the policy is deliberately EXE-only. It deterministically Authenticode-signs every
 visible executable/DLL in the app image with SHA-256 and an RFC 3161 HTTPS timestamp, appending
 rather than replacing an existing vendor signature, and requires `/pa /all /tw` verification
-before EXE creation, in jpackage's package image, and after installation. Digest-locked
+before portable-EXE creation, in jpackage's app image, and after extraction. Digest-locked
 third-party native-source binaries are stored rather than compressed inside a deterministic ZIP;
 platform signing seals that resource without rewriting the upstream bytes later checked during
 runtime extraction. The policy then signs and verifies the outer EXE. On macOS the protected path
@@ -336,7 +337,8 @@ libraries have additional ABI and package requirements. Windows 10 x86-64 or new
 newer on the packaged architecture remain the other project release floors. These are conservative
 tested floors, not a claim that every older machine fails. Each native package bundles its Java
 runtime, so users do not install Java separately. Linux desktop integration depends on the
-distribution's ordinary menu/MIME tools, Windows MSI/EXE creation depends on WiX, and macOS
+distribution's ordinary menu/MIME tools, Windows portable-EXE creation depends on 7-Zip's SFX
+module, and macOS
 Gatekeeper warns for unsigned local/PR builds; only protected release builds may be signed and
 notarized.
 
@@ -433,8 +435,8 @@ keyed by the POMs; `target/`, native caches, settings, ROMs, batteries, and stat
 never cached. Target artifacts expire after seven days and the complete gated bundle after
 fourteen.
 
-Every host verifies jpackage's pre-installer payload, then unpacks or installs the actual DEB/EXE or mounts the
-actual DMG and repeats the checks. Inspection requires:
+Every host verifies jpackage's pre-package payload, then extracts the actual DEB/portable EXE or
+mounts the actual DMG and repeats the checks. Inspection requires:
 
 - exactly one linked runtime and the locked ten-module closure;
 - the exact target-native allowlist and digests, with no foreign native;
@@ -460,7 +462,7 @@ actual DMG and repeats the checks. Inspection requires:
   that prove a visible frame, menu, display content, off-EDT readiness evidence, and bounded normal
   shutdown; and
 - final-package checks proving the DEB desktop entry has no `MimeType`, the DMG application has no
-  document or exported/imported type declarations, and the installed Windows EXE creates no Coffee
+  document or exported/imported type declarations, and the portable Windows EXE creates no Coffee
   GB `.gb`, `.gbc`, or `.rom` class/`OpenWith` registration.
 
 The headless package smoke constructs its reviewable 32 KiB loop ROM, writes it into a private

--- a/docs/native-release-checklist.md
+++ b/docs/native-release-checklist.md
@@ -14,14 +14,14 @@ has a named tester, target/architecture, date, and result. A tag push alone must
 - [ ] The Maven release tag is exactly `coffee-gb-VERSION`, is non-SNAPSHOT, and matches every
   package manifest and `--version`; its fully qualified ref peels to the full `source.commit`
   recorded in `NATIVE-PACKAGE-MATRIX.properties`.
-- [ ] All four required targets passed their unit/integration build, pre-installer inspection,
-  final installer unpack/mount, packaged `--version`, `--package-smoke`, normal and `--debug`
+- [ ] All four required targets passed their unit/integration build, pre-package inspection,
+  final package extract/mount, packaged `--version`, `--package-smoke`, normal and `--debug`
   production desktop launches, no-registration checks for `.gb`, `.gbc`, and `.rom`, bounded
-  shutdown, and uninstall cleanup. Each package smoke named the exact configured target after
+  shutdown, and portable-EXE cleanup where applicable. Each package smoke named the exact configured target after
   starting from its own empty extraction cache.
 - [ ] If protected signing was requested, every target was rebuilt from the same immutable source
-  after the unsigned gate. Windows app-image executables and the EXE, macOS app bundles and DMGs,
-  and Linux detached signatures all passed their independent platform verification. The installed
+  after the unsigned gate. Windows app-image executables and the portable EXE, macOS app bundles and DMGs,
+  and Linux detached signatures all passed their independent platform verification. The extracted
   macOS app retained `com.apple.security.cs.disable-library-validation=true`, passed Gatekeeper,
   and launched with its extracted locked natives; checksums were generated afterward.
 - [ ] The release bundle contains the portable JAR, Linux x64 DEB, Windows x64 EXE, macOS x64 DMG,
@@ -40,9 +40,9 @@ has a named tester, target/architecture, date, and result. A tag push alone must
 
 ## Manual behavior on each target
 
-- [ ] Install or copy the package in a clean standard-user account without a system Java runtime.
-- [ ] In the installer license UI and installed legal file, confirm `Tomasz Rękawek` is displayed
-  exactly, with no replacement characters or mojibake.
+- [ ] Install, copy, or run the package in a clean standard-user account without a system Java runtime.
+- [ ] In the installer license UI where applicable and packaged legal file, confirm `Tomasz Rękawek`
+  is displayed exactly, with no replacement characters or mojibake.
 - [ ] Launch with no ROM; confirm the window opens, remains responsive, and quits cleanly.
 - [ ] Run packaged `--version`; compare the complete Maven version with the release tag and
   portable JAR. On Windows use `Coffee GB Console.exe --version` and confirm normal GUI launches do
@@ -65,10 +65,11 @@ has a named tester, target/architecture, date, and result. A tag push alone must
 - [ ] Launch through the packaged `--debug` path (the secondary console launcher on Windows) and
   confirm the production window starts and package-native fallback diagnostics contain no ROM,
   state, credential, or private path.
-- [ ] Uninstall/remove the application. Confirm launchers and shortcuts are removed, no Coffee GB
-  ROM association was created, and ROMs, batteries, states, settings, screenshots, and other user
-  data remain.
-- [ ] Reinstall the same build and confirm retained user data is still usable.
+- [ ] For the Windows portable EXE, confirm it starts directly without an installer, creates no
+  shortcuts or Installed Apps entry, and leaves no Coffee GB ROM association. For installable
+  packages, uninstall/remove the application and confirm launchers and shortcuts are removed.
+- [ ] Confirm ROMs, batteries, states, settings, screenshots, and other user data remain usable
+  after closing and relaunching the package.
 
 Release notes may include up to three screenshots from lawfully obtained commercial games per
 release when a project maintainer with release authority explicitly approves the exact images for

--- a/packaging/package-native.ps1
+++ b/packaging/package-native.ps1
@@ -52,6 +52,18 @@ if (-not (Test-Path -LiteralPath $Sbom -PathType Leaf)) {
     throw "CycloneDX SBOM is missing: $Sbom"
 }
 
+if ($Target -eq "windows-x86-64" -and (-not $Type -or $Type -eq "exe")) {
+    $SevenZip = Get-Command "7z.exe" -ErrorAction SilentlyContinue
+    if (-not $SevenZip) {
+        throw "Windows portable EXE packaging requires 7z.exe"
+    }
+    $SevenZipSfx = Join-Path (Split-Path -Parent $SevenZip.Source) "7z.sfx"
+    if (-not (Test-Path -LiteralPath $SevenZipSfx -PathType Leaf)) {
+        throw "Windows portable EXE packaging requires the 7-Zip SFX module: $SevenZipSfx"
+    }
+    $env:COFFEE_GB_7ZIP_COMMAND = $SevenZip.Source
+}
+
 $OutputSuffix = if ($Type) { "-$Type" } else { "" }
 $Output = Join-Path `
     $RepositoryRoot `

--- a/packaging/resources/legal/THIRD-PARTY-NOTICES.txt
+++ b/packaging/resources/legal/THIRD-PARTY-NOTICES.txt
@@ -13,6 +13,18 @@ Copyright (c) 2017 Tomasz Rękawek and contributors.
 Source: https://github.com/trekawek/coffee-gb
 License: MIT. See LICENSE.txt.
 
+7-Zip SFX module (Windows portable EXE only)
+--------------------------------------------
+The Windows release EXE prepends the standard 7-Zip self-extracting module to its Coffee GB
+application-image archive. It runs Coffee GB from a temporary extraction directory and is not an
+installer. The module comes from the LZMA SDK, which includes SFX modules and is in the public
+domain.
+
+Source: https://www.7-zip.org/sdk.html
+License: public domain.
+
+The build-time 7z.exe archiver is not distributed in Coffee GB.
+
 OpenPnP OpenCV 4.9.0-0 / OpenCV 4.9.0
 -------------------------------------
 The four packaged OpenCV binaries come from Maven artifact org.openpnp:opencv:4.9.0-0:

--- a/packaging/verify-native-package.ps1
+++ b/packaging/verify-native-package.ps1
@@ -16,11 +16,11 @@ $BuildRoot = if ([System.IO.Path]::IsPathRooted($BuildRoot)) {
     [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $BuildRoot))
 }
 $Dist = Join-Path $BuildRoot "dist"
-$InstalledRoot = Join-Path $BuildRoot "installed-package"
+$UnpackedRoot = Join-Path $BuildRoot "unpacked-portable-exe"
 $SmokeHome = Join-Path $BuildRoot "unpacked-smoke-home"
 
-if (Test-Path -LiteralPath $InstalledRoot) {
-    throw "Installation output already exists: $InstalledRoot"
+if (Test-Path -LiteralPath $UnpackedRoot) {
+    throw "Portable EXE extraction output already exists: $UnpackedRoot"
 }
 
 $AppJars = @(Get-ChildItem -Path $SwingTarget -Filter "coffee-gb-*-app.jar" -File)
@@ -33,49 +33,7 @@ if ($Sboms.Count -ne 1) {
     throw "Expected exactly one Maven SBOM, found $($Sboms.Count)"
 }
 if ($Packages.Count -ne 1) {
-    throw "Expected exactly one Windows EXE package, found $($Packages.Count)"
-}
-
-function Invoke-Package {
-    param(
-        [Parameter(Mandatory = $true)]
-        [ValidateSet("install", "uninstall")]
-        [string] $Action,
-        [Parameter(Mandatory = $true)]
-        [string] $Log
-    )
-    $Arguments = @()
-    if ($Action -eq "uninstall") {
-        $Arguments += "uninstall"
-    }
-    $Arguments += @(
-        "/qn",
-        "/norestart",
-        "/L*V",
-        "`"$Log`""
-    )
-    if ($Action -eq "install") {
-        $Arguments += "INSTALLDIR=`"$InstalledRoot`""
-    }
-    $Process = Start-Process `
-        -FilePath $Packages[0].FullName `
-        -ArgumentList $Arguments `
-        -Wait `
-        -PassThru
-    if ($Process.ExitCode -in @(0, 3010)) {
-        return
-    }
-    try {
-        if (Test-Path -LiteralPath $Log -PathType Leaf) {
-            Write-Host "Windows EXE package $Action log tail:"
-            Get-Content -LiteralPath $Log -Tail 250
-        } else {
-            Write-Warning "Windows EXE package $Action log was not created: $Log"
-        }
-    } catch {
-        Write-Warning "Unable to read Windows EXE package $Action log ${Log}: $($_.Exception.Message)"
-    }
-    throw "Windows EXE package $Action failed with exit code $($Process.ExitCode); see $Log"
+    throw "Expected exactly one Windows portable EXE, found $($Packages.Count)"
 }
 
 function Assert-NoRomAssociations {
@@ -94,7 +52,7 @@ function Assert-NoRomAssociations {
         if (Test-Path -LiteralPath $OpenWithList) {
             foreach ($Application in (Get-Item -LiteralPath $OpenWithList).GetValueNames()) {
                 if ($Application -match '(?i)Coffee GB(?: Console)?\.exe') {
-                    throw "The installed EXE registered $Application for $Extension"
+                    throw "The portable EXE registered $Application for $Extension"
                 }
             }
         }
@@ -105,38 +63,64 @@ function Assert-NoRomAssociations {
             }
             $Command = (Get-Item -LiteralPath $CommandKey).GetValue("")
             if ($Command -match '(?i)Coffee GB(?: Console)?\.exe' -or
-                $Command -like "*$InstalledRoot*") {
-                throw "The installed EXE registered $Extension through $ProgId`: $Command"
+                $Command -like "*$UnpackedRoot*") {
+                throw "The portable EXE registered $Extension through $ProgId`: $Command"
             }
         }
     }
 }
 
-$Installed = $false
+$SevenZip = Get-Command "7z.exe" -ErrorAction SilentlyContinue
+if (-not $SevenZip) {
+    throw "7z.exe is required to inspect the Windows portable EXE"
+}
+
+$PortableMarker = Join-Path $BuildRoot "portable-exe-ready.marker"
+$PreviousMarker = $env:COFFEE_GB_DESKTOP_SMOKE_MARKER
 try {
-    Invoke-Package -Action "install" -Log (Join-Path $BuildRoot "exe-install.log")
-    $Installed = $true
-    Assert-NoRomAssociations
-    $Arguments = @(
-        "-cp", $AppJars[0].FullName,
-        "eu.rekawek.coffeegb.swing.packaging.NativePackageVerifier",
-        "verify",
-        "--target", $Target,
-        "--type", "exe",
-        "--root", $InstalledRoot,
-        "--source-app-jar", $AppJars[0].FullName,
-        "--source-sbom", $Sboms[0].FullName,
-        "--source-legal", (Join-Path $RepositoryRoot "packaging/resources/legal"),
-        "--dist", $Dist,
-        "--run-smoke",
-        "--smoke-home", $SmokeHome
-    )
-    & java @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "Installed EXE verification failed with exit code $LASTEXITCODE"
+    $env:COFFEE_GB_DESKTOP_SMOKE_MARKER = $PortableMarker
+    $Process = Start-Process -FilePath $Packages[0].FullName -PassThru
+    $Deadline = [DateTime]::UtcNow.AddSeconds(45)
+    while (-not (Test-Path -LiteralPath $PortableMarker -PathType Leaf) -and
+            [DateTime]::UtcNow -lt $Deadline) {
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not (Test-Path -LiteralPath $PortableMarker -PathType Leaf)) {
+        throw "Windows portable EXE did not start Coffee GB"
+    }
+    $Evidence = Get-Content -LiteralPath $PortableMarker -Raw
+    if ($Evidence -notmatch "Coffee GB desktop ready OK:") {
+        throw "Windows portable EXE produced invalid startup evidence: $Evidence"
+    }
+    $Process.WaitForExit(45000) | Out-Null
+    if (-not $Process.HasExited) {
+        $Process.Kill()
+        throw "Windows portable EXE did not exit after the desktop smoke"
     }
 } finally {
-    if ($Installed) {
-        Invoke-Package -Action "uninstall" -Log (Join-Path $BuildRoot "exe-uninstall.log")
-    }
+    $env:COFFEE_GB_DESKTOP_SMOKE_MARKER = $PreviousMarker
+}
+
+& $SevenZip.Source x "-o$UnpackedRoot" "-y" $Packages[0].FullName
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to unpack Windows portable EXE with exit code $LASTEXITCODE"
+}
+Assert-NoRomAssociations
+$Arguments = @(
+    "-cp", $AppJars[0].FullName,
+    "eu.rekawek.coffeegb.swing.packaging.NativePackageVerifier",
+    "verify",
+    "--target", $Target,
+    "--type", "exe",
+    "--root", $UnpackedRoot,
+    "--source-app-jar", $AppJars[0].FullName,
+    "--source-sbom", $Sboms[0].FullName,
+    "--source-legal", (Join-Path $RepositoryRoot "packaging/resources/legal"),
+    "--dist", $Dist,
+    "--run-smoke",
+    "--smoke-home", $SmokeHome
+)
+& java @Arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Portable EXE verification failed with exit code $LASTEXITCODE"
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageTool.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageTool.java
@@ -130,7 +130,48 @@ public final class NativePackageTool {
         Path temporary = Files.createDirectory(buildRoot.resolve("jpackage-temp"));
         List<String> signingOptions =
                 signing == null ? List.of() : signing.jpackageOptions();
-        if (signing == null) {
+        boolean portableWindowsExe =
+                targetMetadata.hostOs() == NativePackageMetadata.HostOs.WINDOWS
+                        && packageType == NativePackageMetadata.PackageType.EXE;
+        Path portableWindowsAppImage = null;
+        if (portableWindowsExe) {
+            portableWindowsAppImage = Files.createDirectory(
+                    buildRoot.resolve(signing == null
+                            ? "portable-app-image"
+                            : "signed-portable-app-image"));
+            Path appImageTemporary = Files.createDirectory(
+                    buildRoot.resolve(signing == null
+                            ? "jpackage-portable-app-image-temp"
+                            : "jpackage-signed-portable-app-image-temp"));
+            runInherited(
+                    plan.jpackageCommand(
+                            javaHome,
+                            stage,
+                            runtime,
+                            portableWindowsAppImage,
+                            appImageTemporary,
+                            NativePackageMetadata.PackageType.APP_IMAGE,
+                            signingOptions),
+                    stage.root());
+            Path appImage = plan.expectedAppImage(portableWindowsAppImage, targetMetadata);
+            NativePackageVerifier.verify(new NativePackageVerifier.VerificationRequest(
+                    target,
+                    NativePackageMetadata.PackageType.APP_IMAGE,
+                    portableWindowsAppImage,
+                    stage.appJar(),
+                    stage.sbom(),
+                    resources.resolve("legal")));
+            if (signing != null) {
+                for (List<String> command : signing.appImagePostPackageCommands(appImage)) {
+                    runInherited(command);
+                }
+                for (List<String> command : signing.appImageVerificationCommands(appImage)) {
+                    runInherited(command);
+                }
+            }
+            verifyAppImageLaunchers(
+                    plan, portableWindowsAppImage, targetMetadata, stage.appVersion());
+        } else if (signing == null) {
             runInherited(
                     plan.jpackageCommand(
                             javaHome,
@@ -185,7 +226,10 @@ public final class NativePackageTool {
         }
 
         Path primaryArtifact;
-        if (packageType == NativePackageMetadata.PackageType.APP_IMAGE) {
+        if (portableWindowsExe) {
+            primaryArtifact = buildPortableWindowsExe(
+                    buildRoot, destination, portableWindowsAppImage, environment);
+        } else if (packageType == NativePackageMetadata.PackageType.APP_IMAGE) {
             verifyAppImageLaunchers(plan, destination, targetMetadata, stage.appVersion());
             primaryArtifact = plan.expectedAppImage(destination, targetMetadata);
         } else {
@@ -214,9 +258,11 @@ public final class NativePackageTool {
                         "Verified detached signature is missing: " + signatureArtifact);
             }
         }
-        Path packagedPayload = packageType == NativePackageMetadata.PackageType.APP_IMAGE
-                ? primaryArtifact
-                : temporary.resolve("images");
+        Path packagedPayload = portableWindowsExe
+                ? portableWindowsAppImage
+                : packageType == NativePackageMetadata.PackageType.APP_IMAGE
+                        ? primaryArtifact
+                        : temporary.resolve("images");
         NativePackageVerifier.VerificationResult verification =
                 NativePackageVerifier.verify(new NativePackageVerifier.VerificationRequest(
                         target,
@@ -376,6 +422,34 @@ public final class NativePackageTool {
         if (Files.exists(runtime.resolve("include")) || Files.exists(runtime.resolve("man"))) {
             throw new IOException("jlink runtime unexpectedly contains headers or man pages");
         }
+    }
+
+    private static Path buildPortableWindowsExe(
+            Path buildRoot,
+            Path destination,
+            Path appImageDestination,
+            Map<String, String> environment)
+            throws IOException, InterruptedException {
+        PortableWindowsExe.SevenZip sevenZip = PortableWindowsExe.requireSevenZip(environment);
+        Path appImage = appImageDestination.resolve(NativePackageMetadata.APPLICATION_NAME);
+        if (!Files.isDirectory(appImage, LinkOption.NOFOLLOW_LINKS)
+                || Files.isSymbolicLink(appImage)) {
+            throw new IOException("Windows portable app image is missing: " + appImage);
+        }
+        Path archive = buildRoot.resolve("coffee-gb-portable.7z");
+        runInherited(
+                List.of(
+                        sevenZip.executable().toString(),
+                        "a",
+                        "-t7z",
+                        "-mx=9",
+                        "-bd",
+                        archive.toString(),
+                        NativePackageMetadata.APPLICATION_NAME),
+                appImageDestination);
+        Path portableExe = destination.resolve("Coffee GB.exe");
+        PortableWindowsExe.assemble(sevenZip.sfxModule(), archive, portableExe);
+        return portableExe;
     }
 
     private static Path findInstaller(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/PortableWindowsExe.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/PortableWindowsExe.java
@@ -1,0 +1,86 @@
+package eu.rekawek.coffeegb.swing.packaging;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Produces the single-file Windows release artifact from a verified jpackage application image.
+ *
+ * <p>The standard 7-Zip SFX module extracts the image to a temporary directory and immediately
+ * starts the regular GUI launcher. It is deliberately not an installer: it creates no shortcuts,
+ * uninstall entry, or file association.
+ */
+final class PortableWindowsExe {
+
+    static final String SEVEN_ZIP_COMMAND = "COFFEE_GB_7ZIP_COMMAND";
+    private static final String SFX_MODULE = "7z.sfx";
+    private static final byte[] CONFIGURATION = (
+            ";!@Install@!UTF-8!\r\n"
+                    + "Title=\"Coffee GB\"\r\n"
+                    + "RunProgram=\"Coffee GB\\Coffee GB.exe\"\r\n"
+                    + ";!@InstallEnd@!\r\n")
+            .getBytes(StandardCharsets.UTF_8);
+
+    private PortableWindowsExe() {
+    }
+
+    static SevenZip requireSevenZip(Map<String, String> environment) throws IOException {
+        Objects.requireNonNull(environment, "environment");
+        String configured = environment.get(SEVEN_ZIP_COMMAND);
+        if (configured == null || configured.isBlank()) {
+            throw new IOException(
+                    "Windows portable EXE packaging requires " + SEVEN_ZIP_COMMAND
+                            + " to name 7z.exe");
+        }
+        Path executable = Path.of(configured).toAbsolutePath().normalize();
+        requireRegularFile(executable, SEVEN_ZIP_COMMAND);
+        Path module = executable.resolveSibling(SFX_MODULE);
+        requireRegularFile(module, "7-Zip SFX module");
+        return new SevenZip(executable, module);
+    }
+
+    static void assemble(Path sfxModule, Path archive, Path output) throws IOException {
+        requireRegularFile(sfxModule, "7-Zip SFX module");
+        requireRegularFile(archive, "portable application archive");
+        Path destination = output.toAbsolutePath().normalize();
+        if (Files.exists(destination, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Portable Windows EXE already exists: " + destination);
+        }
+        Path parent = destination.getParent();
+        if (parent == null || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Portable Windows EXE parent is not a directory: " + parent);
+        }
+        try (OutputStream target = Files.newOutputStream(
+                        destination,
+                        StandardOpenOption.CREATE_NEW,
+                        StandardOpenOption.WRITE);
+                InputStream module = Files.newInputStream(sfxModule);
+                InputStream payload = Files.newInputStream(archive)) {
+            module.transferTo(target);
+            target.write(CONFIGURATION);
+            payload.transferTo(target);
+        }
+        requireRegularFile(destination, "portable Windows EXE");
+    }
+
+    private static void requireRegularFile(Path file, String description) throws IOException {
+        if (Files.isSymbolicLink(file)
+                || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(description + " is not a regular non-symlink file: " + file);
+        }
+        if (Files.size(file) == 0) {
+            throw new IOException(description + " is empty: " + file);
+        }
+    }
+
+    record SevenZip(Path executable, Path sfxModule) {
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
@@ -43,6 +43,10 @@ public class NativePackageWorkflowTest {
         assertTrue(packages.contains("cache: maven"));
         assertTrue(packages.contains("cache-dependency-path: \"**/pom.xml\""));
         assertTrue(packages.contains("persist-credentials: false"));
+        assertTrue(packages.contains("7z.exe"));
+        assertTrue(packages.contains("7z.sfx"));
+        assertFalse(packages.contains("candle.exe"));
+        assertFalse(packages.contains("light.exe"));
         assertEquals(2, occurrences(packages, "package_type: exe"));
         assertFalse(packages.contains("package_type: msi"));
         assertTrue(packages.contains("verify-native-package.sh"));

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
@@ -58,6 +58,8 @@ public class NativePackagingScriptTest {
         assertTrue(attributes.lines().anyMatch("* text=auto eol=lf"::equals));
         assertTrue(sh.contains("COFFEE_GB_MAVEN_COMMAND:-mvn"));
         assertTrue(ps.contains("COFFEE_GB_MAVEN_COMMAND"));
+        assertTrue(ps.contains("COFFEE_GB_7ZIP_COMMAND"));
+        assertTrue(ps.contains("7z.sfx"));
         assertFalse(sh.contains("/opt/maven"));
 
         for (String contents :
@@ -76,13 +78,13 @@ public class NativePackagingScriptTest {
         assertTrue(verifyPs.contains("Start-Process"));
         assertTrue(verifyPs.contains("-Filter \"*.exe\""));
         assertTrue(verifyPs.contains("-FilePath $Packages[0].FullName"));
-        assertTrue(verifyPs.contains("[ValidateSet(\"install\", \"uninstall\")]"));
-        assertTrue(verifyPs.contains("$Arguments += \"uninstall\""));
-        assertTrue(verifyPs.contains("INSTALLDIR=`\"$InstalledRoot`\""));
+        assertTrue(verifyPs.contains("Get-Command \"7z.exe\""));
+        assertTrue(verifyPs.contains("portable-exe-ready.marker"));
+        assertTrue(verifyPs.contains("x \"-o$UnpackedRoot\" \"-y\" $Packages[0].FullName"));
         assertTrue(verifyPs.contains("\"--type\", \"exe\""));
-        assertTrue(verifyPs.contains("-Wait"));
         assertTrue(verifyPs.contains("-PassThru"));
-        assertTrue(verifyPs.contains("$Process.ExitCode"));
+        assertTrue(verifyPs.contains("$Process.WaitForExit(45000)"));
+        assertTrue(verifyPs.contains("\"--root\", $UnpackedRoot"));
         assertFalse(verifyPs.contains("msiexec.exe"));
 
         int normalization = verifyPs.indexOf(
@@ -95,20 +97,8 @@ public class NativePackagingScriptTest {
         assertTrue(normalizationBlock.contains(
                 "[System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $BuildRoot))"));
 
-        int failureStart = verifyPs.indexOf("function Invoke-Package {");
-        int failureEnd = verifyPs.indexOf("$Installed = $false", failureStart);
-        assertTrue(failureStart >= 0);
-        assertTrue(failureEnd > failureStart);
-        String failureBlock = verifyPs.substring(failureStart, failureEnd);
-        int logGuard = failureBlock.indexOf("Test-Path -LiteralPath $Log -PathType Leaf");
-        int logTail = failureBlock.indexOf("Get-Content -LiteralPath $Log -Tail 250");
-        int failureThrow = failureBlock.indexOf(
-                "throw \"Windows EXE package $Action failed");
-        assertTrue(logGuard >= 0);
-        assertTrue(logTail > logGuard);
-        assertTrue(failureThrow > logTail);
-        assertTrue(failureBlock.contains("$($Process.ExitCode)"));
-        assertTrue(failureBlock.contains("see $Log"));
+        assertFalse(verifyPs.contains("function Invoke-Package"));
+        assertFalse(verifyPs.contains("INSTALLDIR="));
         assertTrue(verifySh.contains("grep -Eq '^MimeType='"));
         assertTrue(verifySh.contains("CFBundleDocumentTypes"));
         assertTrue(verifySh.contains("UTExportedTypeDeclarations"));

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/PortableWindowsExeTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/PortableWindowsExeTest.java
@@ -1,0 +1,62 @@
+package eu.rekawek.coffeegb.swing.packaging;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class PortableWindowsExeTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void appendsTheSfxConfigurationAndApplicationArchiveToTheModule() throws Exception {
+        Path root = temporaryFolder.getRoot().toPath();
+        Path module = Files.write(root.resolve("7z.sfx"), new byte[] {'M', 'Z', 1, 2});
+        Path archive = Files.write(root.resolve("coffee-gb.7z"), new byte[] {3, 4, 5});
+        Path output = root.resolve("Coffee GB.exe");
+
+        PortableWindowsExe.assemble(module, archive, output);
+
+        byte[] bytes = Files.readAllBytes(output);
+        assertEquals('M', bytes[0]);
+        assertEquals('Z', bytes[1]);
+        String contents = new String(bytes, StandardCharsets.ISO_8859_1);
+        assertTrue(contents.contains(";!@Install@!UTF-8!"));
+        assertTrue(contents.contains("Title=\"Coffee GB\""));
+        assertTrue(contents.contains("RunProgram=\"Coffee GB\\Coffee GB.exe\""));
+        assertTrue(contents.contains(";!@InstallEnd@!"));
+        assertEquals(5, bytes[bytes.length - 1]);
+        assertEquals(4, bytes[bytes.length - 2]);
+        assertEquals(3, bytes[bytes.length - 3]);
+    }
+
+    @Test
+    public void requiresAnExplicitSevenZipCommandAndItsSfxModule() throws Exception {
+        Path root = temporaryFolder.getRoot().toPath();
+        assertThrows(
+                java.io.IOException.class,
+                () -> PortableWindowsExe.requireSevenZip(Map.of()));
+
+        Path sevenZip = Files.writeString(root.resolve("7z.exe"), "tool");
+        assertThrows(
+                java.io.IOException.class,
+                () -> PortableWindowsExe.requireSevenZip(
+                        Map.of(PortableWindowsExe.SEVEN_ZIP_COMMAND, sevenZip.toString())));
+
+        Path module = Files.writeString(root.resolve("7z.sfx"), "module");
+        PortableWindowsExe.SevenZip discovered = PortableWindowsExe.requireSevenZip(
+                Map.of(PortableWindowsExe.SEVEN_ZIP_COMMAND, sevenZip.toString()));
+        assertEquals(sevenZip, discovered.executable());
+        assertEquals(module, discovered.sfxModule());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the Windows installer release asset with a single-file 7-Zip SFX launcher that bundles the verified Coffee GB app image.
- Verify the EXE launches Coffee GB, then extract and inspect its payload in CI.
- Document the portable behavior and SFX provenance.

## Why
The GitHub release EXE should start the emulator rather than install it.

## Validation
- Selected Maven packaging tests (13 tests)
- Focused PortableWindowsExeTest compilation and execution