### PR TITLE
Add guarded release resume workflow

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -11,6 +11,16 @@ on:
         description: Next development version (for example, 1.7.6-SNAPSHOT)
         required: true
         type: string
+      resume_existing_release:
+        description: Resume a prepared release that failed before Maven or GitHub publication
+        required: true
+        default: false
+        type: boolean
+      prepared_source_sha:
+        description: Exact prepared release commit required when resuming an existing release
+        required: false
+        default: ""
+        type: string
       sign_native_packages:
         description: Sign/notarize every native target with protected release credentials
         required: true
@@ -54,6 +64,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Configure the release commit author
+        if: ${{ ! inputs.resume_existing_release }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -96,6 +107,7 @@ jobs:
           fi
 
       - name: Prepare the release commits and exact tag without publishing
+        if: ${{ ! inputs.resume_existing_release }}
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
           DEVELOPMENT_VERSION: ${{ inputs.development_version }}
@@ -113,10 +125,17 @@ jobs:
         shell: bash
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
+          DEVELOPMENT_VERSION: ${{ inputs.development_version }}
+          RESUME_EXISTING_RELEASE: ${{ inputs.resume_existing_release }}
+          EXPECTED_SOURCE_SHA: ${{ inputs.prepared_source_sha }}
         run: |
           tag="coffee-gb-${RELEASE_VERSION}"
           tag_ref="refs/tags/$tag"
           git fetch --no-tags origin "$tag_ref"
+          if [[ "$(git cat-file -t FETCH_HEAD)" != tag ]]; then
+            echo "Prepared release ref is not an annotated tag" >&2
+            exit 1
+          fi
           source_sha=$(git rev-parse 'FETCH_HEAD^{commit}')
           if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Prepared release tag did not resolve to a full commit ID" >&2
@@ -128,6 +147,37 @@ jobs:
           if [[ "$tagged_version" != "$RELEASE_VERSION" ]]; then
             echo "Prepared tag contains Maven version $tagged_version" >&2
             exit 1
+          fi
+          if [[ "$RESUME_EXISTING_RELEASE" == true ]]; then
+            if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ||
+                  "$source_sha" != "$EXPECTED_SOURCE_SHA" ]]; then
+              echo "Prepared release commit does not match the explicitly requested source SHA" >&2
+              exit 1
+            fi
+            development_branch_version=$(sed -n \
+              's:.*<version>\([^<]*\)</version>.*:\1:p' pom.xml | head -1)
+            if [[ "$development_branch_version" != "$DEVELOPMENT_VERSION" ]]; then
+              echo "Default branch contains Maven version $development_branch_version, not $DEVELOPMENT_VERSION" >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$source_sha" HEAD; then
+              echo "Prepared release commit is not an ancestor of the default branch" >&2
+              exit 1
+            fi
+            next_development_commit=$(git rev-list --first-parent --reverse \
+              "$source_sha..HEAD" | head -1)
+            if [[ -z "$next_development_commit" ]]; then
+              echo "Prepared release has no next-development commit" >&2
+              exit 1
+            fi
+            next_development_parent=$(git rev-parse "$next_development_commit^1")
+            next_development_version=$(git show "$next_development_commit:pom.xml" |
+              sed -n 's:.*<version>\([^<]*\)</version>.*:\1:p' | head -1)
+            if [[ "$next_development_parent" != "$source_sha" ||
+                  "$next_development_version" != "$DEVELOPMENT_VERSION" ]]; then
+              echo "Prepared release is not followed by the requested next-development version" >&2
+              exit 1
+            fi
           fi
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "tag_ref=$tag_ref" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/native-packages.yml
+++ b/.github/workflows/native-packages.yml
@@ -144,14 +144,18 @@ jobs:
           if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
             throw "windows-x86-64 requires an X64 runner"
           }
