### PR TITLE
Refresh GPU timing mode only when dirty

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/SpeedMode.java
@@ -67,7 +67,11 @@ public class SpeedMode implements AddressSpace, StatefulComponent<SpeedMode> {
     public void setByte(int address, int value) {
         if (address == 0xff4c) {
             if (biosShadow == null || !biosShadow.isBootFinished()) {
-                dmgCompat = (value & 0x0c) != 0;
+                boolean newDmgCompat = (value & 0x0c) != 0;
+                if (dmgCompat != newDmgCompat) {
+                    dmgCompat = newDmgCompat;
+                    notifyTimingStateChanged();
+                }
             }
         } else if (isSpeedSwitchAccessible()) {
             prepareSpeedSwitch = (value & 0x01) != 0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -41,7 +41,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     private final GpuRegisterValues r;
 
-    private final SpeedMode speedMode;
+    private boolean dmgCompatValue;
 
     private final int[] delayEntry = new int[8];
 
@@ -63,7 +63,11 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         this.bgPalette = bgPalette;
         this.oamPalette = oamPalette;
         this.r = r;
-        this.speedMode = speedMode;
+        this.dmgCompatValue = speedMode != null && speedMode.isDmgCompat();
+    }
+
+    public void setDmgCompat(boolean dmgCompatValue) {
+        this.dmgCompatValue = dmgCompatValue;
     }
 
     @Override
@@ -167,7 +171,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
         // in DMG compatibility mode LCDC.0 blanks the background like on the DMG;
         // in CGB mode it only drops the background's priority
-        boolean compatMode = speedMode != null && speedMode.isDmgCompat();
+        boolean compatMode = dmgCompatValue;
         if (compatMode && !lcdc.isBgAndWindowDisplay()) {
             bgPixel = 0;
             bgAttrPriority = false;
@@ -237,7 +241,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void setOverlay(int[] pixelLine, int offset, TileAttributes spriteAttr, int oamIndex) {
-        boolean compat = speedMode != null && speedMode.isDmgCompat();
+        boolean compat = dmgCompatValue;
         int paletteIndex = compat
                 ? (spriteAttr.getDmgPalette() == GpuRegister.OBP1 ? 1 : 0)
                 : spriteAttr.getColorPaletteIndex();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -57,6 +57,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     // getter calls in the PPU timing decision tree.
     private int speedModeValue = 1;
     private boolean dmgCompatValue;
+    private boolean timingModeDirty = true;
     private boolean timingSnapshotPrepared;
 
     private final boolean earlyCgbLyReadEdge;
@@ -239,7 +240,10 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         this.mode = Mode.OamSearch;
         this.phase = oamSearchPhase.start();
         prepareForTick();
-        speedMode.setTimingStateListener(this::prepareForTick);
+        speedMode.setTimingStateListener(() -> {
+            timingModeDirty = true;
+            prepareForTick();
+        });
         timingSnapshotPrepared = false;
     }
 
@@ -681,10 +685,15 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     /** Refreshes the PPU's owner-thread timing snapshot before subsystem callbacks run. */
     public void prepareForTick() {
-        speedModeValue = speedMode.getSpeedMode();
-        dmgCompatValue = speedMode.isDmgCompat();
-        pixelTransferPhase.prepareForTick(speedModeValue);
-        pixelMachine.prepareForTick(speedModeValue);
+        if (timingModeDirty) {
+            int newSpeedModeValue = speedMode.getSpeedMode();
+            boolean newDmgCompatValue = speedMode.isDmgCompat();
+            speedModeValue = newSpeedModeValue;
+            dmgCompatValue = newDmgCompatValue;
+            pixelTransferPhase.prepareForTick(newSpeedModeValue, newDmgCompatValue);
+            pixelMachine.prepareForTick(newSpeedModeValue, newDmgCompatValue);
+            timingModeDirty = false;
+        }
         timingSnapshotPrepared = true;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -288,7 +288,15 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     /** Refreshes the owner-thread timing snapshot before subsystem callbacks run. */
     public void prepareForTick(int speedModeValue) {
+        prepareForTick(speedModeValue, speedMode != null && speedMode.isDmgCompat());
+    }
+
+    /** Refreshes the cached timing mode and compatibility mode before a tick. */
+    public void prepareForTick(int speedModeValue, boolean dmgCompatValue) {
         this.speedModeValue = speedModeValue;
+        if (fifo instanceof ColorPixelFifo colorPixelFifo) {
+            colorPixelFifo.setDmgCompat(dmgCompatValue);
+        }
     }
 
     public PixelTransfer start(int extraEntryDelay, boolean lcdEnableFirstLine) {


### PR DESCRIPTION
## Summary
- Refresh GPU speed and compatibility snapshots only when the timing mode is dirty.
- Propagate primitive speed and compatibility values into both pixel-transfer machines.
- Replace hot ColorPixelFifo SpeedMode compatibility calls with a cached field.
- Notify GPU timing consumers only when FF4C compatibility state actually changes.

## Measurements
The exact 1800-frame harness target remains unchanged at `126,143,697` ticks. Method-call count decreased from `24,420,221,034` to `23,837,104,165` (`-2.39%`) relative to PR 3. At 120 ticks the reduction is `2.50%`; PixelTransfer.prepareForTick is out of the top 100 and SpeedMode.isDmgCompat is absent.

## Validation
- `mvn -q -pl core -Dtest=SpeedModeTest,DmaSpeedSwitchTest,GpuDisplayEnableTimingTest,GpuCpuWriteSynchronizationTest,ColorPixelFifoWindowStartTest,GameboyMementoTest test`
- `mvn -q -pl core test`
- `mvn -q test`
- 120-tick and exact 1800-frame method-call harness runs