### PR TITLE
Batch PPU interrupt bookkeeping

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
@@ -13,6 +13,12 @@ public class InterruptManager implements AddressSpace, StatefulComponent<Interru
     private static final int PPU_INTERRUPT_MASK =
             (1 << InterruptType.VBlank.ordinal()) | (1 << InterruptType.LCDC.ordinal());
 
+    public static final int PPU_TICK_SIGNAL_LCDC_INTERRUPT_ACKNOWLEDGE = 1;
+
+    public static final int PPU_TICK_SIGNAL_VBLANK_INTERRUPT_ACKNOWLEDGE = 1 << 1;
+
+    public static final int PPU_TICK_SIGNAL_LCDC_INTERRUPT_FLAG_WRITE_CLEAR = 1 << 2;
+
     public enum InterruptType {
         VBlank(0x0040),
         LCDC(0x0048),
@@ -327,6 +333,23 @@ public class InterruptManager implements AddressSpace, StatefulComponent<Interru
         return result;
     }
 
+    public int consumePpuTickSignals() {
+        int result = 0;
+        if (lcdcInterruptAcknowledge) {
+            result |= PPU_TICK_SIGNAL_LCDC_INTERRUPT_ACKNOWLEDGE;
+        }
+        if (vBlankInterruptAcknowledge) {
+            result |= PPU_TICK_SIGNAL_VBLANK_INTERRUPT_ACKNOWLEDGE;
+        }
+        if (lcdcInterruptFlagWriteClear) {
+            result |= PPU_TICK_SIGNAL_LCDC_INTERRUPT_FLAG_WRITE_CLEAR;
+        }
+        lcdcInterruptAcknowledge = false;
+        vBlankInterruptAcknowledge = false;
+        lcdcInterruptFlagWriteClear = false;
+        return result;
+    }
+
     public void finishTimerInterruptAcknowledge() {
         clearInterruptState(InterruptType.Timer);
     }
@@ -425,6 +448,14 @@ public class InterruptManager implements AddressSpace, StatefulComponent<Interru
         }
     }
 
+    public void finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview() {
+        maskLcdcUntilNextPeripheralTick = false;
+        if (maskMode0LcdcReadTicks > 0) {
+            maskMode0LcdcReadTicks--;
+        }
+        cpuReadInterruptPreview = 0;
+    }
+
     public void setCpuReadInterruptPreview(InterruptType type, boolean active) {
         int mask = 1 << type.ordinal();
         if (active) {
@@ -432,6 +463,13 @@ public class InterruptManager implements AddressSpace, StatefulComponent<Interru
         } else {
             cpuReadInterruptPreview &= ~mask;
         }
+    }
+
+    public void setCpuReadPpuInterruptPreview(boolean lcdc, boolean vblank) {
+        int preview = (lcdc ? 1 << InterruptType.LCDC.ordinal() : 0)
+                | (vblank ? 1 << InterruptType.VBlank.ordinal() : 0);
+        cpuReadInterruptPreview =
+                (cpuReadInterruptPreview & ~PPU_INTERRUPT_MASK) | preview;
     }
 
     public void clearCpuReadInterruptPreview() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -249,12 +249,13 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         boolean currentDoubleSpeed = currentCpuMachineCycleDots == 2;
         boolean currentNativeDoubleSpeed = currentGbc && !currentDmgCompat
                 && currentDoubleSpeed;
-        interruptManager.finishLcdcReadMaskWindow();
-        interruptManager.clearCpuReadInterruptPreview();
+        interruptManager.finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview();
         lycIrqClock++;
         cpuStatModeOverride = -1;
         suppressCpuReadCoincidence = false;
