### PR TITLE
Wire Android in-screen menu actions

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -1,10 +1,25 @@
 package eu.rekawek.coffeegb.android;
 
+import android.app.Instrumentation;
+import android.os.ParcelFileDescriptor;
+import android.os.SystemClock;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 /** Exercises the bound runtime through Activity recreation and a visibility transition. */
 @RunWith(AndroidJUnit4.class)
@@ -17,5 +32,76 @@ public class MainActivitySmokeTest {
             scenario.moveToState(Lifecycle.State.RESUMED);
             scenario.recreate();
         }
+    }
+
+    @Test
+    public void systemBackClosesRootMenuBeforeFinishingActivity() throws IOException {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                Button menu = menuButton(activity);
+                assertEquals("Open Coffee GB menu", menu.getContentDescription().toString());
+                menu.performClick();
+                assertEquals("Close Coffee GB menu", menu.getContentDescription().toString());
+            });
+            assertEquals(Lifecycle.State.RESUMED, scenario.getState());
+
+            sendSystemBack(instrumentation);
+
+            scenario.onActivity(activity -> {
+                assertFalse(activity.isFinishing());
+                assertFalse(activity.isDestroyed());
+                assertEquals("Open Coffee GB menu",
+                        menuButton(activity).getContentDescription().toString());
+            });
+            assertEquals(Lifecycle.State.RESUMED, scenario.getState());
+
+            sendSystemBack(instrumentation);
+            waitForState(scenario, Lifecycle.State.DESTROYED, instrumentation);
+        }
+    }
+
+    private static void sendSystemBack(Instrumentation instrumentation) throws IOException {
+        ParcelFileDescriptor result = instrumentation.getUiAutomation()
+                .executeShellCommand("input keyevent 4");
+        try (ParcelFileDescriptor.AutoCloseInputStream stream =
+                     new ParcelFileDescriptor.AutoCloseInputStream(result)) {
+            byte[] buffer = new byte[64];
+            while (stream.read(buffer) != -1) {
+                // Waiting for EOF ensures the shell input command completed before assertions.
+            }
+        }
+        instrumentation.waitForIdleSync();
+    }
+
+    private static Button menuButton(MainActivity activity) {
+        Button button = findButton(activity.getWindow().getDecorView());
+        assertNotNull("menu button", button);
+        return button;
+    }
+
+    private static Button findButton(View view) {
+        if (view instanceof Button button) {
+            return button;
+        }
+        if (view instanceof ViewGroup group) {
+            for (int index = 0; index < group.getChildCount(); index++) {
+                Button button = findButton(group.getChildAt(index));
+                if (button != null) {
+                    return button;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void waitForState(ActivityScenario<?> scenario, Lifecycle.State expected,
+            Instrumentation instrumentation) {
+        long deadline = SystemClock.uptimeMillis() + 3_000L;
+        while (scenario.getState() != expected && SystemClock.uptimeMillis() < deadline) {
+            instrumentation.waitForIdleSync();
+            SystemClock.sleep(25L);
+        }
+        assertEquals(expected, scenario.getState());
     }
 }

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/menu/MenuRendererAndroidTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/menu/MenuRendererAndroidTest.java
@@ -1,0 +1,40 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.RectF;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class MenuRendererAndroidTest {
+
+    @Test
+    public void shortWideThumbnailIsClippedToItsBounds() {
+        int untouched = Color.MAGENTA;
+        Bitmap bitmap = Bitmap.createBitmap(360, 100, Bitmap.Config.ARGB_8888);
+        bitmap.eraseColor(untouched);
+        RectF bounds = new RectF(20, 30, 340, 58);
+
+        new MenuRenderer().drawThumbnail(new Canvas(bitmap), bounds);
+
+        for (int y = 0; y < bitmap.getHeight(); y++) {
+            for (int x = 0; x < bitmap.getWidth(); x++) {
+                boolean inside = x >= (int) bounds.left && x < (int) bounds.right
+                        && y >= (int) bounds.top && y < (int) bounds.bottom;
+                if (!inside) {
+                    assertEquals("pixel outside thumbnail at " + x + "," + y,
+                            untouched, bitmap.getPixel(x, y));
+                }
+            }
+        }
+        assertNotEquals(untouched, bitmap.getPixel(21, 31));
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -13,9 +13,14 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import eu.rekawek.coffeegb.android.menu.MenuPresentation;
 import eu.rekawek.coffeegb.android.menu.MenuRenderer;
+import eu.rekawek.coffeegb.android.menu.MenuKey;
+import eu.rekawek.coffeegb.android.menu.MenuTouchInput;
 import eu.rekawek.coffeegb.core.joypad.Button;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Dedicated nearest-neighbour native-frame surface.
@@ -37,9 +42,11 @@ public final class CoffeeGbSurfaceView extends SurfaceView
     private final RasterSkin portraitSkin;
     private final RasterSkin landscapeSkin;
     private final MenuRenderer menuRenderer = new MenuRenderer();
+    private final Set<Integer> menuTouchPointers = new HashSet<>();
 
     private volatile NativeFrameStore frames;
     private volatile MenuPresentation menuPresentation;
+    private volatile MenuTouchInput menuInput;
     private final TouchControlsPreferences touchPreferences;
     private volatile TouchControlsLayout touchLayout;
     private AndroidInputRouter input;
@@ -94,6 +101,18 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         onFrameAvailable();
     }
 
+    /** Installs the input bridge used to consume skin controls while the menu is visible. */
+    public void setMenuInput(MenuTouchInput input) {
+        MenuTouchInput previous = menuInput;
+        if (previous != null) {
+            previous.releaseAllPointers();
+        }
+        synchronized (menuTouchPointers) {
+            menuTouchPointers.clear();
+        }
+        menuInput = input;
+    }
+
     /** Attaches this transient Surface to the long-lived service frame store. */
     public void attach(NativeFrameStore frameStore, AndroidInputRouter inputRouter) {
         if (frames == frameStore) {
@@ -119,17 +138,64 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         if (input != null) {
             input.releaseAllTouch();
         }
+        MenuTouchInput menu = menuInput;
+        if (menu != null) {
+            menu.releaseAllPointers();
+        }
+        synchronized (menuTouchPointers) {
+            menuTouchPointers.clear();
+        }
         input = null;
         stopRenderer();
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        MenuTouchInput menu = menuInput;
+        int action = event.getActionMasked();
+        int actionPointerId = event.getPointerId(event.getActionIndex());
+        boolean menuVisible = menu != null && menu.visible();
+        boolean menuPointer = false;
+        synchronized (menuTouchPointers) {
+            menuPointer = menuTouchPointers.contains(actionPointerId)
+                    || !menuTouchPointers.isEmpty();
+        }
+        if (menu != null && (menuVisible || menuPointer)) {
+            if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_OUTSIDE) {
+                menu.releaseAllPointers();
+                synchronized (menuTouchPointers) {
+                    menuTouchPointers.clear();
+                }
+                return true;
+            }
+            if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP) {
+                menu.releasePointer(actionPointerId);
+                synchronized (menuTouchPointers) {
+                    menuTouchPointers.remove(actionPointerId);
+                }
+                return true;
+            }
+            if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN
+                    || action == MotionEvent.ACTION_MOVE) {
+                if (menuVisible) {
+                    for (int index = 0; index < event.getPointerCount(); index++) {
+                        int pointerId = event.getPointerId(index);
+                        menu.updatePointer(pointerId, menuKeysAt(event.getX(index), event.getY(index)));
+                        synchronized (menuTouchPointers) {
+                            menuTouchPointers.add(pointerId);
+                        }
+                    }
+                }
+                // A menu may close from the A/B edge generated above. Keep consuming this pointer
+                // until its UP so that no partial touch chord reaches gameplay input.
+                return true;
+            }
+        }
+
         AndroidInputRouter router = input;
         if (router == null) {
             return false;
         }
-        int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_OUTSIDE) {
             router.releaseAllTouch();
             return true;
@@ -153,6 +219,28 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             return true;
         }
         return super.onTouchEvent(event);
+    }
+
+    private List<MenuKey> menuKeysAt(float x, float y) {
+        List<Button> buttons = touchLayout.buttonsAt(x, y, getWidth(), getHeight());
+        if (buttons.isEmpty()) {
+            return List.of();
+        }
+        ArrayList<MenuKey> keys = new ArrayList<>(buttons.size());
+        for (Button button : buttons) {
+            MenuKey key = switch (button) {
+                case UP -> MenuKey.UP;
+                case DOWN -> MenuKey.DOWN;
+                case LEFT -> MenuKey.LEFT;
+                case RIGHT -> MenuKey.RIGHT;
+                case A -> MenuKey.A;
+                case B -> MenuKey.B;
+                case START -> MenuKey.START;
+                case SELECT -> MenuKey.SELECT;
+            };
+            keys.add(key);
+        }
+        return List.copyOf(keys);
     }
 
     @Override
@@ -179,6 +267,13 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         AndroidInputRouter router = input;
         if (router != null) {
             router.releaseAllTouch();
+        }
+        MenuTouchInput menu = menuInput;
+        if (menu != null) {
+            menu.releaseAllPointers();
+        }
+        synchronized (menuTouchPointers) {
+            menuTouchPointers.clear();
         }
         stopRenderer();
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1,6 +1,8 @@
 package eu.rekawek.coffeegb.android;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ClipData;
@@ -10,6 +12,7 @@ import android.net.Uri;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.hardware.input.InputManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -28,6 +31,8 @@ import android.widget.ScrollView;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 import eu.rekawek.coffeegb.android.menu.MenuController;
 import eu.rekawek.coffeegb.android.menu.MenuKey;
 import eu.rekawek.coffeegb.android.menu.MenuPageSpec;
@@ -79,6 +84,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private boolean menuPauseOwned;
     private boolean selectionActionInFlight;
     private OpenRomPickerState openRomPickerState = OpenRomPickerState.none();
+    private Api33MenuBackCallback predictiveMenuBack;
 
     private final InputManager.InputDeviceListener inputDevices = new InputManager.InputDeviceListener() {
         @Override
@@ -164,6 +170,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             }
         });
         video.setMenuInput(menuController);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            predictiveMenuBack = new Api33MenuBackCallback(this, this::dispatchMenuBack);
