### PR TITLE
Restore Harry Potter intro performance

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -623,8 +623,8 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                         }
                         if (oldPosition <= 158
                                 && mode0IntFrom == Integer.MAX_VALUE
-                                && pixelTransferPhase.hasSpriteAtMode0PredictionEdge()
-                                && pixelTransferPhase.getPosition() > 158) {
+                                && pixelTransferPhase.getPosition() > 158
+                                && pixelTransferPhase.hasSpriteAtMode0PredictionEdge()) {
                             mode0IntFrom = ticksInLine + 3;
                         }
                         if (active) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
@@ -9,6 +9,8 @@ import eu.rekawek.coffeegb.core.timer.Timer;
 
 public class SoundMode3 extends AbstractSoundMode {
 
+    private static final int[] VOLUME_SHIFTS = {4, 0, 1, 2};
+
     private static final int[] DMG_WAVE =
             new int[]{
                     0x84, 0x40, 0x43, 0xaa, 0x2d, 0x78, 0x92, 0x3c,
@@ -22,6 +24,8 @@ public class SoundMode3 extends AbstractSoundMode {
             };
 
     private final Ram waveRam = new Ram(0xff30, 0x10);
+
+    private final int[] waveRamData = waveRam.getSpace();
 
     byte[] copyDebugWaveRam() {
         int[] source = waveRam.getSpace();
@@ -37,6 +41,10 @@ public class SoundMode3 extends AbstractSoundMode {
     // counts 2 MHz APU cycles: the CH3 frequency counter is clocked by the 2 MHz APU
     // clock, so the sample fetches are quantized to that lattice
     private int freqDivider;
+
+    private int frequencyPeriod = 2048;
+
+    private int volumeShift = VOLUME_SHIFTS[0];
 
     private int lastOutput;
 
@@ -121,6 +129,7 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     protected void setNr2(int value) {
         super.setNr2(value);
+        volumeShift = VOLUME_SHIFTS[(value >> 5) & 0b11];
         if (channelEnabled) {
             lastOutput = getBufferedOutput();
         }
@@ -129,21 +138,25 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     protected void setNr3(int value) {
         super.setNr3(value);
+        updateFrequencyPeriod();
     }
 
     @Override
     public void setNr4(int value) {
+        // trigger() runs from super.setNr4(), so cache the period with the newly written
+        // high frequency bits before delegating.
+        frequencyPeriod = 2048 - (nr3 | ((value & 0b111) << 8));
         if (!gbc && (value & (1 << 7)) != 0) {
             // retriggering the channel while it is about to fetch a sample corrupts the
             // first bytes of the wave RAM
             if (isEnabled() && freqDivider <= 1) {
-                int pos = ((i + 1) % 32) / 2;
+                int pos = ((i + 1) & 31) >> 1;
                 if (pos < 4) {
-                    waveRam.setByte(0xff30, waveRam.getByte(0xff30 + pos));
+                    waveRamData[0] = waveRamData[pos];
                 } else {
                     pos = pos & ~3;
                     for (int j = 0; j < 4; j++) {
-                        waveRam.setByte(0xff30 + j, waveRam.getByte(0xff30 + ((pos + j) % 0x10)));
+                        waveRamData[j] = waveRamData[(pos + j) & 15];
                     }
                 }
             }
@@ -163,6 +176,7 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     public void stop() {
         super.stop();
+        updateDerivedRegisters();
         i = 0;
         lastOutput = 0;
         buffer = 0;
@@ -179,7 +193,7 @@ public class SoundMode3 extends AbstractSoundMode {
         i = 0;
         // the first wave position advance is delayed by 3 extra APU cycles and does not
         // fetch a sample; the stale buffer keeps playing until the second advance
-        freqDivider = getFrequency() + 3;
+        freqDivider = frequencyPeriod + 3;
         triggered = !gbc;
         if (gbc) {
             // CGB wave-RAM access is redirected to the current byte immediately,
@@ -198,7 +212,7 @@ public class SoundMode3 extends AbstractSoundMode {
         }
         if (clock2Mhz && --freqDivider == 0) {
             resetFreqDivider();
-            i = (i + 1) % 32;
+            i = (i + 1) & 31;
             int stale = applyVolume((buffer >> 4) & 0x0f);
             int out = getWaveEntry();
             // the first advance after the trigger fetches the sample (opening the CPU
@@ -214,20 +228,17 @@ public class SoundMode3 extends AbstractSoundMode {
         return lastOutput;
     }
 
-    private int getVolume() {
-        return (getNr2() >> 5) & 0b11;
-    }
-
     private int getWaveEntry() {
         ticksSinceRead = 0;
-        lastReadAddr = 0xff30 + i / 2;
-        buffer = waveRam.getByte(lastReadAddr);
+        int waveRamIndex = i >> 1;
+        lastReadAddr = 0xff30 + waveRamIndex;
+        buffer = waveRamData[waveRamIndex];
         return getBufferedOutput();
     }
 
     private int getBufferedOutput() {
         int b = buffer;
-        if (i % 2 == 0) {
+        if ((i & 1) == 0) {
             b = (b >> 4) & 0x0f;
         } else {
             b = b & 0x0f;
@@ -236,22 +247,20 @@ public class SoundMode3 extends AbstractSoundMode {
     }
 
     private int applyVolume(int sample) {
-        switch (getVolume()) {
-            case 0:
-                return 0;
-            case 1:
-                return sample;
-            case 2:
-                return sample >> 1;
-            case 3:
-                return sample >> 2;
-            default:
-                throw new IllegalStateException();
-        }
+        return sample >> volumeShift;
     }
 
     private void resetFreqDivider() {
-        freqDivider = getFrequency();
+        freqDivider = frequencyPeriod;
+    }
+
+    private void updateFrequencyPeriod() {
+        frequencyPeriod = 2048 - (nr3 | ((nr4 & 0b111) << 8));
+    }
+
+    private void updateDerivedRegisters() {
+        updateFrequencyPeriod();
+        volumeShift = VOLUME_SHIFTS[(nr2 >> 5) & 0b11];
     }
 
     @Override
@@ -280,6 +289,7 @@ public class SoundMode3 extends AbstractSoundMode {
             throw new IllegalArgumentException("Invalid state type");
         }
         super.restoreState(mem.abstractSoundMemento);
+        updateDerivedRegisters();
         this.waveRam.restoreState(mem.waveRamMemento);
         this.freqDivider = mem.freqDivider;
         this.lastOutput = mem.lastOutput;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMode3Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMode3Test.java
@@ -10,11 +10,96 @@ import static org.junit.Assert.assertEquals;
 public class SoundMode3Test {
 
     @Test
+    public void frequencyLowWriteAffectsTheNextReloadWithoutRestartingTheTimer() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0x30);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xfc);
+        mode.setByte(0xff1e, 0x87);
+
+        // The running trigger delay keeps its period of four APU cycles, while the
+        // following reload observes the newly written period of one APU cycle.
+        mode.setByte(0xff1d, 0xff);
+        assertTicks(mode, 14, 0);
+        assertEquals(3, mode.tick());
+    }
+
+    @Test
+    public void frequencyHighWriteAffectsTheNextReloadWithoutRestartingTheTimer() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0xb0);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xff);
+        mode.setByte(0xff1e, 0x87);
+
+        // A bare NR34 write changes the next reload to 257 APU cycles without
+        // restarting the already running trigger delay.
+        mode.setByte(0xff1e, 0x06);
+        assertTicks(mode, 520, 0);
+        assertEquals(11, mode.tick());
+    }
+
+    @Test
+    public void triggerUsesTheNewFrequencyHighBits() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0xa0);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xff);
+
+        // NR34 changes the high bits from zero to seven and triggers in the same write.
+        // Period one plus the three-cycle trigger delay produces the first fetch at T7
+        // and the first non-stale output at T9.
+        mode.setByte(0xff1e, 0x87);
+        assertTicks(mode, 8, 0);
+        assertEquals(10, mode.tick());
+    }
+
+    @Test
+    public void allVolumeCodesUpdateTheCurrentOutputImmediately() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0xf0);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xff);
+        mode.setByte(0xff1e, 0x87);
+        assertTicks(mode, 8, 0);
+        assertEquals(15, mode.tick());
+
+        mode.setByte(0xff1c, 0x00);
+        assertEquals(0, mode.getCurrentOutput());
+        mode.setByte(0xff1c, 0x20);
+        assertEquals(15, mode.getCurrentOutput());
+        mode.setByte(0xff1c, 0x40);
+        assertEquals(7, mode.getCurrentOutput());
+        mode.setByte(0xff1c, 0x60);
+        assertEquals(3, mode.getCurrentOutput());
+    }
+
+    @Test
+    public void restoreRebuildsFrequencyAndVolumeDerivedState() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0xe0);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xff);
+        mode.setByte(0xff1e, 0x87);
+        var state = mode.captureState();
+
+        mode.setByte(0xff1c, 0x00);
+        mode.setByte(0xff1d, 0x00);
+        mode.setByte(0xff1e, 0x06);
+        mode.restoreState(state);
+
+        assertTicks(mode, 8, 0);
+        assertEquals(14, mode.tick());
+    }
+
+    @Test
     public void mutedRetriggerDoesNotLeakStaleWaveSample() {
-        SpeedMode speedMode = new SpeedMode(false);
-        Timer timer = new Timer(new InterruptManager(false), speedMode);
-        SoundMode3 mode = new SoundMode3(new FrameSequencer(), timer, false);
-        mode.start();
+        SoundMode3 mode = newDmgMode();
 
         mode.setByte(0xff30, 0xff);
         mode.setByte(0xff31, 0xff);
@@ -32,6 +117,20 @@ public class SoundMode3Test {
         mode.setByte(0xff1e, 0x87);
         for (int i = 0; i < 12; i++) {
             assertEquals(0, mode.tick());
+        }
+    }
+
+    private static SoundMode3 newDmgMode() {
+        SpeedMode speedMode = new SpeedMode(false);
+        Timer timer = new Timer(new InterruptManager(false), speedMode);
+        SoundMode3 mode = new SoundMode3(new FrameSequencer(), timer, false);
+        mode.start();
+        return mode;
+    }
+
+    private static void assertTicks(SoundMode3 mode, int ticks, int output) {
+        for (int i = 0; i < ticks; i++) {
+            assertEquals(output, mode.tick());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Cache SoundMode3's frequency period and NR32 volume shift, use its stable wave RAM backing storage directly, and replace modulo operations with equivalent masks. Derived values are rebuilt from canonical registers on stop and restore, so serialized state is unchanged.
- Defer the rare 10-sprite mode-0 prediction-edge scan until the actual 158-to-159 pixel-transfer crossing.

## Root cause

The regression came from post-baseline wrapper and derived-register work in the high-frequency CH3 sample path, plus a sprite scan placed before a crossing predicate that is false on nearly every pixel-transfer tick.

## Performance evidence

Interleaved Harry Potter intro FPS measurements:

- Pair 1: baseline 89.823 FPS, patch 90.862 FPS.
- Pair 2: baseline 93.353 FPS, patch 91.811 FPS.
- Pair centers: baseline 91.588 FPS, patch 91.337 FPS (-0.27%), equivalent within measurement noise.

Audio cadence:

- Baseline p50/p95/p99/max: 16.032 / 29.948 / 34.464 / 41.842 ms; gaps >25 ms / >50 ms: 62 / 0; pacing debt: 0.
- Patch p50/p95/p99/max: 15.299 / 29.801 / 34.717 / 38.722 ms; gaps >25 ms / >50 ms: 71 / 0; pacing debt: 0.

The patch/current audio probe hash is `88db99894b8008b34876417657305d00af3ef0e6e893f7b514d7f60e753a45a2` across 600 frames and 41,943,000 stereo pairs, with an 18-frame maximum quiet run. The older baseline hash differs because later accuracy corrections changed samples; this patch preserves current `master` output.

The following Harry Potter scripts were run:

- `scripts/measure-harry-potter-intro-fps.sh`
- `scripts/measure-harry-potter-intro-audio-timing.sh`
- `scripts/measure-harry-potter-intro-audio.sh`

## Validation

- Focused mode-0/STAT/OAM tests: 220/220.
- GPU tests: 304/304.
- Full core/controller reactor:
  - Core: 1,445 tests, 0 failures/errors, 8 skips.
  - Controller: 886 tests, 0 failures/errors, 7 skips.
- Mooneye PPU: 12/12.
- Gambatte shard: 36/36.
- `git diff --check`.
