### PR TITLE
Optimize PPU timing and audio hot paths

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -78,7 +78,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
     @Override
     public void putPixelToScreen() {
         linePixels++;
-        int entry = popEntry();
+        int entry = popEntry(pixels, palettes, priorities);
         int tail = (delayHead + delaySize) & 7;
         delayEntry[tail] = entry;
         delayStamp[tail] = outputTicks;
@@ -110,10 +110,6 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     // pack bg pixel (2b), bg palette (3b), bg priority (1b), sprite pixel (2b),
     // sprite palette (3b), sprite bg-priority (1b)
-    private int popEntry() {
-        return popEntry(pixels, palettes, priorities);
-    }
-
     private int popEntry(IntQueue bgPixels, IntQueue bgPalettes, IntQueue bgPriorities) {
         int bgPixel = bgPixels.array[bgPixels.offset++];
         if (bgPixels.offset == bgPixels.array.length) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -35,6 +35,10 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     private final Display display;
 
+    // The timing-only PPU machine advances the LCD delay line without resolving
+    // pixels into its throwaway Display.
+    private boolean renderOutput = true;
+
     private final ColorPalette bgPalette;
 
     private final ColorPalette oamPalette;
@@ -70,6 +74,10 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         this.dmgCompatValue = dmgCompatValue;
     }
 
+    public void setRenderOutput(boolean renderOutput) {
+        this.renderOutput = renderOutput;
+    }
+
     @Override
     public int getLength() {
         return pixels.size;
@@ -103,7 +111,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         spriteFifo.rewind();
         if (delaySize > 0) {
             delaySize--;
-        } else {
+        } else if (renderOutput) {
             display.rewindPixel();
         }
     }
@@ -153,7 +161,9 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
             int entry = delayEntry[delayHead];
             delayHead = (delayHead + 1) & 7;
             delaySize--;
-            display.putColorPixel(resolvePixel(entry));
+            if (renderOutput) {
+                display.putColorPixel(resolvePixel(entry));
+            }
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -14,6 +14,10 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
 
     private final Display display;
 
+    // The timing-only PPU machine advances raw output timing without resolving
+    // pixels into its throwaway Display.
+    private boolean renderOutput = true;
+
     private final Lcdc lcdc;
 
     private final GpuRegisterValues registers;
@@ -25,6 +29,10 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
         this.lcdc = lcdc;
         this.registers = registers;
         this.vRamTransfer = vRamTransfer;
+    }
+
+    public void setRenderOutput(boolean renderOutput) {
+        this.renderOutput = renderOutput;
     }
 
     @Override
@@ -100,6 +108,28 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
     @Override
     public void outputTick() {
         outputTicks++;
+        if (!renderOutput) {
+            // Preserve the first-pixel split latch and output cadence, but skip the
+            // palette/register/VRAM-transfer work that only the visible machine needs.
+            if (firstEntry >= 0) {
+                firstEntry = -1;
+            }
+            while (delaySize > 0 && delayStamp[delayHead] + OUTPUT_DELAY <= outputTicks) {
+                int entry = delayEntry[delayHead];
+                delayHead = (delayHead + 1) & 7;
+                delaySize--;
+                if (outCount == 0) {
+                    outCount++;
+                    firstEntry = entry;
+                    firstBgp = registers.getEffective(GpuRegister.BGP);
+                    firstObp0 = registers.getEffective(GpuRegister.OBP0);
+                    firstObp1 = registers.getEffective(GpuRegister.OBP1);
+                    break;
+                }
+                outCount++;
+            }
+            return;
+        }
         if (firstEntry >= 0) {
             // second phase of the first pixel: mux with the current LCDC, palettes from
             // the previous tick
@@ -200,7 +230,7 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
             // the previous pixel is still in the output delay line: remove it, so the
             // next pixel takes its output slot
             delaySize--;
-        } else {
+        } else if (renderOutput) {
             display.rewindPixel();
         }
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -525,8 +525,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         // participates in window rewind/refresh bookkeeping and must advance as a
         // bounded ring just like the shifted output machine.
         pixelTransferPhase.outputTick();
-        pixelMachine.outputTick();
-        pixelMachine.machineTick();
+        pixelMachine.outputAndMachineTick();
 
         Mode oldMode = mode;
         int oldLine = line;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -60,6 +60,12 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     private boolean timingModeDirty = true;
     private boolean timingSnapshotPrepared;
 
+    // Monotonic owner-thread generation for the transient STAT timing view.  The
+    // PPU advances once per master tick, so StatRegister can reuse the snapshot it
+    // captured after the preceding GPU tick and only recapture when GPU state has
+    // actually moved in between.
+    private long timingGeneration;
+
     private final boolean earlyCgbLyReadEdge;
 
     private final ColorPalette bgPalette;
@@ -234,6 +240,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
         this.oamSearchPhase = new OamSearch(oamRam, dma, lcdc, r);
         this.pixelTransferPhase = new PixelTransfer(new Display(gbc), videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), null, speedMode, 0);
