### PR TITLE
Reduce settled joypad tick method calls

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -34,6 +34,9 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     private static final int INPUT_FILTER_MASK = (1 << INPUT_FILTER_SAMPLES) - 1;
 
+    /** Fully settled four-sample history for each active-low input-line level. */
+    private static final int[] SETTLED_HISTORY = createSettledHistory();
+
     private final Set<Button> buttons = new CopyOnWriteArraySet<>();
     private final InterruptManager interruptManager;
     private final boolean isSgb;
@@ -222,8 +225,10 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     public void tick() {
         tick++;
-        PlayerInputSnapshot nextInput = Objects.requireNonNull(
-                playerInputSource.sample(), "PlayerInputSource returned null");
+        PlayerInputSnapshot nextInput = playerInputSource == PlayerInputSource.RELEASED
+                ? PlayerInputSnapshot.RELEASED
+                : Objects.requireNonNull(
+                        playerInputSource.sample(), "PlayerInputSource returned null");
         if (sampledInput != nextInput && !sampledInput.equals(nextInput)) {
             sampledInput = nextInput;
             inputChangedSinceLastTick = true;
@@ -258,6 +263,10 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 inputLines = applyButtons(inputLines, buttons);
             }
         }
+        if (inputHistory == SETTLED_HISTORY[inputLines]
+                && filteredInputLines == inputLines) {
+            return;
+        }
         int nextFilteredInputLines = filteredInputLines;
         for (int line = 0; line < 4; line++) {
             int shift = line * INPUT_FILTER_SAMPLES;
@@ -276,6 +285,20 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (fallingEdges != 0) {
             interruptManager.requestInterrupt(InterruptManager.InterruptType.P10_13);
         }
+    }
+
+    private static int[] createSettledHistory() {
+        int[] settledHistory = new int[1 << 4];
+        for (int inputLines = 0; inputLines < settledHistory.length; inputLines++) {
+            int history = 0;
+            for (int line = 0; line < 4; line++) {
+                if ((inputLines & (1 << line)) == 0) {
+                    history |= INPUT_FILTER_MASK << (line * INPUT_FILTER_SAMPLES);
+                }
+            }
+            settledHistory[inputLines] = history;
+        }
+        return settledHistory;
     }
 
     @Override

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
@@ -43,6 +43,19 @@ public class JoypadHotPathTest {
     }
 
     @Test
+    public void releasedDefaultSourceStillReconcilesSeededPhysicalInput() {
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        PlayerInputSnapshot pressed = PlayerInputSnapshot.of(List.of(
+                Set.of(Button.A), Set.of(), Set.of(), Set.of()));
+        joypad.seedDeterministicReplayInput(Set.of(), pressed);
+
+        joypad.tick();
+
+        assertEquals(PlayerInputSnapshot.RELEASED, joypad.getSampledInput());
+    }
+
+    @Test
     public void stablePhysicalInputHotPathAllocatesNothing() {
         java.lang.management.ThreadMXBean platformBean = ManagementFactory.getThreadMXBean();
         Assume.assumeTrue(platformBean instanceof ThreadMXBean);


### PR DESCRIPTION
PR10 from doc/emulation-performance-next-pass.md. Uses the package-owned released snapshot without invoking the default lambda, and skips the four-line filter loop when both input history and filtered electrical lines are already settled. Replay seeding and custom input-source null validation remain unchanged. Exact harness: 120 frames 1,078,864,930 calls, 8,414,547 ticks; 1800 frames 17,557,286,778 calls, 126,143,697 ticks. Focused Joypad tests, full core test suite, and three throughput probes pass.