### PR TITLE
Cache stable stereo mixer output

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -24,8 +24,6 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     private static final int CGB_BOOT_DIV_APU_OFFSET = 2;
 
-    private static final boolean[] ENABLED = {true, true, true, true};
-
     private static final int[] MASKS =
             new int[]{
                     0x80, 0x3f, 0x00, 0xff, 0xbf, 0xff, 0x3f, 0x00, 0xff, 0xbf, 0x7f, 0xff, 0x9f, 0xff, 0xbf,
@@ -36,7 +34,15 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     private final FrameSequencer frameSequencer = new FrameSequencer();
 
-    private final AbstractSoundMode[] allModes = new AbstractSoundMode[4];
+    private final SoundMode1 mode1;
+
+    private final SoundMode2 mode2;
+
+    private final SoundMode3 mode3;
+
+    private final SoundMode4 mode4;
+
+    private final AbstractSoundMode[] allModes;
 
     private final Ram r = new Ram(0xff24, 0x03);
 
@@ -45,6 +51,13 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     private int routing;
 
     private final int[] channels = new int[4];
+
+    /** Derived mixer state; it is intentionally absent from portable sound state. */
+    private transient boolean mixerDirty = true;
+
+    private transient int mixedLeft;
+
+    private transient int mixedRight;
 
     private boolean enabled = true;
 
@@ -99,10 +112,11 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         this.clockSpec = clockSpec;
         this.buffer = new int[Math.multiplyExact(clockSpec.controllerTicksPerFrame(), 2)];
         frameSequencerDivOffset = gbc ? CGB_BOOT_DIV_APU_OFFSET : 0;
-        allModes[0] = new SoundMode1(frameSequencer, gbc);
-        allModes[1] = new SoundMode2(frameSequencer, gbc);
-        allModes[2] = new SoundMode3(frameSequencer, timer, gbc);
-        allModes[3] = new SoundMode4(frameSequencer, gbc);
+        mode1 = new SoundMode1(frameSequencer, gbc);
+        mode2 = new SoundMode2(frameSequencer, gbc);
+        mode3 = new SoundMode3(frameSequencer, timer, gbc);
+        mode4 = new SoundMode4(frameSequencer, gbc);
+        allModes = new AbstractSoundMode[]{mode1, mode2, mode3, mode4};
         // Initial volume
         r.setByte(0xFF24, 0x77);
     }
@@ -123,31 +137,68 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
         int enabledBefore = debugHooks == null ? 0 : getEnabledChannelMask();
 
-        channels[0] = allModes[0].tick(divReset);
-        channels[1] = allModes[1].tick(divReset);
-        channels[2] = allModes[2].tick();
-        channels[3] = allModes[3].tick();
+        int channel1 = mode1.tick(divReset);
+        int channel2 = mode2.tick(divReset);
+        int channel3 = mode3.tick();
+        int channel4 = mode4.tick();
+        boolean channelOutputsChanged = channel1 != channels[0]
+                | channel2 != channels[1]
+                | channel3 != channels[2]
+                | channel4 != channels[3];
+        mixerDirty |= channelOutputsChanged;
+        channels[0] = channel1;
+        channels[1] = channel2;
+        channels[2] = channel3;
+        channels[3] = channel4;
         if (debugHooks != null) {
             notifyDebugChannelDisables(enabledBefore);
         }
 