-          $SevenZip = Get-Command 7z.exe -ErrorAction SilentlyContinue
-          if (-not $SevenZip) {
-            throw "windows-x86-64 requires 7z.exe to build the portable EXE"
+          $SevenZipRoot = Join-Path $env:ProgramFiles "7-Zip"
+          $SevenZip = Join-Path $SevenZipRoot "7z.exe"
+          $SfxModule = Join-Path $SevenZipRoot "7z.sfx"
+          if (-not (Test-Path -LiteralPath $SevenZip -PathType Leaf) -or
+              (Get-Item -LiteralPath $SevenZip).Length -eq 0) {
+            throw "windows-x86-64 requires the installed 7-Zip executable: $SevenZip"
           }
-          $SfxModule = Join-Path (Split-Path -Parent $SevenZip.Source) "7z.sfx"
-          if (-not (Test-Path -LiteralPath $SfxModule -PathType Leaf)) {
+          if (-not (Test-Path -LiteralPath $SfxModule -PathType Leaf) -or
+              (Get-Item -LiteralPath $SfxModule).Length -eq 0) {
             throw "windows-x86-64 requires the 7-Zip SFX module: $SfxModule"
           }
+          $SevenZipRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Linux package validation prerequisites
         if: runner.os == 'Linux'
@@ -445,6 +449,23 @@ jobs:
           java-version: "21"
           cache: maven
           cache-dependency-path: "**/pom.xml"
+
+      - name: Prove Windows portable-EXE tooling and expose the real 7-Zip installation
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $SevenZipRoot = Join-Path $env:ProgramFiles "7-Zip"
+          $SevenZip = Join-Path $SevenZipRoot "7z.exe"
+          $SfxModule = Join-Path $SevenZipRoot "7z.sfx"
+          if (-not (Test-Path -LiteralPath $SevenZip -PathType Leaf) -or
+              (Get-Item -LiteralPath $SevenZip).Length -eq 0) {
+            throw "windows-x86-64 requires the installed 7-Zip executable: $SevenZip"
+          }
+          if (-not (Test-Path -LiteralPath $SfxModule -PathType Leaf) -or
+              (Get-Item -LiteralPath $SfxModule).Length -eq 0) {
+            throw "windows-x86-64 requires the 7-Zip SFX module: $SfxModule"
+          }
+          $SevenZipRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Linux package validation prerequisites
         if: runner.os == 'Linux'

--- a/docs/native-package-ci.md
+++ b/docs/native-package-ci.md
@@ -102,6 +102,13 @@ commit ID; every matrix and gate checkout uses that ID and verifies `HEAD`, and 
 re-fetched and re-peeled before each promotion. A moved tag therefore fails closed. The release
 matrix records the bound source commit.
 
+If native validation fails after preparation but before either publication job starts, a recovery
+dispatch can set `resume_existing_release=true` and provide the exact peeled release commit as
+`prepared_source_sha`. Resume mode preserves the annotated tag and skips `release:prepare`; it
+fails closed unless the tag, requested SHA, first-parent next-development commit, tagged version,
+and current development version all agree. Do not use resume mode after Maven or GitHub
+publication has started, because Maven deployment is not generally idempotent.
+
 Publication waits for the unsigned build, package inspection, desktop/debug launch, and
 no-registration gates on all four targets. A Linux release-gate job independently downloads the
 results, requires one default package, one canonical byte-identical Maven dependency SBOM, and

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
@@ -45,6 +45,9 @@ public class NativePackageWorkflowTest {
         assertTrue(packages.contains("persist-credentials: false"));
         assertTrue(packages.contains("7z.exe"));
         assertTrue(packages.contains("7z.sfx"));
+        assertEquals(2, occurrences(packages,
+                "Join-Path $env:ProgramFiles \"7-Zip\""));
+        assertEquals(2, occurrences(packages, "$env:GITHUB_PATH"));
         assertFalse(packages.contains("candle.exe"));
         assertFalse(packages.contains("light.exe"));
         assertEquals(2, occurrences(packages, "package_type: exe"));
@@ -104,6 +107,13 @@ public class NativePackageWorkflowTest {
 
         assertTrue(release.contains("uses: ./.github/workflows/native-packages.yml"));
         assertTrue(release.contains("checkout_ref: ${{ needs.prepare.outputs.tag_ref }}"));
+        assertTrue(release.contains("resume_existing_release"));
+        assertTrue(release.contains("prepared_source_sha"));
+        assertTrue(release.contains("if: ${{ ! inputs.resume_existing_release }}"));
+        assertTrue(release.contains("explicitly requested source SHA"));
+        assertTrue(release.contains("Prepared release commit is not an ancestor"));
+        assertTrue(release.contains("requested next-development version"));
+        assertTrue(release.contains("Prepared release ref is not an annotated tag"));
         assertTrue(release.contains("release:clean release:prepare"));
         assertFalse(release.contains("release:perform"));
         assertTrue(release.contains("needs: [prepare, native-packages]"));


### PR DESCRIPTION
## Summary

- Resolve the real `C:\Program Files\7-Zip` installation in both Windows package jobs and prepend it for subsequent tagged packaging steps.
- Add a guarded pre-publication resume mode for a release whose annotated tag and next-development commit were already prepared.
- Require the exact peeled release SHA, tagged version, first-parent lineage, next-development version, and current development version before resuming.
- Document the recovery boundary and cover the workflow contracts in tests.

## Root cause

Release run `31424013613` successfully prepared the annotated `coffee-gb-2.0.1` tag and advanced `master` to `2.0.2-SNAPSHOT`. Its Windows runner then resolved `7z.exe` through the Chocolatey shim at `C:\ProgramData\Chocolatey\bin\7z.exe`, so the workflow incorrectly looked for an adjacent `7z.sfx` and failed before packaging. The real hosted-runner installation contains both required files under `C:\Program Files\7-Zip`.

The failed run did not start either Maven Central or GitHub publication. Re-running it would reuse the original workflow SHA and the same broken probe, while deleting or moving the already-pushed annotated tag would unnecessarily rewrite release history.

## Recovery impact

After this merges, a new dispatch can safely reuse the immutable `2.0.1` release commit only when the caller supplies its exact SHA and every prepared-release lineage/version check passes. The complete native matrix, Maven publication, and GitHub publication still run in their original order.

## Validation

- `mvn --batch-mode --no-transfer-progress -pl swing -am -Dtest=NativePackageWorkflowTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/maven-release.yml .github/workflows/native-packages.yml`
- Parsed both edited workflows with PyYAML 6.0.3.
- Exercised the resume guard inputs against annotated tag object `75027c66`, peeled release commit `1b74027e`, and next-development commit `cc880994`.