+        }
         root.addView(video, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
@@ -238,7 +247,22 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     @Override
+    protected void onDestroy() {
+        if (predictiveMenuBack != null) {
+            predictiveMenuBack.close();
+            predictiveMenuBack = null;
+        }
+        super.onDestroy();
+    }
+
+    @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        if (isSystemBack(event)) {
+            // System/hardware Back must have exactly one owner. Let Activity dispatch it to the
+            // API 33+ OnBackInvokedCallback or the API 26-32 onBackPressed fallback; never route it
+            // through menu/game input first.
+            return super.dispatchKeyEvent(event);
+        }
         MenuKey menuKey = menuKey(event);
         if (menuKey != null) {
             if (event.getAction() == KeyEvent.ACTION_MULTIPLE
@@ -293,13 +317,19 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     @Override
+    @SuppressLint("GestureBackNavigation")
+    @SuppressWarnings("deprecation")
     public void onBackPressed() {
-        if (menuController != null && menuController.visible()) {
-            menuController.onKeyDown(MenuKey.B, false);
-            menuController.onKeyUp(MenuKey.B);
+        // API 26-32 has no OnBackInvokedDispatcher. API 33+ must be owned exclusively by the
+        // dynamically registered predictive-back callback while the menu is visible.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && dispatchMenuBack()) {
             return;
         }
         super.onBackPressed();
+    }
+
+    private boolean dispatchMenuBack() {
+        return menuController != null && menuController.dispatchBackEdge();
     }
 
     @Override
@@ -372,6 +402,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private void presentMenu(MenuPresentation presentation) {
         boolean wasVisible = menuVisible;
         menuVisible = presentation.visible();
+        if (predictiveMenuBack != null) {
+            predictiveMenuBack.setEnabled(menuVisible);
+        }
         if (menuVisible) {
             video.setMenuPresentation(presentation);
             menuButton.setContentDescription("Close Coffee GB menu");
@@ -760,8 +793,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             case KeyEvent.KEYCODE_DPAD_RIGHT -> MenuKey.RIGHT;
             case KeyEvent.KEYCODE_BUTTON_A, KeyEvent.KEYCODE_BUTTON_X,
                     KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_SPACE -> MenuKey.A;
-            case KeyEvent.KEYCODE_BUTTON_B, KeyEvent.KEYCODE_ESCAPE,
-                    KeyEvent.KEYCODE_BACK -> MenuKey.B;
+            case KeyEvent.KEYCODE_BUTTON_B, KeyEvent.KEYCODE_ESCAPE -> MenuKey.B;
             case KeyEvent.KEYCODE_BUTTON_Y, KeyEvent.KEYCODE_FORWARD_DEL,
                     KeyEvent.KEYCODE_DEL -> MenuKey.SECONDARY;
             case KeyEvent.KEYCODE_BUTTON_START -> MenuKey.START;
@@ -769,6 +801,13 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                     KeyEvent.KEYCODE_NUMPAD_ENTER -> MenuKey.SELECT;
             default -> null;
         };
+    }
+
+    @SuppressLint("GestureBackNavigation")
+    private static boolean isSystemBack(KeyEvent event) {
+        // This does not intercept Back: it prevents menu/emulator input interception and delegates
+        // the event unchanged to Activity's platform back pipeline.
+        return event.getKeyCode() == KeyEvent.KEYCODE_BACK;
     }
 
     private void openRomDocument(View ignored) {
@@ -1248,6 +1287,36 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @FunctionalInterface
     private interface RuntimeAction {
         void run(AndroidEmulationRuntime runtime);
+    }
+
+    @TargetApi(Build.VERSION_CODES.TIRAMISU)
+    private static final class Api33MenuBackCallback {
+
+        private final OnBackInvokedDispatcher dispatcher;
+        private final OnBackInvokedCallback callback;
+        private boolean registered;
+
+        private Api33MenuBackCallback(Activity activity, Runnable action) {
+            dispatcher = activity.getOnBackInvokedDispatcher();
+            callback = action::run;
+        }
+
+        private void setEnabled(boolean enabled) {
+            if (enabled == registered) {
+                return;
+            }
+            if (enabled) {
+                dispatcher.registerOnBackInvokedCallback(
+                        OnBackInvokedDispatcher.PRIORITY_OVERLAY, callback);
+            } else {
+                dispatcher.unregisterOnBackInvokedCallback(callback);
+            }
+            registered = enabled;
+        }
+
+        private void close() {
+            setEnabled(false);
+        }
     }
 
     private record PendingDocumentResult(int requestCode, Uri uri, int flags) { }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -11,13 +11,14 @@ import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.hardware.input.InputManager;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -27,7 +28,15 @@ import android.widget.ScrollView;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
+import eu.rekawek.coffeegb.android.menu.MenuController;
+import eu.rekawek.coffeegb.android.menu.MenuKey;
+import eu.rekawek.coffeegb.android.menu.MenuPageSpec;
+import eu.rekawek.coffeegb.android.menu.MenuPresentation;
+import eu.rekawek.coffeegb.android.menu.MenuRoute;
+import eu.rekawek.coffeegb.android.menu.OpenRomPickerState;
+import eu.rekawek.coffeegb.controller.state.StateRef;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -47,33 +56,29 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final int EXPORT_SCREENSHOT_REQUEST = 6;
     private static final int EXPORT_PRINTER_REQUEST = 7;
     private static final int CAMERA_PERMISSION_REQUEST = 8;
+    private static final String STATE_OPEN_ROM_PICKER_ROUTE = "openRomPicker.route";
+    private static final String STATE_OPEN_ROM_PICKER_PAUSE_OWNED = "openRomPicker.pauseOwned";
+    private static final String STATE_OPEN_ROM_PICKER_RESTORE = "openRomPicker.restore";
 
-    private TextView status;
     private CoffeeGbSurfaceView video;
     private Button menuButton;
-    private ScrollView menu;
-    private AlertDialog menuDialog;
-    private Button open;
-    private Button recent;
-    private Button pauseMenu;
-    private Button resume;
-    private Button stop;
-    private Button states;
-    private Button settings;
-    private Button about;
-    private Button importBattery;
-    private Button exportBattery;
-    private Button importState;
-    private Button exportState;
-    private Button exportScreenshot;
-    private Button touchControls;
-    private Button controllerMapping;
 
     private AndroidEmulationRuntime runtime;
     private boolean bound;
     private InputManager inputManager;
-    private long shownSelectionGeneration = -1L;
     private PendingDocumentResult pendingDocumentResult;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private MenuController menuController;
+    private RuntimeState observedState = RuntimeState.stopped();
+    private List<AndroidStateSlot> stateSlots = List.of();
+    private StateMenuMode stateMenuMode = StateMenuMode.SAVE;
+    private ConfirmVariant confirmVariant;
+    private int confirmSlot = -1;
+    private boolean stateSlotsLoading;
+    private boolean menuVisible;
+    private boolean menuPauseOwned;
+    private boolean selectionActionInFlight;
+    private OpenRomPickerState openRomPickerState = OpenRomPickerState.none();
 
     private final InputManager.InputDeviceListener inputDevices = new InputManager.InputDeviceListener() {
         @Override
@@ -113,6 +118,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             }
             applyState(runtime.state());
             dispatchPendingDocumentResult();
+            restoreMenuAfterOpenRomCancel();
         }
 
         @Override
@@ -121,20 +127,43 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 video.detach();
                 runtime.removeObserver(MainActivity.this);
             }
+            menuPauseOwned = false;
+            if (menuController != null) {
+                menuController.hide();
+            }
+            video.clearMenuPresentation();
             runtime = null;
             bound = false;
-            disableCommands();
-            status.setText("Coffee GB runtime stopped. Reopen the app to choose a ROM.");
+            observedState = RuntimeState.stopped();
+            refreshMenuPages();
         }
     };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        restoreOpenRomPickerState(savedInstanceState);
 
         FrameLayout root = new FrameLayout(this);
 
         video = new CoffeeGbSurfaceView(this);
+        menuController = new MenuController(new MenuController.Listener() {
+            @Override
+            public void onPresentation(MenuPresentation presentation) {
+                presentMenu(presentation);
+            }
+
+            @Override
+            public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+                handleMenuItem(route, id, secondary);
+            }
+
+            @Override
+            public void onHeaderSelected(MenuRoute route) {
+                handleMenuHeader(route);
+            }
+        });
+        video.setMenuInput(menuController);
         root.addView(video, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
@@ -145,60 +174,6 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         root.addView(menuButton, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 
-        menu = new ScrollView(this);
-        menu.setFillViewport(false);
-        menu.setBackgroundColor(android.graphics.Color.rgb(239, 232, 216));
-
-        LinearLayout content = new LinearLayout(this);
-        content.setOrientation(LinearLayout.VERTICAL);
-        content.setGravity(Gravity.CENTER_HORIZONTAL);
-        int padding = (int) (24 * getResources().getDisplayMetrics().density);
-        int bottomPadding = padding + (int) (48 * getResources().getDisplayMetrics().density);
-        content.setPadding(padding, padding, padding, bottomPadding);
-
-        status = new TextView(this);
-        status.setGravity(Gravity.CENTER);
-        status.setContentDescription("Coffee GB Android runtime status");
-        status.setText("Starting Coffee GB Android runtime…");
-        content.addView(status);
-
-        open = button("Open ROM", this::openRomDocument);
-        recent = button("Open recent ROM", ignored -> requireRuntime(AndroidEmulationRuntime::requestRecentDocuments));
-        pauseMenu = button("Pause and menu", ignored -> showPauseMenu());
-        resume = button("Resume", ignored -> requireRuntime(AndroidEmulationRuntime::resume));
-        stop = button("Stop game", ignored -> requireRuntime(AndroidEmulationRuntime::stop));
-        states = button("Save states", ignored -> showStateSlots());
-        settings = button("Settings", ignored -> showSettings());
-        about = button("About, licenses, and privacy", ignored -> showAbout());
-        importBattery = button("Import battery save", this::chooseBatteryImport);
-        exportBattery = button("Export battery save", this::chooseBatteryExport);
-        importState = button("Import state slot 0", this::chooseStateImport);
-        exportState = button("Export state slot 0", this::chooseStateExport);
-        exportScreenshot = button("Export native screenshot", this::chooseScreenshotExport);
-        touchControls = button("Touch controls", ignored -> configureTouchControls());
-        controllerMapping = button("Controller mapping", ignored -> configureController());
-        content.addView(open);
-        content.addView(recent);
-        content.addView(pauseMenu);
-        content.addView(resume);
-        content.addView(stop);
-        content.addView(states);
-        content.addView(settings);
-        content.addView(importBattery);
-        content.addView(exportBattery);
-        content.addView(importState);
-        content.addView(exportState);
-        content.addView(exportScreenshot);
-        content.addView(touchControls);
-        content.addView(controllerMapping);
-        content.addView(about);
-        menu.addView(content);
-        menuDialog = new AlertDialog.Builder(this)
-                .setTitle("Coffee GB")
-                .setView(menu)
-                .create();
-        menuDialog.setOnDismissListener(ignored ->
-                menuButton.setContentDescription("Open Coffee GB menu"));
         root.addOnLayoutChangeListener((view, left, top, right, bottom,
                                         oldLeft, oldTop, oldRight, oldBottom) -> {
             positionMenuOverlay(right - left, bottom - top);
@@ -210,7 +185,19 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             return insets;
         });
         setContentView(root);
-        disableCommands();
+        refreshMenuPages();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (openRomPickerState.active()) {
+            outState.putString(STATE_OPEN_ROM_PICKER_ROUTE, openRomPickerState.route().name());
+            outState.putBoolean(
+                    STATE_OPEN_ROM_PICKER_PAUSE_OWNED, openRomPickerState.pauseOwned());
+            outState.putBoolean(
+                    STATE_OPEN_ROM_PICKER_RESTORE, openRomPickerState.restoreRequested());
+        }
     }
 
     @Override
@@ -230,6 +217,15 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             inputManager.unregisterInputDeviceListener(inputDevices);
             inputManager = null;
         }
