### PR TITLE
Resolve one Windows Maven launcher for release packaging

### DIFF
--- a/.github/workflows/native-packages.yml
+++ b/.github/workflows/native-packages.yml
@@ -148,7 +148,13 @@ jobs:
           $MavenWrapper = Join-Path $env:RUNNER_TEMP "coffee-gb-prepared-release-maven.ps1"
           @'
           $ErrorActionPreference = "Stop"
-          $Maven = (Get-Command "mvn" -CommandType Application -ErrorAction Stop).Source
+          $Maven = (
+            Get-Command "mvn.cmd" -CommandType Application -ErrorAction Stop |
+              Select-Object -First 1
+          ).Source
+          if ($Maven -isnot [string] -or [string]::IsNullOrWhiteSpace($Maven)) {
+            throw "Maven command did not resolve to one application path"
+          }
           & $Maven "-Dskip.unit.tests=true" @args
           exit $LASTEXITCODE
           '@ | Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM
@@ -531,7 +537,13 @@ jobs:
           $MavenWrapper = Join-Path $env:RUNNER_TEMP "coffee-gb-prepared-release-maven.ps1"
           @'
           $ErrorActionPreference = "Stop"
-          $Maven = (Get-Command "mvn" -CommandType Application -ErrorAction Stop).Source
+          $Maven = (
+            Get-Command "mvn.cmd" -CommandType Application -ErrorAction Stop |
+              Select-Object -First 1
+          ).Source
+          if ($Maven -isnot [string] -or [string]::IsNullOrWhiteSpace($Maven)) {
+            throw "Maven command did not resolve to one application path"
+          }
           & $Maven "-Dskip.unit.tests=true" @args
           exit $LASTEXITCODE
           '@ | Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
@@ -85,7 +85,11 @@ public class NativePackageWorkflowTest {
                 "& $Maven \"-Dskip.unit.tests=true\" @args"));
         assertEquals(2, occurrences(packages, "exit $LASTEXITCODE"));
         assertEquals(2, occurrences(packages,
-                "Get-Command \"mvn\" -CommandType Application -ErrorAction Stop"));
+                "Get-Command \"mvn.cmd\" -CommandType Application -ErrorAction Stop"));
+        assertEquals(2, occurrences(packages, "Select-Object -First 1"));
+        assertFalse(packages.contains("Get-Command \"mvn\""));
+        assertEquals(2, occurrences(packages,
+                "$Maven -isnot [string] -or [string]::IsNullOrWhiteSpace($Maven)"));
         assertEquals(2, occurrences(packages,
                 "Set-Content -LiteralPath $MavenWrapper -Encoding utf8NoBOM"));
         assertEquals(2, occurrences(packages,


### PR DESCRIPTION
## Summary

- resolve the exact Windows mvn.cmd application instead of collecting both launcher variants
- select one path and reject any empty or non-scalar result before invoking Maven
- lock the runner-discovered failure mode in the workflow contract test

## Release recovery evidence

Run 31434483072 proved the initial generic lookup returned both mvn.cmd and an extensionless mvn path, which PowerShell then treated as one invalid command. The pinned portable-executable tooling completed successfully before that failure. The three non-Windows targets exercised the narrow unit-test reuse behavior successfully.

## Validation

- PowerShell 7.6.4 exact launcher resolution and Maven exit propagation
- actionlint 1.7.12
- PyYAML parse
- NativePackageWorkflowTest: 1 test, 0 failures
- git diff --check

Failed recovery run: https://github.com/trekawek/coffee-gb/actions/runs/31434483072