### PR TITLE
Optimize steady-state emulator tick paths

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -883,11 +883,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.tick();
         // The HBlank request crosses from the PPU to the CPU arbiter while the CPU is
         // still allowed to finish the current machine cycle.
-        int hdmaPhaseFlags = cpu.getHdmaPhaseFlags();
-        hdma.advanceHblankRequest(
-                (hdmaPhaseFlags & Cpu.HDMA_PHASE_IN_FLIGHT_WRITE_CYCLE) != 0,
-                (hdmaPhaseFlags & Cpu.HDMA_PHASE_CPU_REQUEST_SLOT_IN_PROGRESS) != 0,
-                (hdmaPhaseFlags & Cpu.HDMA_PHASE_INTERRUPT_CLAIMED) != 0);
+        if (hdma.requiresCpuHdmaPhaseFlags()) {
+            int hdmaPhaseFlags = cpu.getHdmaPhaseFlags();
+            hdma.advanceHblankRequest(
+                    (hdmaPhaseFlags & Cpu.HDMA_PHASE_IN_FLIGHT_WRITE_CYCLE) != 0,
+                    (hdmaPhaseFlags & Cpu.HDMA_PHASE_CPU_REQUEST_SLOT_IN_PROGRESS) != 0,
+                    (hdmaPhaseFlags & Cpu.HDMA_PHASE_INTERRUPT_CLAIMED) != 0);
+        } else {
+            hdma.advanceHblankRequest();
+        }
         Mode mode = gpu.tick();
         statRegister.tick();
         cpu.onPeripheralsTicked();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -701,7 +701,6 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     private Mode tickSubsystems() {
-        gpu.prepareForTick();
         int statReadPhaseFlags = cpu.getStatReadPhaseFlags();
         boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(
                 (statReadPhaseFlags & Cpu.STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY) != 0,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -702,11 +702,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private Mode tickSubsystems() {
         int statReadPhaseFlags = cpu.getStatReadPhaseFlags();
-        boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(
-                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY) != 0,
-                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY) != 0,
-                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0,
-                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE) != 0);
+        boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(statReadPhaseFlags);
         statRegister.finishCpuReadPhase(
                 cpu.getInterruptFlagReadMaskTicks(mode0InterruptEdgeNextTick),
                 cpu.isMode0InterruptDispatchPhased(mode0InterruptEdgeNextTick),

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -868,10 +868,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // entry latency; STOP and a CGB speed switch pause it immediately.
         boolean halted = finalCpuState == Cpu.State.HALTED;
         dma.setVramDmaBusSample(hdma.consumeSourceBusSample());
-        dma.tick(halted || finalCpuState == Cpu.State.STOPPED
+        boolean dmaCpuClockPaused = halted || finalCpuState == Cpu.State.STOPPED
                         || finalCpuState == Cpu.State.SPEED_SWITCH || speedSwitchTail
-                        || hdma.pausesOamDmaForSpeedSwitchBurst(),
-                halted);
+                        || hdma.pausesOamDmaForSpeedSwitchBurst();
+        if (dma.requiresClockTick(dmaCpuClockPaused)) {
+            dma.tick(dmaCpuClockPaused, halted);
+        }
         sound.tick(divReset);
         serialPort.tick();
         infraredPort.tick();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/genie/Genie.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/genie/Genie.java
@@ -64,6 +64,10 @@ public class Genie implements AddressSpace, StatefulComponent<Genie> {
         if (patches.isEmpty()) {
             return value;
         }
+        return applyPatches(address, value);
+    }
+
+    private int applyPatches(int address, int value) {
         List<CheatPatch> addressPatches = patches.get(address);
         if (addressPatches == null) {
             return value;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -157,13 +157,18 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
     @Override
     public void outputTick() {
         outputTicks++;
+        if (!renderOutput) {
+            // The GPU advances output before the pixel machine can append this dot's
+            // entry. With the one-dot CGB delay, every entry already present is due.
+            delayHead = (delayHead + delaySize) & 7;
+            delaySize = 0;
+            return;
+        }
         while (delaySize > 0 && delayStamp[delayHead] + OUTPUT_DELAY <= outputTicks) {
             int entry = delayEntry[delayHead];
             delayHead = (delayHead + 1) & 7;
             delaySize--;
-            if (renderOutput) {
-                display.putColorPixel(resolvePixel(entry));
-            }
+            display.putColorPixel(resolvePixel(entry));
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -15,19 +15,26 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
     // four-dot entry skew, that leaves one dot in this final output stage.
     static final int OUTPUT_DELAY = 1;
 
-    private final IntQueue pixels = new IntQueue(16);
-
-    private final IntQueue palettes = new IntQueue(16);
-
-    private final IntQueue priorities = new IntQueue(16); // bg attribute priority flag
+    // Low six bits match the delayed pixel layout: bg pixel (2b), palette (3b), priority (1b).
+    private final IntQueue background = new IntQueue(16);
 
     // StartWindowDraw keeps the old background shift register beside the fresh window
     // fetch. On CGB, disabling LCDC.5 during its six startup states plots these pixels.
-    private final IntQueue clearedPixels = new IntQueue(16);
+    private final IntQueue clearedBackground = new IntQueue(16);
 
-    private final IntQueue clearedPalettes = new IntQueue(16);
+    // The portable state layout predates the packed runtime representation. Materialize its
+    // logical ring triples only while capturing or restoring a snapshot.
+    private final IntQueue statePixels = new IntQueue(16);
 
-    private final IntQueue clearedPriorities = new IntQueue(16);
+    private final IntQueue statePalettes = new IntQueue(16);
+
+    private final IntQueue statePriorities = new IntQueue(16);
+
+    private final IntQueue stateClearedPixels = new IntQueue(16);
+
+    private final IntQueue stateClearedPalettes = new IntQueue(16);
+
+    private final IntQueue stateClearedPriorities = new IntQueue(16);
 
     private final SpriteFifo spriteFifo = new SpriteFifo();
 
@@ -80,13 +87,13 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public int getLength() {
-        return pixels.size;
+        return background.size;
     }
 
     @Override
     public void putPixelToScreen() {
         linePixels++;
-        int entry = popEntry(pixels, palettes, priorities);
+        int entry = popEntry(background);
         int tail = (delayHead + delaySize) & 7;
         delayEntry[tail] = entry;
         delayStamp[tail] = outputTicks;
@@ -118,22 +125,12 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     // pack bg pixel (2b), bg palette (3b), bg priority (1b), sprite pixel (2b),
     // sprite palette (3b), sprite bg-priority (1b)
-    private int popEntry(IntQueue bgPixels, IntQueue bgPalettes, IntQueue bgPriorities) {
-        int bgPixel = bgPixels.array[bgPixels.offset++];
-        if (bgPixels.offset == bgPixels.array.length) {
-            bgPixels.offset = 0;
+    private int popEntry(IntQueue background) {
+        int entry = background.array[background.offset++];
+        if (background.offset == background.array.length) {
+            background.offset = 0;
         }
-        bgPixels.size--;
-        int bgPaletteIndex = bgPalettes.array[bgPalettes.offset++];
-        if (bgPalettes.offset == bgPalettes.array.length) {
-            bgPalettes.offset = 0;
-        }
-        bgPalettes.size--;
-        int bgAttrPriority = bgPriorities.array[bgPriorities.offset++];
-        if (bgPriorities.offset == bgPriorities.array.length) {
-            bgPriorities.offset = 0;
-        }
-        bgPriorities.size--;
+        background.size--;
         if (spriteFifo.size == 0) {
             spriteFifo.poppedPixel = 0;
             spriteFifo.poppedPalette = 0;
@@ -146,12 +143,16 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
             spriteFifo.head = (spriteFifo.head + 1) & 7;
             spriteFifo.size--;
         }
-        return bgPixel
-                | (bgPaletteIndex << 2)
-                | (bgAttrPriority << 5)
+        return entry
                 | (spriteFifo.poppedPixel << 6)
                 | (spriteFifo.poppedPalette << 8)
                 | (spriteFifo.poppedBgPriority ? 1 << 11 : 0);
+    }
+
+    private static void dropEntry(IntQueue background) {
+        background.offset = background.offset + 1 == background.array.length
+                ? 0 : background.offset + 1;
+        background.size--;
     }
 
     @Override
@@ -221,12 +222,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void dropPixel() {
-        pixels.offset = pixels.offset + 1 == pixels.array.length ? 0 : pixels.offset + 1;
-        pixels.size--;
-        palettes.offset = palettes.offset + 1 == palettes.array.length ? 0 : palettes.offset + 1;
-        palettes.size--;
-        priorities.offset = priorities.offset + 1 == priorities.array.length ? 0 : priorities.offset + 1;
-        priorities.size--;
+        dropEntry(background);
         if (spriteFifo.size == 0) {
             spriteFifo.poppedPixel = 0;
             spriteFifo.poppedPalette = 0;
@@ -243,11 +239,9 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void enqueue8Pixels(int[] pixelLine, TileAttributes tileAttributes) {
-        int paletteIndex = tileAttributes.getColorPaletteIndex();
-        int priority = tileAttributes.isPriority() ? 1 : 0;
-        pixels.enqueue8(pixelLine);
-        palettes.enqueue8(paletteIndex);
-        priorities.enqueue8(priority);
+        int attributeBits = (tileAttributes.getColorPaletteIndex() << 2)
+                | (tileAttributes.isPriority() ? 1 << 5 : 0);
+        background.enqueue8Packed(pixelLine, attributeBits);
     }
 
     @Override
@@ -266,9 +260,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void clear() {
-        pixels.clear();
-        palettes.clear();
-        priorities.clear();
+        background.clear();
         spriteFifo.clear();
         discardClearedBg();
     }
@@ -276,23 +268,19 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
     @Override
     public void clearBg() {
         discardClearedBg();
-        pixels.copyTo(clearedPixels);
-        palettes.copyTo(clearedPalettes);
-        priorities.copyTo(clearedPriorities);
-        pixels.clear();
-        palettes.clear();
-        priorities.clear();
+        background.copyTo(clearedBackground);
+        background.clear();
     }
 
     @Override
     public int getClearedBgLength() {
-        return clearedPixels.size;
+        return clearedBackground.size;
     }
 
     @Override
     public void putClearedBgToScreen() {
         linePixels++;
-        int entry = popEntry(clearedPixels, clearedPalettes, clearedPriorities);
+        int entry = popEntry(clearedBackground);
         int tail = (delayHead + delaySize) & 7;
         delayEntry[tail] = entry;
         delayStamp[tail] = outputTicks;
@@ -301,15 +289,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void dropClearedBgPixel() {
-        clearedPixels.offset = clearedPixels.offset + 1 == clearedPixels.array.length
-                ? 0 : clearedPixels.offset + 1;
-        clearedPixels.size--;
-        clearedPalettes.offset = clearedPalettes.offset + 1 == clearedPalettes.array.length
-                ? 0 : clearedPalettes.offset + 1;
-        clearedPalettes.size--;
-        clearedPriorities.offset = clearedPriorities.offset + 1 == clearedPriorities.array.length
-                ? 0 : clearedPriorities.offset + 1;
-        clearedPriorities.size--;
+        dropEntry(clearedBackground);
         if (spriteFifo.size == 0) {
             spriteFifo.poppedPixel = 0;
             spriteFifo.poppedPalette = 0;
@@ -326,9 +306,7 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public void discardClearedBg() {
-        clearedPixels.clear();
-        clearedPalettes.clear();
-        clearedPriorities.clear();
+        clearedBackground.clear();
     }
 
     @Override
@@ -338,10 +316,11 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
 
     @Override
     public ComponentState<ColorPixelFifo> captureState() {
+        materializeStateQueues();
         return new ColorPixelFifoState(
-                pixels.captureState(),
-                palettes.captureState(),
-                priorities.captureState(),
+                statePixels.captureState(),
+                statePalettes.captureState(),
+                statePriorities.captureState(),
                 spriteFifo.captureState(),
                 delayEntry.clone(),
                 delayStamp.clone(),
@@ -349,17 +328,18 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
                 delaySize,
                 outputTicks,
                 linePixels,
-                clearedPixels.captureState(),
-                clearedPalettes.captureState(),
-                clearedPriorities.captureState());
+                stateClearedPixels.captureState(),
+                stateClearedPalettes.captureState(),
+                stateClearedPriorities.captureState());
     }
 
     @Override
     public ComponentState<ColorPixelFifo> captureState(MachineStateCapture capture) {
+        materializeStateQueues();
         return new ColorPixelFifoState(
-                pixels.captureState(capture),
-                palettes.captureState(capture),
-                priorities.captureState(capture),
+                statePixels.captureState(capture),
+                statePalettes.captureState(capture),
+                statePriorities.captureState(capture),
                 spriteFifo.captureState(capture),
                 capture.ints(delayEntry),
                 capture.longs(delayStamp),
@@ -367,9 +347,9 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
                 delaySize,
                 outputTicks,
                 linePixels,
-                clearedPixels.captureState(capture),
-                clearedPalettes.captureState(capture),
-                clearedPriorities.captureState(capture));
+                stateClearedPixels.captureState(capture),
+                stateClearedPalettes.captureState(capture),
+                stateClearedPriorities.captureState(capture));
     }
 
     @Override
@@ -377,16 +357,22 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         if (!(state instanceof ColorPixelFifoState mem)) {
             throw new IllegalArgumentException("Invalid state type");
         }
-        pixels.restoreState(mem.pixels);
-        palettes.restoreState(mem.palettes);
-        priorities.restoreState(mem.priorities);
+        statePixels.restoreState(mem.pixels);
+        statePalettes.restoreState(mem.palettes);
+        statePriorities.restoreState(mem.priorities);
+        restorePackedQueue(statePixels, statePalettes, statePriorities, background);
         spriteFifo.restoreState(mem.spriteFifo);
         if (mem.clearedPixels != null
                 && mem.clearedPalettes != null
                 && mem.clearedPriorities != null) {
-            clearedPixels.restoreState(mem.clearedPixels);
-            clearedPalettes.restoreState(mem.clearedPalettes);
-            clearedPriorities.restoreState(mem.clearedPriorities);
+            stateClearedPixels.restoreState(mem.clearedPixels);
+            stateClearedPalettes.restoreState(mem.clearedPalettes);
+            stateClearedPriorities.restoreState(mem.clearedPriorities);
+            restorePackedQueue(
+                    stateClearedPixels,
+                    stateClearedPalettes,
+                    stateClearedPriorities,
+                    clearedBackground);
         } else {
             discardClearedBg();
         }
@@ -401,6 +387,42 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         } else {
             delayHead = 0;
             delaySize = 0;
+        }
+    }
+
+    private void materializeStateQueues() {
+        splitPackedQueue(background, statePixels, statePalettes, statePriorities);
+        splitPackedQueue(
+                clearedBackground,
+                stateClearedPixels,
+                stateClearedPalettes,
+                stateClearedPriorities);
+    }
+
+    private static void splitPackedQueue(
+            IntQueue source, IntQueue pixels, IntQueue palettes, IntQueue priorities) {
+        pixels.size = palettes.size = priorities.size = source.size;
+        pixels.offset = palettes.offset = priorities.offset = source.offset;
+        for (int i = 0; i < source.array.length; i++) {
+            int entry = source.array[i];
+            pixels.array[i] = entry & 0b11;
+            palettes.array[i] = (entry >> 2) & 0b111;
+            priorities.array[i] = (entry >> 5) & 1;
+        }
+    }
+
+    private static void restorePackedQueue(
+            IntQueue pixels, IntQueue palettes, IntQueue priorities, IntQueue target) {
+        if (pixels.size != palettes.size || pixels.size != priorities.size
+                || pixels.offset != palettes.offset || pixels.offset != priorities.offset) {
+            throw new IllegalArgumentException("ColorPixelFifo state queues are not aligned");
+        }
+        target.size = pixels.size;
+        target.offset = pixels.offset;
+        for (int i = 0; i < target.array.length; i++) {
+            target.array[i] = pixels.array[i]
+                    | (palettes.array[i] << 2)
+                    | (priorities.array[i] << 5);
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -543,7 +543,12 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         int oldLine = line;
         ticksInLine++;
         int lineLength = firstLine ? 455 : 456;
-        oamSearchPhase.trackDmaSource(ticksInLine == lineLength ? 0 : ticksInLine);
+        int oamReaderPosition = ticksInLine == lineLength ? 0 : ticksInLine;
+        if (oamReaderPosition < 80
+                || dma.hasPpuOamOwnershipTransitionThisTick()
+                || !oamSearchPhase.isOamReaderInitialized()) {
+            oamSearchPhase.trackDmaSource(oamReaderPosition);
+        }
         // the line started by enabling the LCD is one tick shorter: its grid starts at
         // the LCDC write itself, while the machine-cycle-locked line grid starts one
         // tick later (lcdon_timing-GS vs the steady-state line phase)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -924,6 +924,24 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
+     * Returns whether the current PPU dot can change a STAT source or one of
+     * its closely coupled latches. This is intentionally a live, allocation-
+     * free counterpart of the checkpoint test historically applied to
+     * {@link GpuTimingSnapshot} in {@link StatRegister}.
+     */
+    boolean isStatEventCheckpoint() {
+        if (!lcdEnabled) {
+            return false;
+        }
+        int mode0InterruptTick = getMode0InterruptTick();
+        return ticksInLine < 13
+                || ticksInLine >= 448
+                || ticksInLine == mode0InterruptTick
+                || (line < 144 && mode0InterruptTick != Integer.MAX_VALUE
+                && ticksInLine == mode0InterruptTick + 2);
+    }
+
+    /**
      * Applies the DMG OAM corruption bug if the PPU is currently scanning the OAM.
      */
     public void corruptOam(SpriteBug.CorruptionType type) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -498,10 +498,12 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     public Mode tick() {
         timingGeneration++;
         cpuLyReadAcrossLineEdge = false;
-        directOamReadCorruptionThisTick = false;
-        suppressNextDirectOamReadCorruption = false;
-        directOamWriteCorruptionThisTick = false;
-        suppressNextDirectOamWriteCorruption = false;
+        if (!gbc) {
+            directOamReadCorruptionThisTick = false;
+            suppressNextDirectOamReadCorruption = false;
+            directOamWriteCorruptionThisTick = false;
+            suppressNextDirectOamWriteCorruption = false;
+        }
         if (displayEnabledDelay > 0 && --displayEnabledDelay == 0) {
             display.enableLcd();
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -52,13 +52,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     private final eu.rekawek.coffeegb.core.cpu.SpeedMode speedMode;
 
-    // Cached for the complete owner-thread tick. The clock mode can change only at a
-    // CPU STOP boundary; refreshing once per tick avoids repeating the same cross-object
-    // getter calls in the PPU timing decision tree.
+    // Refreshed synchronously when SpeedMode changes, so the PPU timing decision tree
+    // never needs to repeat cross-object getter calls during a tick.
     private int speedModeValue = 1;
     private boolean dmgCompatValue;
     private boolean timingModeDirty = true;
-    private boolean timingSnapshotPrepared;
 
     // Monotonic owner-thread generation for the transient STAT timing view.  The
     // PPU advances once per master tick, so StatRegister can reuse the snapshot it
@@ -252,7 +250,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             timingModeDirty = true;
             prepareForTick();
         });
-        timingSnapshotPrepared = false;
     }
 
     /**
@@ -309,9 +306,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     @Override
     public void setByte(int address, int value) {
         timingGeneration++;
-        if (!timingSnapshotPrepared) {
-            prepareForTick();
-        }
         cancelPendingPpuWrites(address);
         cancelDelayedPixelWindowWrite(address);
         setByteImmediately(address, value);
@@ -320,9 +314,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     @Override
     public void setByteFromCpu(int address, int value) {
         timingGeneration++;
-        if (!timingSnapshotPrepared) {
-            prepareForTick();
-        }
         scheduleDmgPixelWindowWrite(address, value);
         if (address == LCDC_ADDRESS && gbc && lcdEnabled && mode == Mode.PixelTransfer) {
             int changedTileSelect = (lcdc.get() ^ value) & 0x10;
@@ -425,9 +416,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     @Override
     public int getByte(int address) {
-        if (!timingSnapshotPrepared) {
-            prepareForTick();
-        }
         if (address >= LCDC_ADDRESS && address <= LAST_STANDARD_REGISTER_ADDRESS) {
             int cpuVisible = cpuVisiblePpuRegisters[address - LCDC_ADDRESS];
             if (cpuVisible >= 0) {
@@ -509,10 +497,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     public Mode tick() {
         timingGeneration++;
-        if (!timingSnapshotPrepared) {
-            prepareForTick();
-        }
-        timingSnapshotPrepared = false;
         cpuLyReadAcrossLineEdge = false;
         directOamReadCorruptionThisTick = false;
         suppressNextDirectOamReadCorruption = false;
@@ -711,7 +695,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         lyReadLatchRephasedBySpeedSwitch = lcdEnabled;
     }
 
-    /** Refreshes the PPU's owner-thread timing snapshot before subsystem callbacks run. */
+    /** Refreshes cached PPU timing mode after an owner-thread source change. */
     public void prepareForTick() {
         if (timingModeDirty) {
             int newSpeedModeValue = speedMode.getSpeedMode();
@@ -722,7 +706,6 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             pixelMachine.prepareForTick(newSpeedModeValue, newDmgCompatValue);
             timingModeDirty = false;
         }
-        timingSnapshotPrepared = true;
     }
 
     /** Retains the old CPU-readable STAT phase until the current scanline ends. */
@@ -2411,11 +2394,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         } else {
             phase = oamSearchPhase;
         }
-        // The generation is deliberately transient: it is only a cache-validity
-        // marker for the derived STAT timing snapshot and is not part of emulated
-        // state. Force a fresh capture after restoring the portable state.
+        // The generation is deliberately transient: it only invalidates the derived
+        // STAT timing snapshot and is not part of emulated state. In a full-machine
+        // restore, the later SpeedMode restore synchronously refreshes this GPU's timing
+        // mode; for a standalone GPU restore, the external SpeedMode remains authoritative.
         timingGeneration++;
-        timingSnapshotPrepared = false;
     }
 
     private record GpuState(ComponentState<Ram> videoRam0Memento, ComponentState<Ram> videoRam1Memento,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/IntQueue.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/IntQueue.java
@@ -64,6 +64,22 @@ public class IntQueue implements StatefulComponent<IntQueue> {
         size += 8;
     }
 
+    /** Adds a complete packed pixel group with constant attribute bits. */
+    void enqueue8Packed(int[] values, int bits) {
+        if (size + values.length > array.length) {
+            throw new IllegalStateException("Queue is full");
+        }
+        int writeOffset = (offset + size) % array.length;
+        for (int value : values) {
+            array[writeOffset] = value | bits;
+            writeOffset++;
+            if (writeOffset == array.length) {
+                writeOffset = 0;
+            }
+        }
+        size += values.length;
+    }
+
     void copyTo(IntQueue target) {
         if (target.size + size > target.array.length) {
             throw new IllegalStateException("Queue is full");

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
-    private static final int OAM_SIZE_HISTORY_LENGTH = 8;
+    private static final int CONFLICT_HISTORY_LENGTH = 8;
 
     private boolean gbc;
 
@@ -43,12 +43,23 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     private int pendingTileSelectGlitchTicks;
 
-    private final boolean[] tileSelectGlitchHistory = new boolean[8];
+    private final boolean[] tileSelectGlitchHistory = new boolean[CONFLICT_HISTORY_LENGTH];
 
     // LCDC.2 reaches the OAM reader through its own clock-domain latch. Keep this
     // history running for the complete scanline, including HBlank, because writes at
     // the end of one line can still be pending when entry 0 is read on the next line.
-    private final int[] oamSizeHistory = new int[OAM_SIZE_HISTORY_LENGTH];
+    private final int[] oamSizeHistory = new int[CONFLICT_HISTORY_LENGTH];
+
+    // Both histories advance together in tickConflicts(). Logical index 0 is the newest value;
+    // this cursor maps it to the corresponding physical slot in the two circular buffers.
+    private int historyHead;
+
+    // The transient machine-state path borrows primitive arrays synchronously. Linearize the
+    // circular histories into these owner-thread scratch arrays so the state schema remains
+    // newest-first without allocating on that path. The ordinary capture path clones them.
+    private final boolean[] tileSelectGlitchHistoryCapture = new boolean[CONFLICT_HISTORY_LENGTH];
+
+    private final int[] oamSizeHistoryCapture = new int[CONFLICT_HISTORY_LENGTH];
 
     public Lcdc() {
         this(false);
@@ -92,12 +103,9 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
         } else if (tileSelectGlitchTicks > 0) {
             tileSelectGlitchTicks--;
         }
-        System.arraycopy(tileSelectGlitchHistory, 0, tileSelectGlitchHistory, 1,
-                tileSelectGlitchHistory.length - 1);
-        tileSelectGlitchHistory[0] = tileSelectGlitchTicks > 0;
-        System.arraycopy(oamSizeHistory, 0, oamSizeHistory, 1,
-                oamSizeHistory.length - 1);
-        oamSizeHistory[0] = value;
+        historyHead = (historyHead - 1) & (CONFLICT_HISTORY_LENGTH - 1);
+        tileSelectGlitchHistory[historyHead] = tileSelectGlitchTicks > 0;
+        oamSizeHistory[historyHead] = value;
     }
 
     void triggerTileSelectGlitch() {
@@ -110,7 +118,7 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     public boolean isTileSelectGlitch(int dotsAgo) {
         checkArgument(dotsAgo >= 0 && dotsAgo < tileSelectGlitchHistory.length);
-        return tileSelectGlitchHistory[dotsAgo];
+        return tileSelectGlitchHistory[historyIndex(dotsAgo)];
     }
 
     public int getSpriteHeight() {
@@ -119,7 +127,7 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     public int getOamSpriteHeight(int dotsAgo) {
         checkArgument(dotsAgo >= 0 && dotsAgo < oamSizeHistory.length);
-        return (oamSizeHistory[dotsAgo] & 0x04) == 0 ? 8 : 16;
+        return (oamSizeHistory[historyIndex(dotsAgo)] & 0x04) == 0 ? 8 : 16;
     }
 
     public int getBgTileMapDisplay() {
@@ -210,20 +218,22 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     @Override
     public ComponentState<Lcdc> captureState() {
+        copyHistoriesForCapture();
         return new LcdcState(value, mixValue, pendingMixValue,
                 dmgBlobBackgroundEnable, pendingDmgBlobBackgroundEnable,
                 tileSelectGlitchTicks, pendingTileSelectGlitchTicks,
-                tileSelectGlitchHistory.clone(),
-                oamSizeHistory.clone());
+                tileSelectGlitchHistoryCapture.clone(),
+                oamSizeHistoryCapture.clone());
     }
 
     @Override
     public ComponentState<Lcdc> captureState(MachineStateCapture capture) {
+        copyHistoriesForCapture();
         return new LcdcState(value, mixValue, pendingMixValue,
                 dmgBlobBackgroundEnable, pendingDmgBlobBackgroundEnable,
                 tileSelectGlitchTicks, pendingTileSelectGlitchTicks,
-                capture.booleans(tileSelectGlitchHistory),
-                capture.ints(oamSizeHistory));
+                capture.booleans(tileSelectGlitchHistoryCapture),
+                capture.ints(oamSizeHistoryCapture));
     }
 
     @Override
@@ -247,6 +257,19 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
             throw new IllegalArgumentException("ComponentState OAM-size history length doesn't match");
         }
         System.arraycopy(mem.oamSizeHistory, 0, oamSizeHistory, 0, oamSizeHistory.length);
+        this.historyHead = 0;
+    }
+
+    private int historyIndex(int dotsAgo) {
+        return (historyHead + dotsAgo) & (CONFLICT_HISTORY_LENGTH - 1);
+    }
+
+    private void copyHistoriesForCapture() {
+        for (int dotsAgo = 0; dotsAgo < CONFLICT_HISTORY_LENGTH; dotsAgo++) {
+            int index = historyIndex(dotsAgo);
+            tileSelectGlitchHistoryCapture[dotsAgo] = tileSelectGlitchHistory[index];
+            oamSizeHistoryCapture[dotsAgo] = oamSizeHistory[index];
+        }
     }
 
     private record LcdcState(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -277,6 +277,24 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     }
 
     public void tick() {
+        interruptManager.finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview();
+        lycIrqClock++;
+        clearCpuStatReadPhase();
+        int ppuTickSignals = interruptManager.consumePpuTickSignals();
+        boolean statEventCheckpoint = gpu.isStatEventCheckpoint();
+        boolean scheduledEvent = nextLycIrqEvent == lycIrqClock
+                || pendingLycWriteIrq == lycIrqClock
+                || pendingLycComparatorIrq == lycIrqClock;
+        boolean hasPendingModeRegisterClock = pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingModeIrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqLycClock != NO_LYC_IRQ_EVENT;
+        if (!statEvaluationDirty && !statEventCheckpoint && ppuTickSignals == 0
+                && !pendingCgbMode0Interrupt && !hasPendingModeRegisterClock
+                && !scheduledEvent) {
+            return;
+        }
+
         refreshGpuTiming();
         int currentLine = timing.line;
         int currentTicksInLine = timing.ticksInLine;
@@ -288,11 +306,6 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         int currentCpuMachineCycleDots = timing.cpuMachineCycleDots;
         boolean currentDoubleSpeed = timing.doubleSpeed;
         boolean currentNativeDoubleSpeed = timing.nativeDoubleSpeed;
-        boolean statEventCheckpoint = isStatEventCheckpoint();
-        interruptManager.finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview();
-        lycIrqClock++;
-        clearCpuStatReadPhase();
-        int ppuTickSignals = interruptManager.consumePpuTickSignals();
         boolean mustEvaluateStat = statEvaluationDirty || statEventCheckpoint
                 || ppuTickSignals != 0;
         if ((ppuTickSignals
@@ -347,9 +360,6 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
             pendingModeLatchChanged |= commitPendingMode0IrqRegisters();
         }
         mustEvaluateStat |= pendingModeLatchChanged;
-        boolean scheduledEvent = nextLycIrqEvent == lycIrqClock
-                || pendingLycWriteIrq == lycIrqClock
-                || pendingLycComparatorIrq == lycIrqClock;
         mustEvaluateStat |= scheduledEvent;
         boolean suppressNaturalModeEdge = mustEvaluateStat
                 && updateModeIrqEvents(lcdcInterruptFlagWriteClear);
@@ -561,19 +571,6 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
             }
         }
         statEvaluationDirty = false;
-    }
-
-    private boolean isStatEventCheckpoint() {
-        if (!timing.lcdEnabled) {
-            return false;
-        }
-        int ticksInLine = timing.ticksInLine;
-        int mode0InterruptTick = timing.mode0InterruptTick;
-        return ticksInLine < 13
-                || ticksInLine >= 448
-                || ticksInLine == mode0InterruptTick
-                || (timing.line < 144 && mode0InterruptTick != Integer.MAX_VALUE
-                && ticksInLine == mode0InterruptTick + 2);
     }
 
     public void onLcdEnabled() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.gpu;
 import eu.rekawek.coffeegb.core.memento.Memento;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager.InterruptType;
 import eu.rekawek.coffeegb.core.state.ComponentState;
@@ -41,6 +42,8 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     // Distinct from the ordinary -1 "no CPU override" value: the production
     // CPU phase was captured, but no FF41 read has asked us to resolve it yet.
     private static final int CPU_STAT_MODE_UNRESOLVED = -2;
+
+    private static final int STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE = 1 << 4;
 
     private final InterruptManager interruptManager;
 
@@ -209,17 +212,9 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     // separate from the readable latch used by direct PPU observers.
     private int cpuStatModeOverride = -1;
 
-    // Inputs captured at the CPU/PPU boundary for an eventual FF41 read. They
-    // are deliberately transient: a restored state begins a new CPU phase.
-    private boolean cpuSynchronousHaltEntryPhase;
-
-    private boolean cpuAsynchronousHaltEntryPhase;
-
-    private boolean cpuOrdinaryHaltWakePhase;
-
-    private boolean cpuOneCycleOrdinaryHaltWakePhase;
-
-    private boolean cpuRecentOrdinaryHaltWakePhase;
+    // Packed inputs captured at the CPU/PPU boundary for an eventual FF41 read.
+    // This is deliberately transient: a restored state begins a new CPU phase.
+    private int cpuStatReadPhaseFlags;
 
     /*
      * Between STAT event checkpoints, and absent a register write or pending
@@ -624,9 +619,13 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                                      boolean asynchronousHaltEntryPhase,
                                      boolean ordinaryHaltWakePhase,
                                      boolean oneCycleOrdinaryHaltWakePhase) {
-        captureCpuStatReadPhasePrepared(synchronousHaltEntryPhase,
+        return beginCpuReadPhase(packCpuStatReadPhase(synchronousHaltEntryPhase,
                 asynchronousHaltEntryPhase, ordinaryHaltWakePhase,
-                oneCycleOrdinaryHaltWakePhase);
+                oneCycleOrdinaryHaltWakePhase));
+    }
+
+    public boolean beginCpuReadPhase(int statReadPhaseFlags) {
+        captureCpuStatReadPhasePrepared(statReadPhaseFlags);
         if (!canPublishMode0InterruptEdge()) {
             return false;
         }
@@ -665,15 +664,34 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                                         boolean ordinaryHaltWakePhase,
                                         boolean oneCycleOrdinaryHaltWakePhase) {
         refreshGpuTiming();
-        captureCpuStatReadPhasePrepared(synchronousHaltEntryPhase,
+        captureCpuStatReadPhasePrepared(packCpuStatReadPhase(synchronousHaltEntryPhase,
                 asynchronousHaltEntryPhase, ordinaryHaltWakePhase,
-                oneCycleOrdinaryHaltWakePhase);
+                oneCycleOrdinaryHaltWakePhase));
     }
 
-    private void captureCpuStatReadPhasePrepared(boolean synchronousHaltEntryPhase,
-                                                 boolean asynchronousHaltEntryPhase,
-                                                 boolean ordinaryHaltWakePhase,
-                                                 boolean oneCycleOrdinaryHaltWakePhase) {
+    private static int packCpuStatReadPhase(boolean synchronousHaltEntryPhase,
+                                             boolean asynchronousHaltEntryPhase,
+                                             boolean ordinaryHaltWakePhase,
+                                             boolean oneCycleOrdinaryHaltWakePhase) {
+        int statReadPhaseFlags = 0;
+        if (synchronousHaltEntryPhase) {
+            statReadPhaseFlags |= Cpu.STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY;
+        }
+        if (asynchronousHaltEntryPhase) {
+            statReadPhaseFlags |= Cpu.STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY;
+        }
+        if (ordinaryHaltWakePhase) {
+            statReadPhaseFlags |= Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE;
+        }
+        if (oneCycleOrdinaryHaltWakePhase) {
+            statReadPhaseFlags |= Cpu.STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE;
+        }
+        return statReadPhaseFlags;
+    }
+
+    private void captureCpuStatReadPhasePrepared(int statReadPhaseFlags) {
+        boolean ordinaryHaltWakePhase = (statReadPhaseFlags
+                & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0;
         if (ordinaryHaltWakePhase && !previousOrdinaryHaltWakePhase) {
             ordinaryHaltWakeStatClock = lycIrqClock;
         }
@@ -684,11 +702,11 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                 <= ORDINARY_HALT_WAKE_STAT_HOLD_TICKS;
         gpu.captureCpuLyReadPhase(ordinaryHaltWakePhase
                 && isMode1InterruptSourceOnly());
-        cpuSynchronousHaltEntryPhase = synchronousHaltEntryPhase;
-        cpuAsynchronousHaltEntryPhase = asynchronousHaltEntryPhase;
-        cpuOrdinaryHaltWakePhase = ordinaryHaltWakePhase;
-        cpuOneCycleOrdinaryHaltWakePhase = oneCycleOrdinaryHaltWakePhase;
-        cpuRecentOrdinaryHaltWakePhase = recentOrdinaryHaltWakePhase;
+        statReadPhaseFlags &= ~STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
+        if (recentOrdinaryHaltWakePhase) {
+            statReadPhaseFlags |= STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
+        }
+        cpuStatReadPhaseFlags = statReadPhaseFlags;
         cpuStatModeOverride = CPU_STAT_MODE_UNRESOLVED;
     }
 
@@ -1972,10 +1990,13 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         if (cpuStatModeOverride != CPU_STAT_MODE_UNRESOLVED) {
             return;
         }
+        int statReadPhaseFlags = cpuStatReadPhaseFlags;
         cpuStatModeOverride = gpu.getCpuReadStatModeOverride(
-                cpuSynchronousHaltEntryPhase, cpuAsynchronousHaltEntryPhase,
-                cpuOrdinaryHaltWakePhase, cpuOneCycleOrdinaryHaltWakePhase,
-                cpuRecentOrdinaryHaltWakePhase);
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ASYNCHRONOUS_HALT_ENTRY) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0,
+                (statReadPhaseFlags & Cpu.STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE) != 0,
+                (statReadPhaseFlags & STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE) != 0);
         suppressCpuReadCoincidence = gbc && !timing.dmgCompat
                 && !timing.doubleSpeed && timing.line == 153
                 && timing.ticksInLine == 6 && coincidence;
@@ -1984,11 +2005,8 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     private void clearCpuStatReadPhase() {
         cpuStatModeOverride = -1;
         suppressCpuReadCoincidence = false;
-        cpuSynchronousHaltEntryPhase = false;
-        cpuAsynchronousHaltEntryPhase = false;
-        cpuOrdinaryHaltWakePhase = false;
-        cpuOneCycleOrdinaryHaltWakePhase = false;
-        cpuRecentOrdinaryHaltWakePhase = false;
+        // Packed inputs are read only while the unresolved sentinel is set.
+        // The next capture overwrites them before publishing that sentinel.
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -258,6 +258,11 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
         }
     }
 
+    /** Whether the persistent OAM reader has captured its initial OAM contents. */
+    public boolean isOamReaderInitialized() {
+        return oamReaderInitialized;
+    }
+
     /** Reconnects the persistent reader after its clock was stopped with the LCD. */
     public void onLcdEnabled() {
         initializeOamReader();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -575,6 +575,13 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     /** Advances the delayed WY copy and returns the old-WY collision value, if any. */
     public int advanceWindowYDelay() {
+        if (windowWyDelay < 0 && windowWyOldOnWriteTick < 0) {
+            return -1;
+        }
+        return advanceWindowYDelayTransition();
+    }
+
+    private int advanceWindowYDelayTransition() {
         if (windowWyDelay == 0) {
             windowWy = pendingWindowWy;
             windowWyDelay = -1;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -57,6 +57,14 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     private volatile boolean inputChangedSinceLastTick;
 
+    /**
+     * Derived state for the default released-input fast path. It is deliberately transient and
+     * excluded from portable state: state restore recomputes it from the fields it summarizes.
+     * Volatile invalidation lets a UI input thread conservatively publish a pending mutation
+     * before the emulation thread considers skipping its regular sample path.
+     */
+    private transient volatile boolean releasedInputFastPathEligible;
+
     /** Owner-thread observation only; deliberately absent from portable machine state. */
     private transient DebugHooks debugHooks;
 
@@ -99,6 +107,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         transferInProgress = isSgb;
         transferReadyForData = false;
         sgbBus.register(event -> {
+            invalidateReleasedInputFastPath();
             players = event.getMultiplayerControl() & 0x03;
             if (players == 2) {
                 // Undocumented MLT_REQ value 2 keeps the ICD2 in a distinct state:
@@ -108,7 +117,9 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 currentPlayer &= players;
             }
             LOG.atDebug().log("Players: {}, current player: {}", players, currentPlayer);
+            invalidateReleasedInputFastPath();
         }, Commands.MltReqCmd.class);
+        refreshReleasedInputFastPathEligibility();
     }
 
     public void init(EventBus eventBus) {
@@ -118,6 +129,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
     }
 
     private void onPress(Button button) {
+        invalidateReleasedInputFastPath();
         if (eventBus != null) {
             eventBus.post(new JoypadPressEvent(button, tick));
         }
@@ -127,15 +139,18 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             notifyDebugInputChange();
             notifyLegacyInputChange();
         }
+        invalidateReleasedInputFastPath();
     }
 
     private void onRelease(Button button) {
+        invalidateReleasedInputFastPath();
         LOG.atDebug().log("Released button {} at tick {}", button, tick);
         if (buttons.remove(button)) {
             inputChangedSinceLastTick = true;
             notifyDebugInputChange();
             notifyLegacyInputChange();
         }
+        invalidateReleasedInputFastPath();
     }
 
     /**
@@ -185,11 +200,13 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 Objects.requireNonNull(legacyButtons, "legacyButtons"));
         PlayerInputSnapshot physical = Objects.requireNonNull(
                 sampledPhysicalInput, "sampledPhysicalInput");
+        invalidateReleasedInputFastPath();
         buttons.clear();
         buttons.addAll(legacyCopy);
         sampledInput = physical;
         alignDebugInput();
         alignInputTimeline();
+        refreshReleasedInputFastPathEligibility();
     }
 
     /**
@@ -205,26 +222,38 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (buttons.equals(replayButtons)) {
             return;
         }
+        invalidateReleasedInputFastPath();
         buttons.clear();
         buttons.addAll(replayButtons);
         inputChangedSinceLastTick = true;
         alignDebugInput();
         alignInputTimeline();
+        invalidateReleasedInputFastPath();
     }
 
     public void setPressedButtons(Collection<Button> pressed) {
-        if (buttons.equals(Set.copyOf(pressed))) {
+        Set<Button> pressedCopy = Set.copyOf(pressed);
+        if (buttons.equals(pressedCopy)) {
             return;
         }
+        invalidateReleasedInputFastPath();
         buttons.clear();
-        buttons.addAll(pressed);
+        buttons.addAll(pressedCopy);
         inputChangedSinceLastTick = true;
         notifyDebugInputChange();
         notifyLegacyInputChange();
+        invalidateReleasedInputFastPath();
     }
 
     public void tick() {
         tick++;
+        if (releasedInputFastPathEligible) {
+            return;
+        }
+        tickInputSlowPath();
+    }
+
+    private void tickInputSlowPath() {
         PlayerInputSnapshot nextInput = playerInputSource == PlayerInputSource.RELEASED
                 ? PlayerInputSnapshot.RELEASED
                 : Objects.requireNonNull(
@@ -241,6 +270,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         // the DMG joypad circuit and keeps short selector glitches from raising IF.
         if (inputChangedSinceLastTick) {
             inputChangedSinceLastTick = false;
+            refreshReleasedInputFastPathEligibility();
             return;
         }
         int inputLines;
@@ -265,6 +295,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         }
         if (inputHistory == SETTLED_HISTORY[inputLines]
                 && filteredInputLines == inputLines) {
+            refreshReleasedInputFastPathEligibility();
             return;
         }
         int nextFilteredInputLines = filteredInputLines;
@@ -285,6 +316,21 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (fallingEdges != 0) {
             interruptManager.requestInterrupt(InterruptManager.InterruptType.P10_13);
         }
+        refreshReleasedInputFastPathEligibility();
+    }
+
+    private void invalidateReleasedInputFastPath() {
+        releasedInputFastPathEligible = false;
+    }
+
+    private void refreshReleasedInputFastPathEligibility() {
+        releasedInputFastPathEligible = playerInputSource == PlayerInputSource.RELEASED
+                && sampledInput == PlayerInputSnapshot.RELEASED
+                && players == 0
+                && !inputChangedSinceLastTick
+                && buttons.isEmpty()
+                && inputHistory == SETTLED_HISTORY[0x0f]
+                && filteredInputLines == 0x0f;
     }
 
     private static int[] createSettledHistory() {
@@ -309,8 +355,12 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
     @Override
     public void setByte(int address, int value) {
         int previousSelection = p1;
+        int nextSelection = value & 0x30;
+        if (nextSelection != previousSelection) {
+            invalidateReleasedInputFastPath();
+        }
         if (isSgb) {
-            int input = value & 0x30;
+            int input = nextSelection;
             // The ICD2 receiver reacts to line transitions. Rewriting the level that is
             // already on JOYP must neither add a bit nor abort an in-flight packet.
             if (input != p1) {
@@ -325,9 +375,10 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             }
             LOG.atDebug().log("Player changed to {}", currentPlayer);
         }
-        p1 = value & 0b00110000;
+        p1 = nextSelection;
         if (p1 != previousSelection) {
             inputChangedSinceLastTick = true;
+            invalidateReleasedInputFastPath();
         }
     }
 
@@ -477,6 +528,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             throw new IllegalArgumentException("Invalid state type");
         }
         validateState(mem);
+        invalidateReleasedInputFastPath();
         this.p1 = mem.p1;
         this.tick = mem.tick;
         this.inputHistory = mem.inputHistory;
@@ -493,6 +545,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         this.currentPacketIndex = mem.currentPacketIndex;
         alignDebugInput();
         alignInputTimeline();
+        refreshReleasedInputFastPathEligibility();
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -323,6 +323,10 @@ public class Dma implements AddressSpace, StatefulComponent<Dma> {
         return transferInProgress;
     }
 
+    boolean hasCpuBusSpecialState() {
+        return transferInProgress || restarted;
+    }
+
     /** Captures the OAM-DMA latch and progress without reading FF46 through the bus. */
     public DebugHardwareInspection.OamDma captureDebugOamDmaInspection() {
         return new DebugHardwareInspection.OamDma(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -323,6 +323,20 @@ public class Dma implements AddressSpace, StatefulComponent<Dma> {
         return transferInProgress;
     }
 
+    /**
+     * Returns whether advancing the OAM-DMA clock can still change its observable
+     * state. A settled, inactive engine otherwise has no work on a Game Boy tick.
+     */
+    public boolean requiresClockTick(boolean requestedCpuClockPaused) {
+        return transferInProgress
+                || restarted
+                || ppuOamOwnedThroughRestart
+                || oamOwnedForPpu
+                || oamOwnedForPpuBeforeTick != oamOwnedForPpu
+                || cpuClockPaused != requestedCpuClockPaused
+                || vramDmaBusAddress >= 0;
+    }
+
     boolean hasCpuBusSpecialState() {
         return transferInProgress || restarted;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Dma.java
@@ -299,7 +299,16 @@ public class Dma implements AddressSpace, StatefulComponent<Dma> {
         return oamOwnedForPpuBeforeTick;
     }
 
+    /** True if the persistent PPU OAM reader changed source on the last DMA tick. */
+    public boolean hasPpuOamOwnershipTransitionThisTick() {
+        return oamOwnedForPpuBeforeTick != oamOwnedForPpu;
+    }
+
     private void updatePpuOamOwnership() {
+        if (!transferInProgress && !ppuOamOwnedThroughRestart) {
+            oamOwnedForPpu = false;
+            return;
+        }
         boolean normalSpeedCgb = speedMode.isGbc() && speedMode.getSpeedMode() == 1;
         int acquisitionClocks = normalSpeedCgb ? 7 : 8;
         int releaseClocks = normalSpeedCgb ? 647 : 648;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
@@ -32,6 +32,10 @@ public class DmaCpuAddressSpace implements AddressSpace {
 
     @Override
     public void setByte(int address, int value) {
+        if (!dma.hasCpuBusSpecialState()) {
+            addressSpace.setByteFromCpu(address, value);
+            return;
+        }
         if (dma.isOamBlocked() && address >= 0xfea0 && address < 0xff00) {
             // CGB normally mirrors parts of OAM through the unusable range. OAM DMA
             // disconnects that whole range, so a stack write there must not leak into
@@ -47,6 +51,9 @@ public class DmaCpuAddressSpace implements AddressSpace {
 
     @Override
     public int getByte(int address) {
+        if (!dma.hasCpuBusSpecialState()) {
+            return addressSpace.getByte(address);
+        }
         if (dma.isOamBlocked() && address >= 0xfea0 && address < 0xff00) {
             return 0xff;
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -452,6 +452,36 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
     }
 
     /**
+     * Whether the next HBlank-request synchronizer tick can retain any of the
+     * CPU phase inputs supplied to {@link #advanceHblankRequest(boolean, boolean, boolean)}.
+     *
+     * <p>The overwhelmingly common inactive-request path returns before any
+     * timing calculation. A request crossing the synchronizer captures all
+     * three inputs; an unresolved request on its first HBlank arbitration dot
+     * can additionally retain an interrupt-entry input.</p>
+     */
+    public boolean requiresCpuHdmaPhaseFlags() {
+        int requestTicks = hblankRequestTicks;
+        if (requestTicks < 0 || cpuHalted) {
+            return false;
+        }
+        return requiresCpuHdmaPhaseFlagsAtRequest(requestTicks);
+    }
+
+    private boolean requiresCpuHdmaPhaseFlagsAtRequest(int requestTicks) {
+        if (requestTicks == 1) {
+            return true;
+        }
+        if (requestTicks != 0 || hblankRequestAge != 0
+                || cpuRequestArbitration != CpuRequestArbitration.UNRESOLVED
+                || gpuMode != Mode.HBlank) {
+            return false;
+        }
+        int ticksSinceHblankStart = gpuTicksInLine - hblankStartTicksInLine;
+        return ticksSinceHblankStart >= 0 && ticksSinceHblankStart <= 2;
+    }
+
+    /**
      * HALT acknowledges the asynchronous HDMA request and remembers whether the
      * request line was low, high, or already latched. On wake, a low-to-high request
      * may be asserted again; a request that was already latched is always restored.

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStopTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStopTest.java
@@ -2,10 +2,16 @@ package eu.rekawek.coffeegb.core.cpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.gpu.Gpu;
+import eu.rekawek.coffeegb.core.gpu.StatRegister;
+import eu.rekawek.coffeegb.core.gpu.VRamTransfer;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CpuStopTest {
 
@@ -42,6 +48,20 @@ public class CpuStopTest {
         assertEquals(PROGRAM + 3, cpu.getRegisters().getPC());
     }
 
+    @Test
+    public void speedModeListenerUpdatesGpuMachineCycleTimingSynchronously() {
+        SpeedMode speedMode = new SpeedMode(true);
+        Gpu gpu = gpu(speedMode);
+
+        assertEquals(4, gpu.getCpuMachineCycleDots());
+        speedMode.setByte(0xff4d, 1);
+        assertTrue(speedMode.onStop());
+        assertEquals(2, gpu.getCpuMachineCycleDots());
+        speedMode.setByte(0xff4d, 1);
+        assertTrue(speedMode.onStop());
+        assertEquals(4, gpu.getCpuMachineCycleDots());
+    }
+
     private static Ram stopProgram(int joyp) {
         Ram memory = new Ram(0, 0x10000);
         memory.setByte(PROGRAM, 0x10);
@@ -54,6 +74,20 @@ public class CpuStopTest {
         Cpu cpu = new Cpu(memory, new InterruptManager(false), null, speedMode, new Display(false));
         cpu.getRegisters().setPC(PROGRAM);
         return cpu;
+    }
+
+    private static Gpu gpu(SpeedMode speedMode) {
+        Ram oam = new Ram(0xfe00, 0xa0);
+        StatRegister stat = new StatRegister(new InterruptManager(true));
+        Gpu gpu = new Gpu(new Display(true),
+                new Dma(new Ram(0, 0x10000), oam, speedMode),
+                oam,
+                new VRamTransfer(EventBus.NULL_EVENT_BUS),
+                stat,
+                true,
+                speedMode);
+        stat.init(gpu);
+        return gpu;
     }
 
     private static void runUntilNotExecutingStop(Cpu cpu) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/genie/GenieTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/genie/GenieTest.java
@@ -26,6 +26,23 @@ public class GenieTest {
     }
 
     @Test
+    public void unmatchedAddressFallsBackToDelegateWithPatchesPresent() {
+        CountingAddressSpace delegate = new CountingAddressSpace();
+        delegate.setByte(0xc124, 0x43);
+        Genie genie = new Genie(delegate, false);
+        CountingPatch patch = new CountingPatch(0xc123, true, 0x22);
+
+        try (EventBusImpl eventBus = new EventBusImpl(null, null, false)) {
+            genie.init(eventBus);
+            eventBus.post(new AddPatches(List.of(patch)));
+
+            assertEquals(0x43, genie.getByte(0xc124));
+            assertEquals(0, patch.acceptCalls);
+            assertEquals(1, delegate.reads);
+        }
+    }
+
+    @Test
     public void lookupPreservesFirstAcceptedPatchAndIgnoresOtherAddresses() {
         CountingAddressSpace delegate = new CountingAddressSpace();
         delegate.setByte(0xc123, 0x42);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoOutputTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoOutputTest.java
@@ -1,0 +1,239 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ColorPixelFifoOutputTest {
+
+    @Test
+    public void suppressedTickDrainsPendingOutputWithoutPublishingIt() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.outputTick();
+        fixture.enqueuePixels();
+        fixture.putPixels(1);
+
+        fixture.fifo.setRenderOutput(false);
+        fixture.fifo.outputTick();
+
+        assertEquals(2, longField(fixture.fifo, "outputTicks"));
+        assertEquals(1, intField(fixture.fifo, "delayHead"));
+        assertEquals(0, intField(fixture.fifo, "delaySize"));
+        assertEquals(0, displayPixelCount(fixture.display));
+    }
+
+    @Test
+    public void suppressedDrainAdvancesTheDelayRingHeadAcrossWrap() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.outputTick();
+        fixture.enqueuePixels();
+        for (int i = 0; i < 6; i++) {
+            fixture.putPixels(1);
+            fixture.fifo.outputTick();
+        }
+        assertEquals(6, intField(fixture.fifo, "delayHead"));
+
+        fixture.enqueuePixels();
+        fixture.putPixels(3);
+        fixture.fifo.setRenderOutput(false);
+        fixture.fifo.outputTick();
+
+        assertEquals(1, intField(fixture.fifo, "delayHead"));
+        assertEquals(0, intField(fixture.fifo, "delaySize"));
+    }
+
+    @Test
+    public void sameDotEnqueueThenRewindLeavesNoSuppressedOutputBehind() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.setRenderOutput(false);
+        fixture.fifo.outputTick();
+        fixture.enqueuePixels();
+        fixture.putPixels(1);
+
+        fixture.fifo.rewindOnePixel();
+        fixture.fifo.outputTick();
+
+        assertEquals(0, intField(fixture.fifo, "linePixels"));
+        assertEquals(0, intField(fixture.fifo, "delaySize"));
+        assertEquals(0, displayPixelCount(fixture.display));
+
+        fixture.fifo.setRenderOutput(true);
+        fixture.putPixels(1);
+        fixture.fifo.outputTick();
+        assertEquals(1, displayPixelCount(fixture.display));
+    }
+
+    @Test
+    public void restoredPendingOutputStillResolvesOnItsDueTick() {
+        Fixture source = new Fixture();
+        source.fifo.outputTick();
+        source.enqueuePixels();
+        source.putPixels(1);
+        ComponentState<ColorPixelFifo> pending = source.fifo.captureState();
+
+        Fixture restored = new Fixture();
+        restored.fifo.restoreState(pending);
+        restored.fifo.outputTick();
+
+        assertEquals(1, displayPixelCount(restored.display));
+        assertEquals(restored.bgPalette.getPalette(0)[1], displayPixel(restored.display, 0));
+    }
+
+    @Test
+    public void togglingSuppressionDiscardsOnlyThePendingOutput() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.outputTick();
+        fixture.enqueuePixels();
+        fixture.putPixels(1);
+
+        fixture.fifo.setRenderOutput(false);
+        fixture.fifo.outputTick();
+        fixture.fifo.setRenderOutput(true);
+        fixture.fifo.outputTick();
+        assertEquals(0, displayPixelCount(fixture.display));
+
+        fixture.putPixels(1);
+        fixture.fifo.outputTick();
+        assertEquals(1, displayPixelCount(fixture.display));
+        assertEquals(fixture.bgPalette.getPalette(0)[2], displayPixel(fixture.display, 0));
+    }
+
+    @Test
+    public void suppressedDrainMatchesTheGeneralTimestampLoopForLivePendingState() {
+        Fixture source = new Fixture();
+        source.fifo.outputTick();
+        source.enqueuePixels();
+        source.putPixels(1);
+        ComponentState<ColorPixelFifo> pending = source.fifo.captureState();
+
+        Fixture fast = new Fixture();
+        Fixture general = new Fixture();
+        fast.fifo.restoreState(pending);
+        general.fifo.restoreState(pending);
+
+        fast.fifo.setRenderOutput(false);
+        fast.fifo.outputTick();
+        drainWithGeneralTimestampLoop(general.fifo);
+
+        assertEquals(longField(general.fifo, "outputTicks"), longField(fast.fifo, "outputTicks"));
+        assertEquals(intField(general.fifo, "delayHead"), intField(fast.fifo, "delayHead"));
+        assertEquals(intField(general.fifo, "delaySize"), intField(fast.fifo, "delaySize"));
+        assertArrayEquals(arrayField(general.fifo, "delayEntry"), arrayField(fast.fifo, "delayEntry"));
+        assertArrayEquals(longArrayField(general.fifo, "delayStamp"), longArrayField(fast.fifo, "delayStamp"));
+    }
+
+    /** The timestamp loop used by the pre-fast-path suppressed implementation. */
+    private static void drainWithGeneralTimestampLoop(ColorPixelFifo fifo) {
+        long outputTicks = longField(fifo, "outputTicks") + 1;
+        setLongField(fifo, "outputTicks", outputTicks);
+        int delayHead = intField(fifo, "delayHead");
+        int delaySize = intField(fifo, "delaySize");
+        long[] delayStamp = longArrayField(fifo, "delayStamp");
+        while (delaySize > 0 && delayStamp[delayHead] + ColorPixelFifo.OUTPUT_DELAY <= outputTicks) {
+            delayHead = (delayHead + 1) & 7;
+            delaySize--;
+        }
+        setIntField(fifo, "delayHead", delayHead);
+        setIntField(fifo, "delaySize", delaySize);
+    }
+
+    private static int displayPixelCount(Display display) {
+        return intField(display, "i");
+    }
+
+    private static int displayPixel(Display display, int index) {
+        return arrayField(display, "buffer")[index];
+    }
+
+    private static int intField(Object object, String name) {
+        return (int) getField(object, name);
+    }
+
+    private static long longField(Object object, String name) {
+        return (long) getField(object, name);
+    }
+
+    private static int[] arrayField(Object object, String name) {
+        return (int[]) getField(object, name);
+    }
+
+    private static long[] longArrayField(Object object, String name) {
+        return (long[]) getField(object, name);
+    }
+
+    private static void setIntField(Object object, String name, int value) {
+        setField(object, name, value);
+    }
+
+    private static void setLongField(Object object, String name, long value) {
+        setField(object, name, value);
+    }
+
+    private static Object getField(Object object, String name) {
+        try {
+            return field(object, name).get(object);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void setField(Object object, String name, Object value) {
+        try {
+            field(object, name).set(object, value);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Field field(Object object, String name) {
+        try {
+            Field field = object.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static class Fixture {
+
+        private final Display display = new Display(true);
+
+        private final ColorPalette bgPalette = new ColorPalette(0xff68);
+
+        private final ColorPixelFifo fifo;
+
+        private Fixture() {
+            GpuRegisterValues registers = new GpuRegisterValues();
+            registers.setGbc(true);
+            Lcdc lcdc = new Lcdc();
+            lcdc.setGbc(true);
+            lcdc.set(0x93);
+            bgPalette.getPalette(0)[1] = 0x001f;
+            bgPalette.getPalette(0)[2] = 0x03e0;
+            bgPalette.getPalette(0)[3] = 0x7c00;
+            fifo = new ColorPixelFifo(
+                    display,
+                    lcdc,
+                    bgPalette,
+                    new ColorPalette(0xff6a),
+                    registers,
+                    new SpeedMode(true));
+        }
+
+        private void enqueuePixels() {
+            fifo.enqueue8Pixels(new int[]{1, 2, 3, 1, 2, 3, 1, 2}, TileAttributes.EMPTY);
+        }
+
+        private void putPixels(int count) {
+            for (int i = 0; i < count; i++) {
+                fifo.putPixelToScreen();
+            }
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoPackedBackgroundTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoPackedBackgroundTest.java
@@ -1,0 +1,174 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColorPixelFifoPackedBackgroundTest {
+
+    @Test
+    public void packedBackgroundKeepsPalettePriorityAndSpriteResolution() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.enqueue8Pixels(
+                new int[] {1, 0, 1, 0, 1, 0, 1, 0}, TileAttributes.valueOf(0x82));
+        fixture.fifo.setOverlay(
+                new int[] {3, 3, 0, 0, 0, 0, 0, 0}, 0, TileAttributes.valueOf(0x05), 0);
+
+        fixture.putLivePixel();
+        fixture.putLivePixel();
+
+        assertEquals(fixture.bgPalette.getPalette(2)[1], fixture.displayPixel(0));
+        assertEquals(fixture.oamPalette.getPalette(5)[3], fixture.displayPixel(1));
+    }
+
+    @Test
+    public void clearedPackedBackgroundRetainsDropAndRewindSemantics() {
+        Fixture fixture = new Fixture();
+        fixture.fifo.enqueue8Pixels(
+                new int[] {1, 2, 3, 1, 2, 3, 1, 2}, TileAttributes.valueOf(0x04));
+        fixture.fifo.clearBg();
+
+        fixture.fifo.dropClearedBgPixel();
+        fixture.fifo.putClearedBgToScreen();
+        fixture.fifo.rewindOnePixel();
+        fixture.fifo.outputTick();
+
+        assertEquals(6, fixture.fifo.getClearedBgLength());
+        assertEquals(0, fixture.displaySize());
+
+        fixture.fifo.putClearedBgToScreen();
+        fixture.fifo.outputTick();
+        assertEquals(fixture.bgPalette.getPalette(4)[3], fixture.displayPixel(0));
+    }
+
+    @Test
+    public void wrappedLiveAndClearedBackgroundsSurviveStateRoundTrip() {
+        Fixture source = new Fixture();
+        source.fifo.enqueue8Pixels(
+                new int[] {1, 2, 3, 1, 2, 3, 1, 2}, TileAttributes.valueOf(0x01));
+        source.fifo.clearBg();
+
+        source.fifo.enqueue8Pixels(
+                new int[] {1, 1, 1, 1, 1, 1, 1, 1}, TileAttributes.valueOf(0x02));
+        dropLive(source.fifo, 5);
+        source.fifo.enqueue8Pixels(
+                new int[] {2, 2, 2, 2, 2, 2, 2, 2}, TileAttributes.valueOf(0x03));
+        dropLive(source.fifo, 5);
+        source.fifo.enqueue8Pixels(
+                new int[] {3, 3, 3, 3, 3, 3, 3, 3}, TileAttributes.valueOf(0x04));
+        ComponentState<ColorPixelFifo> state = source.fifo.captureState();
+
+        Fixture restored = new Fixture();
+        restored.fifo.restoreState(state);
+        assertEquals(14, restored.fifo.getLength());
+        assertEquals(8, restored.fifo.getClearedBgLength());
+
+        source.fifo.putClearedBgToScreen();
+        restored.fifo.putClearedBgToScreen();
+        source.fifo.outputTick();
+        restored.fifo.outputTick();
+        assertEquals(source.displayPixel(0), restored.displayPixel(0));
+        assertEquals(source.bgPalette.getPalette(1)[1], restored.displayPixel(0));
+
+        source.fifo.putPixelToScreen();
+        restored.fifo.putPixelToScreen();
+        source.fifo.outputTick();
+        restored.fifo.outputTick();
+        assertEquals(source.displayPixel(1), restored.displayPixel(1));
+        assertEquals(source.bgPalette.getPalette(3)[2], restored.displayPixel(1));
+    }
+
+    @Test
+    public void tokenAwareCaptureRestoresPackedBackgroundQueues() {
+        Fixture source = new Fixture();
+        source.fifo.enqueue8Pixels(
+                new int[] {1, 2, 3, 1, 2, 3, 1, 2}, TileAttributes.valueOf(0x06));
+        dropLive(source.fifo, 3);
+        source.fifo.clearBg();
+        source.fifo.enqueue8Pixels(
+                new int[] {2, 3, 1, 2, 3, 1, 2, 3}, TileAttributes.valueOf(0x07));
+
+        Fixture restored = new Fixture();
+        MachineStateCapture.withVerifiedView(
+                capture -> {},
+                source.fifo::captureState,
+                (state, capture) -> {
+                    restored.fifo.restoreState(state);
+                    return null;
+                });
+
+        assertEquals(8, restored.fifo.getLength());
+        assertEquals(5, restored.fifo.getClearedBgLength());
+        restored.fifo.putClearedBgToScreen();
+        restored.fifo.outputTick();
+        assertEquals(restored.bgPalette.getPalette(6)[1], restored.displayPixel(0));
+        restored.fifo.putPixelToScreen();
+        restored.fifo.outputTick();
+        assertEquals(restored.bgPalette.getPalette(7)[2], restored.displayPixel(1));
+    }
+
+    private static void dropLive(ColorPixelFifo fifo, int count) {
+        for (int i = 0; i < count; i++) {
+            fifo.dropPixel();
+        }
+    }
+
+    private static final class Fixture {
+
+        private final Display display = new Display(true);
+
+        private final ColorPalette bgPalette = new ColorPalette(0xff68);
+
+        private final ColorPalette oamPalette = new ColorPalette(0xff6a);
+
+        private final ColorPixelFifo fifo;
+
+        private Fixture() {
+            GpuRegisterValues registers = new GpuRegisterValues();
+            registers.setGbc(true);
+            Lcdc lcdc = new Lcdc();
+            lcdc.setGbc(true);
+            lcdc.set(0x93);
+            for (int palette = 0; palette < 8; palette++) {
+                for (int pixel = 0; pixel < 4; pixel++) {
+                    bgPalette.getPalette(palette)[pixel] = 0x100 * palette + pixel;
+                    oamPalette.getPalette(palette)[pixel] = 0x4000 + 0x100 * palette + pixel;
+                }
+            }
+            fifo = new ColorPixelFifo(
+                    display, lcdc, bgPalette, oamPalette, registers, new SpeedMode(true));
+        }
+
+        private void putLivePixel() {
+            fifo.putPixelToScreen();
+            fifo.outputTick();
+        }
+
+        private int displayPixel(int index) {
+            return displayBuffer()[index];
+        }
+
+        private int displaySize() {
+            return (int) displayField("i");
+        }
+
+        private int[] displayBuffer() {
+            return (int[]) displayField("buffer");
+        }
+
+        private Object displayField(String name) {
+            try {
+                Field field = Display.class.getDeclaredField(name);
+                field.setAccessible(true);
+                return field.get(display);
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuOamAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuOamAccessTest.java
@@ -2,10 +2,13 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.gpu.phase.OamSearch;
 import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
 
 import static eu.rekawek.coffeegb.core.events.EventBus.NULL_EVENT_BUS;
 import static org.junit.Assert.assertEquals;
@@ -170,6 +173,81 @@ public class GpuOamAccessTest {
         fixture.tick();
         assertTrue(fixture.gpu.isMode0IntWindow());
         assertEquals(Mode.PixelTransfer, fixture.gpu.getMode());
+    }
+
+    @Test
+    public void gpuTracksOamDmaOwnershipChangesAfterMode2() {
+        Fixture fixture = new Fixture(false, 1);
+        fixture.advanceTo(0, 99);
+        OamSearch reader = oamSearchPhase(fixture.gpu);
+        fixture.dma.setByte(0xff46, 0x00);
+
+        for (int i = 0; i < 8; i++) {
+            fixture.tick();
+        }
+
+        assertTrue(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+        assertTrue(booleanField(reader, "oamReaderDmaSource"));
+        assertEquals(80, intField(reader, "oamReaderSourceChangeTicks"));
+    }
+
+    @Test
+    public void gpuSkipsStableOamReaderUpdatesAfterMode2() {
+        Fixture fixture = new Fixture(false, 1);
+        fixture.advanceTo(0, 99);
+        OamSearch reader = oamSearchPhase(fixture.gpu);
+        reader.onLcdEnabled();
+
+        fixture.tick();
+
+        assertEquals(80, intField(reader, "oamReaderSourceChangeTicks"));
+    }
+
+    @Test
+    public void gpuStillTracksTheOamReaderAtTheLineBoundary() {
+        Fixture fixture = new Fixture(false, 1);
+        fixture.advanceTo(0, 455);
+        OamSearch reader = oamSearchPhase(fixture.gpu);
+        reader.onLcdEnabled();
+
+        fixture.tick();
+
+        assertEquals(0, fixture.gpu.getTicksInLine());
+        assertEquals(79, intField(reader, "oamReaderSourceChangeTicks"));
+    }
+
+    private static OamSearch oamSearchPhase(Gpu gpu) {
+        try {
+            return (OamSearch) field(gpu, "oamSearchPhase").get(gpu);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static int intField(Object object, String name) {
+        try {
+            return field(object, name).getInt(object);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static boolean booleanField(Object object, String name) {
+        try {
+            return field(object, name).getBoolean(object);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Field field(Object object, String name) {
+        try {
+            Field field = object.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
     }
 
     private static void assertBgOnlyOamHandoff(int speed, int scx, int closedDot) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuOamReadCorruptionTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuOamReadCorruptionTest.java
@@ -6,8 +6,12 @@ import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+
 import static eu.rekawek.coffeegb.core.events.EventBus.NULL_EVENT_BUS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GpuOamReadCorruptionTest {
 
@@ -53,6 +57,46 @@ public class GpuOamReadCorruptionTest {
         }
     }
 
+    @Test
+    public void directOamCorruptionStateIsResetOnlyOnDmgTicks()
+            throws ReflectiveOperationException {
+        Fixture dmg = new Fixture(false);
+        Fixture cgb = new Fixture(true);
+        for (String field : DIRECT_OAM_CORRUPTION_FIELDS) {
+            setBooleanField(dmg.gpu, field, true);
+            setBooleanField(cgb.gpu, field, true);
+        }
+
+        dmg.tick();
+        cgb.tick();
+
+        for (String field : DIRECT_OAM_CORRUPTION_FIELDS) {
+            assertFalse(field, getBooleanField(dmg.gpu, field));
+            assertTrue(field, getBooleanField(cgb.gpu, field));
+        }
+    }
+
+    private static final String[] DIRECT_OAM_CORRUPTION_FIELDS = {
+            "directOamReadCorruptionThisTick",
+            "suppressNextDirectOamReadCorruption",
+            "directOamWriteCorruptionThisTick",
+            "suppressNextDirectOamWriteCorruption"
+    };
+
+    private static void setBooleanField(Gpu gpu, String name, boolean value)
+            throws ReflectiveOperationException {
+        Field field = Gpu.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.setBoolean(gpu, value);
+    }
+
+    private static boolean getBooleanField(Gpu gpu, String name)
+            throws ReflectiveOperationException {
+        Field field = Gpu.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getBoolean(gpu);
+    }
+
     private static class Fixture {
 
         private final Ram oam = new Ram(0xfe00, 0xa0);
@@ -81,9 +125,13 @@ public class GpuOamReadCorruptionTest {
 
         private void advanceTo(int line, int ticksInLine) {
             while (gpu.getLine() != line || gpu.getTicksInLine() != ticksInLine) {
-                gpu.tick();
-                stat.tick();
+                tick();
             }
+        }
+
+        private void tick() {
+            gpu.tick();
+            stat.tick();
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshotTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshotTest.java
@@ -8,6 +8,8 @@ import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GpuTimingSnapshotTest {
 
@@ -30,6 +32,47 @@ public class GpuTimingSnapshotTest {
                     assertSnapshotMatchesGetters(fixture);
                     fixture.advanceTo(153, 0);
                     assertSnapshotMatchesGetters(fixture);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void liveStatCheckpointMatchesSnapshotPredicateAcrossPpuConfigurations() {
+        for (boolean gbc : new boolean[]{false, true}) {
+            for (int speed : new int[]{1, 2}) {
+                for (boolean dmgCompat : new boolean[]{false, true}) {
+                    Fixture fixture = new Fixture(gbc, speed, dmgCompat);
+
+                    fixture.gpu.setByte(0xff40, 0);
+                    assertFalse(fixture.gpu.isStatEventCheckpoint());
+                    assertCheckpointMatchesSnapshot(fixture);
+
+                    fixture.gpu.setByte(0xff40, 0x91);
+                    int finiteMode0Edges = 0;
+                    int mode0EdgeChanges = 0;
+                    int previousMode0Edge = Integer.MIN_VALUE;
+                    // Scan every dot in a complete frame after LCD enable. This
+                    // covers line/tail boundaries and samples the live mode-0
+                    // prediction while pixel transfer updates it.
+                    for (int dot = 0; dot < 154 * 456; dot++) {
+                        GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
+                        fixture.gpu.captureStatTiming(snapshot);
+                        assertEquals(legacyStatEventCheckpoint(snapshot),
+                                fixture.gpu.isStatEventCheckpoint());
+                        if (snapshot.mode0InterruptTick != Integer.MAX_VALUE) {
+                            finiteMode0Edges++;
+                        }
+                        if (previousMode0Edge != Integer.MIN_VALUE
+                                && previousMode0Edge != snapshot.mode0InterruptTick) {
+                            mode0EdgeChanges++;
+                        }
+                        previousMode0Edge = snapshot.mode0InterruptTick;
+                        fixture.tick();
+                    }
+                    assertTrue("expected a live mode-0 edge", finiteMode0Edges > 0);
+                    assertTrue("expected pixel transfer to update the mode-0 edge",
+                            mode0EdgeChanges > 0);
                 }
             }
         }
@@ -58,6 +101,25 @@ public class GpuTimingSnapshotTest {
         assertEquals(fixture.gpu.isGbc() && !fixture.gpu.isDmgCompatMode()
                         && fixture.gpu.getCpuMachineCycleDots() == 2,
                 snapshot.nativeDoubleSpeed);
+    }
+
+    private static void assertCheckpointMatchesSnapshot(Fixture fixture) {
+        GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
+        fixture.gpu.captureStatTiming(snapshot);
+        assertEquals(legacyStatEventCheckpoint(snapshot), fixture.gpu.isStatEventCheckpoint());
+    }
+
+    private static boolean legacyStatEventCheckpoint(GpuTimingSnapshot snapshot) {
+        if (!snapshot.lcdEnabled) {
+            return false;
+        }
+        int ticksInLine = snapshot.ticksInLine;
+        int mode0InterruptTick = snapshot.mode0InterruptTick;
+        return ticksInLine < 13
+                || ticksInLine >= 448
+                || ticksInLine == mode0InterruptTick
+                || (snapshot.line < 144 && mode0InterruptTick != Integer.MAX_VALUE
+                && ticksInLine == mode0InterruptTick + 2);
     }
 
     private static class Fixture {
@@ -94,6 +156,11 @@ public class GpuTimingSnapshotTest {
                 gpu.tick();
                 stat.tick();
             }
+        }
+
+        private void tick() {
+            gpu.tick();
+            stat.tick();
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshotTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshotTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.memory.Dma;
@@ -78,6 +79,54 @@ public class GpuTimingSnapshotTest {
         }
     }
 
+    @Test
+    public void dmgCompatibilityChangeUpdatesTimingAndCpuAccessWithoutGpuTick() {
+        Fixture fixture = new Fixture(true, 1, false);
+        GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
+        fixture.gpu.captureStatTiming(snapshot);
+        assertFalse(snapshot.dmgCompat);
+
+        fixture.speedMode.setDmgCompat(true);
+
+        assertTrue(fixture.gpu.isDmgCompatMode());
+        fixture.gpu.captureStatTiming(snapshot);
+        assertTrue(snapshot.dmgCompat);
+        fixture.gpu.setByteFromCpu(GpuRegister.VBK.getAddress(), 1);
+        assertEquals(0xfe, fixture.gpu.getByte(GpuRegister.VBK.getAddress()));
+    }
+
+    @Test
+    public void speedSwitchUpdatesTimingSnapshotWithoutGpuTick() {
+        Fixture fixture = new Fixture(true, new SpeedMode(true));
+        GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
+
+        fixture.gpu.captureStatTiming(snapshot);
+        assertEquals(4, snapshot.cpuMachineCycleDots);
+        switchSpeed(fixture, 2);
+        fixture.gpu.captureStatTiming(snapshot);
+        assertEquals(2, snapshot.cpuMachineCycleDots);
+        switchSpeed(fixture, 1);
+        fixture.gpu.captureStatTiming(snapshot);
+        assertEquals(4, snapshot.cpuMachineCycleDots);
+    }
+
+    @Test
+    public void speedModeRestoreAfterGpuRestoreRefreshesTimingSnapshot() {
+        Fixture fixture = new Fixture(true, 1, false);
+        fixture.speedMode.setDmgCompat(true);
+        var gpuState = fixture.gpu.captureState();
+        var speedModeState = fixture.speedMode.captureState();
+
+        fixture.speedMode.setDmgCompat(false);
+        fixture.gpu.restoreState(gpuState);
+        fixture.speedMode.restoreState(speedModeState);
+
+        GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
+        fixture.gpu.captureStatTiming(snapshot);
+        assertTrue(fixture.gpu.isDmgCompatMode());
+        assertTrue(snapshot.dmgCompat);
+    }
+
     private static void assertSnapshotMatchesGetters(Fixture fixture) {
         GpuTimingSnapshot snapshot = new GpuTimingSnapshot();
         fixture.gpu.captureStatTiming(snapshot);
@@ -122,23 +171,44 @@ public class GpuTimingSnapshotTest {
                 && ticksInLine == mode0InterruptTick + 2);
     }
 
+    private static void switchSpeed(Fixture fixture, int expectedSpeed) {
+        Ram memory = new Ram(0, 0x10000);
+        memory.setByte(0x100, 0x10);
+        memory.setByte(0x101, 0);
+        memory.setByte(0xff00, 0xcf);
+        fixture.speedMode.setByte(0xff4d, 1);
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), fixture.gpu,
+                fixture.speedMode, new Display(true));
+        cpu.getRegisters().setPC(0x100);
+        for (int i = 0; i < 20 && fixture.speedMode.getSpeedMode() != expectedSpeed; i++) {
+            cpu.tick();
+        }
+        assertEquals(expectedSpeed, fixture.speedMode.getSpeedMode());
+    }
+
     private static class Fixture {
 
         private final StatRegister stat;
 
         private final Gpu gpu;
 
+        private final SpeedMode speedMode;
+
         private Fixture(boolean gbc, int speed, boolean dmgCompat) {
-            Ram oam = new Ram(0xfe00, 0xa0);
-            InterruptManager interrupts = new InterruptManager(gbc);
-            stat = new StatRegister(interrupts);
-            SpeedMode speedMode = new SpeedMode(gbc) {
+            this(gbc, new SpeedMode(gbc) {
                 @Override
                 public int getSpeedMode() {
                     return speed;
                 }
-            };
+            });
             speedMode.setDmgCompat(dmgCompat);
+        }
+
+        private Fixture(boolean gbc, SpeedMode speedMode) {
+            Ram oam = new Ram(0xfe00, 0xa0);
+            InterruptManager interrupts = new InterruptManager(gbc);
+            stat = new StatRegister(interrupts);
+            this.speedMode = speedMode;
             gpu = new Gpu(
                     new Display(gbc),
                     new Dma(new Ram(0, 0x10000), oam, speedMode),

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/IntQueueTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/IntQueueTest.java
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntQueueTest {
+
+    @Test
+    public void packedGroupWrapsWithoutChangingLogicalOrder() {
+        IntQueue queue = new IntQueue(16);
+        for (int i = 0; i < 12; i++) {
+            queue.enqueue(0x40 + i);
+        }
+        for (int i = 0; i < 4; i++) {
+            queue.dequeue();
+        }
+
+        queue.enqueue8Packed(new int[] {0, 1, 2, 3, 0, 1, 2, 3}, 0x34);
+
+        assertEquals(16, queue.size());
+        for (int i = 0; i < 8; i++) {
+            assertEquals(0x44 + i, queue.get(i));
+        }
+        for (int i = 0; i < 8; i++) {
+            assertEquals(0x34 | (i & 3), queue.get(8 + i));
+        }
+        assertEquals(0x34, queue.array[12]);
+        assertEquals(0x37, queue.array[15]);
+        assertEquals(0x34, queue.array[0]);
+        assertEquals(0x37, queue.array[3]);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/LcdcHistoryTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/LcdcHistoryTest.java
@@ -1,0 +1,199 @@
+package eu.rekawek.coffeegb.core.gpu;
+
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+
+public class LcdcHistoryTest {
+
+    private static final int HISTORY_LENGTH = 8;
+
+    @Test
+    public void circularHistoriesMatchLinearReferenceAcrossWrapsAndRestore() {
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(true);
+        HistoryReference reference = new HistoryReference();
+
+        for (int dot = 0; dot < 37; dot++) {
+            tick(lcdc, reference, dot);
+        }
+
+        ComponentState<Lcdc> beforeRestore = lcdc.captureState();
+        assertCaptureMatches(beforeRestore, reference);
+
+        Lcdc restored = new Lcdc();
+        restored.setGbc(true);
+        restored.restoreState(beforeRestore);
+        assertHistoriesMatch(restored, reference);
+
+        for (int dot = 37; dot < 128; dot++) {
+            tick(restored, reference, dot);
+        }
+        assertHistoriesMatch(restored, reference);
+        assertCaptureMatches(restored.captureState(), reference);
+    }
+
+    @Test
+    public void clearTileSelectGlitchAtNonzeroHeadPreservesOamHistory() {
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(true);
+        HistoryReference reference = new HistoryReference();
+
+        for (int dot = 0; dot < 13; dot++) {
+            tick(lcdc, reference, dot);
+        }
+        int[] oamBeforeClear = reference.oamSizeHistory.clone();
+
+        lcdc.set(0);
+        reference.clearTileSelectGlitch();
+
+        for (int dotsAgo = 0; dotsAgo < HISTORY_LENGTH; dotsAgo++) {
+            assertFalse(lcdc.isTileSelectGlitch(dotsAgo));
+        }
+        assertArrayEquals(oamBeforeClear, oamSizeHistory(lcdc.captureState()));
+        assertCaptureMatches(lcdc.captureState(), reference);
+    }
+
+    @Test
+    public void ordinaryAndPooledCapturesExposeLogicalOrderWithoutSharingMutableArrays() {
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(true);
+        HistoryReference reference = new HistoryReference();
+
+        for (int dot = 0; dot < 19; dot++) {
+            tick(lcdc, reference, dot);
+        }
+
+        ComponentState<Lcdc> first = lcdc.captureState();
+        ComponentState<Lcdc> second = lcdc.captureState();
+        assertCaptureMatches(first, reference);
+        assertCaptureMatches(second, reference);
+        assertNotSame(tileSelectGlitchHistory(first), tileSelectGlitchHistory(second));
+        assertNotSame(oamSizeHistory(first), oamSizeHistory(second));
+
+        tileSelectGlitchHistory(first)[0] = !tileSelectGlitchHistory(first)[0];
+        oamSizeHistory(first)[0] ^= 0x4000_0000;
+        assertCaptureMatches(lcdc.captureState(), reference);
+
+        CapturedHistories pooled = MachineStateCapture.withVerifiedView(
+                capture -> { },
+                capture -> lcdc.captureState(capture),
+                (state, capture) -> new CapturedHistories(
+                        tileSelectGlitchHistory(state).clone(),
+                        oamSizeHistory(state).clone()));
+        assertArrayEquals(reference.tileSelectGlitchHistory, pooled.tileSelectGlitchHistory);
+        assertArrayEquals(reference.oamSizeHistory, pooled.oamSizeHistory);
+    }
+
+    private static void tick(Lcdc lcdc, HistoryReference reference, int dot) {
+        int value = historyValue(dot);
+        lcdc.set(value);
+        reference.set(value);
+        if ((dot % 5) == 1 || (dot % 11) == 7) {
+            lcdc.triggerTileSelectGlitch();
+            reference.triggerTileSelectGlitch();
+        }
+        lcdc.tickConflicts();
+        reference.tickConflicts();
+        assertHistoriesMatch(lcdc, reference);
+    }
+
+    private static int historyValue(int dot) {
+        return switch (dot & 3) {
+            case 0 -> 0x1_0000 | (dot << 8) | ((dot & 1) << 2) | 0x91;
+            case 1 -> 0x7000_0000 | (dot << 4) | ((dot & 1) << 2) | 0x80;
+            case 2 -> 0x8000_0000 | (dot << 12) | ((dot & 1) << 2) | 0x93;
+            default -> -0x10000 | (dot << 2) | ((dot & 1) << 2) | 0xa2;
+        };
+    }
+
+    private static void assertHistoriesMatch(Lcdc lcdc, HistoryReference reference) {
+        for (int dotsAgo = 0; dotsAgo < HISTORY_LENGTH; dotsAgo++) {
+            assertEquals(reference.tileSelectGlitchHistory[dotsAgo], lcdc.isTileSelectGlitch(dotsAgo));
+            assertEquals(reference.oamSpriteHeight(dotsAgo), lcdc.getOamSpriteHeight(dotsAgo));
+        }
+    }
+
+    private static void assertCaptureMatches(ComponentState<Lcdc> state, HistoryReference reference) {
+        assertArrayEquals(reference.tileSelectGlitchHistory, tileSelectGlitchHistory(state));
+        assertArrayEquals(reference.oamSizeHistory, oamSizeHistory(state));
+    }
+
+    private static boolean[] tileSelectGlitchHistory(ComponentState<Lcdc> state) {
+        return (boolean[]) recordComponent(state, "tileSelectGlitchHistory");
+    }
+
+    private static int[] oamSizeHistory(ComponentState<Lcdc> state) {
+        return (int[]) recordComponent(state, "oamSizeHistory");
+    }
+
+    private static Object recordComponent(Object state, String name) {
+        try {
+            Method accessor = state.getClass().getDeclaredMethod(name);
+            accessor.setAccessible(true);
+            return accessor.invoke(state);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private record CapturedHistories(boolean[] tileSelectGlitchHistory, int[] oamSizeHistory) {
+    }
+
+    private static final class HistoryReference {
+
+        private int value = 0x91;
+
+        private int tileSelectGlitchTicks;
+
+        private int pendingTileSelectGlitchTicks;
+
+        private final boolean[] tileSelectGlitchHistory = new boolean[HISTORY_LENGTH];
+
+        private final int[] oamSizeHistory = new int[HISTORY_LENGTH];
+
+        private HistoryReference() {
+            Arrays.fill(oamSizeHistory, value);
+        }
+
+        private void set(int value) {
+            this.value = value;
+        }
+
+        private void triggerTileSelectGlitch() {
+            pendingTileSelectGlitchTicks = 1;
+        }
+
+        private void clearTileSelectGlitch() {
+            tileSelectGlitchTicks = 0;
+            pendingTileSelectGlitchTicks = 0;
+            Arrays.fill(tileSelectGlitchHistory, false);
+        }
+
+        private void tickConflicts() {
+            if (pendingTileSelectGlitchTicks > 0) {
+                tileSelectGlitchTicks = pendingTileSelectGlitchTicks;
+                pendingTileSelectGlitchTicks = 0;
+            } else if (tileSelectGlitchTicks > 0) {
+                tileSelectGlitchTicks--;
+            }
+            System.arraycopy(tileSelectGlitchHistory, 0, tileSelectGlitchHistory, 1,
+                    HISTORY_LENGTH - 1);
+            tileSelectGlitchHistory[0] = tileSelectGlitchTicks > 0;
+            System.arraycopy(oamSizeHistory, 0, oamSizeHistory, 1, HISTORY_LENGTH - 1);
+            oamSizeHistory[0] = value;
+        }
+
+        private int oamSpriteHeight(int dotsAgo) {
+            return (oamSizeHistory[dotsAgo] & 0x04) == 0 ? 8 : 16;
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.core.gpu;
 
+import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.memory.Dma;
@@ -495,6 +496,40 @@ public class StatRegisterTest {
         assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
         fixture.stat.captureCpuStatReadPhase(false, false, true);
         assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+    }
+
+    @Test
+    public void packedCpuStatReadPhaseRetainsEveryCpuInputFlag() throws Exception {
+        for (int flags = 0; flags < 16; flags++) {
+            Fixture fixture = new Fixture(true);
+            fixture.advanceTo(1, 78);
+
+            fixture.stat.beginCpuReadPhase(flags);
+
+            int expected = flags;
+            if ((flags & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0) {
+                expected |= 1 << 4;
+            }
+            assertEquals(expected, intField(fixture.stat, "cpuStatReadPhaseFlags"));
+        }
+    }
+
+    @Test
+    public void stalePackedCpuStatReadPhaseIsHiddenUntilTheNextCapture() throws Exception {
+        Fixture fixture = new Fixture(true);
+        fixture.advanceTo(1, 78);
+
+        fixture.stat.beginCpuReadPhase(Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE);
+        assertEquals(Mode.OamSearch.ordinal(), fixture.readStatMode());
+        int capturedFlags = intField(fixture.stat, "cpuStatReadPhaseFlags");
+
+        fixture.tick();
+
+        assertEquals(capturedFlags, intField(fixture.stat, "cpuStatReadPhaseFlags"));
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
+        fixture.stat.beginCpuReadPhase(0);
+        assertEquals(0, intField(fixture.stat, "cpuStatReadPhaseFlags"));
+        assertEquals(Mode.PixelTransfer.ordinal(), fixture.readStatMode());
     }
 
     @Test
@@ -2380,8 +2415,12 @@ public class StatRegisterTest {
     }
 
     private static int cpuStatModeOverride(StatRegister stat) {
+        return intField(stat, "cpuStatModeOverride");
+    }
+
+    private static int intField(StatRegister stat, String name) {
         try {
-            Field field = StatRegister.class.getDeclaredField("cpuStatModeOverride");
+            Field field = StatRegister.class.getDeclaredField(name);
             field.setAccessible(true);
             return field.getInt(stat);
         } catch (ReflectiveOperationException e) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -13,9 +13,54 @@ import static eu.rekawek.coffeegb.core.cpu.InterruptManager.InterruptType.VBlank
 import static eu.rekawek.coffeegb.core.events.EventBus.NULL_EVENT_BUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class StatRegisterTest {
+
+    @Test
+    public void quietTicksLeaveTimingStaleUntilAStatConsumerNeedsIt() throws Exception {
+        Fixture quiet = quietFixture();
+        int staleTicksInLine = statTiming(quiet.stat).ticksInLine;
+        long staleGeneration = statTimingGeneration(quiet.stat);
+
+        quiet.tick();
+
+        assertEquals(staleGeneration, statTimingGeneration(quiet.stat));
+        assertEquals(staleTicksInLine, statTiming(quiet.stat).ticksInLine);
+        assertNotEquals(quiet.gpu.getTicksInLine(), statTiming(quiet.stat).ticksInLine);
+
+        quiet.stat.getByte(StatRegister.ADDRESS);
+        assertStatTimingMatchesGpu(quiet);
+
+        Fixture checkpoint = quietFixture();
+        checkpoint.advanceTo(1, 447);
+        assertNotEquals(checkpoint.gpu.getTicksInLine(), statTiming(checkpoint.stat).ticksInLine);
+        checkpoint.tick();
+        assertStatTimingMatchesGpu(checkpoint);
+
+        Fixture dirty = quietFixture();
+        dirty.gpu.setByteFromCpu(GpuRegister.SCX.getAddress(), 1);
+        dirty.tick();
+        assertStatTimingMatchesGpu(dirty);
+
+        Fixture signalled = quietFixture();
+        signalled.interrupts.requestInterrupt(LCDC);
+        signalled.interrupts.clearInterrupt(LCDC);
+        signalled.tick();
+        assertStatTimingMatchesGpu(signalled);
+
+        Fixture scheduled = new Fixture(true);
+        scheduled.advanceTo(1, 100);
+        scheduled.stat.setByte(StatRegister.ADDRESS, 0x40);
+        scheduled.gpu.setByte(GpuRegister.LYC.getAddress(), 3);
+        long deadline = longField(scheduled.stat, "nextLycIrqEvent");
+        assertTrue(deadline > longField(scheduled.stat, "lycIrqClock"));
+        while (longField(scheduled.stat, "lycIrqClock") < deadline) {
+            scheduled.tick();
+        }
+        assertStatTimingMatchesGpu(scheduled);
+    }
 
     @Test
     public void hblankEnableMasksStatWriteGlitchAtOamBoundary() {
@@ -2342,6 +2387,38 @@ public class StatRegisterTest {
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
+    }
+
+    private static Fixture quietFixture() {
+        Fixture fixture = new Fixture(true);
+        fixture.advanceTo(1, 100);
+        assertFalse(fixture.gpu.isStatEventCheckpoint());
+        return fixture;
+    }
+
+    private static GpuTimingSnapshot statTiming(StatRegister stat) throws Exception {
+        Field field = StatRegister.class.getDeclaredField("timing");
+        field.setAccessible(true);
+        return (GpuTimingSnapshot) field.get(stat);
+    }
+
+    private static long statTimingGeneration(StatRegister stat) throws Exception {
+        return longField(stat, "timingGeneration");
+    }
+
+    private static long longField(StatRegister stat, String name) throws Exception {
+        Field field = StatRegister.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getLong(stat);
+    }
+
+    private static void assertStatTimingMatchesGpu(Fixture fixture) throws Exception {
+        GpuTimingSnapshot timing = statTiming(fixture.stat);
+        assertEquals(fixture.gpu.getLine(), timing.line);
+        assertEquals(fixture.gpu.getTicksInLine(), timing.ticksInLine);
+        assertEquals(fixture.gpu.getVisibleLy(), timing.visibleLy);
+        assertEquals(fixture.gpu.getMode0InterruptTick(), timing.mode0InterruptTick);
+        assertEquals(fixture.gpu.isLcdEnabled(), timing.lcdEnabled);
     }
 
     private static class Fixture {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
@@ -9,9 +9,11 @@ import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -173,6 +175,64 @@ public class OamSearchTest {
         fixture.tickSearch();
 
         assertEquals(8, fixture.search.getSprites()[0].getX());
+    }
+
+    @Test
+    public void readerInitializesWhenTheFirstTrackedPositionIsOutsideMode2() {
+        Fixture fixture = new Fixture();
+
+        assertFalse(fixture.search.isOamReaderInitialized());
+        fixture.search.trackDmaSource(100);
+
+        assertTrue(fixture.search.isOamReaderInitialized());
+    }
+
+    @Test
+    public void readerTracksDmaSourceChangesOutsideMode2() {
+        Fixture fixture = new Fixture();
+        fixture.search.trackDmaSource(0);
+        fixture.dma.setByte(0xff46, 0x12);
+        fixture.advanceDmaWithoutReader(7);
+        fixture.dma.tick();
+
+        assertTrue(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+        fixture.search.trackDmaSource(100);
+
+        assertTrue(booleanField(fixture.search, "oamReaderDmaSource"));
+        assertEquals(80, intField(fixture.search, "oamReaderSourceChangeTicks"));
+    }
+
+    @Test
+    public void stableTrackingOutsideMode2LeavesTheReaderUntouched() {
+        Fixture fixture = new Fixture();
+        fixture.search.trackDmaSource(0);
+        int[] beforeY = intArrayField(fixture.search, "oamReaderY").clone();
+        int[] beforeX = intArrayField(fixture.search, "oamReaderX").clone();
+        int beforeBusY = intField(fixture.search, "oamReaderBusY");
+        int beforeBusX = intField(fixture.search, "oamReaderBusX");
+        boolean beforeSource = booleanField(fixture.search, "oamReaderDmaSource");
+        int beforeChangeTicks = intField(fixture.search, "oamReaderSourceChangeTicks");
+
+        fixture.search.trackDmaSource(80);
+
+        assertArrayEquals(beforeY, intArrayField(fixture.search, "oamReaderY"));
+        assertArrayEquals(beforeX, intArrayField(fixture.search, "oamReaderX"));
+        assertEquals(beforeBusY, intField(fixture.search, "oamReaderBusY"));
+        assertEquals(beforeBusX, intField(fixture.search, "oamReaderBusX"));
+        assertEquals(beforeSource, booleanField(fixture.search, "oamReaderDmaSource"));
+        assertEquals(beforeChangeTicks, intField(fixture.search, "oamReaderSourceChangeTicks"));
+    }
+
+    @Test
+    public void everyMode2ReaderPositionConsumesOneSourceChangeTick() {
+        Fixture fixture = new Fixture();
+        fixture.search.onLcdEnabled();
+
+        for (int readerPosition = 0; readerPosition < 80; readerPosition++) {
+            fixture.search.trackDmaSource(readerPosition);
+            assertEquals(79 - readerPosition,
+                    intField(fixture.search, "oamReaderSourceChangeTicks"));
+        }
     }
 
     @Test
@@ -342,6 +402,40 @@ public class OamSearchTest {
 
         restored.beginSearchLine();
         assertFalse(restored.search.hadSpriteHeightTransition());
+    }
+
+    private static Field field(OamSearch search, String name) {
+        try {
+            Field field = OamSearch.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static int intField(OamSearch search, String name) {
+        try {
+            return field(search, name).getInt(search);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static int[] intArrayField(OamSearch search, String name) {
+        try {
+            return (int[]) field(search, name).get(search);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static boolean booleanField(OamSearch search, String name) {
+        try {
+            return field(search, name).getBoolean(search);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
     }
 
     private static class Fixture {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowYDelayTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferWindowYDelayTest.java
@@ -1,0 +1,109 @@
+package eu.rekawek.coffeegb.core.gpu.phase;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.gpu.ColorPalette;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.gpu.GpuRegister;
+import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
+import eu.rekawek.coffeegb.core.gpu.Lcdc;
+import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memory.Ram;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PixelTransferWindowYDelayTest {
+
+    @Test
+    public void settledDelayReturnsMinusOneAcrossRepeatedCalls() {
+        Harness h = new Harness();
+
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+    }
+
+    @Test
+    public void delayedWriteCountsDownReturnsOldWyOnceAndCommitsAtZero() {
+        Harness h = new Harness();
+        h.registers.put(GpuRegister.WY, 3);
+        h.registers.put(GpuRegister.LY, 9);
+        h.transfer.scheduleWindowYWrite(9, 2);
+
+        assertFalse(h.transfer.isWindowYMatch());
+        assertEquals(3, h.transfer.advanceWindowYDelay());
+        assertFalse(h.transfer.isWindowYMatch());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+        assertFalse(h.transfer.isWindowYMatch());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+        assertTrue(h.transfer.isWindowYMatch());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+    }
+
+    @Test
+    public void immediateWriteIsSettledAndVisibleWithoutAdvance() {
+        Harness h = new Harness();
+        h.registers.put(GpuRegister.LY, 11);
+        h.transfer.scheduleWindowYWrite(11, 0);
+
+        assertTrue(h.transfer.isWindowYMatch());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+        assertEquals(-1, h.transfer.advanceWindowYDelay());
+    }
+
+    @Test
+    public void countdownAndClearedCollisionLatchRoundTripThroughState() {
+        Harness source = new Harness();
+        source.registers.put(GpuRegister.WY, 4);
+        source.registers.put(GpuRegister.LY, 12);
+        source.transfer.scheduleWindowYWrite(12, 3);
+        assertEquals(4, source.transfer.advanceWindowYDelay());
+        ComponentState<PixelTransfer> countdown = source.transfer.captureState();
+
+        Harness restored = new Harness();
+        restored.registers.put(GpuRegister.LY, 12);
+        restored.transfer.restoreState(countdown);
+
+        for (int i = 0; i < 3; i++) {
+            assertEquals(source.transfer.advanceWindowYDelay(),
+                    restored.transfer.advanceWindowYDelay());
+            assertEquals(source.transfer.isWindowYMatch(), restored.transfer.isWindowYMatch());
+        }
+        assertTrue(restored.transfer.isWindowYMatch());
+        assertEquals(-1, restored.transfer.advanceWindowYDelay());
+    }
+
+    private static class Harness {
+
+        private final GpuRegisterValues registers = new GpuRegisterValues();
+
+        private final PixelTransfer transfer;
+
+        private Harness() {
+            registers.setGbc(true);
+            Lcdc lcdc = new Lcdc();
+            lcdc.setGbc(true);
+            SpritePosition[] sprites = new SpritePosition[10];
+            for (int i = 0; i < sprites.length; i++) {
+                sprites[i] = new SpritePosition();
+            }
+            transfer = new PixelTransfer(
+                    new Display(true),
+                    new Ram(0x8000, 0x2000),
+                    new Ram(0x8000, 0x2000),
+                    new Ram(0xfe00, 0xa0),
+                    lcdc,
+                    registers,
+                    true,
+                    new ColorPalette(0xff68),
+                    new ColorPalette(0xff6a),
+                    sprites,
+                    null,
+                    new SpeedMode(true),
+                    0);
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
@@ -3,14 +3,20 @@ package eu.rekawek.coffeegb.core.joypad;
 import com.sun.management.ThreadMXBean;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.sgb.Commands;
+import eu.rekawek.coffeegb.core.sgb.SgbPacketTestBuilder;
+import eu.rekawek.coffeegb.core.state.ComponentState;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class JoypadHotPathTest {
@@ -49,10 +55,204 @@ public class JoypadHotPathTest {
         PlayerInputSnapshot pressed = PlayerInputSnapshot.of(List.of(
                 Set.of(Button.A), Set.of(), Set.of(), Set.of()));
         joypad.seedDeterministicReplayInput(Set.of(), pressed);
+        assertFalse(releasedInputFastPathEligible(joypad));
 
         joypad.tick();
 
         assertEquals(PlayerInputSnapshot.RELEASED, joypad.getSampledInput());
+        assertTrue(releasedInputFastPathEligible(joypad));
+    }
+
+    @Test
+    public void fullySettledReleasedDefaultInputPreservesOutputAndAdvancesTick() {
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        ComponentState<Joypad> before = joypad.captureState();
+        int output = joypad.getByte(JOYP);
+        assertTrue(releasedInputFastPathEligible(joypad));
+
+        joypad.tick();
+
+        ComponentState<Joypad> after = joypad.captureState();
+        assertEquals(output, joypad.getByte(JOYP));
+        assertEquals(tick(before) + 1, tick(after));
+        assertEquals(inputHistory(before), inputHistory(after));
+        assertEquals(filteredInputLines(before), filteredInputLines(after));
+        assertFalse(inputChangedSinceLastTick(after));
+        assertTrue(releasedInputFastPathEligible(joypad));
+    }
+
+    @Test
+    public void customReleasedSourceIsSampledEveryTick() {
+        AtomicInteger samples = new AtomicInteger();
+        PlayerInputSource source = () -> {
+            samples.incrementAndGet();
+            return PlayerInputSnapshot.RELEASED;
+        };
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, source);
+        assertFalse(releasedInputFastPathEligible(joypad));
+
+        joypad.tick();
+        joypad.tick();
+
+        assertEquals(2, samples.get());
+    }
+
+    @Test
+    public void pendingInputChangeStillClearsOnItsFollowingTick() {
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        assertTrue(releasedInputFastPathEligible(joypad));
+        joypad.setByte(JOYP, 0x30);
+        assertFalse(releasedInputFastPathEligible(joypad));
+
+        joypad.tick();
+
+        assertFalse(inputChangedSinceLastTick(joypad.captureState()));
+        assertTrue(releasedInputFastPathEligible(joypad));
+    }
+
+    @Test
+    public void legacyButtonsStillAdvanceTheInputFilter() {
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        joypad.seedDeterministicReplayInput(Set.of(Button.A), PlayerInputSnapshot.RELEASED);
+        assertFalse(releasedInputFastPathEligible(joypad));
+
+        joypad.tick();
+
+        assertEquals(1, inputHistory(joypad.captureState()));
+    }
+
+    @Test
+    public void multiplayerPlayerIdStillAdvancesTheInputFilter() {
+        try (SgbPacketTestBuilder fixture = new SgbPacketTestBuilder()) {
+            Joypad joypad = fixture.joypad();
+            assertTrue(releasedInputFastPathEligible(joypad));
+            fixture.sendCommand(0x11, 1, 1);
+            assertFalse(releasedInputFastPathEligible(joypad));
+            joypad.setByte(JOYP, 0x10);
+            joypad.setByte(JOYP, 0x30);
+            joypad.tick(); // consume the selector transition
+
+            joypad.tick();
+
+            assertEquals(1, inputHistory(joypad.captureState()));
+        }
+    }
+
+    @Test
+    public void multiplayerControlCallbackInvalidatesReleasedFastPathEligibility() {
+        try (EventBusImpl sgbBus = new EventBusImpl(null, null, false)) {
+            Joypad joypad = new Joypad(new InterruptManager(false), sgbBus, true);
+            assertTrue(releasedInputFastPathEligible(joypad));
+
+            int[] packet = new int[Commands.PACKET_SIZE];
+            packet[0] = 0x11 << 3 | 1;
+            packet[1] = 1;
+            sgbBus.post((Commands.MltReqCmd) Commands.toCommand(packet));
+
+            assertFalse(releasedInputFastPathEligible(joypad));
+            assertEquals(Joypad.SgbMultiplayerMode.TWO_PLAYER,
+                    joypad.getSgbMultiplayerStatus().mode());
+        }
+    }
+
+    @Test
+    public void restoredPartiallySettledReleasedFilterStillConverges() {
+        Joypad original = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        original.setPressedButtons(Set.of(Button.A));
+        original.tick(); // consume the input transition
+        original.tick(); // first pressed sample
+        ComponentState<Joypad> partialFilter = original.captureState();
+        assertEquals(1, inputHistory(partialFilter));
+
+        Joypad restored = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        restored.restoreState(partialFilter);
+        assertFalse(releasedInputFastPathEligible(restored));
+        restored.tick();
+
+        assertEquals(2, inputHistory(restored.captureState()));
+    }
+
+    @Test
+    public void legacyAndReplayMutationsInvalidateReleasedFastPathEligibility() {
+        try (EventBusImpl eventBus = new EventBusImpl(null, null, false)) {
+            Joypad joypad = new Joypad(
+                    new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+            joypad.init(eventBus);
+            assertTrue(releasedInputFastPathEligible(joypad));
+
+            eventBus.post(new ButtonPressEvent(Button.A));
+            assertFalse(releasedInputFastPathEligible(joypad));
+            eventBus.post(new ButtonReleaseEvent(Button.A));
+            assertFalse(releasedInputFastPathEligible(joypad));
+        }
+
+        Joypad replaced = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        replaced.setPressedButtons(Set.of(Button.A));
+        assertFalse(releasedInputFastPathEligible(replaced));
+
+        Joypad replay = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        replay.applyDeterministicReplayLegacyInput(Set.of(Button.A));
+        assertFalse(releasedInputFastPathEligible(replay));
+
+        Joypad seeded = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        seeded.seedDeterministicReplayInput(Set.of(), PlayerInputSnapshot.RELEASED);
+        assertTrue(releasedInputFastPathEligible(seeded));
+        seeded.seedDeterministicReplayInput(Set.of(Button.A), PlayerInputSnapshot.RELEASED);
+        assertFalse(releasedInputFastPathEligible(seeded));
+    }
+
+    @Test
+    public void restoringFullySettledReleasedStateRecomputesFastPathEligibility() {
+        Joypad source = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        ComponentState<Joypad> releasedState = source.captureState();
+
+        Joypad restored = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        restored.setByte(JOYP, 0x30);
+        assertFalse(releasedInputFastPathEligible(restored));
+
+        restored.restoreState(releasedState);
+
+        assertTrue(releasedInputFastPathEligible(restored));
+    }
+
+    @Test
+    public void stableReleasedDefaultInputFastPathAllocatesNothing() {
+        java.lang.management.ThreadMXBean platformBean = ManagementFactory.getThreadMXBean();
+        Assume.assumeTrue(platformBean instanceof ThreadMXBean);
+        ThreadMXBean allocationBean = (ThreadMXBean) platformBean;
+        Assume.assumeTrue(allocationBean.isThreadAllocatedMemorySupported());
+        if (!allocationBean.isThreadAllocatedMemoryEnabled()) {
+            allocationBean.setThreadAllocatedMemoryEnabled(true);
+        }
+
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
+        exercise(joypad, 100_000);
+
+        long threadId = Thread.currentThread().getId();
+        allocationBean.getThreadAllocatedBytes(threadId);
+        long minimumAllocated = Long.MAX_VALUE;
+        long checksum = 0;
+        for (int sample = 0; sample < 5; sample++) {
+            long before = allocationBean.getThreadAllocatedBytes(threadId);
+            checksum += exercise(joypad, 20_000);
+            long after = allocationBean.getThreadAllocatedBytes(threadId);
+            minimumAllocated = Math.min(minimumAllocated, after - before);
+        }
+
+        assertTrue(checksum != 0);
+        assertEquals("stable released joypad path allocated", 0L, minimumAllocated);
     }
 
     @Test
@@ -107,5 +307,41 @@ public class JoypadHotPathTest {
             checksum += joypad.getByte(JOYP);
         }
         return checksum;
+    }
+
+    private static long tick(ComponentState<Joypad> state) {
+        return (long) stateField(state, "tick");
+    }
+
+    private static int inputHistory(ComponentState<Joypad> state) {
+        return (int) stateField(state, "inputHistory");
+    }
+
+    private static int filteredInputLines(ComponentState<Joypad> state) {
+        return (int) stateField(state, "filteredInputLines");
+    }
+
+    private static boolean inputChangedSinceLastTick(ComponentState<Joypad> state) {
+        return (boolean) stateField(state, "inputChangedSinceLastTick");
+    }
+
+    private static boolean releasedInputFastPathEligible(Joypad joypad) {
+        try {
+            var field = Joypad.class.getDeclaredField("releasedInputFastPathEligible");
+            field.setAccessible(true);
+            return field.getBoolean(joypad);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Joypad has no released-input fast-path state", e);
+        }
+    }
+
+    private static Object stateField(ComponentState<Joypad> state, String name) {
+        try {
+            var accessor = state.getClass().getDeclaredMethod(name);
+            accessor.setAccessible(true);
+            return accessor.invoke(state);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Joypad checkpoint has no " + name + " state", e);
+        }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpaceTest.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DmaCpuAddressSpaceTest {
@@ -218,6 +219,51 @@ public class DmaCpuAddressSpaceTest {
         assertEquals(0xe4, memory.getByte(0xff47));
     }
 
+    @Test
+    public void inactiveDmaDelegatesDirectlyAndFf46StillStartsTransfer() {
+        InactiveFixture fixture = new InactiveFixture();
+        fixture.memory.setByte(0xc001, 0x51);
+
+        assertEquals(0x51, fixture.cpu.getByte(0xc001));
+        assertEquals(0xc001, fixture.memory.lastReadAddress);
+        fixture.cpu.setByte(0xc001, 0x62);
+        assertTrue(fixture.memory.cpuWrite);
+        assertEquals(0xc001, fixture.memory.lastCpuWriteAddress);
+        assertEquals(0x62, fixture.memory.getByte(0xc001));
+
+        fixture.cpu.setByte(0xff46, 0x12);
+
+        assertTrue(fixture.dma.isTransferInProgress());
+        assertEquals(0x12, fixture.dma.getByte(0xff46));
+    }
+
+    @Test
+    public void firstActiveDmaTickStartsTheCpuBusConflict() {
+        InactiveFixture fixture = new InactiveFixture();
+        fixture.start();
+
+        fixture.tick(7);
+        assertEquals(0x11, fixture.cpu.getByte(0x0100));
+        fixture.tick(1);
+
+        assertEquals(0x42, fixture.cpu.getByte(0x0100));
+    }
+
+    @Test
+    public void completedDmaReturnsToDirectCpuAccess() {
+        InactiveFixture fixture = new InactiveFixture();
+        fixture.start();
+        fixture.tick(648);
+        fixture.memory.setByte(0x0100, 0x73);
+
+        assertFalse(fixture.dma.isTransferInProgress());
+        assertEquals(0x73, fixture.cpu.getByte(0x0100));
+        fixture.cpu.setByte(0x0100, 0x84);
+
+        assertEquals(0x84, fixture.memory.getByte(0x0100));
+        assertEquals(0x0100, fixture.memory.lastCpuWriteAddress);
+    }
+
     private static class Fixture {
 
         private final TestAddressSpace memory = new TestAddressSpace();
@@ -258,11 +304,82 @@ public class DmaCpuAddressSpaceTest {
         }
     }
 
+    private static class InactiveFixture {
+
+        private final TestAddressSpace memory = new TestAddressSpace();
+
+        private final Ram oam = new Ram(0xfe00, 0xa0);
+
+        private final Dma dma = new Dma(memory, oam, new SpeedMode(false));
+
+        private final DmaCpuAddressSpace cpu = new DmaCpuAddressSpace(
+                new DmaRegisterAddressSpace(memory, dma), dma, false);
+
+        private InactiveFixture() {
+            memory.setByte(0x0100, 0x11);
+            memory.setByte(0x1200, 0x42);
+        }
+
+        private void start() {
+            cpu.setByte(0xff46, 0x12);
+        }
+
+        private void tick(int count) {
+            for (int i = 0; i < count; i++) {
+                dma.tick();
+            }
+        }
+    }
+
+    private static class DmaRegisterAddressSpace implements AddressSpace {
+
+        private final TestAddressSpace memory;
+
+        private final Dma dma;
+
+        private DmaRegisterAddressSpace(TestAddressSpace memory, Dma dma) {
+            this.memory = memory;
+            this.dma = dma;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return true;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            if (dma.accepts(address)) {
+                dma.setByte(address, value);
+            } else {
+                memory.setByte(address, value);
+            }
+        }
+
+        @Override
+        public void setByteFromCpu(int address, int value) {
+            if (dma.accepts(address)) {
+                dma.setByteFromCpu(address, value);
+            } else {
+                memory.setByteFromCpu(address, value);
+            }
+        }
+
+        @Override
+        public int getByte(int address) {
+            return dma.accepts(address) ? dma.getByte(address) : memory.getByte(address);
+        }
+    }
+
     private static class TestAddressSpace implements AddressSpace {
 
         private final int[] data = new int[0x10000];
 
         private boolean cpuWrite;
+
+        private int lastReadAddress = -1;
+
+        private int lastCpuWriteAddress = -1;
 
         @Override
         public boolean accepts(int address) {
@@ -277,11 +394,13 @@ public class DmaCpuAddressSpaceTest {
         @Override
         public void setByteFromCpu(int address, int value) {
             cpuWrite = true;
+            lastCpuWriteAddress = address;
             data[address] = value;
         }
 
         @Override
         public int getByte(int address) {
+            lastReadAddress = address;
             return data[address];
         }
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
@@ -72,6 +72,85 @@ public class DmaTest {
     }
 
     @Test
+    public void settledInactiveDmaDoesNotRequireAClockTick() {
+        Fixture fixture = new Fixture();
+
+        assertFalse(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
+    public void inactivePauseTransitionsRequireOneClockTick() {
+        Fixture fixture = new Fixture();
+
+        assertTrue(fixture.dma.requiresClockTick(true));
+        fixture.dma.tick(true);
+        assertFalse(fixture.dma.requiresClockTick(true));
+
+        assertTrue(fixture.dma.requiresClockTick(false));
+        fixture.dma.tick(false);
+        assertFalse(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
+    public void inactiveVramDmaBusSampleRequiresOneClockTickToClear() {
+        Fixture fixture = new Fixture();
+        fixture.dma.setVramDmaBusSample(new Hdma.SourceBusSample(0x1234, 0x56));
+
+        assertTrue(fixture.dma.requiresClockTick(false));
+        fixture.dma.tick();
+        assertFalse(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
+    public void activeDmaAlwaysRequiresAClockTick() {
+        Fixture fixture = new Fixture();
+        fixture.start();
+
+        assertTrue(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
+    public void completedDmaRequiresExactlyOneOwnershipDrainTick() {
+        Fixture fixture = new Fixture();
+        fixture.start();
+        fixture.tick(648);
+
+        assertFalse(fixture.dma.isTransferInProgress());
+        assertTrue(fixture.dma.requiresClockTick(false));
+        fixture.dma.tick();
+        assertFalse(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
+    public void skippingSettledDmaClockPreservesMementoState() {
+        Fixture fixture = new Fixture();
+        fixture.dma.tick(true);
+        assertFalse(fixture.dma.requiresClockTick(true));
+        var settledState = fixture.dma.captureState();
+
+        Fixture ticked = new Fixture();
+        ticked.dma.restoreState(settledState);
+        ticked.dma.tick(true);
+
+        assertEquals(settledState, ticked.dma.captureState());
+    }
+
+    @Test
+    public void restoredRestartedStateRequiresAClockTick() {
+        Fixture fixture = new Fixture();
+        Dma.DmaState settled = (Dma.DmaState) fixture.dma.captureState();
+        fixture.dma.restoreState(new Dma.DmaState(false, true,
+                settled.from(), settled.ticks(), settled.transferClocks(),
+                settled.oamOwnedForPpuBeforeTick(), settled.oamOwnedForPpu(),
+                settled.ppuOamOwnedThroughRestart(), settled.cpuClockPaused(),
+                settled.pauseEntryClocks(), settled.currentByte(), settled.regValue(),
+                settled.pendingInterruptWriteByte(), settled.pendingInterruptWriteValue(),
+                settled.vramDmaBusCollisionObserved()));
+
+        assertTrue(fixture.dma.requiresClockTick(false));
+    }
+
+    @Test
     public void ppuOamOwnershipTransitionIsObservableAtAcquireAndRelease() {
         Fixture fixture = new Fixture(true);
         fixture.start();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/DmaTest.java
@@ -59,6 +59,39 @@ public class DmaTest {
     }
 
     @Test
+    public void settledInactiveOwnershipKeepsBothPpuReaderSnapshotsFalse() {
+        Fixture fixture = new Fixture();
+
+        for (int i = 0; i < 4; i++) {
+            fixture.dma.tick();
+
+            assertFalse(fixture.dma.ownedOamForPpuBeforeTick());
+            assertFalse(fixture.dma.ownsOamForPpu());
+            assertFalse(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+        }
+    }
+
+    @Test
+    public void ppuOamOwnershipTransitionIsObservableAtAcquireAndRelease() {
+        Fixture fixture = new Fixture(true);
+        fixture.start();
+
+        fixture.tick(6);
+        assertFalse(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+        fixture.tick(1);
+        assertFalse(fixture.dma.ownedOamForPpuBeforeTick());
+        assertTrue(fixture.dma.ownsOamForPpu());
+        assertTrue(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+
+        fixture.tick(639);
+        assertFalse(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+        fixture.tick(1);
+        assertTrue(fixture.dma.ownedOamForPpuBeforeTick());
+        assertFalse(fixture.dma.ownsOamForPpu());
+        assertTrue(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
+    }
+
+    @Test
     public void normalSpeedCgbUsesItsOamReaderClockPhase() {
         Fixture fixture = new Fixture(true);
         fixture.start();
@@ -116,6 +149,7 @@ public class DmaTest {
         fixture.start();
         fixture.tick(1);
         assertTrue(fixture.dma.ownsOamForPpu());
+        assertFalse(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
     }
 
     @Test
@@ -145,6 +179,7 @@ public class DmaTest {
             fixture.dma.tick(true);
         }
 
+        assertFalse(fixture.dma.hasPpuOamOwnershipTransitionThisTick());
         assertEquals(0x40, fixture.oam.getByte(0xfe00));
         assertEquals(0x41, fixture.oam.getByte(0xfe01));
         assertEquals(0x42, fixture.oam.getByte(0xfe02));
@@ -239,6 +274,7 @@ public class DmaTest {
         copiedFinalByte.dma.tick(true, false);
         assertTrue(copiedFinalByte.dma.ownedOamForPpuBeforeTick());
         assertFalse(copiedFinalByte.dma.ownsOamForPpu());
+        assertTrue(copiedFinalByte.dma.hasPpuOamOwnershipTransitionThisTick());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.gpu.Mode;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -154,6 +155,92 @@ public class HdmaTest {
     }
 
     @Test
+    public void cpuHdmaPhaseFlagsAreSampledOnlyAtObservableRequestEdges() {
+        Fixture inactive = new Fixture();
+        assertFalse(inactive.hdma.requiresCpuHdmaPhaseFlags());
+
+        Fixture countdown = hblankRequestCountdown();
+        assertFalse(countdown.hdma.requiresCpuHdmaPhaseFlags());
+        countdown.advanceHblankRequest(2);
+        assertTrue(countdown.hdma.requiresCpuHdmaPhaseFlags());
+        countdown.hdma.advanceHblankRequest(true, true, true);
+        var capturedEdge = (Hdma.HdmaState) countdown.hdma.captureState();
+        assertTrue(capturedEdge.requestOverlappedCpuWrite());
+        assertTrue(capturedEdge.interruptEntryWonArbitration());
+
+        Fixture unresolved = hblankRequestCountdown();
+        unresolved.advanceHblankRequest(3);
+        assertTrue(unresolved.hdma.requiresCpuHdmaPhaseFlags());
+        unresolved.hdma.advanceHblankRequest(false, false, true);
+        assertTrue(unresolved.hdma.isInterruptEntryRequestOwner());
+
+        Fixture aged = hblankRequestCountdown();
+        aged.advanceHblankRequest(4);
+        assertFalse(aged.hdma.requiresCpuHdmaPhaseFlags());
+
+        Fixture outsideWindow = hblankRequestCountdown();
+        outsideWindow.advanceHblankRequest(3);
+        outsideWindow.hdma.onGpuTiming(1, 252);
+        assertFalse(outsideWindow.hdma.requiresCpuHdmaPhaseFlags());
+
+        Fixture halted = hblankRequestCountdown();
+        halted.advanceHblankRequest(2);
+        halted.hdma.onCpuHaltState(true);
+        assertFalse(halted.hdma.requiresCpuHdmaPhaseFlags());
+    }
+
+    @Test
+    public void cpuInstructionPhaseIsCapturedAtCountdownEdgeAfterSpeedSwitch() {
+        Fixture fixture = new Fixture(2);
+        fixture.hdma.onLcdSwitch(true);
+        fixture.hdma.onGpuTiming(0, 120);
+        fixture.hdma.onGpuUpdate(Mode.PixelTransfer);
+        fixture.startTransfer(0x80);
+        assertFalse(fixture.hdma.onSpeedSwitch());
+        fixture.hdma.onGpuTiming(0, 448);
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        fixture.hdma.onSpeedSwitchComplete();
+
+        fixture.advanceHblankRequest(2);
+        assertTrue(fixture.hdma.requiresCpuHdmaPhaseFlags());
+        fixture.hdma.advanceHblankRequest(false, true, false);
+        assertTrue(fixture.hdma.preemptsCpuInstructionForSpeedSwitchWake());
+    }
+
+    @Test
+    public void omittedCpuHdmaPhaseFlagsDoNotChangeAnyNonObservableRequestState() {
+        assertIgnoredCpuPhaseFlags(hdmaState(new Fixture()));
+
+        Fixture countdown = hblankRequestCountdown();
+        assertIgnoredCpuPhaseFlags(hdmaState(countdown));
+
+        Fixture finalCountdownTick = hblankRequestCountdown();
+        finalCountdownTick.advanceHblankRequest(1);
+        assertIgnoredCpuPhaseFlags(hdmaState(finalCountdownTick));
+
+        Fixture aged = hblankRequestCountdown();
+        aged.advanceHblankRequest(4);
+        assertIgnoredCpuPhaseFlags(hdmaState(aged));
+
+        Fixture queuedNextRequest = hblankRequestCountdown(0x81);
+        queuedNextRequest.advanceHblankRequest(4);
+        queuedNextRequest.hdma.onGpuUpdate(Mode.HBlank);
+        assertTrue(hdmaState(queuedNextRequest).nextHblankRequestTicks() > 0);
+        assertFalse(queuedNextRequest.hdma.requiresCpuHdmaPhaseFlags());
+        assertIgnoredCpuPhaseFlags(hdmaState(queuedNextRequest));
+
+        Fixture outsideWindow = hblankRequestCountdown();
+        outsideWindow.advanceHblankRequest(3);
+        outsideWindow.hdma.onGpuTiming(1, 252);
+        assertIgnoredCpuPhaseFlags(hdmaState(outsideWindow));
+
+        Fixture halted = hblankRequestCountdown();
+        halted.advanceHblankRequest(2);
+        halted.hdma.onCpuHaltState(true);
+        assertIgnoredCpuPhaseFlags(hdmaState(halted));
+    }
+
+    @Test
     public void fetchedInstructionOwnsARequestUntilItRetires() {
         Fixture fixture = synchronizedHblankRequest(1);
 
@@ -243,6 +330,83 @@ public class HdmaTest {
         fixture.hdma.onGpuUpdate(Mode.HBlank);
         fixture.advanceHblankRequest(3);
         return fixture;
+    }
+
+    private Fixture hblankRequestCountdown() {
+        return hblankRequestCountdown(0x80);
+    }
+
+    private Fixture hblankRequestCountdown(int control) {
+        Fixture fixture = new Fixture();
+        fixture.hdma.onLcdSwitch(true);
+        fixture.hdma.onGpuTiming(1, 240);
+        fixture.hdma.onGpuUpdate(Mode.PixelTransfer);
+        fixture.startTransfer(control);
+        fixture.hdma.onGpuTiming(1, 248);
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        fixture.hdma.onGpuTiming(1, 249);
+        return fixture;
+    }
+
+    private Hdma.HdmaState hdmaState(Fixture fixture) {
+        return (Hdma.HdmaState) fixture.hdma.captureState();
+    }
+
+    private void assertIgnoredCpuPhaseFlags(Hdma.HdmaState initialState) {
+        Fixture predicate = new Fixture();
+        predicate.hdma.restoreState(initialState);
+        assertFalse(predicate.hdma.requiresCpuHdmaPhaseFlags());
+
+        for (int flags = 0; flags < 8; flags++) {
+            Fixture expected = new Fixture();
+            Fixture actual = new Fixture();
+            expected.hdma.restoreState(initialState);
+            actual.hdma.restoreState(initialState);
+
+            expected.hdma.advanceHblankRequest(false, false, false);
+            actual.hdma.advanceHblankRequest((flags & 1) != 0,
+                    (flags & 2) != 0, (flags & 4) != 0);
+
+            assertSameHdmaState(hdmaState(expected), hdmaState(actual));
+        }
+    }
+
+    private void assertSameHdmaState(Hdma.HdmaState expected, Hdma.HdmaState actual) {
+        assertEquals(expected.gpuMode(), actual.gpuMode());
+        assertEquals(expected.transferInProgress(), actual.transferInProgress());
+        assertEquals(expected.hblankTransfer(), actual.hblankTransfer());
+        assertEquals(expected.lcdEnabled(), actual.lcdEnabled());
+        assertEquals(expected.length(), actual.length());
+        assertEquals(expected.src(), actual.src());
+        assertEquals(expected.dst(), actual.dst());
+        assertEquals(expected.tick(), actual.tick());
+        assertArrayEquals(expected.blockData(), actual.blockData());
+        assertEquals(expected.hblankRequestTicks(), actual.hblankRequestTicks());
+        assertEquals(expected.hblankRequestAge(), actual.hblankRequestAge());
+        assertEquals(expected.nextHblankRequestTicks(), actual.nextHblankRequestTicks());
+        assertEquals(expected.nextHblankRequestAge(), actual.nextHblankRequestAge());
+        assertEquals(expected.sourceBytesTransferred(), actual.sourceBytesTransferred());
+        assertEquals(expected.cpuBusValue(), actual.cpuBusValue());
+        assertEquals(expected.stopAfterCurrentBlock(), actual.stopAfterCurrentBlock());
+        assertEquals(expected.preserveLengthAfterCurrentBlock(), actual.preserveLengthAfterCurrentBlock());
+        assertEquals(expected.speedSwitchInProgress(), actual.speedSwitchInProgress());
+        assertEquals(expected.speedSwitchStartedWithoutRequest(), actual.speedSwitchStartedWithoutRequest());
+        assertEquals(expected.pauseOamDmaForSpeedSwitchBurst(), actual.pauseOamDmaForSpeedSwitchBurst());
+        assertEquals(String.valueOf(expected.wakeRequestArbitration()),
+                String.valueOf(actual.wakeRequestArbitration()));
+        assertEquals(expected.gpuLine(), actual.gpuLine());
+        assertEquals(expected.gpuTicksInLine(), actual.gpuTicksInLine());
+        assertEquals(expected.gpuCpuClockRephased(), actual.gpuCpuClockRephased());
+        assertEquals(expected.hblankStartTicksInLine(), actual.hblankStartTicksInLine());
+        assertEquals(expected.cpuHalted(), actual.cpuHalted());
+        assertEquals(String.valueOf(expected.haltHdmaState()), String.valueOf(actual.haltHdmaState()));
+        assertEquals(expected.haltEnteredThisTick(), actual.haltEnteredThisTick());
+        assertEquals(expected.requestOverlappedCpuWrite(), actual.requestOverlappedCpuWrite());
+        assertEquals(expected.interruptEntryWonArbitration(), actual.interruptEntryWonArbitration());
+        assertEquals(String.valueOf(expected.cpuRequestArbitration()),
+                String.valueOf(actual.cpuRequestArbitration()));
+        assertEquals(expected.cpuRequestAllowsLateInterrupt(), actual.cpuRequestAllowsLateInterrupt());
+        assertEquals(expected.haltOpcodeRequestLatched(), actual.haltOpcodeRequestLatched());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Reduce steady-state per-tick work across joypad, STAT/GPU timing, LCDC/OAM/window, DMA/HDMA, and Game Genie lookup paths.
- Pack CGB background FIFO pixel attributes into single live and cleared queues while preserving the existing portable snapshot layout at capture and restore boundaries.
- Keep the 14 changes as separate commits for review and bisectability.

## Validation

- Core test suite: 1202 tests passed, with 8 intentional performance skips.
- Direct six-pair baseline comparison: 3 wins each; paired-delta median +0.189%. Baseline/candidate aggregate medians were 97.366/96.919 FPS, within host noise; candidate mean was +1.028%.
- The packed-FIFO candidate won 6/6 and improved median performance by +3.713%.
- Forced suppression produced 600 emulated and 300 presented frames, with byte-identical PCM versus full presentation.
- Full-render audio cadence p50/p95/p99/max was 16.660/17.009/17.922/23.478 ms, with zero gaps over 25 ms and zero queue debt.
- Baseline cadence was 16.671/17.056/17.851/26.458 ms, with one gap over 25 ms and zero queue debt.