### PR TITLE
Reduce subsystem method-call overhead

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -127,6 +127,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final Cartridge slotCartridge;
 
+    private final boolean cartridgeClocked;
+
+    private final boolean slotCartridgeClocked;
+
     private final BiosShadow biosShadow;
 
     private final Gpu gpu;
@@ -192,6 +196,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private boolean clearBootTilemapPending;
 
     private boolean clearCgbBootOamShadowPending;
+
+    private transient boolean bootCompatibilityResolved;
 
     private transient volatile boolean doPause;
 
@@ -314,6 +320,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         } else {
             slotCartridge = null;
         }
+        cartridgeClocked = cartridge.isClocked();
+        slotCartridgeClocked = slotCartridge != null && slotCartridge.isClocked();
         Bios bios = new Bios(hardwareProfile, configuration.bootstrapMode != BootstrapMode.SKIP);
         biosShadow = new BiosShadow(bios, cartridge);
         speedMode.setBiosShadow(biosShadow);
@@ -446,6 +454,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     private void applyBootCompatibilityIfReady() {
+        if (bootCompatibilityResolved) {
+            return;
+        }
         if (!biosShadow.isBootFinished()) {
             return;
         }
@@ -476,6 +487,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             }
             clearCgbBootOamShadowPending = false;
         }
