### PR TITLE
Reuse prepared release unit-test results across native targets

### DIFF
--- a/.github/workflows/native-packages.yml
+++ b/.github/workflows/native-packages.yml
@@ -129,8 +129,8 @@ jobs:
           cache: maven
           cache-dependency-path: "**/pom.xml"
 
-      - name: Reuse prepared Linux unit-test result
-        if: runner.os == 'Linux' && inputs.release_version != ''
+      - name: Reuse prepared release unit-test result
+        if: runner.os != 'Windows' && inputs.release_version != ''
         shell: bash
         run: |
           maven_wrapper="$RUNNER_TEMP/coffee-gb-prepared-release-maven"
@@ -140,6 +140,20 @@ jobs:
             > "$maven_wrapper"
           chmod 700 "$maven_wrapper"
           echo "COFFEE_GB_MAVEN_COMMAND=$maven_wrapper" >> "$GITHUB_ENV"
+
+      - name: Reuse prepared Windows release unit-test result
+        if: runner.os == 'Windows' && inputs.release_version != ''
+        shell: pwsh
+        run: |
+          $MavenWrapper = Join-Path $env:RUNNER_TEMP "coffee-gb-prepared-release-maven.ps1"
+          @'
+          $ErrorActionPreference = "Stop"
+          $Maven = (Get-Command "mvn" -CommandType Application -ErrorAction Stop).Source
+          & $Maven "-Dskip.unit.tests=true" @args
+          exit $LASTEXITCODE
+          '@ | Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM
+          "COFFEE_GB_MAVEN_COMMAND=$MavenWrapper" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Prove target runner architecture
         if: runner.os != 'Windows'
@@ -498,8 +512,8 @@ jobs:
           cache: maven
           cache-dependency-path: "**/pom.xml"
 
-      - name: Reuse prepared Linux unit-test result
-        if: runner.os == 'Linux' && inputs.release_version != ''
+      - name: Reuse prepared release unit-test result
+        if: runner.os != 'Windows' && inputs.release_version != ''
         shell: bash
         run: |
           maven_wrapper="$RUNNER_TEMP/coffee-gb-prepared-release-maven"
@@ -509,6 +523,20 @@ jobs:
             > "$maven_wrapper"
           chmod 700 "$maven_wrapper"
           echo "COFFEE_GB_MAVEN_COMMAND=$maven_wrapper" >> "$GITHUB_ENV"
+
+      - name: Reuse prepared Windows release unit-test result
+        if: runner.os == 'Windows' && inputs.release_version != ''
+        shell: pwsh
+        run: |
+          $MavenWrapper = Join-Path $env:RUNNER_TEMP "coffee-gb-prepared-release-maven.ps1"
+          @'
+          $ErrorActionPreference = "Stop"
+          $Maven = (Get-Command "mvn" -CommandType Application -ErrorAction Stop).Source
+          & $Maven "-Dskip.unit.tests=true" @args
+          exit $LASTEXITCODE
+          '@ | Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM
+          "COFFEE_GB_MAVEN_COMMAND=$MavenWrapper" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Prepare pinned Windows portable-EXE tooling
         if: runner.os == 'Windows'

--- a/docs/native-package-ci.md
+++ b/docs/native-package-ci.md
@@ -21,10 +21,10 @@ runner is a release blocker rather than permission to relabel another architectu
 
 The wrapper runs the Maven-authoritative `clean verify` reactor, including unit tests and the
 target-neutral staging integration tests, before building one unsigned target package. For a tagged
