### PR TITLE
Avoid shell icon lookups in ROM chooser

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/RomFileChooser.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/RomFileChooser.kt
@@ -33,11 +33,18 @@ internal class RomFileChooser : JFileChooser() {
         else -> super.getName(file)
       }
 
+  /**
+   * FlatLaf's Windows renderer resolves ordinary icons through the shell while painting each
+   * row, which blocks the EDT when scrolling through a large ROM directory. Use the generic
+   * Swing icons instead; UIManager lookup is constant-time and constructor-safe.
+   */
   override fun getIcon(file: File?): Icon? =
       when (file) {
         is SyntacticDirectoryFile -> UIManager.getIcon("FileView.directoryIcon")
         null -> null
-        else -> super.getIcon(file)
+        else ->
+            if (file.isDirectory()) UIManager.getIcon("FileView.directoryIcon")
+            else UIManager.getIcon("FileView.fileIcon")
       }
 
   private class SyntacticDirectoryFile(path: String) : File(path) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/RomFileChooserTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/RomFileChooserTest.kt
@@ -1,0 +1,54 @@
+package eu.rekawek.coffeegb.swing
+
+import java.io.File
+import java.util.concurrent.FutureTask
+import javax.swing.Icon
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.filechooser.FileSystemView
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import org.junit.Test
+
+class RomFileChooserTest {
+
+  @Test
+  fun `ordinary entry icons use generic UI icons without shell lookup`() =
+      onEdt {
+        val chooser = RomFileChooser()
+        val fileSystemView = NoSystemIconFileSystemView()
+        chooser.fileSystemView = fileSystemView
+
+        val fileIcon = chooser.getIcon(File("game.gb"))
+        val secondFileIcon = chooser.getIcon(File("another.gb"))
+        val directoryIcon = chooser.getIcon(DirectoryEntry("roms"))
+
+        assertSame(UIManager.getIcon("FileView.fileIcon"), fileIcon)
+        assertSame(fileIcon, secondFileIcon)
+        assertSame(UIManager.getIcon("FileView.directoryIcon"), directoryIcon)
+        assertEquals(0, fileSystemView.systemIconCalls)
+      }
+
+  private class DirectoryEntry(path: String) : File(path) {
+    override fun isDirectory(): Boolean = true
+  }
+
+  private class NoSystemIconFileSystemView : FileSystemView() {
+    var systemIconCalls = 0
+
+    override fun createNewFolder(containingDir: File): File {
+      throw UnsupportedOperationException("not needed by this test")
+    }
+
+    override fun getSystemIcon(file: File): Icon {
+      systemIconCalls++
+      throw AssertionError("ROM chooser must not resolve shell icons")
+    }
+  }
+
+  private fun <T> onEdt(action: () -> T): T {
+    val task = FutureTask(action)
+    SwingUtilities.invokeAndWait(task)
+    return task.get()
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the large-directory ROM chooser slowdown reported in #513.

## Root cause

FlatLaf resolves ordinary JFileChooser entries through Windows shell icons while rows are painted. Those lookups run on the Swing EDT and stall scrolling through directories containing thousands of ROMs.

## Change

- Make `RomFileChooser` use generic Swing file/directory icons for ordinary entries.
- Preserve the configured synthetic-directory behavior.
- Add a regression test that fails if the chooser requests a system icon.

This keeps the existing Swing chooser and avoids shell icon work without changing ROM loading behavior.

## Validation

- `mvn -pl swing -am '-Dtest=RomFileChooserTest,PreferencesDialogTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- 33 tests passed (32 existing preferences tests, 1 new chooser regression test).