+        bootCompatibilityResolved = true;
     }
 
     /**
@@ -605,8 +617,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             warmResetRequested = false;
             applyWarmReset();
         }
-        cartridge.tick();
-        if (slotCartridge != null) {
+        if (cartridgeClocked) {
+            cartridge.tick();
+        }
+        if (slotCartridgeClocked) {
             slotCartridge.tick();
         }
         boolean result = false;
@@ -1599,6 +1613,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         blankCgbBootTilePending = mem.blankCgbBootTilePending();
         clearBootTilemapPending = mem.clearBootTilemapPending();
         clearCgbBootOamShadowPending = mem.clearCgbBootOamShadowPending();
+        bootCompatibilityResolved = biosShadow.isBootFinished()
+                && !blankCgbBootTilePending
+                && !clearBootTilemapPending
+                && !clearCgbBootOamShadowPending;
     }
 
     /** Current aggregate emulated motor output, without invoking host services. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -61,6 +61,16 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private Opcode currentOpcode;
 
+    private Op[] currentExecutionOps;
+
+    private boolean[] currentOpAccessesMemory;
+
+    private boolean[] currentOpWritesMemory;
+
+    private int currentOpCount;
+
+    private int currentOperandLength;
+
     private List<Op> ops;
 
     private int operandIndex;
@@ -287,11 +297,11 @@ public class Cpu implements StatefulComponent<Cpu> {
                     if (opcode1 == 0xcb) {
                         state = State.EXT_OPCODE;
                     } else if (opcode1 == 0x10) {
-                        currentOpcode = Opcodes.COMMANDS.get(opcode1);
+                        setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
                         state = State.EXT_OPCODE;
                     } else {
                         state = State.OPERAND;
-                        currentOpcode = Opcodes.COMMANDS.get(opcode1);
+                        setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
                         if (currentOpcode == null) {
                             // an illegal opcode freezes the CPU on hardware; do the
                             // same instead of crashing the emulation thread
@@ -323,7 +333,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                         notifyOpcodeFetched(debugInstructionPc, true, opcode2);
                     }
                     if (currentOpcode == null) {
-                        currentOpcode = Opcodes.EXT_COMMANDS.get(opcode2);
+                        setCurrentOpcode(Opcodes.EXT_COMMANDS.get(opcode2));
                     }
                     if (currentOpcode == null) {
                         state = State.LOCKED;
@@ -335,7 +345,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                     break;
 
                 case OPERAND:
-                    while (operandIndex < currentOpcode.getOperandLength()) {
+                    while (operandIndex < currentOperandLength) {
                         if (accessedMemory) {
                             return;
                         }
@@ -422,13 +432,13 @@ public class Cpu implements StatefulComponent<Cpu> {
                         }
                     }
 
-                    int opCount = currentOpcode.getOpCount();
+                    int opCount = currentOpCount;
                     if (opIndex < opCount) {
-                        Op op = currentOpcode.getOp(opIndex);
-                        boolean opAccessesMemory = currentOpcode.opAccessesMemory(opIndex);
+                        boolean opAccessesMemory = currentOpAccessesMemory[opIndex];
                         if (accessedMemory && opAccessesMemory) {
                             return;
                         }
+                        Op op = currentExecutionOps[opIndex];
                         opIndex++;
 
                         SpriteBug.CorruptionType corruptionType = op.causesOemBug(registers, opContext);
@@ -591,6 +601,11 @@ public class Cpu implements StatefulComponent<Cpu> {
         opcode1 = 0;
         opcode2 = 0;
         currentOpcode = null;
+        currentExecutionOps = null;
+        currentOpAccessesMemory = null;
+        currentOpWritesMemory = null;
+        currentOpCount = 0;
+        currentOperandLength = 0;
         ops = null;
 
         operand[0] = 0x00;
@@ -982,10 +997,10 @@ public class Cpu implements StatefulComponent<Cpu> {
         if (opcode1 == 0xcb || opcode1 == 0x10) {
             state = State.EXT_OPCODE;
             if (opcode1 == 0x10) {
-                currentOpcode = Opcodes.COMMANDS.get(opcode1);
+                setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
             }
         } else {
-            currentOpcode = Opcodes.COMMANDS.get(opcode1);
+            setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
             state = currentOpcode == null ? State.LOCKED : State.OPERAND;
         }
         if (useSpeedSwitchPadding) {
@@ -1102,8 +1117,8 @@ public class Cpu implements StatefulComponent<Cpu> {
     /** Whether an already-started CPU write cycle overlaps the HDMA request edge. */
     public boolean hasInFlightWriteCycleForHdma() {
         return clockCycle >= 2 && state == State.RUNNING && currentOpcode != null
-                && opIndex < currentOpcode.getOpCount()
-                && currentOpcode.opWritesMemory(opIndex);
+                && opIndex < currentOpCount
+                && currentOpWritesMemory[opIndex];
     }
 
     public boolean isSpeedSwitching() {
@@ -1195,8 +1210,26 @@ public class Cpu implements StatefulComponent<Cpu> {
         this.stopFrameBlankRequested = false;
         this.debugInstructionKnown = false;
 
-        this.currentOpcode = (opcode1 == 0xcb) ? Opcodes.EXT_COMMANDS.get(opcode2) : Opcodes.COMMANDS.get(opcode1);
+        setCurrentOpcode((opcode1 == 0xcb)
+                ? Opcodes.EXT_COMMANDS.get(opcode2) : Opcodes.COMMANDS.get(opcode1));
         this.ops = (currentOpcode == null) ? null : currentOpcode.getOps();
+    }
+
+    private void setCurrentOpcode(Opcode opcode) {
+        currentOpcode = opcode;
+        if (opcode == null) {
+            currentExecutionOps = null;
+            currentOpAccessesMemory = null;
+            currentOpWritesMemory = null;
+            currentOpCount = 0;
+            currentOperandLength = 0;
+            return;
+        }
+        currentExecutionOps = opcode.getExecutionOps();
+        currentOpAccessesMemory = opcode.getAccessesMemory();
+        currentOpWritesMemory = opcode.getWritesMemory();
+        currentOpCount = currentExecutionOps.length;
+        currentOperandLength = opcode.getOperandLength();
     }
 
     private record CpuState(ComponentState<Registers> registersMemento, int opcode1, int opcode2, int[] operand,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/opcode/Opcode.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/opcode/Opcode.java
@@ -59,12 +59,27 @@ public class Opcode  {
         return executionOps[index];
     }
 
+    /** Internal execution view used by the CPU to avoid per-micro-op metadata calls. */
+    public Op[] getExecutionOps() {
+        return executionOps;
+    }
+
     public boolean opAccessesMemory(int index) {
         return accessesMemory[index];
     }
 
+    /** Internal execution metadata used by the CPU hot path. */
+    public boolean[] getAccessesMemory() {
+        return accessesMemory;
+    }
+
     public boolean opWritesMemory(int index) {
         return writesMemory[index];
+    }
+
+    /** Internal execution metadata used by HDMA arbitration. */
+    public boolean[] getWritesMemory() {
+        return writesMemory;
     }
 
     public String getLabel() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/FullChanger.java
@@ -71,18 +71,23 @@ public class FullChanger implements StatefulComponent<FullChanger> {
         }
     }
 
-    void tick(int cycles) {
+    boolean tick(int cycles) {
         if (!running) {
-            return;
+            return armed;
         }
         remaining -= cycles;
         while (remaining <= 0) {
             if (++index >= schedule.length) {
                 running = false;
-                return;
+                return false;
             }
             remaining += schedule[index];
         }
+        return true;
+    }
+
+    boolean isActive() {
+        return armed || running;
     }
 
     boolean isLightOn() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -32,6 +32,8 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
 
     private final FullChanger fullChanger = new FullChanger();
 
+    private transient boolean fullChangerActive;
+
     private transient InfraredEndpoint endpoint = InfraredEndpoint.NULL_ENDPOINT;
 
     private transient SerialEndpoint serialEndpoint = SerialEndpoint.NULL_ENDPOINT;
@@ -62,7 +64,10 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         this.endpoint = endpoint;
         endpoint.setLightOn((rp & 0x01) != 0);
         alignDebugSignal();
-        eventBus.register(e -> fullChanger.transform(e.characterId()), FullChanger.TransformEvent.class);
+        eventBus.register(e -> {
+            fullChanger.transform(e.characterId());
+            fullChangerActive = true;
+        }, FullChanger.TransformEvent.class);
     }
 
     /** Connects RP bit 4 to the CGB link port's serial-input pin. */
@@ -80,9 +85,11 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
     }
 
     public void tick() {
-        // the pulse timings are defined in double-speed cycles; advance twice as fast in
-        // double speed so a game sees the same delays regardless of its speed setting
-        fullChanger.tick(speedMode.getSpeedMode());
+        if (fullChangerActive) {
+            // the pulse timings are defined in double-speed cycles; advance twice as fast in
+            // double speed so a game sees the same delays regardless of its speed setting
+            fullChangerActive = fullChanger.tick(speedMode.getSpeedMode());
+        }
         notifyDebugSignalChange();
     }
 
