### PR TITLE
Add adaptive frame skipping under audio pressure

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -569,6 +569,9 @@ class BasicController private constructor(
         disconnectMobileAdapter(Controller.MobileAdapterDisconnectReason.REWIND)
       }
       isRewinding = rewindManager.enabled && it.active
+      // Rewind restores arbitrary machine positions; keep host output complete rather than
+      // carrying an adaptive request across a non-forward presentation path.
+      session?.gameboy?.requestFrameRenderSuppression(false)
     }
     eventQueue.register<SgbDisplay.SetSgbBorder> {
       // The display consumes the same event on its session bus. Keep the configuration identity
@@ -689,6 +692,7 @@ class BasicController private constructor(
     val clockSpec = session?.gameboy?.clockSpec ?: ClockSpec.LEGACY
     val frameTicks = clockSpec.controllerTicksPerFrame()
     if (!rewound && (debugPaused || pendingDebugAction != null)) {
+      session?.gameboy?.requestFrameRenderSuppression(false)
       runDebugTickWindow(clockSpec, stopAtNextBoundary = false)
       return
     }
@@ -697,6 +701,7 @@ class BasicController private constructor(
         !isEffectivelyPaused() &&
         !isRewinding &&
         debugInstrumentation?.hasEnabledBreakpoints() == true) {
+      session?.gameboy?.requestFrameRenderSuppression(false)
       runDebugTickWindow(clockSpec, stopAtNextBoundary = false)
       return
     }
@@ -707,6 +712,16 @@ class BasicController private constructor(
     }
 
     val trackDebugHistory = !rewound && debugCheckpointHistory.enabled
+    session?.gameboy?.requestFrameRenderSuppression(
+        !rewound &&
+            !isEffectivelyPaused() &&
+            !isRewinding &&
+            debugPort == null &&
+            debugInstrumentation == null &&
+            !debugCheckpointHistory.enabled &&
+            !timingTicker.disabled &&
+            timingTicker.hasPacingDebt,
+    )
     repeat(frameTicks) {
       if (rewound || (!isEffectivelyPaused() && !isRewinding)) {
         val gameboy = session?.gameboy
@@ -736,6 +751,7 @@ class BasicController private constructor(
   }
 
   private fun runDebugContinuation() {
+    session?.gameboy?.requestFrameRenderSuppression(false)
     if (pendingDebugAction == null) {
       serviceDebugSafePointControls()
     }
@@ -811,6 +827,7 @@ class BasicController private constructor(
           stopJob?.attempt?.isDone == true
 
   private fun runDebugTickWindow(clockSpec: ClockSpec, stopAtNextBoundary: Boolean) {
+    session?.gameboy?.requestFrameRenderSuppression(false)
     val frameTicks = clockSpec.controllerTicksPerFrame()
     var holdAtBoundary = false
     repeat(frameTicks) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
@@ -116,6 +116,7 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? MachineEntry ?: return false
     state.machine.restore(gameboy)
+    gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 
@@ -127,6 +128,7 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? SessionEntry ?: return false
     state.snapshot.restore(session)
+    session.gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
@@ -73,6 +73,10 @@ internal class RewindManager(
     // This is intentionally the first operation. A disabled manager does not advance cadence,
     // inspect the live machine, allocate a capture DTO, or create a snapshot.
     if (!enabled) return
+    // A suppressed frame is intentionally not a rewind point: resuming a snapshot from the
+    // matching full-output phase keeps rewind presentation coherent. Check before advancing the
+    // six-frame cadence so sustained every-other-frame suppression cannot phase-lock captures.
+    if (!gameboy.isCurrentVisibleFrameFullyRendering) return
     selectHistory(HistoryKind.MACHINE)
     if (frameCounter++ % RECORD_INTERVAL != 0) {
       return
@@ -91,6 +95,7 @@ internal class RewindManager(
   /** Captures machine plus active serial-endpoint state at the controller frame safe point. */
   fun record(session: Session) {
     if (!enabled) return
+    if (!session.gameboy.isCurrentVisibleFrameFullyRendering) return
     selectHistory(HistoryKind.SESSION)
     if (frameCounter++ % RECORD_INTERVAL != 0) return
     if (states.size == capacity) states.removeFirst()
@@ -111,6 +116,7 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? MachineEntry ?: return false
     state.machine.restore(gameboy)
+    gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 
@@ -122,6 +128,7 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? SessionEntry ?: return false
     state.snapshot.restore(session)
+    session.gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
@@ -116,7 +116,6 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? MachineEntry ?: return false
     state.machine.restore(gameboy)
-    gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 
@@ -128,7 +127,6 @@ internal class RewindManager(
     }
     val state = states.removeLastOrNull() as? SessionEntry ?: return false
     state.snapshot.restore(session)
-    session.gameboy.resumeFullFrameRenderingAfterRewindRestore()
     return true
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
@@ -23,12 +23,23 @@ internal constructor(
   internal var completedFrames = 0L
     private set
 
+  /**
+   * Whether the last completed controller cadence arrived after its pacing deadline.
+   *
+   * This is intentionally sampled only at the existing cadence boundary: querying it from a
+   * controller does not introduce a clock read, allocation, or per-master-tick work.
+   */
+  @VisibleForTesting
+  internal var hasPacingDebt = false
+    private set
+
   override fun run() {
     run(ClockSpec.LEGACY)
   }
 
   fun run(clockSpec: ClockSpec) {
     if (disabled) {
+      hasPacingDebt = false
       return
     }
     if (activeClock != clockSpec) {
@@ -36,6 +47,7 @@ internal constructor(
       frameNanos = clockSpec.newFrameNanosecondAccumulator()
       ticks = 0
       deadline = nanoTime()
+      hasPacingDebt = false
     }
     if (++ticks < clockSpec.controllerTicksPerFrame()) {
       return
@@ -50,6 +62,7 @@ internal constructor(
           nanoTime()
         }
     val now = nanoTime()
+    hasPacingDebt = now > deadline
     if (now - deadline > MAX_CATCH_UP_NANOS) {
       // Preserve short scheduling/GC delays so subsequent frames can repay them instead of
       // permanently losing emulated audio time. A long pause retains only a small bounded debt:

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -1073,6 +1073,9 @@ class LinkedController(
 
   fun runFrame() {
     timingFrameProbe?.invoke()
+    // Replays, lifecycle work, and waits below must never inherit a stale adaptive request from
+    // the preceding ordinary frame. The paced forward path installs its new request later.
+    sessions.forEach { it?.gameboy?.requestFrameRenderSuppression(false) }
     processPendingWorkAtSafePoint()
 
     // Local preparation and battery persistence are deliberately owned by a worker. Hold every
@@ -1125,6 +1128,11 @@ class LinkedController(
     }
 
     val clockSpec = requireCompatibleLinkedClock(configs)
+    sessions.forEach {
+      it?.gameboy?.requestFrameRenderSuppression(
+          !timingTicker.disabled && timingTicker.hasPacingDebt,
+      )
+    }
     repeat(clockSpec.controllerTicksPerFrame()) {
       sessions.forEach { it?.gameboy?.tick() }
       timingTicker.run(clockSpec)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -85,7 +85,6 @@ internal class MachineSnapshot private constructor(
     val rollbackRtc = gameboy.captureRtcRuntimeStateWithoutTimeSource()
     val rollbackWallClock = gameboy.captureWallClockRuntimeStateWithoutTimeSource()
     val rollbackFifo = gameboy.captureDmgFifoRuntimeState()
-    val rollbackRenderedOutput = gameboy.isCurrentVisibleFrameFullyRendering
     try {
       probe?.invoke(ApplyStage.BEFORE_LIVE_MUTATION)
       gameboy.restoreStateSilently(candidate)
@@ -94,24 +93,18 @@ internal class MachineSnapshot private constructor(
       gameboy.restoreRtcRuntimeState(candidateRtc)
       gameboy.restoreWallClockRuntimeState(candidateWallClock)
     } catch (failure: Throwable) {
-      var rollbackRestoredMachine = false
       try {
         gameboy.restoreStateSilently(rollbackState)
         gameboy.restoreDmgFifoRuntimeState(rollbackFifo)
         gameboy.restoreRtcRuntimeState(rollbackRtc)
         gameboy.restoreWallClockRuntimeState(rollbackWallClock)
-        rollbackRestoredMachine = true
       } catch (rollbackFailure: Throwable) {
         failure.addSuppressed(rollbackFailure)
-      }
-      if (rollbackRestoredMachine && rollbackRenderedOutput) {
-        gameboy.resumeFullFrameRenderingAfterCoherentRestore()
       }
       throw StateApplyException("Internal machine snapshot could not be applied atomically", failure)
     }
     if (synchronizeHostOutputs) {
       gameboy.synchronizeRumbleOutput(rollbackRumble)
-      gameboy.resumeFullFrameRenderingAfterCoherentRestore()
     }
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -85,6 +85,7 @@ internal class MachineSnapshot private constructor(
     val rollbackRtc = gameboy.captureRtcRuntimeStateWithoutTimeSource()
     val rollbackWallClock = gameboy.captureWallClockRuntimeStateWithoutTimeSource()
     val rollbackFifo = gameboy.captureDmgFifoRuntimeState()
+    val rollbackRenderedOutput = gameboy.isCurrentVisibleFrameFullyRendering
     try {
       probe?.invoke(ApplyStage.BEFORE_LIVE_MUTATION)
       gameboy.restoreStateSilently(candidate)
@@ -93,18 +94,24 @@ internal class MachineSnapshot private constructor(
       gameboy.restoreRtcRuntimeState(candidateRtc)
       gameboy.restoreWallClockRuntimeState(candidateWallClock)
     } catch (failure: Throwable) {
+      var rollbackRestoredMachine = false
       try {
         gameboy.restoreStateSilently(rollbackState)
         gameboy.restoreDmgFifoRuntimeState(rollbackFifo)
         gameboy.restoreRtcRuntimeState(rollbackRtc)
         gameboy.restoreWallClockRuntimeState(rollbackWallClock)
+        rollbackRestoredMachine = true
       } catch (rollbackFailure: Throwable) {
         failure.addSuppressed(rollbackFailure)
+      }
+      if (rollbackRestoredMachine && rollbackRenderedOutput) {
+        gameboy.resumeFullFrameRenderingAfterCoherentRestore()
       }
       throw StateApplyException("Internal machine snapshot could not be applied atomically", failure)
     }
     if (synchronizeHostOutputs) {
       gameboy.synchronizeRumbleOutput(rollbackRumble)
+      gameboy.resumeFullFrameRenderingAfterCoherentRestore()
     }
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/SessionSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/SessionSnapshot.kt
@@ -69,7 +69,6 @@ internal class SessionSnapshot private constructor(
 
     val rollbackMachine = MachineSnapshot.capture(session.gameboy)
     val rollbackRumble = session.gameboy.isRumbleActive
-    val rollbackRenderedOutput = session.gameboy.isCurrentVisibleFrameFullyRendering
     val rollbackSerial = endpoint.captureState()
     val rollbackRuntime = DetachedStateAdapter.captureSerialRuntime(endpoint)
     try {
@@ -81,15 +80,10 @@ internal class SessionSnapshot private constructor(
       DetachedStateAdapter.applySerialRuntime(endpoint, serialRuntime)
       effectiveCartridgePause?.let(session.gameboy::reanchorCartridgeRtcPause)
     } catch (failure: Throwable) {
-      val rollbackRestoredMachine =
-          rollback(session, endpoint, rollbackMachine, rollbackSerial, rollbackRuntime, failure)
-      if (rollbackRestoredMachine && rollbackRenderedOutput) {
-        session.gameboy.resumeFullFrameRenderingAfterCoherentRestore()
-      }
+      rollback(session, endpoint, rollbackMachine, rollbackSerial, rollbackRuntime, failure)
       throw StateApplyException("Internal session snapshot could not be applied atomically", failure)
     }
     session.gameboy.synchronizeRumbleOutput(rollbackRumble)
-    session.gameboy.resumeFullFrameRenderingAfterCoherentRestore()
   }
 
   private fun rollback(
@@ -99,22 +93,18 @@ internal class SessionSnapshot private constructor(
       rollbackSerial: ComponentState<SerialEndpoint>?,
       rollbackRuntime: SerialRuntimeState,
       original: Throwable,
-  ): Boolean {
-    val restoredMachine =
-        try {
-          rollbackMachine.restore(session.gameboy, synchronizeHostOutputs = false)
-          true
-        } catch (rollbackFailure: Throwable) {
-          original.addSuppressed(rollbackFailure)
-          false
-        }
+  ) {
+    try {
+      rollbackMachine.restore(session.gameboy, synchronizeHostOutputs = false)
+    } catch (rollbackFailure: Throwable) {
+      original.addSuppressed(rollbackFailure)
+    }
     try {
       endpoint.restoreState(rollbackSerial)
       DetachedStateAdapter.applySerialRuntime(endpoint, rollbackRuntime)
     } catch (rollbackFailure: Throwable) {
       original.addSuppressed(rollbackFailure)
     }
-    return restoredMachine
   }
 
   companion object {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/SessionSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/SessionSnapshot.kt
@@ -69,6 +69,7 @@ internal class SessionSnapshot private constructor(
 
     val rollbackMachine = MachineSnapshot.capture(session.gameboy)
     val rollbackRumble = session.gameboy.isRumbleActive
+    val rollbackRenderedOutput = session.gameboy.isCurrentVisibleFrameFullyRendering
     val rollbackSerial = endpoint.captureState()
     val rollbackRuntime = DetachedStateAdapter.captureSerialRuntime(endpoint)
     try {
@@ -80,10 +81,15 @@ internal class SessionSnapshot private constructor(
       DetachedStateAdapter.applySerialRuntime(endpoint, serialRuntime)
       effectiveCartridgePause?.let(session.gameboy::reanchorCartridgeRtcPause)
     } catch (failure: Throwable) {
-      rollback(session, endpoint, rollbackMachine, rollbackSerial, rollbackRuntime, failure)
+      val rollbackRestoredMachine =
+          rollback(session, endpoint, rollbackMachine, rollbackSerial, rollbackRuntime, failure)
+      if (rollbackRestoredMachine && rollbackRenderedOutput) {
+        session.gameboy.resumeFullFrameRenderingAfterCoherentRestore()
+      }
       throw StateApplyException("Internal session snapshot could not be applied atomically", failure)
     }
     session.gameboy.synchronizeRumbleOutput(rollbackRumble)
+    session.gameboy.resumeFullFrameRenderingAfterCoherentRestore()
   }
 
   private fun rollback(
@@ -93,18 +99,22 @@ internal class SessionSnapshot private constructor(
       rollbackSerial: ComponentState<SerialEndpoint>?,
       rollbackRuntime: SerialRuntimeState,
       original: Throwable,
-  ) {
-    try {
-      rollbackMachine.restore(session.gameboy, synchronizeHostOutputs = false)
-    } catch (rollbackFailure: Throwable) {
-      original.addSuppressed(rollbackFailure)
-    }
+  ): Boolean {
+    val restoredMachine =
+        try {
+          rollbackMachine.restore(session.gameboy, synchronizeHostOutputs = false)
+          true
+        } catch (rollbackFailure: Throwable) {
+          original.addSuppressed(rollbackFailure)
+          false
+        }
     try {
       endpoint.restoreState(rollbackSerial)
       DetachedStateAdapter.applySerialRuntime(endpoint, rollbackRuntime)
     } catch (rollbackFailure: Throwable) {
       original.addSuppressed(rollbackFailure)
     }
+    return restoredMachine
   }
 
   companion object {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
@@ -1,14 +1,17 @@
 package eu.rekawek.coffeegb.controller
 
+import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.state.MachineSnapshot
 import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.gpu.Display
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
 import eu.rekawek.coffeegb.core.serial.mobile.DeterministicMobileAdapterBackend
 import eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterBackendPort
 import eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterEngine
 import eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -17,6 +20,42 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class RewindManagerTest {
+
+  @Test
+  fun machineRewindEntriesResumeFullOutputOnEveryRestore() {
+    assertRepeatedRewindKeepsPublishing(
+        record = { manager, session -> manager.record(session.gameboy) },
+        rewind = { manager, session -> manager.rewindOneStep(session.gameboy) },
+    )
+  }
+
+  @Test
+  fun sessionRewindEntriesResumeFullOutputOnEveryRestore() {
+    assertRepeatedRewindKeepsPublishing(
+        record = RewindManager::record,
+        rewind = RewindManager::rewindOneStep,
+    )
+  }
+
+  @Test
+  fun suppressedFramesDoNotAdvanceRewindCaptureCadence() {
+    StateCodecTestSupport.session().use { session ->
+      val manager = RewindManager()
+      val gameboy = session.gameboy
+
+      gameboy.requestFrameRenderSuppression(true)
+      tickUntilVBlank(gameboy)
+      assertFalse(gameboy.isCurrentVisibleFrameFullyRendering)
+      repeat(RewindManager.RECORD_INTERVAL * 3) { manager.record(gameboy) }
+      assertEquals(0, manager.captureCount)
+
+      gameboy.requestFrameRenderSuppression(false)
+      tickUntilVBlank(gameboy)
+      assertTrue(gameboy.isCurrentVisibleFrameFullyRendering)
+      repeat(RewindManager.RECORD_INTERVAL) { manager.record(gameboy) }
+      assertEquals(1, manager.captureCount)
+    }
+  }
 
   @Test
   fun sessionRewindRestoresPartialMobileTransferCancelsBackendAndAccountsForSerialState() {
@@ -204,6 +243,38 @@ class RewindManagerTest {
     gameboy.addressSpace.setByte(0xa000 + (frame * 43 and 0x1fff), value xor 0xc3)
   }
 
+  private fun assertRepeatedRewindKeepsPublishing(
+      record: (RewindManager, Session) -> Unit,
+      rewind: (RewindManager, Session) -> Boolean,
+  ) {
+    StateCodecTestSupport.session().use { session ->
+      val publishedFrames = AtomicInteger()
+      session.eventBus.register<Display.DmgFrameReadyEvent> { publishedFrames.incrementAndGet() }
+      val manager = RewindManager()
+
+      repeat(REWIND_ENTRY_COUNT * RewindManager.RECORD_INTERVAL) {
+        tickUntilVBlank(session.gameboy)
+        record(manager, session)
+      }
+      assertEquals(REWIND_ENTRY_COUNT, manager.captureCount)
+      val framesBeforeRewind = publishedFrames.get()
+
+      repeat(REWIND_ENTRY_COUNT) {
+        assertTrue(rewind(manager, session))
+        assertTrue(session.gameboy.isCurrentVisibleFrameFullyRendering)
+        tickUntilVBlank(session.gameboy)
+      }
+      assertEquals(framesBeforeRewind + REWIND_ENTRY_COUNT, publishedFrames.get())
+    }
+  }
+
+  private fun tickUntilVBlank(gameboy: Gameboy) {
+    repeat(Gameboy.TICKS_PER_FRAME * 2) {
+      if (gameboy.tick()) return
+    }
+    error("PPU did not reach VBlank within two physical frames")
+  }
+
   private fun configuration() =
       StateCodecTestSupport.configuration(
               StateCodecTestSupport.rom(cgb = true).also {
@@ -269,6 +340,7 @@ class RewindManagerTest {
     /** Exact production-cadence primitive-array baseline measured on master 195d9172. */
     private const val MASTER_BASELINE_RETAINED_PRIMITIVE_BYTES = 337_665_600L
     private const val EXTRA_CAPTURES = 2
+    private const val REWIND_ENTRY_COUNT = 3
     private const val TEST_ADDRESS = 0xc100
   }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/TimingTickerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/TimingTickerTest.kt
@@ -21,9 +21,11 @@ class TimingTickerTest {
 
     repeat(custom.controllerTicksPerFrame() - 1) { ticker.run(custom) }
     assertEquals(0, ticker.completedFrames)
+    kotlin.test.assertFalse(ticker.hasPacingDebt)
     ticker.run(custom)
 
     assertEquals(1, ticker.completedFrames)
+    kotlin.test.assertTrue(ticker.hasPacingDebt)
     assertEquals(emptyList(), parked)
   }
 
@@ -37,6 +39,7 @@ class TimingTickerTest {
     repeat(99) { ticker.run(first) }
     repeat(199) { ticker.run(second) }
     assertEquals(0, ticker.completedFrames)
+    kotlin.test.assertFalse(ticker.hasPacingDebt)
     ticker.run(second)
     assertEquals(1, ticker.completedFrames)
   }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 class MachineSnapshotTest {
 
   @Test
-  fun directRestoreResumesFullHostOutputAfterCommit() {
+  fun directRestorePreservesFullHostOutputAfterCommit() {
     StateCodecTestSupport.session().use { session ->
       val snapshot = MachineSnapshot.capture(session.gameboy)
       repeat(2_000) { session.gameboy.tick() }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -17,6 +17,18 @@ import org.junit.Test
 class MachineSnapshotTest {
 
   @Test
+  fun directRestoreResumesFullHostOutputAfterCommit() {
+    StateCodecTestSupport.session().use { session ->
+      val snapshot = MachineSnapshot.capture(session.gameboy)
+      repeat(2_000) { session.gameboy.tick() }
+
+      snapshot.restore(session.gameboy)
+
+      assertTrue(session.gameboy.isCurrentVisibleFrameFullyRendering)
+    }
+  }
+
+  @Test
   fun stableProfileIdentityRejectsCgbAndCgb0CrossRestoreBeforeMutation() {
     val bytes = StateCodecTestSupport.rom(cgb = true)
     val cgbConfig =
@@ -433,6 +445,7 @@ class MachineSnapshotTest {
       repeat(2_000) { session.gameboy.tick() }
       session.heldButtons = setOf(Button.START)
       val before = DetachedStateAdapter.capture(session.gameboy)
+      assertTrue(session.gameboy.isCurrentVisibleFrameFullyRendering)
 
       assertFailsWith<StateApplyException> {
         target.restore(session.gameboy) { stage ->
@@ -441,6 +454,10 @@ class MachineSnapshotTest {
       }
       assertEquals(before, DetachedStateAdapter.capture(session.gameboy))
       assertEquals(setOf(Button.START), session.heldButtons)
+      assertTrue(
+          session.gameboy.isCurrentVisibleFrameFullyRendering,
+          "a failed transaction must restore the prior full-output host state",
+      )
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/SessionSnapshotRtcPauseTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/SessionSnapshotRtcPauseTest.kt
@@ -112,6 +112,7 @@ class SessionSnapshotRtcPauseTest {
       session.gameboy.addressSpace.setByte(0xc123, 0x77)
       repeat(128) { session.gameboy.tick() }
       val before = DetachedStateAdapter.capture(session)
+      assertTrue(session.gameboy.isCurrentVisibleFrameFullyRendering)
       rumble.clear()
 
       // The rollback capture consults the paused clock twice. Fail only after that preflight, at
@@ -125,9 +126,14 @@ class SessionSnapshotRtcPauseTest {
 
       assertEquals(before, DetachedStateAdapter.capture(session))
       assertEquals(emptyList(), rumble)
+      assertTrue(
+          session.gameboy.isCurrentVisibleFrameFullyRendering,
+          "a failed outer transaction must restore the prior full-output host state",
+      )
 
       target.restore(session, effectiveCartridgePause = true)
       assertEquals(listOf(true), rumble)
+      assertTrue(session.gameboy.isCurrentVisibleFrameFullyRendering)
     }
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -181,6 +181,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient volatile boolean doStop;
 
+    /**
+     * Host-only request sampled at the next physical VBlank edge. It intentionally is not part
+     * of a machine snapshot: presentation pacing must not affect deterministic replay.
+     */
+    private transient volatile boolean requestedFrameRenderSuppression;
+
+    /** Whether the visible frame currently being scanned out is host-suppressed. */
+    private transient boolean frameRenderSuppressed;
+
     private boolean requestedScreenRefresh;
 
     private boolean lcdDisabled;
@@ -671,8 +680,18 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             }
             if (!stopFrameBlanked && newMode == Mode.VBlank) {
                 requestedScreenRefresh = true;
-                display.frameIsReady();
+                // The request is deliberately not acted on at the controller's shorter
+                // 69,905-tick cadence. At this PPU edge every visible dot of the current frame
+                // has already advanced, so one whole physical frame is either published or held.
+                if (!frameRenderSuppressed) {
+                    display.frameIsReady();
+                }
+                // This is emulated SGB transfer timing, not host presentation. In particular,
+                // it must remain available independently of a future presentation policy.
                 vRamTransfer.frameIsReady();
+                latchFrameRenderSuppressionAtVBlank();
+                // A suppressed frame is still a real emulated VBlank. Keep the long-standing
+                // tick result and requested-screen-refresh cadence for host callers.
                 result = true;
             } else if (requestedScreenRefresh && newMode == Mode.OamSearch) {
                 requestedScreenRefresh = false;
@@ -1198,6 +1217,41 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return gpu;
     }
 
+    /**
+     * Requests that a future visible frame omit host presentation work.
+     *
+     * <p>This is a host-only pacing control. The request is latched only when the PPU reaches
+     * VBlank, is ignored for Super Game Boy profiles (their DMG pixels feed emulated SGB
+     * transfers), and never becomes serialized machine state.</p>
+     */
+    public void requestFrameRenderSuppression(boolean suppress) {
+        requestedFrameRenderSuppression = suppress
+                && !hardwareProfile.capabilities().superGameboyCommands();
+    }
+
+    /**
+     * Returns whether the current PPU frame is producing host-visible pixels.
+     *
+     * <p>This is host-only state used to choose coherent rewind capture points. It is deliberately
+     * not part of serialized machine state.</p>
+     */
+    public boolean isCurrentVisibleFrameFullyRendering() {
+        return !frameRenderSuppressed;
+    }
+
+    /**
+     * Resumes normal output after restoring a rewind snapshot captured at a coherent frame point.
+     *
+     * <p>Manual state loads intentionally keep a partially restored scanout hidden until the next
+     * physical frame edge. Rewind snapshots are selected only while full output is active, so the
+     * controller can safely resume their restored output immediately.</p>
+     */
+    public void resumeFullFrameRenderingAfterRewindRestore() {
+        requestedFrameRenderSuppression = false;
+        frameRenderSuppressed = false;
+        gpu.setRenderOutput(true);
+    }
+
     public Sound getSound() {
         return sound;
     }
@@ -1630,6 +1684,40 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !blankCgbBootTilePending
                 && !clearBootTilemapPending
                 && !clearCgbBootOamShadowPending;
+        resetHostFrameRenderingAfterRestore();
+    }
+
+    /**
+     * A snapshot can be restored in the middle of a scanout. Hold that partial host frame and
+     * return to ordinary rendering at the following physical frame edge; otherwise the restored
+     * tail could be published together with pixels from an abandoned host timeline.
+     */
+    private void resetHostFrameRenderingAfterRestore() {
+        requestedFrameRenderSuppression = false;
+        if (hardwareProfile.capabilities().superGameboyCommands()) {
+            frameRenderSuppressed = false;
+            gpu.setRenderOutput(true);
+            return;
+        }
+        frameRenderSuppressed = true;
+        gpu.setRenderOutput(false);
+    }
+
+    /** Applies the most recent host request at one real PPU frame boundary. */
+    private void latchFrameRenderSuppressionAtVBlank() {
+        // Ordinary playback only performs this one host-request read and false branch. Do not
+        // rewrite the output gate at every VBlank: it is already enabled and no host policy is
+        // asking to change the following physical frame.
+        if (!requestedFrameRenderSuppression) {
+            if (frameRenderSuppressed) {
+                frameRenderSuppressed = false;
+                gpu.setRenderOutput(true);
+            }
+            return;
+        }
+        // Sustained catch-up pressure still presents every other physical LCD frame.
+        frameRenderSuppressed = !frameRenderSuppressed;
+        gpu.setRenderOutput(!frameRenderSuppressed);
     }
 
     /** Current aggregate emulated motor output, without invoking host services. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1240,13 +1240,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
-     * Resumes normal output after a controller-owned coherent restore transaction commits.
+     * Resumes normal output after restoring a rewind snapshot captured at a coherent frame point.
      *
      * <p>Manual state loads intentionally keep a partially restored scanout hidden until the next
-     * physical frame edge. In-process snapshots are captured at controller-owned coherent points,
-     * so their successful transaction can safely resume output immediately.</p>
+     * physical frame edge. Rewind snapshots are selected only while full output is active, so the
+     * controller can safely resume their restored output immediately.</p>
      */
-    public void resumeFullFrameRenderingAfterCoherentRestore() {
+    public void resumeFullFrameRenderingAfterRewindRestore() {
         requestedFrameRenderSuppression = false;
         frameRenderSuppressed = false;
         gpu.setRenderOutput(true);
@@ -1597,12 +1597,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             throw new IllegalArgumentException();
         }
         restoreMachineState(mem, true);
+        resetHostFrameRenderingAfterRestore();
         synchronizeRumbleOutput(previousRumble);
     }
 
     /**
      * Applies emulated state without publishing host output or consulting an external RTC
-     * TimeSource from a speculative transaction.
+     * TimeSource from a speculative transaction. Host-only presentation pacing is deliberately
+     * preserved so the owning transaction can complete or roll back without changing it.
      */
     public void restoreStateSilently(ComponentState<Gameboy> state) {
         if (!(state instanceof GameboyState mem)) {
@@ -1684,7 +1686,6 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !blankCgbBootTilePending
                 && !clearBootTilemapPending
                 && !clearCgbBootOamShadowPending;
-        resetHostFrameRenderingAfterRestore();
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1240,13 +1240,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
-     * Resumes normal output after restoring a rewind snapshot captured at a coherent frame point.
+     * Resumes normal output after a controller-owned coherent restore transaction commits.
      *
      * <p>Manual state loads intentionally keep a partially restored scanout hidden until the next
-     * physical frame edge. Rewind snapshots are selected only while full output is active, so the
-     * controller can safely resume their restored output immediately.</p>
+     * physical frame edge. In-process snapshots are captured at controller-owned coherent points,
+     * so their successful transaction can safely resume output immediately.</p>
      */
-    public void resumeFullFrameRenderingAfterRewindRestore() {
+    public void resumeFullFrameRenderingAfterCoherentRestore() {
         requestedFrameRenderSuppression = false;
         frameRenderSuppressed = false;
         gpu.setRenderOutput(true);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -255,6 +255,17 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         timingSnapshotPrepared = false;
     }
 
+    /**
+     * Enables or suppresses only the resolved panel output of the visible pixel machine.
+     *
+     * <p>The timing-only pixel machine always remains disabled. This host-facing switch leaves
+     * every PPU timing, FIFO advance, and CPU-visible state transition intact while avoiding the
+     * final palette/display work for a deliberately unpresented frame.</p>
+     */
+    public void setRenderOutput(boolean renderOutput) {
+        pixelMachine.setRenderOutput(renderOutput);
+    }
+
     private AddressSpace getAddressSpace(int address) {
         if (videoRam0.accepts(address)) {
             return isVramAvailableForCpu() ? getVideoRam() : null;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Host-only frame skipping must stay aligned with physical PPU frames, not controller frames. */
@@ -59,12 +60,31 @@ public class GameboyAdaptiveFrameRenderingTest {
                 gameboy.tick();
             }
             gameboy.restoreState(state);
+            assertFalse(gameboy.isCurrentVisibleFrameFullyRendering());
 
             // A restored mid-scanout state must not compose a new host frame from its tail.
             runToNextFrame(gameboy);
             assertEquals(1, published.get());
             runToNextFrame(gameboy);
             assertEquals(2, published.get());
+        }
+    }
+
+    @Test
+    public void silentRestorePreservesTheExistingHostRenderGate() throws Exception {
+        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newGameboy()) {
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+            var state = gameboy.captureState();
+
+            gameboy.restoreStateSilently(state);
+            assertTrue(gameboy.isCurrentVisibleFrameFullyRendering());
+
+            gameboy.requestFrameRenderSuppression(true);
+            runToNextFrame(gameboy);
+            assertFalse(gameboy.isCurrentVisibleFrameFullyRendering());
+
+            gameboy.restoreStateSilently(state);
+            assertFalse(gameboy.isCurrentVisibleFrameFullyRendering());
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
@@ -1,0 +1,119 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Host-only frame skipping must stay aligned with physical PPU frames, not controller frames. */
+public class GameboyAdaptiveFrameRenderingTest {
+
+    @Test
+    public void requestLatchesAtVblankAndNeverSuppressesTwoPhysicalFramesInARow() throws Exception {
+        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newGameboy()) {
+            AtomicInteger published = new AtomicInteger();
+            eventBus.register(e -> published.incrementAndGet(), Display.DmgFrameReadyEvent.class);
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            gameboy.requestFrameRenderSuppression(true);
+
+            // This completed scanout started before the request reached its physical edge.
+            runToNextFrame(gameboy);
+            assertEquals(1, published.get());
+
+            // The next frame is entirely suppressed, then the cap requires a presentation.
+            runToNextFrame(gameboy);
+            assertEquals(1, published.get());
+            runToNextFrame(gameboy);
+            assertEquals(2, published.get());
+            runToNextFrame(gameboy);
+            assertEquals(2, published.get());
+        }
+    }
+
+    @Test
+    public void restoreHoldsThePartialHostFrameThenReturnsToFullRendering() throws Exception {
+        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newGameboy()) {
+            AtomicInteger published = new AtomicInteger();
+            eventBus.register(e -> published.incrementAndGet(), Display.DmgFrameReadyEvent.class);
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            runToNextFrame(gameboy);
+            assertEquals(1, published.get());
+            for (int i = 0; i < 123; i++) {
+                gameboy.tick();
+            }
+            var state = gameboy.captureState();
+
+            for (int i = 0; i < 321; i++) {
+                gameboy.tick();
+            }
+            gameboy.restoreState(state);
+
+            // A restored mid-scanout state must not compose a new host frame from its tail.
+            runToNextFrame(gameboy);
+            assertEquals(1, published.get());
+            runToNextFrame(gameboy);
+            assertEquals(2, published.get());
+        }
+    }
+
+    @Test
+    public void superGameBoyOutputIsNeverSuppressed() throws Exception {
+        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newSgbGameboy()) {
+            AtomicInteger published = new AtomicInteger();
+            eventBus.register(e -> published.incrementAndGet(), SgbDisplay.SgbFrameReadyEvent.class);
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            gameboy.requestFrameRenderSuppression(true);
+            runToNextFrame(gameboy);
+            runToNextFrame(gameboy);
+            runToNextFrame(gameboy);
+
+            assertEquals("SGB DMG pixels remain emulated transfer input", 3, published.get());
+        }
+    }
+
+    private static Gameboy newGameboy() throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(testRom()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy newSgbGameboy() throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(testRom()))
+                .setHardwareProfile(HardwareProfileRegistry.SGB2)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] testRom() {
+        byte[] rom = new byte[0x8000];
+        rom[0x100] = 0x18; // jr $0100
+        rom[0x101] = (byte) 0xfe;
+        rom[0x147] = 0;
+        return rom;
+    }
+
+    private static void runToNextFrame(Gameboy gameboy) {
+        for (int tick = 0; tick < 100_000; tick++) {
+            if (gameboy.tick()) {
+                return;
+            }
+        }
+        assertTrue("PPU did not reach VBlank", false);
+    }
+
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroAudioTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroAudioTest.java
@@ -45,6 +45,7 @@ public class HarryPotterIntroAudioTest {
             AudioCapture capture = new AudioCapture(warmupFrames, measurementFrames);
             eventBus.register(event -> capture.accept(event.buffer()), Sound.SoundSampleEvent.class);
             gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+            gameboy.requestFrameRenderSuppression(HarryPotterIntroHarness.forceFrameSkip());
 
             if (Boolean.getBoolean("harryPotterAudioPressStart")) {
                 eventBus.post(new ButtonPressEvent(Button.START));
@@ -58,6 +59,9 @@ public class HarryPotterIntroAudioTest {
                 gameboy.tick();
             }
             capture.printReport();
+            if (HarryPotterIntroHarness.forceFrameSkip()) {
+                System.out.println("Forced frame suppression: enabled");
+            }
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroAudioTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroAudioTimingTest.java
@@ -45,9 +45,13 @@ public class HarryPotterIntroAudioTimingTest {
             AudioCadence capture = new AudioCadence(WARMUP_FRAMES, MEASUREMENT_FRAMES);
             eventBus.register(event -> capture.accept(), Sound.SoundSampleEvent.class);
             gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+            gameboy.requestFrameRenderSuppression(HarryPotterIntroHarness.forceFrameSkip());
 
             paceFrames(gameboy, capture);
             capture.printReport();
+            if (HarryPotterIntroHarness.forceFrameSkip()) {
+                System.out.println("Forced frame suppression: enabled");
+            }
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroFpsTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroFpsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.Recording;
@@ -39,35 +40,50 @@ public class HarryPotterIntroFpsTest {
 
         try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = configuration.build()) {
             gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+            AtomicLong publishedFrames = new AtomicLong();
+            eventBus.register(e -> publishedFrames.incrementAndGet(),
+                    eu.rekawek.coffeegb.core.gpu.Display.DmgFrameReadyEvent.class);
+            eventBus.register(e -> publishedFrames.incrementAndGet(),
+                    eu.rekawek.coffeegb.core.gpu.Display.GbcFrameReadyEvent.class);
+            gameboy.requestFrameRenderSuppression(HarryPotterIntroHarness.forceFrameSkip());
 
-            Window warmup = runFrames(gameboy, WARMUP_FRAMES);
-            Window measurement = runMeasurement(gameboy);
+            Window warmup = runFrames(gameboy, WARMUP_FRAMES, publishedFrames);
+            Window measurement = runMeasurement(gameboy, publishedFrames);
 
-            double fps = measurement.frames * 1_000_000_000.0 / measurement.elapsedNanos;
+            double emulatedFps = measurement.emulatedFrames * 1_000_000_000.0 / measurement.elapsedNanos;
+            double renderedFps = measurement.publishedFrames * 1_000_000_000.0 / measurement.elapsedNanos;
             double ticksPerSecond = measurement.ticks * 1_000_000_000.0 / measurement.elapsedNanos;
             double nominalFps = Gameboy.TICKS_PER_SEC / (456.0 * 154.0);
 
-            System.out.printf("Harry Potter intro FPS: %.3f%n", fps);
+            // Retain the historical line as the emulator/VBlank throughput figure.
+            System.out.printf("Harry Potter intro FPS: %.3f%n", emulatedFps);
+            System.out.printf("Emulated VBlank FPS: %.3f%n", emulatedFps);
+            System.out.printf("Rendered/published FPS: %.3f%n", renderedFps);
             System.out.printf("Ticks/sec: %.0f%n", ticksPerSecond);
-            System.out.printf("Frames: %d in %.6f s%n", measurement.frames,
+            System.out.printf("Frames: %d emulated, %d rendered/published in %.6f s%n",
+                    measurement.emulatedFrames, measurement.publishedFrames,
                     measurement.elapsedNanos / 1_000_000_000.0);
-            System.out.printf("Warm-up: %d frames, %.0f ticks/sec%n", warmup.frames,
+            System.out.printf("Warm-up: %d emulated, %d rendered/published frames, %.0f ticks/sec%n",
+                    warmup.emulatedFrames, warmup.publishedFrames,
                     warmup.ticks * 1_000_000_000.0 / warmup.elapsedNanos);
-            System.out.printf("Nominal-frame headroom: %.1f%%%n", fps * 100.0 / nominalFps);
+            System.out.printf("Nominal-frame headroom: %.1f%%%n", emulatedFps * 100.0 / nominalFps);
+            if (HarryPotterIntroHarness.forceFrameSkip()) {
+                System.out.println("Forced frame suppression: enabled");
+            }
         }
     }
 
-    private static Window runMeasurement(Gameboy gameboy) throws Exception {
+    private static Window runMeasurement(Gameboy gameboy, AtomicLong publishedFrames) throws Exception {
         String jfrPath = System.getProperty(JFR_PROPERTY, "");
         if (jfrPath.isBlank()) {
-            return runFrames(gameboy, MEASUREMENT_FRAMES);
+            return runFrames(gameboy, MEASUREMENT_FRAMES, publishedFrames);
         }
 
         Path output = Path.of(jfrPath).toAbsolutePath();
         Window measurement;
         try (Recording recording = new Recording(Configuration.getConfiguration("profile"))) {
             recording.start();
-            measurement = runFrames(gameboy, MEASUREMENT_FRAMES);
+            measurement = runFrames(gameboy, MEASUREMENT_FRAMES, publishedFrames);
             recording.stop();
             recording.dump(output);
         }
@@ -75,21 +91,23 @@ public class HarryPotterIntroFpsTest {
         return measurement;
     }
 
-    private static Window runFrames(Gameboy gameboy, long targetFrames) {
+    private static Window runFrames(Gameboy gameboy, long targetFrames, AtomicLong publishedFrames) {
         long start = System.nanoTime();
-        long frames = 0;
+        long publishedAtStart = publishedFrames.get();
+        long emulatedFrames = 0;
         long ticks = 0;
 
-        while (frames < targetFrames) {
+        while (emulatedFrames < targetFrames) {
             if (gameboy.tick()) {
-                frames++;
+                emulatedFrames++;
             }
             ticks++;
         }
 
-        return new Window(frames, ticks, System.nanoTime() - start);
+        return new Window(emulatedFrames, publishedFrames.get() - publishedAtStart, ticks,
+                System.nanoTime() - start);
     }
 
-    private record Window(long frames, long ticks, long elapsedNanos) {
+    private record Window(long emulatedFrames, long publishedFrames, long ticks, long elapsedNanos) {
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroHarness.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroHarness.java
@@ -10,6 +10,9 @@ import java.util.zip.GZIPInputStream;
 /** Shared setup for the Harry Potter ROM probes. */
 public final class HarryPotterIntroHarness {
 
+    /** Opt-in deterministic presentation pressure for comparing host-only frame suppression. */
+    public static final String FORCE_FRAME_SKIP_PROPERTY = "harryPotterForceFrameSkip";
+
     /** Gzip-compressed 8 KiB battery save that skips the language-selection menu. */
     private static final String EMBEDDED_BATTERY_SAVE =
             "H4sIAAAAAAAEAO3BMQEAIAgAMKhAAksR0ceSmsGPY9vpXZkrAAAAgH8XAAAAYIgH3AhargAgAAA=";
@@ -52,5 +55,10 @@ public final class HarryPotterIntroHarness {
             System.out.printf("Harry Potter battery save: embedded (%d bytes)%n", data.length);
             return data;
         }
+    }
+
+    /** Returns whether the probe should continually request the core's every-other-frame cap. */
+    public static boolean forceFrameSkip() {
+        return Boolean.getBoolean(FORCE_FRAME_SKIP_PROPERTY);
     }
 }

--- a/scripts/measure-harry-potter-intro-audio-timing.sh
+++ b/scripts/measure-harry-potter-intro-audio-timing.sh
@@ -5,6 +5,7 @@ HARNESS_REF="${HARNESS_REF:-master}"
 DEFAULT_ROM="Z:/emu/roms/gbc/H/Harry Potter and the Sorcerer's Stone (USA, Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi).gbc"
 ROM_PATH="${HARRY_POTTER_ROM:-$DEFAULT_ROM}"
 BATTERY_SAVE="${HARRY_POTTER_BATTERY_SAVE:-}"
+FORCE_FRAME_SKIP="${HARRY_POTTER_FORCE_FRAME_SKIP:-false}"
 if (($# > 0)); then
   ROM_PATH="$1"
 fi
@@ -47,6 +48,7 @@ mvn -q -pl core \
   -Dtest=HarryPotterIntroAudioTimingTest \
   -DharryPotterRom="$ROM_PATH" \
   -DharryPotterBatterySave="$BATTERY_SAVE" \
+  -DharryPotterForceFrameSkip="$FORCE_FRAME_SKIP" \
   -Dsurefire.useFile=false \
   test
 

--- a/scripts/measure-harry-potter-intro-audio.sh
+++ b/scripts/measure-harry-potter-intro-audio.sh
@@ -5,6 +5,7 @@ HARNESS_REF="${HARNESS_REF:-master}"
 DEFAULT_ROM="Z:/emu/roms/gbc/H/Harry Potter and the Sorcerer's Stone (USA, Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi).gbc"
 ROM_PATH="${HARRY_POTTER_ROM:-$DEFAULT_ROM}"
 BATTERY_SAVE="${HARRY_POTTER_BATTERY_SAVE:-}"
+FORCE_FRAME_SKIP="${HARRY_POTTER_FORCE_FRAME_SKIP:-false}"
 if (($# > 0)); then
   ROM_PATH="$1"
 fi
@@ -47,6 +48,7 @@ mvn -q -pl core \
   -Dtest=HarryPotterIntroAudioTest \
   -DharryPotterRom="$ROM_PATH" \
   -DharryPotterBatterySave="$BATTERY_SAVE" \
+  -DharryPotterForceFrameSkip="$FORCE_FRAME_SKIP" \
   -Dsurefire.useFile=false \
   test
 

--- a/scripts/measure-harry-potter-intro-fps.sh
+++ b/scripts/measure-harry-potter-intro-fps.sh
@@ -8,6 +8,7 @@ DEFAULT_ROM="Z:/emu/roms/gbc/H/Harry Potter and the Sorcerer's Stone (USA, Europ
 ROM_PATH="${HARRY_POTTER_ROM:-$DEFAULT_ROM}"
 BATTERY_SAVE="${HARRY_POTTER_BATTERY_SAVE:-}"
 JFR_PATH="${HARRY_POTTER_JFR:-}"
+FORCE_FRAME_SKIP="${HARRY_POTTER_FORCE_FRAME_SKIP:-false}"
 if (($# > 0)); then
   ROM_PATH="$1"
 fi
@@ -46,6 +47,7 @@ mvn -q -pl core \
   -DharryPotterRom="$ROM_PATH" \
   -DharryPotterBatterySave="$BATTERY_SAVE" \
   -DharryPotterJfr="$JFR_PATH" \
+  -DharryPotterForceFrameSkip="$FORCE_FRAME_SKIP" \
   -Dsurefire.useFile=false \
   test
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
@@ -10,6 +10,7 @@ import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.image.BufferedImage
 import java.nio.file.Path
+import java.util.Locale
 import javax.swing.Action
 import javax.swing.BorderFactory
 import javax.swing.Box
@@ -41,6 +42,8 @@ internal data class DesktopPresentation(
     val commands: DesktopCommandPresentation = DesktopCommandPresentation(),
     val netplaySummary: String = "Netplay: Off",
     val persistentStatus: String = "Ready",
+    /** Presentation-thread rate, intentionally distinct from emulated VBlank cadence. */
+    val presentedFramesPerSecond: Double? = null,
     /** Durable recovery notice; routine lifecycle status changes must not erase it. */
     val notice: DesktopNotice? = null,
     /** Compatibility path for direct presentation callers; coordinators use [notice]. */
@@ -50,6 +53,8 @@ internal data class DesktopPresentation(
     require(gameTitle == null || gameTitle.isNotBlank())
     require(netplaySummary.isNotBlank())
     require(persistentStatus.isNotBlank())
+    require(presentedFramesPerSecond == null ||
+        (presentedFramesPerSecond.isFinite() && presentedFramesPerSecond >= 0))
   }
 
   val visibleStatus: String
@@ -205,6 +210,9 @@ internal class DesktopStatusBar(
               if (commandState.paused) add("Paused")
               if (commandState.muted) add("Muted")
               if (presentation.gameTitle != null) add("Slot ${commandState.stateSlot}")
+              presentation.presentedFramesPerSecond?.let {
+                add(String.format(Locale.ROOT, "FPS %.1f", it))
+              }
               add(presentation.netplaySummary)
             }
             .joinToString("  ·  ")

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
@@ -61,6 +61,7 @@ internal class DesktopUiCoordinator(
                   loadableStateSlots = emptySet(),
               ),
           persistentStatus = "$gameTitle is running",
+          presentedFramesPerSecond = null,
           statusRecoveryCommand = null,
       )
     }
@@ -96,6 +97,7 @@ internal class DesktopUiCoordinator(
                   fullscreen = false,
               ),
           persistentStatus = "Ready",
+          presentedFramesPerSecond = null,
           statusRecoveryCommand = null,
       )
     }
@@ -124,6 +126,7 @@ internal class DesktopUiCoordinator(
             persistentStatus =
                 if (paused) "Paused"
                 else it.gameTitle?.let { title -> "$title is running" } ?: "Ready",
+            presentedFramesPerSecond = if (paused) null else it.presentedFramesPerSecond,
             statusRecoveryCommand = null,
         )
       }
@@ -179,6 +182,11 @@ internal class DesktopUiCoordinator(
   fun netplaySummary(summary: String) {
     require(summary.isNotBlank())
     update { it.copy(netplaySummary = summary) }
+  }
+
+  fun presentedFramesPerSecond(value: Double?) {
+    require(value == null || (value.isFinite() && value >= 0))
+    update { it.copy(presentedFramesPerSecond = value) }
   }
 
   fun warning(message: String, recoveryCommand: DesktopCommand? = null) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -19,6 +19,7 @@ import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.memory.cart.type.PocketCamera
 import eu.rekawek.coffeegb.core.sound.Sound
 import eu.rekawek.coffeegb.swing.io.DesktopCameraSource
+import eu.rekawek.coffeegb.swing.io.SwingDisplay
 import eu.rekawek.coffeegb.swing.packaging.NativeRuntimeBootstrap
 import java.awt.Cursor
 import java.awt.Dimension
@@ -471,6 +472,14 @@ class SwingGui private constructor(
     }
     eventBus.register<Sound.SoundEnabledEvent> { event ->
       dispatchSwingMutation { desktopUiCoordinator.muted(!event.enabled()) }
+    }
+    eventBus.register<SwingDisplay.PresentationFrameRateEvent> { event ->
+      dispatchSwingMutation {
+        desktopUiCoordinator.presentedFramesPerSecond(event.framesPerSecond)
+      }
+    }
+    eventBus.register<SwingDisplay.PresentationFrameRateResetEvent> {
+      dispatchSwingMutation { desktopUiCoordinator.presentedFramesPerSecond(null) }
     }
     eventBus.register<DisplaySettingsChangedEvent> { event ->
       dispatchSwingMutation { desktopUiCoordinator.displaySettings(event.display) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/PresentationFrameRateMeter.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/PresentationFrameRateMeter.java
@@ -1,0 +1,46 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import java.util.function.LongSupplier;
+
+/** Low-frequency meter for frames actually accepted by SwingDisplay's presentation thread. */
+final class PresentationFrameRateMeter {
+
+    static final long SAMPLE_WINDOW_NANOS = 1_000_000_000L;
+
+    private final LongSupplier nanoTime;
+
+    private long sampleStartedAt;
+
+    private long acceptedFrames;
+
+    PresentationFrameRateMeter() {
+        this(System::nanoTime);
+    }
+
+    PresentationFrameRateMeter(LongSupplier nanoTime) {
+        this.nanoTime = nanoTime;
+        sampleStartedAt = nanoTime.getAsLong();
+    }
+
+    /**
+     * Records one frame after coalescing and publication. Returns NaN until the next sample is
+     * due, avoiding a desktop/EDT update for every emulator frame.
+     */
+    synchronized double framePublished() {
+        acceptedFrames++;
+        long now = nanoTime.getAsLong();
+        long elapsed = now - sampleStartedAt;
+        if (elapsed < SAMPLE_WINDOW_NANOS) {
+            return Double.NaN;
+        }
+        double framesPerSecond = acceptedFrames * 1_000_000_000.0 / elapsed;
+        sampleStartedAt = now;
+        acceptedFrames = 0;
+        return framesPerSecond;
+    }
+
+    synchronized void reset() {
+        sampleStartedAt = nanoTime.getAsLong();
+        acceptedFrames = 0;
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -38,6 +38,9 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private final AtomicLong preferredSizeRevision = new AtomicLong();
 
+    private final PresentationFrameRateMeter presentationFrameRate =
+            new PresentationFrameRateMeter();
+
     private PendingFrame pendingFrame;
 
     private volatile int displayWidth = DISPLAY_WIDTH;
@@ -127,12 +130,23 @@ public class SwingDisplay extends JPanel implements Runnable {
         // visual rumble through the owner lifecycle while subscribers are still active.
         eventBus.register(e -> this.rumbling = false, Controller.RomLoadingEvent.class);
         eventBus.register(e -> this.rumbling = false, Controller.EmulationStoppedEvent.class);
+        eventBus.register(e -> resetPresentationFrameRate(), Controller.PauseEmulationEvent.class);
+        eventBus.register(e -> resetPresentationFrameRate(), Controller.ResumeEmulationEvent.class);
+        eventBus.register(e -> resetPresentationFrameRate(), Controller.RomLoadingEvent.class);
+        eventBus.register(e -> resetPresentationFrameRate(), Controller.EmulationStartedEvent.class);
+        eventBus.register(e -> resetPresentationFrameRate(), Controller.EmulationStoppedEvent.class);
         requestPreferredSizeUpdate();
     }
 
     /** Resets host-only output state before a controller can quiesce or close its event bus. */
     public void releaseForLifecycleChange() {
         rumbling = false;
+        resetPresentationFrameRate();
+    }
+
+    private void resetPresentationFrameRate() {
+        presentationFrameRate.reset();
+        eventBus.post(new PresentationFrameRateResetEvent());
     }
 
     private synchronized void onHardwareProfile(Controller.HardwareProfileEvent e) {
@@ -434,6 +448,10 @@ public class SwingDisplay extends JPanel implements Runnable {
 
             displayedFrame.set(DisplayFrameSnapshot.copyOf(
                     frame.width(), frame.height(), frame.rgb()));
+            double framesPerSecond = presentationFrameRate.framePublished();
+            if (!Double.isNaN(framesPerSecond)) {
+                eventBus.post(new PresentationFrameRateEvent(framesPerSecond));
+            }
             requestRepaint();
         }
         isStopped = true;
@@ -552,6 +570,19 @@ public class SwingDisplay extends JPanel implements Runnable {
         public Dimension preferredSize() {
             return new Dimension(preferredSize);
         }
+    }
+
+    /** Low-frequency count of frames that survived SwingDisplay coalescing and were published. */
+    public record PresentationFrameRateEvent(double framesPerSecond) implements Event {
+        public PresentationFrameRateEvent {
+            if (!Double.isFinite(framesPerSecond) || framesPerSecond < 0) {
+                throw new IllegalArgumentException("Frame rate must be finite and non-negative");
+            }
+        }
+    }
+
+    /** Clears a stale presentation-rate sample after a pause or session ownership transition. */
+    public record PresentationFrameRateResetEvent() implements Event {
     }
 
     private record PendingFrame(int width, int height, int[] rgb, boolean resetBlend) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopMainPanelTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopMainPanelTest.kt
@@ -255,6 +255,23 @@ class DesktopMainPanelTest {
   }
 
   @Test
+  fun `status reports display-thread FPS instead of an emulated frame cadence`() {
+    onEdt {
+      val panel = panel(actions())
+      val statusBar = descendants(panel).filterIsInstance<DesktopStatusBar>().single()
+
+      panel.render(
+          DesktopPresentation(
+              gameTitle = "Tetris",
+              commands = DesktopCommandPresentation(gameLoaded = true),
+              presentedFramesPerSecond = 29.7,
+          ))
+
+      assertTrue(statusBar.session.text.contains("FPS 29.7"))
+    }
+  }
+
+  @Test
   fun `exact one scale packs to the raster and reveals commands only after a wide resize`() {
     onEdt {
       val surface = JPanel().apply {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinatorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinatorTest.kt
@@ -100,6 +100,21 @@ class DesktopUiCoordinatorTest {
   }
 
   @Test
+  fun `presentation FPS clears on pause and session stop`() {
+    val coordinator =
+        DesktopUiCoordinator(DesktopPresentation(), render = {}, edtCheck = { true })
+    coordinator.opened("Alleyway")
+    coordinator.presentedFramesPerSecond(59.7)
+    assertEquals(59.7, coordinator.current().presentedFramesPerSecond)
+
+    coordinator.paused(true)
+    assertNull(coordinator.current().presentedFramesPerSecond)
+    coordinator.presentedFramesPerSecond(29.7)
+    coordinator.stopped()
+    assertNull(coordinator.current().presentedFramesPerSecond)
+  }
+
+  @Test
   fun `slot load availability is removed when state commands or the session stop`() {
     val coordinator = DesktopUiCoordinator(DesktopPresentation(), render = {}, edtCheck = { true })
     coordinator.opened("Tetris")

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/PresentationFrameRateMeterTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/PresentationFrameRateMeterTest.java
@@ -1,0 +1,39 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PresentationFrameRateMeterTest {
+
+    @Test
+    public void reportsOnlyAfterTheLowFrequencySampleWindow() {
+        AtomicLong now = new AtomicLong();
+        PresentationFrameRateMeter meter = new PresentationFrameRateMeter(now::get);
+
+        for (int frame = 0; frame < 59; frame++) {
+            now.addAndGet(16_666_667L);
+            assertTrue(Double.isNaN(meter.framePublished()));
+        }
+
+        now.set(PresentationFrameRateMeter.SAMPLE_WINDOW_NANOS);
+        assertEquals(60.0, meter.framePublished(), 0.001);
+    }
+
+    @Test
+    public void resetDropsStaleFramesAcrossPauseOrSessionReplacement() {
+        AtomicLong now = new AtomicLong();
+        PresentationFrameRateMeter meter = new PresentationFrameRateMeter(now::get);
+        for (int frame = 0; frame < 30; frame++) {
+            meter.framePublished();
+        }
+
+        now.set(2_000_000_000L);
+        meter.reset();
+        now.addAndGet(PresentationFrameRateMeter.SAMPLE_WINDOW_NANOS);
+        assertEquals(1.0, meter.framePublished(), 0.001);
+    }
+}


### PR DESCRIPTION
## Summary

Preserves emulation on every tick while adaptively suppressing costly pixel resolution and display publication when timing debt indicates audio pressure. Skips are capped at every other frame, retain the last completed frame, and are excluded for SGB.

The controller updates the next-frame render decision from bounded timing debt; the PPU, STAT, APU, and emulated VBlank cadence remain unchanged. Swing now reports coalesced presented-frame FPS at about 1 Hz (about 59.7 normally, about 29.9 when alternating frames are skipped).

## Validation

- Focused adaptive core, TimingTicker, Swing FPS/status, repeated machine/session rewind tests pass.
- Full mvn -q test and git diff --check pass.
- Forced mode produces 600 emulated VBlanks and exactly 300 published frames; PCM is byte-identical to no-skip.
- Audio timing remains bounded: parent p50/p95/p99/max 16.650/17.358/23.513/29.806 ms, candidate forced 16.640/17.992/22.422/27.919 ms; queue-debt ends at zero in both runs.
- Exact-probe no-skip control is neutral: median 66.675 FPS parent vs 66.520 FPS candidate (-0.23%); forced-mode throughput benefit is intentionally small/noisy because this is a tail-resilience mechanism.