### PR TITLE
Consume DIV reset once per tick

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -705,7 +705,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (!speedSwitchTail) {
             timer.tick();
         }
-        sound.tickFrameSequencer();
+        sound.tickFrameSequencer(false);
         boolean deferFrameSequencerClock = sound.isFrameSequencerClockAfterCpu();
         if (!deferFrameSequencerClock) {
             sound.commitFrameSequencerClock();
@@ -845,8 +845,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (deferFrameSequencerClock) {
             sound.commitFrameSequencerClock();
         }
-        if (timer.isDivResetPending()) {
-            sound.tickFrameSequencer();
+        boolean divReset = timer.consumeDivReset();
+        if (divReset) {
+            sound.tickFrameSequencer(true);
             sound.commitFrameSequencerClock();
             serialPort.onDivReset();
         }
@@ -858,7 +859,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                         || finalCpuState == Cpu.State.SPEED_SWITCH || speedSwitchTail
                         || hdma.pausesOamDmaForSpeedSwitchBurst(),
                 halted);
-        sound.tick();
+        sound.tick(divReset);
         serialPort.tick();
         infraredPort.tick();
         joypad.tick();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -112,7 +112,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     }
 
     public void tick() {
-        boolean divReset = timer.consumeDivReset();
+        tick(timer.consumeDivReset());
+    }
+
+    public void tick(boolean divReset) {
         if (!enabled) {
             play(0, 0);
             return;
@@ -162,12 +165,16 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
      * CPU (for natural DIV edges) and after it (for an edge caused by an FF04 write).
      */
     public void tickFrameSequencer() {
+        tickFrameSequencer(timer.isDivResetPending());
+    }
+
+    public void tickFrameSequencer(boolean divReset) {
         int divCounter = (timer.getDivCounter() + frameSequencerDivOffset) & 0xffff;
         int firedStep = frameSequencer.tick(divCounter, enabled, speedMode.getSpeedMode() == 2);
         if (firedStep >= 0) {
             pendingFrameSequencerStep = firedStep;
         }
-        if (timer.isDivResetPending()) {
+        if (divReset) {
             frameSequencerDivOffset = 0;
         }
     }


### PR DESCRIPTION
## Summary
- Snapshot the DIV-reset event once per master tick in Gameboy.
- Pass the snapshot through the pre-CPU and post-CPU sound frame-sequencer paths.
- Preserve the existing Sound compatibility overloads.

## Measurements
The exact 1800-frame harness target remains unchanged at `126,143,697` ticks. Method-call count decreased from `24,672,508,429` to `24,420,221,034` (`-1.02%`) relative to PR 2. At 120 ticks the reduction is `1.08%`, and `Timer.isDivResetPending()` leaves the top 100.

## Validation
- `mvn -q -pl core -Dtest=TimerTest,TimerDoubleSpeedTest,SoundFrameSequencerTimingTest,SoundMementoTest,DmaSpeedSwitchTest test`
- `mvn -q -pl core test`
- `mvn -q test`
- 120-tick and exact 1800-frame method-call harness runs