+        this.pixelTransferPhase.setRenderOutput(false);
         this.pixelMachine = new PixelTransfer(display, videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), vRamTransfer, speedMode, 4);
         this.pixelMachine.setOamReaderBus(oamSearchPhase);
 
@@ -241,6 +248,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         this.phase = oamSearchPhase.start();
         prepareForTick();
         speedMode.setTimingStateListener(() -> {
+            timingGeneration++;
             timingModeDirty = true;
             prepareForTick();
         });
@@ -289,6 +297,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     @Override
     public void setByte(int address, int value) {
+        timingGeneration++;
         if (!timingSnapshotPrepared) {
             prepareForTick();
         }
@@ -299,6 +308,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     @Override
     public void setByteFromCpu(int address, int value) {
+        timingGeneration++;
         if (!timingSnapshotPrepared) {
             prepareForTick();
         }
@@ -487,6 +497,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     public Mode tick() {
+        timingGeneration++;
         if (!timingSnapshotPrepared) {
             prepareForTick();
         }
@@ -518,8 +529,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             pixelTransferPhase.resetWindowLineCounter();
             pixelMachine.resetWindowLineCounter();
         }
-        pixelTransferPhase.checkWindowY(line, ticksInLine);
-        pixelMachine.checkWindowY(line, ticksInLine);
+        int windowYCheckpoint = PixelTransfer.windowYCheckpoint(
+                gbc, speedModeValue, line, ticksInLine);
+        int timingWindowWy = pixelTransferPhase.advanceWindowYDelay();
+        int outputWindowWy = pixelMachine.advanceWindowYDelay();
+        if (windowYCheckpoint != 0) {
+            pixelTransferPhase.sampleWindowY(windowYCheckpoint, timingWindowWy);
+            pixelMachine.sampleWindowY(windowYCheckpoint, outputWindowWy);
+        }
         // Both dot machines enqueue popped pixels into an eight-slot LCD delay line.
         // The timing-only skeleton has a throwaway Display, but its delay line still
         // participates in window rewind/refresh bookkeeping and must advance as a
@@ -677,6 +694,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     /** Rephases the CGB CPU-readable PPU latches when the CPU clock mux changes. */
     public void onSpeedSwitch() {
+        timingGeneration++;
         prepareForTick();
         statModeLatchRephasedBySpeedSwitch = true;
         lyReadLatchRephasedBySpeedSwitch = lcdEnabled;
@@ -698,12 +716,18 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     /** Retains the old CPU-readable STAT phase until the current scanline ends. */
     public void onSpeedSwitchComplete() {
+        timingGeneration++;
         speedSwitchCompletedThisLine = true;
     }
 
     /** Captures the CPU/PPU phase selected when a double-speed mode-2 IRQ is accepted. */
     public void onDoubleSpeedMode2Dispatch() {
+        timingGeneration++;
         doubleSpeedMode2DispatchStatTailThisLine = true;
+    }
+
+    long getTimingGeneration() {
+        return timingGeneration;
     }
 
     public boolean isStatModeLatchRephasedBySpeedSwitch() {
@@ -2358,6 +2382,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         } else {
             phase = oamSearchPhase;
         }
+        // The generation is deliberately transient: it is only a cache-validity
+        // marker for the derived STAT timing snapshot and is not part of emulated
+        // state. Force a fresh capture after restoring the portable state.
+        timingGeneration++;
+        timingSnapshotPrepared = false;
     }
 
     private record GpuState(ComponentState<Ram> videoRam0Memento, ComponentState<Ram> videoRam1Memento,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -42,6 +42,9 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
 
     private final GpuTimingSnapshot timing = new GpuTimingSnapshot();
 
+    // Derived from the GPU; never serialized as part of the STAT memento.
+    private long timingGeneration = Long.MIN_VALUE;
+
     private Gpu gpu;
 
     private boolean gbc;
@@ -224,7 +227,11 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     }
 
     private void refreshGpuTiming() {
-        gpu.captureStatTiming(timing);
+        long generation = gpu.getTimingGeneration();
+        if (generation != timingGeneration) {
+            gpu.captureStatTiming(timing);
+            timingGeneration = generation;
+        }
     }
 
     // TODO remove circular dependency
@@ -1959,6 +1966,9 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         this.ordinaryHaltWakeStatClock = mem.ordinaryHaltWakeStatClock;
         this.previousOrdinaryHaltWakePhase = mem.previousOrdinaryHaltWakePhase;
         this.scxChangedSinceMode0Event = mem.scxChangedSinceMode0Event;
+        // The timing snapshot is derived and may refer to the GPU state from before
+        // the restore.  Let the first consumer recapture it from the restored GPU.
+        timingGeneration = Long.MIN_VALUE;
     }
 
     private record StatRegisterState(int enableBits, int registeredLy, boolean coincidence,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -34,6 +34,10 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     private static final int[] JUNK_PIXEL_LINE = new int[8];
 
+    private static final int WINDOW_Y_FRAME_CHECKPOINT = 1;
+    private static final int WINDOW_Y_CURRENT_LINE_CHECKPOINT = 2;
+    private static final int WINDOW_Y_UPCOMING_LINE_CHECKPOINT = 4;
+
     private final PixelFifo fifo;
 
     private final Fetcher fetcher;
@@ -299,6 +303,15 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         }
     }
 
