### PR TITLE
Gate steady-state emulator work

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -627,7 +627,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         boolean result = false;
 
         Mode newMode = tickSubsystems();
-        applyBootCompatibilityIfReady();
+        if (!bootCompatibilityResolved) {
+            applyBootCompatibilityIfReady();
+        }
         if (newMode != null) {
             hdma.onGpuUpdate(newMode);
         }
@@ -817,13 +819,17 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         } else {
             // A retiring instruction can issue its final VRAM read on the CPU half
             // of the edge immediately before an HBlank request reaches arbitration.
-            boolean retiringIntoHdmaRequest = cpu.isInstructionRetiringForHdma()
-                    && hdma.isHblankRequestArrivingAfterCpuTick();
-            gpu.setCpuRetiringInstructionForHdma(retiringIntoHdmaRequest);
-            try {
+            boolean retiringIntoHdmaRequest = hdma.isHblankRequestArrivingAfterCpuTick()
+                    && cpu.isInstructionRetiringForHdma();
+            if (retiringIntoHdmaRequest) {
+                gpu.setCpuRetiringInstructionForHdma(true);
+                try {
+                    cpu.tick();
+                } finally {
+                    gpu.setCpuRetiringInstructionForHdma(false);
+                }
+            } else {
                 cpu.tick();
-            } finally {
-                gpu.setCpuRetiringInstructionForHdma(false);
             }
         }
         if (!speedSwitching && cpu.isSpeedSwitching()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -90,7 +90,9 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
             // double speed so a game sees the same delays regardless of its speed setting
             fullChangerActive = fullChanger.tick(speedMode.getSpeedMode());
         }
-        notifyDebugSignalChange();
+        if (debugHooks != null) {
+            notifyDebugSignalChange();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Gate one-time boot compatibility work after resolution.
- Avoid per-tick GPU HDMA retirement setter calls on the ordinary CPU path.
- Skip headless infrared debug notification dispatch.

## Measurements
The exact 1800-frame harness target remains unchanged at `126,143,697` ticks. Method-call count decreased from `25,238,460,994` to `24,672,508,429` (`-2.24%`) relative to the PR 1 parent.

## Validation
- `mvn -q -pl core -Dtest=GameboyHdmaArbitrationTest,HdmaTest,GameboyBootStateTest,InfraredPortTest,InfraredPortDebugHooksTest test`
- `mvn -q -pl core test`
- `mvn -q test`
- 120-tick and exact 1800-frame method-call harness runs