### PR TITLE
Eliminate Windows UI audio gaps

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -3192,6 +3192,7 @@ class BasicController private constructor(
     var nextGameboy: Gameboy? = preparedGameboy
     var nextSession: Session? = null
     var nextSnapshotManager: SnapshotManager? = null
+    var preparedRewindSeed: RewindManager.PreparedSessionSeed? = null
     try {
       // Finish constructing and initializing the candidate before releasing the current session.
       // A core-startup failure must leave the old game available for resume/cancel semantics.
@@ -3203,7 +3204,11 @@ class BasicController private constructor(
           } else {
             null
           }
+      // Keep snapshot preparation inside the candidate transaction: a capture failure must
+      // discard this still-staged session and leave the live session/history untouched.
+      preparedRewindSeed = rewindManager.prepareSessionSeed(checkNotNull(nextSession))
     } catch (e: Exception) {
+      preparedRewindSeed?.discard()
       try {
         nextSession?.discardUnstarted()
       } catch (cleanupFailure: RuntimeException) {
@@ -3222,7 +3227,8 @@ class BasicController private constructor(
     if (job.clearPatches) {
       patches.clear()
     }
-    rewindManager.clear()
+    rewindManager.beginSession(checkNotNull(nextSession), preparedRewindSeed)
+    preparedRewindSeed = null
     debugCheckpointHistory.clear(DebugHistoryTruncationReason.SESSION_BOUNDARY)
 
     val previousSession = session

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RewindManager.kt
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.controller
 
+import com.google.common.annotations.VisibleForTesting
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.controller.state.MachineSnapshot
 import eu.rekawek.coffeegb.controller.state.SessionSnapshot
@@ -10,7 +11,7 @@ import eu.rekawek.coffeegb.controller.state.SessionSnapshot
  * Rewinding restores one recorded state per rendered frame, so it plays backwards at
  * [RECORD_INTERVAL] times the game speed.
  */
-internal class RewindManager(
+internal open class RewindManager(
     val enabled: Boolean = true,
     durationSeconds: Int = DEFAULT_DURATION_SECONDS,
     private val memoryBudgetBytes: Long = DEFAULT_MEMORY_BUDGET_BYTES,
@@ -54,6 +55,13 @@ internal class RewindManager(
 
   private var frameCounter = 0
 
+  /**
+   * Incremental baseline captured while a fully initialized candidate is still staged. It is not
+   * a rewind entry: the first post-frame session capture consumes it only as an immutable sharing
+   * source, then becomes the first history entry in its own right.
+   */
+  private var preparedSessionSeed: SessionSnapshot? = null
+
   internal var captureCount = 0
     private set
 
@@ -73,6 +81,9 @@ internal class RewindManager(
     // This is intentionally the first operation. A disabled manager does not advance cadence,
     // inspect the live machine, allocate a capture DTO, or create a snapshot.
     if (!enabled) return
+    // A session seed cannot describe a machine-only recording path. Discard it before the
+    // suppressed-frame return as well: machine and session histories must never share it.
+    discardPreparedSessionSeed()
     // A suppressed frame is intentionally not a rewind point: resuming a snapshot from the
     // matching full-output phase keeps rewind presentation coherent. Check before advancing the
     // six-frame cadence so sustained every-other-frame suppression cannot phase-lock captures.
@@ -97,13 +108,28 @@ internal class RewindManager(
     if (!enabled) return
     if (!session.gameboy.isCurrentVisibleFrameFullyRendering) return
     selectHistory(HistoryKind.SESSION)
-    if (frameCounter++ % RECORD_INTERVAL != 0) return
-    if (states.size == capacity) states.removeFirst()
-    val previous = (states.lastOrNull() as? SessionEntry)?.snapshot
+    if (frameCounter % RECORD_INTERVAL != 0) {
+      frameCounter++
+      return
+    }
+    // Capture before mutating cadence, retained history, or the staged seed. A capture failure
+    // therefore leaves the candidate baseline available for the next successful frame.
+    val usesPreparedSeed = preparedSessionSeed != null
+    val previous = preparedSessionSeed ?: (states.lastOrNull() as? SessionEntry)?.snapshot
     val entry = SessionEntry(SessionSnapshot.capture(session, previous))
+    if (states.size == capacity) states.removeFirst()
     states.addLast(entry)
+    frameCounter++
+    preparedSessionSeed = null
     approximateRetainedBytes =
-        saturatingAdd(approximateRetainedBytes, approximateCaptureBytes(entry))
+        if (usesPreparedSeed) {
+          // The prepared seed was not a history entry. Its capture stats describe only changes
+          // relative to a graph that is about to be released, so account the first real entry as
+          // a complete root rather than under-counting all pages it inherited from the seed.
+          retainedBytes(states.toList())
+        } else {
+          saturatingAdd(approximateRetainedBytes, approximateCaptureBytes(entry))
+        }
     captureCount++
     enforceMemoryBudget()
   }
@@ -137,6 +163,32 @@ internal class RewindManager(
     frameCounter = 0
     approximateRetainedBytes = 0
     historyKind = null
+    preparedSessionSeed = null
+  }
+
+  /**
+   * Captures an incremental baseline for a fully constructed but not yet committed session.
+   * Preparation deliberately has no history, cadence, or capture-count side effects.
+   */
+  internal open fun prepareSessionSeed(session: Session): PreparedSessionSeed? {
+    if (!enabled) return null
+    return PreparedSessionSeed(this, session, SessionSnapshot.capture(session))
+  }
+
+  /**
+   * Starts a new session history at the ownership boundary. The prepared baseline remains hidden
+   * until the first successful post-frame [record] uses it as its incremental predecessor.
+   */
+  internal fun beginSession(session: Session, seed: PreparedSessionSeed?) {
+    clear()
+    if (!enabled) {
+      seed?.discard()
+      return
+    }
+    preparedSessionSeed = seed?.take(this, session)
+    // The manager owns this transient snapshot until the first real frame consumes it. Keep the
+    // conservative ledger honest during that interval even though it is not rewindable history.
+    preparedSessionSeed?.let { approximateRetainedBytes = SessionSnapshot.retainedBytes(listOf(it)) }
   }
 
   internal val historySize: Int
@@ -144,12 +196,59 @@ internal class RewindManager(
 
   internal fun snapshotsForTesting(): List<MachineSnapshot> = states.map(RewindEntry::machine)
 
-  internal fun retainedBytesForTesting(): Long =
-      retainedBytes(states.toList())
+  internal fun retainedBytesForTesting(): Long {
+    val retainedHistory = retainedBytes(states.toList())
+    val retainedSeed = preparedSessionSeed?.let { SessionSnapshot.retainedBytes(listOf(it)) } ?: 0L
+    return saturatingAdd(retainedHistory, retainedSeed)
+  }
+
+  @VisibleForTesting
+  internal val approximateRetainedBytesForTesting: Long
+    get() = approximateRetainedBytes
+
+  @VisibleForTesting
+  internal val hasPreparedSessionSeed: Boolean
+    get() = preparedSessionSeed != null
 
   private fun selectHistory(requested: HistoryKind) {
     if (historyKind != null && historyKind != requested) clear()
     historyKind = requested
+  }
+
+  private fun discardPreparedSessionSeed() {
+    if (preparedSessionSeed == null) return
+    preparedSessionSeed = null
+    // A prepared seed is only installed after beginSession(), which clears history first. Keep
+    // this robust for machine-only test paths and future callers that invalidate it early.
+    approximateRetainedBytes = retainedBytes(states.toList())
+  }
+
+  /** Opaque ownership token for a candidate-only snapshot baseline. */
+  internal class PreparedSessionSeed private constructor(
+      private val owner: RewindManager,
+      private val session: Session,
+      private var snapshot: SessionSnapshot?,
+  ) {
+
+    internal fun take(owner: RewindManager, session: Session): SessionSnapshot? {
+      if (this.owner !== owner || this.session !== session) {
+        discard()
+        return null
+      }
+      return snapshot.also { snapshot = null }
+    }
+
+    internal fun discard() {
+      snapshot = null
+    }
+
+    companion object {
+      operator fun invoke(
+          owner: RewindManager,
+          session: Session,
+          snapshot: SessionSnapshot,
+      ): PreparedSessionSeed = PreparedSessionSeed(owner, session, snapshot)
+    }
   }
 
   private fun enforceMemoryBudget() {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -6,12 +6,17 @@ import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootState
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.Gameboy.GameboyConfiguration
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.ir.InfraredEndpoint
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.DesktopRomPersistenceStore
 import eu.rekawek.coffeegb.controller.state.MachineState
 import eu.rekawek.coffeegb.controller.state.StateIdentity
 import eu.rekawek.coffeegb.controller.state.StateRomHashes
 import eu.rekawek.coffeegb.controller.state.StateStore
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties.Feature
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties.Mapper
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeType
 import eu.rekawek.coffeegb.core.memory.cart.Rom
@@ -19,6 +24,7 @@ import java.security.MessageDigest
 import java.util.Base64
 import java.util.LinkedHashMap
 import java.util.concurrent.CancellationException
+import org.slf4j.LoggerFactory
 
 internal fun interface SessionPreparer {
   fun prepare(properties: EmulatorProperties, event: LoadRomEvent): PreparedSession
@@ -28,6 +34,7 @@ internal fun interface SessionPreparer {
 internal class RomSessionPreparer(
     internal val bootStateCache: BootStateCache = BootStateCache(),
     private val configure: (Gameboy.GameboyConfiguration) -> Unit = {},
+    internal val runtimeWarmupCache: RuntimeWarmupCache = RuntimeWarmupCache.shared,
 ) : SessionPreparer {
 
   override fun prepare(properties: EmulatorProperties, event: LoadRomEvent): PreparedSession {
@@ -54,6 +61,8 @@ internal class RomSessionPreparer(
       return PreparedSession.FromDetachedState(config, it, romHashes, stateStore)
     }
 
+    warmRuntime(config)
+
     bootStateCache.getOrCreate(config)?.let {
       return PreparedSession.FromBootState(config, it, romHashes, stateStore)
     }
@@ -69,7 +78,197 @@ internal class RomSessionPreparer(
       throw CancellationException("ROM preparation superseded")
     }
   }
+
+  /**
+   * Warms ordinary SKIP-start game code before the candidate reaches the controller thread.
+   * This is intentionally best-effort: a failed disposable machine must never reject a playable
+   * ROM. Cancellation remains observable because a superseded load must not continue preparing.
+   */
+  private fun warmRuntime(config: GameboyConfiguration) {
+    try {
+      runtimeWarmupCache.warm(config, ::ensureActive)
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: VirtualMachineError) {
+      throw error
+    } catch (error: ThreadDeath) {
+      throw error
+    } catch (error: Throwable) {
+      ensureActive()
+      LOG.warn(
+          "Disposable runtime warmup failed ({}); continuing with the requested ROM load",
+          error.javaClass.simpleName,
+      )
+    }
+  }
+
+  private companion object {
+    private val LOG = LoggerFactory.getLogger(RomSessionPreparer::class.java)
+  }
 }
+
+/** Invokes a disposable, service-free machine without making tests execute millions of ticks. */
+internal fun interface RuntimeWarmupExecutor {
+  fun warm(config: GameboyConfiguration, ticks: Int, ensureActive: () -> Unit)
+}
+
+/**
+ * Process-local bounded cache of JIT warmups, keyed by execution shape rather than ROM identity.
+ * HotSpot profiles code globally, so title bytes do not warrant another eight-million-tick run;
+ * mapper/type, profile, and every cartridge feature that can alter an execution branch do.
+ */
+internal class RuntimeWarmupCache(
+    private val capacity: Int = DEFAULT_CAPACITY,
+    private val executor: RuntimeWarmupExecutor = GameboyRuntimeWarmupExecutor,
+) {
+
+  private val monitor = Object()
+  private val completed =
+      object : LinkedHashMap<RuntimeWarmupKey, Unit>(capacity + 1, 0.75f, true) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<RuntimeWarmupKey, Unit>?
+        ): Boolean = size > capacity
+      }
+  private val inProgress = mutableSetOf<RuntimeWarmupKey>()
+
+  init {
+    require(capacity > 0) { "Runtime warmup cache capacity must be positive" }
+  }
+
+  internal var hitCount = 0
+    private set
+
+  internal val size: Int
+    get() = synchronized(monitor) { completed.size }
+
+  /**
+   * Performs at most one successful warmup per shape. Waiters observe a completed owner run or
+   * take ownership after its cancellation/failure; only successful, still-active runs are cached.
+   */
+  fun warm(config: GameboyConfiguration, ensureActive: () -> Unit) {
+    val key = RuntimeWarmupKey.from(config) ?: return
+    ensureActive()
+    synchronized(monitor) {
+      while (true) {
+        if (completed[key] != null) {
+          hitCount++
+          return
+        }
+        if (inProgress.add(key)) {
+          break
+        }
+        try {
+          monitor.wait()
+        } catch (interrupted: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw CancellationException("ROM preparation superseded")
+        }
+        ensureActive()
+      }
+    }
+
+    try {
+      val warmupConfig = config.forRuntimeWarmup().setPlayerInputSource(PlayerInputHub())
+      val ticks = Math.multiplyExact(WARMUP_FRAMES, warmupConfig.clockSpec.controllerTicksPerFrame())
+      executor.warm(warmupConfig, ticks, ensureActive)
+      ensureActive()
+      synchronized(monitor) {
+        completed[key] = Unit
+      }
+    } finally {
+      synchronized(monitor) {
+        inProgress.remove(key)
+        monitor.notifyAll()
+      }
+    }
+  }
+
+  private data class RuntimeWarmupKey(
+      val profileId: String,
+      val mapper: Mapper,
+      val cartridgeType: CartridgeType,
+      val gameboyColorFlag: Rom.GameboyColorFlag,
+      val romLength: Int,
+      val ramSize: Int,
+      val cartridgeFeatures: List<Feature>,
+      val displaySgbBorder: Boolean,
+      val mealybugDmgBlob: Boolean,
+      val codeBreakerRumble: Boolean,
+  ) {
+    companion object {
+      fun from(config: GameboyConfiguration): RuntimeWarmupKey? {
+        val rom = config.rom
+        if (config.bootstrapMode != BootstrapMode.SKIP ||
+            config.slotRom != null ||
+            rom.cartridgeProperties.mapper != Mapper.STANDARD ||
+            !isOrdinaryNonRtcCartridge(rom.type)) {
+          return null
+        }
+        val cartridgeFeatures = Feature.values().filter(rom.cartridgeProperties::has)
+        return RuntimeWarmupKey(
+            config.hardwareProfile.id(),
+            rom.cartridgeProperties.mapper,
+            rom.type,
+            rom.gameboyColorFlag,
+            rom.rom.size,
+            rom.ramSize,
+            cartridgeFeatures,
+            config.isDisplaySgbBorder,
+            config.isMealybugDmgBlob,
+            config.isCodeBreakerRumble,
+        )
+      }
+    }
+  }
+
+  private object GameboyRuntimeWarmupExecutor : RuntimeWarmupExecutor {
+    override fun warm(config: GameboyConfiguration, ticks: Int, ensureActive: () -> Unit) {
+      val delegate = EventBusImpl(null, "runtime-warmup", false)
+      val eventBus = StagedEventBus(delegate)
+      var gameboy: Gameboy? = null
+      try {
+        gameboy = config.build()
+        gameboy.init(
+            eventBus,
+            Peer2PeerSerialEndpoint(),
+            InfraredEndpoint.NULL_ENDPOINT,
+            null,
+        )
+        // Match the live Session receiver shape without attaching any UI/audio subscribers.
+        eventBus.activate()
+        repeat(ticks) { tick ->
+          if (tick % CANCELLATION_CHECK_TICKS == 0) {
+            ensureActive()
+          }
+          gameboy.tick()
+        }
+        ensureActive()
+      } finally {
+        try {
+          gameboy?.discardUnstarted()
+        } finally {
+          eventBus.close()
+        }
+      }
+    }
+  }
+
+  companion object {
+    const val WARMUP_FRAMES = 120
+    const val CANCELLATION_CHECK_TICKS = 4_096
+    const val DEFAULT_CAPACITY = 8
+
+    internal val shared = RuntimeWarmupCache()
+  }
+}
+
+private fun isOrdinaryNonRtcCartridge(type: CartridgeType): Boolean =
+    type == CartridgeType.ROM ||
+        type == CartridgeType.ROM_RAM ||
+        type == CartridgeType.ROM_RAM_BATTERY ||
+        type.isMbc1 ||
+        type.isMbc2 ||
+        type.isMbc5
 
 /**
  * Small process-local LRU of exact BIOS handoff states. Cache entries contain no file-backed
@@ -144,14 +343,6 @@ internal class BootStateCache(private val capacity: Int = DEFAULT_CAPACITY) {
             config.isCodeBreakerRumble,
         )
       }
-
-      private fun isOrdinaryNonRtcCartridge(type: CartridgeType): Boolean =
-          type == CartridgeType.ROM ||
-              type == CartridgeType.ROM_RAM ||
-              type == CartridgeType.ROM_RAM_BATTERY ||
-              type.isMbc1 ||
-              type.isMbc2 ||
-              type.isMbc5
 
       private fun digest(rom: Rom): String {
         val digest = MessageDigest.getInstance("SHA-256")

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/TimingTicker.kt
@@ -3,16 +3,18 @@ package eu.rekawek.coffeegb.controller
 import com.google.common.annotations.VisibleForTesting
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
 import java.util.concurrent.locks.LockSupport
+import java.util.function.LongConsumer
+import java.util.function.LongSupplier
 
 class TimingTicker
 @VisibleForTesting
 internal constructor(
-    private val nanoTime: () -> Long,
-    private val parkNanos: (Long) -> Unit,
+    private val nanoTime: LongSupplier,
+    private val parkNanos: LongConsumer,
 ) : Runnable {
-  constructor() : this(System::nanoTime, LockSupport::parkNanos)
+  constructor() : this(LongSupplier(System::nanoTime), LongConsumer(LockSupport::parkNanos))
 
-  private var deadline = nanoTime()
+  private var deadline = nanoTime.asLong
   private var ticks: Long = 0
   private var activeClock = ClockSpec.LEGACY
   private var frameNanos = activeClock.newFrameNanosecondAccumulator()
@@ -46,7 +48,7 @@ internal constructor(
       activeClock = clockSpec
       frameNanos = clockSpec.newFrameNanosecondAccumulator()
       ticks = 0
-      deadline = nanoTime()
+      deadline = nanoTime.asLong
       hasPacingDebt = false
     }
     if (++ticks < clockSpec.controllerTicksPerFrame()) {
@@ -59,9 +61,9 @@ internal constructor(
         try {
           Math.addExact(deadline, frameDurationNanos)
         } catch (_: ArithmeticException) {
-          nanoTime()
+          nanoTime.asLong
         }
-    val now = nanoTime()
+    val now = nanoTime.asLong
     hasPacingDebt = now > deadline
     if (now - deadline > MAX_CATCH_UP_NANOS) {
       // Preserve short scheduling/GC delays so subsequent frames can repay them instead of
@@ -73,12 +75,12 @@ internal constructor(
     // millisecond-ish slack depending on the OS timer, and yielding keeps fine-grained pacing
     // without relying on Java 9's unavailable spin-wait hint or pegging a core for the whole frame.
     while (true) {
-      val remaining = deadline - nanoTime()
+      val remaining = deadline - nanoTime.asLong
       if (remaining <= 0) {
         break
       }
       if (remaining > SPIN_THRESHOLD_NANOS) {
-        parkNanos(remaining - SPIN_THRESHOLD_NANOS)
+        parkNanos.accept(remaining - SPIN_THRESHOLD_NANOS)
       } else {
         Thread.yield()
       }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -136,6 +136,21 @@ internal class MachineSnapshot private constructor(
 
   internal data class ArrayDebug(val size: Int, val pageTokens: List<Any>)
 
+  /** Read-only identity probe for tests; tokens are immutable field wrappers, never payloads. */
+  internal fun debugRecordFields(ownerClassName: String): List<RecordDebug> {
+    val result = ArrayList<RecordDebug>()
+    root.visitRecords { record ->
+      if (SnapshotGraph.recordClassName(record.typeId) == ownerClassName) {
+        val fields = LinkedHashMap<String, Any>()
+        record.fields.forEach { fields[it.name] = it }
+        result += RecordDebug(Collections.unmodifiableMap(fields))
+      }
+    }
+    return Collections.unmodifiableList(result)
+  }
+
+  internal data class RecordDebug(val fieldTokens: Map<String, Any>)
+
   internal data class CaptureStats(
       val copiedPages: Int,
       val copiedPageBytes: Long,
@@ -543,7 +558,12 @@ private class BytePage(private val data: ByteArray, hash: Int) :
     SnapshotPage(PageKind.BYTE, data.size, hash) {
   override fun matches(source: Any, offset: Int): Boolean {
     source as ByteArray
-    return data.indices.all { data[it] == source[offset + it] }
+    var index = 0
+    while (index < data.size) {
+      if (data[index] != source[offset + index]) return false
+      index++
+    }
+    return true
   }
 
   override fun copyTo(target: Any, offset: Int) {
@@ -555,7 +575,12 @@ private class IntPage(private val data: IntArray, hash: Int) :
     SnapshotPage(PageKind.INT, data.size, hash) {
   override fun matches(source: Any, offset: Int): Boolean {
     source as IntArray
-    return data.indices.all { data[it] == source[offset + it] }
+    var index = 0
+    while (index < data.size) {
+      if (data[index] != source[offset + index]) return false
+      index++
+    }
+    return true
   }
 
   override fun copyTo(target: Any, offset: Int) {
@@ -567,7 +592,12 @@ private class LongPage(private val data: LongArray, hash: Int) :
     SnapshotPage(PageKind.LONG, data.size, hash) {
   override fun matches(source: Any, offset: Int): Boolean {
     source as LongArray
-    return data.indices.all { data[it] == source[offset + it] }
+    var index = 0
+    while (index < data.size) {
+      if (data[index] != source[offset + index]) return false
+      index++
+    }
+    return true
   }
 
   override fun copyTo(target: Any, offset: Int) {
@@ -579,7 +609,12 @@ private class BooleanPage(private val data: BooleanArray, hash: Int) :
     SnapshotPage(PageKind.BOOLEAN, data.size, hash) {
   override fun matches(source: Any, offset: Int): Boolean {
     source as BooleanArray
-    return data.indices.all { data[it] == source[offset + it] }
+    var index = 0
+    while (index < data.size) {
+      if (data[index] != source[offset + index]) return false
+      index++
+    }
+    return true
   }
 
   override fun copyTo(target: Any, offset: Int) {
@@ -587,36 +622,64 @@ private class BooleanPage(private val data: BooleanArray, hash: Int) :
   }
 }
 
-private class SnapshotPagePool(previous: SnapshotRecord?) {
-  private val pages = HashMap<PageKey, MutableList<SnapshotPage>>()
+private class SnapshotPagePool(private val previous: SnapshotRecord?) {
+  // A first capture needs immediate cross-array deduplication. An incremental capture begins with
+  // same-position preferred pages, so defer the map (and PageKey/bucket allocations) until one
+  // page misses and genuinely needs a graph-wide lookup.
+  private var pages: HashMap<PageKey, MutableList<SnapshotPage>>? =
+      if (previous == null) HashMap() else null
+  private var previousIndexed = previous == null
 
-  init {
-    previous?.visit { value ->
-      if (value is SnapshotPrimitiveArray) value.pages.forEach(::add)
-    }
-  }
-
-  fun reuse(
+  fun reusePreferred(
       kind: PageKind,
       source: Any,
       offset: Int,
       length: Int,
-      hash: Int,
       preferred: SnapshotPage?,
   ): SnapshotPage? {
     if (preferred != null &&
         preferred.kind == kind &&
         preferred.length == length &&
-        preferred.hash == hash &&
         preferred.matches(source, offset)) {
       return preferred
     }
-    return pages[PageKey(kind, length, hash)]?.firstOrNull { it.matches(source, offset) }
+    return null
+  }
+
+  fun reuseFallback(
+      kind: PageKind,
+      source: Any,
+      offset: Int,
+      length: Int,
+      hash: Int,
+  ): SnapshotPage? {
+    indexPreviousOnFirstPreferredMiss()
+    return pages
+        ?.get(PageKey(kind, length, hash))
+        ?.firstOrNull { it.matches(source, offset) }
   }
 
   fun add(page: SnapshotPage) {
-    val bucket = pages.getOrPut(PageKey(page.kind, page.length, page.hash), ::ArrayList)
+    // Before the first miss every selected page is its same-position predecessor, already
+    // reachable from the previous graph. There is nothing new to index yet.
+    val indexed = pages ?: return
+    val bucket = indexed.getOrPut(PageKey(page.kind, page.length, page.hash), ::ArrayList)
     if (bucket.none { it === page }) bucket += page
+  }
+
+  /**
+   * Most incremental pages are in exactly the same array position as their predecessor. Avoid
+   * scanning/indexing the complete previous graph until a page actually needs cross-position
+   * lookup; selected pages before that point are already reachable from the prior graph and are
+   * recovered when it is indexed.
+   */
+  private fun indexPreviousOnFirstPreferredMiss() {
+    if (previousIndexed) return
+    previousIndexed = true
+    pages = HashMap()
+    previous?.visit { value ->
+      if (value is SnapshotPrimitiveArray) value.pages.forEach(::add)
+    }
   }
 }
 
@@ -867,11 +930,11 @@ private object SnapshotGraph {
       countValue()
       if (source == null) return SnapshotNull
       return when (source) {
-        is Int -> reuseScalar(previous, SnapshotInt(source))
-        is Long -> reuseScalar(previous, SnapshotLong(source))
-        is Boolean -> reuseScalar(previous, SnapshotBoolean(source))
-        is Double -> reuseScalar(previous, SnapshotDoubleBits(source.toBits()))
-        is String -> reuseScalar(previous, SnapshotString(source))
+        is Int -> captureInt(source, previous)
+        is Long -> captureLong(source, previous)
+        is Boolean -> captureBoolean(source, previous)
+        is Double -> captureDouble(source, previous)
+        is String -> captureString(source, previous)
         is ByteArray -> captureBytes(source, previous as? SnapshotBytes)
         is IntArray -> captureInts(source, previous as? SnapshotInts)
         is LongArray -> captureLongs(source, previous as? SnapshotLongs)
@@ -882,7 +945,7 @@ private object SnapshotGraph {
           val id =
               enumIds[source.javaClass]
                   ?: error("Unregistered snapshot enum ${source.javaClass.name}")
-          reuseScalar(previous, SnapshotEnum(id, source.ordinal))
+          captureEnum(id, source.ordinal, previous)
         }
         else ->
             if (source.javaClass.isArray) {
@@ -893,8 +956,48 @@ private object SnapshotGraph {
       }
     }
 
-    private fun reuseScalar(previous: SnapshotValue?, candidate: SnapshotValue): SnapshotValue =
-        if (previous == candidate) previous else candidate.also { newValueNodes++ }
+    private fun captureInt(source: Int, previous: SnapshotValue?): SnapshotValue {
+      if (previous is SnapshotInt && previous.value == source) return previous
+      newValueNodes++
+      return SnapshotInt(source)
+    }
+
+    private fun captureLong(source: Long, previous: SnapshotValue?): SnapshotValue {
+      if (previous is SnapshotLong && previous.value == source) return previous
+      newValueNodes++
+      return SnapshotLong(source)
+    }
+
+    private fun captureBoolean(source: Boolean, previous: SnapshotValue?): SnapshotValue {
+      if (previous is SnapshotBoolean && previous.value == source) return previous
+      newValueNodes++
+      return SnapshotBoolean(source)
+    }
+
+    private fun captureDouble(source: Double, previous: SnapshotValue?): SnapshotValue {
+      val bits = source.toBits()
+      if (previous is SnapshotDoubleBits && previous.bits == bits) return previous
+      newValueNodes++
+      return SnapshotDoubleBits(bits)
+    }
+
+    private fun captureString(source: String, previous: SnapshotValue?): SnapshotValue {
+      if (previous is SnapshotString && previous.value == source) return previous
+      newValueNodes++
+      return SnapshotString(source)
+    }
+
+    private fun captureEnum(
+        typeId: Int,
+        ordinal: Int,
+        previous: SnapshotValue?,
+    ): SnapshotValue {
+      if (previous is SnapshotEnum && previous.typeId == typeId && previous.ordinal == ordinal) {
+        return previous
+      }
+      newValueNodes++
+      return SnapshotEnum(typeId, ordinal)
+    }
 
     private fun captureBytes(source: ByteArray, previous: SnapshotBytes?): SnapshotValue =
         capturePrimitive(
@@ -953,38 +1056,47 @@ private object SnapshotGraph {
     ): SnapshotValue {
       val pageElements = bytePageElements(kind.width)
       val pageCount = if (size == 0) 0 else (size - 1) / pageElements + 1
-      val result = ArrayList<SnapshotPage>(pageCount)
+      val compatiblePrevious =
+          previous?.takeIf { it.size == size && it.pages.size == pageCount }
+      var result: ArrayList<SnapshotPage>? = null
       repeat(pageCount) { index ->
         val offset = index * pageElements
         val length = min(pageElements, size - offset)
-        val hash = pageHash(offset, length)
-        val reused =
-            pool.reuse(
-                kind,
-                source,
-                offset,
-                length,
-                hash,
-                previous?.takeIf { it.size == size }?.pages?.getOrNull(index),
-            )
+        val preferred = compatiblePrevious?.pages?.get(index)
+        val reusedPreferred = pool.reusePreferred(kind, source, offset, length, preferred)
         val page =
-            reused
-                ?: create(offset, length, hash).also {
+            if (reusedPreferred != null) {
+              reusedPages++
+              reusedPreferred
+            } else {
+              val hash = pageHash(offset, length)
+              val reusedFallback = pool.reuseFallback(kind, source, offset, length, hash)
+              if (reusedFallback != null) {
+                reusedPages++
+                reusedFallback
+              } else {
+                create(offset, length, hash).also {
                   copiedPages++
                   copiedPageBytes += length.toLong() * kind.width
                 }
-        if (reused != null) reusedPages++
+              }
+            }
         pool.add(page)
-        result += page
+        val materialized = result
+        if (materialized != null) {
+          materialized += page
+        } else if (page !== preferred) {
+          result = ArrayList<SnapshotPage>(pageCount).also { materialized ->
+            if (compatiblePrevious != null) {
+              materialized.addAll(compatiblePrevious.pages.subList(0, index))
+            }
+            materialized += page
+          }
+        }
       }
-      if (previous != null &&
-          previous.size == size &&
-          previous.pages.size == result.size &&
-          result.indices.all { result[it] === previous.pages[it] }) {
-        return previous
-      }
+      if (result == null && compatiblePrevious != null) return compatiblePrevious
       newValueNodes++
-      return array(size, result)
+      return array(size, result ?: emptyList())
     }
 
     private fun captureObjectArray(
@@ -1060,37 +1172,42 @@ private object SnapshotGraph {
     ): SnapshotValue {
       val type = source.javaClass
       val typeId = recordIds[type] ?: error("Unregistered snapshot record ${type.name}")
-      val sameType = previous?.takeIf { it.typeId == typeId }
-      val fields =
-          StateRecordIntrospection.components(type).mapIndexed { index, component ->
-            val old =
-                sameType
-                    ?.fields
-                    ?.getOrNull(index)
-                    ?.takeIf { it.name == component.name }
-                    ?.value
+      val components = StateRecordIntrospection.components(type)
+      val compatiblePrevious =
+          previous?.takeIf {
+            it.typeId == typeId &&
+                it.fields.size == components.size &&
+                components.indices.all { index -> it.fields[index].name == components[index].name }
+          }
+      var fields: ArrayList<SnapshotField>? = null
+      components.forEachIndexed { index, component ->
+        val previousField = compatiblePrevious?.fields?.get(index)
+        val captured =
             try {
-              SnapshotField(
-                  component.name,
-                  value(component.value(source), old, depth + 1),
-              )
+              value(component.value(source), previousField?.value, depth + 1)
             } catch (failure: IllegalStateException) {
               throw IllegalStateException(
                   "${type.name}.${component.name}: ${failure.message}",
                   failure,
               )
             }
+        val materialized = fields
+        if (materialized != null) {
+          materialized +=
+              previousField?.takeIf { captured === it.value }
+                  ?: SnapshotField(component.name, captured)
+        } else if (captured !== previousField?.value) {
+          fields = ArrayList<SnapshotField>(components.size).also { materialized ->
+            if (compatiblePrevious != null) {
+              materialized.addAll(compatiblePrevious.fields.subList(0, index))
+            }
+            materialized += SnapshotField(component.name, captured)
           }
-      if (sameType != null &&
-          sameType.fields.size == fields.size &&
-          fields.indices.all {
-            fields[it].name == sameType.fields[it].name &&
-                fields[it].value === sameType.fields[it].value
-          }) {
-        return sameType
+        }
       }
+      if (fields == null && compatiblePrevious != null) return compatiblePrevious
       newValueNodes++
-      return SnapshotRecord(typeId, fields)
+      return SnapshotRecord(typeId, fields ?: emptyList())
     }
 
     private fun countValue() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -755,6 +755,83 @@ class BasicControllerTest {
   }
 
   @Test
+  fun preparedRewindSeedCommitsBeforeCandidateEventsAndFailedPreparationKeepsOldSession() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val failures = LinkedBlockingQueue<LoadRomFailedEvent>()
+    val frames = LinkedBlockingQueue<GbcFrameReadyEvent>()
+    val sourceEvents = LinkedBlockingQueue<PreparedSeedSourceEvent>()
+    val rewind = TrackingRewindManager()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<LoadRomFailedEvent>(failures::add)
+    eventBus.register<GbcFrameReadyEvent>(frames::add)
+    eventBus.register<PreparedSeedSourceEvent> {
+      rewind.sourceEventObservedAfterCommit =
+          rewind.preparationCount.get() == 1 && rewind.hasPreparedSessionSeed
+      sourceEvents.add(it)
+    }
+    val oldRom = namedRom("SEED_OLD")
+    val failingRom = namedRom("SEED_FAIL")
+    val preparer =
+        SessionPreparer { properties, event ->
+          val config =
+              Controller.createGameboyConfig(properties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+          val gameboy =
+              object : Gameboy(config) {
+                override fun init(
+                    eventBus: EventBus,
+                    serialEndpoint: SerialEndpoint,
+                    infraredEndpoint: InfraredEndpoint,
+                    console: Console?,
+                ) {
+                  super.init(eventBus, serialEndpoint, infraredEndpoint, console)
+                  eventBus.post(PreparedSeedSourceEvent())
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller =
+        BasicController(
+            eventBus,
+            EmulatorProperties(),
+            null,
+            preparer,
+            SnapshotManagerFactory.DEFAULT,
+            rewind,
+        )
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(oldRom))
+      assertNotNull(sourceEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals("SEED_OLD", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+      assertEquals(1, rewind.preparationCount.get())
+      assertTrue(rewind.sourceEventObservedAfterCommit)
+
+      rewind.failPreparation = true
+      frames.clear()
+      eventBus.post(LoadRomEvent(failingRom))
+
+      assertEquals(failingRom, assertNotNull(failures.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).rom)
+      assertEquals(2, rewind.preparationCount.get())
+      assertNull(
+          sourceEvents.poll(300, TimeUnit.MILLISECONDS),
+          "a discarded candidate must not publish its staged source event",
+      )
+      assertNotNull(
+          frames.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "the old session must continue after candidate seed preparation fails",
+      )
+    } finally {
+      controller.close()
+      eventBus.close()
+      oldRom.delete()
+      failingRom.delete()
+    }
+  }
+
+  @Test
   fun disabledRewindCreatesNoFrameCapturesAndCannotFreezeForwardEmulation() {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()
@@ -1559,6 +1636,18 @@ class BasicControllerTest {
     }
   }
 
+  private class TrackingRewindManager : RewindManager() {
+    val preparationCount = AtomicInteger()
+    @Volatile var failPreparation = false
+    @Volatile var sourceEventObservedAfterCommit = false
+
+    override fun prepareSessionSeed(session: Session): PreparedSessionSeed? {
+      preparationCount.incrementAndGet()
+      if (failPreparation) throw IOException("injected rewind seed failure")
+      return super.prepareSessionSeed(session)
+    }
+  }
+
   private class TrackingConsole : Console() {
     @Volatile var attachedDebugPort: DebugPort? = null
 
@@ -1570,4 +1659,6 @@ class BasicControllerTest {
   private class StalledSessionEvent : Event
 
   private class FinalCloseEvent : Event
+
+  private class PreparedSeedSourceEvent : Event
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RewindManagerTest.kt
@@ -16,6 +16,8 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Test
 
@@ -153,6 +155,121 @@ class RewindManagerTest {
       assertEquals(0, manager.captureCount)
       assertEquals(0, manager.historySize)
       assertFalse(manager.rewindOneStep(session.gameboy))
+    }
+  }
+
+  @Test
+  fun disabledManagerDoesNotPrepareSessionSeed() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager(enabled = false)
+
+      assertNull(manager.prepareSessionSeed(session))
+      assertFalse(manager.hasPreparedSessionSeed)
+      assertEquals(0, manager.captureCount)
+      assertEquals(0, manager.historySize)
+    }
+  }
+
+  @Test
+  fun preparedSessionSeedLeavesHistoryCadenceAndCaptureCountUntouched() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+
+      val seed = assertNotNull(manager.prepareSessionSeed(session))
+
+      assertFalse(manager.hasPreparedSessionSeed, "a candidate token is not history state")
+      assertEquals(0, manager.captureCount)
+      assertEquals(0, manager.historySize)
+      seed.discard()
+    }
+  }
+
+  @Test
+  fun firstSessionRecordUsesPreparedSeedButOnlyRestoresPostFrameState() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+      session.gameboy.addressSpace.setByte(TEST_ADDRESS, 0x11)
+      val seed = assertNotNull(manager.prepareSessionSeed(session))
+
+      manager.beginSession(session, seed)
+      assertTrue(manager.hasPreparedSessionSeed)
+      session.gameboy.addressSpace.setByte(TEST_ADDRESS, 0x22)
+      manager.record(session)
+
+      assertEquals(1, manager.captureCount)
+      assertEquals(1, manager.historySize)
+      assertFalse(manager.hasPreparedSessionSeed)
+      session.gameboy.addressSpace.setByte(TEST_ADDRESS, 0x33)
+      assertTrue(manager.rewindOneStep(session))
+      assertEquals(0x22, session.gameboy.addressSpace.getByte(TEST_ADDRESS))
+      assertFalse(manager.rewindOneStep(session), "the pre-frame seed is never rewindable")
+    }
+  }
+
+  @Test
+  fun preparedSessionSeedRetainsSixFrameCadenceAndSurvivesSuppressedFrames() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+      val seed = assertNotNull(manager.prepareSessionSeed(session))
+      manager.beginSession(session, seed)
+
+      session.gameboy.requestFrameRenderSuppression(true)
+      tickUntilVBlank(session.gameboy)
+      manager.record(session)
+      assertTrue(manager.hasPreparedSessionSeed)
+      assertEquals(0, manager.captureCount)
+
+      session.gameboy.requestFrameRenderSuppression(false)
+      tickUntilVBlank(session.gameboy)
+      repeat(RewindManager.RECORD_INTERVAL * 2) { manager.record(session) }
+
+      assertEquals(2, manager.captureCount)
+      assertFalse(manager.hasPreparedSessionSeed)
+    }
+  }
+
+  @Test
+  fun clearAndMachineRecordingReleasePreparedSessionSeed() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager = RewindManager()
+      manager.beginSession(session, assertNotNull(manager.prepareSessionSeed(session)))
+      assertTrue(manager.hasPreparedSessionSeed)
+      manager.clear()
+      assertFalse(manager.hasPreparedSessionSeed)
+
+      manager.beginSession(session, assertNotNull(manager.prepareSessionSeed(session)))
+      manager.record(session.gameboy)
+
+      assertFalse(manager.hasPreparedSessionSeed)
+      assertEquals(1, manager.historySize)
+      assertFailsWith<IllegalStateException> { manager.rewindOneStep(session) }
+    }
+  }
+
+  @Test
+  fun preparedSeedTransfersExactRetentionIntoFirstHistoryEntry() {
+    StateCodecTestSupport.session(configuration()).use { session ->
+      val manager =
+          RewindManager(memoryBudgetBytes = RewindManager.MIN_MEMORY_BUDGET_BYTES)
+      manager.beginSession(session, assertNotNull(manager.prepareSessionSeed(session)))
+
+      val pendingBytes = manager.retainedBytesForTesting()
+      assertTrue(pendingBytes > 0L, "the staged baseline is manager-owned memory")
+      assertEquals(pendingBytes, manager.approximateRetainedBytesForTesting)
+
+      session.gameboy.addressSpace.setByte(TEST_ADDRESS, 0x5a)
+      manager.record(session)
+
+      assertEquals(1, manager.historySize)
+      assertFalse(manager.hasPreparedSessionSeed)
+      assertEquals(
+          manager.retainedBytesForTesting(),
+          manager.approximateRetainedBytesForTesting,
+          "the first seed-relative entry must be charged as a complete retained root",
+      )
+      manager.clear()
+      assertEquals(0L, manager.retainedBytesForTesting())
+      assertEquals(0L, manager.approximateRetainedBytesForTesting)
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -8,15 +8,27 @@ import eu.rekawek.coffeegb.controller.state.FileStateStore
 import eu.rekawek.coffeegb.controller.state.RomPersistenceStore
 import eu.rekawek.coffeegb.controller.state.SessionPersistence
 import eu.rekawek.coffeegb.controller.state.StateStorageLayout
+import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSource
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.memory.cart.RomImage
 import eu.rekawek.coffeegb.core.memory.cart.RomOrigin
 import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -60,7 +72,8 @@ class RomSessionPreparerTest {
     val cache = BootStateCache(2)
     val prepared =
         assertIs<PreparedSession.FromDetachedState>(
-            RomSessionPreparer(cache).prepare(PROPERTIES, LoadRomEvent(ROM, state)))
+            RomSessionPreparer(cache, runtimeWarmupCache = noopWarmupCache())
+                .prepare(PROPERTIES, LoadRomEvent(ROM, state)))
     val restored = prepared.materialize()
     try {
       assertEquals(0x5a, restored.addressSpace.getByte(0xc123))
@@ -79,7 +92,7 @@ class RomSessionPreparerTest {
       val image = RomImage(origin, bytes)
 
       val prepared =
-          RomSessionPreparer(BootStateCache(2))
+          RomSessionPreparer(BootStateCache(2), runtimeWarmupCache = noopWarmupCache())
               .prepare(PROPERTIES, LoadRomEvent(image))
 
       assertEquals(origin, prepared.config.rom.origin)
@@ -113,7 +126,7 @@ class RomSessionPreparerTest {
           }
 
       val prepared =
-          RomSessionPreparer(BootStateCache(2)).prepare(
+          RomSessionPreparer(BootStateCache(2), runtimeWarmupCache = noopWarmupCache()).prepare(
               PROPERTIES,
               LoadRomEvent(image, persistenceStore = store),
           )
@@ -126,6 +139,239 @@ class RomSessionPreparerTest {
       Files.walk(root).use { paths ->
         paths.sorted(java.util.Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
       }
+    }
+  }
+
+  @Test
+  fun skipLoadWarmsExactlyOneHundredTwentyControllerFramesBeforeDeferring() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(2, executor)
+
+    val prepared =
+        RomSessionPreparer(BootStateCache(2), runtimeWarmupCache = cache)
+            .prepare(PROPERTIES, LoadRomEvent(ROM))
+
+    assertIs<PreparedSession.Deferred>(prepared)
+    val call = assertIs<WarmupCall>(executor.calls.single())
+    assertEquals(
+        120 * prepared.config.clockSpec.controllerTicksPerFrame(),
+        call.ticks,
+    )
+    assertEquals(BootstrapMode.SKIP, call.config.bootstrapMode)
+  }
+
+  @Test
+  fun runtimeWarmupOnlyAcceptsFreshOrdinarySkipCartridges() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(8, executor)
+
+    cache.warm(skipConfig()) {}
+    cache.warm(skipConfig().setBootstrapMode(BootstrapMode.FAST_FORWARD)) {}
+    cache.warm(skipConfig().setBootstrapMode(BootstrapMode.NORMAL)) {}
+    cache.warm(skipConfig().setSlotRom(Rom(ROM))) {}
+    cache.warm(skipConfig(exoticRtcImage())) {}
+    cache.warm(skipConfig(nonStandardMapperImage())) {}
+
+    assertEquals(1, executor.calls.size)
+    assertEquals(1, cache.size)
+  }
+
+  @Test
+  fun runtimeWarmupSharesExecutionShapeButSeparatesProfileMapperAndRamShapes() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(8, executor)
+
+    cache.warm(skipConfig()) {}
+    cache.warm(skipConfig(RomImage.memory(alteredRomBytes(), "same-shape.gb"))) {}
+    cache.warm(skipConfig().setHardwareProfile(HardwareProfileRegistry.DMG)) {}
+    cache.warm(skipConfig(mbc5Image())) {}
+    cache.warm(skipConfig(RomImage.memory(largerRamBytes(), "larger-ram.gb"))) {}
+    cache.warm(skipConfig().setMealybugDmgBlob(true)) {}
+    cache.warm(skipConfig().setCodeBreakerRumble(true)) {}
+
+    assertEquals(6, executor.calls.size)
+    assertEquals(6, cache.size)
+  }
+
+  @Test
+  fun runtimeWarmupUsesAccessOrderedBoundedCache() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(2, executor)
+    val first = skipConfig()
+    val second = skipConfig(mbc5Image())
+    val third = skipConfig(RomImage.memory(largerRamBytes(), "larger-ram.gb"))
+
+    cache.warm(first) {}
+    cache.warm(second) {}
+    cache.warm(first) {}
+    cache.warm(third) {}
+    cache.warm(second) {}
+
+    assertEquals(4, executor.calls.size)
+    assertEquals(2, cache.size)
+    assertEquals(1, cache.hitCount)
+  }
+
+  @Test
+  fun canceledOrFailedWarmupIsNotCachedAndDoesNotRejectTheRealLoad() {
+    val canceled = RecordingWarmupExecutor(checkCancellation = true)
+    val canceledCache = RuntimeWarmupCache(2, canceled)
+    var cancellationChecks = 0
+
+    assertFailsWith<CancellationException> {
+      canceledCache.warm(skipConfig()) {
+        if (++cancellationChecks == 2) {
+          throw CancellationException("superseded")
+        }
+      }
+    }
+    assertEquals(0, canceledCache.size)
+    canceled.checkCancellation = false
+    canceledCache.warm(skipConfig()) {}
+    assertEquals(2, canceled.calls.size)
+    assertEquals(1, canceledCache.size)
+
+    val canceledAfterRun = RecordingWarmupExecutor()
+    val afterRunCache = RuntimeWarmupCache(2, canceledAfterRun)
+    var afterRunChecks = 0
+    assertFailsWith<CancellationException> {
+      afterRunCache.warm(skipConfig()) {
+        if (++afterRunChecks == 2) {
+          throw CancellationException("superseded after warmup")
+        }
+      }
+    }
+    assertEquals(1, canceledAfterRun.calls.size)
+    assertEquals(0, afterRunCache.size)
+
+    val failed = RecordingWarmupExecutor(failure = IllegalStateException("throwaway failed"))
+    val failedCache = RuntimeWarmupCache(2, failed)
+    val preparer = RomSessionPreparer(BootStateCache(2), runtimeWarmupCache = failedCache)
+
+    assertIs<PreparedSession.Deferred>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+    assertEquals(0, failedCache.size)
+    failed.failure = null
+    assertIs<PreparedSession.Deferred>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+    assertEquals(2, failed.calls.size)
+    assertEquals(1, failedCache.size)
+  }
+
+  @Test
+  fun concurrentSameShapeLoadWaitsForOneSuccessfulWarmup() {
+    val started = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val calls = AtomicInteger()
+    val failure = AtomicReference<Throwable?>()
+    val cache =
+        RuntimeWarmupCache(
+            2,
+            RuntimeWarmupExecutor { _, _, _ ->
+              calls.incrementAndGet()
+              started.countDown()
+              check(release.await(3, TimeUnit.SECONDS)) { "Timed out waiting to release warmup" }
+            },
+        )
+    val owner = Thread { runWarmup(cache, failure) }
+    val waiter = Thread { runWarmup(cache, failure) }
+
+    owner.start()
+    assertTrue(started.await(3, TimeUnit.SECONDS))
+    waiter.start()
+    release.countDown()
+    owner.join(3_000)
+    waiter.join(3_000)
+
+    assertFalse(owner.isAlive)
+    assertFalse(waiter.isAlive)
+    assertNull(failure.get())
+    assertEquals(1, calls.get())
+    assertEquals(1, cache.size)
+    assertEquals(1, cache.hitCount)
+  }
+
+  @Test
+  fun runtimeWarmupUsesAServiceFreeCopyWithoutChangingThePreparedSession() {
+    val liveSamples = AtomicInteger()
+    val liveInput = PlayerInputSource {
+      liveSamples.incrementAndGet()
+      PlayerInputSource.RELEASED.sample()
+    }
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(2, executor)
+    val preparer =
+        RomSessionPreparer(
+            BootStateCache(2),
+            configure = {
+              it.setPlayerInputSource(liveInput)
+                  .setBatteryData(byteArrayOf(0x5a))
+                  .setSupportBatterySave(true)
+            },
+            runtimeWarmupCache = cache,
+        )
+
+    val prepared =
+        assertIs<PreparedSession.Deferred>(preparer.prepare(PROPERTIES, LoadRomEvent(ROM)))
+    val warmup = executor.calls.single().config
+
+    assertEquals(BootstrapMode.SKIP, warmup.bootstrapMode)
+    assertFalse(warmup.isSupportBatterySave)
+    assertNull(warmup.batteryStorage)
+    assertNull(warmup.slotBatteryStorage)
+    assertIs<PlayerInputHub>(warmup.playerInputSource)
+    assertNotSame(liveInput, warmup.playerInputSource)
+    assertSame(liveInput, prepared.config.playerInputSource)
+    assertTrue(prepared.config.isSupportBatterySave)
+    assertEquals(BootstrapMode.SKIP, prepared.config.bootstrapMode)
+    assertEquals(0, liveSamples.get())
+  }
+
+  private fun skipConfig(image: RomImage? = null): Gameboy.GameboyConfiguration =
+      Controller.createGameboyConfig(PROPERTIES, image?.let(::Rom) ?: Rom(ROM))
+
+  private fun exoticRtcImage(): RomImage =
+      RomImage.memory(ROM.readBytes().also { it[0x147] = 0x0f }, "rtc.gb")
+
+  private fun mbc5Image(): RomImage = RomImage.memory(mbc5Bytes(), "mbc5.gb")
+
+  private fun mbc5Bytes(): ByteArray = ROM.readBytes().also { it[0x147] = 0x19 }
+
+  private fun nonStandardMapperImage(): RomImage =
+      RomImage.memory(ROM.readBytes().also { it[0x147] = 0x00 }, "oversized-rom.gb")
+
+  private fun largerRamBytes(): ByteArray = ROM.readBytes().also { it[0x149] = 0x03 }
+
+  private fun alteredRomBytes(): ByteArray =
+      ROM.readBytes().also { it[0x200] = (it[0x200] + 1).toByte() }
+
+  private fun noopWarmupCache(): RuntimeWarmupCache =
+      RuntimeWarmupCache(1, RuntimeWarmupExecutor { _, _, _ -> })
+
+  private fun runWarmup(cache: RuntimeWarmupCache, failure: AtomicReference<Throwable?>) {
+    try {
+      cache.warm(skipConfig()) {}
+    } catch (error: Throwable) {
+      failure.compareAndSet(null, error)
+    }
+  }
+
+  private data class WarmupCall(val config: Gameboy.GameboyConfiguration, val ticks: Int)
+
+  private class RecordingWarmupExecutor(
+      var failure: Throwable? = null,
+      var checkCancellation: Boolean = false,
+  ) : RuntimeWarmupExecutor {
+    val calls = mutableListOf<WarmupCall>()
+
+    override fun warm(
+        config: Gameboy.GameboyConfiguration,
+        ticks: Int,
+        ensureActive: () -> Unit,
+    ) {
+      calls += WarmupCall(config, ticks)
+      if (checkCancellation) {
+        ensureActive()
+      }
+      failure?.let { throw it }
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/TimingTickerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/TimingTickerTest.kt
@@ -1,13 +1,18 @@
 package eu.rekawek.coffeegb.controller
 
+import com.sun.management.ThreadMXBean
 import eu.rekawek.coffeegb.controller.state.StateCodec
 import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicLong
+import java.util.function.LongConsumer
+import java.util.function.LongSupplier
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class TimingTickerTest {
@@ -16,7 +21,10 @@ class TimingTickerTest {
   fun `controller pacing boundary uses supplied session clock`() {
     val now = AtomicLong(0)
     val parked = mutableListOf<Long>()
-    val ticker = TimingTicker({ now.addAndGet(1_000_000_000L) }, parked::add)
+    val ticker = TimingTicker(
+        LongSupplier { now.addAndGet(1_000_000_000L) },
+        LongConsumer { parked.add(it) },
+    )
     val custom = ClockSpec(1_000, 10, 1)
 
     repeat(custom.controllerTicksPerFrame() - 1) { ticker.run(custom) }
@@ -32,7 +40,10 @@ class TimingTickerTest {
   @Test
   fun `changing clock discards an incomplete prior frame`() {
     val now = AtomicLong(0)
-    val ticker = TimingTicker({ now.addAndGet(1_000_000_000L) }, {})
+    val ticker = TimingTicker(
+        LongSupplier { now.addAndGet(1_000_000_000L) },
+        LongConsumer {},
+    )
     val first = ClockSpec(1_000, 10, 1)
     val second = ClockSpec(2_000, 10, 1)
 
@@ -50,8 +61,8 @@ class TimingTickerTest {
     val parked = mutableListOf<Long>()
     val ticker =
         TimingTicker(
-            { now.addAndGet(1_000_000L) },
-            { duration ->
+            LongSupplier { now.addAndGet(1_000_000L) },
+            LongConsumer { duration ->
               parked += duration
               now.addAndGet(duration)
             },
@@ -89,8 +100,8 @@ class TimingTickerTest {
     val parked = mutableListOf<Long>()
     val ticker =
         TimingTicker(
-            { now.addAndGet(1_000_000L) },
-            { duration ->
+            LongSupplier { now.addAndGet(1_000_000L) },
+            LongConsumer { duration ->
               parked += duration
               now.addAndGet(duration)
             },
@@ -131,7 +142,10 @@ class TimingTickerTest {
               .setHardwareProfile(HardwareProfileRegistry.SGB2)
       return StateCodecTestSupport.session(configuration).use { session ->
         val now = AtomicLong(0)
-        val ticker = TimingTicker({ now.addAndGet(hostStep) }, {})
+        val ticker = TimingTicker(
+            LongSupplier { now.addAndGet(hostStep) },
+            LongConsumer {},
+        )
         val clock = session.gameboy.clockSpec
         repeat(clock.controllerTicksPerFrame()) {
           session.gameboy.tick()
@@ -150,4 +164,65 @@ class TimingTickerTest {
 
     assertContentEquals(runWithHostStep(17_000_000L), runWithHostStep(91_000_000L))
   }
+
+  @Test
+  fun `primitive timing seams do not allocate inside repeated fine waits`() {
+    val allocation = threadAllocation() ?: return
+    val seam = FineWaitSeam()
+    val ticker = TimingTicker(seam, seam)
+    val clock = ClockSpec(1, 1, 1)
+
+    repeat(2_000) { ticker.run(clock) }
+    assertEquals(2_000, seam.parkCalls)
+    assertTrue(
+        seam.nanoTimeCalls > seam.parkCalls * 10,
+        "the deterministic clock must force repeated final-stretch wait iterations",
+    )
+
+    var minimumAllocated = Long.MAX_VALUE
+    repeat(5) {
+      val before = allocation.current()
+      repeat(2_000) { ticker.run(clock) }
+      minimumAllocated = minOf(minimumAllocated, allocation.current() - before)
+    }
+
+    assertEquals(0L, minimumAllocated, "primitive fine-wait seam allocated")
+  }
+
+  private fun threadAllocation(): AllocationCounter? {
+    val bean = ManagementFactory.getThreadMXBean() as? ThreadMXBean ?: return null
+    if (!bean.isThreadAllocatedMemorySupported) return null
+    if (!bean.isThreadAllocatedMemoryEnabled) bean.isThreadAllocatedMemoryEnabled = true
+    return AllocationCounter(bean, Thread.currentThread().id)
+  }
+
+  private data class AllocationCounter(
+      val bean: ThreadMXBean,
+      val threadId: Long,
+  ) {
+    fun current(): Long = bean.getThreadAllocatedBytes(threadId)
+  }
+
+  private class FineWaitSeam : LongSupplier, LongConsumer {
+    private var now = 0L
+    var nanoTimeCalls = 0
+      private set
+    var parkCalls = 0
+      private set
+    var lastParkNanos = 0L
+      private set
+
+    override fun getAsLong(): Long {
+      nanoTimeCalls++
+      now += 100_000L
+      return now
+    }
+
+    override fun accept(duration: Long) {
+      parkCalls++
+      lastParkNanos = duration
+      now += duration
+    }
+  }
+
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -83,6 +83,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.MessageDigest
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.Semaphore
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -3507,6 +3508,7 @@ class LinkedControllerTest {
     sut.timingTicker.disabled = true
     val failures = mutableListOf<ProtocolErrorReason>()
     val offender = PeerEventSource(1) { reason, _ -> failures += reason }
+    val feedbackGate = Semaphore(0)
     eventBus.post(LoadRomEvent(ROM))
     eventBus.post(
         PeerLoadedGameEvent(
@@ -3520,13 +3522,22 @@ class LinkedControllerTest {
         ))
     sut.runFrame()
 
-    eventBus.register<ValidatedPeerResetEvent> {
-      eventBus.post(
-          ReceivedRemoteResetEvent(sut.currentFrame(), player = 1, source = offender))
+    eventBus.register<ValidatedPeerResetEvent> { validated ->
+      if (validated.event.source === offender) {
+        // Keep the asynchronous feedback event in flight until the frame that accepted it has
+        // completed. This prevents the event-bus worker from refilling the current dispatch.
+        feedbackGate.acquireUninterruptibly()
+        eventBus.post(
+            ReceivedRemoteResetEvent(sut.currentFrame(), player = 1, source = offender))
+      }
     }
     eventBus.post(ReceivedRemoteResetEvent(sut.currentFrame(), player = 1, source = offender))
     repeat(12) {
-      if (failures.isEmpty()) sut.runFrame()
+      if (failures.isEmpty()) {
+        sut.runFrame()
+        feedbackGate.release()
+        eventBus.drainAsyncEvents()
+      }
     }
 
     assertEquals(listOf(ProtocolErrorReason.EXCESSIVE_REPLAY_WORK), failures)
@@ -3548,18 +3559,25 @@ class LinkedControllerTest {
     sut.timingTicker.disabled = true
     val failures = mutableListOf<ProtocolErrorReason>()
     val offender = PeerEventSource(1) { reason, _ -> failures += reason }
+    val feedbackGate = Semaphore(0)
     eventBus.post(LoadRomEvent(ROM))
     sut.runFrame()
 
     eventBus.register<ValidatedPeerStateEvent> { validated ->
       if (validated.event.source === offender) {
+        // Release exactly one feedback event after its owning emulator frame, then wait for the
+        // active async subscriber to queue it for the following frame.
+        feedbackGate.acquireUninterruptibly()
         eventBus.post(peerState(sut.currentFrame(), offender))
       }
     }
     eventBus.post(peerState(sut.currentFrame(), offender))
     repeat(24) {
-      eventBus.drainAsyncEvents()
-      if (failures.isEmpty()) sut.runFrame()
+      if (failures.isEmpty()) {
+        sut.runFrame()
+        feedbackGate.release()
+        eventBus.drainAsyncEvents()
+      }
     }
 
     assertEquals(listOf(ProtocolErrorReason.EXCESSIVE_REPLAY_WORK), failures)
@@ -3581,24 +3599,30 @@ class LinkedControllerTest {
     sut.timingTicker.disabled = true
     val failures = mutableListOf<ProtocolErrorReason>()
     val offender = PeerEventSource(1) { reason, _ -> failures += reason }
+    val feedbackGate = Semaphore(0)
     eventBus.post(LoadRomEvent(ROM))
     sut.runFrame()
 
     eventBus.register<ValidatedPeerStateEvent> { validated ->
       if (validated.event.source === offender) {
+        feedbackGate.acquireUninterruptibly()
         eventBus.post(
             ReceivedRemoteStopEvent(sut.currentFrame(), player = 1, source = offender))
       }
     }
     eventBus.register<ValidatedPeerStopEvent> { validated ->
       if (validated.event.source === offender) {
+        feedbackGate.acquireUninterruptibly()
         eventBus.post(peerState(sut.currentFrame(), offender))
       }
     }
     eventBus.post(peerState(sut.currentFrame(), offender))
     repeat(24) {
-      eventBus.drainAsyncEvents()
-      if (failures.isEmpty()) sut.runFrame()
+      if (failures.isEmpty()) {
+        sut.runFrame()
+        feedbackGate.release()
+        eventBus.drainAsyncEvents()
+      }
     }
 
     assertEquals(listOf(ProtocolErrorReason.EXCESSIVE_REPLAY_WORK), failures)
@@ -3648,9 +3672,14 @@ class LinkedControllerTest {
     sut.timingTicker.disabled = true
     val failures = mutableListOf<ProtocolErrorReason>()
     val offender = PeerEventSource(0) { reason, _ -> failures += reason }
+    val feedbackGate = Semaphore(0)
     var acceptedCheckpoints = 0
     eventBus.register<ValidatedPeerCheckpointEvent> { validated ->
       if (validated.event.source === offender) {
+        // Keep the asynchronous feedback event in flight until the frame that accepted it has
+        // completed. This makes the test's one-checkpoint-per-frame model deterministic while
+        // drainAsyncEvents still verifies that it waits for an active subscriber.
+        feedbackGate.acquireUninterruptibly()
         acceptedCheckpoints++
         eventBus.post(
             SessionCheckpointEvent(
@@ -3664,9 +3693,9 @@ class LinkedControllerTest {
     repeat(20) {
       if (failures.isEmpty()) {
         sut.runFrame()
-        // Accepted peer lifecycle notifications deliberately share the asynchronous publication
-        // FIFO with ROM payloads. Wait for the listener to enqueue the next streaming checkpoint
-        // before advancing the controller-owned work budget again.
+        // Release one feedback checkpoint only after its owning emulator frame completed, then
+        // wait until the async subscriber has enqueued it for the next frame.
+        feedbackGate.release()
         eventBus.drainAsyncEvents()
       }
     }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/replay/ReplayRecorderPlayerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/replay/ReplayRecorderPlayerTest.kt
@@ -61,14 +61,10 @@ class ReplayRecorderPlayerTest {
                     ReplayInputPhase.LEGACY_P1_BEFORE_TICK,
                     ReplayInputPhase.PHYSICAL_JOYPAD_SAMPLE,
                     ReplayInputPhase.LEGACY_P1_BEFORE_TICK,
-                    ReplayInputPhase.PHYSICAL_JOYPAD_SAMPLE,
-                    ReplayInputPhase.PHYSICAL_JOYPAD_SAMPLE,
-                    ReplayInputPhase.PHYSICAL_JOYPAD_SAMPLE,
-                    ReplayInputPhase.PHYSICAL_JOYPAD_SAMPLE,
                 ),
                 replay.inputs.map { it.phase },
             )
-            assertEquals(listOf(0L, 0L, 1L, 1L, 1L, 2L, 2L), replay.inputs.map { it.tick })
+            assertEquals(listOf(0L, 0L, 1L), replay.inputs.map { it.tick })
 
             val decoded = ReplayCodec.decode(ReplayCodec.encode(replay))
             ReplayPlayer.open(decoded, rig.configuration).use { player ->

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/MachineSnapshotTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import eu.rekawek.coffeegb.core.ir.FullChanger
 import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memory.GbcRam
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
 import java.util.concurrent.TimeUnit
@@ -83,6 +84,7 @@ class MachineSnapshotTest {
   fun unchangedPagesReuseIdentityAndOneWramWriteCopiesOnlyItsPage() {
     StateCodecTestSupport.session(cgbMbc5Configuration()).use { session ->
       val gameboy = session.gameboy
+      seedIdenticalGbcWramBanks(gameboy, 0x13)
       val first = MachineSnapshot.capture(gameboy)
       assertPagedArray(first, GBC_RAM_MEMENTO, "ram", 7 * 0x1000)
       assertTrue(
@@ -97,10 +99,32 @@ class MachineSnapshotTest {
       assertPagedArray(first, DISPLAY_MEMENTO, "buffer", 160 * 144)
       assertPagedArray(first, DISPLAY_MEMENTO, "lastFrame", 160 * 144)
       assertPagedArray(first, MBC5_MEMENTO, "ram", 0x8000)
-      val unchanged = MachineSnapshot.capture(gameboy, first)
+      val workRam = first.debugArrays(GBC_RAM_MEMENTO, "ram").single()
+      assertTrue(
+          workRam.pageTokens.drop(1).all { it === workRam.pageTokens.first() },
+          "identical primitive pages in one array must deduplicate during the first capture",
+      )
+      writeGbcWramBank(gameboy, 1, 0xa7)
+      writeGbcWramBank(gameboy, 2, 0xa7)
+      gameboy.addressSpace.setByte(GbcRam.SVBK, 1)
+      val crossPosition = MachineSnapshot.capture(gameboy, first)
+      val crossPositionPages = crossPosition.debugArrays(GBC_RAM_MEMENTO, "ram").single()
+      assertTrue(
+          crossPositionPages.pageTokens[0] === crossPositionPages.pageTokens[1],
+          "a preferred miss must retain cross-position fallback deduplication",
+      )
+      assertTrue(crossPositionPages.pageTokens[0] !== workRam.pageTokens[0])
+      assertEquals(1, crossPosition.captureStats.copiedPages)
+
+      val unchanged = MachineSnapshot.capture(gameboy, crossPosition)
 
       assertEquals(0, unchanged.captureStats.copiedPages)
       assertEquals(0, unchanged.captureStats.copiedPageBytes)
+      assertEquals(
+          0,
+          unchanged.captureStats.newValueNodes,
+          "an unchanged graph must reuse scalar, array, record, and field identities",
+      )
       assertTrue(unchanged.captureStats.identityVerifiedPayloadArrays > 0)
       assertTrue(unchanged.captureStats.identityVerifiedPayloadBytes > 0)
       assertTrue(unchanged.captureStats.reusedPages > 0)
@@ -113,6 +137,8 @@ class MachineSnapshotTest {
       val changed = MachineSnapshot.capture(gameboy, unchanged)
       val before = unchanged.debugArrays(RAM_MEMENTO, "space")
       val after = changed.debugArrays(RAM_MEMENTO, "space")
+      val fieldsBefore = unchanged.debugRecordFields(RAM_MEMENTO)
+      val fieldsAfter = changed.debugRecordFields(RAM_MEMENTO)
       val changedPageCount =
           before.indices.sumOf { index ->
             before[index].pageTokens.indices.count { page ->
@@ -122,6 +148,17 @@ class MachineSnapshotTest {
       assertEquals(1, changedPageCount)
       assertEquals(1, changed.captureStats.copiedPages)
       assertEquals(MachineSnapshot.PAGE_BYTES.toLong(), changed.captureStats.copiedPageBytes)
+      assertEquals(fieldsBefore.size, fieldsAfter.size)
+      assertEquals(
+          1,
+          fieldsBefore.indices.sumOf { index ->
+            val old = fieldsBefore[index].fieldTokens
+            val next = fieldsAfter[index].fieldTokens
+            assertEquals(old.keys, next.keys)
+            old.keys.count { field -> old[field] !== next[field] }
+          },
+          "one WRAM page mutation must materialize only its owning record field",
+      )
       assertEquals(
           unchanged.captureStats.identityVerifiedPayloadArrays,
           changed.captureStats.identityVerifiedPayloadArrays,
@@ -483,6 +520,18 @@ class MachineSnapshotTest {
     val array = snapshot.debugArrays(owner, field).single()
     assertEquals(size, array.size)
     assertTrue(array.pageTokens.isNotEmpty())
+  }
+
+  private fun seedIdenticalGbcWramBanks(gameboy: Gameboy, seed: Int) {
+    (1..7).forEach { bank -> writeGbcWramBank(gameboy, bank, seed) }
+    gameboy.addressSpace.setByte(GbcRam.SVBK, 1)
+  }
+
+  private fun writeGbcWramBank(gameboy: Gameboy, bank: Int, seed: Int) {
+    gameboy.addressSpace.setByte(GbcRam.SVBK, bank)
+    repeat(0x1000) { offset ->
+      gameboy.addressSpace.setByte(0xd000 + offset, (seed + offset * 37) and 0xff)
+    }
   }
 
   private fun MachineState.record(className: String): RecordState {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/SgbInputStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/SgbInputStateTest.kt
@@ -47,7 +47,8 @@ class SgbInputStateTest {
       val portable = StateCodec.encode(StateCodec.capture(session))
 
       playerTwo.update(setOf(Button.START))
-      session.gameboy.tick()
+      // The desktop PlayerInputHub is sampled at its bounded 64-master-tick cadence.
+      repeat(64) { session.gameboy.tick() }
       sendMltReq(session, 0)
       assertEquals(0, session.gameboy.sgbMultiplayerStatus.selectedPlayer)
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -2128,6 +2128,25 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return copy;
         }
 
+        /**
+         * Service-free copy for disposable real-game execution warmup. The caller has already
+         * limited this to ordinary non-RTC cartridges, but a fixed clock source keeps that
+         * boundary explicit should a future eligibility rule widen. No live input or writable
+         * battery/storage service can reach the throwaway machine.
+         */
+        public GameboyConfiguration forRuntimeWarmup() {
+            GameboyConfiguration copy = forBootTemplate();
+            copy.bootstrapMode = BootstrapMode.SKIP;
+            copy.batteryStorage = null;
+            copy.slotBatteryStorage = null;
+            copy.debugHistoryReplay = false;
+            copy.debugHistoryPrimaryBatteryShape = null;
+            copy.debugHistorySlotBatteryShape = null;
+            copy.rtcTimeSource = () -> 0L;
+            copy.playerInputSource = PlayerInputSource.RELEASED;
+            return copy;
+        }
+
         private GameboyConfiguration copy() {
             GameboyConfiguration copy = new GameboyConfiguration(rom);
             copy.hardwareProfile = hardwareProfile;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBusImpl.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBusImpl.java
@@ -9,6 +9,7 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 public class EventBusImpl implements EventBus {
@@ -32,6 +33,9 @@ public class EventBusImpl implements EventBus {
     private int activeSynchronousDispatches;
 
     private final BlockingDeque<Event> asyncEvents = new LinkedBlockingDeque<>();
+    /** One permit for every accepted async event; wakes the worker without idle polling. */
+    private final Semaphore asyncEventSignal = new Semaphore(0);
+    private volatile boolean asyncWorkerWaitingForEvent;
 
     public EventBusImpl() {
         this(null, null, true);
@@ -104,6 +108,7 @@ public class EventBusImpl implements EventBus {
                 throw new IllegalStateException("This EventBus is no longer active.");
             }
             asyncEvents.addLast(event);
+            asyncEventSignal.release();
         }
     }
 
@@ -310,23 +315,43 @@ public class EventBusImpl implements EventBus {
     private record Registration(Subscriber<?> subscriber, Class<?> eventType, String callerFilter) {
     }
 
+    /** Package-private test seam for confirming the idle worker is blocking on its event signal. */
+    boolean isAsyncWorkerBlockedForEvent() {
+        return asyncThread != null
+                && asyncWorkerWaitingForEvent
+                && asyncThread.getState() == Thread.State.WAITING;
+    }
+
     private class AsyncRunnable implements Runnable {
         @Override
         public void run() {
             try {
                 while (!doStop) {
-                    // peek first and remove only after dispatching, so the queue reads
-                    // as non-empty for the whole duration of the dispatch (drainAsyncEvents
-                    // relies on it)
+                    try {
+                        asyncWorkerWaitingForEvent = true;
+                        asyncEventSignal.acquire();
+                    } catch (InterruptedException e) {
+                        // close() interrupts a blocked worker after setting doStop. An unrelated
+                        // interrupt must clear normally, then return to the blocking acquire so it
+                        // cannot become a spin loop or discard a queued event.
+                        if (doStop) {
+                            break;
+                        }
+                        continue;
+                    } finally {
+                        asyncWorkerWaitingForEvent = false;
+                    }
+                    if (doStop) {
+                        break;
+                    }
+                    // Peek first and remove only after dispatching, so the queue remains
+                    // non-empty for the whole subscriber callback (drainAsyncEvents relies on it).
                     Event event = asyncEvents.peekFirst();
                     if (event == null) {
-                        try {
-                            Thread.sleep(1);
-                        } catch (InterruptedException e) {
-                            if (!doStop) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }
+                        // The one-per-enqueue protocol makes this unreachable in normal operation.
+                        // Keep the worker defensive if a future queue implementation ever breaks
+                        // that invariant: wait for another signal rather than spinning or
+                        // inventing an event delivery.
                         continue;
                     }
                     try {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -34,6 +34,13 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     private static final int INPUT_FILTER_MASK = (1 << INPUT_FILTER_SAMPLES) - 1;
 
+    /**
+     * Host input is stable between GUI updates, so the thread-safe live hub needs polling only at
+     * this master-tick cadence. The initial tick is a poll boundary and later boundaries reuse the
+     * persisted {@link #tick} phase rather than storing a second cadence counter.
+     */
+    static final int PLAYER_INPUT_HUB_POLL_TICKS = 64;
+
     /** Fully settled four-sample history for each active-low input-line level. */
     private static final int[] SETTLED_HISTORY = createSettledHistory();
 
@@ -64,6 +71,12 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      * before the emulation thread considers skipping its regular sample path.
      */
     private transient volatile boolean releasedInputFastPathEligible;
+
+    /**
+     * Derived settled-state shortcut for the default thread-safe desktop input hub. Unlike the
+     * released-only shortcut, this permits a held physical input once its JOYP filter has settled.
+     */
+    private transient volatile boolean playerInputHubFastPathEligible;
 
     /** Owner-thread observation only; deliberately absent from portable machine state. */
     private transient DebugHooks debugHooks;
@@ -107,7 +120,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         transferInProgress = isSgb;
         transferReadyForData = false;
         sgbBus.register(event -> {
-            invalidateReleasedInputFastPath();
+            invalidateInputFastPaths();
             players = event.getMultiplayerControl() & 0x03;
             if (players == 2) {
                 // Undocumented MLT_REQ value 2 keeps the ICD2 in a distinct state:
@@ -117,7 +130,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 currentPlayer &= players;
             }
             LOG.atDebug().log("Players: {}, current player: {}", players, currentPlayer);
-            invalidateReleasedInputFastPath();
+            invalidateInputFastPaths();
         }, Commands.MltReqCmd.class);
         refreshReleasedInputFastPathEligibility();
     }
@@ -129,7 +142,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
     }
 
     private void onPress(Button button) {
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         if (eventBus != null) {
             eventBus.post(new JoypadPressEvent(button, tick));
         }
@@ -139,18 +152,18 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             notifyDebugInputChange();
             notifyLegacyInputChange();
         }
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
     }
 
     private void onRelease(Button button) {
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         LOG.atDebug().log("Released button {} at tick {}", button, tick);
         if (buttons.remove(button)) {
             inputChangedSinceLastTick = true;
             notifyDebugInputChange();
             notifyLegacyInputChange();
         }
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
     }
 
     /**
@@ -200,7 +213,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 Objects.requireNonNull(legacyButtons, "legacyButtons"));
         PlayerInputSnapshot physical = Objects.requireNonNull(
                 sampledPhysicalInput, "sampledPhysicalInput");
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         buttons.clear();
         buttons.addAll(legacyCopy);
         sampledInput = physical;
@@ -222,13 +235,13 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (buttons.equals(replayButtons)) {
             return;
         }
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         buttons.clear();
         buttons.addAll(replayButtons);
         inputChangedSinceLastTick = true;
         alignDebugInput();
         alignInputTimeline();
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
     }
 
     public void setPressedButtons(Collection<Button> pressed) {
@@ -236,13 +249,13 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (buttons.equals(pressedCopy)) {
             return;
         }
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         buttons.clear();
         buttons.addAll(pressedCopy);
         inputChangedSinceLastTick = true;
         notifyDebugInputChange();
         notifyLegacyInputChange();
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
     }
 
     public void tick() {
@@ -250,19 +263,23 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (releasedInputFastPathEligible) {
             return;
         }
+        if (playerInputHubFastPathEligible && !isPlayerInputHubPollDue()) {
+            return;
+        }
         tickInputSlowPath();
     }
 
     private void tickInputSlowPath() {
-        PlayerInputSnapshot nextInput = playerInputSource == PlayerInputSource.RELEASED
-                ? PlayerInputSnapshot.RELEASED
-                : Objects.requireNonNull(
-                        playerInputSource.sample(), "PlayerInputSource returned null");
-        if (sampledInput != nextInput && !sampledInput.equals(nextInput)) {
+        PlayerInputSnapshot nextInput = sampleInputForTick();
+        if (sampledInput != nextInput) {
+            boolean physicalButtonsChanged =
+                    sampledInput.packedButtonMasks != nextInput.packedButtonMasks;
             sampledInput = nextInput;
-            inputChangedSinceLastTick = true;
-            notifyDebugInputChange();
-            notifyPhysicalInputChanges();
+            if (physicalButtonsChanged) {
+                inputChangedSinceLastTick = true;
+                notifyDebugInputChange();
+                notifyPhysicalInputChanges();
+            }
         }
         // JOYP writes happen after the joypad clock edge represented by this emulator
         // tick. Start sampling a changed input on the following tick, then require four
@@ -296,6 +313,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (inputHistory == SETTLED_HISTORY[inputLines]
                 && filteredInputLines == inputLines) {
             refreshReleasedInputFastPathEligibility();
+            refreshPlayerInputHubFastPathEligibility(inputLines);
             return;
         }
         int nextFilteredInputLines = filteredInputLines;
@@ -317,10 +335,28 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             interruptManager.requestInterrupt(InterruptManager.InterruptType.P10_13);
         }
         refreshReleasedInputFastPathEligibility();
+        refreshPlayerInputHubFastPathEligibility(inputLines);
     }
 
-    private void invalidateReleasedInputFastPath() {
+    private PlayerInputSnapshot sampleInputForTick() {
+        if (playerInputSource == PlayerInputSource.RELEASED) {
+            return PlayerInputSnapshot.RELEASED;
+        }
+        if (playerInputSource instanceof PlayerInputHub && !isPlayerInputHubPollDue()) {
+            return sampledInput;
+        }
+        return Objects.requireNonNull(playerInputSource.sample(), "PlayerInputSource returned null");
+    }
+
+    private boolean isPlayerInputHubPollDue() {
+        // tick is incremented before sampling. Poll the first clock edge and then every 64th
+        // edge, preserving that phase through portable state capture/restore without extra state.
+        return (tick & (PLAYER_INPUT_HUB_POLL_TICKS - 1L)) == 1;
+    }
+
+    private void invalidateInputFastPaths() {
         releasedInputFastPathEligible = false;
+        playerInputHubFastPathEligible = false;
     }
 
     private void refreshReleasedInputFastPathEligibility() {
@@ -331,6 +367,16 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 && buttons.isEmpty()
                 && inputHistory == SETTLED_HISTORY[0x0f]
                 && filteredInputLines == 0x0f;
+        // Hub eligibility additionally depends on the current selector and filtered electrical
+        // lines. It is recomputed only after this tick has calculated those values.
+        playerInputHubFastPathEligible = false;
+    }
+
+    private void refreshPlayerInputHubFastPathEligibility(int inputLines) {
+        playerInputHubFastPathEligible = playerInputSource instanceof PlayerInputHub
+                && !inputChangedSinceLastTick
+                && inputHistory == SETTLED_HISTORY[inputLines]
+                && filteredInputLines == inputLines;
     }
 
     private static int[] createSettledHistory() {
@@ -357,7 +403,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         int previousSelection = p1;
         int nextSelection = value & 0x30;
         if (nextSelection != previousSelection) {
-            invalidateReleasedInputFastPath();
+            invalidateInputFastPaths();
         }
         if (isSgb) {
             int input = nextSelection;
@@ -378,7 +424,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         p1 = nextSelection;
         if (p1 != previousSelection) {
             inputChangedSinceLastTick = true;
-            invalidateReleasedInputFastPath();
+            invalidateInputFastPaths();
         }
     }
 
@@ -528,7 +574,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             throw new IllegalArgumentException("Invalid state type");
         }
         validateState(mem);
-        invalidateReleasedInputFastPath();
+        invalidateInputFastPaths();
         this.p1 = mem.p1;
         this.tick = mem.tick;
         this.inputHistory = mem.inputHistory;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/events/EventBusImplTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/events/EventBusImplTest.java
@@ -2,6 +2,9 @@ package eu.rekawek.coffeegb.core.events;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -308,6 +311,85 @@ public class EventBusImplTest {
         assertEquals(1, closeCalls.get());
     }
 
+    @Test
+    public void asyncBurstIsDeliveredOnceAndInFifoOrder() {
+        EventBusImpl bus = new EventBusImpl(null, "fifo", true, 1_000);
+        List<Integer> deliveries = Collections.synchronizedList(new ArrayList<>());
+        bus.register(event -> deliveries.add(event.sequence), SequencedEvent.class);
+
+        for (int sequence = 0; sequence < 100; sequence++) {
+            bus.postAsync(new SequencedEvent(sequence));
+        }
+        bus.drainAsyncEvents();
+
+        assertEquals(100, deliveries.size());
+        for (int sequence = 0; sequence < deliveries.size(); sequence++) {
+            assertEquals(sequence, deliveries.get(sequence).intValue());
+        }
+        bus.close();
+    }
+
+    @Test
+    public void drainWaitsWhileTheHeadAsyncSubscriberIsStillRunning() throws Exception {
+        EventBusImpl bus = new EventBusImpl(null, "drain", true, 1_000);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch drained = new CountDownLatch(1);
+        bus.register(
+                event -> {
+                    entered.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                },
+                TestEvent.class);
+        bus.postAsync(new TestEvent());
+        assertTrue(entered.await(2, TimeUnit.SECONDS));
+
+        Thread drainer = new Thread(() -> {
+            bus.drainAsyncEvents();
+            drained.countDown();
+        });
+        drainer.setDaemon(true);
+        drainer.start();
+        assertFalse("the head must remain visible through subscriber dispatch",
+                drained.await(50, TimeUnit.MILLISECONDS));
+
+        release.countDown();
+        assertTrue(drained.await(2, TimeUnit.SECONDS));
+        drainer.join(2_000);
+        assertFalse(drainer.isAlive());
+        bus.close();
+    }
+
+    @Test
+    public void idleAsyncWorkerBlocksUntilSignalledAndCloseWakesIt() throws Exception {
+        EventBusImpl bus = new EventBusImpl(null, "idle", true, 1_000);
+        await("the async worker to block on its event signal", bus::isAsyncWorkerBlockedForEvent);
+
+        long started = System.nanoTime();
+        bus.close();
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started);
+
+        assertTrue("close took " + elapsedMillis + " ms", elapsedMillis < 1_000);
+        assertThrows(IllegalStateException.class, () -> bus.postAsync(new TestEvent()));
+    }
+
+    private static void await(String description, Condition condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!condition.evaluate() && System.nanoTime() < deadline) {
+            Thread.sleep(1);
+        }
+        assertTrue("Timed out waiting for " + description, condition.evaluate());
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean evaluate();
+    }
+
     private static class TestEvent implements Event {
     }
 
@@ -316,6 +398,14 @@ public class EventBusImplTest {
 
         private NestedEvent(int depth) {
             this.depth = depth;
+        }
+    }
+
+    private static class SequencedEvent implements Event {
+        private final int sequence;
+
+        private SequencedEvent(int sequence) {
+            this.sequence = sequence;
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
@@ -8,6 +8,7 @@ import eu.rekawek.coffeegb.core.sgb.Commands;
 import eu.rekawek.coffeegb.core.sgb.SgbPacketTestBuilder;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,6 +18,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class JoypadHotPathTest {
@@ -97,6 +100,174 @@ public class JoypadHotPathTest {
         joypad.tick();
 
         assertEquals(2, samples.get());
+    }
+
+    @Test
+    public void settledPlayerInputHubReusesReleasedAndPressedLatchesBetweenPolls() {
+        PlayerInputHub releasedHub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle releasedSource = releasedHub.openSource(0);
+        Joypad releasedJoypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, releasedHub);
+
+        releasedJoypad.tick(); // first persisted tick is a hub-poll boundary
+        assertTrue(playerInputHubFastPathEligible(releasedJoypad));
+        PlayerInputSnapshot releasedBefore = releasedJoypad.getSampledInput();
+        releasedSource.update(Set.of());
+        PlayerInputSnapshot releasedAfter = releasedHub.sample();
+        assertNotSame(releasedBefore, releasedAfter);
+
+        tickNonPollHubInterval(releasedJoypad);
+
+        assertSame(releasedBefore, releasedJoypad.getSampledInput());
+        assertTrue(playerInputHubFastPathEligible(releasedJoypad));
+        releasedJoypad.tick();
+        assertSame(releasedAfter, releasedJoypad.getSampledInput());
+        assertTrue(playerInputHubFastPathEligible(releasedJoypad));
+
+        PlayerInputHub pressedHub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle pressedSource = pressedHub.openSource(0);
+        pressedSource.update(Set.of(Button.A));
+        Joypad pressedJoypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, pressedHub);
+        settlePlayerInputHub(pressedJoypad);
+        assertTrue(playerInputHubFastPathEligible(pressedJoypad));
+        tickToNextHubPoll(pressedJoypad);
+        PlayerInputSnapshot pressedBefore = pressedJoypad.getSampledInput();
+        pressedSource.update(Set.of(Button.A));
+        PlayerInputSnapshot pressedAfter = pressedHub.sample();
+        assertNotSame(pressedBefore, pressedAfter);
+
+        tickNonPollHubInterval(pressedJoypad);
+
+        assertSame(pressedBefore, pressedJoypad.getSampledInput());
+        assertTrue(playerInputHubFastPathEligible(pressedJoypad));
+        pressedJoypad.tick();
+        assertSame(pressedAfter, pressedJoypad.getSampledInput());
+        assertTrue(playerInputHubFastPathEligible(pressedJoypad));
+    }
+
+    @Test
+    public void playerInputHubChangesAreBoundedAndRetainFourSampleFilterTiming() {
+        InterruptManager interrupts = new InterruptManager(false);
+        interrupts.setByte(0xff0f, 0);
+        PlayerInputHub hub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle source = hub.openSource(0);
+        Joypad joypad = new Joypad(interrupts, EventBus.NULL_EVENT_BUS, false, hub);
+        joypad.setByte(JOYP, 0x10);
+        joypad.tick(); // poll and consume the selector transition
+        joypad.tick(); // settle the released selector state
+        tickToNextHubPoll(joypad);
+        assertTrue(playerInputHubFastPathEligible(joypad));
+
+        source.update(Set.of(Button.A));
+        PlayerInputSnapshot pressed = hub.sample();
+        tickNonPollHubInterval(joypad);
+
+        assertSame(PlayerInputSnapshot.RELEASED, joypad.getSampledInput());
+        assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
+        joypad.tick(); // next 64-tick poll adopts the new physical latch
+        assertSame(pressed, joypad.getSampledInput());
+        assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
+        for (int sample = 0; sample < 3; sample++) {
+            joypad.tick();
+            assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
+        }
+        joypad.tick();
+        assertTrue(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
+        assertEquals(0x0e, filteredInputLines(joypad.captureState()));
+
+        interrupts.setByte(0xff0f, 0);
+        tickToNextHubPoll(joypad);
+        source.update(Set.of());
+        PlayerInputSnapshot released = hub.sample();
+        tickNonPollHubInterval(joypad);
+
+        assertSame(pressed, joypad.getSampledInput());
+        joypad.tick(); // next poll adopts release; the filter starts on its following tick
+        assertSame(released, joypad.getSampledInput());
+        for (int sample = 0; sample < 3; sample++) {
+            joypad.tick();
+            assertEquals(0x0e, filteredInputLines(joypad.captureState()));
+        }
+        joypad.tick();
+        assertEquals(0x0f, filteredInputLines(joypad.captureState()));
+        assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
+    }
+
+    @Test
+    public void playerInputHubFastPathIsInvalidatedByStateAndInputMutations() {
+        PlayerInputHub hub = new PlayerInputHub();
+        hub.openSource(0).update(Set.of(Button.A));
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, hub);
+        settlePlayerInputHub(joypad);
+        assertTrue(playerInputHubFastPathEligible(joypad));
+
+        var state = joypad.captureState();
+        joypad.setByte(JOYP, 0x30);
+        assertFalse(playerInputHubFastPathEligible(joypad));
+        joypad.restoreState(state);
+        assertFalse(playerInputHubFastPathEligible(joypad));
+        joypad.setPressedButtons(Set.of(Button.START));
+        assertFalse(playerInputHubFastPathEligible(joypad));
+        joypad.applyDeterministicReplayLegacyInput(Set.of(Button.A));
+        assertFalse(playerInputHubFastPathEligible(joypad));
+        joypad.seedDeterministicReplayInput(Set.of(), joypad.getSampledInput());
+        assertFalse(playerInputHubFastPathEligible(joypad));
+
+        try (EventBusImpl sgbBus = new EventBusImpl(null, null, false)) {
+            PlayerInputHub multiplayerHub = new PlayerInputHub();
+            multiplayerHub.openSource(0).update(Set.of(Button.A));
+            Joypad multiplayerJoypad = new Joypad(
+                    new InterruptManager(false), sgbBus, true, multiplayerHub);
+            settlePlayerInputHub(multiplayerJoypad);
+            assertTrue(playerInputHubFastPathEligible(multiplayerJoypad));
+
+            int[] packet = new int[Commands.PACKET_SIZE];
+            packet[0] = 0x11 << 3 | 1;
+            packet[1] = 1;
+            sgbBus.post((Commands.MltReqCmd) Commands.toCommand(packet));
+
+            assertFalse(playerInputHubFastPathEligible(multiplayerJoypad));
+        }
+    }
+
+    @Test
+    public void equalDistinctLiveSnapshotIsAdoptedWithoutAPhysicalTransition() {
+        AtomicReference<PlayerInputSnapshot> input =
+                new AtomicReference<>(PlayerInputSnapshot.released());
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, input::get);
+        List<PhysicalInputEvent> physicalEvents = new ArrayList<>();
+        assertTrue(joypad.attachInputTimelineObserver(
+                (phase, player, buttonMask, changedMask) ->
+                        physicalEvents.add(new PhysicalInputEvent(
+                                phase, player, buttonMask, changedMask))));
+        PlayerInputSnapshot equalButDistinctReleased = PlayerInputSnapshot.of(List.of(
+                Set.of(), Set.of(), Set.of(), Set.of()));
+        assertNotSame(PlayerInputSnapshot.released(), equalButDistinctReleased);
+
+        input.set(equalButDistinctReleased);
+        joypad.tick();
+
+        assertSame(equalButDistinctReleased, joypad.getSampledInput());
+        assertEquals(List.of(), physicalEvents);
+
+        input.set(PlayerInputSnapshot.of(List.of(
+                Set.of(Button.A), Set.of(), Set.of(Button.LEFT), Set.of())));
+        joypad.tick();
+
+        assertEquals(List.of(
+                new PhysicalInputEvent(
+                        InputTimelineObserver.Phase.PHYSICAL_JOYPAD_SAMPLE,
+                        0,
+                        JoypadButtonMask.A,
+                        JoypadButtonMask.A),
+                new PhysicalInputEvent(
+                        InputTimelineObserver.Phase.PHYSICAL_JOYPAD_SAMPLE,
+                        2,
+                        JoypadButtonMask.LEFT,
+                        JoypadButtonMask.LEFT)), physicalEvents);
     }
 
     @Test
@@ -256,6 +427,39 @@ public class JoypadHotPathTest {
     }
 
     @Test
+    public void stablePlayerInputHubHotPathAllocatesNothing() {
+        java.lang.management.ThreadMXBean platformBean = ManagementFactory.getThreadMXBean();
+        Assume.assumeTrue(platformBean instanceof ThreadMXBean);
+        ThreadMXBean allocationBean = (ThreadMXBean) platformBean;
+        Assume.assumeTrue(allocationBean.isThreadAllocatedMemorySupported());
+        if (!allocationBean.isThreadAllocatedMemoryEnabled()) {
+            allocationBean.setThreadAllocatedMemoryEnabled(true);
+        }
+
+        PlayerInputHub hub = new PlayerInputHub();
+        hub.openSource(0).update(Set.of(Button.RIGHT, Button.A));
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, hub);
+        joypad.setByte(JOYP, 0x00);
+        exercise(joypad, 100_000);
+        assertTrue(playerInputHubFastPathEligible(joypad));
+
+        long threadId = Thread.currentThread().getId();
+        allocationBean.getThreadAllocatedBytes(threadId);
+        long minimumAllocated = Long.MAX_VALUE;
+        long checksum = 0;
+        for (int sample = 0; sample < 5; sample++) {
+            long before = allocationBean.getThreadAllocatedBytes(threadId);
+            checksum += exercise(joypad, 20_000);
+            long after = allocationBean.getThreadAllocatedBytes(threadId);
+            minimumAllocated = Math.min(minimumAllocated, after - before);
+        }
+
+        assertTrue(checksum != 0);
+        assertEquals("stable PlayerInputHub joypad path allocated", 0L, minimumAllocated);
+    }
+
+    @Test
     public void stablePhysicalInputHotPathAllocatesNothing() {
         java.lang.management.ThreadMXBean platformBean = ManagementFactory.getThreadMXBean();
         Assume.assumeTrue(platformBean instanceof ThreadMXBean);
@@ -290,6 +494,46 @@ public class JoypadHotPathTest {
         assertEquals("stable physical joypad path allocated", 0L, minimumAllocated);
     }
 
+    @Test
+    public void adoptedEqualDistinctLiveSnapshotHotPathAllocatesNothing() {
+        java.lang.management.ThreadMXBean platformBean = ManagementFactory.getThreadMXBean();
+        Assume.assumeTrue(platformBean instanceof ThreadMXBean);
+        ThreadMXBean allocationBean = (ThreadMXBean) platformBean;
+        Assume.assumeTrue(allocationBean.isThreadAllocatedMemorySupported());
+        if (!allocationBean.isThreadAllocatedMemoryEnabled()) {
+            allocationBean.setThreadAllocatedMemoryEnabled(true);
+        }
+
+        AtomicReference<PlayerInputSnapshot> input =
+                new AtomicReference<>(PlayerInputSnapshot.released());
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, input::get);
+        PlayerInputSnapshot equalButDistinctReleased = PlayerInputSnapshot.of(List.of(
+                Set.of(), Set.of(), Set.of(), Set.of()));
+        input.set(equalButDistinctReleased);
+        joypad.tick();
+        assertSame(equalButDistinctReleased, joypad.getSampledInput());
+        exercise(joypad, 100_000);
+
+        long threadId = Thread.currentThread().getId();
+        allocationBean.getThreadAllocatedBytes(threadId);
+        long minimumAllocated = Long.MAX_VALUE;
+        long checksum = 0;
+        for (int sample = 0; sample < 5; sample++) {
+            long before = allocationBean.getThreadAllocatedBytes(threadId);
+            checksum += exercise(joypad, 20_000);
+            long after = allocationBean.getThreadAllocatedBytes(threadId);
+            minimumAllocated = Math.min(minimumAllocated, after - before);
+        }
+
+        assertTrue(checksum != 0);
+        assertEquals("adopted equal physical joypad path allocated", 0L, minimumAllocated);
+    }
+
+    private record PhysicalInputEvent(
+            InputTimelineObserver.Phase phase, int player, int buttonMask, int changedMask) {
+    }
+
     private static int expectedInputLines(int selector, Set<Button> buttons) {
         int inputLines = 0x0f;
         for (Button button : buttons) {
@@ -307,6 +551,25 @@ public class JoypadHotPathTest {
             checksum += joypad.getByte(JOYP);
         }
         return checksum;
+    }
+
+    private static void settlePlayerInputHub(Joypad joypad) {
+        joypad.tick(); // initial hub poll adopts the source and consumes its change flag
+        for (int sample = 0; sample < 4; sample++) {
+            joypad.tick();
+        }
+    }
+
+    private static void tickToNextHubPoll(Joypad joypad) {
+        do {
+            joypad.tick();
+        } while ((tick(joypad.captureState()) & (Joypad.PLAYER_INPUT_HUB_POLL_TICKS - 1L)) != 1);
+    }
+
+    private static void tickNonPollHubInterval(Joypad joypad) {
+        for (int tick = 0; tick < Joypad.PLAYER_INPUT_HUB_POLL_TICKS - 1; tick++) {
+            joypad.tick();
+        }
     }
 
     private static long tick(ComponentState<Joypad> state) {
@@ -332,6 +595,16 @@ public class JoypadHotPathTest {
             return field.getBoolean(joypad);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError("Joypad has no released-input fast-path state", e);
+        }
+    }
+
+    private static boolean playerInputHubFastPathEligible(Joypad joypad) {
+        try {
+            var field = Joypad.class.getDeclaredField("playerInputHubFastPathEligible");
+            field.setAccessible(true);
+            return field.getBoolean(joypad);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Joypad has no PlayerInputHub fast-path state", e);
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/SgbFourPlayerInputTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/SgbFourPlayerInputTest.java
@@ -153,7 +153,7 @@ public class SgbFourPlayerInputTest {
         physical.update(Set.of(Button.B));
         assertEquals("the old latch remains intact before the next tick",
                 Set.of(Button.A), joypad.getPressedButtons());
-        joypad.tick();
+        tickThroughNextHubPoll(joypad);
         assertEquals("A to B is one atomic sample, never an A+B transient",
                 Set.of(Button.B), joypad.getPressedButtons());
 
@@ -208,6 +208,7 @@ public class SgbFourPlayerInputTest {
             joypad.tick();
             fixture.sendCommand(0x11, 1, 0);
             joypad.restoreState(state);
+            tickThroughNextHubPoll(joypad);
 
             assertEquals(1, joypad.getSgbMultiplayerStatus().selectedPlayer());
             assertPlayer(joypad, 0x07);
@@ -244,6 +245,12 @@ public class SgbFourPlayerInputTest {
     private static void selectNext(Joypad joypad) {
         joypad.setByte(JOYP, 0x10);
         joypad.setByte(JOYP, 0x30);
+    }
+
+    private static void tickThroughNextHubPoll(Joypad joypad) {
+        for (int tick = 0; tick < Joypad.PLAYER_INPUT_HUB_POLL_TICKS; tick++) {
+            joypad.tick();
+        }
     }
 
     private static void assertPlayer(Joypad joypad, int expectedLines) {

--- a/scripts/measure-harry-potter-intro-audio-timing.sh
+++ b/scripts/measure-harry-potter-intro-audio-timing.sh
@@ -6,18 +6,18 @@ DEFAULT_ROM="Z:/emu/roms/gbc/H/Harry Potter and the Sorcerer's Stone (USA, Europ
 ROM_PATH="${HARRY_POTTER_ROM:-$DEFAULT_ROM}"
 BATTERY_SAVE="${HARRY_POTTER_BATTERY_SAVE:-}"
 FORCE_FRAME_SKIP="${HARRY_POTTER_FORCE_FRAME_SKIP:-false}"
+LATENCY_PRESET="${HARRY_POTTER_AUDIO_LATENCY:-BALANCED}"
+JFR_PATH="${HARRY_POTTER_JFR:-}"
 if (($# > 0)); then
   ROM_PATH="$1"
 fi
-PROBE_PATH="core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroAudioTimingTest.java"
-SUPPORT_PATH="core/src/test/java/eu/rekawek/coffeegb/core/performance/HarryPotterIntroHarness.java"
+PROBE_PATH="swing/src/test/java/eu/rekawek/coffeegb/swing/io/HarryPotterIntroUiAudioTimingTest.java"
 HARNESS_FILE="${HARRY_POTTER_AUDIO_TIMING_HARNESS:-}"
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 cleanup_probe=false
-cleanup_support=false
 if [[ ! -f "$PROBE_PATH" ]]; then
   mkdir -p "$(dirname "$PROBE_PATH")"
   if [[ -n "$HARNESS_FILE" ]]; then
@@ -27,32 +27,27 @@ if [[ ! -f "$PROBE_PATH" ]]; then
   fi
   cleanup_probe=true
 fi
-if [[ ! -f "$SUPPORT_PATH" ]]; then
-  mkdir -p "$(dirname "$SUPPORT_PATH")"
-  git show "${HARNESS_REF}:${SUPPORT_PATH}" > "$SUPPORT_PATH"
-  cleanup_support=true
-fi
 
 cleanup() {
   if [[ "$cleanup_probe" == true ]]; then
     rm -f "$PROBE_PATH"
   fi
-  if [[ "$cleanup_support" == true ]]; then
-    rm -f "$SUPPORT_PATH"
-  fi
   rmdir --ignore-fail-on-non-empty "$(dirname "$PROBE_PATH")"
 }
 trap cleanup EXIT
 
-mvn -q -pl core \
-  -Dtest=HarryPotterIntroAudioTimingTest \
+mvn -q -pl swing -am \
+  -Dtest=HarryPotterIntroUiAudioTimingTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
   -DharryPotterRom="$ROM_PATH" \
   -DharryPotterBatterySave="$BATTERY_SAVE" \
   -DharryPotterForceFrameSkip="$FORCE_FRAME_SKIP" \
+  -DharryPotterAudioLatency="$LATENCY_PRESET" \
+  -DharryPotterJfr="$JFR_PATH" \
   -Dsurefire.useFile=false \
   test
 
-report="core/target/surefire-reports/TEST-eu.rekawek.coffeegb.core.performance.HarryPotterIntroAudioTimingTest.xml"
+report="swing/target/surefire-reports/TEST-eu.rekawek.coffeegb.swing.io.HarryPotterIntroUiAudioTimingTest.xml"
 sed -n '/<system-out><!\[CDATA\[/,/]]><\/system-out>/p' "$report" \
   | sed -e 's/^.*<!\[CDATA\[//' -e 's/]]><\/system-out>.*$//' \
-  | sed -n '/Timed audio\|Audio event\|Audio gaps\|Maximum simulated/p'
+  | sed -n '/UI audio timing\|Audio frontend\|Audio line\|Producer event\|Controller frame\|Audio gaps\|Audio underruns\|Audio gap\|Audio worker\|Forced frame suppression\|JFR/p'

--- a/scripts/measure-harry-potter-intro-audio-timing.sh
+++ b/scripts/measure-harry-potter-intro-audio-timing.sh
@@ -5,9 +5,18 @@ HARNESS_REF="${HARNESS_REF:-master}"
 DEFAULT_ROM="Z:/emu/roms/gbc/H/Harry Potter and the Sorcerer's Stone (USA, Europe) (En,Fr,De,Es,It,Nl,Pt,Sv,No,Da,Fi).gbc"
 ROM_PATH="${HARRY_POTTER_ROM:-$DEFAULT_ROM}"
 BATTERY_SAVE="${HARRY_POTTER_BATTERY_SAVE:-}"
-FORCE_FRAME_SKIP="${HARRY_POTTER_FORCE_FRAME_SKIP:-false}"
 LATENCY_PRESET="${HARRY_POTTER_AUDIO_LATENCY:-BALANCED}"
+REWIND_ENABLED="${HARRY_POTTER_REWIND_ENABLED:-true}"
+BOOTSTRAP_MODE="${HARRY_POTTER_BOOTSTRAP_MODE:-SKIP}"
+SAMPLE_LINE_OCCUPANCY="${HARRY_POTTER_SAMPLE_LINE_OCCUPANCY:-false}"
 JFR_PATH="${HARRY_POTTER_JFR:-}"
+case "$SAMPLE_LINE_OCCUPANCY" in
+  true|false) ;;
+  *)
+    echo "HARRY_POTTER_SAMPLE_LINE_OCCUPANCY must be true or false: $SAMPLE_LINE_OCCUPANCY" >&2
+    exit 2
+    ;;
+esac
 if (($# > 0)); then
   ROM_PATH="$1"
 fi
@@ -41,8 +50,10 @@ mvn -q -pl swing -am \
   -Dsurefire.failIfNoSpecifiedTests=false \
   -DharryPotterRom="$ROM_PATH" \
   -DharryPotterBatterySave="$BATTERY_SAVE" \
-  -DharryPotterForceFrameSkip="$FORCE_FRAME_SKIP" \
   -DharryPotterAudioLatency="$LATENCY_PRESET" \
+  -DharryPotterRewindEnabled="$REWIND_ENABLED" \
+  -DharryPotterBootstrapMode="$BOOTSTRAP_MODE" \
+  -DharryPotterSampleLineOccupancy="$SAMPLE_LINE_OCCUPANCY" \
   -DharryPotterJfr="$JFR_PATH" \
   -Dsurefire.useFile=false \
   test
@@ -50,4 +61,4 @@ mvn -q -pl swing -am \
 report="swing/target/surefire-reports/TEST-eu.rekawek.coffeegb.swing.io.HarryPotterIntroUiAudioTimingTest.xml"
 sed -n '/<system-out><!\[CDATA\[/,/]]><\/system-out>/p' "$report" \
   | sed -e 's/^.*<!\[CDATA\[//' -e 's/]]><\/system-out>.*$//' \
-  | sed -n '/UI audio timing\|Audio frontend\|Audio line\|Producer event\|Controller frame\|Audio gaps\|Audio underruns\|Audio gap\|Audio worker\|Forced frame suppression\|JFR/p'
+  | sed -n '/Full intro/p'

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -35,6 +35,14 @@ import javax.swing.JFrame
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 
+fun interface SwingAudioOutputFactory {
+  fun create(
+      configuration: AudioRuntimeConfiguration,
+      eventBus: EventBus,
+      callerId: String,
+  ): AudioSystemSound
+}
+
 /** Synchronous boundary emitted before an old controller is closed and replaced. */
 internal class ControllerOwnershipChangingEvent : Event
 
@@ -54,6 +62,10 @@ class SwingEmulator(
         },
     private val mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink =
         MobileAdapterGuestConfigurationSink.NO_OP,
+    private val audioOutputFactory: SwingAudioOutputFactory =
+        SwingAudioOutputFactory { configuration, bus, callerId ->
+          AudioSystemSound(configuration, bus, callerId) {}
+        },
 ) {
   private val display: SwingDisplay
   private val joypad: SwingJoypad
@@ -88,11 +100,11 @@ class SwingEmulator(
   init {
     display = SwingDisplay(properties.display, eventBus, "main")
     sound =
-        AudioSystemSound(
+        audioOutputFactory.create(
             properties.applicationSettings.audio.toRuntimeConfiguration(),
             eventBus,
             "main",
-        ) {}
+        )
     val playerInput = DesktopPlayerInput(properties.playerInputSource, eventBus)
     tiltInput = DesktopTiltInput(eventBus)
     joypad = SwingJoypad(properties.playerInputMapping, eventBus, playerInput)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioBackend.java
@@ -15,6 +15,9 @@ interface AudioBackend {
     interface AudioLine extends AutoCloseable {
         void start();
 
+        /** True when the provider currently reports that playback is running. */
+        boolean isRunning();
+
         int write(byte[] bytes, int offset, int length);
 
         int available();

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
  * Validated host-audio settings applied without mutating emulation state.
  *
  * <p>The balanced preset deliberately retains Coffee GB's historical 8192-byte line and
- * three-frame producer queue. Every line buffer is stereo-frame aligned and every queue stays
- * bounded so a slow host cannot create ever-growing latency.
+ * three-frame startup watermark. Runtime producer capacity is separately bounded so it can be
+ * tuned without changing startup priming or line-buffer latency.
  */
 public record AudioRuntimeConfiguration(
         String outputDeviceId,
@@ -54,23 +54,32 @@ public record AudioRuntimeConfiguration(
     }
 
     public enum LatencyPreset {
-        LOW(2048, 1),
-        BALANCED(8192, 3),
-        SAFE(16384, 6);
+        /** Latency-first: one startup frame plus three controller frames of catch-up headroom. */
+        LOW(2048, 1, 4),
+        /** Historical default startup latency with nine transient scheduling-headroom frames. */
+        BALANCED(8192, 3, 12),
+        /** Conservative startup latency with the same nine-frame transient scheduling headroom. */
+        SAFE(16384, 6, 15);
 
         private final int lineBufferBytes;
         private final int queuedFrames;
+        private final int runtimeQueueCapacity;
 
-        LatencyPreset(int lineBufferBytes, int queuedFrames) {
+        LatencyPreset(int lineBufferBytes, int queuedFrames, int runtimeQueueCapacity) {
             if (lineBufferBytes <= 0 || lineBufferBytes % 4 != 0) {
                 throw new IllegalArgumentException(
                         "Audio line buffers must contain complete stereo frames");
             }
             if (queuedFrames <= 0) {
-                throw new IllegalArgumentException("Audio queue capacity must be positive");
+                throw new IllegalArgumentException("Audio startup watermark must be positive");
+            }
+            if (runtimeQueueCapacity < queuedFrames) {
+                throw new IllegalArgumentException(
+                        "Audio runtime queue capacity cannot be below its startup watermark");
             }
             this.lineBufferBytes = lineBufferBytes;
             this.queuedFrames = queuedFrames;
+            this.runtimeQueueCapacity = runtimeQueueCapacity;
         }
 
         public int lineBufferBytes() {
@@ -79,6 +88,17 @@ public record AudioRuntimeConfiguration(
 
         public int queuedFrames() {
             return queuedFrames;
+        }
+
+        /**
+         * Maximum real PCM frames retained while playback is running.
+         *
+         * <p>This does not change startup priming or line-buffer latency. BALANCED and SAFE retain
+         * nine controller frames (about 150 ms) beyond their startup watermarks to absorb short
+         * Windows Java Sound/JVM scheduling stalls; LOW intentionally retains only three.</p>
+         */
+        public int runtimeQueueCapacity() {
+            return runtimeQueueCapacity;
         }
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioRuntimeConfiguration.java
@@ -6,9 +6,9 @@ import java.util.regex.Pattern;
 /**
  * Validated host-audio settings applied without mutating emulation state.
  *
- * <p>The balanced preset deliberately retains Coffee GB's historical 8192-byte line and
- * three-frame startup watermark. Runtime producer capacity is separately bounded so it can be
- * tuned without changing startup priming or line-buffer latency.
+ * <p>The balanced default prioritizes continuity across bounded host-audio stalls: its 16 KiB
+ * line provides about 92.88 ms of device runway, it primes six source frames, and its separate
+ * runtime producer capacity remains bounded at twenty-four frames.
  */
 public record AudioRuntimeConfiguration(
         String outputDeviceId,
@@ -56,10 +56,10 @@ public record AudioRuntimeConfiguration(
     public enum LatencyPreset {
         /** Latency-first: one startup frame plus three controller frames of catch-up headroom. */
         LOW(2048, 1, 4),
-        /** Historical default startup latency with nine transient scheduling-headroom frames. */
-        BALANCED(8192, 3, 12),
-        /** Conservative startup latency with the same nine-frame transient scheduling headroom. */
-        SAFE(16384, 6, 15);
+        /** Continuity-safe default: 92.88 ms line/startup runway and 400 ms catch-up capacity. */
+        BALANCED(16384, 6, 24),
+        /** Conservative option: 185.76 ms line/startup runway and about 533 ms catch-up capacity. */
+        SAFE(32768, 12, 32);
 
         private final int lineBufferBytes;
         private final int queuedFrames;
@@ -93,9 +93,11 @@ public record AudioRuntimeConfiguration(
         /**
          * Maximum real PCM frames retained while playback is running.
          *
-         * <p>This does not change startup priming or line-buffer latency. BALANCED and SAFE retain
-         * nine controller frames (about 150 ms) beyond their startup watermarks to absorb short
-         * Windows Java Sound/JVM scheduling stalls; LOW intentionally retains only three.</p>
+         * <p>BALANCED retains up to twenty-four controller frames (about 400 ms), in addition to
+         * its 16 KiB device line and six-frame startup prime, to absorb measured Windows provider
+         * stalls without unbounded producer growth. SAFE retains thirty-two frames (about
+         * 533 ms) with its 32 KiB line and twelve-frame prime; LOW intentionally retains only
+         * four frames.</p>
          */
         public int runtimeQueueCapacity() {
             return runtimeQueueCapacity;

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -58,10 +58,14 @@ public class AudioSystemSound implements Runnable {
     private static final long RETRY_UNAVAILABLE_MILLIS = 1000;
     private static final long STOP_TIMEOUT_MILLIS = 2000;
     private static final long FORCED_CLOSE_TIMEOUT_MILLIS = 250;
+    private static final int WINDOWS_AUDIO_WORKER_PRIORITY =
+            Math.min(Thread.MAX_PRIORITY, Thread.NORM_PRIORITY + 1);
     private static final int MAX_RUNTIME_QUEUED_FRAMES =
             AudioRuntimeConfiguration.LatencyPreset.SAFE.runtimeQueueCapacity();
 
     private final AudioBackend backend;
+    private final String operatingSystemName;
+    private final WorkerThreadPrioritySetter workerThreadPrioritySetter;
     private final AtomicReference<AudioRuntimeConfiguration> desiredConfiguration;
     private final BlockingQueue<AudioRuntimeConfiguration> configurationQueue =
             new ArrayBlockingQueue<>(1);
@@ -83,6 +87,13 @@ public class AudioSystemSound implements Runnable {
     private volatile boolean doStop;
     private volatile Thread workerThread;
     private volatile AudioBackend.AudioLine activeLine;
+
+    /**
+     * Worker-local ownership of one dequeued PCM buffer, including any blocking provider writes.
+     * Package-private observation lets the external timing probe avoid treating an empty shared
+     * queue as delivered while this buffer is still in flight.
+     */
+    private volatile boolean pcmBufferWriteInProgress;
 
     private final StereoPcmConverter pcmConverter = new StereoPcmConverter(SAMPLE_RATE);
 
@@ -125,8 +136,46 @@ public class AudioSystemSound implements Runnable {
             String callerId,
             AudioBackend backend,
             Consumer<AudioOutputStatus> statusObserver) {
+        this(
+                initialConfiguration,
+                eventBus,
+                callerId,
+                backend,
+                statusObserver,
+                System.getProperty("os.name"),
+                Thread::setPriority);
+    }
+
+    AudioSystemSound(
+            AudioRuntimeConfiguration initialConfiguration,
+            EventBus eventBus,
+            String callerId,
+            AudioBackend backend,
+            Consumer<AudioOutputStatus> statusObserver,
+            String operatingSystemName) {
+        this(
+                initialConfiguration,
+                eventBus,
+                callerId,
+                backend,
+                statusObserver,
+                operatingSystemName,
+                Thread::setPriority);
+    }
+
+    AudioSystemSound(
+            AudioRuntimeConfiguration initialConfiguration,
+            EventBus eventBus,
+            String callerId,
+            AudioBackend backend,
+            Consumer<AudioOutputStatus> statusObserver,
+            String operatingSystemName,
+            WorkerThreadPrioritySetter workerThreadPrioritySetter) {
         Objects.requireNonNull(eventBus, "eventBus");
         this.backend = Objects.requireNonNull(backend, "backend");
+        this.operatingSystemName = operatingSystemName;
+        this.workerThreadPrioritySetter =
+                Objects.requireNonNull(workerThreadPrioritySetter, "workerThreadPrioritySetter");
         this.desiredConfiguration =
                 new AtomicReference<>(Objects.requireNonNull(
                         initialConfiguration, "initialConfiguration"));
@@ -156,6 +205,7 @@ public class AudioSystemSound implements Runnable {
         }
         Thread thread = new Thread(this::runWorker, "coffee-gb-audio-output");
         thread.setDaemon(true);
+        configureOwnedWorkerPriority(thread, operatingSystemName, workerThreadPrioritySetter);
         workerThread = thread;
         thread.start();
         return thread;
@@ -354,9 +404,10 @@ public class AudioSystemSound implements Runnable {
                         int watermark = applied.latencyPreset().queuedFrames();
                         if (primingFrames.size() >= watermark) {
                             // A running line lets a staged batch larger than its physical buffer
-                            // drain while writeFully completes. start() is an idempotent recovery
-                            // nudge for providers that stop themselves after an underrun.
-                            line.start();
+                            // drain while writeFully completes. Providers may stop after an
+                            // underrun, so recover that state without issuing a native start for
+                            // every normal PCM buffer.
+                            ensureLineRunning(line);
                             while (!primingFrames.isEmpty()) {
                                 if (appliedGeneration != configurationGeneration.get()) {
                                     // A SAFE batch can span several blocking device writes. Do not
@@ -373,7 +424,7 @@ public class AudioSystemSound implements Runnable {
                         // SourceDataLine providers may stop after naturally draining. Resume the
                         // real frame immediately; withholding it to rebuild the startup watermark
                         // would turn a slow producer into a larger periodic burst/pause cycle.
-                        line.start();
+                        ensureLineRunning(line);
                         writeFully(line, buffer);
                     }
                 } catch (RuntimeException failure) {
@@ -496,6 +547,18 @@ public class AudioSystemSound implements Runnable {
         }
     }
 
+    /**
+     * Ensures the provider has been asked to run when its public running state is false. Some
+     * Java Sound implementations report false until their first PCM write, so that can require
+     * one idempotent priming start. {@link javax.sound.sampled.DataLine#isActive()} is deliberately
+     * unsuitable: a naturally empty {@code SourceDataLine} can be inactive while still running.
+     */
+    private void ensureLineRunning(AudioBackend.AudioLine line) {
+        if (!line.isRunning()) {
+            line.start();
+        }
+    }
+
     private void publishUnavailable(
             String requested, Throwable requestedFailure, Throwable fallbackFailure) {
         String detail = "No audio output is currently available ("
@@ -593,13 +656,18 @@ public class AudioSystemSound implements Runnable {
     }
 
     private void writeFully(AudioBackend.AudioLine line, byte[] bytes) {
-        int offset = 0;
-        while (offset < bytes.length && !doStop) {
-            int written = line.write(bytes, offset, bytes.length - offset);
-            if (written <= 0) {
-                throw new IllegalStateException("Audio line made no write progress");
+        pcmBufferWriteInProgress = true;
+        try {
+            int offset = 0;
+            while (offset < bytes.length && !doStop) {
+                int written = line.write(bytes, offset, bytes.length - offset);
+                if (written <= 0) {
+                    throw new IllegalStateException("Audio line made no write progress");
+                }
+                offset += written;
             }
-            offset += written;
+        } finally {
+            pcmBufferWriteInProgress = false;
         }
     }
 
@@ -665,5 +733,34 @@ public class AudioSystemSound implements Runnable {
 
     Thread workerThreadForTesting() {
         return workerThread;
+    }
+
+    /** Package-private timing-probe seam for a worker-local dequeued PCM buffer. */
+    boolean isPcmBufferWriteInProgressForTesting() {
+        return pcmBufferWriteInProgress;
+    }
+
+    static boolean isWindows(String operatingSystemName) {
+        return operatingSystemName != null
+                && operatingSystemName.regionMatches(true, 0, "Windows", 0, "Windows".length());
+    }
+
+    static void configureOwnedWorkerPriority(
+            Thread worker,
+            String operatingSystemName,
+            WorkerThreadPrioritySetter prioritySetter) {
+        if (!isWindows(operatingSystemName)) {
+            return;
+        }
+        try {
+            prioritySetter.setPriority(worker, WINDOWS_AUDIO_WORKER_PRIORITY);
+        } catch (SecurityException | UnsupportedOperationException failure) {
+            LOG.debug("Unable to raise owned audio worker priority");
+        }
+    }
+
+    @FunctionalInterface
+    interface WorkerThreadPrioritySetter {
+        void setPriority(Thread worker, int priority);
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/AudioSystemSound.java
@@ -58,8 +58,8 @@ public class AudioSystemSound implements Runnable {
     private static final long RETRY_UNAVAILABLE_MILLIS = 1000;
     private static final long STOP_TIMEOUT_MILLIS = 2000;
     private static final long FORCED_CLOSE_TIMEOUT_MILLIS = 250;
-    private static final int MAX_QUEUED_FRAMES =
-            AudioRuntimeConfiguration.LatencyPreset.SAFE.queuedFrames();
+    private static final int MAX_RUNTIME_QUEUED_FRAMES =
+            AudioRuntimeConfiguration.LatencyPreset.SAFE.runtimeQueueCapacity();
 
     private final AudioBackend backend;
     private final AtomicReference<AudioRuntimeConfiguration> desiredConfiguration;
@@ -69,10 +69,11 @@ public class AudioSystemSound implements Runnable {
 
     /*
      * Keep this field name and BlockingQueue type source-compatible with the deterministic clock
-     * probes. The physical capacity is the largest preset; enqueuePcm enforces the active preset.
+     * probes. The physical capacity is the largest runtime preset; enqueuePcm enforces the active
+     * bounded runtime capacity while startup priming continues to use queuedFrames().
      */
     private final BlockingQueue<byte[]> queue =
-            new ArrayBlockingQueue<>(MAX_QUEUED_FRAMES);
+            new ArrayBlockingQueue<>(MAX_RUNTIME_QUEUED_FRAMES);
 
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean emergencyCloseStarted = new AtomicBoolean();
@@ -244,7 +245,7 @@ public class AudioSystemSound implements Runnable {
         AudioBackend.AudioLine line = null;
         boolean usingFallback = false;
         boolean priming = true;
-        Deque<byte[]> primingFrames = new ArrayDeque<>(MAX_QUEUED_FRAMES);
+        Deque<byte[]> primingFrames = new ArrayDeque<>(MAX_RUNTIME_QUEUED_FRAMES);
         long appliedGeneration = configurationGeneration.get();
         long retryAtNanos = 0;
         publishStatus(new AudioOutputStatus(
@@ -637,7 +638,7 @@ public class AudioSystemSound implements Runnable {
                 configuration.masterVolume(), configuration.muted(), pcmScratch);
         byte[] trimmed = Arrays.copyOf(pcmScratch, written);
         if (generation == configurationGeneration.get()) {
-            enqueuePcm(trimmed, configuration.latencyPreset().queuedFrames());
+            enqueuePcm(trimmed, configuration.latencyPreset().runtimeQueueCapacity());
         }
     }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshot.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshot.java
@@ -3,6 +3,10 @@ package eu.rekawek.coffeegb.swing.io;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
+import java.awt.image.DirectColorModel;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -10,21 +14,47 @@ import java.util.Objects;
  */
 final class DisplayFrameSnapshot {
 
+    private static final int RED_MASK = 0x00ff0000;
+
+    private static final int GREEN_MASK = 0x0000ff00;
+
+    private static final int BLUE_MASK = 0x000000ff;
+
+    private static final int[] RGB_MASKS = {RED_MASK, GREEN_MASK, BLUE_MASK};
+
+    private static final DirectColorModel RGB_COLOR_MODEL =
+            new DirectColorModel(24, RED_MASK, GREEN_MASK, BLUE_MASK);
+
     private final int width;
 
     private final int height;
 
     private final BufferedImage image;
 
-    private DisplayFrameSnapshot(int width, int height, int[] rgb) {
+    private DisplayFrameSnapshot(int width, int height, int[] ownedRgb) {
         this.width = width;
         this.height = height;
-        this.image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        int[] imagePixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
-        System.arraycopy(rgb, 0, imagePixels, 0, imagePixels.length);
+        DataBufferInt dataBuffer = new DataBufferInt(ownedRgb, ownedRgb.length);
+        WritableRaster raster = Raster.createPackedRaster(
+                dataBuffer, width, height, width, RGB_MASKS, null);
+        this.image = new BufferedImage(RGB_COLOR_MODEL, raster, false, null);
     }
 
     static DisplayFrameSnapshot copyOf(int width, int height, int[] rgb) {
+        int expectedLength = validate(width, height, rgb);
+        return takeOwnership(width, height, Arrays.copyOf(rgb, expectedLength));
+    }
+
+    /**
+     * Takes sole ownership of a validated exact-length raster. Callers must not mutate or reuse
+     * the array after this method returns.
+     */
+    static DisplayFrameSnapshot takeOwnership(int width, int height, int[] ownedRgb) {
+        validate(width, height, ownedRgb);
+        return new DisplayFrameSnapshot(width, height, ownedRgb);
+    }
+
+    private static int validate(int width, int height, int[] rgb) {
         Objects.requireNonNull(rgb, "rgb");
         if (width <= 0 || height <= 0) {
             throw new IllegalArgumentException("Frame dimensions must be positive");
@@ -34,7 +64,7 @@ final class DisplayFrameSnapshot {
             throw new IllegalArgumentException(
                     "Frame pixel count must be exactly " + expectedLength);
         }
-        return new DisplayFrameSnapshot(width, height, rgb);
+        return expectedLength;
     }
 
     int width() {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/JavaSoundAudioBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/JavaSoundAudioBackend.java
@@ -169,6 +169,11 @@ final class JavaSoundAudioBackend implements AudioBackend {
         }
 
         @Override
+        public boolean isRunning() {
+            return line.isRunning();
+        }
+
+        @Override
         public int write(byte[] bytes, int offset, int length) {
             return line.write(bytes, offset, length);
         }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -446,7 +446,7 @@ public class SwingDisplay extends JPanel implements Runnable {
                 }
             }
 
-            displayedFrame.set(DisplayFrameSnapshot.copyOf(
+            displayedFrame.set(DisplayFrameSnapshot.takeOwnership(
                     frame.width(), frame.height(), frame.rgb()));
             double framesPerSecond = presentationFrameRate.framePublished();
             if (!Double.isNaN(framesPerSecond)) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
@@ -19,8 +19,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -74,7 +78,7 @@ public class AudioSystemSoundTest {
     }
 
     @Test
-    public void balancedRuntimeQueueAcceptsCatchUpHeadroomWithoutChangingStartupWatermark()
+    public void balancedRuntimeQueueAcceptsContinuityHeadroomAndBoundsOldestFrame()
             throws Exception {
         EventBusImpl eventBus = synchronousBus();
         AudioSystemSound sound = new AudioSystemSound(
@@ -84,17 +88,138 @@ public class AudioSystemSoundTest {
                 new FakeBackend(),
                 ignored -> {
                 });
-        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int ticks = ClockSpec.LEGACY.controllerTicksPerFrame();
         int capacity = AudioRuntimeConfiguration.LatencyPreset.BALANCED.runtimeQueueCapacity();
 
-        for (int frame = 0; frame < capacity; frame++) {
-            eventBus.post(new Sound.SoundSampleEvent(samples));
+        for (int frame = 1; frame <= capacity; frame++) {
+            eventBus.post(new Sound.SoundSampleEvent(constantSamples(ticks, frame * 480)));
         }
-        assertEquals(12, capacity);
+        assertEquals(24, capacity);
         assertEquals(capacity, queue(sound).size());
+        List<byte[]> beforeOverflow = new ArrayList<>(queue(sound));
 
-        eventBus.post(new Sound.SoundSampleEvent(samples));
+        eventBus.post(new Sound.SoundSampleEvent(constantSamples(ticks, (capacity + 1) * 480)));
         assertEquals("runtime queue must remain bounded", capacity, queue(sound).size());
+        assertArrayEquals("overflow must discard the oldest real PCM frame",
+                beforeOverflow.get(1), queue(sound).peek());
+    }
+
+    @Test
+    public void balancedQueueCoversA324MillisecondScriptedWorkerStallWithoutSleeping()
+            throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                new FakeBackend(),
+                ignored -> {
+                });
+        ClockSpec clock = ClockSpec.LEGACY;
+        int stalledFrames = 20;
+        ClockSpec.RateAccumulator elapsed = clock.newFrameNanosecondAccumulator();
+
+        for (int frame = 0; frame < stalledFrames; frame++) {
+            eventBus.post(new Sound.SoundSampleEvent(
+                    constantSamples(clock.controllerTicksPerFrame(), 480)));
+        }
+
+        long scriptedStallNanos = elapsed.advance(stalledFrames);
+        assertTrue(scriptedStallNanos >= TimeUnit.MILLISECONDS.toNanos(324));
+        assertTrue(scriptedStallNanos < TimeUnit.MILLISECONDS.toNanos(400));
+        assertTrue(stalledFrames <= AudioRuntimeConfiguration.LatencyPreset.BALANCED
+                .runtimeQueueCapacity());
+        assertEquals(stalledFrames, queue(sound).size());
+    }
+
+    @Test
+    public void windowsPriorityIsAppliedBeforeStartWhileNonWindowsLeavesItUntouched() {
+        Thread windowsWorker = new Thread();
+        AtomicReference<Thread.State> stateDuringConfiguration = new AtomicReference<>();
+        AtomicInteger requestedPriority = new AtomicInteger();
+
+        AudioSystemSound.configureOwnedWorkerPriority(
+                windowsWorker,
+                "wInDoWs 11",
+                (worker, priority) -> {
+                    stateDuringConfiguration.set(worker.getState());
+                    requestedPriority.set(priority);
+                    worker.setPriority(priority);
+                });
+
+        assertEquals(Thread.State.NEW, stateDuringConfiguration.get());
+        assertEquals(Thread.NORM_PRIORITY + 1, requestedPriority.get());
+        assertEquals(Thread.NORM_PRIORITY + 1, windowsWorker.getPriority());
+        assertTrue(AudioSystemSound.isWindows("Windows NT"));
+        assertFalse(AudioSystemSound.isWindows("Linux"));
+
+        Thread nonWindowsWorker = new Thread();
+        nonWindowsWorker.setPriority(Thread.NORM_PRIORITY - 2);
+        AtomicBoolean nonWindowsSetterCalled = new AtomicBoolean();
+
+        AudioSystemSound.configureOwnedWorkerPriority(
+                nonWindowsWorker,
+                "Mac OS X",
+                (worker, priority) -> nonWindowsSetterCalled.set(true));
+
+        assertFalse("non-Windows worker priority must remain inherited", nonWindowsSetterCalled.get());
+        assertEquals(Thread.NORM_PRIORITY - 2, nonWindowsWorker.getPriority());
+    }
+
+    @Test
+    public void windowsOwnedWorkerStartsAsNamedDaemonAtRaisedPriority() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add("default", "System Default");
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                },
+                "Windows 11");
+
+        Thread worker = sound.start();
+        try {
+            await("Windows-priority output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            assertEquals("coffee-gb-audio-output", worker.getName());
+            assertTrue(worker.isDaemon());
+            assertEquals(Thread.NORM_PRIORITY + 1, worker.getPriority());
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void priorityFailureDoesNotPreventWindowsAudioWorkerStartup() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add("default", "System Default");
+        AtomicBoolean priorityAttempted = new AtomicBoolean();
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                },
+                "Windows 11",
+                (worker, priority) -> {
+                    priorityAttempted.set(true);
+                    throw new SecurityException("priority denied");
+                });
+
+        Thread worker = sound.start();
+        try {
+            await("audio worker after a failed priority request",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            assertTrue(priorityAttempted.get());
+            assertTrue(worker.isAlive());
+        } finally {
+            sound.stopThread();
+        }
     }
 
     @Test
@@ -169,6 +294,232 @@ public class AudioSystemSoundTest {
 
             eventBus.post(new Sound.SoundSampleEvent(samples));
             await("primed PCM batch", () -> line.nonSilentWriteCount() == watermark);
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void runningLineStartsOnlyAtOpenNotAtPrimingOrEachRealBuffer() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add("default", "System Default");
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int watermark = AudioRuntimeConfiguration.LatencyPreset.BALANCED.queuedFrames();
+
+        sound.start();
+        try {
+            await("default output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            FakeLine line = backend.lastLine("default");
+            assertEquals("openAndStart starts the fresh provider once", 1, line.startCount);
+
+            for (int frame = 0; frame < watermark; frame++) {
+                eventBus.post(new Sound.SoundSampleEvent(samples));
+            }
+            await("primed PCM batch", () -> line.nonSilentWriteCount() == watermark);
+            assertEquals("priming must not restart a running line", 1, line.startCount);
+
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("steady-state PCM frame", () -> line.nonSilentWriteCount() == watermark + 1);
+            assertEquals("steady PCM must not restart a running line", 1, line.startCount);
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void windowsPublicRunningStateMayNeedOnePrimingStartButNotSteadyStarts()
+            throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.runningBecomesPublicAfterFirstWrite = true;
+        backend.add("default", "System Default");
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int watermark = AudioRuntimeConfiguration.LatencyPreset.BALANCED.queuedFrames();
+
+        sound.start();
+        try {
+            await("Windows-like output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            FakeLine line = backend.lastLine("default");
+            assertEquals(1, line.startCount);
+            assertFalse("some providers do not report running until the first PCM write",
+                    line.isRunning());
+
+            for (int frame = 0; frame < watermark; frame++) {
+                eventBus.post(new Sound.SoundSampleEvent(samples));
+            }
+            await("primed Windows-like PCM", () -> line.nonSilentWriteCount() == watermark);
+            assertEquals("the false public state permits one idempotent priming start", 2,
+                    line.startCount);
+            assertTrue(line.isRunning());
+
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("steady Windows-like PCM", () -> line.nonSilentWriteCount() == watermark + 1);
+            assertEquals("steady PCM must not repeat native starts", 2, line.startCount);
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void stoppedLineRestartsBeforeRealPcmAndStartFailureFallsBack() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        FakeBackend backend = new FakeBackend();
+        backend.add(DEVICE_A, "Output A");
+        backend.add("default", "System Default");
+        AudioSystemSound sound = new AudioSystemSound(
+                new AudioRuntimeConfiguration(
+                        DEVICE_A, 100, false,
+                        AudioRuntimeConfiguration.LatencyPreset.BALANCED),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int watermark = AudioRuntimeConfiguration.LatencyPreset.BALANCED.queuedFrames();
+
+        sound.start();
+        try {
+            await("configured output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            FakeLine line = backend.lastLine(DEVICE_A);
+            for (int frame = 0; frame < watermark; frame++) {
+                eventBus.post(new Sound.SoundSampleEvent(samples));
+            }
+            await("initial real PCM", () -> line.nonSilentWriteCount() == watermark);
+
+            line.running = false;
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("stopped provider restart", () -> line.nonSilentWriteCount() == watermark + 1);
+            assertEquals("the stopped provider must restart before writing real PCM", 2,
+                    line.startCount);
+
+            line.running = false;
+            line.failStarts = true;
+            backend.remove(DEVICE_A);
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("restart failure fallback", () -> sound.currentStatus().state()
+                    == AudioOutputStatus.State.FALLBACK);
+            assertTrue("failed restart line must be closed", line.closed);
+            assertEquals("default", sound.currentStatus().activeDeviceId());
+            assertEquals(1, backend.lastLine("default").startCount);
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void workerCompletesPartialProviderWritesInOrderWithoutAvailabilityPolling()
+            throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        PartialWriteBackend backend = new PartialWriteBackend(12);
+        AudioRuntimeConfiguration configuration = new AudioRuntimeConfiguration(
+                "default", 100, false, AudioRuntimeConfiguration.LatencyPreset.LOW);
+        AudioSystemSound sound = new AudioSystemSound(
+                configuration,
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        byte[] expected = render(configuration, samples);
+
+        sound.start();
+        try {
+            await("partial-write output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("complete PCM frame through partial writes",
+                    () -> backend.line.writtenBytes() == expected.length);
+
+            assertTrue("the provider must report more than one partial write",
+                    backend.line.writeLengths.size() > 1);
+            assertEquals("the initial provider call receives the whole PCM frame", expected.length,
+                    (int) backend.line.requestLengths.get(0));
+            assertEquals("writeFully must not second-guess provider availability", 0,
+                    backend.line.availableCalls);
+            assertArrayEquals(expected, backend.line.concatenatedWrites());
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void wholePcmBufferWriteObservationSpansBlockingPartialProviderWrites() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        PausingPartialWriteBackend backend = new PausingPartialWriteBackend(16);
+        AudioRuntimeConfiguration configuration = new AudioRuntimeConfiguration(
+                "default", 100, false, AudioRuntimeConfiguration.LatencyPreset.LOW);
+        AudioSystemSound sound = new AudioSystemSound(
+                configuration,
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int expectedBytes = render(configuration, samples).length;
+
+        sound.start();
+        try {
+            await("partial-write output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+            await("first PCM chunk before the provider blocks", backend.line::firstChunkWritten);
+
+            assertTrue("the dequeued PCM buffer must remain visible between chunks",
+                    sound.isPcmBufferWriteInProgressForTesting());
+            backend.line.allowRemainingWrites();
+            await("complete PCM buffer after availability resumes",
+                    () -> backend.line.writtenBytes() == expectedBytes);
+            await("completed PCM buffer observation to clear",
+                    () -> !sound.isPcmBufferWriteInProgressForTesting());
+        } finally {
+            sound.stopThread();
+        }
+    }
+
+    @Test
+    public void zeroProgressProviderWriteReopensTheOutput() throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        PartialWriteBackend backend = new PartialWriteBackend(12, 1);
+        AudioSystemSound sound = new AudioSystemSound(
+                new AudioRuntimeConfiguration(
+                        "default", 100, false, AudioRuntimeConfiguration.LatencyPreset.LOW),
+                eventBus,
+                null,
+                backend,
+                ignored -> {
+                });
+
+        sound.start();
+        try {
+            await("zero-progress output to open",
+                    () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
+            PartialWriteLine first = backend.line;
+            eventBus.post(new Sound.SoundSampleEvent(
+                    audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame())));
+            await("zero-progress output to reopen", () -> backend.openCount() >= 2);
+            assertTrue("the no-progress provider must be closed", first.closed);
+            assertEquals(AudioOutputStatus.State.ACTIVE, sound.currentStatus().state());
         } finally {
             sound.stopThread();
         }
@@ -251,7 +602,7 @@ public class AudioSystemSoundTest {
                 () -> sound.currentStatus().state() == AudioOutputStatus.State.ACTIVE);
         assertEquals(DEVICE_A, sound.currentStatus().activeDeviceId());
         FakeLine first = backend.lastLine(DEVICE_A);
-        assertEquals(8192, first.requestedBufferBytes);
+        assertEquals(16384, first.requestedBufferBytes);
 
         int opensBeforeGain = backend.openedIds.size();
         sound.applyConfiguration(new AudioRuntimeConfiguration(
@@ -266,7 +617,7 @@ public class AudioSystemSoundTest {
         await("latency change to reopen line",
                 () -> backend.openedIds.size() > opensBeforeGain);
         FakeLine safe = backend.lastLine(DEVICE_A);
-        assertEquals(16384, safe.requestedBufferBytes);
+        assertEquals(32768, safe.requestedBufferBytes);
         assertTrue(first.closed);
 
         backend.remove(DEVICE_A);
@@ -369,11 +720,13 @@ public class AudioSystemSoundTest {
         assertEquals(
                 AudioRuntimeConfiguration.LatencyPreset.BALANCED,
                 defaults.latencyPreset());
-        assertEquals(8192, defaults.latencyPreset().lineBufferBytes());
-        assertEquals(3, defaults.latencyPreset().queuedFrames());
+        assertEquals(16384, defaults.latencyPreset().lineBufferBytes());
+        assertEquals(6, defaults.latencyPreset().queuedFrames());
         assertEquals(4, AudioRuntimeConfiguration.LatencyPreset.LOW.runtimeQueueCapacity());
-        assertEquals(12, defaults.latencyPreset().runtimeQueueCapacity());
-        assertEquals(15, AudioRuntimeConfiguration.LatencyPreset.SAFE.runtimeQueueCapacity());
+        assertEquals(24, defaults.latencyPreset().runtimeQueueCapacity());
+        assertEquals(32768, AudioRuntimeConfiguration.LatencyPreset.SAFE.lineBufferBytes());
+        assertEquals(12, AudioRuntimeConfiguration.LatencyPreset.SAFE.queuedFrames());
+        assertEquals(32, AudioRuntimeConfiguration.LatencyPreset.SAFE.runtimeQueueCapacity());
 
         assertInvalid(() -> new AudioRuntimeConfiguration(
                 "array-index-0", 100, false,
@@ -387,6 +740,11 @@ public class AudioSystemSoundTest {
     }
 
     private static byte[] render(AudioRuntimeConfiguration configuration) throws Exception {
+        return render(configuration, constantSamples(2000, 480));
+    }
+
+    private static byte[] render(AudioRuntimeConfiguration configuration, int[] samples)
+            throws Exception {
         EventBusImpl eventBus = synchronousBus();
         AudioSystemSound sound = new AudioSystemSound(
                 configuration,
@@ -395,7 +753,7 @@ public class AudioSystemSoundTest {
                 new FakeBackend(),
                 ignored -> {
                 });
-        eventBus.post(new Sound.SoundSampleEvent(constantSamples(2000, 480)));
+        eventBus.post(new Sound.SoundSampleEvent(samples));
         return queue(sound).remove();
     }
 
@@ -478,6 +836,7 @@ public class AudioSystemSoundTest {
         private final List<String> operationThreads = new CopyOnWriteArrayList<>();
         private volatile String exclusivePreferredDevice;
         private volatile int exclusiveOpenConflicts;
+        private volatile boolean runningBecomesPublicAfterFirstWrite;
 
         void add(String id, String name) {
             available.put(
@@ -515,7 +874,8 @@ public class AudioSystemSoundTest {
                 throw new LineUnavailableException(
                         "preferred output is exclusive while fallback remains open");
             }
-            FakeLine line = new FakeLine(bufferBytes, operationThreads);
+            FakeLine line = new FakeLine(
+                    bufferBytes, operationThreads, runningBecomesPublicAfterFirstWrite);
             lines.put(stableId, line);
             openedIds.add(stableId);
             return line;
@@ -525,15 +885,24 @@ public class AudioSystemSoundTest {
     private static final class FakeLine implements AudioBackend.AudioLine {
         private final int requestedBufferBytes;
         private final List<String> operationThreads;
+        private final boolean runningBecomesPublicAfterFirstWrite;
         private volatile boolean open = true;
+        private volatile boolean running;
+        private volatile boolean startRequested;
         private volatile boolean closed;
         private volatile boolean failWrites;
+        private volatile boolean failStarts;
         private volatile int flushCount;
+        private volatile int startCount;
         private final List<byte[]> writes = new CopyOnWriteArrayList<>();
 
-        private FakeLine(int requestedBufferBytes, List<String> operationThreads) {
+        private FakeLine(
+                int requestedBufferBytes,
+                List<String> operationThreads,
+                boolean runningBecomesPublicAfterFirstWrite) {
             this.requestedBufferBytes = requestedBufferBytes;
             this.operationThreads = operationThreads;
+            this.runningBecomesPublicAfterFirstWrite = runningBecomesPublicAfterFirstWrite;
         }
 
         private void record() {
@@ -543,6 +912,19 @@ public class AudioSystemSoundTest {
         @Override
         public void start() {
             record();
+            startCount++;
+            if (failStarts) {
+                throw new IllegalStateException("provider failed to start");
+            }
+            startRequested = true;
+            if (!runningBecomesPublicAfterFirstWrite) {
+                running = true;
+            }
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
         }
 
         @Override
@@ -550,6 +932,9 @@ public class AudioSystemSoundTest {
             record();
             if (failWrites) {
                 throw new IllegalStateException("device disconnected");
+            }
+            if (runningBecomesPublicAfterFirstWrite && startRequested) {
+                running = true;
             }
             writes.add(Arrays.copyOfRange(bytes, offset, offset + length));
             return length;
@@ -598,13 +983,241 @@ public class AudioSystemSoundTest {
         @Override
         public void stop() {
             record();
+            running = false;
         }
 
         @Override
         public void close() {
             record();
             open = false;
+            running = false;
             closed = true;
+        }
+    }
+
+    private static final class PartialWriteBackend implements AudioBackend {
+        private final int maximumProgressBytes;
+        private int zeroProgressOpensRemaining;
+        private final List<PartialWriteLine> lines = new CopyOnWriteArrayList<>();
+        private volatile PartialWriteLine line;
+
+        private PartialWriteBackend(int maximumProgressBytes) {
+            this(maximumProgressBytes, 0);
+        }
+
+        private PartialWriteBackend(int maximumProgressBytes, int zeroProgressOpens) {
+            this.maximumProgressBytes = maximumProgressBytes;
+            this.zeroProgressOpensRemaining = zeroProgressOpens;
+        }
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return List.of(AudioDeviceSnapshot.systemDefaultDevice());
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+                throws LineUnavailableException {
+            if (!AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(stableId)) {
+                throw new LineUnavailableException("missing " + stableId);
+            }
+            PartialWriteLine opened = new PartialWriteLine(
+                    maximumProgressBytes, zeroProgressOpensRemaining-- > 0);
+            lines.add(opened);
+            line = opened;
+            return opened;
+        }
+
+        private int openCount() {
+            return lines.size();
+        }
+    }
+
+    private static final class PartialWriteLine implements AudioBackend.AudioLine {
+        private final int maximumProgressBytes;
+        private final boolean zeroProgress;
+        private final List<byte[]> writes = new CopyOnWriteArrayList<>();
+        private final List<Integer> requestLengths = new CopyOnWriteArrayList<>();
+        private final List<Integer> writeLengths = new CopyOnWriteArrayList<>();
+        private volatile int availableCalls;
+        private volatile boolean running;
+        private volatile boolean closed;
+
+        private PartialWriteLine(int maximumProgressBytes, boolean zeroProgress) {
+            this.maximumProgressBytes = maximumProgressBytes;
+            this.zeroProgress = zeroProgress;
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            requestLengths.add(length);
+            if (zeroProgress) {
+                return 0;
+            }
+            int written = Math.min(length, maximumProgressBytes);
+            writeLengths.add(written);
+            writes.add(Arrays.copyOfRange(bytes, offset, offset + written));
+            return written;
+        }
+
+        private int writtenBytes() {
+            return writeLengths.stream().mapToInt(Integer::intValue).sum();
+        }
+
+        private byte[] concatenatedWrites() {
+            byte[] result = new byte[writtenBytes()];
+            int offset = 0;
+            for (byte[] write : writes) {
+                System.arraycopy(write, 0, result, offset, write.length);
+                offset += write.length;
+            }
+            return result;
+        }
+
+        @Override
+        public int available() {
+            availableCalls++;
+            return 0;
+        }
+
+        @Override
+        public int bufferSize() {
+            return maximumProgressBytes;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            running = false;
+        }
+    }
+
+    private static final class PausingPartialWriteBackend implements AudioBackend {
+        private final PausingPartialWriteLine line;
+
+        private PausingPartialWriteBackend(int chunkBytes) {
+            this.line = new PausingPartialWriteLine(chunkBytes);
+        }
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return List.of(AudioDeviceSnapshot.systemDefaultDevice());
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+                throws LineUnavailableException {
+            if (!AudioDeviceSnapshot.SYSTEM_DEFAULT_ID.equals(stableId)) {
+                throw new LineUnavailableException("missing " + stableId);
+            }
+            return line;
+        }
+    }
+
+    private static final class PausingPartialWriteLine implements AudioBackend.AudioLine {
+        private final int chunkBytes;
+        private final CountDownLatch firstChunk = new CountDownLatch(1);
+        private final CountDownLatch allowRemainingWrites = new CountDownLatch(1);
+        private volatile boolean firstWrite = true;
+        private volatile boolean running;
+        private volatile int writtenBytes;
+
+        private PausingPartialWriteLine(int chunkBytes) {
+            this.chunkBytes = chunkBytes;
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            if (firstWrite) {
+                firstWrite = false;
+                int written = Math.min(length, chunkBytes);
+                writtenBytes += written;
+                firstChunk.countDown();
+                return written;
+            }
+            try {
+                allowRemainingWrites.await();
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return 0;
+            }
+            int written = Math.min(length, chunkBytes);
+            writtenBytes += written;
+            return written;
+        }
+
+        private boolean firstChunkWritten() {
+            return firstChunk.getCount() == 0;
+        }
+
+        private void allowRemainingWrites() {
+            allowRemainingWrites.countDown();
+        }
+
+        private int writtenBytes() {
+            return writtenBytes;
+        }
+
+        @Override
+        public int available() {
+            return chunkBytes;
+        }
+
+        @Override
+        public int bufferSize() {
+            return chunkBytes;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public void close() {
         }
     }
 
@@ -623,6 +1236,11 @@ public class AudioSystemSoundTest {
             return new AudioLine() {
                 @Override
                 public void start() {
+                }
+
+                @Override
+                public boolean isRunning() {
+                    return true;
                 }
 
                 @Override

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/AudioSystemSoundTest.java
@@ -68,7 +68,33 @@ public class AudioSystemSoundTest {
             eventBus.post(new Sound.SoundSampleEvent(new int[400]));
         }
 
-        assertEquals(1, queue(sound).size());
+        assertEquals(
+                AudioRuntimeConfiguration.LatencyPreset.LOW.runtimeQueueCapacity(),
+                queue(sound).size());
+    }
+
+    @Test
+    public void balancedRuntimeQueueAcceptsCatchUpHeadroomWithoutChangingStartupWatermark()
+            throws Exception {
+        EventBusImpl eventBus = synchronousBus();
+        AudioSystemSound sound = new AudioSystemSound(
+                AudioRuntimeConfiguration.defaults(),
+                eventBus,
+                null,
+                new FakeBackend(),
+                ignored -> {
+                });
+        int[] samples = audibleSamples(ClockSpec.LEGACY.controllerTicksPerFrame());
+        int capacity = AudioRuntimeConfiguration.LatencyPreset.BALANCED.runtimeQueueCapacity();
+
+        for (int frame = 0; frame < capacity; frame++) {
+            eventBus.post(new Sound.SoundSampleEvent(samples));
+        }
+        assertEquals(12, capacity);
+        assertEquals(capacity, queue(sound).size());
+
+        eventBus.post(new Sound.SoundSampleEvent(samples));
+        assertEquals("runtime queue must remain bounded", capacity, queue(sound).size());
     }
 
     @Test
@@ -345,6 +371,9 @@ public class AudioSystemSoundTest {
                 defaults.latencyPreset());
         assertEquals(8192, defaults.latencyPreset().lineBufferBytes());
         assertEquals(3, defaults.latencyPreset().queuedFrames());
+        assertEquals(4, AudioRuntimeConfiguration.LatencyPreset.LOW.runtimeQueueCapacity());
+        assertEquals(12, defaults.latencyPreset().runtimeQueueCapacity());
+        assertEquals(15, AudioRuntimeConfiguration.LatencyPreset.SAFE.runtimeQueueCapacity());
 
         assertInvalid(() -> new AudioRuntimeConfiguration(
                 "array-index-0", 100, false,

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshotTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayFrameSnapshotTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -41,6 +42,28 @@ public class DisplayFrameSnapshotTest {
     }
 
     @Test
+    public void ownedRasterRendersAndCopiesRgbWithoutExposingTheBackingArray() {
+        int[] ownedDisplayFrame = {0xff010203, 0x00a0b0c0};
+
+        DisplayFrameSnapshot snapshot =
+                DisplayFrameSnapshot.takeOwnership(2, 1, ownedDisplayFrame);
+
+        assertEquals(0x010203, snapshot.rgbAt(0, 0));
+        assertEquals(0xa0b0c0, snapshot.rgbAt(1, 0));
+        assertArrayEquals(new int[]{0x010203, 0xa0b0c0}, snapshot.copyRgb());
+
+        BufferedImage target = new BufferedImage(2, 1, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = target.createGraphics();
+        try {
+            snapshot.paint(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        assertEquals(0x010203, target.getRGB(0, 0) & 0xffffff);
+        assertEquals(0xa0b0c0, target.getRGB(1, 0) & 0xffffff);
+    }
+
+    @Test
     public void snapshotRequiresAnExactPixelCount() {
         assertThrows(
                 IllegalArgumentException.class,
@@ -48,5 +71,11 @@ public class DisplayFrameSnapshotTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> DisplayFrameSnapshot.copyOf(2, 2, new int[5]));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayFrameSnapshot.takeOwnership(2, 2, new int[3]));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DisplayFrameSnapshot.takeOwnership(0, 2, new int[0]));
     }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/HarryPotterIntroUiAudioTimingTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/HarryPotterIntroUiAudioTimingTest.java
@@ -1,0 +1,784 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.controller.TimingTicker;
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.sound.Sound;
+import org.junit.Assume;
+import org.junit.Test;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.LineUnavailableException;
+import javax.swing.SwingUtilities;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.zip.GZIPInputStream;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * External-ROM probe for the Swing audio path used by the desktop application.
+ *
+ * <p>This intentionally opens the real Java Sound backend. It is therefore skipped before any
+ * desktop/audio setup unless {@code -DharryPotterRom} is supplied. The shell harness is the
+ * supported way to run it against a locally owned Harry Potter ROM.</p>
+ */
+public class HarryPotterIntroUiAudioTimingTest {
+
+    private static final int WARMUP_FRAMES = 1_200;
+    private static final int MEASUREMENT_FRAMES = 600;
+    private static final long SAMPLE_RATE = 44_100;
+    private static final int BYTES_PER_STEREO_FRAME = 4;
+    private static final long BYTES_PER_SECOND = SAMPLE_RATE * BYTES_PER_STEREO_FRAME;
+    private static final Duration OUTPUT_DELIVERY_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration OUTPUT_QUIESCENCE = Duration.ofMillis(50);
+    private static final String EMBEDDED_BATTERY_SAVE =
+            "H4sIAAAAAAAEAO3BMQEAIAgAMKhAAksR0ceSmsGPY9vpXZkrAAAAgH8XAAAAYIgH3AhargAgAAA=";
+
+    @Test
+    public void measuresHarryPotterIntroThroughTheDesktopAudioPath() throws Exception {
+        File romFile = requireRom();
+        AudioRuntimeConfiguration.LatencyPreset latencyPreset = latencyPreset();
+        UiAudioMetrics metrics = new UiAudioMetrics();
+        MeasuringAudioBackend backend = new MeasuringAudioBackend(metrics);
+        EmulatorProperties properties = new EmulatorProperties();
+        EventBusImpl rootBus = new EventBusImpl(null, null, false);
+        EventBusImpl mainBus = rootBus.fork("main");
+        SwingDisplay display = null;
+        Thread displayThread = null;
+        AudioSystemSound audio = null;
+
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(romFile))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setBatteryData(loadBatteryData())
+                .setSupportBatterySave(false)
+                .build()) {
+            display = onEdt(() -> new SwingDisplay(properties.getDisplay(), mainBus, "main"));
+            displayThread = new Thread(display, "coffee-gb-harry-potter-display");
+            displayThread.setDaemon(true);
+            displayThread.start();
+
+            // Register this first so a producer timestamp precedes the synchronous PCM conversion
+            // and a very fast device write cannot appear to predate its source event.
+            mainBus.register(metrics::onProducerEvent, Sound.SoundSampleEvent.class, "main");
+            AudioSystemSound output = new AudioSystemSound(
+                    new AudioRuntimeConfiguration(
+                            AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
+                            100,
+                            false,
+                            latencyPreset),
+                    mainBus,
+                    "main",
+                    backend,
+                    ignored -> {
+            });
+            audio = output;
+            BlockingQueue<byte[]> workerQueue = workerQueue(output);
+            // EventBusImpl dispatches registrations in order. This observer is intentionally
+            // registered after AudioSystemSound so queue.size() sees the synchronous play/enqueue
+            // result rather than the depth before PCM conversion.
+            mainBus.register(
+                    event -> metrics.onFrontendQueueAfterSynchronousPlay(workerQueue.size()),
+                    Sound.SoundSampleEvent.class,
+                    "main");
+            output.start();
+            await("a real Java Sound line", () -> {
+                AudioOutputStatus.State state = output.currentStatus().state();
+                return state == AudioOutputStatus.State.ACTIVE
+                        || state == AudioOutputStatus.State.UNAVAILABLE;
+            });
+            if (output.currentStatus().state() != AudioOutputStatus.State.ACTIVE) {
+                throw new IllegalStateException("Java Sound output was unavailable: "
+                        + output.currentStatus().detail());
+            }
+
+            metrics.startCumulativeDeliveryAccounting();
+            gameboy.init(mainBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            // Recording.start() can briefly retransform classes. Include that one-off host pause
+            // in warmup so its line gap cannot be misattributed to the measured game workload.
+            Recording recording = startRecording();
+            try {
+                TimingTicker ticker = new TimingTicker();
+                ClockSpec clockSpec = gameboy.getClockSpec();
+                ClockSpec.RateAccumulator frameNanos = clockSpec.newFrameNanosecondAccumulator();
+                for (int frame = 0; frame < WARMUP_FRAMES; frame++) {
+                    runControllerFrame(gameboy, ticker, clockSpec, frameNanos.advance(1), null);
+                }
+
+                // Keep the worker and its device buffer in their normal steady state. Startup
+                // priming and optional JFR startup both happened during paced warmup; deliberately
+                // draining here would create an artificial empty-line write at measurement start.
+                metrics.resetForMeasurement();
+                for (int frame = 0; frame < MEASUREMENT_FRAMES; frame++) {
+                    long nominalNanos = frameNanos.advance(1);
+                    runControllerFrame(gameboy, ticker, clockSpec, nominalNanos, metrics);
+                }
+                metrics.awaitProducedPcmAtWorker(workerQueue, OUTPUT_DELIVERY_TIMEOUT);
+            } finally {
+                stopAndDump(recording);
+            }
+
+            metrics.printReport(latencyPreset);
+            if (forceFrameSkip()) {
+                System.out.println("Forced frame suppression: enabled");
+            }
+        } finally {
+            if (audio != null) {
+                audio.stopThread();
+            }
+            if (display != null) {
+                display.stop();
+            }
+            if (displayThread != null) {
+                displayThread.join(TimeUnit.SECONDS.toMillis(2));
+            }
+            mainBus.close();
+            rootBus.close();
+            properties.close();
+        }
+    }
+
+    private static void runControllerFrame(
+            Gameboy gameboy,
+            TimingTicker ticker,
+            ClockSpec clockSpec,
+            long nominalNanos,
+            UiAudioMetrics metrics) {
+        gameboy.requestFrameRenderSuppression(
+                forceFrameSkip() || ticker.getHasPacingDebt$controller());
+
+        long workStarted = System.nanoTime();
+        int ticks = clockSpec.controllerTicksPerFrame();
+        for (int tick = 0; tick < ticks; tick++) {
+            gameboy.tick();
+            // The final ticker call is the controller's sleep/yield boundary. Measure only work
+            // that can starve the producer, exactly as BasicController orders this cadence.
+            if (tick + 1 < ticks) {
+                ticker.run(clockSpec);
+            }
+        }
+        long workNanos = System.nanoTime() - workStarted;
+        ticker.run(clockSpec);
+        if (metrics != null) {
+            metrics.onControllerFrame(
+                    workNanos, nominalNanos, ticker.getHasPacingDebt$controller());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BlockingQueue<byte[]> workerQueue(AudioSystemSound output) {
+        try {
+            Field field = AudioSystemSound.class.getDeclaredField("queue");
+            field.setAccessible(true);
+            return (BlockingQueue<byte[]>) field.get(output);
+        } catch (ReflectiveOperationException failure) {
+            throw new IllegalStateException("Unable to observe the audio worker queue", failure);
+        }
+    }
+
+    private static Recording startRecording() throws Exception {
+        String configuredPath = System.getProperty("harryPotterJfr");
+        if (configuredPath == null || configuredPath.isBlank()) {
+            return null;
+        }
+        Recording recording = new Recording(Configuration.getConfiguration("profile"));
+        recording.setName("Coffee GB Harry Potter UI audio timing");
+        recording.start();
+        return recording;
+    }
+
+    private static void stopAndDump(Recording recording) throws IOException {
+        if (recording == null) {
+            return;
+        }
+        try (recording) {
+            recording.stop();
+            Path destination = Paths.get(System.getProperty("harryPotterJfr"));
+            Path parent = destination.toAbsolutePath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            recording.dump(destination);
+            System.out.println("JFR measurement recording: " + destination.toAbsolutePath());
+        }
+    }
+
+    private static AudioRuntimeConfiguration.LatencyPreset latencyPreset() {
+        String configured = System.getProperty("harryPotterAudioLatency", "BALANCED");
+        try {
+            return AudioRuntimeConfiguration.LatencyPreset.valueOf(configured.trim().toUpperCase());
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException(
+                    "harryPotterAudioLatency must be LOW, BALANCED, or SAFE: " + configured,
+                    failure);
+        }
+    }
+
+    private static File requireRom() {
+        String configured = System.getProperty("harryPotterRom");
+        Assume.assumeTrue(
+                "Set -DharryPotterRom=<absolute path> to run the UI audio timing probe",
+                configured != null && !configured.isBlank());
+        File rom = new File(configured);
+        if (!rom.isFile()) {
+            throw new IllegalArgumentException("ROM not found: " + rom);
+        }
+        return rom;
+    }
+
+    private static byte[] loadBatteryData() throws IOException {
+        String configured = System.getProperty("harryPotterBatterySave");
+        if (configured != null && !configured.isBlank()) {
+            File save = new File(configured);
+            if (!save.isFile()) {
+                throw new IllegalArgumentException("Battery save not found: " + save);
+            }
+            byte[] data = Files.readAllBytes(save.toPath());
+            System.out.printf("Harry Potter battery save: %s (%d bytes)%n",
+                    save.getAbsolutePath(), data.length);
+            return data;
+        }
+        byte[] compressed = Base64.getDecoder().decode(EMBEDDED_BATTERY_SAVE);
+        try (GZIPInputStream input = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
+            byte[] data = input.readAllBytes();
+            System.out.printf("Harry Potter battery save: embedded (%d bytes)%n", data.length);
+            return data;
+        }
+    }
+
+    private static boolean forceFrameSkip() {
+        return Boolean.getBoolean("harryPotterForceFrameSkip");
+    }
+
+    private static void await(String description, BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(4);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        if (!condition.getAsBoolean()) {
+            throw new IllegalStateException("Timed out waiting for " + description);
+        }
+    }
+
+    private static <T> T onEdt(ThrowingSupplier<T> supplier) throws Exception {
+        if (SwingUtilities.isEventDispatchThread()) {
+            return supplier.get();
+        }
+        FutureTask<T> task = new FutureTask<>(supplier::get);
+        SwingUtilities.invokeAndWait(task);
+        return task.get();
+    }
+
+    @Test
+    public void estimatesAudibleGapFromPriorDeviceOccupancy() {
+        long tenMillisOfPcm = BYTES_PER_SECOND / 100;
+        assertEquals(10_000_000L,
+                GapAccounting.audibleGapNanos(20_000_000L, (int) tenMillisOfPcm));
+        assertEquals(0L,
+                GapAccounting.audibleGapNanos(5_000_000L, (int) tenMillisOfPcm));
+    }
+
+    @Test
+    public void accountsForExactPcmPhaseAndFrontendDropsAcrossTheMeasurementBoundary() {
+        PcmExpectation expectation = new PcmExpectation();
+        ClockSpec clock = ClockSpec.LEGACY;
+        for (int frame = 0; frame < WARMUP_FRAMES; frame++) {
+            expectation.accept(clock, clock.controllerTicksPerFrame());
+        }
+        expectation.resetMeasuredBytes();
+        for (int frame = 0; frame < MEASUREMENT_FRAMES; frame++) {
+            expectation.accept(clock, clock.controllerTicksPerFrame());
+        }
+
+        assertEquals(1_763_996L, expectation.measuredBytes());
+        assertEquals(2_940L, expectation.largestChunkBytes());
+        assertEquals(58_800L, DropAccounting.droppedBytes(
+                expectation.measuredBytes(), 1_705_196L));
+        assertEquals("20", DropAccounting.frameEquivalent(58_800L, expectation.largestChunkBytes()));
+    }
+
+    @Test
+    public void cumulativeDeliveryAccountingDoesNotLetWarmupTailMaskMeasurementDrops() {
+        ClockSpec clock = ClockSpec.LEGACY;
+        CumulativePcmAccounting accounting = new CumulativePcmAccounting();
+        for (int frame = 0; frame < 3; frame++) {
+            accounting.onProducerEvent(clock, clock.controllerTicksPerFrame());
+        }
+        long warmupBytes = accounting.expectedBytes();
+
+        // resetForMeasurement intentionally clears only the windowed timing metrics. These three
+        // writes are warmup PCM that reaches the worker after the boundary.
+        for (int frame = 0; frame < 3; frame++) {
+            accounting.onProducerEvent(clock, clock.controllerTicksPerFrame());
+        }
+        long measurementBytes = accounting.expectedBytes() - warmupBytes;
+        accounting.onWorkerWrite(warmupBytes + measurementBytes - 2L * 2_940);
+
+        assertEquals(5_880L, accounting.droppedBytes());
+        assertEquals("2", DropAccounting.frameEquivalent(
+                accounting.droppedBytes(), accounting.largestChunkBytes()));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    /** Delegates to Java Sound while retaining the actual device values around every write. */
+    private static final class MeasuringAudioBackend implements AudioBackend {
+        private final AudioBackend delegate = new JavaSoundAudioBackend();
+        private final UiAudioMetrics metrics;
+
+        private MeasuringAudioBackend(UiAudioMetrics metrics) {
+            this.metrics = metrics;
+        }
+
+        @Override
+        public List<AudioDeviceSnapshot> devices() {
+            return delegate.devices();
+        }
+
+        @Override
+        public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
+                throws LineUnavailableException {
+            return new MeasuringAudioLine(delegate.open(stableId, format, bufferBytes), metrics);
+        }
+    }
+
+    private static final class MeasuringAudioLine implements AudioBackend.AudioLine {
+        private final AudioBackend.AudioLine delegate;
+        private final UiAudioMetrics metrics;
+
+        private MeasuringAudioLine(AudioBackend.AudioLine delegate, UiAudioMetrics metrics) {
+            this.delegate = delegate;
+            this.metrics = metrics;
+        }
+
+        @Override
+        public void start() {
+            delegate.start();
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            int bufferBytes = delegate.bufferSize();
+            int availableBefore = delegate.available();
+            long started = System.nanoTime();
+            metrics.onLineWriteStarted(started);
+            try {
+                int written = delegate.write(bytes, offset, length);
+                long completed = System.nanoTime();
+                int availableAfter = delegate.available();
+                metrics.onLineWrite(
+                        bufferBytes, availableBefore, availableAfter, written, started, completed);
+                return written;
+            } finally {
+                metrics.onLineWriteFinished(System.nanoTime());
+            }
+        }
+
+        @Override
+        public int available() {
+            return delegate.available();
+        }
+
+        @Override
+        public int bufferSize() {
+            return delegate.bufferSize();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public void flush() {
+            delegate.flush();
+        }
+
+        @Override
+        public void stop() {
+            delegate.stop();
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+
+    /** Measurement-only collector; all methods are synchronized across the emulation and worker threads. */
+    private static final class UiAudioMetrics {
+        private final List<Long> producerIntervalsNanos = new ArrayList<>();
+        private final List<Long> controllerWorkNanos = new ArrayList<>();
+        private final List<Long> lineWriteIntervalsNanos = new ArrayList<>();
+        private final List<Long> writeBlockingNanos = new ArrayList<>();
+        private volatile boolean measuring;
+        private long lastProducerNanos;
+        private long lastPostWriteNanos;
+        private long lastLineWriteCompletedNanos;
+        private int lineWritesInProgress;
+        private int previousPostWriteOccupancyBytes;
+        private final CumulativePcmAccounting delivery = new CumulativePcmAccounting();
+        private int lineBufferBytes;
+        private int producerGapsOver25Ms;
+        private int producerGapsOver50Ms;
+        private int controllerWorkOverNominal;
+        private int pacingDebtFrames;
+        private int emptyLineWrites;
+        private int frontendQueuePeakFrames;
+        private double totalAudibleGapMs;
+        private double maximumAudibleGapMs;
+        private double minimumBufferedBeforeWriteMs = Double.POSITIVE_INFINITY;
+        private boolean cumulativeDeliveryAccounting;
+
+        synchronized void startCumulativeDeliveryAccounting() {
+            cumulativeDeliveryAccounting = true;
+        }
+
+        synchronized void resetForMeasurement() {
+            measuring = false;
+            producerIntervalsNanos.clear();
+            controllerWorkNanos.clear();
+            lineWriteIntervalsNanos.clear();
+            writeBlockingNanos.clear();
+            lastProducerNanos = 0;
+            lastPostWriteNanos = 0;
+            previousPostWriteOccupancyBytes = 0;
+            lineBufferBytes = 0;
+            producerGapsOver25Ms = 0;
+            producerGapsOver50Ms = 0;
+            controllerWorkOverNominal = 0;
+            pacingDebtFrames = 0;
+            emptyLineWrites = 0;
+            frontendQueuePeakFrames = 0;
+            totalAudibleGapMs = 0;
+            maximumAudibleGapMs = 0;
+            minimumBufferedBeforeWriteMs = Double.POSITIVE_INFINITY;
+            measuring = true;
+        }
+
+        synchronized void onProducerEvent(Sound.SoundSampleEvent event) {
+            if (!cumulativeDeliveryAccounting) {
+                return;
+            }
+            int ticks = event.buffer().length / 2;
+            delivery.onProducerEvent(event.clockSpec(), ticks);
+            if (!measuring) {
+                return;
+            }
+            long now = System.nanoTime();
+            if (lastProducerNanos != 0) {
+                long interval = now - lastProducerNanos;
+                producerIntervalsNanos.add(interval);
+                if (interval > TimeUnit.MILLISECONDS.toNanos(25)) {
+                    producerGapsOver25Ms++;
+                }
+                if (interval > TimeUnit.MILLISECONDS.toNanos(50)) {
+                    producerGapsOver50Ms++;
+                }
+            }
+            lastProducerNanos = now;
+        }
+
+        synchronized void onFrontendQueueAfterSynchronousPlay(int queuedFrames) {
+            if (measuring) {
+                frontendQueuePeakFrames = Math.max(frontendQueuePeakFrames, queuedFrames);
+            }
+        }
+
+        synchronized void onControllerFrame(long workNanos, long nominalNanos, boolean pacingDebt) {
+            if (!measuring) {
+                return;
+            }
+            controllerWorkNanos.add(workNanos);
+            if (workNanos > nominalNanos) {
+                controllerWorkOverNominal++;
+            }
+            if (pacingDebt) {
+                pacingDebtFrames++;
+            }
+        }
+
+        synchronized void onLineWrite(
+                int bufferBytes,
+                int availableBefore,
+                int availableAfter,
+                int written,
+                long started,
+                long completed) {
+            if (!cumulativeDeliveryAccounting || written <= 0) {
+                return;
+            }
+            delivery.onWorkerWrite(written);
+            if (!measuring) {
+                return;
+            }
+            lineBufferBytes = Math.max(lineBufferBytes, bufferBytes);
+            int occupancyBefore = Math.max(0, bufferBytes - availableBefore);
+            int occupancyAfter = Math.max(0, bufferBytes - availableAfter);
+            minimumBufferedBeforeWriteMs = Math.min(
+                    minimumBufferedBeforeWriteMs, millisecondsForBytes(occupancyBefore));
+            if (lastPostWriteNanos != 0) {
+                long interval = Math.max(0, started - lastPostWriteNanos);
+                lineWriteIntervalsNanos.add(interval);
+                long gapNanos = GapAccounting.audibleGapNanos(
+                        interval, previousPostWriteOccupancyBytes);
+                double gapMs = gapNanos / 1_000_000.0;
+                totalAudibleGapMs += gapMs;
+                maximumAudibleGapMs = Math.max(maximumAudibleGapMs, gapMs);
+                // Java Sound providers can report a single stereo frame as still occupied while
+                // the DAC has effectively drained. Treat that four-byte rounding residue as an
+                // empty line, matching the historic desktop underrun interpretation.
+                if (availableBefore >= bufferBytes - BYTES_PER_STEREO_FRAME) {
+                    emptyLineWrites++;
+                }
+            }
+            writeBlockingNanos.add(Math.max(0, completed - started));
+            previousPostWriteOccupancyBytes = occupancyAfter;
+            lastPostWriteNanos = completed;
+            notifyAll();
+        }
+
+        synchronized void onLineWriteStarted(long started) {
+            if (!cumulativeDeliveryAccounting) {
+                return;
+            }
+            lineWritesInProgress++;
+            notifyAll();
+        }
+
+        synchronized void onLineWriteFinished(long completed) {
+            if (!cumulativeDeliveryAccounting) {
+                return;
+            }
+            if (lineWritesInProgress <= 0) {
+                throw new IllegalStateException("Unbalanced audio line-write accounting");
+            }
+            lineWritesInProgress--;
+            lastLineWriteCompletedNanos = completed;
+            notifyAll();
+        }
+
+        synchronized void awaitProducedPcmAtWorker(
+                BlockingQueue<byte[]> workerQueue, Duration timeout) throws InterruptedException {
+            long deadline = System.nanoTime() + timeout.toNanos();
+            while (!deliveryReached(workerQueue) && System.nanoTime() < deadline) {
+                long remaining = Math.min(
+                        Math.max(1, deadline - System.nanoTime()),
+                        nanosUntilDeliveryCanBeQuiescent(workerQueue));
+                TimeUnit.NANOSECONDS.timedWait(this, remaining);
+            }
+            if (!deliveryReached(workerQueue)) {
+                throw new IllegalStateException("Audio worker delivery timed out: "
+                        + delivery.workerBytes() + " worker PCM bytes (expected "
+                        + delivery.expectedBytes()
+                        + "), queue empty=" + workerQueue.isEmpty()
+                        + ", final source/write timestamps=" + lastProducerNanos
+                        + "/" + lastPostWriteNanos + ", line writes in progress="
+                        + lineWritesInProgress + " after " + timeout.toMillis() + " ms");
+            }
+            measuring = false;
+        }
+
+        private boolean deliveryReached(BlockingQueue<byte[]> workerQueue) {
+            // A short frontend queue can legitimately drop PCM. After the final producer event,
+            // wait for a line write that began/completed after it, no in-flight write, and a short
+            // quiet interval. This prevents an older write completing after the source timestamp
+            // from racing an already-polled final buffer that has not reached AudioLine.write().
+            return workerQueue.isEmpty()
+                    && lastProducerNanos != 0
+                    && lastPostWriteNanos >= lastProducerNanos
+                    && lineWritesInProgress == 0
+                    && System.nanoTime() - lastLineWriteCompletedNanos >= OUTPUT_QUIESCENCE.toNanos();
+        }
+
+        private long nanosUntilDeliveryCanBeQuiescent(BlockingQueue<byte[]> workerQueue) {
+            if (!workerQueue.isEmpty()
+                    || lastProducerNanos == 0
+                    || lastPostWriteNanos < lastProducerNanos
+                    || lineWritesInProgress != 0) {
+                return OUTPUT_DELIVERY_TIMEOUT.toNanos();
+            }
+            return Math.max(1, lastLineWriteCompletedNanos + OUTPUT_QUIESCENCE.toNanos()
+                    - System.nanoTime());
+        }
+
+        synchronized void printReport(AudioRuntimeConfiguration.LatencyPreset latencyPreset) {
+            System.out.printf("UI audio timing preset: %s%n", latencyPreset);
+            System.out.printf("Audio frontend expected/worker PCM bytes: %d / %d%n",
+                    delivery.expectedBytes(), delivery.workerBytes());
+            long droppedBytes = delivery.droppedBytes();
+            System.out.printf("Audio frontend dropped PCM bytes/ms/frames: %d / %.3f / %s%n",
+                    droppedBytes,
+                    millisecondsForBytes(droppedBytes),
+                    DropAccounting.frameEquivalent(droppedBytes, delivery.largestChunkBytes()));
+            System.out.printf("Audio frontend queue peak/capacity frames: %d / %d%n",
+                    frontendQueuePeakFrames, latencyPreset.runtimeQueueCapacity());
+            System.out.printf("Audio line buffer bytes/ms: %d / %.3f%n",
+                    lineBufferBytes, millisecondsForBytes(lineBufferBytes));
+            System.out.printf("Producer event interval p50/p95/p99/max ms: %s%n",
+                    percentileSummary(producerIntervalsNanos));
+            System.out.printf("Audio gaps >25ms/>50ms: %d / %d%n",
+                    producerGapsOver25Ms, producerGapsOver50Ms);
+            System.out.printf("Controller frame work p50/p95/p99/max ms: %s%n",
+                    percentileSummary(controllerWorkNanos));
+            System.out.printf("Controller work > nominal / pacing-debt frames: %d / %d%n",
+                    controllerWorkOverNominal, pacingDebtFrames);
+            System.out.printf("Audio line write interval p50/p95/p99/max ms: %s%n",
+                    percentileSummary(lineWriteIntervalsNanos));
+            System.out.printf("Audio line max write blocking ms: %.3f%n",
+                    maximumMillis(writeBlockingNanos));
+            System.out.printf("Audio line minimum buffered before write ms: %.3f%n",
+                    Double.isInfinite(minimumBufferedBeforeWriteMs) ? 0 : minimumBufferedBeforeWriteMs);
+            System.out.printf("Audio underruns (empty-line writes after priming): %d%n",
+                    emptyLineWrites);
+            System.out.printf("Audio gap estimate total/max ms: %.3f / %.3f%n",
+                    totalAudibleGapMs, maximumAudibleGapMs);
+        }
+
+        private static double millisecondsForBytes(long bytes) {
+            return bytes * 1_000.0 / BYTES_PER_SECOND;
+        }
+
+        private static double maximumMillis(List<Long> nanos) {
+            return nanos.stream().mapToLong(Long::longValue).max().orElse(0) / 1_000_000.0;
+        }
+
+        private static String percentileSummary(List<Long> values) {
+            if (values.isEmpty()) {
+                return "n/a";
+            }
+            long[] sorted = values.stream().mapToLong(Long::longValue).toArray();
+            Arrays.sort(sorted);
+            return String.format("%.3f / %.3f / %.3f / %.3f",
+                    percentileMillis(sorted, 0.50), percentileMillis(sorted, 0.95),
+                    percentileMillis(sorted, 0.99), sorted[sorted.length - 1] / 1_000_000.0);
+        }
+
+        private static double percentileMillis(long[] sorted, double percentile) {
+            int index = (int) Math.ceil(percentile * sorted.length) - 1;
+            return sorted[Math.max(0, Math.min(sorted.length - 1, index))] / 1_000_000.0;
+        }
+    }
+
+    /** Mirrors StereoPcmConverter's fractional sample accumulator without rendering samples. */
+    private static final class PcmExpectation {
+        private ClockSpec activeClock;
+        private ClockSpec.RateAccumulator sampleAccumulator;
+        private long measuredBytes;
+        private long largestChunkBytes;
+
+        long accept(ClockSpec clock, int ticks) {
+            if (activeClock == null || !activeClock.equals(clock)) {
+                activeClock = clock;
+                sampleAccumulator = clock.newTickRateAccumulator(SAMPLE_RATE);
+            }
+            long bytes = Math.multiplyExact(
+                    sampleAccumulator.advance(ticks), BYTES_PER_STEREO_FRAME);
+            measuredBytes = Math.addExact(measuredBytes, bytes);
+            largestChunkBytes = Math.max(largestChunkBytes, bytes);
+            return bytes;
+        }
+
+        void resetMeasuredBytes() {
+            measuredBytes = 0;
+            largestChunkBytes = 0;
+        }
+
+        long measuredBytes() {
+            return measuredBytes;
+        }
+
+        long largestChunkBytes() {
+            return largestChunkBytes;
+        }
+    }
+
+    /** PCM accounting deliberately spans the warmup/measurement boundary. */
+    private static final class CumulativePcmAccounting {
+        private final PcmExpectation expectation = new PcmExpectation();
+        private long expectedBytes;
+        private long workerBytes;
+        private long largestChunkBytes;
+
+        void onProducerEvent(ClockSpec clock, int ticks) {
+            long bytes = expectation.accept(clock, ticks);
+            expectedBytes = Math.addExact(expectedBytes, bytes);
+            largestChunkBytes = Math.max(largestChunkBytes, bytes);
+        }
+
+        void onWorkerWrite(long bytes) {
+            workerBytes = Math.addExact(workerBytes, bytes);
+        }
+
+        long expectedBytes() {
+            return expectedBytes;
+        }
+
+        long workerBytes() {
+            return workerBytes;
+        }
+
+        long largestChunkBytes() {
+            return largestChunkBytes;
+        }
+
+        long droppedBytes() {
+            return DropAccounting.droppedBytes(expectedBytes, workerBytes);
+        }
+    }
+
+    private static final class DropAccounting {
+        private DropAccounting() {
+        }
+
+        static long droppedBytes(long expectedBytes, long workerBytes) {
+            return Math.max(0, expectedBytes - workerBytes);
+        }
+
+        static String frameEquivalent(long droppedBytes, long chunkBytes) {
+            if (chunkBytes <= 0) {
+                return "n/a";
+            }
+            if (droppedBytes % chunkBytes == 0) {
+                return Long.toString(droppedBytes / chunkBytes);
+            }
+            return String.format("%.3f", droppedBytes * 1.0 / chunkBytes);
+        }
+    }
+
+    /** Pure byte-rate calculation kept separate so its interpretation has a deterministic test. */
+    private static final class GapAccounting {
+        private GapAccounting() {
+        }
+
+        static long audibleGapNanos(long elapsedNanos, int priorBufferedBytes) {
+            long bufferedNanos = priorBufferedBytes * 1_000_000_000L / BYTES_PER_SECOND;
+            return Math.max(0, elapsedNanos - bufferedNanos);
+        }
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/HarryPotterIntroUiAudioTimingTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/HarryPotterIntroUiAudioTimingTest.java
@@ -1,22 +1,30 @@
 package eu.rekawek.coffeegb.swing.io;
 
-import eu.rekawek.coffeegb.controller.TimingTicker;
+import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterGuestConfigurationSink;
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore;
+import eu.rekawek.coffeegb.controller.state.SessionPersistence;
 import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
-import eu.rekawek.coffeegb.core.memory.cart.Rom;
-import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import eu.rekawek.coffeegb.core.sound.Sound;
+import eu.rekawek.coffeegb.swing.SwingAudioOutputFactory;
+import eu.rekawek.coffeegb.swing.SwingEmulator;
 import org.junit.Assume;
 import org.junit.Test;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.LineUnavailableException;
+import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,17 +33,27 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
 import java.util.zip.GZIPInputStream;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.Recording;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * External-ROM probe for the Swing audio path used by the desktop application.
@@ -46,8 +64,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class HarryPotterIntroUiAudioTimingTest {
 
-    private static final int WARMUP_FRAMES = 1_200;
-    private static final int MEASUREMENT_FRAMES = 600;
+    private static final int INTRO_FRAMES = 1_800;
     private static final long SAMPLE_RATE = 44_100;
     private static final int BYTES_PER_STEREO_FRAME = 4;
     private static final long BYTES_PER_SECOND = SAMPLE_RATE * BYTES_PER_STEREO_FRAME;
@@ -60,130 +77,158 @@ public class HarryPotterIntroUiAudioTimingTest {
     public void measuresHarryPotterIntroThroughTheDesktopAudioPath() throws Exception {
         File romFile = requireRom();
         AudioRuntimeConfiguration.LatencyPreset latencyPreset = latencyPreset();
-        UiAudioMetrics metrics = new UiAudioMetrics();
-        MeasuringAudioBackend backend = new MeasuringAudioBackend(metrics);
+        boolean sampleLineOccupancy = sampleLineOccupancy();
+        UiAudioMetrics metrics = new UiAudioMetrics(sampleLineOccupancy);
+        MeasuringAudioBackend backend = new MeasuringAudioBackend(metrics, sampleLineOccupancy);
         EmulatorProperties properties = new EmulatorProperties();
-        EventBusImpl rootBus = new EventBusImpl(null, null, false);
-        EventBusImpl mainBus = rootBus.fork("main");
-        SwingDisplay display = null;
-        Thread displayThread = null;
-        AudioSystemSound audio = null;
+        boolean rewindEnabled = rewindEnabled();
+        Gameboy.BootstrapMode bootstrapMode = bootstrapMode();
+        applyRewindEnabled(properties, rewindEnabled);
+        applyBootstrapMode(properties, bootstrapMode);
+        EventBusImpl rootBus = new EventBusImpl();
+        List<EventBus> idleBuses = new ArrayList<>();
+        AtomicReference<AudioSystemSound> audioReference = new AtomicReference<>();
+        AtomicReference<SwingEmulator> emulatorReference = new AtomicReference<>();
+        AtomicReference<JFrame> frameReference = new AtomicReference<>();
+        CountDownLatch introFramesProduced = new CountDownLatch(1);
+        AtomicBoolean pauseRequested = new AtomicBoolean();
 
-        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(romFile))
-                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
-                .setBatteryData(loadBatteryData())
-                .setSupportBatterySave(false)
-                .build()) {
-            display = onEdt(() -> new SwingDisplay(properties.getDisplay(), mainBus, "main"));
-            displayThread = new Thread(display, "coffee-gb-harry-potter-display");
-            displayThread.setDaemon(true);
-            displayThread.start();
+        try {
+            metrics.limitToSourceFrames(INTRO_FRAMES);
+            SwingAudioOutputFactory audioFactory = (configuration, eventBus, callerId) -> {
+                AudioSystemSound output = new AudioSystemSound(
+                        new AudioRuntimeConfiguration(
+                                configuration.outputDeviceId(),
+                                configuration.masterVolume(),
+                                configuration.muted(),
+                                latencyPreset),
+                        eventBus,
+                        callerId,
+                        backend,
+                        ignored -> {
+                        });
+                audioReference.set(output);
+                return output;
+            };
 
-            // Register this first so a producer timestamp precedes the synchronous PCM conversion
-            // and a very fast device write cannot appear to predate its source event.
-            mainBus.register(metrics::onProducerEvent, Sound.SoundSampleEvent.class, "main");
-            AudioSystemSound output = new AudioSystemSound(
-                    new AudioRuntimeConfiguration(
-                            AudioDeviceSnapshot.SYSTEM_DEFAULT_ID,
-                            100,
-                            false,
-                            latencyPreset),
-                    mainBus,
-                    "main",
-                    backend,
-                    ignored -> {
+            // Register this before SwingEmulator installs AudioSystemSound. Its timestamp therefore
+            // precedes synchronous conversion and it can request a controller-safe pause exactly
+            // after the 1,800th source frame.
+            rootBus.register(event -> {
+                if (metrics.onProducerEvent(event)
+                        && pauseRequested.compareAndSet(false, true)) {
+                    introFramesProduced.countDown();
+                    rootBus.post(new Controller.PauseEmulationEvent());
+                }
+            }, Sound.SoundSampleEvent.class, "main");
+
+            onEdt(() -> {
+                JFrame frame = new JFrame("Coffee GB Harry Potter UI audio timing");
+                SwingEmulator emulator = new SwingEmulator(
+                        rootBus,
+                        null,
+                        properties,
+                        () -> Controller.MobileAdapterConfiguration.syntheticOffline(),
+                        MobileAdapterGuestConfigurationSink.NO_OP,
+                        audioFactory);
+                emulator.bind(frame, () -> true);
+                frame.pack();
+                frame.setVisible(true);
+                emulatorReference.set(emulator);
+                frameReference.set(frame);
+                return null;
             });
-            audio = output;
-            BlockingQueue<byte[]> workerQueue = workerQueue(output);
-            // EventBusImpl dispatches registrations in order. This observer is intentionally
-            // registered after AudioSystemSound so queue.size() sees the synchronous play/enqueue
-            // result rather than the depth before PCM conversion.
-            mainBus.register(
+
+            // SwingEmulator/BasicController owns the production "session" fork. These are the
+            // remaining desktop pollers created by SwingGui before it activates a ROM; the active
+            // "main" fork remains controller-owned and is created only during activation.
+            idleBuses.add(rootBus.fork("desktop-state-ux"));
+            idleBuses.add(rootBus.fork("desktop-debugger"));
+            idleBuses.add(rootBus.fork("desktop-netplay"));
+            idleBuses.add(rootBus.fork("desktop-mobile-adapter-configuration"));
+
+            AudioSystemSound audio = requireAudio(audioReference);
+            BlockingQueue<byte[]> workerQueue = workerQueue(audio);
+            // Registrations are invoked in registration order. This observer is deliberately after
+            // the output constructor, so it observes the real post-enqueue queue depth.
+            rootBus.register(
                     event -> metrics.onFrontendQueueAfterSynchronousPlay(workerQueue.size()),
                     Sound.SoundSampleEvent.class,
                     "main");
-            output.start();
-            await("a real Java Sound line", () -> {
-                AudioOutputStatus.State state = output.currentStatus().state();
-                return state == AudioOutputStatus.State.ACTIVE
-                        || state == AudioOutputStatus.State.UNAVAILABLE;
-            });
-            if (output.currentStatus().state() != AudioOutputStatus.State.ACTIVE) {
-                throw new IllegalStateException("Java Sound output was unavailable: "
-                        + output.currentStatus().detail());
-            }
 
             metrics.startCumulativeDeliveryAccounting();
-            gameboy.init(mainBus, SerialEndpoint.NULL_ENDPOINT, null);
-
-            // Recording.start() can briefly retransform classes. Include that one-off host pause
-            // in warmup so its line gap cannot be misattributed to the measured game workload.
+            // The sole metrics reset is immediately before activation/frame zero. JFR starts
+            // before the same boundary so the initial desktop startup overlap is observable.
+            metrics.resetForMeasurement();
             Recording recording = startRecording();
             try {
-                TimingTicker ticker = new TimingTicker();
-                ClockSpec clockSpec = gameboy.getClockSpec();
-                ClockSpec.RateAccumulator frameNanos = clockSpec.newFrameNanosecondAccumulator();
-                for (int frame = 0; frame < WARMUP_FRAMES; frame++) {
-                    runControllerFrame(gameboy, ticker, clockSpec, frameNanos.advance(1), null);
+                byte[] batteryData = loadBatteryData();
+                RomPersistenceStore persistenceStore = (configuration, hashes) -> {
+                    configuration.setBatteryData(batteryData).setSupportBatterySave(false);
+                    return new SessionPersistence(null, null, null);
+                };
+                rootBus.post(new Controller.LoadRomEvent(
+                        romFile, null, null, persistenceStore, null, false));
+
+                // Production does not hold ROM activation for Java Sound. The status wait happens
+                // only after submission, while the controller is already running frame zero.
+                await("a real Java Sound line after ROM activation", () -> {
+                    AudioOutputStatus.State state = audio.currentStatus().state();
+                    return state == AudioOutputStatus.State.ACTIVE
+                            || state == AudioOutputStatus.State.UNAVAILABLE;
+                });
+                if (audio.currentStatus().state() != AudioOutputStatus.State.ACTIVE) {
+                    throw new IllegalStateException("Java Sound output was unavailable: "
+                            + audio.currentStatus().detail());
                 }
 
-                // Keep the worker and its device buffer in their normal steady state. Startup
-                // priming and optional JFR startup both happened during paced warmup; deliberately
-                // draining here would create an artificial empty-line write at measurement start.
-                metrics.resetForMeasurement();
-                for (int frame = 0; frame < MEASUREMENT_FRAMES; frame++) {
-                    long nominalNanos = frameNanos.advance(1);
-                    runControllerFrame(gameboy, ticker, clockSpec, nominalNanos, metrics);
+                if (!introFramesProduced.await(45, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting for " + INTRO_FRAMES
+                            + " full-intro audio source frames; observed "
+                            + metrics.sourceFrameCount());
                 }
-                metrics.awaitProducedPcmAtWorker(workerQueue, OUTPUT_DELIVERY_TIMEOUT);
+                metrics.awaitProducedPcmAtWorker(audio, workerQueue, OUTPUT_DELIVERY_TIMEOUT);
             } finally {
                 stopAndDump(recording);
             }
 
             metrics.printReport(latencyPreset);
-            if (forceFrameSkip()) {
-                System.out.println("Forced frame suppression: enabled");
+            Thread audioWorker = audio.workerThreadForTesting();
+            System.out.printf("Full intro audio worker priority: %s%n",
+                    audioWorker == null ? "n/a" : Integer.toString(audioWorker.getPriority()));
+            System.out.printf("Full intro rewind enabled: %s%n", rewindEnabled);
+            System.out.printf("Full intro bootstrap mode: %s%n", bootstrapMode);
+            if (metrics.postLimitSourceEvents() != 0) {
+                throw new IllegalStateException("Controller pause leaked "
+                        + metrics.postLimitSourceEvents()
+                        + " source events beyond the full-intro window");
             }
         } finally {
-            if (audio != null) {
-                audio.stopThread();
+            SwingEmulator emulator = emulatorReference.get();
+            if (emulator != null) {
+                emulator.stop();
             }
-            if (display != null) {
-                display.stop();
+            JFrame frame = frameReference.get();
+            if (frame != null) {
+                onEdt(() -> {
+                    frame.dispose();
+                    return null;
+                });
             }
-            if (displayThread != null) {
-                displayThread.join(TimeUnit.SECONDS.toMillis(2));
+            for (EventBus idleBus : idleBuses) {
+                idleBus.close();
             }
-            mainBus.close();
             rootBus.close();
             properties.close();
         }
     }
 
-    private static void runControllerFrame(
-            Gameboy gameboy,
-            TimingTicker ticker,
-            ClockSpec clockSpec,
-            long nominalNanos,
-            UiAudioMetrics metrics) {
-        gameboy.requestFrameRenderSuppression(
-                forceFrameSkip() || ticker.getHasPacingDebt$controller());
-
-        long workStarted = System.nanoTime();
-        int ticks = clockSpec.controllerTicksPerFrame();
-        for (int tick = 0; tick < ticks; tick++) {
-            gameboy.tick();
-            // The final ticker call is the controller's sleep/yield boundary. Measure only work
-            // that can starve the producer, exactly as BasicController orders this cadence.
-            if (tick + 1 < ticks) {
-                ticker.run(clockSpec);
-            }
-        }
-        long workNanos = System.nanoTime() - workStarted;
-        ticker.run(clockSpec);
-        if (metrics != null) {
-            metrics.onControllerFrame(
-                    workNanos, nominalNanos, ticker.getHasPacingDebt$controller());
+    private static void measureFullIntro(UiAudioMetrics metrics, IntroFrameRunner runner) {
+        // The sole window reset happens before frame zero. The cumulative PCM ledger is
+        // deliberately not reset, so it represents every produced intro frame.
+        metrics.resetForMeasurement();
+        for (int frame = 0; frame < INTRO_FRAMES; frame++) {
+            runner.run(frame);
         }
     }
 
@@ -196,6 +241,14 @@ public class HarryPotterIntroUiAudioTimingTest {
         } catch (ReflectiveOperationException failure) {
             throw new IllegalStateException("Unable to observe the audio worker queue", failure);
         }
+    }
+
+    private static AudioSystemSound requireAudio(AtomicReference<AudioSystemSound> audioReference) {
+        AudioSystemSound audio = audioReference.get();
+        if (audio == null) {
+            throw new IllegalStateException("SwingEmulator did not create its audio output");
+        }
+        return audio;
     }
 
     private static Recording startRecording() throws Exception {
@@ -221,7 +274,7 @@ public class HarryPotterIntroUiAudioTimingTest {
                 Files.createDirectories(parent);
             }
             recording.dump(destination);
-            System.out.println("JFR measurement recording: " + destination.toAbsolutePath());
+            System.out.println("Full intro JFR recording: " + destination.toAbsolutePath());
         }
     }
 
@@ -234,6 +287,113 @@ public class HarryPotterIntroUiAudioTimingTest {
                     "harryPotterAudioLatency must be LOW, BALANCED, or SAFE: " + configured,
                     failure);
         }
+    }
+
+    private static boolean rewindEnabled() {
+        return parseRewindEnabled(System.getProperty("harryPotterRewindEnabled", "true"));
+    }
+
+    private static boolean parseRewindEnabled(String configured) {
+        if ("true".equalsIgnoreCase(configured)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(configured)) {
+            return false;
+        }
+        throw new IllegalArgumentException(
+                "harryPotterRewindEnabled must be true or false: " + configured);
+    }
+
+    private static Gameboy.BootstrapMode bootstrapMode() {
+        return bootstrapMode(System.getProperty("harryPotterBootstrapMode"));
+    }
+
+    private static Gameboy.BootstrapMode bootstrapMode(String configured) {
+        return configured == null ? Gameboy.BootstrapMode.SKIP : parseBootstrapMode(configured);
+    }
+
+    private static Gameboy.BootstrapMode parseBootstrapMode(String configured) {
+        try {
+            return Gameboy.BootstrapMode.valueOf(configured.trim());
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException(
+                    "harryPotterBootstrapMode must be one of "
+                            + Arrays.toString(Gameboy.BootstrapMode.values())
+                            + ": " + configured,
+                    failure);
+        }
+    }
+
+    private static boolean sampleLineOccupancy() {
+        return sampleLineOccupancy(System.getProperty("harryPotterSampleLineOccupancy"));
+    }
+
+    private static boolean sampleLineOccupancy(String configured) {
+        if (configured == null) {
+            return false;
+        }
+        if ("true".equals(configured)) {
+            return true;
+        }
+        if ("false".equals(configured)) {
+            return false;
+        }
+        throw new IllegalArgumentException(
+                "harryPotterSampleLineOccupancy must be true or false: " + configured);
+    }
+
+    private static void applyRewindEnabled(EmulatorProperties properties, boolean rewindEnabled) {
+        properties.updateApplicationSettings(settings -> withRewindEnabled(settings, rewindEnabled));
+    }
+
+    private static void applyBootstrapMode(
+            EmulatorProperties properties, Gameboy.BootstrapMode bootstrapMode) {
+        properties.updateApplicationSettings(settings -> withBootstrapMode(settings, bootstrapMode));
+    }
+
+    private static ApplicationSettings withRewindEnabled(
+            ApplicationSettings settings, boolean rewindEnabled) {
+        ApplicationSettings.Saves saves = settings.getSaves();
+        ApplicationSettings.Saves updatedSaves = saves.copy(
+                saves.getDirectory(),
+                saves.getPreviousDirectories(),
+                saves.getBatterySavesEnabled(),
+                rewindEnabled,
+                saves.getRewindSeconds(),
+                saves.getAutosavePolicy(),
+                saves.getResumePolicy(),
+                saves.getRewindMemoryMiB());
+        return settings.copy(
+                settings.getSchemaVersion(),
+                settings.getGeneral(),
+                settings.getDisplay(),
+                settings.getAudio(),
+                settings.getInput(),
+                settings.getPeripherals(),
+                updatedSaves,
+                settings.getAdvanced(),
+                settings.getDesktop());
+    }
+
+    private static ApplicationSettings withBootstrapMode(
+            ApplicationSettings settings, Gameboy.BootstrapMode bootstrapMode) {
+        ApplicationSettings.Advanced advanced = settings.getAdvanced();
+        ApplicationSettings.Advanced updatedAdvanced = advanced.copy(
+                advanced.getDmgGamesProfile(),
+                advanced.getCgbGamesProfile(),
+                bootstrapMode,
+                advanced.getDatelSlotRom(),
+                advanced.getFullChangerCharacter());
+        return settings.copy(
+                settings.getSchemaVersion(),
+                settings.getGeneral(),
+                settings.getDisplay(),
+                settings.getAudio(),
+                settings.getInput(),
+                settings.getPeripherals(),
+                settings.getSaves(),
+                updatedAdvanced,
+                settings.getDesktop());
     }
 
     private static File requireRom() {
@@ -268,10 +428,6 @@ public class HarryPotterIntroUiAudioTimingTest {
         }
     }
 
-    private static boolean forceFrameSkip() {
-        return Boolean.getBoolean("harryPotterForceFrameSkip");
-    }
-
     private static void await(String description, BooleanSupplier condition) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(4);
         while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
@@ -292,7 +448,9 @@ public class HarryPotterIntroUiAudioTimingTest {
     }
 
     @Test
-    public void estimatesAudibleGapFromPriorDeviceOccupancy() {
+    public void estimatesAudibleGapFromIdleTimeAfterPriorProviderWrite() {
+        // The interval begins when the prior provider call returned. Its blocking wall time is
+        // recorded separately and must not be interpreted as an inter-write/output gap.
         long tenMillisOfPcm = BYTES_PER_SECOND / 100;
         assertEquals(10_000_000L,
                 GapAccounting.audibleGapNanos(20_000_000L, (int) tenMillisOfPcm));
@@ -301,40 +459,224 @@ public class HarryPotterIntroUiAudioTimingTest {
     }
 
     @Test
-    public void accountsForExactPcmPhaseAndFrontendDropsAcrossTheMeasurementBoundary() {
-        PcmExpectation expectation = new PcmExpectation();
-        ClockSpec clock = ClockSpec.LEGACY;
-        for (int frame = 0; frame < WARMUP_FRAMES; frame++) {
-            expectation.accept(clock, clock.controllerTicksPerFrame());
-        }
-        expectation.resetMeasuredBytes();
-        for (int frame = 0; frame < MEASUREMENT_FRAMES; frame++) {
-            expectation.accept(clock, clock.controllerTicksPerFrame());
-        }
+    public void lineStartMetricsCountOnlyTheResetWindowAndRetainTheMaximumDuration() {
+        UiAudioMetrics metrics = new UiAudioMetrics(() -> 0, null);
 
-        assertEquals(1_763_996L, expectation.measuredBytes());
-        assertEquals(2_940L, expectation.largestChunkBytes());
-        assertEquals(58_800L, DropAccounting.droppedBytes(
-                expectation.measuredBytes(), 1_705_196L));
-        assertEquals("20", DropAccounting.frameEquivalent(58_800L, expectation.largestChunkBytes()));
+        metrics.onLineStart(10, 30);
+        metrics.resetForMeasurement();
+        metrics.onLineStart(100, 1_100);
+        metrics.onLineStart(2_000, 2_500);
+
+        assertEquals(2, metrics.lineStartCalls);
+        assertEquals(1_000L, metrics.maximumLineStartBlockingNanos);
+
+        metrics.resetForMeasurement();
+        assertEquals(0, metrics.lineStartCalls);
+        assertEquals(0L, metrics.maximumLineStartBlockingNanos);
     }
 
     @Test
-    public void cumulativeDeliveryAccountingDoesNotLetWarmupTailMaskMeasurementDrops() {
+    public void lineOccupancySamplingIsStrictAndDisabledByDefault() {
+        assertFalse(sampleLineOccupancy(null));
+        assertTrue(sampleLineOccupancy("true"));
+        assertFalse(sampleLineOccupancy("false"));
+        assertThrows(IllegalArgumentException.class, () -> sampleLineOccupancy("TRUE"));
+        assertThrows(IllegalArgumentException.class, () -> sampleLineOccupancy(" false"));
+    }
+
+    @Test
+    public void lineOccupancySamplingIsOptInWithoutChangingProviderWriteAccounting() {
+        byte[] pcm = new byte[BYTES_PER_STEREO_FRAME];
+
+        UiAudioMetrics unsampled = new UiAudioMetrics(false, () -> 0, null);
+        unsampled.startCumulativeDeliveryAccounting();
+        unsampled.resetForMeasurement();
+        CountingAudioLine unsampledDelegate = new CountingAudioLine(100, 96, 0, 0, 0, 0);
+        MeasuringAudioLine unsampledLine = new MeasuringAudioLine(
+                unsampledDelegate, unsampled, false);
+        unsampledLine.write(pcm, 0, pcm.length);
+        unsampledLine.write(pcm, 0, pcm.length);
+
+        assertEquals(0, unsampledDelegate.availableCalls);
+        assertEquals(2, unsampledDelegate.writeCalls);
+        assertEquals(2L * BYTES_PER_STEREO_FRAME, unsampled.delivery.workerBytes());
+        assertEquals(2, unsampled.writeBlockingNanos.size());
+        assertEquals("n/a", unsampled.minimumBufferedBeforeWriteSummary());
+        assertEquals("n/a", unsampled.emptyLineWritesSummary());
+        assertEquals("n/a", unsampled.audibleGapSummary());
+
+        UiAudioMetrics sampled = new UiAudioMetrics(true, () -> 0, null);
+        sampled.startCumulativeDeliveryAccounting();
+        sampled.resetForMeasurement();
+        CountingAudioLine sampledDelegate = new CountingAudioLine(100, 100, 96, 96, 0);
+        MeasuringAudioLine sampledLine = new MeasuringAudioLine(sampledDelegate, sampled, true);
+        sampledLine.write(pcm, 0, pcm.length);
+        sampledLine.write(pcm, 0, pcm.length);
+
+        assertEquals(4, sampledDelegate.availableCalls);
+        assertEquals(2L * BYTES_PER_STEREO_FRAME, sampled.delivery.workerBytes());
+        assertEquals(2, sampled.writeBlockingNanos.size());
+        assertEquals(1, sampled.emptyLineWrites);
+        assertEquals("0.000", sampled.minimumBufferedBeforeWriteSummary());
+        assertEquals("1", sampled.emptyLineWritesSummary());
+
+        UiAudioMetrics gapSample = new UiAudioMetrics(true, () -> 0, null);
+        gapSample.startCumulativeDeliveryAccounting();
+        gapSample.resetForMeasurement();
+        gapSample.onLineWrite(100, 100, 96, pcm.length, 1, 1);
+        gapSample.onLineWrite(100, 96, 96, pcm.length,
+                TimeUnit.MILLISECONDS.toNanos(20) + 1, TimeUnit.MILLISECONDS.toNanos(20) + 1);
+        assertEquals(1, gapSample.emptyLineWrites);
+        assertEquals("19.977 / 19.977", gapSample.audibleGapSummary());
+    }
+
+    @Test
+    public void parsesAndAppliesTheHarnessRewindSettingWithoutChangingOtherSettings() {
+        assertTrue(parseRewindEnabled("TrUe"));
+        assertFalse(parseRewindEnabled("false"));
+        assertThrows(IllegalArgumentException.class, () -> parseRewindEnabled("enabled"));
+
+        ApplicationSettings before = new ApplicationSettings();
+        ApplicationSettings after = withRewindEnabled(before, false);
+
+        assertFalse(after.getSaves().getRewindEnabled());
+        assertEquals(before.getSaves().getDirectory(), after.getSaves().getDirectory());
+        assertEquals(before.getSaves().getPreviousDirectories(), after.getSaves().getPreviousDirectories());
+        assertEquals(before.getSaves().getBatterySavesEnabled(), after.getSaves().getBatterySavesEnabled());
+        assertEquals(before.getSaves().getRewindSeconds(), after.getSaves().getRewindSeconds());
+        assertEquals(before.getSaves().getAutosavePolicy(), after.getSaves().getAutosavePolicy());
+        assertEquals(before.getSaves().getResumePolicy(), after.getSaves().getResumePolicy());
+        assertEquals(before.getSaves().getRewindMemoryMiB(), after.getSaves().getRewindMemoryMiB());
+        assertSame(before.getGeneral(), after.getGeneral());
+        assertSame(before.getDisplay(), after.getDisplay());
+        assertSame(before.getAudio(), after.getAudio());
+        assertSame(before.getInput(), after.getInput());
+        assertSame(before.getPeripherals(), after.getPeripherals());
+        assertSame(before.getAdvanced(), after.getAdvanced());
+        assertSame(before.getDesktop(), after.getDesktop());
+    }
+
+    @Test
+    public void parsesAndAppliesTheHarnessBootstrapModeWithoutChangingOtherSettings() {
+        assertEquals(Gameboy.BootstrapMode.SKIP, bootstrapMode(null));
+        assertEquals(Gameboy.BootstrapMode.SKIP, parseBootstrapMode("SKIP"));
+        assertEquals(Gameboy.BootstrapMode.FAST_FORWARD, parseBootstrapMode("FAST_FORWARD"));
+        assertEquals(Gameboy.BootstrapMode.NORMAL, parseBootstrapMode("NORMAL"));
+        assertThrows(IllegalArgumentException.class, () -> parseBootstrapMode("fast-forward"));
+
+        ApplicationSettings before = new ApplicationSettings();
+        ApplicationSettings after = withBootstrapMode(before, Gameboy.BootstrapMode.FAST_FORWARD);
+
+        assertEquals(Gameboy.BootstrapMode.FAST_FORWARD, after.getAdvanced().getBootstrapMode());
+        assertEquals(before.getAdvanced().getDmgGamesProfile(), after.getAdvanced().getDmgGamesProfile());
+        assertEquals(before.getAdvanced().getCgbGamesProfile(), after.getAdvanced().getCgbGamesProfile());
+        assertEquals(before.getAdvanced().getDatelSlotRom(), after.getAdvanced().getDatelSlotRom());
+        assertEquals(before.getAdvanced().getFullChangerCharacter(),
+                after.getAdvanced().getFullChangerCharacter());
+        assertSame(before.getGeneral(), after.getGeneral());
+        assertSame(before.getDisplay(), after.getDisplay());
+        assertSame(before.getAudio(), after.getAudio());
+        assertSame(before.getInput(), after.getInput());
+        assertSame(before.getPeripherals(), after.getPeripherals());
+        assertSame(before.getSaves(), after.getSaves());
+        assertSame(before.getDesktop(), after.getDesktop());
+    }
+
+    @Test
+    public void fullIntroWindowIncludesInitialFramesAndAnEarlyProducerGap() {
+        ClockSpec clock = ClockSpec.LEGACY;
+        UiAudioMetrics metrics = new UiAudioMetrics();
+        metrics.limitToSourceFrames(INTRO_FRAMES);
+        metrics.startCumulativeDeliveryAccounting();
+        Sound.SoundSampleEvent event = new Sound.SoundSampleEvent(
+                new int[clock.controllerTicksPerFrame() * 2], clock);
+        long[] now = {1};
+        measureFullIntro(metrics, frame -> {
+            now[0] += TimeUnit.MILLISECONDS.toNanos(frame == 7 ? 76 : 16);
+            metrics.onProducerEventAtNanos(event, now[0]);
+        });
+
+        assertEquals(INTRO_FRAMES - 1, metrics.producerIntervals.size());
+        assertEquals(1, metrics.producerGapsOver50Ms);
+        assertEquals(INTRO_FRAMES, metrics.sourceFrameCount());
+        assertEquals(5_291_992L, metrics.delivery.expectedBytes());
+        assertEquals(2_940L, metrics.delivery.largestChunkBytes());
+
+        metrics.onProducerEventAtNanos(event, now[0] + TimeUnit.MILLISECONDS.toNanos(16));
+        assertEquals(INTRO_FRAMES - 1, metrics.producerIntervals.size());
+        assertEquals(1, metrics.postLimitSourceEvents());
+        assertEquals(5_291_992L, metrics.delivery.expectedBytes());
+    }
+
+    @Test
+    public void pairsProducerWallAndControllerCpuIntervalsByEndingFrame() {
+        ClockSpec clock = ClockSpec.LEGACY;
+        long millis = TimeUnit.MILLISECONDS.toNanos(1);
+        long[] wallNanos = {10 * millis, 28 * millis, 98 * millis, 138 * millis, 168 * millis, 183 * millis};
+        long[] cpuNanos = {100 * millis, 108 * millis, 168 * millis, 173 * millis, 203 * millis, 213 * millis};
+        AtomicInteger wallReads = new AtomicInteger();
+        AtomicInteger cpuReads = new AtomicInteger();
+        UiAudioMetrics metrics = new UiAudioMetrics(
+                () -> wallNanos[wallReads.getAndIncrement()],
+                () -> cpuNanos[cpuReads.getAndIncrement()]);
+        Sound.SoundSampleEvent event = new Sound.SoundSampleEvent(
+                new int[clock.controllerTicksPerFrame() * 2], clock);
+
+        metrics.startCumulativeDeliveryAccounting();
+        metrics.resetForMeasurement();
+        for (int frame = 0; frame < wallNanos.length; frame++) {
+            metrics.onProducerEvent(event);
+        }
+
+        assertEquals(wallNanos.length, wallReads.get());
+        assertEquals(cpuNanos.length, cpuReads.get());
+        assertEquals(wallNanos.length - 1, metrics.producerIntervals.size());
+        assertProducerInterval(metrics.producerIntervals.get(0), 1, 18 * millis, 8 * millis);
+        assertProducerInterval(metrics.producerIntervals.get(1), 2, 70 * millis, 60 * millis);
+
+        List<ProducerInterval> topIntervals = metrics.topProducerIntervals(5);
+        assertEquals(5, topIntervals.size());
+        assertProducerInterval(topIntervals.get(0), 2, 70 * millis, 60 * millis);
+        assertProducerInterval(topIntervals.get(1), 3, 40 * millis, 5 * millis);
+        assertProducerInterval(topIntervals.get(2), 4, 30 * millis, 30 * millis);
+        assertProducerInterval(topIntervals.get(3), 1, 18 * millis, 8 * millis);
+        assertProducerInterval(topIntervals.get(4), 5, 15 * millis, 10 * millis);
+        assertEquals("2: 70.000/60.000 ms", metrics.maximumProducerIntervalSummary());
+        assertEquals("2: 70.000/60.000 ms, 3: 40.000/5.000 ms, "
+                        + "4: 30.000/30.000 ms, 1: 18.000/8.000 ms, 5: 15.000/10.000 ms",
+                metrics.topProducerIntervalsSummary());
+
+        UiAudioMetrics unavailableCpu = new UiAudioMetrics(() -> 1, null);
+        unavailableCpu.startCumulativeDeliveryAccounting();
+        unavailableCpu.resetForMeasurement();
+        unavailableCpu.onProducerEventAtNanos(event, 1, -1);
+        unavailableCpu.onProducerEventAtNanos(event, TimeUnit.MILLISECONDS.toNanos(20) + 1, -1);
+        assertEquals("1: 20.000/n/a ms", unavailableCpu.maximumProducerIntervalSummary());
+    }
+
+    private static void assertProducerInterval(
+            ProducerInterval interval, int endingSourceFrameIndex, long wallNanos, long cpuNanos) {
+        assertEquals(endingSourceFrameIndex, interval.endingSourceFrameIndex());
+        assertEquals(wallNanos, interval.wallNanos());
+        assertEquals(cpuNanos, interval.controllerCpuNanos());
+    }
+
+    @Test
+    public void cumulativeDeliveryAccountingDoesNotLetEarlierTailMaskLaterDrops() {
         ClockSpec clock = ClockSpec.LEGACY;
         CumulativePcmAccounting accounting = new CumulativePcmAccounting();
         for (int frame = 0; frame < 3; frame++) {
             accounting.onProducerEvent(clock, clock.controllerTicksPerFrame());
         }
-        long warmupBytes = accounting.expectedBytes();
+        long earlierBytes = accounting.expectedBytes();
 
-        // resetForMeasurement intentionally clears only the windowed timing metrics. These three
-        // writes are warmup PCM that reaches the worker after the boundary.
+        // A prior queue tail reaches the worker after later producer frames. Cumulative accounting
+        // must retain those matching earlier source bytes instead of masking the later loss.
         for (int frame = 0; frame < 3; frame++) {
             accounting.onProducerEvent(clock, clock.controllerTicksPerFrame());
         }
-        long measurementBytes = accounting.expectedBytes() - warmupBytes;
-        accounting.onWorkerWrite(warmupBytes + measurementBytes - 2L * 2_940);
+        long laterBytes = accounting.expectedBytes() - earlierBytes;
+        accounting.onWorkerWrite(earlierBytes + laterBytes - 2L * 2_940);
 
         assertEquals(5_880L, accounting.droppedBytes());
         assertEquals("2", DropAccounting.frameEquivalent(
@@ -346,13 +688,20 @@ public class HarryPotterIntroUiAudioTimingTest {
         T get() throws Exception;
     }
 
-    /** Delegates to Java Sound while retaining the actual device values around every write. */
+    @FunctionalInterface
+    private interface IntroFrameRunner {
+        void run(int frame);
+    }
+
+    /** Delegates to Java Sound and optionally samples the device's occupancy around each write. */
     private static final class MeasuringAudioBackend implements AudioBackend {
         private final AudioBackend delegate = new JavaSoundAudioBackend();
         private final UiAudioMetrics metrics;
+        private final boolean sampleLineOccupancy;
 
-        private MeasuringAudioBackend(UiAudioMetrics metrics) {
+        private MeasuringAudioBackend(UiAudioMetrics metrics, boolean sampleLineOccupancy) {
             this.metrics = metrics;
+            this.sampleLineOccupancy = sampleLineOccupancy;
         }
 
         @Override
@@ -363,39 +712,64 @@ public class HarryPotterIntroUiAudioTimingTest {
         @Override
         public AudioLine open(String stableId, AudioFormat format, int bufferBytes)
                 throws LineUnavailableException {
-            return new MeasuringAudioLine(delegate.open(stableId, format, bufferBytes), metrics);
+            return new MeasuringAudioLine(
+                    delegate.open(stableId, format, bufferBytes), metrics, sampleLineOccupancy);
         }
     }
 
     private static final class MeasuringAudioLine implements AudioBackend.AudioLine {
         private final AudioBackend.AudioLine delegate;
         private final UiAudioMetrics metrics;
+        private final boolean sampleLineOccupancy;
+        private final int bufferBytes;
 
-        private MeasuringAudioLine(AudioBackend.AudioLine delegate, UiAudioMetrics metrics) {
+        private MeasuringAudioLine(
+                AudioBackend.AudioLine delegate,
+                UiAudioMetrics metrics,
+                boolean sampleLineOccupancy) {
             this.delegate = delegate;
             this.metrics = metrics;
+            this.sampleLineOccupancy = sampleLineOccupancy;
+            this.bufferBytes = delegate.bufferSize();
         }
 
         @Override
         public void start() {
-            delegate.start();
+            long started = System.nanoTime();
+            try {
+                delegate.start();
+            } finally {
+                metrics.onLineStart(started, System.nanoTime());
+            }
+        }
+
+        @Override
+        public boolean isRunning() {
+            return delegate.isRunning();
         }
 
         @Override
         public int write(byte[] bytes, int offset, int length) {
-            int bufferBytes = delegate.bufferSize();
-            int availableBefore = delegate.available();
+            int availableBefore = sampleLineOccupancy ? delegate.available() : 0;
             long started = System.nanoTime();
             metrics.onLineWriteStarted(started);
+            long completed = 0;
             try {
                 int written = delegate.write(bytes, offset, length);
-                long completed = System.nanoTime();
-                int availableAfter = delegate.available();
+                // Preserve provider-call timing even when optional diagnostic sampling itself is
+                // slow or perturbs a platform mixer.
+                completed = System.nanoTime();
+                int availableAfter = sampleLineOccupancy ? delegate.available() : 0;
                 metrics.onLineWrite(
-                        bufferBytes, availableBefore, availableAfter, written, started, completed);
+                        bufferBytes,
+                        availableBefore,
+                        availableAfter,
+                        written,
+                        started,
+                        completed);
                 return written;
             } finally {
-                metrics.onLineWriteFinished(System.nanoTime());
+                metrics.onLineWriteFinished(completed == 0 ? System.nanoTime() : completed);
             }
         }
 
@@ -430,24 +804,93 @@ public class HarryPotterIntroUiAudioTimingTest {
         }
     }
 
+    /** Deterministic line used to prove diagnostic sampling does not touch the normal write path. */
+    private static final class CountingAudioLine implements AudioBackend.AudioLine {
+        private final int bufferBytes;
+        private final int[] availability;
+        private int availabilityIndex;
+        private int availableCalls;
+        private int writeCalls;
+
+        private CountingAudioLine(int bufferBytes, int... availability) {
+            this.bufferBytes = bufferBytes;
+            this.availability = availability;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public int write(byte[] bytes, int offset, int length) {
+            writeCalls++;
+            return length;
+        }
+
+        @Override
+        public int available() {
+            availableCalls++;
+            if (availability.length == 0) {
+                return bufferBytes;
+            }
+            int index = Math.min(availabilityIndex++, availability.length - 1);
+            return availability[index];
+        }
+
+        @Override
+        public int bufferSize() {
+            return bufferBytes;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
     /** Measurement-only collector; all methods are synchronized across the emulation and worker threads. */
     private static final class UiAudioMetrics {
-        private final List<Long> producerIntervalsNanos = new ArrayList<>();
-        private final List<Long> controllerWorkNanos = new ArrayList<>();
+        private static final long CPU_TIME_UNAVAILABLE = -1;
+
+        private final boolean sampleLineOccupancy;
+        private final LongSupplier wallClock;
+        private final LongSupplier controllerCpuClock;
+        private final List<ProducerInterval> producerIntervals = new ArrayList<>();
         private final List<Long> lineWriteIntervalsNanos = new ArrayList<>();
         private final List<Long> writeBlockingNanos = new ArrayList<>();
         private volatile boolean measuring;
+        private int sourceFrameLimit = Integer.MAX_VALUE;
+        private int sourceFrameCount;
+        private int postLimitSourceEvents;
         private long lastProducerNanos;
+        private long lastProducerCpuNanos = CPU_TIME_UNAVAILABLE;
         private long lastPostWriteNanos;
         private long lastLineWriteCompletedNanos;
         private int lineWritesInProgress;
+        private int lineStartCalls;
+        private long maximumLineStartBlockingNanos;
         private int previousPostWriteOccupancyBytes;
         private final CumulativePcmAccounting delivery = new CumulativePcmAccounting();
         private int lineBufferBytes;
         private int producerGapsOver25Ms;
         private int producerGapsOver50Ms;
-        private int controllerWorkOverNominal;
-        private int pacingDebtFrames;
         private int emptyLineWrites;
         private int frontendQueuePeakFrames;
         private double totalAudibleGapMs;
@@ -455,24 +898,54 @@ public class HarryPotterIntroUiAudioTimingTest {
         private double minimumBufferedBeforeWriteMs = Double.POSITIVE_INFINITY;
         private boolean cumulativeDeliveryAccounting;
 
+        private UiAudioMetrics() {
+            this(false, System::nanoTime, controllerThreadCpuClock());
+        }
+
+        private UiAudioMetrics(boolean sampleLineOccupancy) {
+            this(sampleLineOccupancy, System::nanoTime, controllerThreadCpuClock());
+        }
+
+        private UiAudioMetrics(LongSupplier wallClock, LongSupplier controllerCpuClock) {
+            this(false, wallClock, controllerCpuClock);
+        }
+
+        private UiAudioMetrics(
+                boolean sampleLineOccupancy,
+                LongSupplier wallClock,
+                LongSupplier controllerCpuClock) {
+            this.sampleLineOccupancy = sampleLineOccupancy;
+            this.wallClock = wallClock;
+            this.controllerCpuClock = controllerCpuClock;
+        }
+
         synchronized void startCumulativeDeliveryAccounting() {
             cumulativeDeliveryAccounting = true;
         }
 
+        synchronized void limitToSourceFrames(int sourceFrameLimit) {
+            if (sourceFrameLimit <= 0) {
+                throw new IllegalArgumentException("Source frame limit must be positive");
+            }
+            this.sourceFrameLimit = sourceFrameLimit;
+        }
+
         synchronized void resetForMeasurement() {
             measuring = false;
-            producerIntervalsNanos.clear();
-            controllerWorkNanos.clear();
+            producerIntervals.clear();
             lineWriteIntervalsNanos.clear();
             writeBlockingNanos.clear();
+            sourceFrameCount = 0;
+            postLimitSourceEvents = 0;
             lastProducerNanos = 0;
+            lastProducerCpuNanos = CPU_TIME_UNAVAILABLE;
             lastPostWriteNanos = 0;
             previousPostWriteOccupancyBytes = 0;
+            lineStartCalls = 0;
+            maximumLineStartBlockingNanos = 0;
             lineBufferBytes = 0;
             producerGapsOver25Ms = 0;
             producerGapsOver50Ms = 0;
-            controllerWorkOverNominal = 0;
-            pacingDebtFrames = 0;
             emptyLineWrites = 0;
             frontendQueuePeakFrames = 0;
             totalAudibleGapMs = 0;
@@ -481,19 +954,41 @@ public class HarryPotterIntroUiAudioTimingTest {
             measuring = true;
         }
 
-        synchronized void onProducerEvent(Sound.SoundSampleEvent event) {
+        synchronized boolean onProducerEvent(Sound.SoundSampleEvent event) {
+            long wallNanos = wallClock.getAsLong();
+            long controllerCpuNanos = controllerCpuClock == null
+                    ? CPU_TIME_UNAVAILABLE
+                    : controllerCpuClock.getAsLong();
+            return onProducerEventAtNanos(event, wallNanos, controllerCpuNanos);
+        }
+
+        synchronized boolean onProducerEventAtNanos(Sound.SoundSampleEvent event, long now) {
+            return onProducerEventAtNanos(event, now, CPU_TIME_UNAVAILABLE);
+        }
+
+        synchronized boolean onProducerEventAtNanos(
+                Sound.SoundSampleEvent event, long now, long controllerCpuNanos) {
             if (!cumulativeDeliveryAccounting) {
-                return;
+                return false;
             }
+            if (sourceFrameCount >= sourceFrameLimit) {
+                postLimitSourceEvents++;
+                return false;
+            }
+            sourceFrameCount++;
             int ticks = event.buffer().length / 2;
             delivery.onProducerEvent(event.clockSpec(), ticks);
             if (!measuring) {
-                return;
+                return sourceFrameCount == sourceFrameLimit;
             }
-            long now = System.nanoTime();
             if (lastProducerNanos != 0) {
                 long interval = now - lastProducerNanos;
-                producerIntervalsNanos.add(interval);
+                long controllerCpuInterval = lastProducerCpuNanos == CPU_TIME_UNAVAILABLE
+                        || controllerCpuNanos == CPU_TIME_UNAVAILABLE
+                        ? CPU_TIME_UNAVAILABLE
+                        : Math.max(0, controllerCpuNanos - lastProducerCpuNanos);
+                producerIntervals.add(new ProducerInterval(
+                        sourceFrameCount - 1, interval, controllerCpuInterval));
                 if (interval > TimeUnit.MILLISECONDS.toNanos(25)) {
                     producerGapsOver25Ms++;
                 }
@@ -502,24 +997,13 @@ public class HarryPotterIntroUiAudioTimingTest {
                 }
             }
             lastProducerNanos = now;
+            lastProducerCpuNanos = controllerCpuNanos;
+            return sourceFrameCount == sourceFrameLimit;
         }
 
         synchronized void onFrontendQueueAfterSynchronousPlay(int queuedFrames) {
             if (measuring) {
                 frontendQueuePeakFrames = Math.max(frontendQueuePeakFrames, queuedFrames);
-            }
-        }
-
-        synchronized void onControllerFrame(long workNanos, long nominalNanos, boolean pacingDebt) {
-            if (!measuring) {
-                return;
-            }
-            controllerWorkNanos.add(workNanos);
-            if (workNanos > nominalNanos) {
-                controllerWorkOverNominal++;
-            }
-            if (pacingDebt) {
-                pacingDebtFrames++;
             }
         }
 
@@ -538,29 +1022,44 @@ public class HarryPotterIntroUiAudioTimingTest {
                 return;
             }
             lineBufferBytes = Math.max(lineBufferBytes, bufferBytes);
-            int occupancyBefore = Math.max(0, bufferBytes - availableBefore);
-            int occupancyAfter = Math.max(0, bufferBytes - availableAfter);
-            minimumBufferedBeforeWriteMs = Math.min(
-                    minimumBufferedBeforeWriteMs, millisecondsForBytes(occupancyBefore));
             if (lastPostWriteNanos != 0) {
                 long interval = Math.max(0, started - lastPostWriteNanos);
                 lineWriteIntervalsNanos.add(interval);
-                long gapNanos = GapAccounting.audibleGapNanos(
-                        interval, previousPostWriteOccupancyBytes);
-                double gapMs = gapNanos / 1_000_000.0;
-                totalAudibleGapMs += gapMs;
-                maximumAudibleGapMs = Math.max(maximumAudibleGapMs, gapMs);
-                // Java Sound providers can report a single stereo frame as still occupied while
-                // the DAC has effectively drained. Treat that four-byte rounding residue as an
-                // empty line, matching the historic desktop underrun interpretation.
-                if (availableBefore >= bufferBytes - BYTES_PER_STEREO_FRAME) {
-                    emptyLineWrites++;
-                }
             }
             writeBlockingNanos.add(Math.max(0, completed - started));
-            previousPostWriteOccupancyBytes = occupancyAfter;
+            if (sampleLineOccupancy) {
+                int occupancyBefore = Math.max(0, bufferBytes - availableBefore);
+                int occupancyAfter = Math.max(0, bufferBytes - availableAfter);
+                minimumBufferedBeforeWriteMs = Math.min(
+                        minimumBufferedBeforeWriteMs, millisecondsForBytes(occupancyBefore));
+                if (lastPostWriteNanos != 0) {
+                    long interval = Math.max(0, started - lastPostWriteNanos);
+                    long gapNanos = GapAccounting.audibleGapNanos(
+                            interval, previousPostWriteOccupancyBytes);
+                    double gapMs = gapNanos / 1_000_000.0;
+                    totalAudibleGapMs += gapMs;
+                    maximumAudibleGapMs = Math.max(maximumAudibleGapMs, gapMs);
+                    // Java Sound providers can report a single stereo frame as still occupied
+                    // while the DAC has effectively drained. Treat that four-byte rounding
+                    // residue as an empty line, matching the historic desktop interpretation.
+                    if (availableBefore >= bufferBytes - BYTES_PER_STEREO_FRAME) {
+                        emptyLineWrites++;
+                    }
+                }
+                previousPostWriteOccupancyBytes = occupancyAfter;
+            }
             lastPostWriteNanos = completed;
             notifyAll();
+        }
+
+        /** Counts only starts issued after the frame-zero measurement reset. */
+        synchronized void onLineStart(long started, long completed) {
+            if (!measuring) {
+                return;
+            }
+            lineStartCalls++;
+            maximumLineStartBlockingNanos = Math.max(
+                    maximumLineStartBlockingNanos, Math.max(0, completed - started));
         }
 
         synchronized void onLineWriteStarted(long started) {
@@ -584,80 +1083,128 @@ public class HarryPotterIntroUiAudioTimingTest {
         }
 
         synchronized void awaitProducedPcmAtWorker(
-                BlockingQueue<byte[]> workerQueue, Duration timeout) throws InterruptedException {
+                AudioSystemSound output,
+                BlockingQueue<byte[]> workerQueue,
+                Duration timeout) throws InterruptedException {
             long deadline = System.nanoTime() + timeout.toNanos();
-            while (!deliveryReached(workerQueue) && System.nanoTime() < deadline) {
+            while (!deliveryReached(output, workerQueue) && System.nanoTime() < deadline) {
                 long remaining = Math.min(
                         Math.max(1, deadline - System.nanoTime()),
-                        nanosUntilDeliveryCanBeQuiescent(workerQueue));
+                        nanosUntilDeliveryCanBeQuiescent(output, workerQueue));
                 TimeUnit.NANOSECONDS.timedWait(this, remaining);
             }
-            if (!deliveryReached(workerQueue)) {
+            if (!deliveryReached(output, workerQueue)) {
                 throw new IllegalStateException("Audio worker delivery timed out: "
                         + delivery.workerBytes() + " worker PCM bytes (expected "
                         + delivery.expectedBytes()
                         + "), queue empty=" + workerQueue.isEmpty()
                         + ", final source/write timestamps=" + lastProducerNanos
                         + "/" + lastPostWriteNanos + ", line writes in progress="
-                        + lineWritesInProgress + " after " + timeout.toMillis() + " ms");
+                        + lineWritesInProgress + ", whole PCM buffer write in progress="
+                        + output.isPcmBufferWriteInProgressForTesting()
+                        + " after " + timeout.toMillis() + " ms");
             }
             measuring = false;
         }
 
-        private boolean deliveryReached(BlockingQueue<byte[]> workerQueue) {
+        private boolean deliveryReached(AudioSystemSound output, BlockingQueue<byte[]> workerQueue) {
             // A short frontend queue can legitimately drop PCM. After the final producer event,
-            // wait for a line write that began/completed after it, no in-flight write, and a short
-            // quiet interval. This prevents an older write completing after the source timestamp
-            // from racing an already-polled final buffer that has not reached AudioLine.write().
+            // wait for a line write that began/completed after it, no in-flight provider call or
+            // worker-local dequeued buffer, and a short quiet interval. This prevents an older
+            // write completing after the source timestamp from racing an already-polled final
+            // buffer that has not entered its blocking provider call yet.
             return workerQueue.isEmpty()
                     && lastProducerNanos != 0
                     && lastPostWriteNanos >= lastProducerNanos
                     && lineWritesInProgress == 0
+                    && !output.isPcmBufferWriteInProgressForTesting()
                     && System.nanoTime() - lastLineWriteCompletedNanos >= OUTPUT_QUIESCENCE.toNanos();
         }
 
-        private long nanosUntilDeliveryCanBeQuiescent(BlockingQueue<byte[]> workerQueue) {
+        private long nanosUntilDeliveryCanBeQuiescent(
+                AudioSystemSound output, BlockingQueue<byte[]> workerQueue) {
+            if (lineWritesInProgress != 0) {
+                // MeasuringAudioLine notifies on provider-call completion. Do not add an
+                // independent 1 ms wakeup loop while that native call is intentionally blocking.
+                return OUTPUT_DELIVERY_TIMEOUT.toNanos();
+            }
             if (!workerQueue.isEmpty()
                     || lastProducerNanos == 0
                     || lastPostWriteNanos < lastProducerNanos
-                    || lineWritesInProgress != 0) {
-                return OUTPUT_DELIVERY_TIMEOUT.toNanos();
+                    || output.isPcmBufferWriteInProgressForTesting()) {
+                // This is only the short queue-to-worker handoff before the provider call has
+                // started (or after it returned and before the ownership flag clears).
+                return TimeUnit.MILLISECONDS.toNanos(10);
             }
             return Math.max(1, lastLineWriteCompletedNanos + OUTPUT_QUIESCENCE.toNanos()
                     - System.nanoTime());
         }
 
         synchronized void printReport(AudioRuntimeConfiguration.LatencyPreset latencyPreset) {
-            System.out.printf("UI audio timing preset: %s%n", latencyPreset);
-            System.out.printf("Audio frontend expected/worker PCM bytes: %d / %d%n",
+            System.out.printf("Full intro UI audio timing preset: %s%n", latencyPreset);
+            System.out.printf("Full intro source frames observed/target/post-limit: %d / %d / %d%n",
+                    sourceFrameCount, sourceFrameLimit, postLimitSourceEvents);
+            System.out.printf("Full intro audio frontend expected/worker PCM bytes: %d / %d%n",
                     delivery.expectedBytes(), delivery.workerBytes());
             long droppedBytes = delivery.droppedBytes();
-            System.out.printf("Audio frontend dropped PCM bytes/ms/frames: %d / %.3f / %s%n",
+            System.out.printf("Full intro audio frontend dropped PCM bytes/ms/frames: %d / %.3f / %s%n",
                     droppedBytes,
                     millisecondsForBytes(droppedBytes),
                     DropAccounting.frameEquivalent(droppedBytes, delivery.largestChunkBytes()));
-            System.out.printf("Audio frontend queue peak/capacity frames: %d / %d%n",
+            System.out.printf("Full intro audio frontend queue peak/capacity frames: %d / %d%n",
                     frontendQueuePeakFrames, latencyPreset.runtimeQueueCapacity());
-            System.out.printf("Audio line buffer bytes/ms: %d / %.3f%n",
+            // The audio worker can open before frame zero. This deliberately reports only starts
+            // after reset/activation, which exposes redundant priming and steady-state starts.
+            System.out.printf("Full intro audio line start calls (after frame zero): %d%n",
+                    lineStartCalls);
+            System.out.printf("Full intro audio line max start blocking ms (after frame zero): %.3f%n",
+                    maximumLineStartBlockingNanos / 1_000_000.0);
+            System.out.printf("Full intro audio line buffer bytes/ms: %d / %.3f%n",
                     lineBufferBytes, millisecondsForBytes(lineBufferBytes));
-            System.out.printf("Producer event interval p50/p95/p99/max ms: %s%n",
-                    percentileSummary(producerIntervalsNanos));
-            System.out.printf("Audio gaps >25ms/>50ms: %d / %d%n",
+            System.out.printf("Full intro audio line occupancy sampling: %s%n", sampleLineOccupancy);
+            System.out.printf("Full intro producer event interval p50/p95/p99/max ms: %s%n",
+                    producerPercentileSummary(producerIntervals));
+            System.out.printf("Full intro producer max wall/controller CPU interval ms: %s%n",
+                    maximumProducerIntervalSummary());
+            System.out.printf("Full intro producer top 5 wall intervals frame: wall/controller CPU ms: %s%n",
+                    topProducerIntervalsSummary());
+            System.out.printf("Full intro audio gaps >25ms/>50ms: %d / %d%n",
                     producerGapsOver25Ms, producerGapsOver50Ms);
-            System.out.printf("Controller frame work p50/p95/p99/max ms: %s%n",
-                    percentileSummary(controllerWorkNanos));
-            System.out.printf("Controller work > nominal / pacing-debt frames: %d / %d%n",
-                    controllerWorkOverNominal, pacingDebtFrames);
-            System.out.printf("Audio line write interval p50/p95/p99/max ms: %s%n",
+            System.out.printf("Full intro audio line provider write return-to-next-call interval p50/p95/p99/max ms: %s%n",
                     percentileSummary(lineWriteIntervalsNanos));
-            System.out.printf("Audio line max write blocking ms: %.3f%n",
+            System.out.printf("Full intro audio line max provider write blocking ms: %.3f%n",
                     maximumMillis(writeBlockingNanos));
-            System.out.printf("Audio line minimum buffered before write ms: %.3f%n",
-                    Double.isInfinite(minimumBufferedBeforeWriteMs) ? 0 : minimumBufferedBeforeWriteMs);
-            System.out.printf("Audio underruns (empty-line writes after priming): %d%n",
-                    emptyLineWrites);
-            System.out.printf("Audio gap estimate total/max ms: %.3f / %.3f%n",
-                    totalAudibleGapMs, maximumAudibleGapMs);
+            System.out.printf("Full intro audio line minimum buffered before provider write ms: %s%n",
+                    minimumBufferedBeforeWriteSummary());
+            System.out.printf("Full intro audio underruns (empty-line writes after priming): %s%n",
+                    emptyLineWritesSummary());
+            System.out.printf("Full intro audio gap estimate total/max ms: %s%n",
+                    audibleGapSummary());
+        }
+
+        private String minimumBufferedBeforeWriteSummary() {
+            return sampleLineOccupancy
+                    ? String.format("%.3f", Double.isInfinite(minimumBufferedBeforeWriteMs)
+                            ? 0 : minimumBufferedBeforeWriteMs)
+                    : "n/a";
+        }
+
+        private String emptyLineWritesSummary() {
+            return sampleLineOccupancy ? Integer.toString(emptyLineWrites) : "n/a";
+        }
+
+        private String audibleGapSummary() {
+            return sampleLineOccupancy
+                    ? String.format("%.3f / %.3f", totalAudibleGapMs, maximumAudibleGapMs)
+                    : "n/a";
+        }
+
+        synchronized int sourceFrameCount() {
+            return sourceFrameCount;
+        }
+
+        synchronized int postLimitSourceEvents() {
+            return postLimitSourceEvents;
         }
 
         private static double millisecondsForBytes(long bytes) {
@@ -668,11 +1215,63 @@ public class HarryPotterIntroUiAudioTimingTest {
             return nanos.stream().mapToLong(Long::longValue).max().orElse(0) / 1_000_000.0;
         }
 
+        private List<ProducerInterval> topProducerIntervals(int maximumEntries) {
+            List<ProducerInterval> top = new ArrayList<>(producerIntervals);
+            top.sort(Comparator.comparingLong(ProducerInterval::wallNanos)
+                    .reversed()
+                    .thenComparingInt(ProducerInterval::endingSourceFrameIndex));
+            return top.subList(0, Math.min(maximumEntries, top.size()));
+        }
+
+        private String maximumProducerIntervalSummary() {
+            List<ProducerInterval> top = topProducerIntervals(1);
+            return top.isEmpty() ? "n/a" : formatProducerInterval(top.get(0));
+        }
+
+        private String topProducerIntervalsSummary() {
+            List<ProducerInterval> top = topProducerIntervals(5);
+            if (top.isEmpty()) {
+                return "n/a";
+            }
+            StringBuilder summary = new StringBuilder();
+            for (ProducerInterval interval : top) {
+                if (summary.length() != 0) {
+                    summary.append(", ");
+                }
+                summary.append(formatProducerInterval(interval));
+            }
+            return summary.toString();
+        }
+
+        private static String formatProducerInterval(ProducerInterval interval) {
+            return String.format("%d: %.3f/%s ms",
+                    interval.endingSourceFrameIndex(),
+                    interval.wallNanos() / 1_000_000.0,
+                    interval.controllerCpuNanos() == CPU_TIME_UNAVAILABLE
+                            ? "n/a"
+                            : String.format("%.3f", interval.controllerCpuNanos() / 1_000_000.0));
+        }
+
+        private static String producerPercentileSummary(List<ProducerInterval> intervals) {
+            long[] wallIntervals = new long[intervals.size()];
+            for (int i = 0; i < intervals.size(); i++) {
+                wallIntervals[i] = intervals.get(i).wallNanos();
+            }
+            return percentileSummary(wallIntervals);
+        }
+
         private static String percentileSummary(List<Long> values) {
             if (values.isEmpty()) {
                 return "n/a";
             }
             long[] sorted = values.stream().mapToLong(Long::longValue).toArray();
+            return percentileSummary(sorted);
+        }
+
+        private static String percentileSummary(long[] sorted) {
+            if (sorted.length == 0) {
+                return "n/a";
+            }
             Arrays.sort(sorted);
             return String.format("%.3f / %.3f / %.3f / %.3f",
                     percentileMillis(sorted, 0.50), percentileMillis(sorted, 0.95),
@@ -683,42 +1282,48 @@ public class HarryPotterIntroUiAudioTimingTest {
             int index = (int) Math.ceil(percentile * sorted.length) - 1;
             return sorted[Math.max(0, Math.min(sorted.length - 1, index))] / 1_000_000.0;
         }
+
+        private static LongSupplier controllerThreadCpuClock() {
+            ThreadMXBean threadMxBean;
+            try {
+                threadMxBean = ManagementFactory.getThreadMXBean();
+                if (!threadMxBean.isCurrentThreadCpuTimeSupported()) {
+                    return null;
+                }
+                if (!threadMxBean.isThreadCpuTimeEnabled()) {
+                    threadMxBean.setThreadCpuTimeEnabled(true);
+                }
+            } catch (SecurityException | UnsupportedOperationException ignored) {
+                return null;
+            }
+            return () -> {
+                try {
+                    return threadMxBean.getCurrentThreadCpuTime();
+                } catch (UnsupportedOperationException ignored) {
+                    return CPU_TIME_UNAVAILABLE;
+                }
+            };
+        }
+    }
+
+    private record ProducerInterval(int endingSourceFrameIndex, long wallNanos, long controllerCpuNanos) {
     }
 
     /** Mirrors StereoPcmConverter's fractional sample accumulator without rendering samples. */
     private static final class PcmExpectation {
         private ClockSpec activeClock;
         private ClockSpec.RateAccumulator sampleAccumulator;
-        private long measuredBytes;
-        private long largestChunkBytes;
 
         long accept(ClockSpec clock, int ticks) {
             if (activeClock == null || !activeClock.equals(clock)) {
                 activeClock = clock;
                 sampleAccumulator = clock.newTickRateAccumulator(SAMPLE_RATE);
             }
-            long bytes = Math.multiplyExact(
-                    sampleAccumulator.advance(ticks), BYTES_PER_STEREO_FRAME);
-            measuredBytes = Math.addExact(measuredBytes, bytes);
-            largestChunkBytes = Math.max(largestChunkBytes, bytes);
-            return bytes;
-        }
-
-        void resetMeasuredBytes() {
-            measuredBytes = 0;
-            largestChunkBytes = 0;
-        }
-
-        long measuredBytes() {
-            return measuredBytes;
-        }
-
-        long largestChunkBytes() {
-            return largestChunkBytes;
+            return Math.multiplyExact(sampleAccumulator.advance(ticks), BYTES_PER_STEREO_FRAME);
         }
     }
 
-    /** PCM accounting deliberately spans the warmup/measurement boundary. */
+    /** PCM accounting deliberately spans the entire intro window. */
     private static final class CumulativePcmAccounting {
         private final PcmExpectation expectation = new PcmExpectation();
         private long expectedBytes;

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -184,6 +184,40 @@ public class SwingDisplayTest {
     }
 
     @Test
+    public void publishedFrameRemainsImmutableAcrossLaterFramesAndSourceMutation() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        eventBus.post(new SwingDisplay.SetBlendingEvent(false));
+        int size = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
+        int[] firstSource = new int[size];
+        Arrays.fill(firstSource, 3);
+        int[] expectedFirst = dmgRgb(firstSource);
+        int[] secondSource = new int[size];
+        Arrays.fill(secondSource, 2);
+        int[] expectedSecond = dmgRgb(secondSource);
+        Thread displayThread = daemonThread(display);
+        displayThread.start();
+        try {
+            eventBus.post(new Display.DmgFrameReadyEvent(firstSource));
+            DisplayFrameSnapshot first = awaitDisplayedFrame(
+                    display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expectedFirst);
+            Arrays.fill(firstSource, 0);
+
+            eventBus.post(new Display.DmgFrameReadyEvent(secondSource));
+            DisplayFrameSnapshot second = awaitDisplayedFrame(
+                    display, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT, expectedSecond);
+            Arrays.fill(secondSource, 0);
+
+            assertArrayEquals(expectedFirst, first.copyRgb());
+            assertArrayEquals(expectedSecond, second.copyRgb());
+        } finally {
+            display.stop();
+            displayThread.join(2_000);
+            eventBus.close();
+        }
+    }
+
+    @Test
     public void cgbFrameIsTranslatedAndCopiedBeforePublication() throws Exception {
         EventBusImpl eventBus = new EventBusImpl(null, "test", false);
         SwingDisplay display = newDisplay(eventBus);


### PR DESCRIPTION
## Summary

- Replace the old core-only timing probe with an exact desktop-path harness that drives `SwingEmulator`, the production controller/session buses, Swing display work, PCM conversion, the audio worker, and a real Java Sound `SourceDataLine` for the full first 1,800 source frames.
- Remove the measured Windows hot-path and cold-start regressions: idle EventBus polling, live-input snapshot equality/allocation, boxed timing-clock calls, first-frame rewind initialization, cold SKIP-start core/JIT work, snapshot capture allocation, and the second Swing frame copy.
- Restore provider-owned whole-buffer Java Sound writes, avoid redundant public line starts, and give the Windows audio worker a modest priority of 6.
- Keep audio buffering bounded while making the default resilient to the measured stalls: BALANCED is now a 16,384-byte / six-frame runway with a 24-frame runtime cap; SAFE is 32,768 bytes / twelve frames with a 32-frame cap; LOW remains unchanged.

## Root cause

Adaptive frame suppression cannot repair audio. It suppresses future GPU presentation work only; core ticks, input, sound production, rewind work, and pacing still run. A Windows/JVM stall can therefore be followed by a burst of real PCM.

The previous drop-oldest queue could delete part of that burst while Java Sound remained fed. This explains why queue-debt or sampled-underrun counters could be zero while music was missing. The actual UI path also contained work that the earlier probe omitted: seven polling EventBus workers, equal-but-distinct desktop input snapshots compared on the 4.19 MHz path, boxed TimingTicker clock calls, synchronous rewind snapshots, cold SKIP-start compilation, and duplicate display raster allocation/copies.

JFR also found Windows DirectAudio waits whose requested 11 ms delay reached 88.234 ms, longer than the old 46.44 ms BALANCED line runway. A provider stall could additionally fill the runtime queue. With the otherwise-final 15-frame configuration, one of the final stress runs reached 15/15 and dropped one real 16.667 ms PCM frame, so that configuration was not published.

The harness itself was corrected too: native `SourceDataLine.available()` sampling is now opt-in because those calls perturbed DirectAudio. Default acceptance runs use lossless producer/worker byte accounting and non-intrusive timing only.

## Final Windows results

Three independent cold BALANCED runs, with JFR and line-occupancy sampling disabled:

| Metric | Run 1 | Run 2 | Run 3 |
|---|---:|---:|---:|
| Source frames | 1,800 | 1,800 | 1,800 |
| Expected / worker PCM bytes | 5,291,992 / 5,291,992 | 5,291,992 / 5,291,992 | 5,291,992 / 5,291,992 |
| Dropped PCM | 0 | 0 | 0 |
| Queue peak / capacity | 18 / 24 | 20 / 24 | 13 / 24 |
| Max producer interval | 61.560 ms | 71.558 ms | 59.590 ms |
| Max provider-write wall time | 311.392 ms | 326.146 ms | 256.017 ms |
| Java Sound runway | 92.880 ms | 92.880 ms | 92.880 ms |

The default runway exceeded every producer pause, and the bounded queue absorbed every observed provider stall without deleting PCM.

The standalone audio conformance harness remains stable:

- 600 frames, first non-zero frame 0
- PCM SHA-256 `88db99894b8008b34876417657305d00af3ef0e6e893f7b514d7f60e753a45a2`
- max fully quiet run: 18 frames

## Baseline throughput

Interleaved same-host `measure-harry-potter-intro-fps.sh` comparisons against `8eba81aa68e65c1511a3423f91e58ecba34e0527`:

| Pair | Baseline | Candidate |
|---|---:|---:|
| 1 | 88.579 FPS | 89.490 FPS |
| 2 | 90.742 FPS | 90.266 FPS |
| Median | 89.6605 FPS | 89.878 FPS |

That is +0.24%, within host variance: no measurable throughput regression. A later heavy-host pair was also favorable (69.398 baseline versus 73.191 candidate).

## Validation

- core unit suite: 1,224 tests, 0 failures/errors, 8 skipped
- controller unit suite: 901 tests, 0 failures/errors, 7 skipped
- Swing unit suite: 704 tests, 0 failures/errors, 1 expected external-ROM skip
- bundled Blargg CPU, timing, OAM, halt, DMG sound, and CGB sound ROM groups passed
- exact UI audio timing harness: three final cold real-device runs passed as shown above
- executable fat JAR built successfully and passed the production desktop smoke (visible/displayable EDT frame, menu, renderer, audio/input adapters, Mobile Adapter controls, bounded normal shutdown)
- all three harness scripts pass shell syntax checks; `git diff --check` passes

## Tradeoff and measurement boundary

BALANCED intentionally adds about 46 ms of normal Java Sound/startup runway compared with the previous setting. LOW remains available for latency-first use; all runtime queues remain bounded.

Exact producer/worker byte equality proves that the application did not delete PCM. Because intrusive device-occupancy sampling is disabled in final runs, it is not a DAC/loopback proof. The doubled runway is nevertheless longer than every observed producer pause, and packaged-UI listening remains the final user-facing confirmation.