-        if (interruptManager.consumeLcdcInterruptAcknowledge()) {
+        int ppuTickSignals = interruptManager.consumePpuTickSignals();
+        if ((ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_ACKNOWLEDGE) != 0) {
             lastLcdcInterruptAcknowledgeClock = lycIrqClock;
             if (currentNativeDoubleSpeed
                     && previousMode0Window
@@ -269,11 +270,12 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                 interruptManager.requestInterruptBeforeHaltWake(InterruptType.LCDC);
             }
         }
-        if (interruptManager.consumeVBlankInterruptAcknowledge()) {
+        if ((ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_VBLANK_INTERRUPT_ACKNOWLEDGE) != 0) {
             lastVBlankInterruptAcknowledgeClock = lycIrqClock;
         }
-        boolean lcdcInterruptFlagWriteClear =
-                interruptManager.consumeLcdcInterruptFlagWriteClear();
+        boolean lcdcInterruptFlagWriteClear = (ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_FLAG_WRITE_CLEAR) != 0;
         if (lcdcInterruptFlagWriteClear
                 && currentGbc && !currentDmgCompat
                 && previousMode0Window
@@ -620,13 +622,12 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         boolean frameMode2 = nativeNormalRephased
                 && line == 153 && ticksInLine >= 452
                 && ticksInLine <= 455 && enableBits == 0x20;
-        interruptManager.setCpuReadInterruptPreview(
-                InterruptType.LCDC,
-                dmgMode0 || doubleSpeedMode0 || earlyVisibleMode2 || frameMode2);
         boolean frameVBlank = nativeNormalRephased
                 && line == 143 && ticksInLine >= 452
                 && ticksInLine <= 455 && enableBits == 0x20;
-        interruptManager.setCpuReadInterruptPreview(InterruptType.VBlank, frameVBlank);
+        interruptManager.setCpuReadPpuInterruptPreview(
+                dmgMode0 || doubleSpeedMode0 || earlyVisibleMode2 || frameMode2,
+                frameVBlank);
     }
 
     /** Returns whether this scheduler tick will publish the delayed mode-0 edge. */

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/InterruptManagerTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/InterruptManagerTest.java
@@ -82,6 +82,38 @@ public class InterruptManagerTest {
     }
 
     @Test
+    public void ppuPreviewBatchPreservesNonPpuPreviewBits() {
+        InterruptManager interrupts = enabledInterrupt(LCDC);
+
+        interrupts.setCpuReadInterruptPreview(Timer, true);
+        interrupts.setCpuReadPpuInterruptPreview(true, false);
+
+        assertEquals((1 << LCDC.ordinal()) | (1 << Timer.ordinal()),
+                interrupts.getByte(0xff0f) & 0x1f);
+
+        interrupts.setCpuReadPpuInterruptPreview(false, true);
+
+        assertEquals((1 << VBlank.ordinal()) | (1 << Timer.ordinal()),
+                interrupts.getByte(0xff0f) & 0x1f);
+    }
+
+    @Test
+    public void ppuTickSignalsAreConsumedTogether() {
+        InterruptManager interrupts = enabledInterrupt(LCDC);
+        interrupts.requestInterrupt(VBlank);
+        interrupts.clearInterrupt(VBlank);
+        interrupts.requestInterrupt(LCDC);
+        interrupts.clearInterrupt(LCDC);
+        interrupts.setByteFromCpu(0xff0f, 0);
+
+        int expected = InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_ACKNOWLEDGE
+                | InterruptManager.PPU_TICK_SIGNAL_VBLANK_INTERRUPT_ACKNOWLEDGE
+                | InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_FLAG_WRITE_CLEAR;
+        assertEquals(expected, interrupts.consumePpuTickSignals());
+        assertEquals(0, interrupts.consumePpuTickSignals());
+    }
+
+    @Test
     public void debugFlagViewsDoNotConsumeTransientIfReadMasks() {
         InterruptManager interrupts = new InterruptManager(false);
         interrupts.setByte(0xff0f,


### PR DESCRIPTION
## Summary

- publish LCDC and VBlank CPU-read preview bits with one InterruptManager call
- combine LCDC read-mask cleanup with preview clearing
- consume LCDC acknowledge, VBlank acknowledge, and LCDC IF-write-clear as one packed PPU signal
- retain the existing single-operation APIs for compatibility and direct tests

## Validation

- Focused: mvn -q -pl core -Dtest=InterruptManagerTest,StatRegisterTest,CpuPpuInterruptTimingTest test
- Core suite: mvn -q -pl core test
- 120-frame harness: 1,443,444,003 calls vs 1,477,102,191 parent calls (-2.28%)
- 1800-frame harness: 22,857,864,331 calls vs 23,362,439,119 parent calls (-2.16%)

The harness tick count remained 126,143,697 at 1800 frames.