-release on Linux, `release:prepare` has already run that unit-test suite against the same immutable
-commit, so the package job reuses that result instead of repeating Surefire inside Xvfb. Maven still
-compiles the tests, runs the staging integration tests, and produces every artifact consumed by the
-native package and launch gates. The package tool then:
+release, `release:prepare` has already run that unit-test suite against the same immutable commit, so
+each target package job reuses that result instead of repeating Surefire. Maven still compiles the
+tests, runs the staging integration tests, and produces every artifact consumed by the native package
+and launch gates. The package tool then:
 
 1. verifies the minimized runtime module closure and launches the neutral JAR with that runtime;
 2. validates the canonical NFC UTF-8 license and exact `Tomasz Rękawek` author name, generates the

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
@@ -21,6 +21,7 @@ public class NativePackageWorkflowTest {
         Path packaging = Path.of("../packaging").toAbsolutePath().normalize();
         String packageSh = normalizedText(packaging.resolve("verify-native-package.sh"));
         String packagePs1 = normalizedText(packaging.resolve("verify-native-package.ps1"));
+        String packageBuilderPs1 = normalizedText(packaging.resolve("package-native.ps1"));
 
         for (String target :
                 new String[] {
@@ -69,13 +70,31 @@ public class NativePackageWorkflowTest {
         assertTrue(packages.contains("COFFEE_GB_DESKTOP_SMOKE: \"true\""));
         assertTrue(packages.contains("xvfb-run -a ./packaging/package-native.sh"));
         assertEquals(2, occurrences(packages,
-                "name: Reuse prepared Linux unit-test result"));
+                "name: Reuse prepared release unit-test result"));
         assertEquals(2, occurrences(packages,
-                "if: runner.os == 'Linux' && inputs.release_version != ''"));
+                "if: runner.os != 'Windows' && inputs.release_version != ''"));
+        assertEquals(2, occurrences(packages,
+                "name: Reuse prepared Windows release unit-test result"));
+        assertEquals(2, occurrences(packages,
+                "if: runner.os == 'Windows' && inputs.release_version != ''"));
         assertEquals(2, occurrences(packages,
                 "exec mvn -Dskip.unit.tests=true \"$@\""));
         assertEquals(2, occurrences(packages,
                 "COFFEE_GB_MAVEN_COMMAND=$maven_wrapper"));
+        assertEquals(2, occurrences(packages,
+                "& $Maven \"-Dskip.unit.tests=true\" @args"));
+        assertEquals(2, occurrences(packages, "exit $LASTEXITCODE"));
+        assertEquals(2, occurrences(packages,
+                "Get-Command \"mvn\" -CommandType Application -ErrorAction Stop"));
+        assertEquals(2, occurrences(packages,
+                "Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM"));
+        assertEquals(2, occurrences(packages,
+                "COFFEE_GB_MAVEN_COMMAND=$MavenWrapper"));
+        assertTrue(packageBuilderPs1.contains("$env:COFFEE_GB_MAVEN_COMMAND"));
+        assertTrue(packageBuilderPs1.contains("& $MavenCommand -B"));
+        assertTrue(packageBuilderPs1.contains("if ($LASTEXITCODE -ne 0)"));
+        assertFalse(packages.contains("-DskipTests"));
+        assertFalse(packages.contains("-Dmaven.test.skip"));
         assertEquals(2, occurrences(packages,
                 "sudo apt-get install --yes --no-install-recommends "
                         + "desktop-file-utils gnome-menus xdg-utils"));


### PR DESCRIPTION
## Summary

- reuse the already-passed release preparation unit suite on every tagged native target
- preserve test compilation, Failsafe native integration tests, packaging, and strict launch smokes
- generate a Windows Maven wrapper with argument and exit-code propagation

## Release recovery evidence

Run 31431583845 passed exact-tag resolution and three native targets, including the repaired portable executable. Its sole failure was a duplicate controller unit-test timing timeout on macOS arm64; Maven Central and GitHub publication were skipped.

## Validation

- actionlint 1.7.12
- PyYAML parse for both release workflows
- NativePackageWorkflowTest: 1 test, 0 failures
- PowerShell 7.6.4 wrapper execution: arguments forwarded and exit status propagated
- git diff --check

Failed recovery run: https://github.com/trekawek/coffee-gb/actions/runs/31431583845