### PR TITLE
Fuse pixel output and machine tick

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -78,7 +78,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
     @Override
     public void putPixelToScreen() {
         linePixels++;
-        int entry = popEntry();
+        int entry = popEntry(pixels, palettes, priorities);
         int tail = (delayHead + delaySize) & 7;
         delayEntry[tail] = entry;
         delayStamp[tail] = outputTicks;
@@ -110,10 +110,6 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     // pack bg pixel (2b), bg palette (3b), bg priority (1b), sprite pixel (2b),
     // sprite palette (3b), sprite bg-priority (1b)
-    private int popEntry() {
-        return popEntry(pixels, palettes, priorities);
-    }
-
     private int popEntry(IntQueue bgPixels, IntQueue bgPalettes, IntQueue bgPriorities) {
         int bgPixel = bgPixels.array[bgPixels.offset++];
         if (bgPixels.offset == bgPixels.array.length) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -525,8 +525,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         // participates in window rewind/refresh bookkeeping and must advance as a
         // bounded ring just like the shifted output machine.
         pixelTransferPhase.outputTick();
-        pixelMachine.outputTick();
-        pixelMachine.machineTick();
+        pixelMachine.outputAndMachineTick();
 
         Mode oldMode = mode;
         int oldLine = line;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -357,6 +357,14 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         fifo.outputTick();
     }
 
+    /** Advances the LCD output stage and the output-producing pixel machine in one boundary. */
+    public void outputAndMachineTick() {
+        fifo.outputTick();
+        if (machineActive && !tick()) {
+            machineActive = false;
+        }
+    }
+
     public DmgPixelFifo.RuntimeState captureDmgFifoRuntimeState() {
         return fifo instanceof DmgPixelFifo dmgFifo ? dmgFifo.captureRuntimeState() : null;
     }


### PR DESCRIPTION
PR11 from doc/emulation-performance-next-pass.md. Fuses the output-producing PixelTransfer outputTick and machineTick boundary into one GPU call, while retaining the timing-only outputTick call. ColorPixelFifo now calls the queue-pop implementation directly; the optional resolvePixel inline was measured and excluded because it regressed throughput. Exact harness: 120 frames 1,066,076,050 calls, 8,414,547 ticks; 1800 frames 17,360,292,454 calls, 126,143,697 ticks. Focused GPU tests and full core test suite pass. Fresh parent/candidate throughput medians: 53.063 / 53.718 FPS.