### PR TITLE
Pack CPU phase queries for STAT and HDMA

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -864,9 +864,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.tick();
         // The HBlank request crosses from the PPU to the CPU arbiter while the CPU is
         // still allowed to finish the current machine cycle.
-        hdma.advanceHblankRequest(cpu.hasInFlightWriteCycleForHdma(),
-                cpu.isCpuRequestSlotInProgressForHdma(),
-                cpu.isInterruptClaimedAtHdmaSample());
+        int hdmaPhaseFlags = cpu.getHdmaPhaseFlags();
+        hdma.advanceHblankRequest(
+                (hdmaPhaseFlags & Cpu.HDMA_PHASE_IN_FLIGHT_WRITE_CYCLE) != 0,
+                (hdmaPhaseFlags & Cpu.HDMA_PHASE_CPU_REQUEST_SLOT_IN_PROGRESS) != 0,
+                (hdmaPhaseFlags & Cpu.HDMA_PHASE_INTERRUPT_CLAIMED) != 0);
         Mode mode = gpu.tick();
         statRegister.tick();
         cpu.onPeripheralsTicked();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -683,11 +683,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private Mode tickSubsystems() {
         gpu.prepareForTick();
+        int statReadPhaseFlags = cpu.getStatReadPhaseFlags();
         boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(
-                cpu.isSynchronousHaltEntryStatPhase(),
-                cpu.isAsynchronousHaltEntryStatPhase(),
-                cpu.isOrdinaryHaltWakeStatPhase(),
-                cpu.isOneCycleOrdinaryHaltWakeStatPhase());
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE) != 0);
         statRegister.finishCpuReadPhase(
                 cpu.getInterruptFlagReadMaskTicks(mode0InterruptEdgeNextTick),
                 cpu.isMode0InterruptDispatchPhased(mode0InterruptEdgeNextTick),

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -18,6 +18,14 @@ import java.util.List;
 
 public class Cpu implements StatefulComponent<Cpu> {
 
+    public static final int STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY = 1;
+
+    public static final int STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY = 1 << 1;
+
+    public static final int STAT_READ_PHASE_ORDINARY_HALT_WAKE = 1 << 2;
+
+    public static final int STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE = 1 << 3;
+
     public enum State {
         OPCODE, EXT_OPCODE, OPERAND, RUNNING, IRQ_WAIT_1, IRQ_WAIT_2, IRQ_PUSH_1, IRQ_PUSH_2, IRQ_JUMP, STOPPED, HALTED,
         SPEED_SWITCH,
@@ -758,6 +766,24 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     public boolean isOneCycleOrdinaryHaltWakeStatPhase() {
         return ordinaryHaltWakeStatPhase && haltedCpuCycles == 1;
+    }
+
+    /** Returns all STAT CPU-read phase flags sampled at this point in one call. */
+    public int getStatReadPhaseFlags() {
+        int flags = 0;
+        if (synchronousHaltEntryStatPhase) {
+            flags |= STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY;
+        }
+        if (asynchronousHaltEntryStatPhase) {
+            flags |= STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY;
+        }
+        if (ordinaryHaltWakeStatPhase) {
+            flags |= STAT_READ_PHASE_ORDINARY_HALT_WAKE;
+            if (haltedCpuCycles == 1) {
+                flags |= STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE;
+            }
+        }
+        return flags;
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -26,6 +26,12 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     public static final int STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE = 1 << 3;
 
+    public static final int HDMA_PHASE_IN_FLIGHT_WRITE_CYCLE = 1;
+
+    public static final int HDMA_PHASE_CPU_REQUEST_SLOT_IN_PROGRESS = 1 << 1;
+
+    public static final int HDMA_PHASE_INTERRUPT_CLAIMED = 1 << 2;
+
     public enum State {
         OPCODE, EXT_OPCODE, OPERAND, RUNNING, IRQ_WAIT_1, IRQ_WAIT_2, IRQ_PUSH_1, IRQ_PUSH_2, IRQ_JUMP, STOPPED, HALTED,
         SPEED_SWITCH,
@@ -1145,6 +1151,30 @@ public class Cpu implements StatefulComponent<Cpu> {
         return clockCycle >= 2 && state == State.RUNNING && currentOpcode != null
                 && opIndex < currentOpCount
                 && currentOpWritesMemory[opIndex];
+    }
+
+    /** Returns the post-CPU HDMA arbitration flags sampled at this point in one call. */
+    public int getHdmaPhaseFlags() {
+        int flags = 0;
+        boolean instructionRetiring = !hdmaOpcodePrefetched
+                && (state == State.EXT_OPCODE || state == State.OPERAND
+                || state == State.RUNNING);
+        if (clockCycle >= 2 && state == State.RUNNING && currentOpcode != null
+                && opIndex < currentOpCount && currentOpWritesMemory[opIndex]) {
+            flags |= HDMA_PHASE_IN_FLIGHT_WRITE_CYCLE;
+        }
+        if (instructionRetiring
+                || (!hdmaOpcodePrefetched && state == State.OPCODE && clockCycle >= 2)) {
+            flags |= HDMA_PHASE_CPU_REQUEST_SLOT_IN_PROGRESS;
+        }
+        boolean interruptEntry = state == State.IRQ_WAIT_1 || state == State.IRQ_WAIT_2
+                || state == State.IRQ_PUSH_1 || state == State.IRQ_PUSH_2
+                || ((state == State.OPCODE || state == State.RUNNING) && clockCycle == 2
+                && interruptManager.isIme() && interruptManager.isInterruptRequested());
+        if (interruptEntry) {
+            flags |= HDMA_PHASE_INTERRUPT_CLAIMED;
+        }
+        return flags;
     }
 
     public boolean isSpeedSwitching() {


### PR DESCRIPTION
## Summary
- Commit A adds direct CPU STAT phase flags and replaces four once-per-tick getters with one packed query.
- Commit B adds direct post-CPU HDMA arbitration flags and replaces three queries plus the nested retirement query with one packed query.
- Existing public CPU getters remain unchanged for tests and debug callers.

## Measurement

| Measurement | Parent (master / PR8) | Patch (PR9) | Delta |
| --- | ---: | ---: | ---: |
| 120-frame ticks | 8,414,547 | 8,414,547 | 0 |
| 120-frame calls | 1,146,181,305 | 1,087,279,476 | -58,901,829 (-5.138963%) |
| 1,800-frame ticks | 126,143,697 | 126,143,697 | 0 |
| 1,800-frame calls | 18,566,436,353 | 17,683,430,474 | -883,005,879 (-4.755925%) |

Commit A alone reduced the 120-frame count to 1,120,937,664, a reduction of 25,243,641. Commit B reduced the combined result by a further 33,658,188.

## Verification
- mvn -q -pl core -Dtest=CpuPpuInterruptTimingTest,GameboyHdmaArbitrationTest,HdmaTest,DmaSpeedSwitchTest test
- mvn -q -pl core test
- independent 120-frame top-100 harness runs after each commit
- exact 1800-frame harness run on the combined commits
- ticks remain exactly 126,143,697