### PR TITLE
Add exact Proposal 3 menu to desktop

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -290,8 +290,8 @@ public class MainActivitySmokeTest {
             moveFocusTo(scenario, instrumentation, "confirm");
             press(instrumentation, KeyEvent.KEYCODE_ENTER, 1);
 
-            await("native picker resumed", () -> externalSurfaceActive(scenario)
-                    && nativePickerResumed(instrumentation));
+            await("native picker input ready", () -> externalSurfaceActive(scenario)
+                    && nativePickerInputReady(instrumentation));
             sendSystemBack(instrumentation);
             awaitRoute(scenario, eu.rekawek.coffeegb.ui.menu.MenuRoute.DATA_MEDIA);
             awaitFocused(scenario, "import-battery");
@@ -546,14 +546,61 @@ public class MainActivitySmokeTest {
         String activities = shellOutput(instrumentation, "dumpsys activity activities");
         for (String line : activities.split("\\R")) {
             String trimmed = line.trim();
-            if (currentResumedActivity(trimmed)
-                    && (trimmed.contains("com.google.android.documentsui/")
-                    || trimmed.contains("com.android.documentsui/"))
-                    && trimmed.contains("PickActivity")) {
+            if (currentResumedActivity(trimmed) && nativePickerActivity(trimmed)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean nativePickerInputReady(Instrumentation instrumentation)
+            throws IOException {
+        if (!nativePickerResumed(instrumentation)) {
+            return false;
+        }
+        boolean legacy = Build.VERSION.SDK_INT <= Build.VERSION_CODES.O;
+        String windows = shellOutput(instrumentation,
+                legacy ? "dumpsys window -a" : "dumpsys window windows");
+        if (legacy && !appTransitionSnapshot(windows).idle()) {
+            return false;
+        }
+        FocusedWindow windowsCurrentFocus = currentFocusFromWindowDump(windows);
+        FocusedWindow currentFocus = windowsCurrentFocus;
+        if (!legacy) {
+            DisplayFocus displayFocus = displayZeroFocus(shellOutput(instrumentation,
+                    "dumpsys window displays"));
+            if (displayFocus.currentFocus().present()) {
+                if (windowsCurrentFocus.present()
+                        && !displayFocus.currentFocus().sameIdentity(windowsCurrentFocus)) {
+                    return false;
+                }
+                currentFocus = displayFocus.currentFocus();
+            }
+            if (displayFocus.focusedWindow().present()
+                    && !displayFocus.focusedWindow().sameIdentityAndTitle(currentFocus)) {
+                return false;
+            }
+        }
+        if (!nativePickerActivity(currentFocus.title())
+                || !windowBlockState(windows, currentFocus).ready()) {
+            return false;
+        }
+        String input = shellOutput(instrumentation, "dumpsys input");
+        InputFocusSignals inputFocusSignals = inputFocusSignals(input, legacy);
+        if (!inputFocusSignals.agree()) {
+            return false;
+        }
+        FocusedWindow inputFocus = inputFocusSignals.selected();
+        boolean inputIdentityMatches = currentFocus.sameIdentity(inputFocus);
+        return nativePickerActivity(inputFocus.title())
+                && inputIdentityMatches
+                && inputWindowState(input, currentFocus, legacy, inputIdentityMatches).ready();
+    }
+
+    private static boolean nativePickerActivity(String line) {
+        return (line.contains("com.google.android.documentsui/")
+                || line.contains("com.android.documentsui/"))
+                && line.contains("PickActivity");
     }
 
     private static boolean cameraPermissionResumed(Instrumentation instrumentation)
@@ -1384,8 +1431,10 @@ public class MainActivitySmokeTest {
     }
 
     private static void await(String action, CheckedCondition condition) throws Exception {
-        long deadline = SystemClock.uptimeMillis() + 60_000L;
-        while (!condition.get() && SystemClock.uptimeMillis() < deadline) {
+        for (int poll = 0; poll < 2_400; poll++) {
+            if (condition.get()) {
+                return;
+            }
             SystemClock.sleep(25L);
         }
         assertTrue("timed out waiting for " + action, condition.get());
@@ -1410,8 +1459,10 @@ public class MainActivitySmokeTest {
 
     private static void waitForState(ActivityScenario<?> scenario, Lifecycle.State expected,
             Instrumentation instrumentation) {
-        long deadline = SystemClock.uptimeMillis() + 3_000L;
-        while (scenario.getState() != expected && SystemClock.uptimeMillis() < deadline) {
+        for (int poll = 0; poll < 120; poll++) {
+            if (scenario.getState() == expected) {
+                return;
+            }
             instrumentation.waitForIdleSync();
             SystemClock.sleep(25L);
         }

--- a/swing/pom.xml
+++ b/swing/pom.xml
@@ -201,6 +201,11 @@
         </dependency>
         <dependency>
             <groupId>eu.rekawek.coffeegb</groupId>
+            <artifactId>ui-portable</artifactId>
+            <version>2.0.3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.rekawek.coffeegb</groupId>
             <artifactId>core</artifactId>
             <version>2.0.3-SNAPSHOT</version>
         </dependency>

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -14,6 +14,7 @@ internal enum class DesktopCommand {
   CLOSE_GAME,
   PREFERENCES,
   QUIT,
+  OPEN_MENU,
   PAUSE,
   RESET,
   SAVE_STATE,
@@ -64,6 +65,9 @@ internal data class DesktopCommandHandlers(
     val screenshot: () -> Unit,
     val setCommandBarVisible: (Boolean) -> Unit,
     val selectStateSlot: (Int) -> Unit,
+    val preferencesForCategory: ((PreferencesCategory) -> Unit)? = null,
+    val openMenu: () -> Unit = {},
+    val openAbout: (() -> Unit)? = null,
 )
 
 /**
@@ -72,12 +76,12 @@ internal data class DesktopCommandHandlers(
  */
 internal class DesktopActionRegistry(
     private val handlers: DesktopCommandHandlers,
-) {
+) : PortableMenuCommandBridge {
   private var presentation = DesktopCommandPresentation()
   private var appliedShortcuts: DesktopShortcutRegistry? = null
   private val actions =
       DesktopCommand.entries.associateWith { command ->
-        DesktopAction(commandMetadata(command)) { invoke(command) }
+        DesktopAction(commandMetadata(command)) { invokeCommand(command) }
       }
   val stateSlotActions: List<Action> =
       (0..9).map { slot ->
@@ -125,6 +129,56 @@ internal class DesktopActionRegistry(
     }
   }
 
+  override fun menuState(): DesktopPresentation =
+      DesktopPresentation(
+          gameTitle = if (presentation.gameLoaded) "loaded" else null,
+          commands = presentation,
+      )
+
+  override fun isEnabled(command: DesktopCommand): Boolean = actions.getValue(command).isEnabled
+
+  override fun invoke(command: DesktopCommand) {
+    val action = actions.getValue(command)
+    if (action.isEnabled) {
+      action.actionPerformed(
+          ActionEvent(this, ActionEvent.ACTION_PERFORMED, "portable-menu"),
+      )
+    }
+  }
+
+  override fun canOpenAbout(): Boolean = handlers.openAbout != null
+
+  override fun openAbout() {
+    handlers.openAbout?.invoke()
+  }
+
+  override fun setPaused(paused: Boolean) {
+    if (presentation.paused != paused && isEnabled(DesktopCommand.PAUSE)) {
+      handlers.setPaused(paused)
+    }
+  }
+
+  override fun openPreferences(category: PreferencesCategory) {
+    if (!isEnabled(DesktopCommand.PREFERENCES)) return
+    handlers.preferencesForCategory?.invoke(category) ?: handlers.preferences()
+  }
+
+  override fun canSaveState(slot: Int): Boolean =
+      slot in 0..9 && presentation.stateCommandsAvailable && !presentation.sessionBusy
+
+  override fun canLoadState(slot: Int): Boolean =
+      canSaveState(slot) && slot in presentation.loadableStateSlots
+
+  override fun saveState(slot: Int) {
+    if (canSaveState(slot)) handlers.saveState(slot)
+  }
+
+  override fun loadState(slot: Int) {
+    if (canLoadState(slot)) handlers.loadState(slot)
+  }
+
+  fun commandPresentation(): DesktopCommandPresentation = presentation
+
   fun current(): DesktopCommandPresentation = presentation
 
   /** The resolved shortcut, including a gameplay-conflict explanation, for Help surfaces. */
@@ -134,12 +188,13 @@ internal class DesktopActionRegistry(
   fun stateSlotShortcuts(): List<KeyStroke> =
       appliedShortcuts?.stateSlotShortcuts.orEmpty()
 
-  private fun invoke(command: DesktopCommand) {
+  private fun invokeCommand(command: DesktopCommand) {
     when (command) {
       DesktopCommand.OPEN_ROM -> handlers.openRom()
       DesktopCommand.CLOSE_GAME -> handlers.closeGame()
       DesktopCommand.PREFERENCES -> handlers.preferences()
       DesktopCommand.QUIT -> handlers.quit()
+      DesktopCommand.OPEN_MENU -> handlers.openMenu()
       DesktopCommand.PAUSE -> handlers.setPaused(!presentation.paused)
       DesktopCommand.RESET -> handlers.reset()
       DesktopCommand.SAVE_STATE -> handlers.saveState(presentation.stateSlot)
@@ -163,9 +218,10 @@ internal class DesktopActionRegistry(
         DesktopCommand.NETPLAY,
         DesktopCommand.MUTE,
         DesktopCommand.SHOW_COMMAND_BAR -> !state.sessionBusy
+        DesktopCommand.OPEN_MENU -> state.gameLoaded && !state.sessionBusy
         DesktopCommand.CLOSE_GAME,
         DesktopCommand.RESET -> state.gameLoaded && !state.sessionBusy
-        DesktopCommand.PAUSE ->
+      DesktopCommand.PAUSE ->
             state.gameLoaded && state.pauseSupported && !state.sessionBusy
         DesktopCommand.SAVE_STATE -> state.stateCommandsAvailable && !state.sessionBusy
         DesktopCommand.LOAD_STATE ->
@@ -209,6 +265,8 @@ private fun commandMetadata(command: DesktopCommand): DesktopActionMetadata =
     when (command) {
       DesktopCommand.OPEN_ROM ->
           DesktopActionMetadata("Open ROM…", "Open a Game Boy ROM or supported archive")
+      DesktopCommand.OPEN_MENU ->
+          DesktopActionMetadata("On-screen Menu", "Open the controller-friendly Proposal 3 menu")
       DesktopCommand.CLOSE_GAME ->
           DesktopActionMetadata("Close Game", "Close the current game")
       DesktopCommand.PREFERENCES ->

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopInputRouter.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopInputRouter.kt
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.swing
 
+import eu.rekawek.coffeegb.swing.io.DesktopMenuKeyboardInput
+import eu.rekawek.coffeegb.ui.menu.MenuKey
 import java.awt.Component
 import java.awt.KeyEventDispatcher
 import java.awt.KeyboardFocusManager
@@ -38,6 +40,8 @@ internal class DesktopInputRouter private constructor(
     private val belongsToMainWindow: (Component?) -> Boolean,
     private val yieldsToComponent: (Component?, Int) -> Boolean,
     private val isMenuActive: () -> Boolean,
+    private val portableMenu: DesktopMenuKeyboardInput?,
+    private val menuKeyForKeyCode: (Int) -> MenuKey?,
     private val joypadHandles: (Int) -> Boolean,
     private val joypadPressed: (KeyEvent) -> Unit,
     private val joypadReleased: (KeyEvent) -> Unit,
@@ -67,12 +71,16 @@ internal class DesktopInputRouter private constructor(
       releaseAll: () -> Unit,
       focusManager: KeyboardFocusManager =
           KeyboardFocusManager.getCurrentKeyboardFocusManager(),
+      portableMenu: DesktopMenuKeyboardInput? = null,
+      menuKeyForKeyCode: (Int) -> MenuKey? = { null },
   ) : this(
       DesktopKeyboardFocusManagerDispatcherRegistry(focusManager),
       WindowDesktopInputLifecycleRegistry(mainWindow, focusManager),
       belongsToMainWindow = { component -> component.belongsToInputWindow(mainWindow) },
       yieldsToComponent = ::componentOwnsDesktopKey,
       isMenuActive = { MenuSelectionManager.defaultManager().selectedPath.isNotEmpty() },
+      portableMenu,
+      menuKeyForKeyCode,
       joypadHandles,
       joypadPressed,
       joypadReleased,
@@ -97,12 +105,16 @@ internal class DesktopInputRouter private constructor(
       tiltReleased: (KeyEvent) -> Unit,
       releaseAll: () -> Unit,
       @Suppress("UNUSED_PARAMETER") testSeam: Unit = Unit,
+      portableMenu: DesktopMenuKeyboardInput? = null,
+      menuKeyForKeyCode: (Int) -> MenuKey? = { null },
   ) : this(
       registry,
       lifecycle,
       belongsToMainWindow,
       yieldsToComponent,
       isMenuActive,
+      portableMenu,
+      menuKeyForKeyCode,
       joypadHandles,
       joypadPressed,
       joypadReleased,
@@ -142,14 +154,33 @@ internal class DesktopInputRouter private constructor(
   override fun dispatchKeyEvent(event: KeyEvent): Boolean {
     val keyCode = event.keyCode
     if (event.id == KeyEvent.KEY_TYPED) {
-      return synchronized(lock) { captured.isNotEmpty() }
+      return synchronized(lock) { captured.isNotEmpty() } || portableMenu?.visible() == true
     }
     if (keyCode == KeyEvent.VK_UNDEFINED) return false
 
-    if (!belongsToMainWindow(event.component) ||
-        yieldsToComponent(event.component, keyCode) ||
-        isMenuActive() ||
-        hasDesktopCommandModifier(event)) {
+    if (!belongsToMainWindow(event.component) || hasDesktopCommandModifier(event)) {
+      releaseScope()
+      return false
+    }
+
+    val currentPortableMenu = portableMenu
+    if (currentPortableMenu?.visible() == true) {
+      val menuKey = menuKeyForKeyCode(keyCode)
+      return when (event.id) {
+        KeyEvent.KEY_PRESSED ->
+            menuKey?.let { currentPortableMenu.onKeyDown(it, false) } ?: true
+        KeyEvent.KEY_RELEASED ->
+            menuKey?.let { currentPortableMenu.onKeyUp(it) } ?: true
+        else -> false
+      }
+    }
+
+    if (yieldsToComponent(event.component, keyCode)) {
+      releaseScope()
+      return false
+    }
+
+    if (isMenuActive()) {
       releaseScope()
       return false
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
@@ -713,7 +713,10 @@ internal class DesktopQuitBridge(
 }
 
 /** Visible and screen-reader feedback for a supported drag entering the ROM drop target. */
-internal class RomDropFeedback(private val root: JRootPane) : AutoCloseable {
+internal class RomDropFeedback(
+    private val root: JRootPane,
+    private val enabled: () -> Boolean = { true },
+) : AutoCloseable {
   private var normalBorder = root.border
   private var activeDuringThemeChange = false
   private val idleDescription =
@@ -782,15 +785,16 @@ internal class RomDropFeedback(private val root: JRootPane) : AutoCloseable {
   }
 
   fun update(active: Boolean) {
-    root.border = if (active) highlight else normalBorder
-    message.isVisible = active
+    val effectiveActive = active && enabled()
+    root.border = if (effectiveActive) highlight else normalBorder
+    message.isVisible = effectiveActive
     root.accessibleContext.accessibleDescription =
-        if (active) {
+        if (effectiveActive) {
           "ROM drop target active. Release to open the selected input."
         } else {
           idleDescription
         }
-    if (active) {
+    if (effectiveActive) {
       layoutMessage()
       clearTimer.restart()
     } else {
@@ -822,9 +826,14 @@ internal class RomDropFeedback(private val root: JRootPane) : AutoCloseable {
 internal class RomDropTransferHandler(
     private val submit: (List<RomOpenInput>) -> Unit,
     private val feedback: (Boolean) -> Unit = {},
+    private val enabled: () -> Boolean = { true },
 ) : TransferHandler() {
 
   override fun canImport(support: TransferSupport): Boolean {
+    if (!enabled()) {
+      feedback(false)
+      return false
+    }
     val accepted =
         support.isDataFlavorSupported(DataFlavor.javaFileListFlavor) ||
             support.isDataFlavorSupported(DataFlavor.stringFlavor)
@@ -836,7 +845,7 @@ internal class RomDropTransferHandler(
   }
 
   override fun importData(support: TransferSupport): Boolean {
-    if (!canImport(support)) {
+    if (!enabled() || !canImport(support)) {
       feedback(false)
       return false
     }
@@ -854,7 +863,7 @@ internal class RomDropTransferHandler(
                 support.transferable.getTransferData(DataFlavor.stringFlavor) as String)
           }
       feedback(false)
-      if (inputs.isEmpty()) {
+      if (inputs.isEmpty() || !enabled()) {
         false
       } else {
         submit(inputs)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
@@ -28,21 +28,18 @@ import java.nio.file.Path
 import java.util.Locale
 import java.util.concurrent.Executor
 import javax.swing.BorderFactory
-import javax.swing.DefaultListCellRenderer
 import javax.swing.JButton
 import javax.swing.JDialog
 import javax.swing.JFileChooser
 import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JLayeredPane
-import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.JProgressBar
 import javax.swing.JRootPane
 import javax.swing.JScrollPane
 import javax.swing.JTextArea
 import javax.swing.JToggleButton
-import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import javax.swing.Timer
@@ -85,6 +82,16 @@ internal class DesktopRomOpen(
 
   private val service =
       RomOpenService(eventBus, properties.recentRoms) { update -> handleUpdate(update) }
+
+  private var archiveSelectionHost: DesktopArchiveSelectionHost? = null
+
+  /** Installs the in-screen archive-entry host after the emulator overlay is constructed. */
+  internal fun setArchiveSelectionHost(host: DesktopArchiveSelectionHost) {
+    check(SwingUtilities.isEventDispatchThread()) {
+      "Archive-selection host must be installed on the Event Dispatch Thread"
+    }
+    archiveSelectionHost = host
+  }
 
   fun open(path: Path, source: RomOpenSource) {
     open(listOf(RomOpenInput.LocalPath(path)), source)
@@ -182,13 +189,16 @@ internal class DesktopRomOpen(
     when (update) {
       is RomOpenUpdate.Progress -> handleProgress(update)
       is RomOpenUpdate.Opened -> {
+        archiveSelectionHost?.closeArchiveSelection(update.requestId)
         progress.close(update.requestId)
         onRecentChanged()
       }
       is RomOpenUpdate.Cancelled -> {
+        archiveSelectionHost?.closeArchiveSelection(update.requestId)
         progress.close(update.requestId)
       }
       is RomOpenUpdate.Failed -> {
+        archiveSelectionHost?.closeArchiveSelection(update.requestId)
         progress.close(update.requestId)
         if (update.source == RomOpenSource.RECENT &&
             update.failure.kind == RomOpenFailureKind.MISSING) {
@@ -204,15 +214,36 @@ internal class DesktopRomOpen(
     when (update.stage) {
       RomOpenStage.AWAITING_ARCHIVE_SELECTION -> {
         progress.close(update.requestId)
-        val selected = chooseArchiveCandidate(owner, update.candidates, dialogFactory)
-        applyArchiveSelectionIfCurrent(
-            update.requestId,
-            selected,
-            service::ownsVisibleRequest,
-            service::cancel,
-        ) { candidate ->
-          progress.show(update.requestId, "Opening ${candidate.displayName()}…")
-          service.selectArchive(update.requestId, candidate.token())
+        val host = archiveSelectionHost
+        if (host == null) {
+          // The host is installed during SwingGui initialization, before a request can be
+          // submitted. Cancelling is the safe fallback if a lifecycle race reaches this point.
+          LOG.warn("Archive selection arrived before the Proposal 3 host was installed")
+          service.cancel(update.requestId)
+        } else {
+          host.showArchiveSelection(
+              update.requestId,
+              update.candidates,
+              onSelected = { candidate ->
+                applyArchiveSelectionIfCurrent(
+                    update.requestId,
+                    candidate,
+                    service::ownsVisibleRequest,
+                    service::cancel,
+                ) { selected ->
+                  progress.show(update.requestId, "Opening ${selected.displayName()}…")
+                  service.selectArchive(update.requestId, selected.token())
+                }
+              },
+              onCancelled = {
+                applyArchiveSelectionIfCurrent(
+                    update.requestId,
+                    null,
+                    service::ownsVisibleRequest,
+                    service::cancel,
+                ) { error("Cancelled archive selection cannot be accepted") }
+              },
+          )
         }
       }
       RomOpenStage.AWAITING_PERSISTENCE_DECISION ->
@@ -221,8 +252,11 @@ internal class DesktopRomOpen(
               update.persistenceFileName ?: "the current game's save",
           )
       // Routine opening work is represented by DesktopMainPanel's nonmodal task banner. Keep the
-      // retained dialog only for archive selection and persistence decisions that require input.
-      else -> progress.close(update.requestId)
+      // retained progress UI only for persistence decisions that require input.
+      else -> {
+        archiveSelectionHost?.closeArchiveSelection(update.requestId)
+        progress.close(update.requestId)
+      }
     }
   }
 
@@ -324,10 +358,7 @@ internal class DesktopRomOpen(
   }
 }
 
-/**
- * A modal archive chooser runs a nested EDT event loop. Revalidate ownership after it returns
- * because another desktop-open request may have superseded this one while the dialog was open.
- */
+/** Revalidates ownership before applying an asynchronous archive-selection result. */
 internal fun <T> applyArchiveSelectionIfCurrent(
     requestId: Long,
     selected: T?,
@@ -457,88 +488,6 @@ internal class RomOpenProgressDialog(
       dialog.isVisible = true
     }
   }
-}
-
-internal fun chooseArchiveCandidate(
-    owner: Window,
-    candidates: List<RomSourceSnapshot.ArchiveCandidate>,
-    dialogFactory: DesktopDialogFactory = DesktopDialogFactory(),
-): RomSourceSnapshot.ArchiveCandidate? {
-  if (candidates.isEmpty()) {
-    return null
-  }
-  val list =
-      JList(candidates.toTypedArray()).apply {
-        selectionMode = ListSelectionModel.SINGLE_SELECTION
-        selectedIndex = 0
-        visibleRowCount = minOf(candidates.size, 10)
-        getAccessibleContext().accessibleName = "ROMs in archive"
-        cellRenderer =
-            object : DefaultListCellRenderer() {
-              override fun getListCellRendererComponent(
-                  list: JList<*>?,
-                  value: Any?,
-                  index: Int,
-                  isSelected: Boolean,
-                  cellHasFocus: Boolean,
-              ) =
-                  super.getListCellRendererComponent(
-                          list,
-                          value,
-                          index,
-                          isSelected,
-                          cellHasFocus,
-                      )
-                      .also { component ->
-                        val candidate = value as RomSourceSnapshot.ArchiveCandidate
-                        (component as JLabel).text = archiveCandidateLabel(candidate)
-                        component.putClientProperty("html.disable", true)
-                        component.toolTipText =
-                            "<html>${escapeHtml(candidate.entryName())}</html>"
-                        component.accessibleContext.accessibleName =
-                            archiveCandidateAccessibleLabel(candidate)
-                      }
-            }
-      }
-  val content =
-      JScrollPane(list).apply {
-        preferredSize = Dimension(540, minOf(360, 75 + candidates.size * 28))
-        getAccessibleContext().accessibleName = "ROMs available in the archive"
-      }
-  val outcome =
-      dialogFactory.showForm(
-          owner,
-          DesktopFormSpec(
-              title = "Choose ROM — Coffee GB",
-              heading = "Choose a game from this archive",
-              description =
-                  "The archive contains more than one supported ROM. Select the game to open.",
-              contentAccessibleName = "ROM archive contents",
-              buttons =
-                  DesktopDialogButtons(
-                      primary =
-                          DesktopDialogAction(
-                              "Open selected ROM",
-                              ArchiveSelectionDecision.OPEN,
-                              mnemonic = KeyEvent.VK_O,
-                          ),
-                      cancel =
-                          DesktopDialogAction(
-                              "Cancel",
-                              ArchiveSelectionDecision.CANCEL,
-                          ),
-                      defaultButton = DesktopDialogDefaultButton.PRIMARY,
-                  ),
-              modality = DesktopOwnedDialogModality.DOCUMENT,
-          ),
-          content,
-      )
-  return list.selectedValue.takeIf { outcome == ArchiveSelectionDecision.OPEN }
-}
-
-private enum class ArchiveSelectionDecision {
-  OPEN,
-  CANCEL,
 }
 
 internal fun archiveCandidateLabel(candidate: RomSourceSnapshot.ArchiveCandidate): String {
@@ -1031,9 +980,6 @@ internal fun formatByteCount(bytes: Long): String =
       bytes < 1024 * 1024 -> String.format(Locale.ROOT, "%.1f KiB", bytes / 1024.0)
       else -> String.format(Locale.ROOT, "%.1f MiB", bytes / (1024.0 * 1024.0))
     }
-
-private fun escapeHtml(value: String): String =
-    value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 private val LOG = LoggerFactory.getLogger("DesktopRomOpen")
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -75,6 +75,8 @@ class SwingEmulator(
   private val audioDeviceCatalog = AudioDeviceCatalog()
   private val accelerometer: SwingAccelerometer
 
+  private val playerInput: DesktopPlayerInput
+
   private val tiltInput: DesktopTiltInput
 
   private val tiltKeys: SwingTiltKeys
@@ -91,6 +93,8 @@ class SwingEmulator(
 
   private var inputRouter: DesktopInputRouter? = null
 
+  private var portableMenu: SwingProposal3Menu? = null
+
   private var preferredSizeChangedWhileFullscreen = false
 
   private val controllerLifecycle = ControllerLifecycleGate()
@@ -105,7 +109,7 @@ class SwingEmulator(
             eventBus,
             "main",
         )
-    val playerInput = DesktopPlayerInput(properties.playerInputSource, eventBus)
+    playerInput = DesktopPlayerInput(properties.playerInputSource, eventBus)
     tiltInput = DesktopTiltInput(eventBus)
     joypad = SwingJoypad(properties.playerInputMapping, eventBus, playerInput)
     gamepad = SwingGamepad(properties.playerInputMapping, playerInput, tiltInput, eventBus)
@@ -207,6 +211,9 @@ class SwingEmulator(
           closeControllerAfterLifecycleRelease(::releaseForLifecycleChange, controller::close)
         },
         finishTeardown = {
+          portableMenu?.closeForLifecycle()
+          portableMenu = null
+          playerInput.setMenuCapture(null)
           inputRouter?.close()
           inputRouter = null
           eventBus.post(ConnectionController.StopServerEvent())
@@ -224,6 +231,44 @@ class SwingEmulator(
   }
 
   internal fun isLinkedControllerActive(): Boolean = linkedControllerActive
+
+  /** Installs the portable Proposal 3 host after desktop actions and native dialogs exist. */
+  internal fun installPortableMenu(commands: PortableMenuCommandBridge): DesktopArchiveSelectionHost {
+    check(portableMenu == null) { "The portable menu is already installed" }
+    val installedMenu =
+        SwingProposal3Menu(
+            frameSink = { frame ->
+              if (frame == null) display.clearMenuOverlay() else display.setMenuOverlay(frame)
+            },
+            commands = commands,
+            releaseGameplay = {
+              joypad.releaseForLifecycleChange()
+              tiltInput.releaseForLifecycleChange()
+              gamepad.releaseForLifecycleChange()
+              inputRouter?.releaseForOwnershipChange()
+              playerInput.releaseAll()
+            },
+            printer =
+                object : PortableMenuPrinterBridge {
+                  override fun hasPaper() = printer.hasPaper()
+
+                  override fun paperPreview() = printer.menuPreview()
+
+                  override fun open() = printer.showWindow()
+
+                  override fun clear() = printer.clearFromPortableMenu()
+
+                  override fun export() = printer.exportFromPortableMenu()
+                },
+            )
+    portableMenu = installedMenu
+    playerInput.setMenuCapture(portableMenu)
+    return installedMenu
+  }
+
+  internal fun openPortableMenu() {
+    portableMenu?.openFromDesktop()
+  }
 
   internal fun attachPrinterWindow(owner: java.awt.Window, bounds: PrinterWindowBounds) {
     printer.attachDesktopWindow(owner, bounds)
@@ -258,6 +303,7 @@ class SwingEmulator(
   fun captureDisplayImage(): StateImage = display.captureStateImage()
 
   private fun releaseForLifecycleChange() {
+    portableMenu?.closeForLifecycle()
     joypad.releaseForLifecycleChange()
     tiltInput.releaseForLifecycleChange()
     gamepad.releaseForLifecycleChange()
@@ -300,6 +346,8 @@ class SwingEmulator(
                   joypad.releaseForLifecycleChange()
                   tiltInput.releaseForLifecycleChange()
                 },
+                portableMenu = portableMenu,
+                menuKeyForKeyCode = joypad::menuKeyForKeyCode,
             )
             .also(DesktopInputRouter::install)
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -233,7 +233,10 @@ class SwingEmulator(
   internal fun isLinkedControllerActive(): Boolean = linkedControllerActive
 
   /** Installs the portable Proposal 3 host after desktop actions and native dialogs exist. */
-  internal fun installPortableMenu(commands: PortableMenuCommandBridge): DesktopArchiveSelectionHost {
+  internal fun installPortableMenu(
+      commands: PortableMenuCommandBridge,
+      onVisibilityChanged: (Boolean) -> Unit = {},
+  ): SwingProposal3Menu {
     check(portableMenu == null) { "The portable menu is already installed" }
     val installedMenu =
         SwingProposal3Menu(
@@ -241,6 +244,7 @@ class SwingEmulator(
               if (frame == null) display.clearMenuOverlay() else display.setMenuOverlay(frame)
             },
             commands = commands,
+            onVisibilityChanged = onVisibilityChanged,
             releaseGameplay = {
               joypad.releaseForLifecycleChange()
               tiltInput.releaseForLifecycleChange()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -399,7 +399,10 @@ class SwingGui private constructor(
     desktopActions.applyShortcuts(
         DesktopShortcutRegistry(
             DesktopKeyboardKeyAdapter.keyCodes(properties.applicationSettings.input.keyboard.values)))
-    val portableMenu = emulator.installPortableMenu(desktopActions)
+    val portableMenu =
+        emulator.installPortableMenu(desktopActions) { visible ->
+          if (visible && ::dropFeedback.isInitialized) dropFeedback.update(false)
+        }
     romOpen.setArchiveSelectionHost(portableMenu)
     menu =
         SwingMenu(
@@ -561,7 +564,7 @@ class SwingGui private constructor(
           }
         })
 
-    installRomDropTarget()
+    installRomDropTarget(portableMenu::visible)
     mainWindow.pack()
     mainWindow.minimumSize =
         minimumFrameSize(
@@ -597,13 +600,15 @@ class SwingGui private constructor(
     requestDesktopStartupSmokeIfConfigured()
   }
 
-  private fun installRomDropTarget() {
+  private fun installRomDropTarget(menuVisible: () -> Boolean) {
     val root = mainWindow.rootPane
-    dropFeedback = RomDropFeedback(root)
+    val dropEnabled = { !menuVisible() }
+    dropFeedback = RomDropFeedback(root, dropEnabled)
     root.transferHandler =
         RomDropTransferHandler(
             submit = { inputs -> romOpen.open(inputs, RomOpenSource.DROP) },
             feedback = dropFeedback::update,
+            enabled = dropEnabled,
         )
   }
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -366,6 +366,7 @@ class SwingGui private constructor(
                 closeGame = { menu.requestCloseGame() },
                 preferences = ::showPreferences,
                 quit = ::requestClose,
+                openMenu = emulator::openPortableMenu,
                 setPaused = { paused ->
                   eventBus.post(
                       if (paused) Controller.PauseEmulationEvent()
@@ -392,10 +393,14 @@ class SwingGui private constructor(
                   desktopUiCoordinator.stateSlot(slot)
                   stateUxController.selectSlot(slot)
                 },
+                preferencesForCategory = { category -> showPreferences(category) },
+                openAbout = { menu.showAbout() },
             ))
     desktopActions.applyShortcuts(
         DesktopShortcutRegistry(
             DesktopKeyboardKeyAdapter.keyCodes(properties.applicationSettings.input.keyboard.values)))
+    val portableMenu = emulator.installPortableMenu(desktopActions)
+    romOpen.setArchiveSelectionHost(portableMenu)
     menu =
         SwingMenu(
             properties,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -356,6 +356,8 @@ internal class SwingMenu(
   private fun createGameMenu(): JMenu {
     val gameMenu = JMenu("Game")
 
+    gameMenu.add(JMenuItem(desktopActions[DesktopCommand.OPEN_MENU]))
+    gameMenu.addSeparator()
     gameMenu.add(pauseResumeMenuItem(desktopActions[DesktopCommand.PAUSE]))
     gameMenu.add(JMenuItem(desktopActions[DesktopCommand.RESET]))
 
@@ -611,13 +613,17 @@ internal class SwingMenu(
               mnemonic = KeyEvent.VK_A
               getAccessibleContext().accessibleDescription =
                   "Show Coffee GB version, license, and source information"
-              addActionListener {
-                val version =
-                    SwingMenu::class.java.`package`.implementationVersion ?: "development build"
-                helpDialogs.showAbout(window, version)
-              }
+              addActionListener { showAbout() }
             })
       }
+
+  /** Opens the same native About/notices surface used by Help > About. */
+  internal fun showAbout() {
+    check(SwingUtilities.isEventDispatchThread()) { "About dialog must open on the EDT" }
+    val version =
+        SwingMenu::class.java.`package`.implementationVersion ?: "development build"
+    helpDialogs.showAbout(window, version)
+  }
 
   private fun enableWhenEmulationActive(item: JMenuItem) {
     eventBus.register<EmulationStartedEvent> { event ->

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingPrinter.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingPrinter.kt
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.controller.Controller.SetPrinterEvent
 import eu.rekawek.coffeegb.controller.Controller.SetSerialPeripheralEvent
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.core.events.EventBus
+import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
@@ -153,6 +154,64 @@ internal class PrinterPaperSnapshot internal constructor(
     var remaining = y
     for (segment in segments) {
       if (remaining < segment.height) return segment.rgbAt(x, remaining)
+      remaining -= segment.height
+    }
+    error("Paper snapshot height does not match its segments")
+  }
+
+  /**
+   * Creates the bounded immutable preview consumed by the portable Proposal 3 menu.
+   *
+   * The printer keeps its native 160-pixel roll width. A short roll is copied at native
+   * resolution; a taller roll is reduced to the largest aspect-preserving raster that fits the
+   * portable preview budget. MenuPreview defensively copies the generated ARGB array, so neither
+   * this snapshot nor the producer-owned row buffer can be mutated by the renderer.
+   */
+  internal fun menuPreview(): MenuPreview {
+    if (isEmpty || contentHeight <= 0) return MenuPreview.empty()
+
+    val maximumHeight = MenuPreview.MAX_PIXELS / PRINTER_PAPER_WIDTH
+    val previewHeight = min(contentHeight, maximumHeight)
+    val previewWidth =
+        if (contentHeight <= maximumHeight) {
+          PRINTER_PAPER_WIDTH
+        } else {
+          (PRINTER_PAPER_WIDTH.toLong() * previewHeight / contentHeight)
+              .toInt()
+              .coerceAtLeast(1)
+        }
+    val previewPixels = IntArray(Math.multiplyExact(previewWidth, previewHeight))
+    val sourceRow = IntArray(PRINTER_PAPER_WIDTH)
+    var copiedSourceRow = -1
+    for (destinationY in 0 until previewHeight) {
+      val sourceY =
+          (destinationY.toLong() * contentHeight / previewHeight)
+              .toInt()
+      if (sourceY != copiedSourceRow) {
+        copyRgbRow(sourceY, sourceRow)
+        copiedSourceRow = sourceY
+      }
+      val destinationOffset = destinationY * previewWidth
+      for (destinationX in 0 until previewWidth) {
+        val sourceX =
+            (destinationX.toLong() * PRINTER_PAPER_WIDTH / previewWidth)
+                .toInt()
+        previewPixels[destinationOffset + destinationX] =
+            0xff000000.toInt() or (sourceRow[sourceX] and 0x00ffffff)
+      }
+    }
+    return MenuPreview.ready(previewWidth, previewHeight, previewPixels)
+  }
+
+  private fun copyRgbRow(row: Int, destination: IntArray) {
+    require(row in 0 until contentHeight)
+    require(destination.size >= PRINTER_PAPER_WIDTH)
+    var remaining = row
+    for (segment in segments) {
+      if (remaining < segment.height) {
+        segment.copyRgbRow(remaining, destination)
+        return
+      }
       remaining -= segment.height
     }
     error("Paper snapshot height does not match its segments")
@@ -824,6 +883,24 @@ class SwingPrinter internal constructor(
       showOnEdt(raise = true)
     }
   }
+
+  /** Host bridge for the portable menu; both operations retain the native printer UI semantics. */
+  internal fun clearFromPortableMenu() {
+    requireEdt()
+    requestClear()
+  }
+
+  /** Host bridge for the portable menu; the file save dialog remains native Swing. */
+  internal fun exportFromPortableMenu() {
+    requireEdt()
+    requestSave()
+  }
+
+  /** Cheap availability query used to keep the portable printer route unreachable when empty. */
+  internal fun hasPaper(): Boolean = dependencies.store.model().hasContent
+
+  /** Returns the current immutable paper generation for the portable menu preview. */
+  internal fun menuPreview(): MenuPreview = dependencies.store.model().snapshot().menuPreview()
 
   /** Connects the retained tool to the main desktop owner before first use. */
   internal fun attachDesktopWindow(owner: Component, bounds: PrinterWindowBounds) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -29,6 +29,7 @@ internal class SwingProposal3Menu(
     private val commands: PortableMenuCommandBridge,
     private val releaseGameplay: () -> Unit,
     private val printer: PortableMenuPrinterBridge? = null,
+    private val onVisibilityChanged: (Boolean) -> Unit = {},
 ) : DesktopMenuInputCapture, DesktopMenuKeyboardInput, DesktopArchiveSelectionHost {
 
   private data class PendingArchiveSelection(
@@ -797,7 +798,10 @@ internal class SwingProposal3Menu(
           compositor.compose(presentation).orElseThrow {
             IllegalStateException("Visible Proposal 3 presentation did not compose")
           }
-      renderedVisible = true
+      if (!renderedVisible) {
+        renderedVisible = true
+        onVisibilityChanged(true)
+      }
       frameSink(frame)
       return
     }
@@ -805,6 +809,7 @@ internal class SwingProposal3Menu(
     frameSink(null)
     if (renderedVisible) {
       renderedVisible = false
+      onVisibilityChanged(false)
       releaseGameplaySoon()
       if (pauseOwnedByMenu) {
         pauseOwnedByMenu = false

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -1,0 +1,901 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot
+import eu.rekawek.coffeegb.swing.io.DesktopMenuInputCapture
+import eu.rekawek.coffeegb.swing.io.DesktopMenuKeyboardInput
+import eu.rekawek.coffeegb.ui.menu.MenuController
+import eu.rekawek.coffeegb.ui.menu.MenuKey
+import eu.rekawek.coffeegb.ui.menu.MenuPageSpec
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation
+import eu.rekawek.coffeegb.ui.menu.MenuPreview
+import eu.rekawek.coffeegb.ui.menu.MenuRoute
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame
+import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor
+import java.util.EnumSet
+import javax.swing.SwingUtilities
+
+/**
+ * Swing host for the complete Proposal 3 route tree.
+ *
+ * <p>Each route is still rendered by the portable compositor. This host only supplies route
+ * state, controller capture, and a command bridge to existing desktop actions. Unsupported
+ * operations remain disabled; the filesystem picker and printer export chooser stay native Swing
+ * dialogs. Once a native picker returns a multi-ROM archive, its bounded candidates are rendered
+ * by the portable CHOOSE_ROM page.</p>
+ */
+internal class SwingProposal3Menu(
+    private val frameSink: (MenuArgbFrame?) -> Unit,
+    private val commands: PortableMenuCommandBridge,
+    private val releaseGameplay: () -> Unit,
+    private val printer: PortableMenuPrinterBridge? = null,
+) : DesktopMenuInputCapture, DesktopMenuKeyboardInput, DesktopArchiveSelectionHost {
+
+  private data class PendingArchiveSelection(
+      val requestId: Long,
+      val candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+      val byItemId: Map<String, RomSourceSnapshot.ArchiveCandidate>,
+      val onSelected: (RomSourceSnapshot.ArchiveCandidate) -> Unit,
+      val onCancelled: () -> Unit,
+  )
+
+  private val compositor = Proposal3MenuCompositor()
+  private val controller =
+      MenuController(
+          object : MenuController.Listener {
+            override fun onPresentation(presentation: MenuPresentation) {
+              render(presentation)
+            }
+
+            override fun onItemSelected(
+                route: MenuRoute,
+                id: String,
+                secondary: Boolean,
+            ) {
+              handleItem(route, id, secondary)
+            }
+
+            override fun onHeaderSelected(route: MenuRoute) {
+              if (route == MenuRoute.PAUSE_CONSOLE) {
+                openRoute(MenuRoute.LIBRARY)
+              } else if (route == MenuRoute.LIBRARY) {
+                runNativeRomChooser()
+              }
+            }
+
+            override fun onBackIntercepted(route: MenuRoute) {
+              if (route == MenuRoute.CHOOSE_ROM) {
+                cancelArchiveSelection()
+              }
+            }
+          })
+
+  private val gamepadHeld = EnumSet.noneOf(Button::class.java)
+
+  @Volatile private var opening = false
+
+  @Volatile private var chordLatched = false
+
+  private var pauseOwnedByMenu = false
+
+  private var pendingConfirmation: DesktopCommand? = null
+
+  private var pendingArchiveSelection: PendingArchiveSelection? = null
+
+  private var selectedArchiveItemId: String? = null
+
+  private var renderedVisible = false
+
+  override fun visible(): Boolean = controller.visible() || opening
+
+  /** Opens the menu from a desktop command or test seam on the EDT. */
+  internal fun openFromDesktop() {
+    runOnEdt(::openOnEdt)
+  }
+
+  /** Hides the menu during ROM/controller lifecycle transitions without resuming a new session. */
+  internal fun closeForLifecycle() {
+    runOnEdt {
+      pauseOwnedByMenu = false
+      pendingConfirmation = null
+      pendingArchiveSelection = null
+      selectedArchiveItemId = null
+      controller.setBackIntercepted(false)
+      opening = false
+      if (controller.visible()) controller.hide()
+      else frameSink(null)
+      releaseGameplaySoon()
+    }
+  }
+
+  override fun updatePlayerButtons(buttons: Collection<Button>): Boolean {
+    val current = EnumSet.noneOf(Button::class.java)
+    current.addAll(buttons)
+    val wasVisible = visible()
+
+    if (!wasVisible) {
+      val startAndSelect =
+          current.contains(Button.START) && current.contains(Button.SELECT)
+      if (!startAndSelect) {
+        chordLatched = false
+      } else if (!chordLatched) {
+        chordLatched = true
+        opening = true
+        SwingUtilities.invokeLater {
+          opening = false
+          openOnEdt()
+        }
+        gamepadHeld.clear()
+        gamepadHeld.addAll(current)
+        return true
+      }
+      gamepadHeld.clear()
+      gamepadHeld.addAll(current)
+      return false
+    }
+
+    val previous = EnumSet.noneOf(Button::class.java)
+    previous.addAll(gamepadHeld)
+    gamepadHeld.clear()
+    gamepadHeld.addAll(current)
+    refreshPrinterPageBeforeInput()
+
+    // Physical polling is edge-triggered here. Holding a controller button across polls never
+    // repeats the semantic action, while releasing it always clears MenuController's capture.
+    for (button in Button.values()) {
+      val becamePressed = current.contains(button) && !previous.contains(button)
+      val becameReleased = !current.contains(button) && previous.contains(button)
+      if (becamePressed) {
+        controller.onKeyDown(button.toMenuKey(), false)
+      }
+      if (becameReleased) {
+        controller.onKeyUp(button.toMenuKey())
+      }
+      if (!visible()) break
+    }
+    return true
+  }
+
+  override fun onKeyDown(key: MenuKey, repeat: Boolean): Boolean {
+    if (!visible()) return false
+    if (opening) return true
+    refreshPrinterPageBeforeInput()
+    return controller.onKeyDown(key, repeat)
+  }
+
+  override fun onKeyUp(key: MenuKey): Boolean {
+    if (!visible()) return false
+    if (opening) return true
+    return controller.onKeyUp(key)
+  }
+
+  override fun showArchiveSelection(
+      requestId: Long,
+      candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+      onSelected: (RomSourceSnapshot.ArchiveCandidate) -> Unit,
+      onCancelled: () -> Unit,
+  ) {
+    require(candidates.size > 1) { "Archive selection requires multiple candidates" }
+    runOnEdt {
+      pendingArchiveSelection?.let { stale ->
+        pendingArchiveSelection = null
+        selectedArchiveItemId = null
+        stale.onCancelled()
+      }
+
+      val copiedCandidates = candidates.toList()
+      val byItemId =
+          copiedCandidates.associateBy { archiveItemId(it) }
+      check(byItemId.size == copiedCandidates.size) {
+        "Archive candidates must have unique selection tokens"
+      }
+      pendingArchiveSelection =
+          PendingArchiveSelection(
+              requestId,
+              copiedCandidates,
+              byItemId,
+              onSelected,
+              onCancelled,
+          )
+      selectedArchiveItemId = archiveItemId(copiedCandidates.first())
+      controller.setBackIntercepted(true)
+
+      val current = commands.menuState()
+      pauseOwnedByMenu = current.commands.pauseSupported && !current.commands.paused
+      if (pauseOwnedByMenu) {
+        commands.setPaused(true)
+      }
+      controller.setPage(pageFor(MenuRoute.CHOOSE_ROM, current))
+      controller.show(MenuRoute.CHOOSE_ROM)
+      releaseGameplaySoon()
+    }
+  }
+
+  override fun closeArchiveSelection(requestId: Long) {
+    runOnEdt {
+      val pending = pendingArchiveSelection ?: return@runOnEdt
+      // Request IDs are monotonic. A newer request supersedes an older visible chooser, while a
+      // late terminal update from an older request must not close the newer chooser.
+      if (pending.requestId > requestId) return@runOnEdt
+      pendingArchiveSelection = null
+      selectedArchiveItemId = null
+      controller.setBackIntercepted(false)
+      hideAndResume()
+    }
+  }
+
+  // Package-private seams keep route/action tests on the semantic controller rather than on
+  // raster pixels. Production callers only need the input-capture interfaces above.
+  internal fun routeForTest(): MenuRoute? = controller.route().takeIf { controller.visible() }
+
+  internal fun focusedItemIdForTest(): String? {
+    if (!controller.visible()) return null
+    val presentation = controller.presentation()
+    return presentation.items().getOrNull(presentation.focusedIndex())?.id()
+  }
+
+  private fun openOnEdt() {
+    check(SwingUtilities.isEventDispatchThread()) { "Portable menu must open on the EDT" }
+    if (opening || controller.visible()) return
+    val current = commands.menuState()
+    if (!current.commands.gameLoaded || current.commands.sessionBusy) return
+
+    controller.setPage(pageFor(MenuRoute.PAUSE_CONSOLE, current))
+    pauseOwnedByMenu = current.commands.pauseSupported && !current.commands.paused
+    if (pauseOwnedByMenu) {
+      commands.setPaused(true)
+    }
+    controller.show(MenuRoute.PAUSE_CONSOLE)
+    releaseGameplaySoon()
+  }
+
+  private fun pageFor(
+      route: MenuRoute,
+      presentation: DesktopPresentation,
+      confirmationAction: DesktopCommand? = null,
+  ): MenuPageSpec {
+    fun enabled(command: DesktopCommand): Boolean = commands.isEnabled(command)
+    fun item(
+        id: String,
+        label: String,
+        isEnabled: Boolean,
+        secondaryId: String? = null,
+        adjustable: Boolean = false,
+        progress: Int = -1,
+    ) = MenuPageSpec.Item(id, label, "", isEnabled, secondaryId, adjustable, progress)
+
+    fun page(
+        context: String,
+        sideHeading: String,
+        sideLines: List<String>,
+        items: List<MenuPageSpec.Item>,
+        preferredFocus: String? = null,
+        headerAction: String = "",
+        preview: MenuPreview = MenuPreview.empty(),
+    ) = MenuPageSpec(
+        route,
+        "COFFEE GB",
+        context,
+        headerAction,
+        sideHeading,
+        sideLines,
+        items,
+        1,
+        listOf("D-PAD MOVE", "[A] OK", "[B] BACK"),
+        preferredFocus ?: items.firstOrNull { it.enabled() }?.id() ?: items.first().id(),
+        preview,
+    )
+
+    val state = presentation.commands
+    val stateAvailable = state.stateCommandsAvailable && !state.sessionBusy
+    val printerHasPaper = printer?.hasPaper() == true
+    return when (route) {
+      MenuRoute.PAUSE_CONSOLE ->
+          page(
+              "PAUSED",
+              "CURRENT GAME",
+              listOf(
+                  if (presentation.gameTitle == null) "READY" else "PLAYING",
+                  "PAUSED",
+                  "CONTROLLER MENU",
+              ),
+              listOf(
+                  item("resume", "RESUME", enabled(DesktopCommand.PAUSE)),
+                  item("save-state", "SAVE STATE", stateAvailable),
+                  item("load-state", "LOAD STATE", stateAvailable),
+                  item("reset", "RESET GAME", enabled(DesktopCommand.RESET)),
+                  item("settings", "SETTINGS", enabled(DesktopCommand.PREFERENCES)),
+                  item("stop", "STOP GAME", enabled(DesktopCommand.CLOSE_GAME)),
+              ),
+              headerAction = if (enabled(DesktopCommand.OPEN_ROM)) "OPEN ROM" else "",
+          )
+
+      MenuRoute.SAVE_STATES -> {
+        val slots =
+            (0..3).map { slot ->
+              val load = commands.canLoadState(slot)
+              item(
+                  "slot-$slot",
+                  "SLOT $slot",
+                  commands.canSaveState(slot),
+                  secondaryId = "load-slot-$slot".takeIf { load },
+              )
+            }
+        page(
+            "SAVE STATES",
+            "STATE BANK",
+            listOf("SLOT 0 READY", "SLOT 1 EMPTY", "SLOT 2 EMPTY"),
+            slots +
+                item("manage-states", "MANAGE STATES", enabled(DesktopCommand.MANAGE_STATES)) +
+                item("back", "BACK", true),
+            preferredFocus = slots.firstOrNull { it.enabled() }?.id() ?: "manage-states",
+        )
+      }
+
+      MenuRoute.SETTINGS ->
+          page(
+              "SETTINGS",
+              "SETTINGS HUB",
+              listOf("AUDIO + INPUT", "DEVICES + DATA", "SYSTEM PROFILE"),
+              listOf(
+                  item("audio", "AUDIO", true),
+                  item("touch-controls", "TOUCH CONTROLS", true),
+                  item("controller-mapping", "CONTROLLER MAPPING", true),
+                  item("optional-devices", "OPTIONAL DEVICES", true),
+                  item("video", "VIDEO", enabled(DesktopCommand.PREFERENCES)),
+                  item("system-profile", "SYSTEM PROFILE", true),
+                  item("rewind-save", "REWIND & SAVE", enabled(DesktopCommand.PREFERENCES)),
+                  item("data-media", "DATA & MEDIA", true),
+                  item("about", "ABOUT", true),
+                  item("back", "BACK", true),
+              ),
+          )
+
+      MenuRoute.AUDIO ->
+          page(
+              "AUDIO",
+              "AUDIO MIX",
+              listOf("NO LIVE PREVIEW", "VOLUME  75%", "EMULATED AUDIO  ON"),
+              listOf(
+                  item("volume", "VOLUME", false),
+                  item("mute-audio", "MUTE", enabled(DesktopCommand.MUTE)),
+                  item("emulated-audio", "EMULATED AUDIO", false),
+                  item("save-audio", "SAVE", enabled(DesktopCommand.PREFERENCES)),
+                  item("cancel-audio", "CANCEL", true),
+              ),
+              preferredFocus = "mute-audio",
+          )
+
+      MenuRoute.TOUCH_CONTROLS ->
+          page(
+              "TOUCH CONTROLS",
+              "INPUT DECK",
+              listOf("SKIN  CLASSIC", "HAPTICS  ON", "LAYOUT  SAVED"),
+              listOf(
+                  item("haptics", "HAPTIC FEEDBACK", false),
+                  item("button-opacity", "BUTTON OPACITY", false),
+                  item("reset-touch", "RESET DEFAULTS", false),
+                  item("save-touch", "SAVE", enabled(DesktopCommand.PREFERENCES)),
+                  item("cancel-touch", "CANCEL", true),
+              ),
+              preferredFocus = "save-touch",
+          )
+
+      MenuRoute.CONTROLLER_MAPPING ->
+          page(
+              "CONTROLLER MAPPING",
+              "INPUT MAP",
+              listOf("DEVICE  BLUETOOTH", "PROFILE  DEFAULT", "A + B TO CANCEL"),
+              listOf(
+                  item("map-a", "A", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-b", "B", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-start", "START", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-select", "SELECT", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-up", "UP", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-down", "DOWN", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-left", "LEFT", enabled(DesktopCommand.PREFERENCES)),
+                  item("map-right", "RIGHT", enabled(DesktopCommand.PREFERENCES)),
+                  item("invert-x", "HORIZONTAL AXIS", enabled(DesktopCommand.PREFERENCES)),
+                  item("invert-y", "VERTICAL AXIS", enabled(DesktopCommand.PREFERENCES)),
+                  item("reset-controller", "RESET MAPPINGS", enabled(DesktopCommand.PREFERENCES)),
+                  item("back", "BACK", true),
+              ),
+              preferredFocus = "map-a",
+          )
+
+      MenuRoute.OPTIONAL_DEVICES ->
+          page(
+              "OPTIONAL DEVICES",
+              "ACCESSORIES",
+              listOf("RUMBLE  READY", "CAMERA  PERMISSION", "PRINTER  READY"),
+              listOf(
+                  item("rumble", "RUMBLE", false),
+                  item("live-camera", "LIVE CAMERA", enabled(DesktopCommand.PREFERENCES)),
+                  item("game-boy-printer", "GAME BOY PRINTER", printer != null),
+                  item("calibrate-tilt", "CALIBRATE TILT", enabled(DesktopCommand.PREFERENCES)),
+                  item("preview-printer-paper", "PREVIEW PRINTER PAPER", printerHasPaper),
+                  item("export-share-paper", "EXPORT & SHARE PAPER", printerHasPaper),
+                  item("save-devices", "SAVE", enabled(DesktopCommand.PREFERENCES)),
+                  item("cancel-devices", "CANCEL", true),
+              ),
+              preferredFocus = "live-camera",
+          )
+
+      MenuRoute.PRINTER_PAPER -> {
+        val currentPrinter = printer
+        val currentPreview =
+            if (currentPrinter != null && printerHasPaper) {
+              currentPrinter.paperPreview()
+            } else {
+              MenuPreview.empty()
+            }
+        val paperAvailable = currentPreview.state() == MenuPreview.State.READY
+        page(
+            "PRINTER PAPER",
+            "PRINTER ROLL",
+            listOf("LAST PRINT  READY", "PAPER  248 PX", "EXPORT IS NATIVE"),
+            listOf(
+                item("clear-paper", "CLEAR PAPER", paperAvailable),
+                item("export-share-paper", "EXPORT & SHARE", paperAvailable),
+                item("back", "BACK", true),
+            ),
+            preferredFocus = if (paperAvailable) "export-share-paper" else "back",
+            preview = currentPreview,
+        )
+      }
+
+      MenuRoute.DATA_MEDIA ->
+          page(
+              "DATA & MEDIA",
+              "DATA DECK",
+              listOf("BATTERY SAVE  READY", "STATE SLOT 0  READY", "SCREENSHOT  PNG"),
+              listOf(
+                  item("import-battery", "IMPORT BATTERY SAVE", false),
+                  item("export-battery", "EXPORT BATTERY SAVE", false),
+                  item("import-state-0", "IMPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
+                  item("export-state-0", "EXPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
+                  item("export-screenshot", "EXPORT NATIVE SCREENSHOT", enabled(DesktopCommand.SCREENSHOT)),
+                  item("preview-printer-paper", "PRINTER PAPER", printerHasPaper),
+                  item("back", "BACK", true),
+              ),
+              preferredFocus = "export-screenshot",
+          )
+
+      MenuRoute.LIBRARY ->
+          page(
+              "LIBRARY",
+              "RECENT ROMS",
+              listOf("LAST OPENED  TODAY", "DOCUMENT PICKER  NATIVE", "ZIP  MULTI-SELECT"),
+              listOf(
+                  item("recent-rom", "RECENT ROM", false),
+                  item("open-rom", "OPEN ROM", enabled(DesktopCommand.OPEN_ROM)),
+                  item("choose-rom", "CHOOSE ROM", enabled(DesktopCommand.OPEN_ROM)),
+                  item("clear-recent", "CLEAR RECENTS", false),
+                  item("back", "BACK", true),
+              ),
+              preferredFocus = "open-rom",
+              headerAction = if (enabled(DesktopCommand.OPEN_ROM)) "OPEN ROM" else "",
+          )
+
+      MenuRoute.SYSTEM ->
+          page(
+              "SYSTEM",
+              "SYSTEM PROFILE",
+              listOf("VIDEO  RASTER SKIN", "PROFILE  AUTO", "REWIND  DISABLED"),
+              listOf(
+                  item("video-status", "VIDEO", enabled(DesktopCommand.PREFERENCES)),
+                  item("profile-status", "SYSTEM PROFILE", false),
+                  item("rewind-save-status", "REWIND & SAVE", enabled(DesktopCommand.PREFERENCES)),
+                  item("back", "BACK", true),
+              ),
+              preferredFocus = "video-status",
+          )
+
+      MenuRoute.ABOUT ->
+          page(
+              "ABOUT",
+              "COFFEE GB",
+              listOf("GAME BOY EMULATOR", "MIT LICENSE", "NO NETWORK"),
+              listOf(
+                  item("privacy-notices", "PRIVACY & NOTICES", commands.canOpenAbout()),
+                  item("network", "NO NETWORK ACCESS", false),
+                  item("storage", "NO BROAD STORAGE ACCESS", false),
+                  item("live-camera", "CAMERA ONLY WHEN ENABLED", false),
+                  item("source-notices", "SOURCE & THIRD-PARTY NOTICES", false),
+              ),
+              preferredFocus = "privacy-notices",
+          )
+
+      MenuRoute.CHOOSE_ROM -> {
+        val archive =
+            requireNotNull(pendingArchiveSelection) {
+              "${route.label()} requires an active archive selection"
+            }
+        val candidateItems =
+            archive.candidates.map { candidate ->
+              item(
+                  archiveItemId(candidate),
+                  archiveCandidateLabel(candidate),
+                  true,
+              )
+            }
+        page(
+            "CHOOSE ROM",
+            "ZIP CONTENTS",
+            listOf(
+                "${archive.candidates.size} ROMS FOUND",
+                "SELECT ONE TO OPEN",
+                "B BACK TO LIBRARY",
+            ),
+            candidateItems +
+                item("open-selected", "OPEN SELECTED", true) +
+                item("cancel", "CANCEL", true),
+            preferredFocus = candidateItems.first().id(),
+        )
+      }
+
+      MenuRoute.CONFIRM_ACTION -> {
+        val action = confirmationAction ?: pendingConfirmation
+        requireNotNull(action) { "Confirmation route requires a pending action" }
+        val actionLabel = action.confirmationLabel()
+        page(
+            "CONFIRM ACTION",
+            actionLabel,
+            listOf("UNSAVED PROGRESS MAY BE LOST", "A CONFIRM", "B CANCEL"),
+            listOf(
+                MenuPageSpec.Item("cancel", "CANCEL", "RETURN", true),
+                MenuPageSpec.Item("confirm", "CONFIRM", actionLabel, true),
+            ),
+        )
+      }
+    }
+  }
+
+  private fun handleItem(route: MenuRoute, id: String, secondary: Boolean) {
+    when (route) {
+      MenuRoute.PAUSE_CONSOLE ->
+          when (id) {
+            "resume" -> runOnEdt(::resumeAndHide)
+            "save-state", "load-state" -> openRoute(MenuRoute.SAVE_STATES)
+            "reset" -> openConfirmation(DesktopCommand.RESET)
+            "settings" -> openRoute(MenuRoute.SETTINGS)
+            "stop" -> openConfirmation(DesktopCommand.CLOSE_GAME)
+          }
+      MenuRoute.SAVE_STATES ->
+          when {
+            id.startsWith("slot-") || id.startsWith("load-slot-") -> {
+              val slot =
+                  (if (id.startsWith("load-slot-")) {
+                    id.removePrefix("load-slot-")
+                  } else {
+                    id.removePrefix("slot-")
+                  }).toIntOrNull() ?: return
+              if (secondary || id.startsWith("load-slot-")) {
+                runOnEdt {
+                  hideAndResume()
+                  commands.loadState(slot)
+                }
+              } else {
+                runOnEdt { commands.saveState(slot) }
+              }
+            }
+            id == "manage-states" -> runCommandAndHide(DesktopCommand.MANAGE_STATES)
+            id == "back" -> back()
+          }
+      MenuRoute.SETTINGS ->
+          when (id) {
+            "audio" -> openRoute(MenuRoute.AUDIO)
+            "touch-controls" -> openRoute(MenuRoute.TOUCH_CONTROLS)
+            "controller-mapping" -> openRoute(MenuRoute.CONTROLLER_MAPPING)
+            "optional-devices" -> openRoute(MenuRoute.OPTIONAL_DEVICES)
+            "video" -> runPreferencesAndHide(PreferencesCategory.DISPLAY)
+            "system-profile" -> openRoute(MenuRoute.SYSTEM)
+            "rewind-save" -> runPreferencesAndHide(PreferencesCategory.SAVES_AND_REWIND)
+            "data-media" -> openRoute(MenuRoute.DATA_MEDIA)
+            "about" -> openRoute(MenuRoute.ABOUT)
+            "back" -> back()
+          }
+      MenuRoute.AUDIO ->
+          when (id) {
+            "mute-audio" -> runCommandAndHide(DesktopCommand.MUTE)
+            "save-audio" -> runPreferencesAndHide(PreferencesCategory.AUDIO)
+            "cancel-audio" -> back()
+          }
+      MenuRoute.TOUCH_CONTROLS ->
+          when (id) {
+            "save-touch" -> runPreferencesAndHide(PreferencesCategory.CONTROLS)
+            "cancel-touch" -> back()
+          }
+      MenuRoute.CONTROLLER_MAPPING ->
+          when {
+            id.startsWith("map-") || id == "invert-x" || id == "invert-y" ||
+                id == "reset-controller" -> runPreferencesAndHide(PreferencesCategory.CONTROLS)
+            id == "back" -> back()
+          }
+      MenuRoute.OPTIONAL_DEVICES ->
+          when (id) {
+            "live-camera", "calibrate-tilt", "save-devices" ->
+                runPreferencesAndHide(PreferencesCategory.PERIPHERALS)
+            "game-boy-printer" -> runPrinterAndHide { it.open() }
+            "preview-printer-paper" -> openRoute(MenuRoute.PRINTER_PAPER)
+            "export-share-paper" -> openRoute(MenuRoute.PRINTER_PAPER)
+            "cancel-devices" -> back()
+          }
+      MenuRoute.PRINTER_PAPER ->
+          when (id) {
+            "clear-paper" ->
+                if (printer?.hasPaper() == true) runPrinterAndHide { it.clear() }
+            "export-share-paper" ->
+                if (printer?.hasPaper() == true) runPrinterAndHide { it.export() }
+            "back" -> back()
+          }
+      MenuRoute.DATA_MEDIA ->
+          when (id) {
+            "import-state-0", "export-state-0" -> runCommandAndHide(DesktopCommand.MANAGE_STATES)
+            "export-screenshot" -> runCommandAndHide(DesktopCommand.SCREENSHOT)
+            "preview-printer-paper" -> openRoute(MenuRoute.PRINTER_PAPER)
+            "back" -> back()
+          }
+      MenuRoute.LIBRARY ->
+          when (id) {
+            "open-rom", "choose-rom" -> runNativeRomChooser()
+            "back" -> back()
+          }
+      MenuRoute.SYSTEM ->
+          when (id) {
+            "video-status" -> runPreferencesAndHide(PreferencesCategory.DISPLAY)
+            "rewind-save-status" -> runPreferencesAndHide(PreferencesCategory.SAVES_AND_REWIND)
+            "back" -> back()
+          }
+      MenuRoute.ABOUT ->
+          if (id == "privacy-notices") runAboutAndHide()
+      MenuRoute.CONFIRM_ACTION ->
+          when (id) {
+            "cancel" -> back()
+            "confirm" -> confirmPendingAction()
+          }
+      MenuRoute.CHOOSE_ROM ->
+          when {
+            id.startsWith("archive:") -> selectedArchiveItemId = id
+            id == "open-selected" -> openSelectedArchiveCandidate()
+            id == "cancel" -> cancelArchiveSelection()
+          }
+    }
+  }
+
+  private fun openSelectedArchiveCandidate() {
+    runOnEdt {
+      val pending = pendingArchiveSelection ?: return@runOnEdt
+      val itemId = selectedArchiveItemId ?: archiveItemId(pending.candidates.first())
+      val candidate = pending.byItemId[itemId] ?: return@runOnEdt
+      pendingArchiveSelection = null
+      selectedArchiveItemId = null
+      controller.setBackIntercepted(false)
+      hideAndResume()
+      pending.onSelected(candidate)
+    }
+  }
+
+  private fun cancelArchiveSelection() {
+    runOnEdt {
+      val pending = pendingArchiveSelection ?: return@runOnEdt
+      pendingArchiveSelection = null
+      selectedArchiveItemId = null
+      controller.setBackIntercepted(false)
+      hideAndResume()
+      pending.onCancelled()
+    }
+  }
+
+  private fun openConfirmation(command: DesktopCommand) {
+    runOnEdt {
+      if (!controller.visible() || !commands.isEnabled(command)) return@runOnEdt
+      pendingConfirmation = command
+      val current = commands.menuState()
+      controller.setPage(pageFor(MenuRoute.CONFIRM_ACTION, current, command))
+      controller.push(MenuRoute.CONFIRM_ACTION)
+    }
+  }
+
+  private fun confirmPendingAction() {
+    val command = pendingConfirmation ?: return
+    pendingConfirmation = null
+    runCommandAndHide(command)
+  }
+
+  private fun runCommandAndHide(command: DesktopCommand) {
+    runOnEdt {
+      hideAndResume()
+      commands.invoke(command)
+    }
+  }
+
+  private fun runPreferencesAndHide(category: PreferencesCategory) {
+    runOnEdt {
+      hideAndResume()
+      commands.openPreferences(category)
+    }
+  }
+
+  private fun runAboutAndHide() {
+    runOnEdt {
+      if (!commands.canOpenAbout()) return@runOnEdt
+      hideAndResume()
+      commands.openAbout()
+    }
+  }
+
+  private fun runPrinterAndHide(action: (PortableMenuPrinterBridge) -> Unit) {
+    runOnEdt {
+      val printer = printer ?: return@runOnEdt
+      hideAndResume()
+      action(printer)
+    }
+  }
+
+  private fun runNativeRomChooser() {
+    runCommandAndHide(DesktopCommand.OPEN_ROM)
+  }
+
+  private fun openRoute(route: MenuRoute) {
+    runOnEdt {
+      if (!controller.visible()) return@runOnEdt
+      if (route == MenuRoute.PRINTER_PAPER && printer?.hasPaper() != true) {
+        return@runOnEdt
+      }
+      val current = commands.menuState()
+      controller.setPage(pageFor(route, current))
+      controller.push(route)
+    }
+  }
+
+  /** Rebinds the live printer snapshot before input can act on a stale paper page. */
+  private fun refreshPrinterPageBeforeInput() {
+    if (!controller.visible() || controller.route() != MenuRoute.PRINTER_PAPER) return
+    controller.setPage(pageFor(MenuRoute.PRINTER_PAPER, commands.menuState()))
+  }
+
+  private fun back() {
+    runOnEdt {
+      val route = controller.route()
+      controller.back()
+      if (route == MenuRoute.CONFIRM_ACTION) pendingConfirmation = null
+    }
+  }
+
+  private fun resumeAndHide() {
+    check(SwingUtilities.isEventDispatchThread()) { "Portable menu action must run on the EDT" }
+    val shouldResume = pauseOwnedByMenu || commands.menuState().commands.paused
+    pauseOwnedByMenu = false
+    if (controller.visible()) controller.hide()
+    if (shouldResume && commands.isEnabled(DesktopCommand.PAUSE)) {
+      commands.setPaused(false)
+    }
+  }
+
+  private fun hideAndResume() {
+    check(SwingUtilities.isEventDispatchThread()) { "Portable menu action must run on the EDT" }
+    val shouldResume = pauseOwnedByMenu
+    pauseOwnedByMenu = false
+    if (controller.visible()) controller.hide()
+    if (shouldResume && commands.isEnabled(DesktopCommand.PAUSE)) {
+      commands.setPaused(false)
+    }
+  }
+
+  private fun render(presentation: MenuPresentation) {
+    if (presentation.visible() && presentation.route() == MenuRoute.CHOOSE_ROM) {
+      val pending = pendingArchiveSelection
+      val focusedId =
+          presentation.items().getOrNull(presentation.focusedIndex())?.id()
+      if (pending != null && focusedId != null && pending.byItemId.containsKey(focusedId)) {
+        selectedArchiveItemId = focusedId
+      }
+    }
+    if (presentation.visible()) {
+      val frame =
+          compositor.compose(presentation).orElseThrow {
+            IllegalStateException("Visible Proposal 3 presentation did not compose")
+          }
+      renderedVisible = true
+      frameSink(frame)
+      return
+    }
+
+    frameSink(null)
+    if (renderedVisible) {
+      renderedVisible = false
+      releaseGameplaySoon()
+      if (pauseOwnedByMenu) {
+        pauseOwnedByMenu = false
+        runOnEdt {
+          if (commands.isEnabled(DesktopCommand.PAUSE)) commands.setPaused(false)
+        }
+      }
+    }
+  }
+
+  private fun releaseGameplaySoon() {
+    SwingUtilities.invokeLater(releaseGameplay)
+  }
+
+  private fun runOnEdt(action: () -> Unit) {
+    if (SwingUtilities.isEventDispatchThread()) action() else SwingUtilities.invokeLater(action)
+  }
+
+  private fun Button.toMenuKey(): MenuKey =
+      when (this) {
+        Button.RIGHT -> MenuKey.RIGHT
+        Button.LEFT -> MenuKey.LEFT
+        Button.UP -> MenuKey.UP
+        Button.DOWN -> MenuKey.DOWN
+        Button.A -> MenuKey.A
+        Button.B -> MenuKey.B
+        Button.SELECT -> MenuKey.SELECT
+        Button.START -> MenuKey.START
+      }
+
+  private fun archiveItemId(candidate: RomSourceSnapshot.ArchiveCandidate): String =
+      "archive:${candidate.token()}"
+
+  private fun DesktopCommand.confirmationLabel(): String =
+      when (this) {
+        DesktopCommand.RESET -> "RESET GAME"
+        DesktopCommand.CLOSE_GAME -> "STOP GAME"
+        else -> error("Unsupported confirmation command: $this")
+      }
+}
+
+/**
+ * Host seam for archive entries discovered by [RomOpenService]. The host owns only presentation;
+ * the callbacks return to [DesktopRomOpen], which revalidates request ownership before touching
+ * the service.
+ */
+internal interface DesktopArchiveSelectionHost {
+  fun showArchiveSelection(
+      requestId: Long,
+      candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+      onSelected: (RomSourceSnapshot.ArchiveCandidate) -> Unit,
+      onCancelled: () -> Unit,
+  )
+
+  fun closeArchiveSelection(requestId: Long)
+}
+
+/** Command boundary keeps the native Swing action implementations outside the portable model. */
+internal interface PortableMenuCommandBridge {
+  fun menuState(): DesktopPresentation
+
+  fun isEnabled(command: DesktopCommand): Boolean
+
+  fun invoke(command: DesktopCommand)
+
+  fun canOpenAbout(): Boolean
+
+  fun openAbout()
+
+  fun setPaused(paused: Boolean)
+
+  fun openPreferences(category: PreferencesCategory)
+
+  fun canSaveState(slot: Int): Boolean
+
+  fun canLoadState(slot: Int): Boolean
+
+  fun saveState(slot: Int)
+
+  fun loadState(slot: Int)
+}
+
+/** The printer keeps its existing modeless Swing window and native export chooser. */
+internal interface PortableMenuPrinterBridge {
+  fun hasPaper(): Boolean
+
+  fun paperPreview(): MenuPreview
+
+  fun open()
+
+  fun clear()
+
+  fun export()
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuInputCapture.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuInputCapture.java
@@ -1,0 +1,18 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.util.Collection;
+
+/**
+ * Optional host capture for the portable menu's player-one controller input.
+ *
+ * <p>The desktop input hub calls this with the union of every physical player-one source. A true
+ * result means that the current sample belongs to the menu and must not reach gameplay.</p>
+ */
+public interface DesktopMenuInputCapture {
+
+    boolean updatePlayerButtons(Collection<Button> buttons);
+
+    boolean visible();
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuKeyboardInput.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuKeyboardInput.java
@@ -1,0 +1,13 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.ui.menu.MenuKey;
+
+/** Keyboard-side capture boundary for the portable in-screen menu. */
+public interface DesktopMenuKeyboardInput {
+
+    boolean visible();
+
+    boolean onKeyDown(MenuKey key, boolean repeat);
+
+    boolean onKeyUp(MenuKey key);
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopPlayerInput.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopPlayerInput.java
@@ -8,7 +8,9 @@ import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,6 +20,11 @@ public final class DesktopPlayerInput {
     private final PlayerInputHub hub;
     private final EventBus eventBus;
     private final Map<Object, Registration> sources = new IdentityHashMap<>();
+
+    private DesktopMenuInputCapture menuCapture;
+
+    /** True after a menu capture until every physical source has returned to neutral. */
+    private boolean gameplaySuppressed;
 
     private boolean focused = true;
 
@@ -37,7 +44,37 @@ public final class DesktopPlayerInput {
             registration = new Registration(player, hub.openSource(player));
             sources.put(identity, registration);
         }
-        emit(registration.handle.update(focused ? buttons : Set.of()));
+        registration.physical.clear();
+        for (Button button : buttons) {
+            registration.physical.add(button);
+        }
+
+        boolean menuConsumed = menuCapture != null && player == 0
+                && menuCapture.updatePlayerButtons(playerZeroButtonsLocked());
+        boolean menuVisible = menuCapture != null && menuCapture.visible();
+        if (menuConsumed || menuVisible || gameplaySuppressed) {
+            gameplaySuppressed = true;
+            suppressGameplayLocked();
+            // A released physical source is deliberately not replayed into the hub here. The
+            // next non-neutral sample must be a new press, which prevents a button held while
+            // closing the menu from becoming a gameplay latch.
+            if (!anyPhysicalButtonHeldLocked() && !menuVisible) {
+                gameplaySuppressed = false;
+            }
+            return;
+        }
+
+        emit(registration.handle.update(focused ? registration.physical : Set.of()));
+    }
+
+    /** Installs or replaces the optional Proposal 3 controller capture. */
+    public synchronized void setMenuCapture(DesktopMenuInputCapture capture) {
+        menuCapture = capture;
+        if (capture == null) {
+            gameplaySuppressed = false;
+            return;
+        }
+        suppressGameplayLocked();
     }
 
     public synchronized void disconnect(Object identity) {
@@ -67,9 +104,35 @@ public final class DesktopPlayerInput {
     }
 
     public synchronized void close() {
-        sources.values().forEach(registration -> emit(registration.handle.closeAndGetChange()));
+        List<Registration> registrations = List.copyOf(sources.values());
+        registrations.forEach(registration -> emit(registration.handle.closeAndGetChange()));
         sources.clear();
         emit(hub.releaseAll());
+    }
+
+    private EnumSet<Button> playerZeroButtonsLocked() {
+        EnumSet<Button> buttons = EnumSet.noneOf(Button.class);
+        for (Registration registration : sources.values()) {
+            if (registration.player == 0) {
+                buttons.addAll(registration.physical);
+            }
+        }
+        return buttons;
+    }
+
+    private boolean anyPhysicalButtonHeldLocked() {
+        return sources.values().stream().anyMatch(registration -> !registration.physical.isEmpty());
+    }
+
+    private void suppressGameplayLocked() {
+        List<Registration> registrations = List.copyOf(sources.values());
+        registrations.forEach(registration -> {
+            // A menu callback may release a keyboard source synchronously. Avoid updating a
+            // handle that was removed during that callback.
+            if (sources.containsValue(registration)) {
+                emit(registration.handle.update(Set.of()));
+            }
+        });
     }
 
     private void emit(PlayerInputHub.InputChange change) {
@@ -89,6 +152,17 @@ public final class DesktopPlayerInput {
         eventBus.post(new LogicalPlayerButtonReleaseEvent(player, button));
     }
 
-    private record Registration(int player, PlayerInputHub.SourceHandle handle) {
+    private static final class Registration {
+
+        private final int player;
+
+        private final PlayerInputHub.SourceHandle handle;
+
+        private final EnumSet<Button> physical = EnumSet.noneOf(Button.class);
+
+        private Registration(int player, PlayerInputHub.SourceHandle handle) {
+            this.player = player;
+            this.handle = handle;
+        }
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -12,6 +12,7 @@ import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
 
 import javax.swing.*;
 import java.awt.*;
@@ -40,6 +41,8 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private final PresentationFrameRateMeter presentationFrameRate =
             new PresentationFrameRateMeter();
+
+    private final SwingMenuOverlay menuOverlay = new SwingMenuOverlay();
 
     private PendingFrame pendingFrame;
 
@@ -314,6 +317,17 @@ public class SwingDisplay extends JPanel implements Runnable {
         return new StateImage(frame.width(), frame.height(), frame.copyRgb());
     }
 
+    /** Installs one immutable portable Proposal 3 frame over the display. */
+    public void setMenuOverlay(MenuArgbFrame frame) {
+        menuOverlay.setFrame(frame);
+        requestRepaint();
+    }
+
+    /** Clears the portable menu overlay and exposes the emulator frame again. */
+    public void clearMenuOverlay() {
+        setMenuOverlay(null);
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
         requireEventDispatchThread("Display painting");
@@ -347,6 +361,15 @@ public class SwingDisplay extends JPanel implements Runnable {
         Graphics2D notificationGraphics = (Graphics2D) g.create();
         paintNotification(notificationGraphics, viewport);
         notificationGraphics.dispose();
+
+        if (menuOverlay.visible()) {
+            // The aspect-fit bars belong to the menu presentation, not the game frame beneath it.
+            // Clearing the component first prevents a narrow/tall host from leaking gameplay
+            // pixels around the exact 924x736 Proposal 3 artwork.
+            g.setColor(getBackground());
+            g.fillRect(0, 0, getWidth(), getHeight());
+            menuOverlay.paint((Graphics2D) g, getWidth(), getHeight());
+        }
     }
 
     private void showNotification(String text) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.controller.properties.ControllerProperties;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.joypad.Button;
 import eu.rekawek.coffeegb.swing.DesktopKeyboardKeyAdapter;
+import eu.rekawek.coffeegb.ui.menu.MenuKey;
 
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -76,6 +77,24 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
     /** True when an unmodified key belongs to a configured button or the fallback rewind key. */
     public synchronized boolean handlesKeyCode(int keyCode) {
         return mapping.containsKey(keyCode) || keyCode == REWIND_KEY;
+    }
+
+    /** Returns the configured player-one logical key for portable-menu capture, if any. */
+    public synchronized MenuKey menuKeyForKeyCode(int keyCode) {
+        ControllerProperties.PlayerButton binding = mapping.get(keyCode);
+        if (binding == null || binding.getPlayer() != 0) {
+            return null;
+        }
+        return switch (binding.getButton()) {
+            case RIGHT -> MenuKey.RIGHT;
+            case LEFT -> MenuKey.LEFT;
+            case UP -> MenuKey.UP;
+            case DOWN -> MenuKey.DOWN;
+            case A -> MenuKey.A;
+            case B -> MenuKey.B;
+            case SELECT -> MenuKey.SELECT;
+            case START -> MenuKey.START;
+        };
     }
 
     @Override

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingMenuOverlay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingMenuOverlay.java
@@ -1,0 +1,81 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuRect;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.Objects;
+
+/**
+ * Swing's tiny adapter around the platform-neutral Proposal 3 frame.
+ *
+ * <p>The portable frame is decoded exactly once per object identity and then drawn with an
+ * integer destination rectangle from {@link MenuViewport}. No Swing text, layout, or widget is
+ * painted here.</p>
+ */
+final class SwingMenuOverlay {
+
+    private MenuArgbFrame frame;
+
+    private BufferedImage image;
+
+    synchronized void setFrame(MenuArgbFrame next) {
+        if (next == frame) {
+            return;
+        }
+        frame = next;
+        image = next == null ? null : decode(next);
+    }
+
+    synchronized boolean visible() {
+        return frame != null;
+    }
+
+    void paint(Graphics2D graphics, int viewWidth, int viewHeight) {
+        Objects.requireNonNull(graphics, "graphics");
+        if (viewWidth <= 0 || viewHeight <= 0) {
+            return;
+        }
+        BufferedImage current;
+        synchronized (this) {
+            current = image;
+        }
+        if (current == null) {
+            return;
+        }
+
+        MenuViewport viewport = MenuViewport.fit(viewWidth, viewHeight);
+        MenuRect destination = viewport.contentBounds();
+        Graphics2D copy = (Graphics2D) graphics.create();
+        copy.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+        copy.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+        copy.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
+                RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
+        copy.drawImage(current,
+                destination.x(), destination.y(), destination.right(), destination.bottom(),
+                0, 0, current.getWidth(), current.getHeight(), null);
+        copy.dispose();
+    }
+
+    /** Package-private identity seam for cache tests. */
+    synchronized BufferedImage imageForTest() {
+        return image;
+    }
+
+    /** Package-private identity seam for cache tests. */
+    synchronized MenuArgbFrame frameForTest() {
+        return frame;
+    }
+
+    private static BufferedImage decode(MenuArgbFrame source) {
+        BufferedImage decoded = new BufferedImage(source.width(), source.height(),
+                BufferedImage.TYPE_INT_ARGB);
+        int[] pixels = source.copyPixels();
+        decoded.setRGB(0, 0, source.width(), source.height(), pixels, 0, source.width());
+        return decoded;
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopInputRouterTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopInputRouterTest.kt
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.swing
 
+import eu.rekawek.coffeegb.swing.io.DesktopMenuKeyboardInput
+import eu.rekawek.coffeegb.ui.menu.MenuKey
 import java.awt.Component
 import java.awt.KeyEventDispatcher
 import java.awt.event.InputEvent
@@ -183,6 +185,33 @@ class DesktopInputRouterTest {
     fixture.router.close()
   }
 
+  @Test
+  fun `portable menu captures configured keys and returns ownership cleanly`() {
+    val menu = RecordingPortableMenu()
+    val text = JTextField()
+    val fixture =
+        Fixture(
+            joypadKeys = setOf(KeyEvent.VK_UP),
+            portableMenu = menu,
+            menuKeyForKeyCode = { if (it == KeyEvent.VK_UP) MenuKey.UP else null },
+            yieldsToComponent = { component, _ -> component === text },
+        )
+    fixture.router.install()
+
+    assertTrue(fixture.dispatch(press(KeyEvent.VK_UP)))
+    assertTrue(fixture.dispatch(release(KeyEvent.VK_UP)))
+    assertTrue(fixture.dispatch(press(KeyEvent.VK_UP, component = text)))
+    assertTrue(fixture.dispatch(release(KeyEvent.VK_UP, component = text)))
+    assertEquals(listOf("down:UP", "up:UP", "down:UP", "up:UP"), menu.events)
+    assertTrue(fixture.events.isEmpty())
+
+    menu.visible = false
+    assertTrue(fixture.dispatch(press(KeyEvent.VK_UP)))
+    assertTrue(fixture.dispatch(release(KeyEvent.VK_UP)))
+    assertEquals(listOf("joypad-press", "joypad-release"), fixture.events)
+    fixture.router.close()
+  }
+
   private class Fixture(
       joypadKeys: Set<Int> = emptySet(),
       tiltKeys: Set<Int> = emptySet(),
@@ -191,6 +220,8 @@ class DesktopInputRouterTest {
       belongsToMainWindow: (Component?) -> Boolean = { true },
       yieldsToComponent: (Component?, Int) -> Boolean = { _, _ -> false },
       isMenuActive: () -> Boolean = { false },
+      val portableMenu: DesktopMenuKeyboardInput? = null,
+      val menuKeyForKeyCode: (Int) -> MenuKey? = { null },
   ) {
     val events = mutableListOf<String>()
     var releaseAllCount = 0
@@ -201,6 +232,8 @@ class DesktopInputRouterTest {
             belongsToMainWindow = belongsToMainWindow,
             yieldsToComponent = yieldsToComponent,
             isMenuActive = isMenuActive,
+            portableMenu = portableMenu,
+            menuKeyForKeyCode = menuKeyForKeyCode,
             joypadHandles = { it in joypadKeys },
             joypadPressed = { events += "joypad-press" },
             joypadReleased = { events += "joypad-release" },
@@ -211,6 +244,23 @@ class DesktopInputRouterTest {
         )
 
     fun dispatch(event: KeyEvent): Boolean = registry.dispatch(event)
+  }
+
+  private class RecordingPortableMenu : DesktopMenuKeyboardInput {
+    var visible = true
+    val events = mutableListOf<String>()
+
+    override fun visible(): Boolean = visible
+
+    override fun onKeyDown(key: MenuKey, repeat: Boolean): Boolean {
+      events += "down:$key"
+      return true
+    }
+
+    override fun onKeyUp(key: MenuKey): Boolean {
+      events += "up:$key"
+      return true
+    }
   }
 
   private class RecordingRegistry : KeyEventDispatcherRegistry {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
@@ -67,6 +67,35 @@ class DesktopRomOpenTest {
   }
 
   @Test
+  fun `drop transfer handler rejects menu-visible drops and resumes when hidden`() {
+    val submitted = mutableListOf<List<RomOpenInput>>()
+    val feedback = mutableListOf<Boolean>()
+    val local = Path.of("gated.gb").toAbsolutePath().normalize()
+    var menuVisible = true
+    val handler =
+        RomDropTransferHandler(
+            submit = submitted::add,
+            feedback = feedback::add,
+            enabled = { !menuVisible },
+        )
+
+    fun support() =
+        TransferHandler.TransferSupport(
+            JPanel(),
+            StringSelection(local.toUri().toString()),
+        )
+
+    assertFalse(handler.canImport(support()))
+    assertFalse(handler.importData(support()))
+    assertTrue(submitted.isEmpty())
+    assertEquals(false, feedback.last())
+
+    menuVisible = false
+    assertTrue(handler.importData(support()))
+    assertEquals(local, assertIs<RomOpenInput.LocalPath>(submitted.single().single()).path)
+  }
+
+  @Test
   fun `dropped text is bounded by characters encoded bytes lines and input count`() {
     val characterLimit =
         assertIs<RomOpenInput.Rejected>(
@@ -325,7 +354,8 @@ class DesktopRomOpenTest {
   fun `drop feedback includes visible text and an accessible active state`() {
     val root = JRootPane()
     root.setSize(640, 480)
-    val feedback = RomDropFeedback(root)
+    var enabled = true
+    val feedback = RomDropFeedback(root) { enabled }
 
     feedback.update(true)
 
@@ -337,6 +367,14 @@ class DesktopRomOpenTest {
     assertEquals("Drop to open this ROM or archive", label.text)
     assertTrue(root.accessibleContext.accessibleDescription.contains("active"))
 
+    enabled = false
+    feedback.update(true)
+    assertFalse(label.isVisible)
+    assertTrue(root.accessibleContext.accessibleDescription.startsWith("Drop one"))
+
+    enabled = true
+    feedback.update(true)
+    assertTrue(label.isVisible)
     feedback.update(false)
     assertFalse(label.isVisible)
     assertTrue(root.accessibleContext.accessibleDescription.startsWith("Drop one"))

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingPrinterTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingPrinterTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.controller.Controller.SerialPeripheralSelection
 import eu.rekawek.coffeegb.controller.Controller.SetPrinterEvent
 import eu.rekawek.coffeegb.controller.Controller.SetSerialPeripheralEvent
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import java.awt.Component
 import java.nio.file.Files
 import java.util.concurrent.Executor
@@ -52,6 +53,38 @@ class SwingPrinterTest {
     assertEquals(1L, rejected.model.omittedStripCount)
     assertTrue(rejected.model.rollFull)
     assertEquals(RED, stable.rgbAt(0, 3), "A later overflow must not alter the old generation")
+  }
+
+  @Test
+  fun `portable preview is an immutable ARGB view of the current paper generation`() {
+    val source = IntArray(PRINTER_PAPER_WIDTH * 2) { index -> if (index < 160) RED else BLUE }
+    val model =
+        PrinterPaperModel.empty()
+            .append(printEvent(source, height = 2, topMargin = 1, bottomMargin = 1))
+            .model
+
+    val preview = model.snapshot().menuPreview()
+
+    assertEquals(MenuPreview.State.READY, preview.state())
+    assertEquals(PRINTER_PAPER_WIDTH, preview.width())
+    assertEquals(8, preview.height())
+    assertEquals(0xffffffff.toInt(), preview.copyPixels()[0])
+    assertEquals(0xffcc2211.toInt(), preview.copyPixels()[3 * PRINTER_PAPER_WIDTH])
+    assertEquals(0xff2244cc.toInt(), preview.copyPixels()[4 * PRINTER_PAPER_WIDTH])
+
+    val detached = preview.copyPixels()
+    detached[3 * PRINTER_PAPER_WIDTH] = 0xff000000.toInt()
+    assertEquals(0xffcc2211.toInt(), preview.copyPixels()[3 * PRINTER_PAPER_WIDTH])
+
+    val tall =
+        PrinterPaperModel.empty()
+            .append(solidStrip(height = 193, color = RED))
+            .model
+            .snapshot()
+            .menuPreview()
+    assertEquals(192, tall.height())
+    assertTrue(tall.width() < PRINTER_PAPER_WIDTH)
+    assertTrue(tall.width() * tall.height() <= MenuPreview.MAX_PIXELS)
   }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
@@ -1,0 +1,484 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.joypad.Button
+import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot
+import eu.rekawek.coffeegb.ui.menu.MenuKey
+import eu.rekawek.coffeegb.ui.menu.MenuRoute
+import eu.rekawek.coffeegb.ui.menu.MenuPreview
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame
+import java.util.EnumSet
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SwingProposal3MenuTest {
+
+  @Test
+  fun `start and select controller chord captures gameplay and neutral rearm is explicit`() {
+    val bridge = FakeBridge()
+    val releaseCount = AtomicInteger()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = { releaseCount.incrementAndGet() },
+        )
+
+    assertTrue(menu.updatePlayerButtons(EnumSet.of(Button.START, Button.SELECT)))
+    assertTrue(menu.visible())
+    repeat(2) { javax.swing.SwingUtilities.invokeAndWait {} }
+    assertTrue(releaseCount.get() >= 1)
+  }
+
+  @Test
+  fun `open rom header delegates to desktop native chooser command boundary`() {
+    val bridge = FakeBridge()
+    val frames = mutableListOf<MenuArgbFrame?>()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = { frames += it },
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait { menu.openFromDesktop() }
+    javax.swing.SwingUtilities.invokeAndWait {
+      assertTrue(menu.onKeyDown(MenuKey.START, false))
+      assertTrue(menu.onKeyUp(MenuKey.START))
+      assertTrue(menu.onKeyDown(MenuKey.START, false))
+    }
+
+    assertEquals(listOf(DesktopCommand.OPEN_ROM), bridge.invoked)
+    assertTrue(frames.any { it != null })
+    assertTrue(frames.last() == null)
+  }
+
+  @Test
+  fun `archive candidates are rendered as dynamic rows and open selected returns the candidate`() {
+    val bridge = FakeBridge()
+    val selected = mutableListOf<RomSourceSnapshot.ArchiveCandidate>()
+    val cancelled = AtomicInteger()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+    val candidates =
+        listOf(
+            archiveCandidate(41, "games/first.gb", "FIRST GAME"),
+            archiveCandidate(42, "games/second.gbc", "SECOND GAME"),
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.showArchiveSelection(
+          requestId = 17,
+          candidates = candidates,
+          onSelected = selected::add,
+          onCancelled = { cancelled.incrementAndGet() },
+      )
+      assertEquals(MenuRoute.CHOOSE_ROM, menu.routeForTest())
+      assertEquals("archive:41", menu.focusedItemIdForTest())
+
+      press(menu, MenuKey.DOWN)
+      assertEquals("archive:42", menu.focusedItemIdForTest())
+      press(menu, MenuKey.DOWN)
+      assertEquals("open-selected", menu.focusedItemIdForTest())
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+    }
+
+    assertEquals(listOf(candidates[1]), selected)
+    assertEquals(0, cancelled.get())
+    assertFalse(menu.visible())
+    assertEquals(listOf(true, false), bridge.pauseTransitions)
+  }
+
+  @Test
+  fun `archive B cancels the request and does not select a candidate`() {
+    val bridge = FakeBridge()
+    val selected = mutableListOf<RomSourceSnapshot.ArchiveCandidate>()
+    val cancelled = AtomicInteger()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.showArchiveSelection(
+          requestId = 23,
+          candidates =
+              listOf(
+                  archiveCandidate(51, "first.gb", "FIRST"),
+                  archiveCandidate(52, "second.gbc", "SECOND"),
+              ),
+          onSelected = selected::add,
+          onCancelled = { cancelled.incrementAndGet() },
+      )
+      assertTrue(menu.onKeyDown(MenuKey.B, false))
+    }
+
+    assertTrue(selected.isEmpty())
+    assertEquals(1, cancelled.get())
+    assertFalse(menu.visible())
+    assertEquals(listOf(true, false), bridge.pauseTransitions)
+  }
+
+  @Test
+  fun `newer archive request closes the stale screen but an older callback cannot close it`() {
+    val bridge = FakeBridge()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+    val candidates =
+        listOf(
+            archiveCandidate(61, "first.gb", "FIRST"),
+            archiveCandidate(62, "second.gbc", "SECOND"),
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.showArchiveSelection(17, candidates, onSelected = {}, onCancelled = {})
+      menu.showArchiveSelection(18, candidates, onSelected = {}, onCancelled = {})
+      assertEquals(MenuRoute.CHOOSE_ROM, menu.routeForTest())
+
+      menu.closeArchiveSelection(17)
+      assertEquals(MenuRoute.CHOOSE_ROM, menu.routeForTest())
+      menu.closeArchiveSelection(18)
+    }
+
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `reset opens the onscreen confirmation and back returns to pause without invoking`() {
+    val bridge = FakeBridge()
+    val menu = newMenu(bridge)
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      moveToPauseItem(menu, 3)
+      press(menu, MenuKey.A)
+
+      assertEquals(MenuRoute.CONFIRM_ACTION, menu.routeForTest())
+      press(menu, MenuKey.B)
+      assertEquals(MenuRoute.PAUSE_CONSOLE, menu.routeForTest())
+    }
+
+    assertTrue(bridge.invoked.isEmpty())
+    assertEquals(listOf(true), bridge.pauseTransitions)
+  }
+
+  @Test
+  fun `stop opens the onscreen confirmation and cancel returns to pause without invoking`() {
+    val bridge = FakeBridge()
+    val menu = newMenu(bridge)
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      moveToPauseItem(menu, 5)
+      press(menu, MenuKey.A)
+
+      assertEquals(MenuRoute.CONFIRM_ACTION, menu.routeForTest())
+      assertEquals("cancel", menu.focusedItemIdForTest())
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.PAUSE_CONSOLE, menu.routeForTest())
+    }
+
+    assertTrue(bridge.invoked.isEmpty())
+    assertEquals(listOf(true), bridge.pauseTransitions)
+  }
+
+  @Test
+  fun `confirming reset invokes reset and hides while resuming`() {
+    val bridge = FakeBridge()
+    val menu = newMenu(bridge)
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      moveToPauseItem(menu, 3)
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.CONFIRM_ACTION, menu.routeForTest())
+      press(menu, MenuKey.DOWN)
+      assertEquals("confirm", menu.focusedItemIdForTest())
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+      menu.onKeyUp(MenuKey.A)
+    }
+
+    assertEquals(listOf(DesktopCommand.RESET), bridge.invoked)
+    assertEquals(listOf(true, false), bridge.pauseTransitions)
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `confirming stop invokes close game and hides while resuming`() {
+    val bridge = FakeBridge()
+    val menu = newMenu(bridge)
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      moveToPauseItem(menu, 5)
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.CONFIRM_ACTION, menu.routeForTest())
+      press(menu, MenuKey.DOWN)
+      assertEquals("confirm", menu.focusedItemIdForTest())
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+      menu.onKeyUp(MenuKey.A)
+    }
+
+    assertEquals(listOf(DesktopCommand.CLOSE_GAME), bridge.invoked)
+    assertEquals(listOf(true, false), bridge.pauseTransitions)
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `settings reaches about with privacy notices as the visible enabled selection`() {
+    val bridge = FakeBridge()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.openFromDesktop()
+    }
+    javax.swing.SwingUtilities.invokeAndWait {
+      repeat(4) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.SETTINGS, menu.routeForTest())
+
+      repeat(8) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.ABOUT, menu.routeForTest())
+      assertEquals("privacy-notices", menu.focusedItemIdForTest())
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+      menu.onKeyUp(MenuKey.A)
+    }
+
+    assertTrue(bridge.aboutOpened)
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `about back navigation returns through settings without a hidden back row`() {
+    val bridge = FakeBridge()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait { menu.openFromDesktop() }
+    javax.swing.SwingUtilities.invokeAndWait {
+      repeat(4) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      repeat(8) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.ABOUT, menu.routeForTest())
+      assertEquals("privacy-notices", menu.focusedItemIdForTest())
+
+      press(menu, MenuKey.B)
+      assertEquals(MenuRoute.SETTINGS, menu.routeForTest())
+      press(menu, MenuKey.B)
+      assertEquals(MenuRoute.PAUSE_CONSOLE, menu.routeForTest())
+    }
+  }
+
+  @Test
+  fun `save states secondary select loads the focused slot`() {
+    val bridge = FakeBridge()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait { menu.openFromDesktop() }
+    javax.swing.SwingUtilities.invokeAndWait {
+      press(menu, MenuKey.DOWN)
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.SAVE_STATES, menu.routeForTest())
+      assertEquals("slot-0", menu.focusedItemIdForTest())
+      assertTrue(menu.onKeyDown(MenuKey.SELECT, false))
+    }
+
+    assertEquals(0, bridge.loadedSlot)
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `printer route renders the bridge paper preview and keeps export native`() {
+    val bridge = FakeBridge()
+    val printer = FakePrinter(MenuPreview.ready(1, 1, intArrayOf(0xffd02020.toInt())))
+    val frames = mutableListOf<MenuArgbFrame?>()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = { frames += it },
+            commands = bridge,
+            releaseGameplay = {},
+            printer = printer,
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.openFromDesktop()
+      repeat(4) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      repeat(3) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      repeat(3) { press(menu, MenuKey.DOWN) }
+      assertEquals("preview-printer-paper", menu.focusedItemIdForTest())
+      press(menu, MenuKey.A)
+
+      assertEquals(MenuRoute.PRINTER_PAPER, menu.routeForTest())
+      assertEquals("export-share-paper", menu.focusedItemIdForTest())
+    }
+
+    val frame = frames.filterNotNull().last()
+    assertEquals(0xffd02020.toInt(), frame.copyPixels()[345 * frame.width() + 642])
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+    }
+    assertEquals(1, printer.exportCount)
+    assertFalse(menu.visible())
+  }
+
+  @Test
+  fun `printer route refreshes to visible back after paper disappears`() {
+    val bridge = FakeBridge()
+    val printer = FakePrinter(MenuPreview.ready(1, 1, intArrayOf(0xffd02020.toInt())))
+    val menu = newMenu(bridge, printer)
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      repeat(4) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      repeat(3) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      repeat(3) { press(menu, MenuKey.DOWN) }
+      press(menu, MenuKey.A)
+      assertEquals(MenuRoute.PRINTER_PAPER, menu.routeForTest())
+
+      printer.preview = MenuPreview.empty()
+      press(menu, MenuKey.A)
+
+      assertEquals(MenuRoute.OPTIONAL_DEVICES, menu.routeForTest())
+    }
+
+    assertEquals(0, printer.exportCount)
+    assertEquals(0, printer.clearCount)
+  }
+
+  private fun newMenu(
+      bridge: FakeBridge,
+      printer: PortableMenuPrinterBridge? = null,
+  ): SwingProposal3Menu {
+    val menu =
+        SwingProposal3Menu(
+            frameSink = {},
+            commands = bridge,
+            releaseGameplay = {},
+            printer = printer,
+        )
+    javax.swing.SwingUtilities.invokeAndWait { menu.openFromDesktop() }
+    return menu
+  }
+
+  private fun moveToPauseItem(menu: SwingProposal3Menu, downPresses: Int) {
+    repeat(downPresses) { press(menu, MenuKey.DOWN) }
+  }
+
+  private fun press(menu: SwingProposal3Menu, key: MenuKey) {
+    assertTrue(menu.onKeyDown(key, false))
+    assertTrue(menu.onKeyUp(key))
+  }
+
+  private fun archiveCandidate(
+      token: Long,
+      entryName: String,
+      title: String,
+  ): RomSourceSnapshot.ArchiveCandidate =
+      RomSourceSnapshot.ArchiveCandidate(token, entryName, 0, 32 * 1024, title)
+
+  private class FakeBridge : PortableMenuCommandBridge {
+    val invoked = mutableListOf<DesktopCommand>()
+    val pauseTransitions = mutableListOf<Boolean>()
+    var aboutOpened = false
+    var loadedSlot: Int? = null
+    private val enabled =
+        setOf(
+            DesktopCommand.OPEN_ROM,
+            DesktopCommand.PAUSE,
+            DesktopCommand.RESET,
+            DesktopCommand.SAVE_STATE,
+            DesktopCommand.LOAD_STATE,
+            DesktopCommand.PREFERENCES,
+            DesktopCommand.CLOSE_GAME,
+        )
+
+    override fun menuState(): DesktopPresentation =
+        DesktopPresentation(
+            gameTitle = "TEST GAME",
+            commands =
+                DesktopCommandPresentation(
+                    gameLoaded = true,
+                    pauseSupported = true,
+                    stateCommandsAvailable = true,
+                    stateBrowserAvailable = true,
+                ),
+        )
+
+    override fun isEnabled(command: DesktopCommand): Boolean = command in enabled
+
+    override fun invoke(command: DesktopCommand) {
+      invoked += command
+    }
+
+    override fun canOpenAbout(): Boolean = true
+
+    override fun openAbout() {
+      aboutOpened = true
+    }
+
+    override fun setPaused(paused: Boolean) {
+      pauseTransitions += paused
+    }
+
+    override fun openPreferences(category: PreferencesCategory) = Unit
+
+    override fun canSaveState(slot: Int): Boolean = true
+
+    override fun canLoadState(slot: Int): Boolean = true
+
+    override fun saveState(slot: Int) = Unit
+
+    override fun loadState(slot: Int) {
+      loadedSlot = slot
+    }
+  }
+
+  private class FakePrinter(initialPreview: MenuPreview) : PortableMenuPrinterBridge {
+    var preview = initialPreview
+    var clearCount = 0
+    var exportCount = 0
+
+    override fun hasPaper(): Boolean = preview.state() == MenuPreview.State.READY
+
+    override fun paperPreview(): MenuPreview = preview
+
+    override fun open() = Unit
+
+    override fun clear() {
+      clearCount++
+      preview = MenuPreview.empty()
+    }
+
+    override fun export() {
+      exportCount++
+    }
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
@@ -8,6 +8,7 @@ import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JRootPane
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -53,6 +54,46 @@ class SwingProposal3MenuTest {
     assertEquals(listOf(DesktopCommand.OPEN_ROM), bridge.invoked)
     assertTrue(frames.any { it != null })
     assertTrue(frames.last() == null)
+  }
+
+  @Test
+  fun `opening Proposal 3 clears drag feedback before its first frame`() {
+    val root = JRootPane()
+    root.setSize(640, 480)
+    lateinit var menu: SwingProposal3Menu
+    val feedback = RomDropFeedback(root) { !menu.visible() }
+    val label =
+        root.layeredPane.components
+            .filterIsInstance<javax.swing.JLabel>()
+            .single { it.name == "romDropFeedback" }
+    val visibility = mutableListOf<Boolean>()
+    var feedbackVisibleAtFirstFrame: Boolean? = null
+    menu =
+        SwingProposal3Menu(
+            frameSink = { frame ->
+              if (frame != null && feedbackVisibleAtFirstFrame == null) {
+                feedbackVisibleAtFirstFrame = label.isVisible
+              }
+            },
+            commands = FakeBridge(),
+            releaseGameplay = {},
+            onVisibilityChanged = { visible ->
+              visibility += visible
+              if (visible) feedback.update(false)
+            },
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      feedback.update(true)
+      assertTrue(label.isVisible)
+      menu.openFromDesktop()
+      assertFalse(label.isVisible)
+      assertTrue(menu.onKeyDown(MenuKey.A, false))
+    }
+
+    assertEquals(false, feedbackVisibleAtFirstFrame)
+    assertEquals(listOf(true, false), visibility)
+    feedback.close()
   }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingMenuOverlayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingMenuOverlayTest.java
@@ -1,0 +1,86 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
+import eu.rekawek.coffeegb.ui.menu.MenuRoute;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuRect;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor;
+import org.junit.Test;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class SwingMenuOverlayTest {
+
+    @Test
+    public void menuViewportIsUniformAndCentered() {
+        MenuViewport viewport = MenuViewport.fit(1600, 900);
+
+        assertEquals(new MenuRect(235, 0, 1129, 900), viewport.contentBounds());
+        assertEquals(viewport.contentBounds().width() / (double) viewport.contentBounds().height(),
+                MenuViewport.SOURCE_WIDTH / (double) MenuViewport.SOURCE_HEIGHT,
+                0.002);
+    }
+
+    @Test
+    public void frameIdentityReusesTheDecodedSwingImage() {
+        MenuArgbFrame frame = composePauseFrame();
+        SwingMenuOverlay overlay = new SwingMenuOverlay();
+
+        overlay.setFrame(frame);
+        BufferedImage first = overlay.imageForTest();
+        overlay.setFrame(frame);
+
+        assertSame(first, overlay.imageForTest());
+        assertSame(frame, overlay.frameForTest());
+        overlay.setFrame(null);
+        assertNull(overlay.imageForTest());
+    }
+
+    @Test
+    public void exactFitRendersPortablePixelsWithoutReflow() {
+        MenuArgbFrame frame = composePauseFrame();
+        SwingMenuOverlay overlay = new SwingMenuOverlay();
+        overlay.setFrame(frame);
+        BufferedImage target = new BufferedImage(frame.width(), frame.height(),
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = target.createGraphics();
+        overlay.paint(graphics, target.getWidth(), target.getHeight());
+        graphics.dispose();
+
+        int[] expected = frame.copyPixels();
+        assertEquals(expected[0], target.getRGB(0, 0));
+        int center = (frame.height() / 2) * frame.width() + frame.width() / 2;
+        assertEquals(expected[center], target.getRGB(frame.width() / 2, frame.height() / 2));
+    }
+
+    private static MenuArgbFrame composePauseFrame() {
+        AtomicReference<MenuPresentation> presentation = new AtomicReference<>();
+        MenuController controller = new MenuController(new MenuController.Listener() {
+            @Override
+            public void onPresentation(MenuPresentation next) {
+                presentation.set(next);
+            }
+
+            @Override
+            public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+            }
+
+            @Override
+            public void onHeaderSelected(MenuRoute route) {
+            }
+        });
+        controller.show(MenuRoute.PAUSE_CONSOLE);
+        return new Proposal3MenuCompositor()
+                .compose(presentation.get())
+                .orElseThrow(() -> new AssertionError("pause frame was not composed"));
+    }
+}


### PR DESCRIPTION
## Summary
- render the shared Proposal 3 compositor frame as a single aspect-fitted Swing overlay, including full-screen
- capture configured keyboard/controller navigation while the menu is open and safely re-arm gameplay input
- keep the native Swing file picker and printer export surfaces, while moving multi-ROM archive selection into the Proposal 3 route tree
- suppress native drag/drop feedback and drop handling while the exact in-screen raster is visible
- bridge existing desktop actions, saved states, preferences, printer preview, confirmations, and About into the portable menu
- make API 26 native-picker lifecycle instrumentation wait for true input readiness without guest-uptime deadline races

## Verification
- `/opt/maven/bin/mvn -pl swing test`
- 726 tests, 0 failures, 0 errors, 1 intentional skip
- Android API 26: 19/19 instrumentation tests; both previously flaky lifecycle flows also passed 3 consecutive isolated runs each
- Android API 36: 19/19 instrumentation tests
- exact-fit raster, route/action, archive ownership, printer preview, keyboard/controller capture, and drag/drop isolation tests
- Sol Ultra final design/supervision audit: PASS