+        if (menuController != null && menuController.visible()) {
+            // Backgrounding must preserve the runtime's paused lifecycle state; it must not
+            // resume a game merely because the transient Activity menu was dismissed.
+            menuPauseOwned = false;
+            menuController.hide();
+        }
+        if (menuController != null) {
+            menuController.cancelInput();
+        }
         if (bound) {
             runtime.input().releaseAll();
             video.detach();
@@ -243,6 +239,22 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        MenuKey menuKey = menuKey(event);
+        if (menuKey != null) {
+            if (event.getAction() == KeyEvent.ACTION_MULTIPLE
+                    && menuController != null && menuController.visible()) {
+                return true;
+            }
+            if (event.getAction() == KeyEvent.ACTION_DOWN
+                    && menuController != null && menuController.visible()
+                    && menuController.onKeyDown(menuKey, event.getRepeatCount() > 0)) {
+                return true;
+            }
+            if (event.getAction() == KeyEvent.ACTION_UP
+                    && menuController != null && menuController.onKeyUp(menuKey)) {
+                return true;
+            }
+        }
         AndroidEmulationRuntime active = runtime;
         if (active != null && active.input().onKeyEvent(event)) {
             return true;
@@ -252,6 +264,16 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
+        if (menuController != null && menuController.visible()
+                && isGameController(event.getSource())
+                && event.getAction() == MotionEvent.ACTION_MOVE) {
+            float hatX = event.getAxisValue(MotionEvent.AXIS_HAT_X);
+            float hatY = event.getAxisValue(MotionEvent.AXIS_HAT_Y);
+            float x = Math.abs(hatX) >= .45f ? hatX : event.getAxisValue(MotionEvent.AXIS_X);
+            float y = Math.abs(hatY) >= .45f ? hatY : event.getAxisValue(MotionEvent.AXIS_Y);
+            menuController.onAxis(x, y);
+            return true;
+        }
         AndroidEmulationRuntime active = runtime;
         if (active != null && active.input().onMotionEvent(event)) {
             return true;
@@ -264,7 +286,20 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         super.onWindowFocusChanged(hasFocus);
         if (!hasFocus && runtime != null) {
             runtime.input().releaseAll();
+            if (menuController != null) {
+                menuController.cancelInput();
+            }
         }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (menuController != null && menuController.visible()) {
+            menuController.onKeyDown(MenuKey.B, false);
+            menuController.onKeyUp(MenuKey.B);
+            return;
+        }
+        super.onBackPressed();
     }
 
     @Override
@@ -272,38 +307,37 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         applyState(state);
     }
 
-    private Button button(String label, View.OnClickListener listener) {
-        Button button = new Button(this);
-        button.setText(label);
-        button.setOnClickListener(view -> {
-            hideMenu();
-            listener.onClick(view);
-        });
-        return button;
-    }
-
     private void toggleMenu() {
-        if (menuDialog.isShowing()) {
-            hideMenu();
+        if (menuController == null) {
+            return;
+        }
+        if (menuController.visible()) {
+            menuController.hide();
+            return;
+        }
+        AndroidEmulationRuntime active = runtime;
+        RuntimeState current = active == null ? observedState : active.state();
+        observedState = current;
+        if (active != null) {
+            // No touch/key state that opened the menu may leak into the emulated game.
+            active.input().releaseAll();
+        }
+        menuPauseOwned = current.phase() == RuntimeState.Phase.RUNNING;
+        if (menuPauseOwned && active != null) {
+            active.pause();
+        }
+        refreshMenuPages();
+        if (current.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION) {
+            menuController.show(MenuRoute.CHOOSE_ROM);
+        } else if (current.phase() == RuntimeState.Phase.AWAITING_RECENT_SELECTION) {
+            menuController.show(MenuRoute.LIBRARY);
+        } else if (current.phase() == RuntimeState.Phase.PAUSED
+                || (current.transferReady() && current.paused())) {
+            menuController.show(MenuRoute.PAUSE_CONSOLE);
+        } else if (current.transferReady() && current.phase() == RuntimeState.Phase.RUNNING) {
+            menuController.show(MenuRoute.PAUSE_CONSOLE);
         } else {
-            menuDialog.show();
-            Window window = menuDialog.getWindow();
-            if (window != null) {
-                int density = Math.max(1, Math.round(getResources().getDisplayMetrics().density));
-                int width = Math.max(1, video.getWidth() - 32 * density);
-                int height = Math.max(1, video.getHeight() - 32 * density);
-                window.setLayout(Math.min(360 * density, width), Math.min(640 * density, height));
-            }
-            menuButton.setContentDescription("Close Coffee GB menu");
-        }
-    }
-
-    private void hideMenu() {
-        if (menuDialog != null && menuDialog.isShowing()) {
-            menuDialog.dismiss();
-        }
-        if (menuButton != null) {
-            menuButton.setContentDescription("Open Coffee GB menu");
+            menuController.show(MenuRoute.LIBRARY);
         }
     }
 
@@ -335,6 +369,408 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         menuButton.setLayoutParams(buttonLayout);
     }
 
+    private void presentMenu(MenuPresentation presentation) {
+        boolean wasVisible = menuVisible;
+        menuVisible = presentation.visible();
+        if (menuVisible) {
+            video.setMenuPresentation(presentation);
+            menuButton.setContentDescription("Close Coffee GB menu");
+        } else {
+            video.clearMenuPresentation();
+            menuButton.setContentDescription("Open Coffee GB menu");
+            if (wasVisible) {
+                onMenuClosed();
+            }
+        }
+    }
+
+    private void onMenuClosed() {
+        if (selectionActionInFlight) {
+            selectionActionInFlight = false;
+        } else if (runtime != null && (observedState.phase()
+                == RuntimeState.Phase.AWAITING_RECENT_SELECTION
+                || observedState.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION)) {
+            runtime.cancelPendingSelection();
+        }
+        if (menuPauseOwned) {
+            menuPauseOwned = false;
+            AndroidEmulationRuntime active = runtime;
+            if (active != null) {
+                active.resume();
+            }
+        }
+    }
+
+    private void handleMenuHeader(MenuRoute route) {
+        if (route == MenuRoute.PAUSE_CONSOLE || route == MenuRoute.LIBRARY) {
+            openRomFromMenu();
+        }
+    }
+
+    private void handleMenuItem(MenuRoute route, String id, boolean secondary) {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null || id == null) {
+            return;
+        }
+        if (route == MenuRoute.PAUSE_CONSOLE) {
+            switch (id) {
+                case "resume" -> resumeAndClose(active);
+                case "save-state" -> showStateMenu(StateMenuMode.SAVE);
+                case "load-state" -> showStateMenu(StateMenuMode.LOAD);
+                case "reset" -> showConfirmation(ConfirmVariant.RESET, -1);
+                case "settings" -> menuController.push(MenuRoute.SETTINGS);
+                case "stop" -> showConfirmation(ConfirmVariant.STOP, -1);
+                case "open-rom" -> openRomFromMenu();
+                default -> { }
+            }
+            return;
+        }
+        if (route == MenuRoute.SAVE_STATES) {
+            if (id.equals("back")) {
+                menuController.back();
+                return;
+            }
+            if (secondary || id.startsWith("delete-slot:")) {
+                String value = id.startsWith("delete-slot:")
+                        ? id.substring("delete-slot:".length()) : id;
+                int slot = parseSlot(value);
+                if (slot >= 0) {
+                    showConfirmation(ConfirmVariant.DELETE, slot);
+                }
+                return;
+            }
+            if (id.startsWith("slot:")) {
+                int slot = parseSlot(id.substring("slot:".length()));
+                if (slot < 0) {
+                    return;
+                }
+                AndroidStateSlot stateSlot = stateSlot(slot);
+                if (stateMenuMode == StateMenuMode.LOAD) {
+                    if (stateSlot != null && stateSlot.loadable()) {
+                        active.restoreSnapshot(slot);
+                        closeMenuWithoutResume();
+                    }
+                } else if (stateSlot != null && stateSlot.loadable()) {
+                    showConfirmation(ConfirmVariant.OVERWRITE, slot);
+                } else {
+                    active.saveSnapshot(slot);
+                    refreshStateSlotsAfterMutation();
+                }
+            }
+            return;
+        }
+        if (route == MenuRoute.LIBRARY) {
+            if (id.equals("open-rom")) {
+                openRomFromMenu();
+            } else if (id.equals("recent-rom")) {
+                active.requestRecentDocuments();
+            } else if (id.startsWith("recent:")) {
+                long token = parseToken(id.substring("recent:".length()));
+                if (token >= 0) {
+                    selectRecentFromMenu(active, token);
+                }
+            } else if (id.equals("choose-rom")) {
+                menuController.push(MenuRoute.CHOOSE_ROM);
+            }
+            return;
+        }
+        if (route == MenuRoute.CHOOSE_ROM) {
+            if (id.equals("cancel")) {
+                menuController.back();
+                return;
+            }
+            if (id.startsWith("archive:")) {
+                long token = parseToken(id.substring("archive:".length()));
+                if (token >= 0) {
+                    selectionActionInFlight = true;
+                    menuPauseOwned = false;
+                    menuController.hide();
+                    active.selectArchiveCandidate(token);
+                }
+            }
+            return;
+        }
+        if (route == MenuRoute.CONFIRM_ACTION) {
+            if (id.equals("cancel")) {
+                menuController.back();
+            } else if (id.equals("confirm")) {
+                executeConfirmation(active);
+            }
+        }
+    }
+
+    private void selectRecentFromMenu(AndroidEmulationRuntime active, long token) {
+        selectionActionInFlight = true;
+        menuPauseOwned = false;
+        menuController.hide();
+        active.selectRecentDocument(token);
+    }
+
+    private void showStateMenu(StateMenuMode mode) {
+        stateMenuMode = mode;
+        stateSlotsLoading = true;
+        refreshMenuPages();
+        menuController.push(MenuRoute.SAVE_STATES);
+        AndroidEmulationRuntime active = runtime;
+        if (active != null) {
+            active.listStateSlots(slots -> {
+                stateSlots = List.copyOf(slots);
+                stateSlotsLoading = false;
+                refreshMenuPages();
+            });
+        }
+    }
+
+    private void showConfirmation(ConfirmVariant variant, int slot) {
+        confirmVariant = variant;
+        confirmSlot = slot;
+        refreshMenuPages();
+        menuController.push(MenuRoute.CONFIRM_ACTION);
+    }
+
+    private void executeConfirmation(AndroidEmulationRuntime active) {
+        ConfirmVariant variant = confirmVariant;
+        int slot = confirmSlot;
+        if (variant == null) {
+            menuController.back();
+            return;
+        }
+        switch (variant) {
+            case RESET -> {
+                closeMenuWithoutResume();
+                active.reset();
+            }
+            case STOP -> {
+                closeMenuWithoutResume();
+                active.stop();
+            }
+            case OVERWRITE -> {
+                active.saveSnapshot(slot);
+                menuController.back();
+                refreshStateSlotsAfterMutation();
+            }
+            case DELETE -> {
+                active.deleteSnapshot(slot);
+                menuController.back();
+                refreshStateSlotsAfterMutation();
+            }
+        }
+        confirmVariant = null;
+        confirmSlot = -1;
+    }
+
+    private void resumeAndClose(AndroidEmulationRuntime active) {
+        menuPauseOwned = false;
+        menuController.hide();
+        active.resume();
+    }
+
+    private void closeMenuWithoutResume() {
+        menuPauseOwned = false;
+        menuController.hide();
+    }
+
+    private void openRomFromMenu() {
+        if (runtime == null || menuController == null || !menuController.visible()) {
+            return;
+        }
+        // A native picker owns the screen. Keep a paused session paused while it is open and do not
+        // attempt to represent provider/filesystem rows in the emulator renderer.
+        openRomPickerState = OpenRomPickerState.launched(
+                menuController.route(), menuPauseOwned);
+        menuPauseOwned = false;
+        menuController.hide();
+        openRomDocument(null);
+    }
+
+    private void refreshStateSlotsAfterMutation() {
+        AndroidEmulationRuntime active = runtime;
+        if (active == null) {
+            return;
+        }
+        stateSlotsLoading = true;
+        refreshMenuPages();
+        active.listStateSlots(slots -> {
+            stateSlots = List.copyOf(slots);
+            stateSlotsLoading = false;
+            refreshMenuPages();
+        });
+        // Manual state workers finish asynchronously; these bounded re-reads make the visible row
+        // reflect the catalog after the controller has committed the save/delete operation.
+        mainHandler.postDelayed(() -> refreshStateSlotsIfMenuVisible(), 250L);
+        mainHandler.postDelayed(() -> refreshStateSlotsIfMenuVisible(), 750L);
+    }
+
+    private void refreshStateSlotsIfMenuVisible() {
+        if (!menuVisible || menuController.route() != MenuRoute.SAVE_STATES) {
+            return;
+        }
+        AndroidEmulationRuntime active = runtime;
+        if (active != null) {
+            active.listStateSlots(slots -> {
+                stateSlots = List.copyOf(slots);
+                stateSlotsLoading = false;
+                refreshMenuPages();
+            });
+        }
+    }
+
+    private AndroidStateSlot stateSlot(int index) {
+        for (AndroidStateSlot slot : stateSlots) {
+            if (slot.index() == index) {
+                return slot;
+            }
+        }
+        return null;
+    }
+
+    private static int parseSlot(String value) {
+        try {
+            int slot = Integer.parseInt(value);
+            return slot >= StateRef.MIN_SLOT && slot <= StateRef.MAX_SLOT ? slot : -1;
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private static long parseToken(String value) {
+        try {
+            long token = Long.parseLong(value);
+            return token >= 0 ? token : -1L;
+        } catch (NumberFormatException ignored) {
+            return -1L;
+        }
+    }
+
+    private void refreshMenuPages() {
+        if (menuController == null) {
+            return;
+        }
+        menuController.setPages(List.of(
+                pausePage(), statePage(), libraryPage(), chooseRomPage(), confirmationPage()));
+    }
+
+    private MenuPageSpec pausePage() {
+        return page(MenuRoute.PAUSE_CONSOLE, "COFFEE GB", "PAUSED", "OPEN ROM", "CURRENT GAME",
+                List.of(observedState.message(), "INPUT  MENU CAPTURED", "A RESUME / B BACK"),
+                List.of(
+                        item("resume", "RESUME", "RUN GAME", true),
+                        item("save-state", "SAVE STATE", "SAVE MODE", true),
+                        item("load-state", "LOAD STATE", "LOAD MODE", true),
+                        item("reset", "RESET GAME", "CONFIRM", true),
+                        item("settings", "SETTINGS", "OPEN", true),
+                        item("stop", "STOP GAME", "CONFIRM", true),
+                        item("open-rom", "OPEN ROM", "NATIVE PICKER", runtime != null)),
+                List.of("D-PAD MOVE", "[A] OK", "[B] BACK", "[START] OPEN ROM"));
+    }
+
+    private MenuPageSpec statePage() {
+        ArrayList<MenuPageSpec.Item> items = new ArrayList<>();
+        for (int index = StateRef.MIN_SLOT; index <= StateRef.MAX_SLOT; index++) {
+            AndroidStateSlot slot = stateSlot(index);
+            boolean loadable = slot != null && slot.loadable();
+            boolean enabled = !stateSlotsLoading && (stateMenuMode == StateMenuMode.SAVE || loadable);
+            String detail = stateSlotsLoading ? "LOADING" : slot == null ? "EMPTY"
+                    : slot.detail();
+            String secondary = loadable ? "delete-slot:" + index : null;
+            items.add(item("slot:" + index, "SLOT " + index, detail, enabled, secondary));
+        }
+        items.add(item("back", "BACK", "RETURN", true));
+        String mode = stateMenuMode == StateMenuMode.SAVE ? "SAVE" : "LOAD";
+        return page(MenuRoute.SAVE_STATES, "COFFEE GB", "SAVE STATES / " + mode, "", "STATE BANK",
+                List.of("SLOTS " + StateRef.MIN_SLOT + "-" + StateRef.MAX_SLOT,
+                        stateSlotsLoading ? "READING CATALOG" : "A SELECTS",
+                        "SELECT/Y DELETE"), items,
+                List.of("D-PAD MOVE", "[A] SELECT", "[SELECT] DELETE", "[B] BACK"));
+    }
+
+    private MenuPageSpec libraryPage() {
+        ArrayList<MenuPageSpec.Item> items = new ArrayList<>();
+        if (observedState.phase() == RuntimeState.Phase.AWAITING_RECENT_SELECTION) {
+            for (RuntimeState.Selection selection : observedState.selections()) {
+                items.add(item("recent:" + selection.token(), selection.label(), "A OPEN", true));
+            }
+        } else {
+            items.add(item("recent-rom", "RECENT ROMS", "CHOOSE", runtime != null));
+            items.add(item("choose-rom", "CHOOSE ROM", "ZIP RESULTS",
+                    observedState.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION));
+        }
+        items.add(item("open-rom", "OPEN ROM", "NATIVE PICKER", runtime != null));
+        if (runtime == null) {
+            items.add(item("wait", "RUNTIME STARTING", "WAIT", true));
+        }
+        return page(MenuRoute.LIBRARY, "COFFEE GB", "LIBRARY", "OPEN ROM", "RECENT ROMS",
+                List.of("DOCUMENT PICKER  NATIVE", "RECENT METADATA  PRIVATE", "ZIP  MULTI-ROM"),
+                items, List.of("D-PAD MOVE", "[A] OPEN", "[B] BACK", "[START] OPEN ROM"));
+    }
+
+    private MenuPageSpec chooseRomPage() {
+        ArrayList<MenuPageSpec.Item> items = new ArrayList<>();
+        for (RuntimeState.Selection selection : observedState.selections()) {
+            items.add(item("archive:" + selection.token(), selection.label(), "A OPEN", true));
+        }
+        if (items.isEmpty()) {
+            items.add(item("empty", "NO ROM CANDIDATES", "CANCEL", false));
+        }
+        items.add(item("cancel", "BACK TO LIBRARY", "CANCEL", true));
+        return page(MenuRoute.CHOOSE_ROM, "COFFEE GB", "CHOOSE ROM", "", "ZIP CONTENTS",
+                List.of("SELECT ONE TO OPEN", "A OPENS ROM", "B CANCELS PENDING ZIP"), items,
+                List.of("D-PAD MOVE", "[A] OPEN", "[B] CANCEL"));
+    }
+
+    private MenuPageSpec confirmationPage() {
+        ConfirmVariant variant = confirmVariant == null ? ConfirmVariant.RESET : confirmVariant;
+        return page(MenuRoute.CONFIRM_ACTION, "COFFEE GB", "CONFIRM ACTION", "", variant.label,
+                List.of(variant.description, "A CONFIRM", "B CANCEL"),
+                List.of(item("cancel", "CANCEL", "RETURN", true),
+                        item("confirm", "CONFIRM", variant.label, true)),
+                List.of("D-PAD MOVE", "[A] CONFIRM", "[B] CANCEL"));
+    }
+
+    private static MenuPageSpec page(MenuRoute route, String title, String context,
+            String headerAction, String sideHeading, List<String> sideLines,
+            List<MenuPageSpec.Item> items, List<String> hints) {
+        return new MenuPageSpec(route, title, context, headerAction, sideHeading, sideLines,
+                items, 1, hints);
+    }
+
+    private static MenuPageSpec.Item item(String id, String label, String detail, boolean enabled) {
+        return new MenuPageSpec.Item(id, label, detail, enabled);
+    }
+
+    private static MenuPageSpec.Item item(String id, String label, String detail, boolean enabled,
+            String secondaryId) {
+        return new MenuPageSpec.Item(id, label, detail, enabled, secondaryId);
+    }
+
+    private static boolean isGameController(int source) {
+        return (source & android.view.InputDevice.SOURCE_GAMEPAD)
+                        == android.view.InputDevice.SOURCE_GAMEPAD
+                || (source & android.view.InputDevice.SOURCE_JOYSTICK)
+                        == android.view.InputDevice.SOURCE_JOYSTICK
+                || (source & android.view.InputDevice.SOURCE_DPAD)
+                        == android.view.InputDevice.SOURCE_DPAD;
+    }
+
+    private static MenuKey menuKey(KeyEvent event) {
+        return switch (event.getKeyCode()) {
+            case KeyEvent.KEYCODE_DPAD_UP -> MenuKey.UP;
+            case KeyEvent.KEYCODE_DPAD_DOWN -> MenuKey.DOWN;
+            case KeyEvent.KEYCODE_DPAD_LEFT -> MenuKey.LEFT;
+            case KeyEvent.KEYCODE_DPAD_RIGHT -> MenuKey.RIGHT;
+            case KeyEvent.KEYCODE_BUTTON_A, KeyEvent.KEYCODE_BUTTON_X,
+                    KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_SPACE -> MenuKey.A;
+            case KeyEvent.KEYCODE_BUTTON_B, KeyEvent.KEYCODE_ESCAPE,
+                    KeyEvent.KEYCODE_BACK -> MenuKey.B;
+            case KeyEvent.KEYCODE_BUTTON_Y, KeyEvent.KEYCODE_FORWARD_DEL,
+                    KeyEvent.KEYCODE_DEL -> MenuKey.SECONDARY;
+            case KeyEvent.KEYCODE_BUTTON_START -> MenuKey.START;
+            case KeyEvent.KEYCODE_BUTTON_SELECT, KeyEvent.KEYCODE_DPAD_CENTER,
+                    KeyEvent.KEYCODE_NUMPAD_ENTER -> MenuKey.SELECT;
+            default -> null;
+        };
+    }
+
     private void openRomDocument(View ignored) {
         if (runtime == null) {
             return;
@@ -356,16 +792,61 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (resultCode != RESULT_OK || data == null || data.getData() == null) {
+        Uri uri = data == null ? null : data.getData();
+        if (requestCode == OPEN_ROM_REQUEST) {
+            if (resultCode != RESULT_OK || uri == null) {
+                openRomPickerState = openRomPickerState.canceled();
+                restoreMenuAfterOpenRomCancel();
+                return;
+            }
+            // Opening another ROM supersedes the old paused/menu session. Do not restore or resume
+            // it even when runtime binding finishes after this result callback.
+            openRomPickerState = openRomPickerState.completed();
+        }
+        if (resultCode != RESULT_OK || uri == null) {
             return;
         }
         PendingDocumentResult result = new PendingDocumentResult(
-                requestCode, data.getData(), data.getFlags());
+                requestCode, uri, data.getFlags());
         if (runtime == null) {
             pendingDocumentResult = result;
             return;
         }
         dispatchDocumentResult(result);
+    }
+
+    private void restoreOpenRomPickerState(Bundle savedInstanceState) {
+        if (savedInstanceState == null) {
+            return;
+        }
+        String routeName = savedInstanceState.getString(STATE_OPEN_ROM_PICKER_ROUTE);
+        if (routeName == null) {
+            return;
+        }
+        try {
+            openRomPickerState = OpenRomPickerState.restored(
+                    MenuRoute.valueOf(routeName),
+                    savedInstanceState.getBoolean(STATE_OPEN_ROM_PICKER_PAUSE_OWNED),
+                    savedInstanceState.getBoolean(STATE_OPEN_ROM_PICKER_RESTORE));
+        } catch (IllegalArgumentException ignored) {
+            openRomPickerState = OpenRomPickerState.none();
+        }
+    }
+
+    private void restoreMenuAfterOpenRomCancel() {
+        OpenRomPickerState pickerState = openRomPickerState;
+        AndroidEmulationRuntime active = runtime;
+        if (!pickerState.restoreRequested() || active == null || menuController == null) {
+            return;
+        }
+        openRomPickerState = pickerState.completed();
+        active.input().releaseAll();
+        menuPauseOwned = pickerState.pauseOwned();
+        if (menuPauseOwned) {
+            active.pause();
+        }
+        refreshMenuPages();
+        menuController.show(pickerState.route());
     }
 
     private void dispatchPendingDocumentResult() {
@@ -440,7 +921,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void chooseScreenshotExport(View ignored) {
-        if (runtime == null || !exportScreenshot.isEnabled()) {
+        if (!canTransfer()) {
             return;
         }
         startActivityForResult(
@@ -558,79 +1039,6 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                     }
                 })
                 .show();
-    }
-
-    private void showPauseMenu() {
-        AndroidEmulationRuntime active = runtime;
-        if (active == null || !pauseMenu.isEnabled()) {
-            return;
-        }
-        active.pause();
-        String[] choices = {"Resume", "Reset game", "Save state (slot 0)", "Load state (slot 0)",
-                "Save states", "Settings", "Stop game"};
-        new AlertDialog.Builder(this)
-                .setTitle("Game paused")
-                .setItems(choices, (dialog, which) -> {
-                    switch (which) {
-                        case 0 -> active.resume();
-                        case 1 -> new AlertDialog.Builder(this).setTitle("Reset game?")
-                                .setMessage("Unsaved progress in the running game may be lost.")
-                                .setNegativeButton("Cancel", null)
-                                .setPositiveButton("Reset", (ignored, button) -> active.reset()).show();
-                        case 2 -> active.saveSnapshot(0);
-                        case 3 -> active.restoreSnapshot(0);
-                        case 4 -> showStateSlots();
-                        case 5 -> showSettings();
-                        case 6 -> new AlertDialog.Builder(this).setTitle("Stop game?")
-                                .setMessage("The running session will end after its safe cleanup.")
-                                .setNegativeButton("Cancel", null)
-                                .setPositiveButton("Stop", (ignored, button) -> active.stop()).show();
-                        default -> { }
-                    }
-                }).show();
-    }
-
-    private void showStateSlots() {
-        AndroidEmulationRuntime active = runtime;
-        if (active == null || !states.isEnabled()) {
-            return;
-        }
-        active.listStateSlots(slots -> {
-            if (slots.isEmpty()) {
-                Toast.makeText(this, "Open a ROM before managing save states.", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            String[] labels = slots.stream().map(AndroidStateSlot::label).toArray(String[]::new);
-            new AlertDialog.Builder(this).setTitle("Save states")
-                    .setItems(labels, (dialog, which) -> showStateSlotActions(slots.get(which))).show();
-        });
-    }
-
-    private void showStateSlotActions(AndroidStateSlot slot) {
-        AndroidEmulationRuntime active = runtime;
-        if (active == null) {
-            return;
-        }
-        List<String> choices = new java.util.ArrayList<>();
-        choices.add("Save or overwrite");
-        if (slot.loadable()) {
-            choices.add("Load");
-            choices.add("Delete");
-        }
-        new AlertDialog.Builder(this).setTitle("State slot " + slot.index() + ": " + slot.detail())
-                .setItems(choices.toArray(new String[0]), (dialog, which) -> {
-                    String choice = choices.get(which);
-                    if (choice.equals("Save or overwrite")) {
-                        active.saveSnapshot(slot.index());
-                    } else if (choice.equals("Load")) {
-                        active.restoreSnapshot(slot.index());
-                    } else {
-                        new AlertDialog.Builder(this).setTitle("Delete state slot?")
-                                .setMessage("This cannot be undone.").setNegativeButton("Cancel", null)
-                                .setPositiveButton("Delete", (ignored, button) -> active.deleteSnapshot(slot.index()))
-                                .show();
-                    }
-                }).show();
     }
 
     private void showSettings() {
@@ -771,7 +1179,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void confirmImport(String title, String message, int requestCode) {
-        if (runtime == null || !importBattery.isEnabled()) {
+        if (!canTransfer()) {
             return;
         }
         new AlertDialog.Builder(this)
@@ -788,7 +1196,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void chooseExport(int requestCode, String suggestedName) {
-        if (runtime == null || !exportBattery.isEnabled()) {
+        if (!canTransfer()) {
             return;
         }
         startActivityForResult(
@@ -809,52 +1217,25 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 .show();
     }
 
-    private void applyState(RuntimeState state) {
-        status.setText(state.message());
-        boolean ready = runtime != null;
-        open.setEnabled(ready);
-        recent.setEnabled(ready);
-        pauseMenu.setEnabled(ready && state.transferReady() && !state.paused());
-        resume.setEnabled(ready && state.paused() && state.transferReady());
-        stop.setEnabled(ready && state.transferReady());
-        states.setEnabled(ready && state.transferReady() && !state.flushPending());
-        settings.setEnabled(ready);
-        about.setEnabled(true);
-        importBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
-        exportBattery.setEnabled(ready && state.transferReady() && !state.flushPending());
-        importState.setEnabled(ready && state.transferReady() && !state.flushPending());
-        exportState.setEnabled(ready && state.transferReady() && !state.flushPending());
-        exportScreenshot.setEnabled(ready && state.transferReady() && !state.flushPending());
-        touchControls.setEnabled(ready);
-        controllerMapping.setEnabled(ready);
-        showSelectionIfNeeded(state);
+    private boolean canTransfer() {
+        return runtime != null && observedState.transferReady() && !observedState.flushPending();
     }
 
-    private void showSelectionIfNeeded(RuntimeState state) {
-        if (runtime == null || state.selections().isEmpty()
-                || state.generation() == shownSelectionGeneration) {
+    private void applyState(RuntimeState state) {
+        observedState = state;
+        refreshMenuPages();
+        if (runtime == null || menuController == null) {
             return;
         }
-        boolean archive = state.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION;
-        boolean recentSelection = state.phase() == RuntimeState.Phase.AWAITING_RECENT_SELECTION;
-        if (!archive && !recentSelection) {
-            return;
+        if (state.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION
+                && !menuController.visible()) {
+            menuPauseOwned = false;
+            menuController.show(MenuRoute.CHOOSE_ROM);
+        } else if (state.phase() == RuntimeState.Phase.AWAITING_RECENT_SELECTION
+                && !menuController.visible()) {
+            menuPauseOwned = false;
+            menuController.show(MenuRoute.LIBRARY);
         }
-        shownSelectionGeneration = state.generation();
-        List<RuntimeState.Selection> selections = state.selections();
-        String[] labels = selections.stream().map(RuntimeState.Selection::label).toArray(String[]::new);
-        new AlertDialog.Builder(this)
-                .setTitle(archive ? "Choose ROM from archive" : "Open recent ROM")
-                .setItems(labels, (dialog, index) -> {
-                    RuntimeState.Selection selection = selections.get(index);
-                    if (archive) {
-                        runtime.selectArchiveCandidate(selection.token());
-                    } else {
-                        runtime.selectRecentDocument(selection.token());
-                    }
-                })
-                .setOnCancelListener(dialog -> runtime.cancelPendingSelection())
-                .show();
     }
 
     private void requireRuntime(RuntimeAction action) {
@@ -864,31 +1245,30 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
     }
 
-    private void disableCommands() {
-        if (open == null) {
-            return;
-        }
-        open.setEnabled(false);
-        recent.setEnabled(false);
-        pauseMenu.setEnabled(false);
-        resume.setEnabled(false);
-        stop.setEnabled(false);
-        states.setEnabled(false);
-        settings.setEnabled(false);
-        about.setEnabled(true);
-        importBattery.setEnabled(false);
-        exportBattery.setEnabled(false);
-        importState.setEnabled(false);
-        exportState.setEnabled(false);
-        exportScreenshot.setEnabled(false);
-        touchControls.setEnabled(false);
-        controllerMapping.setEnabled(false);
-    }
-
     @FunctionalInterface
     private interface RuntimeAction {
         void run(AndroidEmulationRuntime runtime);
     }
 
     private record PendingDocumentResult(int requestCode, Uri uri, int flags) { }
+
+    private enum StateMenuMode {
+        SAVE,
+        LOAD
+    }
+
+    private enum ConfirmVariant {
+        RESET("RESET GAME", "UNSAVED PROGRESS MAY BE LOST"),
+        STOP("STOP GAME", "THE CURRENT SESSION WILL END"),
+        OVERWRITE("OVERWRITE STATE", "THE EXISTING SLOT WILL BE REPLACED"),
+        DELETE("DELETE STATE", "THE SAVED SLOT CANNOT BE RECOVERED");
+
+        private final String label;
+        private final String description;
+
+        ConfirmVariant(String label, String description) {
+            this.label = label;
+            this.description = description;
+        }
+    }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuController.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuController.java
@@ -159,6 +159,15 @@ public final class MenuController implements MenuTouchInput {
         }
     }
 
+    /** Dispatches system back as one complete B edge and reports whether the menu consumed it. */
+    public boolean dispatchBackEdge() {
+        if (!onKeyDown(MenuKey.B, false)) {
+            return false;
+        }
+        onKeyUp(MenuKey.B);
+        return true;
+    }
+
     /** Converts joystick/hat values to edge-triggered menu movement with a stable dead zone. */
     public boolean onAxis(float x, float y) {
         EnumSet<MenuKey> nextAxis = EnumSet.noneOf(MenuKey.class);

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuController.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuController.java
@@ -1,0 +1,399 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Thread-safe coordinator for menu navigation and edge-triggered input.
+ *
+ * <p>All state transitions are immutable reducer transitions. The listener receives snapshots and
+ * semantic actions after the lock is released, so an Android callback can safely call back into
+ * this controller while a render thread retains the previous presentation.
+ */
+public final class MenuController implements MenuTouchInput {
+
+    private static final float AXIS_DEAD_ZONE = 0.45f;
+
+    private final Object lock = new Object();
+    private final Listener listener;
+    private final EnumMap<MenuRoute, MenuPage> pages = new EnumMap<>(MenuRoute.class);
+    private final EnumSet<MenuKey> keyHeld = EnumSet.noneOf(MenuKey.class);
+    private final EnumSet<MenuKey> axisHeld = EnumSet.noneOf(MenuKey.class);
+    private final Map<Integer, EnumSet<MenuKey>> touchPointers = new HashMap<>();
+    private final EnumSet<MenuKey> capturedKeys = EnumSet.noneOf(MenuKey.class);
+
+    private MenuState state = MenuReducer.initial();
+
+    public MenuController(Listener listener) {
+        this.listener = Objects.requireNonNull(listener, "listener");
+        for (MenuRoute route : MenuRoute.values()) {
+            pages.put(route, MenuPages.forRoute(route));
+        }
+    }
+
+    public MenuPresentation presentation() {
+        synchronized (lock) {
+            return state.presentation();
+        }
+    }
+
+    public MenuRoute route() {
+        synchronized (lock) {
+            return state.route();
+        }
+    }
+
+    /** Replaces one route's immutable content and preserves focus by item id when visible. */
+    public void setPage(MenuPageSpec spec) {
+        Objects.requireNonNull(spec, "spec");
+        MenuPresentation next;
+        synchronized (lock) {
+            MenuPage page = MenuPage.from(spec);
+            pages.put(spec.route(), page);
+            if (state.visible() && state.route() == spec.route()) {
+                state = MenuReducer.replaceCurrent(state, page);
+            }
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    /** Replaces several routes atomically so dynamic rows do not produce intermediate frames. */
+    public void setPages(Collection<MenuPageSpec> specs) {
+        Objects.requireNonNull(specs, "specs");
+        MenuPresentation next;
+        synchronized (lock) {
+            for (MenuPageSpec spec : specs) {
+                MenuPage page = MenuPage.from(Objects.requireNonNull(spec, "spec"));
+                pages.put(spec.route(), page);
+                if (state.visible() && state.route() == spec.route()) {
+                    state = MenuReducer.replaceCurrent(state, page);
+                }
+            }
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    public void show(MenuRoute route) {
+        MenuPresentation next;
+        synchronized (lock) {
+            state = MenuReducer.show(state, page(route));
+            clearTransientInputsLocked(true);
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    public void push(MenuRoute route) {
+        MenuPresentation next;
+        synchronized (lock) {
+            state = MenuReducer.push(state, page(route));
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    public void back() {
+        MenuPresentation next;
+        synchronized (lock) {
+            if (!state.visible()) {
+                return;
+            }
+            state = MenuReducer.back(state);
+            if (!state.visible()) {
+                clearTransientInputsLocked(false);
+            }
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    public void hide() {
+        MenuPresentation next;
+        synchronized (lock) {
+            if (!state.visible()) {
+                return;
+            }
+            state = MenuReducer.hide(state);
+            clearTransientInputsLocked(false);
+            next = state.presentation();
+        }
+        notifyPresentation(next);
+    }
+
+    /** Handles a physical/keypad key. Repeats are consumed without re-running the action. */
+    public boolean onKeyDown(MenuKey key, boolean repeat) {
+        Objects.requireNonNull(key, "key");
+        MenuPresentation next = null;
+        Event event = null;
+        synchronized (lock) {
+            if (!state.visible()) {
+                return false;
+            }
+            capturedKeys.add(key);
+            if (repeat || !keyHeld.add(key)) {
+                return true;
+            }
+            Transition transition = activateLocked(key);
+            next = transition.presentation;
+            event = transition.event;
+        }
+        notifyTransition(next, event);
+        return true;
+    }
+
+    /** Consumes key-up for every key whose key-down was captured by the visible menu. */
+    public boolean onKeyUp(MenuKey key) {
+        Objects.requireNonNull(key, "key");
+        synchronized (lock) {
+            boolean consumed = capturedKeys.remove(key);
+            keyHeld.remove(key);
+            return consumed || state.visible();
+        }
+    }
+
+    /** Converts joystick/hat values to edge-triggered menu movement with a stable dead zone. */
+    public boolean onAxis(float x, float y) {
+        EnumSet<MenuKey> nextAxis = EnumSet.noneOf(MenuKey.class);
+        if (Float.isFinite(x) && Math.abs(x) >= AXIS_DEAD_ZONE) {
+            nextAxis.add(x < 0.0f ? MenuKey.LEFT : MenuKey.RIGHT);
+        }
+        if (Float.isFinite(y) && Math.abs(y) >= AXIS_DEAD_ZONE) {
+            nextAxis.add(y < 0.0f ? MenuKey.UP : MenuKey.DOWN);
+        }
+
+        MenuPresentation nextPresentation = null;
+        List<Event> events = new ArrayList<>();
+        synchronized (lock) {
+            if (!state.visible()) {
+                axisHeld.clear();
+                return false;
+            }
+            EnumSet<MenuKey> previous = EnumSet.copyOf(axisHeld);
+            axisHeld.clear();
+            axisHeld.addAll(nextAxis);
+            for (MenuKey key : nextAxis) {
+                if (!previous.contains(key) && !heldByOtherSourceLocked(key)) {
+                    Transition transition = activateLocked(key);
+                    nextPresentation = transition.presentation;
+                    if (transition.event != null) {
+                        events.add(transition.event);
+                    }
+                }
+            }
+        }
+        if (nextPresentation != null) {
+            notifyPresentation(nextPresentation);
+        }
+        for (Event event : events) {
+            notifyEvent(event);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean visible() {
+        return visibleInternal();
+    }
+
+    @Override
+    public void updatePointer(int pointerId, Collection<MenuKey> keys) {
+        Objects.requireNonNull(keys, "keys");
+        MenuPresentation nextPresentation = null;
+        List<Event> events = new ArrayList<>();
+        synchronized (lock) {
+            if (!state.visible()) {
+                touchPointers.remove(pointerId);
+                return;
+            }
+            EnumSet<MenuKey> previous = touchPointers.get(pointerId);
+            if (previous == null) {
+                previous = EnumSet.noneOf(MenuKey.class);
+            }
+            EnumSet<MenuKey> next = EnumSet.noneOf(MenuKey.class);
+            for (MenuKey key : keys) {
+                if (key != null) {
+                    next.add(key);
+                }
+            }
+            touchPointers.remove(pointerId);
+            for (MenuKey key : next) {
+                if (!previous.contains(key) && !heldByOtherSourceLocked(key)) {
+                    Transition transition = activateLocked(key);
+                    nextPresentation = transition.presentation;
+                    if (transition.event != null) {
+                        events.add(transition.event);
+                    }
+                }
+            }
+            if (state.visible() && !next.isEmpty()) {
+                touchPointers.put(pointerId, next);
+            }
+        }
+        if (nextPresentation != null) {
+            notifyPresentation(nextPresentation);
+        }
+        for (Event event : events) {
+            notifyEvent(event);
+        }
+    }
+
+    @Override
+    public void releasePointer(int pointerId) {
+        synchronized (lock) {
+            touchPointers.remove(pointerId);
+        }
+    }
+
+    @Override
+    public void releaseAllPointers() {
+        synchronized (lock) {
+            touchPointers.clear();
+        }
+    }
+
+    /** Clears transient input after focus loss without changing the current menu route. */
+    public void cancelInput() {
+        synchronized (lock) {
+            clearTransientInputsLocked(true);
+        }
+    }
+
+    private boolean visibleInternal() {
+        synchronized (lock) {
+            return state.visible();
+        }
+    }
+
+    private MenuPage page(MenuRoute route) {
+        Objects.requireNonNull(route, "route");
+        MenuPage page = pages.get(route);
+        if (page == null) {
+            throw new IllegalArgumentException("No page for route " + route);
+        }
+        return page;
+    }
+
+    private Transition activateLocked(MenuKey key) {
+        switch (key) {
+            case UP -> state = MenuReducer.move(state, MenuCommand.Direction.UP);
+            case DOWN -> state = MenuReducer.move(state, MenuCommand.Direction.DOWN);
+            case LEFT -> state = MenuReducer.move(state, MenuCommand.Direction.LEFT);
+            case RIGHT -> state = MenuReducer.move(state, MenuCommand.Direction.RIGHT);
+            case B -> {
+                state = MenuReducer.back(state);
+                if (!state.visible()) {
+                    clearTransientInputsLocked(false);
+                }
+            }
+            case A -> {
+                MenuItem item = state.page().items().get(state.focusedIndex());
+                if (item.enabled()) {
+                    return new Transition(state.presentation(), Event.item(
+                            state.route(), item.id(), false));
+                }
+            }
+            case SELECT, SECONDARY -> {
+                MenuItem item = state.page().items().get(state.focusedIndex());
+                if (item.enabled() && item.secondaryId() != null) {
+                    return new Transition(state.presentation(), Event.item(
+                            state.route(), item.secondaryId(), true));
+                }
+            }
+            case START -> {
+                if (!state.page().headerAction().isEmpty()) {
+                    return new Transition(state.presentation(), Event.header(state.route()));
+                }
+            }
+        }
+        return new Transition(state.presentation(), null);
+    }
+
+    private boolean heldByOtherSourceLocked(MenuKey key) {
+        if (keyHeld.contains(key)) {
+            return true;
+        }
+        for (EnumSet<MenuKey> pointer : touchPointers.values()) {
+            if (pointer.contains(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void clearTransientInputsLocked(boolean clearCaptured) {
+        keyHeld.clear();
+        axisHeld.clear();
+        touchPointers.clear();
+        if (clearCaptured) {
+            capturedKeys.clear();
+        }
+    }
+
+    private void notifyTransition(MenuPresentation presentation, Event event) {
+        notifyPresentation(presentation);
+        if (event != null) {
+            notifyEvent(event);
+        }
+    }
+
+    private void notifyPresentation(MenuPresentation presentation) {
+        listener.onPresentation(presentation);
+    }
+
+    private void notifyEvent(Event event) {
+        if (event.header) {
+            listener.onHeaderSelected(event.route);
+        } else {
+            listener.onItemSelected(event.route, event.id, event.secondary);
+        }
+    }
+
+    private static final class Transition {
+        private final MenuPresentation presentation;
+        private final Event event;
+
+        private Transition(MenuPresentation presentation, Event event) {
+            this.presentation = presentation;
+            this.event = event;
+        }
+    }
+
+    private static final class Event {
+        private final MenuRoute route;
+        private final String id;
+        private final boolean secondary;
+        private final boolean header;
+
+        private Event(MenuRoute route, String id, boolean secondary, boolean header) {
+            this.route = route;
+            this.id = id;
+            this.secondary = secondary;
+            this.header = header;
+        }
+
+        private static Event item(MenuRoute route, String id, boolean secondary) {
+            return new Event(route, id, secondary, false);
+        }
+
+        private static Event header(MenuRoute route) {
+            return new Event(route, null, false, true);
+        }
+    }
+
+    /** Semantic menu callbacks; implementations normally run on Android's main thread. */
+    public interface Listener {
+        void onPresentation(MenuPresentation presentation);
+
+        void onItemSelected(MenuRoute route, String id, boolean secondary);
+
+        void onHeaderSelected(MenuRoute route);
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuGeometry.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuGeometry.java
@@ -13,6 +13,8 @@ final class MenuGeometry {
     static final int LANDSCAPE_HEIGHT = 240;
     static final int PORTRAIT_WIDTH = 240;
     static final int PORTRAIT_HEIGHT = 320;
+    private static final float THUMBNAIL_COLUMNS = 36.0f;
+    private static final float THUMBNAIL_ROWS = 20.0f;
 
     private MenuGeometry() {
     }
@@ -30,6 +32,51 @@ final class MenuGeometry {
         return new Layout(portrait, (int) logicalWidth, (int) logicalHeight, scale,
                 (displayWidth - contentWidth) / 2.0f, (displayHeight - contentHeight) / 2.0f,
                 contentWidth, contentHeight);
+    }
+
+    static ThumbnailGrid thumbnailGrid(float width, float height) {
+        if (!(width > 0.0f) || !(height > 0.0f)
+                || !Float.isFinite(width) || !Float.isFinite(height)) {
+            return new ThumbnailGrid(0.0f, 0.0f);
+        }
+        return new ThumbnailGrid(width / THUMBNAIL_COLUMNS, height / THUMBNAIL_ROWS);
+    }
+
+    static final class ThumbnailGrid {
+
+        private final float unitX;
+        private final float unitY;
+
+        private ThumbnailGrid(float unitX, float unitY) {
+            this.unitX = unitX;
+            this.unitY = unitY;
+        }
+
+        float unitX() {
+            return unitX;
+        }
+
+        float unitY() {
+            return unitY;
+        }
+
+        float x(float column) {
+            return column * unitX;
+        }
+
+        float y(float row) {
+            return row * unitY;
+        }
+
+        boolean valid() {
+            return unitX > 0.0f && unitY > 0.0f;
+        }
+
+        boolean contains(float left, float top, float right, float bottom) {
+            return valid() && left >= 0.0f && top >= 0.0f
+                    && right >= left && bottom >= top
+                    && right <= THUMBNAIL_COLUMNS && bottom <= THUMBNAIL_ROWS;
+        }
     }
 
     static final class Layout {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuKey.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuKey.java
@@ -1,0 +1,14 @@
+package eu.rekawek.coffeegb.android.menu;
+
+/** Logical controls understood by the in-screen menu. */
+public enum MenuKey {
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT,
+    A,
+    B,
+    START,
+    SELECT,
+    SECONDARY
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPage.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPage.java
@@ -40,6 +40,16 @@ final class MenuPage {
         }
     }
 
+    static MenuPage from(MenuPageSpec spec) {
+        ArrayList<MenuItem> items = new ArrayList<>(spec.items().size());
+        for (MenuPageSpec.Item item : spec.items()) {
+            items.add(new MenuItem(item.id(), item.label(), item.detail(), item.enabled(),
+                    item.secondaryId()));
+        }
+        return new MenuPage(spec.route(), spec.title(), spec.context(), spec.headerAction(),
+                spec.sideHeading(), spec.sideLines(), items, spec.columns(), spec.footerHints());
+    }
+
     MenuRoute route() {
         return route;
     }
@@ -130,20 +140,26 @@ final class MenuItem {
     private final String label;
     private final String detail;
     private final boolean enabled;
+    private final String secondaryId;
 
     MenuItem(String id, String label) {
         this(id, label, "", true);
     }
 
     MenuItem(String id, String label, String detail) {
-        this(id, label, detail, true);
+        this(id, label, detail, true, null);
     }
 
     MenuItem(String id, String label, String detail, boolean enabled) {
+        this(id, label, detail, enabled, null);
+    }
+
+    MenuItem(String id, String label, String detail, boolean enabled, String secondaryId) {
         this.id = text(id, "id");
         this.label = text(label, "label");
         this.detail = text(detail, "detail");
         this.enabled = enabled;
+        this.secondaryId = secondaryId == null ? null : text(secondaryId, "secondaryId");
     }
 
     String id() {
@@ -162,8 +178,12 @@ final class MenuItem {
         return enabled;
     }
 
+    String secondaryId() {
+        return secondaryId;
+    }
+
     MenuPresentation.Item presentation() {
-        return new MenuPresentation.Item(id, label, detail, enabled);
+        return new MenuPresentation.Item(id, label, detail, enabled, secondaryId);
     }
 
     private static String text(String value, String name) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPageSpec.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPageSpec.java
@@ -1,0 +1,151 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable page data supplied by the Android coordinator, including dynamic runtime rows. */
+public final class MenuPageSpec {
+
+    private final MenuRoute route;
+    private final String title;
+    private final String context;
+    private final String headerAction;
+    private final String sideHeading;
+    private final List<String> sideLines;
+    private final List<Item> items;
+    private final int columns;
+    private final List<String> footerHints;
+
+    public MenuPageSpec(MenuRoute route, String title, String context, String headerAction,
+            String sideHeading, List<String> sideLines, List<Item> items, int columns,
+            List<String> footerHints) {
+        this.route = Objects.requireNonNull(route, "route");
+        this.title = text(title, "title");
+        this.context = text(context, "context");
+        this.headerAction = text(headerAction, "headerAction");
+        this.sideHeading = text(sideHeading, "sideHeading");
+        this.sideLines = strings(sideLines, "sideLines");
+        this.items = items(items);
+        this.columns = Math.max(1, columns);
+        this.footerHints = strings(footerHints, "footerHints");
+        boolean enabled = false;
+        for (Item item : this.items) {
+            if (item.enabled()) {
+                enabled = true;
+                break;
+            }
+        }
+        if (!enabled) {
+            throw new IllegalArgumentException("A menu page needs an enabled item");
+        }
+    }
+
+    public MenuRoute route() {
+        return route;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String context() {
+        return context;
+    }
+
+    public String headerAction() {
+        return headerAction;
+    }
+
+    public String sideHeading() {
+        return sideHeading;
+    }
+
+    public List<String> sideLines() {
+        return sideLines;
+    }
+
+    public List<Item> items() {
+        return items;
+    }
+
+    public int columns() {
+        return columns;
+    }
+
+    public List<String> footerHints() {
+        return footerHints;
+    }
+
+    private static String text(String value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        return value;
+    }
+
+    private static List<String> strings(List<String> values, String name) {
+        if (values == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        ArrayList<String> copy = new ArrayList<>(values.size());
+        for (String value : values) {
+            copy.add(text(value, name + " entry"));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    private static List<Item> items(List<Item> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("A menu page needs items");
+        }
+        ArrayList<Item> copy = new ArrayList<>(values.size());
+        for (Item item : values) {
+            copy.add(Objects.requireNonNull(item, "items cannot contain null"));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    /** One immutable primary row and optional secondary action. */
+    public static final class Item {
+
+        private final String id;
+        private final String label;
+        private final String detail;
+        private final boolean enabled;
+        private final String secondaryId;
+
+        public Item(String id, String label, String detail, boolean enabled) {
+            this(id, label, detail, enabled, null);
+        }
+
+        public Item(String id, String label, String detail, boolean enabled, String secondaryId) {
+            this.id = text(id, "id");
+            this.label = text(label, "label");
+            this.detail = text(detail, "detail");
+            this.enabled = enabled;
+            this.secondaryId = secondaryId == null ? null : text(secondaryId, "secondaryId");
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String label() {
+            return label;
+        }
+
+        public String detail() {
+            return detail;
+        }
+
+        public boolean enabled() {
+            return enabled;
+        }
+
+        public String secondaryId() {
+            return secondaryId;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPresentation.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuPresentation.java
@@ -137,12 +137,18 @@ public final class MenuPresentation {
         private final String label;
         private final String detail;
         private final boolean enabled;
+        private final String secondaryId;
 
         public Item(String id, String label, String detail, boolean enabled) {
+            this(id, label, detail, enabled, null);
+        }
+
+        public Item(String id, String label, String detail, boolean enabled, String secondaryId) {
             this.id = requireText(id, "id");
             this.label = requireText(label, "label");
             this.detail = requireText(detail, "detail");
             this.enabled = enabled;
+            this.secondaryId = secondaryId == null ? null : requireText(secondaryId, "secondaryId");
         }
 
         public String id() {
@@ -159,6 +165,10 @@ public final class MenuPresentation {
 
         public boolean enabled() {
             return enabled;
+        }
+
+        public String secondaryId() {
+            return secondaryId;
         }
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuReducer.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuReducer.java
@@ -29,6 +29,13 @@ final class MenuReducer {
     static MenuState show(MenuState state, MenuRoute route) {
         requireRoute(route);
         MenuPage page = MenuPages.forRoute(route);
+        return show(state, page);
+    }
+
+    static MenuState show(MenuState state, MenuPage page) {
+        if (page == null) {
+            throw new IllegalArgumentException("page is required");
+        }
         return MenuState.visible(page, page.firstEnabledIndex());
     }
 
@@ -45,11 +52,42 @@ final class MenuReducer {
         }
         requireRoute(route);
         MenuPage page = MenuPages.forRoute(route);
+        return push(state, page);
+    }
+
+    static MenuState push(MenuState state, MenuPage page) {
+        if (state == null) {
+            throw new IllegalArgumentException("state is required");
+        }
+        if (page == null) {
+            throw new IllegalArgumentException("page is required");
+        }
         if (!state.visible()) {
             return MenuState.visible(page, page.firstEnabledIndex());
         }
         ArrayList<MenuState.Frame> stack = new ArrayList<>(state.stack());
         stack.add(new MenuState.Frame(page, page.firstEnabledIndex()));
+        return MenuState.withStack(stack);
+    }
+
+    static MenuState replaceCurrent(MenuState state, MenuPage page) {
+        if (state == null || page == null) {
+            throw new IllegalArgumentException("state and page are required");
+        }
+        if (!state.visible()) {
+            return state;
+        }
+        String focusedId = state.focusedItemId();
+        int focusedIndex = page.firstEnabledIndex();
+        for (int index = 0; index < page.items().size(); index++) {
+            if (page.items().get(index).enabled()
+                    && page.items().get(index).id().equals(focusedId)) {
+                focusedIndex = index;
+                break;
+            }
+        }
+        ArrayList<MenuState.Frame> stack = new ArrayList<>(state.stack());
+        stack.set(stack.size() - 1, new MenuState.Frame(page, focusedIndex));
         return MenuState.withStack(stack);
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRenderer.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRenderer.java
@@ -127,30 +127,46 @@ public final class MenuRenderer {
         }
     }
 
-    private void drawThumbnail(Canvas canvas, RectF bounds) {
-        fill.setColor(OLIVE_LIGHT);
-        canvas.drawRect(bounds, fill);
-        stroke.setColor(INK);
-        stroke.setStrokeWidth(1.0f);
-        canvas.drawRect(bounds, stroke);
-        float unit = Math.max(1.0f, bounds.width() / 36.0f);
-        fill.setColor(MINT_DARK);
-        for (int index = 0; index < 13; index++) {
-            float x = bounds.left + (index * 7 % 31) * unit;
-            float y = bounds.top + (index * 11 % 19) * unit;
-            canvas.drawRect(x, y, x + unit * 3, y + unit * 2, fill);
+    void drawThumbnail(Canvas canvas, RectF bounds) {
+        MenuGeometry.ThumbnailGrid grid = MenuGeometry.thumbnailGrid(
+                bounds.width(), bounds.height());
+        if (!grid.valid()) {
+            return;
         }
-        fill.setColor(MINT);
-        canvas.drawRect(bounds.left + unit * 3, bounds.bottom - unit * 7,
-                bounds.left + unit * 13, bounds.bottom - unit * 3, fill);
-        canvas.drawRect(bounds.left + unit * 23, bounds.bottom - unit * 13,
-                bounds.left + unit * 31, bounds.bottom - unit * 3, fill);
-        fill.setColor(CREAM);
-        float characterX = bounds.left + bounds.width() * 0.28f;
-        float characterY = bounds.bottom - unit * 8;
-        canvas.drawRect(characterX, characterY, characterX + unit * 4, characterY + unit * 5, fill);
-        canvas.drawRect(characterX + unit, characterY - unit * 3,
-                characterX + unit * 3, characterY, fill);
+        int save = canvas.save();
+        try {
+            // Thumbnail art is decorative and must never escape into side text or menu rows.
+            canvas.clipRect(bounds);
+            fill.setColor(OLIVE_LIGHT);
+            canvas.drawRect(bounds, fill);
+            stroke.setColor(INK);
+            stroke.setStrokeWidth(1.0f);
+            canvas.drawRect(bounds, stroke);
+
+            fill.setColor(MINT_DARK);
+            for (int index = 0; index < 13; index++) {
+                float column = index * 7 % 31;
+                float row = index * 11 % 19;
+                drawThumbnailRect(canvas, bounds, grid, column, row, column + 3, row + 2);
+            }
+            fill.setColor(MINT);
+            drawThumbnailRect(canvas, bounds, grid, 3, 13, 13, 17);
+            drawThumbnailRect(canvas, bounds, grid, 23, 7, 31, 17);
+            fill.setColor(CREAM);
+            float characterColumn = 36.0f * 0.28f;
+            drawThumbnailRect(canvas, bounds, grid, characterColumn, 12,
+                    characterColumn + 4, 17);
+            drawThumbnailRect(canvas, bounds, grid, characterColumn + 1, 9,
+                    characterColumn + 3, 12);
+        } finally {
+            canvas.restoreToCount(save);
+        }
+    }
+
+    private void drawThumbnailRect(Canvas canvas, RectF bounds,
+            MenuGeometry.ThumbnailGrid grid, float left, float top, float right, float bottom) {
+        canvas.drawRect(bounds.left + grid.x(left), bounds.top + grid.y(top),
+                bounds.left + grid.x(right), bounds.top + grid.y(bottom), fill);
     }
 
     private void drawList(Canvas canvas, MenuPresentation presentation, RectF bounds) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRoute.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuRoute.java
@@ -23,7 +23,7 @@ public enum MenuRoute {
         this.label = label;
     }
 
-    String label() {
+    public String label() {
         return label;
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuTouchInput.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/MenuTouchInput.java
@@ -1,0 +1,15 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.Collection;
+
+/** Touch bridge used by the video surface while an in-screen menu is visible. */
+public interface MenuTouchInput {
+
+    boolean visible();
+
+    void updatePointer(int pointerId, Collection<MenuKey> keys);
+
+    void releasePointer(int pointerId);
+
+    void releaseAllPointers();
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/OpenRomPickerState.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/menu/OpenRomPickerState.java
@@ -1,0 +1,58 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import java.util.Objects;
+
+/** Immutable origin state for a native ROM picker launched from the in-screen menu. */
+public final class OpenRomPickerState {
+
+    private static final OpenRomPickerState NONE =
+            new OpenRomPickerState(null, false, false);
+
+    private final MenuRoute route;
+    private final boolean pauseOwned;
+    private final boolean restoreRequested;
+
+    private OpenRomPickerState(MenuRoute route, boolean pauseOwned, boolean restoreRequested) {
+        this.route = route;
+        this.pauseOwned = pauseOwned;
+        this.restoreRequested = restoreRequested;
+    }
+
+    public static OpenRomPickerState none() {
+        return NONE;
+    }
+
+    public static OpenRomPickerState launched(MenuRoute route, boolean pauseOwned) {
+        return new OpenRomPickerState(Objects.requireNonNull(route, "route"), pauseOwned, false);
+    }
+
+    public static OpenRomPickerState restored(MenuRoute route, boolean pauseOwned,
+            boolean restoreRequested) {
+        return new OpenRomPickerState(
+                Objects.requireNonNull(route, "route"), pauseOwned, restoreRequested);
+    }
+
+    public OpenRomPickerState canceled() {
+        return active() ? new OpenRomPickerState(route, pauseOwned, true) : this;
+    }
+
+    public OpenRomPickerState completed() {
+        return NONE;
+    }
+
+    public boolean active() {
+        return route != null;
+    }
+
+    public MenuRoute route() {
+        return route;
+    }
+
+    public boolean pauseOwned() {
+        return pauseOwned;
+    }
+
+    public boolean restoreRequested() {
+        return restoreRequested;
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuControllerTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuControllerTest.java
@@ -62,6 +62,22 @@ public class MenuControllerTest {
         assertEquals("delete:0", controller.presentation().items().get(0).secondaryId());
     }
 
+    @Test
+    public void systemBackDispatchesExactlyOneBEdgeAndFallsThroughWhenHidden() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.show(MenuRoute.PAUSE_CONSOLE);
+        controller.push(MenuRoute.SETTINGS);
+
+        assertTrue(controller.dispatchBackEdge());
+        assertTrue(controller.visible());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, controller.route());
+
+        assertTrue(controller.dispatchBackEdge());
+        assertFalse(controller.visible());
+        assertFalse(controller.dispatchBackEdge());
+    }
+
     private static MenuPageSpec page(MenuRoute route, int columns, List<MenuPageSpec.Item> items) {
         return new MenuPageSpec(route, "COFFEE GB", "TEST", "", "TEST", List.of("TEST"),
                 items, columns, List.of("[A] OK", "[B] BACK"));

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuControllerTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuControllerTest.java
@@ -1,0 +1,91 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MenuControllerTest {
+
+    @Test
+    public void repeatedConfirmAndKeyUpAreConsumedOnce() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.setPage(page(MenuRoute.CONFIRM_ACTION, 1,
+                List.of(item("confirm", "CONFIRM", true, null))));
+        controller.show(MenuRoute.CONFIRM_ACTION);
+
+        assertTrue(controller.onKeyDown(MenuKey.A, false));
+        assertTrue(controller.onKeyDown(MenuKey.A, true));
+        assertTrue(controller.onKeyUp(MenuKey.A));
+
+        assertEquals(List.of("confirm:false"), events.items);
+        controller.onKeyDown(MenuKey.B, false);
+        assertFalse(controller.visible());
+        assertTrue(controller.onKeyUp(MenuKey.B));
+    }
+
+    @Test
+    public void axisMovementTriggersOnlyOnEdgesUntilNeutral() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.setPage(page(MenuRoute.CONFIRM_ACTION, 2, List.of(
+                item("one", "ONE", true, null), item("two", "TWO", true, null))));
+        controller.show(MenuRoute.CONFIRM_ACTION);
+
+        controller.onAxis(1.0f, 0.0f);
+        controller.onAxis(1.0f, 0.0f);
+        assertEquals(1, controller.presentation().focusedIndex());
+        controller.onAxis(0.0f, 0.0f);
+        controller.onAxis(1.0f, 0.0f);
+        assertEquals(0, controller.presentation().focusedIndex());
+    }
+
+    @Test
+    public void secondaryPointerActionUsesImmutablePageMetadata() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.setPage(page(MenuRoute.SAVE_STATES, 1,
+                List.of(item("slot:0", "SLOT 0", true, "delete:0"))));
+        controller.show(MenuRoute.SAVE_STATES);
+
+        controller.updatePointer(7, List.of(MenuKey.SELECT));
+        controller.updatePointer(7, List.of(MenuKey.SELECT));
+        controller.releasePointer(7);
+
+        assertEquals(List.of("delete:0:true"), events.items);
+        assertEquals("slot:0", controller.presentation().items().get(0).id());
+        assertEquals("delete:0", controller.presentation().items().get(0).secondaryId());
+    }
+
+    private static MenuPageSpec page(MenuRoute route, int columns, List<MenuPageSpec.Item> items) {
+        return new MenuPageSpec(route, "COFFEE GB", "TEST", "", "TEST", List.of("TEST"),
+                items, columns, List.of("[A] OK", "[B] BACK"));
+    }
+
+    private static MenuPageSpec.Item item(String id, String label, boolean enabled,
+            String secondaryId) {
+        return new MenuPageSpec.Item(id, label, "", enabled, secondaryId);
+    }
+
+    private static final class Events implements MenuController.Listener {
+        private final List<String> items = new ArrayList<>();
+
+        @Override
+        public void onPresentation(MenuPresentation presentation) {
+        }
+
+        @Override
+        public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+            items.add(id + ":" + secondary);
+        }
+
+        @Override
+        public void onHeaderSelected(MenuRoute route) {
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuGeometryTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/MenuGeometryTest.java
@@ -47,4 +47,23 @@ public class MenuGeometryTest {
         assertEquals(0, invalid.logicalWidth());
         assertEquals(0, invalid.logicalHeight());
     }
+
+    @Test
+    public void shortWideThumbnailUsesIndependentAxesAndKeepsDecorationInBounds() {
+        MenuGeometry.ThumbnailGrid grid = MenuGeometry.thumbnailGrid(294.0f, 28.0f);
+
+        assertTrue(grid.valid());
+        assertEquals(294.0f / 36.0f, grid.unitX(), 0.001f);
+        assertEquals(28.0f / 20.0f, grid.unitY(), 0.001f);
+        assertTrue(grid.unitY() < grid.unitX());
+        for (int index = 0; index < 13; index++) {
+            float column = index * 7 % 31;
+            float row = index * 11 % 19;
+            assertTrue(grid.contains(column, row, column + 3, row + 2));
+        }
+        assertTrue(grid.contains(3, 13, 13, 17));
+        assertTrue(grid.contains(23, 7, 31, 17));
+        assertTrue(grid.contains(36.0f * 0.28f, 12, 36.0f * 0.28f + 4, 17));
+        assertFalse(MenuGeometry.thumbnailGrid(294.0f, 0.0f).valid());
+    }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/OpenRomPickerStateTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/menu/OpenRomPickerStateTest.java
@@ -1,0 +1,42 @@
+package eu.rekawek.coffeegb.android.menu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OpenRomPickerStateTest {
+
+    @Test
+    public void cancelRequestsTheExactMenuRouteWithPauseOwnership() {
+        OpenRomPickerState state = OpenRomPickerState
+                .launched(MenuRoute.PAUSE_CONSOLE, true)
+                .canceled();
+
+        assertTrue(state.active());
+        assertTrue(state.restoreRequested());
+        assertTrue(state.pauseOwned());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, state.route());
+    }
+
+    @Test
+    public void successfulSelectionDiscardsTheOldMenuSession() {
+        OpenRomPickerState state = OpenRomPickerState
+                .launched(MenuRoute.LIBRARY, false)
+                .completed();
+
+        assertFalse(state.active());
+        assertFalse(state.restoreRequested());
+        assertFalse(state.pauseOwned());
+    }
+
+    @Test
+    public void recreatedCanceledPickerStillRequestsRestore() {
+        OpenRomPickerState state = OpenRomPickerState.restored(
+                MenuRoute.PAUSE_CONSOLE, true, true);
+
+        assertTrue(state.restoreRequested());
+        assertEquals(MenuRoute.PAUSE_CONSOLE, state.route());
+    }
+}


### PR DESCRIPTION
## Summary

- replace the Android popup entry points for Library, Pause, save states, recent ROMs, ZIP selection, and confirmations with Proposal 3 routes rendered inside the Game Boy screen
- add edge-triggered keyboard, controller, and skin-touch menu input without leaking held controls into gameplay
- keep ROM browsing in Android Documents UI and restore the originating menu when the picker is canceled, including Activity recreation
- add dynamic state/recent rows, predictive/system Back handling, and regression coverage for portrait thumbnail clipping and picker state

## Validation

- Android unit tests: 46 passed
- API 36 connected instrumentation tests: 4 passed
- lint, debug APK, and minified release APK passed
- portrait and landscape Library rendering checked on the emulator
- native Documents UI handoff and cancel restoration checked on the emulator
- live API 36 system Back check: first Back closes the in-screen menu; second Back finishes the Activity
- git diff --check
