### PR TITLE
Add in-screen Android menu renderer foundation

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -11,6 +11,8 @@ import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import eu.rekawek.coffeegb.android.menu.MenuPresentation;
+import eu.rekawek.coffeegb.android.menu.MenuRenderer;
 import eu.rekawek.coffeegb.core.joypad.Button;
 
 import java.util.List;
@@ -34,8 +36,10 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             NativeFrameStore.MAX_WIDTH, NativeFrameStore.MAX_HEIGHT, Bitmap.Config.ARGB_8888);
     private final RasterSkin portraitSkin;
     private final RasterSkin landscapeSkin;
+    private final MenuRenderer menuRenderer = new MenuRenderer();
 
     private volatile NativeFrameStore frames;
+    private volatile MenuPresentation menuPresentation;
     private final TouchControlsPreferences touchPreferences;
     private volatile TouchControlsLayout touchLayout;
     private AndroidInputRouter input;
@@ -69,6 +73,24 @@ public final class CoffeeGbSurfaceView extends SurfaceView
     void resetTouchLayout() {
         touchPreferences.reset();
         touchLayout = touchPreferences.load();
+        onFrameAvailable();
+    }
+
+    /**
+     * Publishes an immutable in-screen menu snapshot for the render thread.
+     *
+     * <p>The volatile handoff does not retain a controller lock or wait for a frame. The existing
+     * frame signal only wakes the short-lived Surface renderer so the next canvas pass includes the
+     * new snapshot. Passing {@code null} is equivalent to {@link #clearMenuPresentation()}.
+     */
+    public void setMenuPresentation(MenuPresentation presentation) {
+        menuPresentation = presentation;
+        onFrameAvailable();
+    }
+
+    /** Clears the in-screen menu and schedules one redraw without changing frame ownership. */
+    public void clearMenuPresentation() {
+        menuPresentation = null;
         onFrameAvailable();
     }
 
@@ -272,6 +294,10 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                     destination.set(Math.round(display.left), Math.round(display.top),
                             Math.round(display.right), Math.round(display.bottom));
                     canvas.drawBitmap(bitmap, source, destination, videoPaint);