@@ -164,6 +171,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         this.rp = mem.rp;
         endpoint.setLightOn((rp & 0x01) != 0);
         fullChanger.restoreState(mem.fullChangerMemento);
+        fullChangerActive = fullChanger.isActive();
         alignDebugSignal();
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -224,7 +224,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         tick++;
         PlayerInputSnapshot nextInput = Objects.requireNonNull(
                 playerInputSource.sample(), "PlayerInputSource returned null");
-        if (!sampledInput.equals(nextInput)) {
+        if (sampledInput != nextInput && !sampledInput.equals(nextInput)) {
             sampledInput = nextInput;
             inputChangedSinceLastTick = true;
             notifyDebugInputChange();
@@ -238,7 +238,26 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             inputChangedSinceLastTick = false;
             return;
         }
-        int inputLines = getInputLines();
+        int inputLines;
+        if (players > 0 && (p1 & 0x30) == 0x30) {
+            LOG.atDebug().log("Returning player {} as current player", currentPlayer);
+            inputLines = 0x0f - currentPlayer;
+        } else {
+            int pressedButtonMask = (sampledInput.packedButtonMasks >>> (currentPlayer * Byte.SIZE))
+                    & JoypadButtonMask.ALL;
+            int pressedInputLines = 0;
+            if ((p1 & 0x10) == 0) {
+                pressedInputLines |= pressedButtonMask & 0x0f;
+            }
+            if ((p1 & 0x20) == 0) {
+                pressedInputLines |= (pressedButtonMask >>> 4) & 0x0f;
+            }
+            inputLines = 0x0f & ~pressedInputLines & 0x0f;
+            // The historical event-driven API remains P1-only for controller/netplay replay.
+            if (currentPlayer == 0 && !buttons.isEmpty()) {
+                inputLines = applyButtons(inputLines, buttons);
+            }
+        }
         int nextFilteredInputLines = filteredInputLines;
         for (int line = 0; line < 4; line++) {
             int shift = line * INPUT_FILTER_SAMPLES;
@@ -380,15 +399,8 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             return 0x0f - currentPlayer;
         }
 
-        int result = applyButtonMask(0x0f, sampledInput.buttonMask(currentPlayer));
-        // The historical event-driven API remains P1-only for controller/netplay replay.
-        if (currentPlayer == 0 && !buttons.isEmpty()) {
-            result = applyButtons(result, buttons);
-        }
-        return result;
-    }
-
-    private int applyButtonMask(int inputLines, int pressedButtonMask) {
+        int pressedButtonMask = (sampledInput.packedButtonMasks >>> (currentPlayer * Byte.SIZE))
+                & JoypadButtonMask.ALL;
         int pressedInputLines = 0;
         if ((p1 & 0x10) == 0) {
             pressedInputLines |= pressedButtonMask & 0x0f;
@@ -396,7 +408,12 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if ((p1 & 0x20) == 0) {
             pressedInputLines |= (pressedButtonMask >>> 4) & 0x0f;
         }
-        return inputLines & ~pressedInputLines & 0x0f;
+        int result = 0x0f & ~pressedInputLines & 0x0f;
+        // The historical event-driven API remains P1-only for controller/netplay replay.
+        if (currentPlayer == 0 && !buttons.isEmpty()) {
+            result = applyButtons(result, buttons);
+        }
+        return result;
     }
 
     private int applyButtons(int inputLines, Collection<Button> pressedButtons) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/PlayerInputSnapshot.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/PlayerInputSnapshot.java
@@ -11,13 +11,13 @@ import java.util.Set;
 /** Immutable, deeply owned physical-button sample for exactly P1 through P4. */
 public final class PlayerInputSnapshot {
 
-    private static final PlayerInputSnapshot RELEASED =
+    static final PlayerInputSnapshot RELEASED =
             new PlayerInputSnapshot(List.of(Set.of(), Set.of(), Set.of(), Set.of()));
 
     private final List<Set<Button>> players;
 
     /** Four stable eight-bit button masks packed from P1 in the low byte through P4. */
-    private final int packedButtonMasks;
+    final int packedButtonMasks;
 
     private PlayerInputSnapshot(List<Set<Button>> players) {
         this.players = players;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/PlayerInputSource.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/PlayerInputSource.java
@@ -13,7 +13,7 @@ public interface PlayerInputSource {
 
     int PLAYER_COUNT = 4;
 
-    PlayerInputSource RELEASED = PlayerInputSnapshot::released;
+    PlayerInputSource RELEASED = () -> PlayerInputSnapshot.RELEASED;
 
     /** Returns one immutable, deeply owned sample for all slots P1 through P4. */
     PlayerInputSnapshot sample();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -117,7 +117,8 @@ public class Dma implements AddressSpace, StatefulComponent<Dma> {
                 return;
             }
             ticks++;
-            for (int i = 0; i < speedMode.getSpeedMode(); i++) {
+            int speed = speedMode.getSpeedMode();
+            for (int i = 0; i < speed; i++) {
                 if (cpuClockPaused && pauseEntryClocks == 0) {
                     break;
                 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -29,6 +29,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
 
     private final Battery battery;
 
+    private final boolean clocked;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -75,6 +77,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
         this.battery = battery;
         this.debugRom = rom.getRom();
         this.addressSpace = createMemoryController(rom, battery, rtcTimeSource, clockSpec);
+        this.clocked = addressSpace.isClocked();
     }
 
     /** Freezes the built cartridge's battery ownership independently of mutable configuration. */
@@ -201,6 +204,11 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
     /** Advances cartridge hardware clocked from the Game Boy master clock. */
     public void tick() {
         addressSpace.tick();
+    }
+
+    /** Returns whether the mapper has a clocked hardware component. */
+    public boolean isClocked() {
+        return clocked;
     }
 
     public void setDebugHooks(DebugHooks hooks) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MemoryController.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MemoryController.java
@@ -7,6 +7,11 @@ import eu.rekawek.coffeegb.core.state.StatefulComponent;
 import java.util.Objects;
 
 public interface MemoryController extends AddressSpace, StatefulComponent<MemoryController> {
+    /** Whether this mapper has hardware that must be advanced by every master tick. */
+    default boolean isClocked() {
+        return false;
+    }
+
     default void tick() {
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -142,6 +142,11 @@ public class Mbc3 implements MemoryController {
     }
 
     @Override
+    public boolean isClocked() {
+        return true;
+    }
+
+    @Override
     public void setClockPaused(boolean paused) {
         clock.setEmulationPaused(paused);
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -62,9 +62,18 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     public void tick() {
         // Link-port peripherals such as GPS receivers have their own wall clock and keep
         // driving the input pin even when no hardware serial transfer is armed.
-        serialEndpoint.tick();
+        if (serialEndpoint != SerialEndpoint.NULL_ENDPOINT) {
+            serialEndpoint.tick();
+        }
         acknowledgeInterruptIfNeeded();
-        for (int i = 0; i < speedMode.getSpeedMode(); i++) {
+        int speed = speedMode.getSpeedMode();
+        if (serialEndpoint == SerialEndpoint.NULL_ENDPOINT
+                && (sc & 0x80) == 0
+                && haltWakeDelay == 0) {
+            serialClocks = (serialClocks + speed) & 0xff;
+            return;
+        }
+        for (int i = 0; i < speed; i++) {
             tickCpuClock();
         }
     }
@@ -135,7 +144,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
             interruptManager.releaseHaltWake(InterruptManager.InterruptType.Serial);
         }
         boolean transferInProgress = (sc & (1 << 7)) != 0;
-        if (ClockType.getFromSc(sc) == ClockType.EXTERNAL) {
+        if ((sc & 1) == 0) {
             serialEndpoint.setExternalTransfer(transferInProgress);
             int incomingBit = serialEndpoint.recvBit();
             if (incomingBit != -1) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -40,6 +40,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     private final Ram r = new Ram(0xff24, 0x03);
 
+    private int volume = 0x77;
+
+    private int routing;
+
     private final int[] channels = new int[4];
 
     private boolean enabled = true;
@@ -114,15 +118,17 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             return;
         }
 
-        int enabledBefore = getDebugEnabledChannelMask();
+        int enabledBefore = debugHooks == null ? 0 : getEnabledChannelMask();
 
         channels[0] = allModes[0].tick(divReset);
         channels[1] = allModes[1].tick(divReset);
-        channels[2] = allModes[2].tick(divReset);
-        channels[3] = allModes[3].tick(divReset);
-        notifyDebugChannelDisables(enabledBefore);
+        channels[2] = allModes[2].tick();
+        channels[3] = allModes[3].tick();
+        if (debugHooks != null) {
+            notifyDebugChannelDisables(enabledBefore);
+        }
 
-        int selection = r.getByte(0xff25);
+        int selection = routing;
         int left = 0;
         int right = 0;
         for (int i = 0; i < 4; i++) {
@@ -134,7 +140,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             // constant positive offset. Games play PCM speech by parking such a DC and
             // modulating the master volume (Perfect Dark's intro voice, issue #56); a
             // disabled DAC outputs true analog zero.
-            int analog = allModes[i].isDacEnabled() ? 15 - 2 * channels[i] : 0;
+            int analog = allModes[i].dacEnabled ? 15 - 2 * channels[i] : 0;
             if ((selection & (1 << i + 4)) != 0) {
                 left += analog;
             }
@@ -144,7 +150,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         }
 
         // NR50 volume 0 means "very quiet", not silence: the scale factor is volume+1
-        int volumes = r.getByte(0xff24);
+        int volumes = volume;
         left *= ((volumes >> 4) & 0b111) + 1;
         right *= (volumes & 0b111) + 1;
 
@@ -294,6 +300,11 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
                 || mode3.isWriteAccepted(address);
         int enabledBefore = getDebugEnabledChannelMask();
         s.setByte(address, value);
+        if (address == 0xff24) {
+            volume = value;
+        } else if (address == 0xff25) {
+            routing = value;
+        }
         if (!accepted) {
             return;
         }
@@ -473,6 +484,8 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         }
         r.setByte(0xff24, 0);
         r.setByte(0xff25, 0);
+        volume = 0;
+        routing = 0;
     }
 
     public void enableChannel(int i, boolean enabled) {
@@ -539,6 +552,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             this.allModes[i].restoreState(mem.allModeMementos[i]);
         }
         this.r.restoreState(mem.ramMemento());
+        int[] restoredRegisters = r.getSpace();
+        this.volume = restoredRegisters[0];
+        this.routing = restoredRegisters[1];
         this.frameSequencer.restoreState(mem.frameSequencerMemento());
         System.arraycopy(mem.channels, 0, this.channels, 0, this.channels.length);
         this.enabled = mem.enabled();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
@@ -117,7 +117,7 @@ public class SoundMode1 extends AbstractSoundMode {
         }
 
         boolean e;
-        e = updateLength();
+        e = channelEnabled;
         e = updateSweep() && e;
         e = dacEnabled && e;
         if (!e) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode2.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode2.java
@@ -92,7 +92,7 @@ public class SoundMode2 extends AbstractSoundMode {
         }
 
         boolean e;
-        e = updateLength();
+        e = channelEnabled;
         e = dacEnabled && e;
         if (!e) {
             return 0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
@@ -196,10 +196,6 @@ public class SoundMode3 extends AbstractSoundMode {
         if (!channelEnabled) {
             return lastOutput;
         }
-        if (!updateLength()) {
-            return 0;
-        }
-
         if (clock2Mhz && --freqDivider == 0) {
             resetFreqDivider();
             i = (i + 1) % 32;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode4.java
@@ -59,7 +59,7 @@ public class SoundMode4 extends AbstractSoundMode {
     @Override
     public int tick() {
         boolean stepLfsr = polynomialCounter.tick();
-        if (!updateLength()) {
+        if (!channelEnabled) {
             return 0;
         }
         if (!dacEnabled) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -92,7 +92,8 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
     public void tick() {
         acknowledgeInterruptIfNeeded();
         divReset = false;
-        for (int i = 0; i < speedMode.getSpeedMode(); i++) {
+        int speed = speedMode.getSpeedMode();
+        for (int i = 0; i < speed; i++) {
             tickCpuClock();
         }
     }
@@ -134,7 +135,13 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
             interruptManager.releaseHaltWake(InterruptManager.InterruptType.Timer);
         }
         int oldDiv = div;
-        updateDiv((div + 1) & 0xffff);
+        div = (div + 1) & 0xffff;
+        boolean bit = (tac & 0x04) != 0
+                && (div & (1 << FREQ_TO_BIT[tac & 0x03])) != 0;
+        if (!bit && previousBit) {
+            incTima();
+        }
+        previousBit = bit;
         if (ticksSinceDivReset != Integer.MAX_VALUE) {
             ticksSinceDivReset++;
         }


### PR DESCRIPTION
## What
Reduce repeated method calls across the non-GPU emulator hot paths measured by the Harry Potter 1,800-frame harness.

## Why
The harness counts method entries rather than wall-clock time. Several stable or inactive paths were still invoking deep getter/helper chains on every master tick.

## Impact
- Serial: skip null-endpoint work while idle, cache speed per tick, and remove repeated clock-type dispatch.
- Joypad: use the released singleton, identity-check stable samples, and consume packed button masks directly.
- Infrared and cartridges: skip inactive Full Changer simulation and unclocked mapper ticks.
- Timer/APU: cache speed, inline divider/length/DAC checks, direct-call the two simple sound modes, and cache NR50/NR51.
- CPU/DMA: cache opcode execution metadata and per-transfer speed values.

Exact harness result:
- Current master baseline: 35,814,318,447 calls
- This branch: 30,656,856,605 calls
- Reduction: 5,157,461,842 calls (14.401%)
- Both runs: 126,143,697 ticks / 1,800 frames

## Checks
- `mvn -q -pl core test`
- `mvn -q clean test -f core/pom.xml -Ptest-mealybug`
- `mvn -q clean test -f core/pom.xml -Ptest-gambatte-hw`
- Exact 1,800-frame method-call harness