+    /** Enables/disables visible pixel resolution for this dot machine. */
+    public void setRenderOutput(boolean renderOutput) {
+        if (fifo instanceof ColorPixelFifo colorPixelFifo) {
+            colorPixelFifo.setRenderOutput(renderOutput);
+        } else if (fifo instanceof DmgPixelFifo dmgPixelFifo) {
+            dmgPixelFifo.setRenderOutput(renderOutput);
+        }
+    }
+
     public PixelTransfer start(int extraEntryDelay, boolean lcdEnableFirstLine) {
         this.lcdEnableFirstLine = lcdEnableFirstLine;
         entryTicks = entryDelay + extraEntryDelay;
@@ -560,14 +573,8 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         }
     }
 
-    /**
-     * Advances the delayed WY copy and samples the persistent window master at the
-     * PPU's line-edge checkpoints. Gambatte's CGB checkpoints at 450/454 map to
-     * Coffee's normal-speed skeleton at 446/450; double speed observes them at
-     * 449/453, and DMG uses 450/454. Normal-speed CGB and DMG sample frame line zero
-     * on line 153 dot 454, while double-speed CGB samples it on line zero dot 1.
-     */
-    public void checkWindowY(int line, int ticksInLine) {
+    /** Advances the delayed WY copy and returns the old-WY collision value, if any. */
+    public int advanceWindowYDelay() {
         if (windowWyDelay == 0) {
             windowWy = pendingWindowWy;
             windowWyDelay = -1;
@@ -576,7 +583,18 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         }
         int oldWindowWy = windowWyOldOnWriteTick;
         windowWyOldOnWriteTick = -1;
+        return oldWindowWy;
+    }
 
+    /**
+     * Returns the shared checkpoint mask for the current PPU line/tick. Gambatte's
+     * CGB checkpoints at 450/454 map to Coffee's normal-speed skeleton at 446/450;
+     * double speed observes them at 449/453, and DMG uses 450/454. Normal-speed CGB
+     * and DMG sample frame line zero on line 153 dot 454, while double-speed CGB samples
+     * it on line zero dot 1.
+     */
+    public static int windowYCheckpoint(boolean gbc, int speedModeValue,
+                                        int line, int ticksInLine) {
         boolean earlyFrameCheckpoint = !gbc || speedModeValue == 1;
         int currentLineTick = gbc
                 ? speedModeValue == 1 ? 446 : 449
@@ -584,29 +602,49 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         int upcomingLineTick = gbc
                 ? speedModeValue == 1 ? 450 : 453
                 : 454;
-        boolean frameCheckpoint = earlyFrameCheckpoint
+        int checkpoint = 0;
+        if (earlyFrameCheckpoint
                 ? line == 153 && ticksInLine == 454
-                : line == 0 && ticksInLine == 1;
-        boolean currentLineCheckpoint = line < 143 && ticksInLine == currentLineTick;
-        boolean upcomingLineCheckpoint = line < 143 && ticksInLine == upcomingLineTick;
-        if (!frameCheckpoint && !currentLineCheckpoint && !upcomingLineCheckpoint) {
+                : line == 0 && ticksInLine == 1) {
+            checkpoint |= WINDOW_Y_FRAME_CHECKPOINT;
+        }
+        if (line < 143 && ticksInLine == currentLineTick) {
+            checkpoint |= WINDOW_Y_CURRENT_LINE_CHECKPOINT;
+        }
+        if (line < 143 && ticksInLine == upcomingLineTick) {
+            checkpoint |= WINDOW_Y_UPCOMING_LINE_CHECKPOINT;
+        }
+        return checkpoint;
+    }
+
+    /** Applies a previously computed checkpoint to this machine's WY state. */
+    public void sampleWindowY(int checkpoint, int oldWindowWy) {
+        if (checkpoint == 0) {
             return;
         }
 
         int primaryWy = oldWindowWy >= 0 ? oldWindowWy : r.get(WY);
         boolean windowDisplay = isWindowDisplay();
-        if (frameCheckpoint) {
+        if ((checkpoint & WINDOW_Y_FRAME_CHECKPOINT) != 0) {
             setWindowYTriggered(windowDisplay && primaryWy == 0);
         }
-        if (currentLineCheckpoint || upcomingLineCheckpoint) {
+        if ((checkpoint & (WINDOW_Y_CURRENT_LINE_CHECKPOINT
+                | WINDOW_Y_UPCOMING_LINE_CHECKPOINT)) != 0) {
             int currentLy = r.get(LY);
-            if (currentLineCheckpoint && windowDisplay && currentLy == primaryWy) {
+            if ((checkpoint & WINDOW_Y_CURRENT_LINE_CHECKPOINT) != 0
+                    && windowDisplay && currentLy == primaryWy) {
                 setWindowYTriggered(true);
             }
-            if (upcomingLineCheckpoint && windowDisplay && currentLy + 1 == primaryWy) {
+            if ((checkpoint & WINDOW_Y_UPCOMING_LINE_CHECKPOINT) != 0
+                    && windowDisplay && currentLy + 1 == primaryWy) {
                 setWindowYTriggered(true);
             }
         }
+    }
+
+    public void checkWindowY(int line, int ticksInLine) {
+        int oldWindowWy = advanceWindowYDelay();
+        sampleWindowY(windowYCheckpoint(gbc, speedModeValue, line, ticksInLine), oldWindowWy);
     }
 
     /** Schedules the secondary WY comparator latch after a WY write. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -357,6 +357,14 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         fifo.outputTick();
     }
 
+    /** Advances the LCD output stage and the output-producing pixel machine in one boundary. */
+    public void outputAndMachineTick() {
+        fifo.outputTick();
+        if (machineActive && !tick()) {
+            machineActive = false;
+        }
+    }
+
     public DmgPixelFifo.RuntimeState captureDmgFifoRuntimeState() {
         return fifo instanceof DmgPixelFifo dmgFifo ? dmgFifo.captureRuntimeState() : null;
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.LineUnavailableException;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -83,6 +84,11 @@ public class AudioSystemSound implements Runnable {
     private volatile AudioBackend.AudioLine activeLine;
 
     private final StereoPcmConverter pcmConverter = new StereoPcmConverter(SAMPLE_RATE);
+
+    // Event delivery is synchronous on the emulation thread, so one grow-only scratch
+    // buffer is safe to reuse between conversions. The queued frame remains an owned,
+    // right-sized copy while the worker drains it.
+    private byte[] pcmScratch = new byte[0];
 
     /** Existing desktop constructor; preserves the old enabled/default-device behavior. */
     public AudioSystemSound(SoundProperties properties, EventBus eventBus, String callerId) {
@@ -623,11 +629,13 @@ public class AudioSystemSound implements Runnable {
         AudioRuntimeConfiguration configuration = desiredConfiguration.get();
         int[] source = event.buffer();
         int ticks = source.length / 2;
-        byte[] out = new byte[pcmConverter.maximumPcmBytes(ticks, event.clockSpec())];
+        int maximumBytes = pcmConverter.maximumPcmBytes(ticks, event.clockSpec());
+        if (pcmScratch.length < maximumBytes) {
+            pcmScratch = Arrays.copyOf(pcmScratch, maximumBytes);
+        }
         int written = pcmConverter.render(source, event.clockSpec(),
-                configuration.masterVolume(), configuration.muted(), out);
-        byte[] trimmed = new byte[written];
-        System.arraycopy(out, 0, trimmed, 0, written);
+                configuration.masterVolume(), configuration.muted(), pcmScratch);
+        byte[] trimmed = Arrays.copyOf(pcmScratch, written);
         if (generation == configurationGeneration.get()) {
             enqueuePcm(trimmed, configuration.latencyPreset().queuedFrames());
         }


### PR DESCRIPTION
## Summary
- Reuse STAT GPU timing snapshots until the GPU generation changes.
- Skip color/display resolution in the timing-only PPU machine while preserving FIFO timing and state.
- Share WY checkpoint calculation across both PPU machines.
- Reuse the desktop audio converter scratch buffer to reduce per-event allocation.

## Validation
- `mvn -q test` passed locally.
- Audio output and clock tests passed after the final audio change.
- Harry Potter intro FPS improved from the prior median of about 52.8 FPS to about 56.8 FPS across post-change runs.
- Audio probe output remained PCM-identical.