+                }
+                MenuPresentation menu = menuPresentation;
+                if (menu != null) {
+                    menuRenderer.draw(canvas, menu, display);
                 }
                 skin.draw(canvas, skinPaint);
             } finally {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuCommand.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuCommand.java
@@ -1,0 +1,62 @@
+package eu.rekawek.coffeegb.android.menu;
+
+/** A small, allocation-free command vocabulary for the menu reducer. */
+final class MenuCommand {
+
+    enum Type {
+        SHOW,
+        HIDE,
+        MOVE,
+        PUSH,
+        BACK
+    }
+
+    enum Direction {
+        UP,
+        DOWN,
+        LEFT,
+        RIGHT
+    }
+
+    private final Type type;
+    private final Direction direction;
+    private final MenuRoute route;
+
+    private MenuCommand(Type type, Direction direction, MenuRoute route) {
+        this.type = type;
+        this.direction = direction;
+        this.route = route;
+    }
+
+    static MenuCommand show(MenuRoute route) {
+        return new MenuCommand(Type.SHOW, null, route);
+    }
+
+    static MenuCommand hide() {
+        return new MenuCommand(Type.HIDE, null, null);
+    }
+
+    static MenuCommand move(Direction direction) {
+        return new MenuCommand(Type.MOVE, direction, null);
+    }
+
+    static MenuCommand push(MenuRoute route) {
+        return new MenuCommand(Type.PUSH, null, route);
+    }
+
+    static MenuCommand back() {
+        return new MenuCommand(Type.BACK, null, null);
+    }
+
+    Type type() {
+        return type;
+    }
+
+    Direction direction() {
+        return direction;
+    }
+
+    MenuRoute route() {
+        return route;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuGeometry.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuGeometry.java
@@ -1,0 +1,96 @@
+package eu.rekawek.coffeegb.android.menu;
+
+/**
+ * Stable logical-coordinate fitting for the menu renderer.
+ *
+ * <p>Landscape uses a 320x240 design grid and portrait uses the same grid rotated to 240x320.
+ * The fit is uniform and centered inside the RasterSkin display window, so neither orientation
+ * can crop a panel or footer.
+ */
+final class MenuGeometry {
+
+    static final int LANDSCAPE_WIDTH = 320;
+    static final int LANDSCAPE_HEIGHT = 240;
+    static final int PORTRAIT_WIDTH = 240;
+    static final int PORTRAIT_HEIGHT = 320;
+
+    private MenuGeometry() {
+    }
+
+    static Layout forDisplay(float displayWidth, float displayHeight) {
+        if (!(displayWidth > 0.0f) || !(displayHeight > 0.0f)) {
+            return new Layout(false, 0, 0, 0, 0, 0, 0, 0);
+        }
+        boolean portrait = displayHeight > displayWidth;
+        float logicalWidth = portrait ? PORTRAIT_WIDTH : LANDSCAPE_WIDTH;
+        float logicalHeight = portrait ? PORTRAIT_HEIGHT : LANDSCAPE_HEIGHT;
+        float scale = Math.min(displayWidth / logicalWidth, displayHeight / logicalHeight);
+        float contentWidth = logicalWidth * scale;
+        float contentHeight = logicalHeight * scale;
+        return new Layout(portrait, (int) logicalWidth, (int) logicalHeight, scale,
+                (displayWidth - contentWidth) / 2.0f, (displayHeight - contentHeight) / 2.0f,
+                contentWidth, contentHeight);
+    }
+
+    static final class Layout {
+
+        private final boolean portrait;
+        private final int logicalWidth;
+        private final int logicalHeight;
+        private final float scale;
+        private final float offsetX;
+        private final float offsetY;
+        private final float contentWidth;
+        private final float contentHeight;
+
+        private Layout(boolean portrait, int logicalWidth, int logicalHeight, float scale,
+                float offsetX, float offsetY, float contentWidth, float contentHeight) {
+            this.portrait = portrait;
+            this.logicalWidth = logicalWidth;
+            this.logicalHeight = logicalHeight;
+            this.scale = scale;
+            this.offsetX = offsetX;
+            this.offsetY = offsetY;
+            this.contentWidth = contentWidth;
+            this.contentHeight = contentHeight;
+        }
+
+        boolean portrait() {
+            return portrait;
+        }
+
+        int logicalWidth() {
+            return logicalWidth;
+        }
+
+        int logicalHeight() {
+            return logicalHeight;
+        }
+
+        float scale() {
+            return scale;
+        }
+
+        float offsetX() {
+            return offsetX;
+        }
+
+        float offsetY() {
+            return offsetY;
+        }
+
+        float contentWidth() {
+            return contentWidth;
+        }
+
+        float contentHeight() {
+            return contentHeight;
+        }
+
+        boolean fits(float displayWidth, float displayHeight) {
+            return offsetX >= -0.001f && offsetY >= -0.001f
+                    && contentWidth <= displayWidth + 0.001f
+                    && contentHeight <= displayHeight + 0.001f;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPage.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPage.java
@@ -1,0 +1,175 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Immutable content definition for one menu route. */
+final class MenuPage {
+
+    private final MenuRoute route;
+    private final String title;
+    private final String context;
+    private final String headerAction;
+    private final String sideHeading;
+    private final List<String> sideLines;
+    private final List<MenuItem> items;
+    private final int columns;
+    private final List<String> footerHints;
+
+    MenuPage(MenuRoute route, String title, String context, String headerAction,
+            String sideHeading, List<String> sideLines, List<MenuItem> items, int columns,
+            List<String> footerHints) {
+        if (route == null) {
+            throw new IllegalArgumentException("route cannot be null");
+        }
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("A menu page needs at least one item");
+        }
+        this.route = route;
+        this.title = text(title, "title");
+        this.context = text(context, "context");
+        this.headerAction = text(headerAction, "headerAction");
+        this.sideHeading = text(sideHeading, "sideHeading");
+        this.sideLines = immutableStrings(sideLines, "sideLines");
+        this.items = immutableItems(items);
+        this.columns = Math.max(1, columns);
+        this.footerHints = immutableStrings(footerHints, "footerHints");
+        if (firstEnabledIndex() < 0) {
+            throw new IllegalArgumentException("A menu page needs an enabled item");
+        }
+    }
+
+    MenuRoute route() {
+        return route;
+    }
+
+    String title() {
+        return title;
+    }
+
+    String context() {
+        return context;
+    }
+
+    String headerAction() {
+        return headerAction;
+    }
+
+    String sideHeading() {
+        return sideHeading;
+    }
+
+    List<String> sideLines() {
+        return sideLines;
+    }
+
+    List<MenuItem> items() {
+        return items;
+    }
+
+    int columns() {
+        return columns;
+    }
+
+    List<String> footerHints() {
+        return footerHints;
+    }
+
+    int firstEnabledIndex() {
+        for (int index = 0; index < items.size(); index++) {
+            if (items.get(index).enabled()) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    MenuPresentation presentation(int focusedIndex) {
+        ArrayList<MenuPresentation.Item> rows = new ArrayList<>(items.size());
+        for (MenuItem item : items) {
+            rows.add(item.presentation());
+        }
+        return new MenuPresentation(true, route, title, context, headerAction, sideHeading,
+                sideLines, rows, focusedIndex, columns, footerHints);
+    }
+
+    private static String text(String value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        return value;
+    }
+
+    private static List<String> immutableStrings(List<String> values, String name) {
+        if (values == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        ArrayList<String> copy = new ArrayList<>(values.size());
+        for (String value : values) {
+            copy.add(text(value, name + " entry"));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    private static List<MenuItem> immutableItems(List<MenuItem> values) {
+        ArrayList<MenuItem> copy = new ArrayList<>(values.size());
+        for (MenuItem value : values) {
+            if (value == null) {
+                throw new IllegalArgumentException("items cannot contain null");
+            }
+            copy.add(value);
+        }
+        return Collections.unmodifiableList(copy);
+    }
+}
+
+final class MenuItem {
+
+    private final String id;
+    private final String label;
+    private final String detail;
+    private final boolean enabled;
+
+    MenuItem(String id, String label) {
+        this(id, label, "", true);
+    }
+
+    MenuItem(String id, String label, String detail) {
+        this(id, label, detail, true);
+    }
+
+    MenuItem(String id, String label, String detail, boolean enabled) {
+        this.id = text(id, "id");
+        this.label = text(label, "label");
+        this.detail = text(detail, "detail");
+        this.enabled = enabled;
+    }
+
+    String id() {
+        return id;
+    }
+
+    String label() {
+        return label;
+    }
+
+    String detail() {
+        return detail;
+    }
+
+    boolean enabled() {
+        return enabled;
+    }
+
+    MenuPresentation.Item presentation() {
+        return new MenuPresentation.Item(id, label, detail, enabled);
+    }
+
+    private static String text(String value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        return value;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPages.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPages.java
@@ -1,0 +1,146 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Proposal 3 page catalog; side effects remain outside this foundation slice. */
+final class MenuPages {
+
+    private static final List<String> DEFAULT_HINTS = List.of("D-PAD MOVE", "[A] OK", "[B] BACK");
+
+    private MenuPages() {
+    }
+
+    static MenuPage forRoute(MenuRoute route) {
+        if (route == null) {
+            throw new IllegalArgumentException("route cannot be null");
+        }
+        return switch (route) {
+            case PAUSE_CONSOLE -> page(route, "COFFEE GB", "PAUSED", "OPEN ROM", "CURRENT GAME",
+                    List.of("PLAYING", "01:24", "BATTERY SAVE READY"),
+                    items(
+                            item("resume", "RESUME"),
+                            item("save-state", "SAVE STATE"),
+                            item("load-state", "LOAD STATE"),
+                            item("reset", "RESET GAME"),
+                            item("settings", "SETTINGS"),
+                            item("stop", "STOP GAME")));
+            case SAVE_STATES -> page(route, "COFFEE GB", "SAVE STATES", "", "STATE BANK",
+                    List.of("SLOT 0 READY", "SLOT 1 EMPTY", "SLOT 2 EMPTY"),
+                    items(
+                            item("slot-0-save", "SLOT 0", "SAVE / LOAD"),
+                            item("slot-1-save", "SLOT 1", "SAVE / LOAD"),
+                            item("slot-2-save", "SLOT 2", "SAVE / LOAD"),
+                            item("slot-3-save", "SLOT 3", "SAVE / LOAD"),
+                            item("delete-state", "DELETE STATE")));
+            case SETTINGS -> page(route, "COFFEE GB", "SETTINGS", "", "SETTINGS HUB",
+                    List.of("AUDIO + INPUT", "DEVICES + DATA", "SYSTEM PROFILE"),
+                    items(
+                            item("audio", "AUDIO"),
+                            item("touch-controls", "TOUCH CONTROLS"),
+                            item("controller-mapping", "CONTROLLER MAPPING"),
+                            item("optional-devices", "OPTIONAL DEVICES"),
+                            item("system", "SYSTEM"),
+                            item("data-media", "DATA & MEDIA"),
+                            item("about", "ABOUT")));
+            case AUDIO -> page(route, "COFFEE GB", "AUDIO", "", "AUDIO MIX",
+                    List.of("OUTPUT  ON", "VOLUME  80%", "LOW LATENCY"),
+                    items(
+                            item("audio-enabled", "AUDIO", "ON"),
+                            item("volume", "VOLUME", "80%"),
+                            item("latency", "LATENCY", "LOW"),
+                            item("save-audio", "SAVE")));
+            case TOUCH_CONTROLS -> page(route, "COFFEE GB", "TOUCH CONTROLS", "", "INPUT DECK",
+                    List.of("SKIN  CLASSIC", "HAPTICS  ON", "LAYOUT  SAVED"),
+                    items(
+                            item("skin", "SKIN", "CLASSIC"),
+                            item("haptics", "HAPTICS", "ON"),
+                            item("edit-layout", "EDIT LAYOUT"),
+                            item("reset-layout", "RESET LAYOUT"),
+                            item("save-controls", "SAVE")));
+            case CONTROLLER_MAPPING -> page(route, "COFFEE GB", "CONTROLLER MAPPING", "", "INPUT MAP",
+                    List.of("DEVICE  BLUETOOTH", "PROFILE  DEFAULT", "A + B TO CANCEL"),
+                    items(
+                            item("map-up", "UP"),
+                            item("map-down", "DOWN"),
+                            item("map-a", "A"),
+                            item("map-b", "B"),
+                            item("map-start", "START"),
+                            item("save-mapping", "SAVE")));
+            case OPTIONAL_DEVICES -> page(route, "COFFEE GB", "OPTIONAL DEVICES", "", "ACCESSORIES",
+                    List.of("RUMBLE  READY", "CAMERA  PERMISSION", "PRINTER  READY"),
+                    items(
+                            item("rumble", "RUMBLE", "ON"),
+                            item("camera", "CAMERA", "READY"),
+                            item("tilt", "TILT", "OFF"),
+                            item("printer", "PRINTER"),
+                            item("printer-paper", "PRINTER PAPER"),
+                            item("export-paper", "EXPORT PAPER")));
+            case PRINTER_PAPER -> page(route, "COFFEE GB", "PRINTER PAPER", "", "PRINTER ROLL",
+                    List.of("LAST PRINT  READY", "PAPER  248 PX", "EXPORT IS NATIVE"),
+                    items(
+                            item("preview-paper", "PREVIEW"),
+                            item("export-paper", "EXPORT PAPER"),
+                            item("share-paper", "SHARE"),
+                            item("clear-paper", "CLEAR PAPER")));
+            case DATA_MEDIA -> page(route, "COFFEE GB", "DATA & MEDIA", "", "DATA DECK",
+                    List.of("BATTERY SAVE  READY", "STATE SLOT 0  READY", "SCREENSHOT  PNG"),
+                    items(
+                            item("import-battery", "IMPORT BATTERY SAVE"),
+                            item("export-battery", "EXPORT BATTERY SAVE"),
+                            item("import-state", "IMPORT STATE SLOT 0"),
+                            item("export-state", "EXPORT STATE SLOT 0"),
+                            item("export-screenshot", "EXPORT SCREENSHOT"),
+                            item("printer-paper", "PRINTER PAPER")));
+            case LIBRARY -> page(route, "COFFEE GB", "LIBRARY", "OPEN ROM", "RECENT ROMS",
+                    List.of("LAST OPENED  TODAY", "DOCUMENT PICKER  NATIVE", "ZIP  MULTI-SELECT"),
+                    items(
+                            item("recent-rom", "RECENT ROM"),
+                            item("open-rom", "OPEN ROM"),
+                            item("choose-rom", "CHOOSE ROM"),
+                            item("clear-recent", "CLEAR RECENTS")));
+            case CHOOSE_ROM -> page(route, "COFFEE GB", "CHOOSE ROM", "", "ZIP CONTENTS",
+                    List.of("3 ROMS FOUND", "SELECT ONE TO OPEN", "B BACK TO LIBRARY"),
+                    items(
+                            item("rom-1", "GAME A", ".GB"),
+                            item("rom-2", "GAME B", ".GBC"),
+                            item("rom-3", "GAME C", ".GB")));
+            case SYSTEM -> page(route, "COFFEE GB", "SYSTEM", "", "SYSTEM PROFILE",
+                    List.of("VIDEO  RASTER SKIN", "PROFILE  AUTO", "REWIND  DISABLED"),
+                    items(
+                            item("video", "VIDEO", "RASTER SKIN"),
+                            item("profile", "SYSTEM PROFILE", "AUTO"),
+                            item("rewind", "REWIND", "UNAVAILABLE"),
+                            item("save-system", "SAVE")));
+            case ABOUT -> page(route, "COFFEE GB", "ABOUT", "", "COFFEE GB",
+                    List.of("GAME BOY EMULATOR", "GPL LICENSE", "NO TRACKING"),
+                    items(
+                            item("version", "VERSION", "CURRENT"),
+                            item("license", "GPL LICENSE"),
+                            item("privacy", "PRIVACY"),
+                            item("source", "SOURCE CODE"),
+                            item("notices", "THIRD-PARTY NOTICES")));
+            case CONFIRM_ACTION -> page(route, "COFFEE GB", "CONFIRM ACTION", "", "ARE YOU SURE?",
+                    List.of("THIS ACTION CANNOT BE UNDONE", "CURRENT GAME IS PAUSED", "B CANCEL"),
+                    items(item("cancel", "CANCEL"), item("confirm", "CONFIRM")));
+        };
+    }
+
+    private static MenuPage page(MenuRoute route, String title, String context, String headerAction,
+            String sideHeading, List<String> sideLines, List<MenuItem> items) {
+        return new MenuPage(route, title, context, headerAction, sideHeading, sideLines, items, 1,
+                DEFAULT_HINTS);
+    }
+
+    private static List<MenuItem> items(MenuItem... items) {
+        return Arrays.asList(items);
+    }
+
+    private static MenuItem item(String id, String label) {
+        return new MenuItem(id, label);
+    }
+
+    private static MenuItem item(String id, String label, String detail) {
+        return new MenuItem(id, label, detail);
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPresentation.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPresentation.java
@@ -1,0 +1,164 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable render-thread handoff for one menu frame.
+ *
+ * <p>The reducer owns construction. Consumers can retain a snapshot without synchronizing with
+ * the controller or UI thread; all strings and collections exposed by this class are immutable.
+ */
+public final class MenuPresentation {
+
+    private static final MenuPresentation HIDDEN = new MenuPresentation(
+            false, null, "", "", "", "", Collections.emptyList(), Collections.emptyList(),
+            -1, 1, Collections.emptyList());
+
+    private final boolean visible;
+    private final MenuRoute route;
+    private final String title;
+    private final String context;
+    private final String headerAction;
+    private final String sideHeading;
+    private final List<String> sideLines;
+    private final List<Item> items;
+    private final int focusedIndex;
+    private final int columns;
+    private final List<String> footerHints;
+
+    MenuPresentation(boolean visible, MenuRoute route, String title, String context,
+            String headerAction, String sideHeading, List<String> sideLines, List<Item> items,
+            int focusedIndex, int columns, List<String> footerHints) {
+        this.visible = visible;
+        this.route = route;
+        this.title = requireText(title, "title");
+        this.context = requireText(context, "context");
+        this.headerAction = requireText(headerAction, "headerAction");
+        this.sideHeading = requireText(sideHeading, "sideHeading");
+        this.sideLines = immutableStrings(sideLines, "sideLines");
+        this.items = immutableItems(items);
+        this.focusedIndex = focusedIndex;
+        this.columns = Math.max(1, columns);
+        this.footerHints = immutableStrings(footerHints, "footerHints");
+        if (visible && route == null) {
+            throw new IllegalArgumentException("A visible menu needs a route");
+        }
+        if (focusedIndex < -1 || focusedIndex >= this.items.size()) {
+            throw new IllegalArgumentException("Focused item is outside the presentation");
+        }
+    }
+
+    static MenuPresentation hidden() {
+        return HIDDEN;
+    }
+
+    public boolean visible() {
+        return visible;
+    }
+
+    public MenuRoute route() {
+        return route;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String context() {
+        return context;
+    }
+
+    public String headerAction() {
+        return headerAction;
+    }
+
+    public String sideHeading() {
+        return sideHeading;
+    }
+
+    public List<String> sideLines() {
+        return sideLines;
+    }
+
+    public List<Item> items() {
+        return items;
+    }
+
+    public int focusedIndex() {
+        return focusedIndex;
+    }
+
+    public int columns() {
+        return columns;
+    }
+
+    public List<String> footerHints() {
+        return footerHints;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        return value;
+    }
+
+    private static List<String> immutableStrings(List<String> values, String name) {
+        if (values == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        ArrayList<String> copy = new ArrayList<>(values.size());
+        for (String value : values) {
+            copy.add(requireText(value, name + " entry"));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    private static List<Item> immutableItems(List<Item> values) {
+        if (values == null) {
+            throw new IllegalArgumentException("items cannot be null");
+        }
+        ArrayList<Item> copy = new ArrayList<>(values.size());
+        for (Item value : values) {
+            if (value == null) {
+                throw new IllegalArgumentException("items cannot contain null");
+            }
+            copy.add(value);
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    /** Immutable row data used by the Canvas renderer. */
+    public static final class Item {
+
+        private final String id;
+        private final String label;
+        private final String detail;
+        private final boolean enabled;
+
+        public Item(String id, String label, String detail, boolean enabled) {
+            this.id = requireText(id, "id");
+            this.label = requireText(label, "label");
+            this.detail = requireText(detail, "detail");
+            this.enabled = enabled;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String label() {
+            return label;
+        }
+
+        public String detail() {
+            return detail;
+        }
+
+        public boolean enabled() {
+            return enabled;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuReducer.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuReducer.java
@@ -1,0 +1,148 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Pure reducer for menu visibility, focus, and route-stack navigation. */
+final class MenuReducer {
+
+    private MenuReducer() {
+    }
+
+    static MenuState initial() {
+        return MenuState.hidden();
+    }
+
+    static MenuState reduce(MenuState state, MenuCommand command) {
+        if (state == null || command == null) {
+            throw new IllegalArgumentException("state and command are required");
+        }
+        return switch (command.type()) {
+            case SHOW -> show(state, command.route());
+            case HIDE -> MenuState.hidden();
+            case MOVE -> move(state, command.direction());
+            case PUSH -> push(state, command.route());
+            case BACK -> back(state);
+        };
+    }
+
+    static MenuState show(MenuState state, MenuRoute route) {
+        requireRoute(route);
+        MenuPage page = MenuPages.forRoute(route);
+        return MenuState.visible(page, page.firstEnabledIndex());
+    }
+
+    static MenuState hide(MenuState state) {
+        if (state == null) {
+            throw new IllegalArgumentException("state is required");
+        }
+        return MenuState.hidden();
+    }
+
+    static MenuState push(MenuState state, MenuRoute route) {
+        if (state == null) {
+            throw new IllegalArgumentException("state is required");
+        }
+        requireRoute(route);
+        MenuPage page = MenuPages.forRoute(route);
+        if (!state.visible()) {
+            return MenuState.visible(page, page.firstEnabledIndex());
+        }
+        ArrayList<MenuState.Frame> stack = new ArrayList<>(state.stack());
+        stack.add(new MenuState.Frame(page, page.firstEnabledIndex()));
+        return MenuState.withStack(stack);
+    }
+
+    static MenuState back(MenuState state) {
+        if (state == null) {
+            throw new IllegalArgumentException("state is required");
+        }
+        if (!state.visible() || state.depth() == 1) {
+            return MenuState.hidden();
+        }
+        List<MenuState.Frame> stack = state.stack();
+        return MenuState.withStack(stack.subList(0, stack.size() - 1));
+    }
+
+    static MenuState move(MenuState state, MenuCommand.Direction direction) {
+        if (state == null || direction == null) {
+            throw new IllegalArgumentException("state and direction are required");
+        }
+        if (!state.visible()) {
+            return state;
+        }
+        MenuPage page = state.page();
+        int next = nextEnabledIndex(page, state.focusedIndex(), direction);
+        if (next == state.focusedIndex()) {
+            return state;
+        }
+        ArrayList<MenuState.Frame> stack = new ArrayList<>(state.stack());
+        stack.set(stack.size() - 1, new MenuState.Frame(page, next));
+        return MenuState.withStack(stack);
+    }
+
+    private static int nextEnabledIndex(MenuPage page, int current, MenuCommand.Direction direction) {
+        if (page.columns() == 1 && (direction == MenuCommand.Direction.LEFT
+                || direction == MenuCommand.Direction.RIGHT)) {
+            return current;
+        }
+        int currentRow = current / page.columns();
+        int currentColumn = current % page.columns();
+        int rowCount = (page.items().size() + page.columns() - 1) / page.columns();
+        if (direction == MenuCommand.Direction.LEFT || direction == MenuCommand.Direction.RIGHT) {
+            int delta = direction == MenuCommand.Direction.LEFT ? -1 : 1;
+            for (int offset = 1; offset <= page.columns(); offset++) {
+                int candidateColumn = Math.floorMod(currentColumn + delta * offset, page.columns());
+                int candidate = itemAt(page, currentRow, candidateColumn);
+                if (candidate >= 0 && page.items().get(candidate).enabled()) {
+                    return candidate;
+                }
+            }
+            return current;
+        }
+        int delta = direction == MenuCommand.Direction.UP ? -1 : 1;
+        for (int offset = 1; offset <= rowCount; offset++) {
+            int candidateRow = Math.floorMod(currentRow + delta * offset, rowCount);
+            int candidate = itemAt(page, candidateRow, currentColumn);
+            if (candidate < 0 || !page.items().get(candidate).enabled()) {
+                candidate = nearestEnabledInRow(page, candidateRow, currentColumn);
+            }
+            if (candidate >= 0 && page.items().get(candidate).enabled()) {
+                return candidate;
+            }
+        }
+        return current;
+    }
+
+    private static int itemAt(MenuPage page, int row, int column) {
+        int index = row * page.columns() + column;
+        return index >= 0 && index < page.items().size() ? index : -1;
+    }
+
+    private static int nearestEnabledInRow(MenuPage page, int row, int requestedColumn) {
+        int first = row * page.columns();
+        int last = Math.min(page.items().size(), first + page.columns());
+        if (first >= last) {
+            return -1;
+        }
+        int nearest = -1;
+        int distance = Integer.MAX_VALUE;
+        for (int index = first; index < last; index++) {
+            if (!page.items().get(index).enabled()) {
+                continue;
+            }
+            int candidateDistance = Math.abs(index - first - requestedColumn);
+            if (candidateDistance < distance) {
+                nearest = index;
+                distance = candidateDistance;
+            }
+        }
+        return nearest;
+    }
+
+    private static void requireRoute(MenuRoute route) {
+        if (route == null) {
+            throw new IllegalArgumentException("route is required");
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRenderer.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRenderer.java
@@ -1,0 +1,279 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+
+import java.util.Locale;
+import java.util.List;
+
+/** Canvas renderer for the Proposal 3 in-screen menu. */
+public final class MenuRenderer {
+
+    private static final int CREAM = Color.rgb(239, 240, 211);
+    private static final int MINT = Color.rgb(211, 226, 181);
+    private static final int MINT_DARK = Color.rgb(177, 194, 143);
+    private static final int OLIVE = Color.rgb(38, 52, 35);
+    private static final int OLIVE_LIGHT = Color.rgb(65, 79, 49);
+    private static final int INK = Color.rgb(29, 42, 28);
+    private static final int OXBLOOD = Color.rgb(119, 38, 43);
+    private static final int MUTED = Color.rgb(117, 127, 87);
+
+    private final Paint fill = new Paint();
+    private final Paint stroke = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint text = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    public MenuRenderer() {
+        fill.setStyle(Paint.Style.FILL);
+        stroke.setStyle(Paint.Style.STROKE);
+        stroke.setStrokeWidth(1.0f);
+        text.setTypeface(Typeface.create(Typeface.MONOSPACE, Typeface.BOLD));
+        text.setFakeBoldText(true);
+        text.setSubpixelText(true);
+        text.setLinearText(false);
+    }
+
+    /** Draws one immutable menu snapshot into the supplied RasterSkin display bounds. */
+    public void draw(Canvas canvas, MenuPresentation presentation, RectF displayBounds) {
+        if (canvas == null || presentation == null || !presentation.visible()
+                || displayBounds == null || displayBounds.width() <= 0.0f
+                || displayBounds.height() <= 0.0f) {
+            return;
+        }
+        MenuGeometry.Layout layout = MenuGeometry.forDisplay(
+                displayBounds.width(), displayBounds.height());
+        if (layout.scale() <= 0.0f) {
+            return;
+        }
+
+        int save = canvas.save();
+        try {
+            canvas.clipRect(displayBounds);
+            canvas.translate(displayBounds.left + layout.offsetX(),
+                    displayBounds.top + layout.offsetY());
+            canvas.scale(layout.scale(), layout.scale());
+            fill.setColor(CREAM);
+            canvas.drawRect(0, 0, layout.logicalWidth(), layout.logicalHeight(), fill);
+            if (layout.portrait()) {
+                drawPortrait(canvas, presentation, layout.logicalWidth(), layout.logicalHeight());
+            } else {
+                drawLandscape(canvas, presentation, layout.logicalWidth(), layout.logicalHeight());
+            }
+        } finally {
+            canvas.restoreToCount(save);
+        }
+    }
+
+    private void drawLandscape(Canvas canvas, MenuPresentation presentation, int width, int height) {
+        RectF header = new RectF(5, 5, width - 5, 34);
+        RectF side = new RectF(8, 42, 120, height - 16);
+        RectF list = new RectF(123, 42, width - 8, height - 16);
+        RectF footer = new RectF(5, height - 13, width - 5, height - 4);
+        drawHeader(canvas, presentation, header);
+        drawSide(canvas, presentation, side, false);
+        drawList(canvas, presentation, list);
+        drawFooter(canvas, presentation, footer);
+    }
+
+    private void drawPortrait(Canvas canvas, MenuPresentation presentation, int width, int height) {
+        RectF header = new RectF(5, 5, width - 5, 34);
+        RectF side = new RectF(8, 40, width - 8, 127);
+        RectF list = new RectF(8, 131, width - 8, height - 25);
+        RectF footer = new RectF(5, height - 20, width - 5, height - 5);
+        drawHeader(canvas, presentation, header);
+        drawSide(canvas, presentation, side, true);
+        drawList(canvas, presentation, list);
+        drawFooter(canvas, presentation, footer);
+    }
+
+    private void drawHeader(Canvas canvas, MenuPresentation presentation, RectF bounds) {
+        drawPanel(canvas, bounds, CREAM, INK);
+        drawText(canvas, upper(presentation.title()), bounds.left + 8, bounds.centerY() + 4,
+                12, INK, Paint.Align.LEFT);
+        drawText(canvas, upper(presentation.context()), bounds.centerX(), bounds.centerY() + 3,
+                8, OLIVE_LIGHT, Paint.Align.CENTER);
+        if (!presentation.headerAction().isEmpty()) {
+            float right = bounds.right - 5;
+            float buttonWidth = Math.min(68, Math.max(46, presentation.headerAction().length() * 5.2f));
+            RectF button = new RectF(right - buttonWidth, bounds.top + 5, right, bounds.bottom - 5);
+            drawPanel(canvas, button, MINT, INK);
+            drawText(canvas, upper(presentation.headerAction()), button.centerX(), button.centerY() + 3,
+                    6.5f, INK, Paint.Align.CENTER);
+        }
+    }
+
+    private void drawSide(Canvas canvas, MenuPresentation presentation, RectF bounds,
+            boolean portrait) {
+        drawPanel(canvas, bounds, MINT, INK);
+        drawText(canvas, upper(presentation.sideHeading()), bounds.left + 6, bounds.top + 14,
+                portrait ? 6.5f : 7.5f, INK, Paint.Align.LEFT);
+
+        float thumbnailTop = bounds.top + 19;
+        float thumbnailHeight = portrait ? 28 : 61;
+        float thumbnailBottom = Math.min(bounds.bottom - 45, thumbnailTop + thumbnailHeight);
+        drawThumbnail(canvas, new RectF(bounds.left + 5, thumbnailTop, bounds.right - 5, thumbnailBottom));
+
+        ListTextLayout sideText = new ListTextLayout(bounds.left + 6, thumbnailBottom + 14,
+                bounds.right - 6, bounds.bottom - 6, presentation.sideLines().size());
+        float size = portrait ? 6.0f : 7.5f;
+        for (String line : presentation.sideLines()) {
+            if (sideText.nextBaseline() > sideText.bottom()) {
+                break;
+            }
+            drawText(canvas, upper(line), sideText.left(), sideText.nextBaseline(), size, OLIVE, Paint.Align.LEFT);
+            sideText.advance();
+        }
+    }
+
+    private void drawThumbnail(Canvas canvas, RectF bounds) {
+        fill.setColor(OLIVE_LIGHT);
+        canvas.drawRect(bounds, fill);
+        stroke.setColor(INK);
+        stroke.setStrokeWidth(1.0f);
+        canvas.drawRect(bounds, stroke);
+        float unit = Math.max(1.0f, bounds.width() / 36.0f);
+        fill.setColor(MINT_DARK);
+        for (int index = 0; index < 13; index++) {
+            float x = bounds.left + (index * 7 % 31) * unit;
+            float y = bounds.top + (index * 11 % 19) * unit;
+            canvas.drawRect(x, y, x + unit * 3, y + unit * 2, fill);
+        }
+        fill.setColor(MINT);
+        canvas.drawRect(bounds.left + unit * 3, bounds.bottom - unit * 7,
+                bounds.left + unit * 13, bounds.bottom - unit * 3, fill);
+        canvas.drawRect(bounds.left + unit * 23, bounds.bottom - unit * 13,
+                bounds.left + unit * 31, bounds.bottom - unit * 3, fill);
+        fill.setColor(CREAM);
+        float characterX = bounds.left + bounds.width() * 0.28f;
+        float characterY = bounds.bottom - unit * 8;
+        canvas.drawRect(characterX, characterY, characterX + unit * 4, characterY + unit * 5, fill);
+        canvas.drawRect(characterX + unit, characterY - unit * 3,
+                characterX + unit * 3, characterY, fill);
+    }
+
+    private void drawList(Canvas canvas, MenuPresentation presentation, RectF bounds) {
+        drawPanel(canvas, bounds, OLIVE, MINT_DARK);
+        List<MenuPresentation.Item> items = presentation.items();
+        if (items.isEmpty()) {
+            return;
+        }
+        float rowHeight = bounds.height() / items.size();
+        float textSize = Math.max(5.5f, Math.min(10.0f, rowHeight * 0.43f));
+        for (int index = 0; index < items.size(); index++) {
+            float top = bounds.top + rowHeight * index;
+            float bottom = index == items.size() - 1 ? bounds.bottom : top + rowHeight;
+            MenuPresentation.Item item = items.get(index);
+            if (index == presentation.focusedIndex()) {
+                fill.setColor(OXBLOOD);
+                canvas.drawRect(bounds.left + 1, top + 1, bounds.right - 1, bottom, fill);
+            }
+            stroke.setColor(MINT_DARK);
+            stroke.setStrokeWidth(0.75f);
+            canvas.drawLine(bounds.left + 1, bottom, bounds.right - 1, bottom, stroke);
+            if (index == presentation.focusedIndex()) {
+                drawFocusArrow(canvas, bounds.left + 7, (top + bottom) / 2.0f);
+            }
+            int color = item.enabled() ? CREAM : MUTED;
+            drawText(canvas, upper(item.label()), bounds.left + 17, (top + bottom) / 2.0f + textSize * 0.34f,
+                    textSize, color, Paint.Align.LEFT);
+            if (!item.detail().isEmpty()) {
+                drawText(canvas, upper(item.detail()), bounds.right - 7,
+                        (top + bottom) / 2.0f + textSize * 0.34f, Math.max(5.0f, textSize - 1),
+                        item.enabled() ? MINT_DARK : MUTED, Paint.Align.RIGHT);
+            }
+        }
+    }
+
+    private void drawFocusArrow(Canvas canvas, float x, float centerY) {
+        fill.setColor(CREAM);
+        canvas.drawPath(triangle(x - 3, centerY - 4, x - 3, centerY + 4, x + 2, centerY), fill);
+    }
+
+    private android.graphics.Path triangle(float x1, float y1, float x2, float y2,
+            float x3, float y3) {
+        android.graphics.Path path = new android.graphics.Path();
+        path.moveTo(x1, y1);
+        path.lineTo(x2, y2);
+        path.lineTo(x3, y3);
+        path.close();
+        return path;
+    }
+
+    private void drawFooter(Canvas canvas, MenuPresentation presentation, RectF bounds) {
+        drawPanel(canvas, bounds, CREAM, INK);
+        List<String> hints = presentation.footerHints();
+        if (hints.isEmpty()) {
+            return;
+        }
+        float segment = bounds.width() / hints.size();
+        for (int index = 0; index < hints.size(); index++) {
+            float left = bounds.left + segment * index;
+            float right = index == hints.size() - 1 ? bounds.right : left + segment;
+            if (index > 0) {
+                stroke.setColor(MINT_DARK);
+                stroke.setStrokeWidth(0.75f);
+                canvas.drawLine(left, bounds.top + 2, left, bounds.bottom - 2, stroke);
+            }
+            drawText(canvas, upper(hints.get(index)), (left + right) / 2.0f,
+                    bounds.centerY() + 2.3f, bounds.height() < 12 ? 4.5f : 5.5f, INK,
+                    Paint.Align.CENTER);
+        }
+    }
+
+    private void drawPanel(Canvas canvas, RectF bounds, int background, int border) {
+        fill.setColor(background);
+        canvas.drawRect(bounds, fill);
+        stroke.setColor(border);
+        stroke.setStrokeWidth(1.0f);
+        canvas.drawRect(bounds, stroke);
+        if (bounds.width() > 12 && bounds.height() > 12) {
+            stroke.setStrokeWidth(0.75f);
+            canvas.drawRect(bounds.left + 2, bounds.top + 2, bounds.right - 2, bounds.bottom - 2, stroke);
+        }
+    }
+
+    private void drawText(Canvas canvas, String value, float x, float baseline, float size, int color,
+            Paint.Align align) {
+        text.setColor(color);
+        text.setTextSize(size);
+        text.setTextAlign(align);
+        canvas.drawText(value, x, baseline, text);
+    }
+
+    private static String upper(String value) {
+        return value.toUpperCase(Locale.US);
+    }
+
+    private static final class ListTextLayout {
+
+        private final float left;
+        private final float bottom;
+        private final float step;
+        private float baseline;
+
+        private ListTextLayout(float left, float top, float right, float bottom, int count) {
+            this.left = left;
+            this.bottom = bottom;
+            this.step = count == 0 ? 0.0f : Math.max(8.0f, (bottom - top) / count);
+            this.baseline = top;
+        }
+
+        private float left() {
+            return left;
+        }
+
+        private float bottom() {
+            return bottom;
+        }
+
+        private float nextBaseline() {
+            return baseline;
+        }
+
+        private void advance() {
+            baseline += step;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRoute.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRoute.java
@@ -1,0 +1,29 @@
+package eu.rekawek.coffeegb.android.menu;
+
+/** Stable page identities used by the in-screen emulator menu. */
+public enum MenuRoute {
+    PAUSE_CONSOLE("PAUSE CONSOLE"),
+    SAVE_STATES("SAVE STATES"),
+    SETTINGS("SETTINGS"),
+    AUDIO("AUDIO"),
+    TOUCH_CONTROLS("TOUCH CONTROLS"),
+    CONTROLLER_MAPPING("CONTROLLER MAPPING"),
+    OPTIONAL_DEVICES("OPTIONAL DEVICES"),
+    PRINTER_PAPER("PRINTER PAPER"),
+    DATA_MEDIA("DATA & MEDIA"),
+    LIBRARY("LIBRARY"),
+    CHOOSE_ROM("CHOOSE ROM"),
+    SYSTEM("SYSTEM"),
+    ABOUT("ABOUT"),
+    CONFIRM_ACTION("CONFIRM ACTION");
+
+    private final String label;
+
+    MenuRoute(String label) {
+        this.label = label;
+    }
+
+    String label() {
+        return label;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuState.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuState.java
@@ -1,0 +1,101 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Immutable reducer state; only the reducer creates new instances. */
+final class MenuState {
+
+    private final List<Frame> stack;
+
+    private MenuState(List<Frame> stack) {
+        this.stack = Collections.unmodifiableList(new ArrayList<>(stack));
+    }
+
+    static MenuState hidden() {
+        return new MenuState(Collections.emptyList());
+    }
+
+    static MenuState visible(MenuPage page, int focusedIndex) {
+        return withStack(List.of(new Frame(page, focusedIndex)));
+    }
+
+    static MenuState withStack(List<Frame> stack) {
+        if (stack == null || stack.isEmpty()) {
+            return hidden();
+        }
+        for (Frame frame : stack) {
+            if (frame == null) {
+                throw new IllegalArgumentException("Menu stack cannot contain null");
+            }
+        }
+        return new MenuState(stack);
+    }
+
+    boolean visible() {
+        return !stack.isEmpty();
+    }
+
+    MenuRoute route() {
+        return visible() ? current().page.route() : null;
+    }
+
+    int focusedIndex() {
+        return visible() ? current().focusedIndex() : -1;
+    }
+
+    String focusedItemId() {
+        if (!visible() || focusedIndex() < 0) {
+            return null;
+        }
+        return current().page.items().get(focusedIndex()).id();
+    }
+
+    int depth() {
+        return stack.size();
+    }
+
+    MenuPage page() {
+        return current().page;
+    }
+
+    List<Frame> stack() {
+        return stack;
+    }
+
+    MenuPresentation presentation() {
+        return visible() ? current().page.presentation(current().focusedIndex())
+                : MenuPresentation.hidden();
+    }
+
+    private Frame current() {
+        return stack.get(stack.size() - 1);
+    }
+
+    static final class Frame {
+
+        private final MenuPage page;
+        private final int focusedIndex;
+
+        Frame(MenuPage page, int focusedIndex) {
+            if (page == null) {
+                throw new IllegalArgumentException("Menu frame needs a page");
+            }
+            if (focusedIndex < 0 || focusedIndex >= page.items().size()
+                    || !page.items().get(focusedIndex).enabled()) {
+                throw new IllegalArgumentException("Menu frame has an invalid focused item");
+            }
+            this.page = page;
+            this.focusedIndex = focusedIndex;
+        }
+
+        MenuPage page() {
+            return page;
+        }
+
+        int focusedIndex() {
+            return focusedIndex;
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuGeometryTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuGeometryTest.java
@@ -1,0 +1,50 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MenuGeometryTest {
+
+    @Test
+    public void landscapeUsesTheStableLandscapeGridAndDoesNotClip() {
+        MenuGeometry.Layout layout = MenuGeometry.forDisplay(920.0f, 718.0f);
+
+        assertFalse(layout.portrait());
+        assertEquals(MenuGeometry.LANDSCAPE_WIDTH, layout.logicalWidth());
+        assertEquals(MenuGeometry.LANDSCAPE_HEIGHT, layout.logicalHeight());
+        assertTrue(layout.scale() > 0.0f);
+        assertTrue(layout.fits(920.0f, 718.0f));
+        assertEquals(920.0f, layout.contentWidth(), 0.001f);
+        assertEquals(690.0f, layout.contentHeight(), 0.001f);
+        assertEquals(14.0f, layout.offsetY(), 0.001f);
+    }
+
+    @Test
+    public void portraitReflowsToThePortraitGridAndDoesNotClip() {
+        MenuGeometry.Layout layout = MenuGeometry.forDisplay(718.0f, 920.0f);
+
+        assertTrue(layout.portrait());
+        assertEquals(MenuGeometry.PORTRAIT_WIDTH, layout.logicalWidth());
+        assertEquals(MenuGeometry.PORTRAIT_HEIGHT, layout.logicalHeight());
+        assertTrue(layout.scale() > 0.0f);
+        assertTrue(layout.fits(718.0f, 920.0f));
+        assertEquals(690.0f, layout.contentWidth(), 0.001f);
+        assertEquals(920.0f, layout.contentHeight(), 0.001f);
+        assertEquals(14.0f, layout.offsetX(), 0.001f);
+    }
+
+    @Test
+    public void verySmallAndInvalidWindowsRemainSafe() {
+        MenuGeometry.Layout tiny = MenuGeometry.forDisplay(1.0f, 1.0f);
+        assertTrue(tiny.scale() > 0.0f);
+        assertTrue(tiny.fits(1.0f, 1.0f));
+
+        MenuGeometry.Layout invalid = MenuGeometry.forDisplay(0.0f, 100.0f);
+        assertEquals(0.0f, invalid.scale(), 0.0f);
+        assertEquals(0, invalid.logicalWidth());
+        assertEquals(0, invalid.logicalHeight());
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuReducerTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuReducerTest.java
@@ -1,0 +1,107 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MenuReducerTest {
+
+    @Test
+    public void showAndMoveExposeAnImmutableFocusedPresentation() {
+        MenuState hidden = MenuReducer.initial();
+        assertFalse(hidden.visible());
+        assertFalse(hidden.presentation().visible());
+
+        MenuState state = MenuReducer.reduce(hidden, MenuCommand.show(MenuRoute.PAUSE_CONSOLE));
+        assertTrue(state.visible());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, state.route());
+        assertEquals("resume", state.focusedItemId());
+
+        state = MenuReducer.reduce(state, MenuCommand.move(MenuCommand.Direction.DOWN));
+        assertEquals("save-state", state.focusedItemId());
+        state = MenuReducer.reduce(state, MenuCommand.move(MenuCommand.Direction.UP));
+        assertEquals("resume", state.focusedItemId());
+        state = MenuReducer.reduce(state, MenuCommand.move(MenuCommand.Direction.UP));
+        assertEquals("stop", state.focusedItemId());
+
+        MenuPresentation presentation = state.presentation();
+        assertTrue(presentation.visible());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, presentation.route());
+        assertEquals("stop", presentation.items().get(presentation.focusedIndex()).id());
+        assertUnmodifiable(presentation.items());
+        assertNotSame(presentation, state.presentation());
+    }
+
+    @Test
+    public void horizontalAndVerticalMovementWorkOnMultiColumnPages() {
+        MenuPage page = new MenuPage(
+                MenuRoute.SETTINGS,
+                "COFFEE GB",
+                "GRID TEST",
+                "",
+                "TEST",
+                List.of("GRID"),
+                List.of(
+                        new MenuItem("one", "ONE"),
+                        new MenuItem("two", "TWO"),
+                        new MenuItem("three", "THREE"),
+                        new MenuItem("four", "FOUR")),
+                2,
+                List.of("MOVE"));
+        MenuState state = MenuState.visible(page, 0);
+
+        state = MenuReducer.move(state, MenuCommand.Direction.RIGHT);
+        assertEquals("two", state.focusedItemId());
+        state = MenuReducer.move(state, MenuCommand.Direction.DOWN);
+        assertEquals("four", state.focusedItemId());
+        state = MenuReducer.move(state, MenuCommand.Direction.LEFT);
+        assertEquals("three", state.focusedItemId());
+        state = MenuReducer.move(state, MenuCommand.Direction.UP);
+        assertEquals("one", state.focusedItemId());
+    }
+
+    @Test
+    public void pushAndBackPreserveParentFocusThenHideAtRoot() {
+        MenuState state = MenuReducer.show(MenuReducer.initial(), MenuRoute.PAUSE_CONSOLE);
+        state = MenuReducer.move(state, MenuCommand.Direction.DOWN);
+        assertEquals("save-state", state.focusedItemId());
+
+        state = MenuReducer.push(state, MenuRoute.SETTINGS);
+        assertEquals(2, state.depth());
+        assertEquals(MenuRoute.SETTINGS, state.route());
+        assertEquals("audio", state.focusedItemId());
+
+        state = MenuReducer.back(state);
+        assertEquals(1, state.depth());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, state.route());
+        assertEquals("save-state", state.focusedItemId());
+
+        state = MenuReducer.back(state);
+        assertFalse(state.visible());
+        assertNull(state.route());
+        assertEquals(-1, state.presentation().focusedIndex());
+    }
+
+    @Test
+    public void leftAndRightAreNoOpsForTheProposalVerticalLists() {
+        MenuState state = MenuReducer.show(MenuReducer.initial(), MenuRoute.SETTINGS);
+        assertEquals("audio", state.focusedItemId());
+        assertEquals("audio", MenuReducer.move(state, MenuCommand.Direction.LEFT).focusedItemId());
+        assertEquals("audio", MenuReducer.move(state, MenuCommand.Direction.RIGHT).focusedItemId());
+    }
+
+    private static void assertUnmodifiable(List<?> values) {
+        try {
+            values.clear();
+        } catch (UnsupportedOperationException expected) {
+            return;
+        }
+        throw new AssertionError("Expected an immutable list");
+    }
+}


### PR DESCRIPTION
## What
- add the Proposal 3 menu route/model/reducer foundation
- render immutable menu presentations inside the RasterSkin display bounds
- add thread-safe surface handoff plus reducer and geometry tests

## Why
This establishes the isolated rendering and navigation layer needed to replace the Android AlertDialog menu tree without changing runtime behavior yet.

## Impact
No user-facing behavior changes in this slice. MainActivity does not publish a menu presentation until the follow-up integration PRs.

## Checks
- pure JVM compile and JUnit: 7 tests passed
- git diff --check
- full Android Gradle verification deferred to GitHub Actions because this host has no Android SDK