### PR TITLE
Share production STAT CPU phase snapshot

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -683,18 +683,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private Mode tickSubsystems() {
         gpu.prepareForTick();
-        statRegister.captureCpuStatReadPhase(cpu.isSynchronousHaltEntryStatPhase(),
+        boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(
+                cpu.isSynchronousHaltEntryStatPhase(),
                 cpu.isAsynchronousHaltEntryStatPhase(),
                 cpu.isOrdinaryHaltWakeStatPhase(),
                 cpu.isOneCycleOrdinaryHaltWakeStatPhase());
-        boolean mode0InterruptEdgeNextTick =
-                statRegister.isMode0InterruptEdgeNextTick();
-        statRegister.captureCpuInterruptReadPhase(
+        statRegister.finishCpuReadPhase(
                 cpu.getInterruptFlagReadMaskTicks(mode0InterruptEdgeNextTick),
                 cpu.isMode0InterruptDispatchPhased(mode0InterruptEdgeNextTick),
                 cpu.doesMode0InstructionWinInterruptAcceptance(
                         mode0InterruptEdgeNextTick));
-        statRegister.publishFrameLyc0Mode2HandoffBeforeCpu();
         boolean speedSwitching = cpu.isSpeedSwitching();
         boolean speedSwitchTail = speedSwitchTailTicks > 0;
         Cpu.State initialCpuState = cpu.getState();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -562,6 +562,27 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         }
     }
 
+    /** Captures all STAT state needed by the production pre-CPU phase. */
+    public boolean beginCpuReadPhase(boolean synchronousHaltEntryPhase,
+                                     boolean asynchronousHaltEntryPhase,
+                                     boolean ordinaryHaltWakePhase,
+                                     boolean oneCycleOrdinaryHaltWakePhase) {
+        refreshGpuTiming();
+        captureCpuStatReadPhasePrepared(synchronousHaltEntryPhase,
+                asynchronousHaltEntryPhase, ordinaryHaltWakePhase,
+                oneCycleOrdinaryHaltWakePhase);
+        return isMode0InterruptEdgeNextTickPrepared();
+    }
+
+    /** Completes the production pre-CPU STAT phase without recapturing GPU timing. */
+    public void finishCpuReadPhase(int interruptFlagReadMaskTicks,
+                                   boolean mode0InterruptDispatchPhased,
+                                   boolean mode0InstructionWinsAcceptance) {
+        captureCpuInterruptReadPhasePrepared(interruptFlagReadMaskTicks,
+                mode0InterruptDispatchPhased, mode0InstructionWinsAcceptance);
+        publishFrameLyc0Mode2HandoffBeforeCpuPrepared();
+    }
+
     /** Captures the PPU mux phase before this tick's CPU memory callback. */
     public void captureCpuStatReadPhase(boolean synchronousHaltEntryPhase,
                                         boolean asynchronousHaltEntryPhase,
@@ -575,6 +596,15 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                                         boolean ordinaryHaltWakePhase,
                                         boolean oneCycleOrdinaryHaltWakePhase) {
         refreshGpuTiming();
+        captureCpuStatReadPhasePrepared(synchronousHaltEntryPhase,
+                asynchronousHaltEntryPhase, ordinaryHaltWakePhase,
+                oneCycleOrdinaryHaltWakePhase);
+    }
+
+    private void captureCpuStatReadPhasePrepared(boolean synchronousHaltEntryPhase,
+                                                 boolean asynchronousHaltEntryPhase,
+                                                 boolean ordinaryHaltWakePhase,
+                                                 boolean oneCycleOrdinaryHaltWakePhase) {
         if (ordinaryHaltWakePhase && !previousOrdinaryHaltWakePhase) {
             ordinaryHaltWakeStatClock = lycIrqClock;
         }
@@ -603,6 +633,13 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                                              boolean mode0InterruptDispatchPhased,
                                              boolean mode0InstructionWinsAcceptance) {
         refreshGpuTiming();
+        captureCpuInterruptReadPhasePrepared(interruptFlagReadMaskTicks,
+                mode0InterruptDispatchPhased, mode0InstructionWinsAcceptance);
+    }
+
+    private void captureCpuInterruptReadPhasePrepared(int interruptFlagReadMaskTicks,
+                                                      boolean mode0InterruptDispatchPhased,
+                                                      boolean mode0InstructionWinsAcceptance) {
         cpuInterruptFlagReadMaskTicks = interruptFlagReadMaskTicks;
         cpuMode0InterruptDispatchPhased = mode0InterruptDispatchPhased;
         cpuMode0InstructionWinsAcceptance = mode0InstructionWinsAcceptance;
@@ -647,6 +684,10 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
             return false;
         }
         refreshGpuTiming();
+        return isMode0InterruptEdgeNextTickPrepared();
+    }
+
+    private boolean isMode0InterruptEdgeNextTickPrepared() {
         return mode0EventArmed
                 && ((enableBits | mode0IrqStatLatch) & 0x08) != 0
                 && !interruptManager.isInterruptFlagSet(InterruptType.LCDC)
@@ -660,6 +701,10 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     /** Publishes line 1's LYC=0-blocked normal-speed mode-2 handoff before CPU I/O. */
     public void publishFrameLyc0Mode2HandoffBeforeCpu() {
         refreshGpuTiming();
+        publishFrameLyc0Mode2HandoffBeforeCpuPrepared();
+    }
+
+    private void publishFrameLyc0Mode2HandoffBeforeCpuPrepared() {
         if (pendingCgbMode2Interrupt && !timing.doubleSpeed
                 && isDeferredCgbMode2Phase()
                 && timing.line == 1


### PR DESCRIPTION
## Summary
- Add prepared STAT phase helpers that reuse PR7's GPU timing snapshot across the production pre-CPU sequence.
- Keep the existing public STAT entry points as refresh-safe wrappers for focused tests and direct callers.
- Replace four consecutive Gameboy STAT calls with one begin/finish production pair while preserving call order and CPU-derived arguments.

## Measurement

| Measurement | Parent (master / PR7) | Patch | Delta |
| --- | ---: | ---: | ---: |
| 120-frame ticks | 8,414,547 | 8,414,547 | 0 |
| 120-frame calls | 1,179,839,493 | 1,146,181,305 | -33,658,188 (-2.8528%) |
| 1,800-frame ticks | 126,143,697 | 126,143,697 | 0 |
| 1,800-frame calls | 19,071,011,141 | 18,566,436,353 | -504,574,788 (-2.6458%) |

## Verification
- mvn -q -pl core -Dtest=StatRegisterTest,CpuPpuInterruptTimingTest,GameboyHdmaArbitrationTest test
- mvn -q -pl core test
- 120-frame top-100 harness run
- 1800-frame acceptance harness run
- mvn -q test was attempted with a 300-second bound; it remained silent after SLF4J warnings and timed out in the broader controller/integration portion. Full GitHub CI is required before merge.