+        if (mixerDirty) {
+            mixChannels();
+        }
+        play(mixedLeft, mixedRight);
+    }
+
+    private void mixChannels() {
         int selection = routing;
         int left = 0;
         int right = 0;
-        for (int i = 0; i < 4; i++) {
-            if (!overriddenEnabled[i] || !ENABLED[i]) {
-                continue;
-            }
-            // the DAC maps the digital 0-15 to analog +15..-15 (0 = the highest level);
-            // a DAC that is enabled while its channel is inactive therefore outputs a
-            // constant positive offset. Games play PCM speech by parking such a DC and
-            // modulating the master volume (Perfect Dark's intro voice, issue #56); a
-            // disabled DAC outputs true analog zero.
-            int analog = allModes[i].dacEnabled ? 15 - 2 * channels[i] : 0;
-            if ((selection & (1 << i + 4)) != 0) {
+        // The DAC maps digital 0-15 to analog +15..-15. Keep the call sites concrete so
+        // HotSpot can inline this 4.2 MHz mixer rather than dispatching through allModes.
+        if (overriddenEnabled[0]) {
+            int analog = mode1.dacEnabled ? 15 - 2 * channels[0] : 0;
+            if ((selection & 0x10) != 0) {
                 left += analog;
             }
-            if ((selection & (1 << i)) != 0) {
+            if ((selection & 0x01) != 0) {
+                right += analog;
+            }
+        }
+        if (overriddenEnabled[1]) {
+            int analog = mode2.dacEnabled ? 15 - 2 * channels[1] : 0;
+            if ((selection & 0x20) != 0) {
+                left += analog;
+            }
+            if ((selection & 0x02) != 0) {
+                right += analog;
+            }
+        }
+        if (overriddenEnabled[2]) {
+            int analog = mode3.dacEnabled ? 15 - 2 * channels[2] : 0;
+            if ((selection & 0x40) != 0) {
+                left += analog;
+            }
+            if ((selection & 0x04) != 0) {
+                right += analog;
+            }
+        }
+        if (overriddenEnabled[3]) {
+            int analog = mode4.dacEnabled ? 15 - 2 * channels[3] : 0;
+            if ((selection & 0x80) != 0) {
+                left += analog;
+            }
+            if ((selection & 0x08) != 0) {
                 right += analog;
             }
         }
@@ -157,7 +208,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         left *= ((volumes >> 4) & 0b111) + 1;
         right *= (volumes & 0b111) + 1;
 
-        play(left, right);
+        mixedLeft = left;
+        mixedRight = right;
+        mixerDirty = false;
     }
 
     /**
@@ -266,6 +319,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             }
             notifyDebugRegisterWrite(-1, address, value);
             notifyDebugChannelDisables(enabledBefore);
+            mixerDirty = true;
             return;
         }
 
@@ -294,6 +348,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
                 }
             }
             if (channel != -1) {
+                mixerDirty = true;
                 notifyDebugRegisterWrite(channel, address, value);
             }
             return;
@@ -315,6 +370,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (!accepted) {
             return;
         }
+        mixerDirty = true;
         int channel = getDebugChannel(address);
         notifyDebugRegisterWrite(channel, address, value);
         if (isTriggerRegister(address) && (value & 0x80) != 0) {
@@ -497,6 +553,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     public void enableChannel(int i, boolean enabled) {
         overriddenEnabled[i] = enabled;
+        mixerDirty = true;
     }
 
     @Override
@@ -571,6 +628,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         this.pendingFrameSequencerStep = mem.pendingFrameSequencerStep;
         this.frameSequencerClockPhase = mem.frameSequencerClockPhase;
         this.frameSequencerDivOffset = mem.frameSequencerDivOffset;
+        this.mixerDirty = true;
 
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMixerCacheTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMixerCacheTest.java
@@ -1,0 +1,122 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.timer.Timer;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SoundMixerCacheTest {
+
+    @Test
+    public void stableMixerOutputIsPublishedOnEveryTickAndChannelOutputChangesIt() {
+        Fixture fixture = newFixture();
+        enableChannel1DacAndRouteBoth(fixture.sound);
+
+        assertSample(fixture, 120, 120);
+        assertSample(fixture, 120, 120);
+        assertSample(fixture, 120, 120);
+
+        fixture.sound.setByte(0xff11, 0xc0);
+        fixture.sound.setByte(0xff13, 0xff);
+        fixture.sound.setByte(0xff14, 0x87);
+
+        boolean observedChannelOutputChange = false;
+        for (int i = 0; i < 20; i++) {
+            int[] sample = tick(fixture);
+            if (sample[0] == -120 && sample[1] == -120) {
+                observedChannelOutputChange = true;
+                break;
+            }
+        }
+        assertTrue("channel output change did not reach the cached mixer", observedChannelOutputChange);
+    }
+
+    @Test
+    public void mixerAndDacRegisterWritesInvalidateCachedOutput() {
+        Fixture fixture = newFixture();
+        enableChannel1DacAndRouteBoth(fixture.sound);
+        assertSample(fixture, 120, 120);
+
+        fixture.sound.setByte(0xff24, 0x00);
+        assertSample(fixture, 15, 15);
+
+        fixture.sound.setByte(0xff25, 0x01);
+        assertSample(fixture, 0, 15);
+
+        fixture.sound.setByte(0xff12, 0x00);
+        assertSample(fixture, 0, 0);
+
+        fixture.sound.setByte(0xff12, 0xf0);
+        assertSample(fixture, 0, 15);
+    }
+
+    @Test
+    public void channelOverrideAndApuPowerTransitionsInvalidateCachedOutput() {
+        Fixture fixture = newFixture();
+        enableChannel1DacAndRouteBoth(fixture.sound);
+        assertSample(fixture, 120, 120);
+
+        fixture.sound.enableChannel(0, false);
+        assertSample(fixture, 0, 0);
+
+        fixture.sound.enableChannel(0, true);
+        assertSample(fixture, 120, 120);
+
+        fixture.sound.setByte(0xff26, 0x00);
+        assertSample(fixture, 0, 0);
+
+        fixture.sound.setByte(0xff26, 0x80);
+        assertSample(fixture, 0, 0);
+
+        enableChannel1DacAndRouteBoth(fixture.sound);
+        assertSample(fixture, 120, 120);
+    }
+
+    @Test
+    public void restoringStateInvalidatesCachedOutput() {
+        Fixture fixture = newFixture();
+        enableChannel1DacAndRouteBoth(fixture.sound);
+        assertSample(fixture, 120, 120);
+        var state = fixture.sound.captureState();
+
+        fixture.sound.setByte(0xff12, 0x00);
+        assertSample(fixture, 0, 0);
+
+        fixture.sound.restoreState(state);
+        assertSample(fixture, 120, 120);
+    }
+
+    private static Fixture newFixture() {
+        SpeedMode speedMode = new SpeedMode(true);
+        Sound sound = new Sound(new Timer(new InterruptManager(true), speedMode), speedMode, true);
+        List<int[]> samples = new ArrayList<>();
+        assertTrue(sound.attachOutputObserver((left, right) -> samples.add(new int[]{left, right})));
+        return new Fixture(sound, samples);
+    }
+
+    private static void enableChannel1DacAndRouteBoth(Sound sound) {
+        sound.setByte(0xff24, 0x77);
+        sound.setByte(0xff12, 0xf0);
+        sound.setByte(0xff25, 0x11);
+    }
+
+    private static void assertSample(Fixture fixture, int left, int right) {
+        assertArrayEquals(new int[]{left, right}, tick(fixture));
+    }
+
+    private static int[] tick(Fixture fixture) {
+        int before = fixture.samples.size();
+        fixture.sound.tick();
+        assertEquals(before + 1, fixture.samples.size());
+        return fixture.samples.get(before);
+    }
+
+    private record Fixture(Sound sound, List<int[]> samples) {
+    }
+}


### PR DESCRIPTION
## Summary

- retain concrete references to all four APU modes so their hot tick calls stay monomorphic
- cache the derived stereo mix while still ticking every channel and publishing every sample
- invalidate the cache after accepted APU writes, power transitions, channel overrides, and state restore
- add focused coverage for stable output, channel changes, NR50/NR51, DAC state, overrides, power, and restore

## Correctness

- full intro PCM is byte-identical to the parent
- the mixer cache is transient derived state and is excluded from portable snapshots
- channel timing, debug hooks, output observers, sample buffering, and event cadence are unchanged

## Performance

Six controlled alternating post-warm-up pairs, with emulated and rendered FPS equal in every run:

- parent median: 65.978 FPS
- candidate median: 70.299 FPS
- median gain: 6.55 percent
- paired median absolute delta: +4.912 FPS

Audio cadence medians across three runs:

- parent p50/p95/p99/max: 16.665 / 17.488 / 22.446 / 27.659 ms; gaps over 25/50 ms: 3/0; debt: 0 ms
- candidate p50/p95/p99/max: 16.657 / 17.761 / 23.971 / 29.059 ms; gaps over 25/50 ms: 4/0; debt: 0 ms

## Validation

- git diff --check
- focused SoundMixerCacheTest, SoundOutputObserverTest, SoundMementoTest, and SoundFrameSequencerTimingTest
- full mvn -q test
- measure-harry-potter-intro-audio.sh
- measure-harry-potter-intro-fps.sh
- measure-harry-potter-intro-audio-timing.sh