### PR TITLE
Gate Proposal 3 desktop menu behind opt-in flag

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -76,6 +76,7 @@ internal data class DesktopCommandHandlers(
  */
 internal class DesktopActionRegistry(
     private val handlers: DesktopCommandHandlers,
+    private val proposal3MenuAvailable: Boolean = false,
 ) : PortableMenuCommandBridge {
   private var presentation = DesktopCommandPresentation()
   private var appliedShortcuts: DesktopShortcutRegistry? = null
@@ -218,7 +219,8 @@ internal class DesktopActionRegistry(
         DesktopCommand.NETPLAY,
         DesktopCommand.MUTE,
         DesktopCommand.SHOW_COMMAND_BAR -> !state.sessionBusy
-        DesktopCommand.OPEN_MENU -> state.gameLoaded && !state.sessionBusy
+        DesktopCommand.OPEN_MENU ->
+            proposal3MenuAvailable && state.gameLoaded && !state.sessionBusy
         DesktopCommand.CLOSE_GAME,
         DesktopCommand.RESET -> state.gameLoaded && !state.sessionBusy
       DesktopCommand.PAUSE ->

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopFeatureFlags.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopFeatureFlags.kt
@@ -1,0 +1,11 @@
+package eu.rekawek.coffeegb.swing
+
+/** Opt-in desktop features that are intentionally not part of the stable default UI yet. */
+internal object DesktopFeatureFlags {
+  /** Enables the portable Proposal 3 menu with `-Dcoffee-gb.desktop.proposal3-menu=true`. */
+  const val PROPOSAL3_MENU_PROPERTY = "coffee-gb.desktop.proposal3-menu"
+
+  fun proposal3MenuEnabled(
+      value: String? = System.getProperty(PROPOSAL3_MENU_PROPERTY),
+  ): Boolean = value.equals("true", ignoreCase = true)
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
@@ -28,18 +28,21 @@ import java.nio.file.Path
 import java.util.Locale
 import java.util.concurrent.Executor
 import javax.swing.BorderFactory
+import javax.swing.DefaultListCellRenderer
 import javax.swing.JButton
 import javax.swing.JDialog
 import javax.swing.JFileChooser
 import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JLayeredPane
+import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.JProgressBar
 import javax.swing.JRootPane
 import javax.swing.JScrollPane
 import javax.swing.JTextArea
 import javax.swing.JToggleButton
+import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import javax.swing.Timer
@@ -214,36 +217,23 @@ internal class DesktopRomOpen(
     when (update.stage) {
       RomOpenStage.AWAITING_ARCHIVE_SELECTION -> {
         progress.close(update.requestId)
-        val host = archiveSelectionHost
-        if (host == null) {
-          // The host is installed during SwingGui initialization, before a request can be
-          // submitted. Cancelling is the safe fallback if a lifecycle race reaches this point.
-          LOG.warn("Archive selection arrived before the Proposal 3 host was installed")
-          service.cancel(update.requestId)
-        } else {
-          host.showArchiveSelection(
+        presentArchiveSelection(
+            archiveSelectionHost,
+            update.requestId,
+            update.candidates,
+            chooseNative = { candidates ->
+              chooseArchiveCandidate(owner, candidates, dialogFactory)
+            },
+        ) { selected ->
+          applyArchiveSelectionIfCurrent(
               update.requestId,
-              update.candidates,
-              onSelected = { candidate ->
-                applyArchiveSelectionIfCurrent(
-                    update.requestId,
-                    candidate,
-                    service::ownsVisibleRequest,
-                    service::cancel,
-                ) { selected ->
-                  progress.show(update.requestId, "Opening ${selected.displayName()}…")
-                  service.selectArchive(update.requestId, selected.token())
-                }
-              },
-              onCancelled = {
-                applyArchiveSelectionIfCurrent(
-                    update.requestId,
-                    null,
-                    service::ownsVisibleRequest,
-                    service::cancel,
-                ) { error("Cancelled archive selection cannot be accepted") }
-              },
-          )
+              selected,
+              service::ownsVisibleRequest,
+              service::cancel,
+          ) { candidate ->
+            progress.show(update.requestId, "Opening ${candidate.displayName()}…")
+            service.selectArchive(update.requestId, candidate.token())
+          }
         }
       }
       RomOpenStage.AWAITING_PERSISTENCE_DECISION ->
@@ -355,6 +345,27 @@ internal class DesktopRomOpen(
       RomOpenStage.AWAITING_ARCHIVE_SELECTION,
       RomOpenStage.AWAITING_PERSISTENCE_DECISION -> error("Handled separately")
     }
+  }
+}
+
+/** Uses the portable archive page when installed, otherwise preserving the native Swing chooser. */
+internal fun presentArchiveSelection(
+    host: DesktopArchiveSelectionHost?,
+    requestId: Long,
+    candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+    chooseNative: (List<RomSourceSnapshot.ArchiveCandidate>) ->
+        RomSourceSnapshot.ArchiveCandidate?,
+    onDecision: (RomSourceSnapshot.ArchiveCandidate?) -> Unit,
+) {
+  if (host == null) {
+    onDecision(chooseNative(candidates))
+  } else {
+    host.showArchiveSelection(
+        requestId,
+        candidates,
+        onSelected = onDecision,
+        onCancelled = { onDecision(null) },
+    )
   }
 }
 
@@ -488,6 +499,86 @@ internal class RomOpenProgressDialog(
       dialog.isVisible = true
     }
   }
+}
+
+internal fun chooseArchiveCandidate(
+    owner: Window,
+    candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+    dialogFactory: DesktopDialogFactory = DesktopDialogFactory(),
+): RomSourceSnapshot.ArchiveCandidate? {
+  if (candidates.isEmpty()) return null
+  val list =
+      JList(candidates.toTypedArray()).apply {
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+        selectedIndex = 0
+        visibleRowCount = minOf(candidates.size, 10)
+        getAccessibleContext().accessibleName = "ROMs in archive"
+        cellRenderer =
+            object : DefaultListCellRenderer() {
+              override fun getListCellRendererComponent(
+                  list: JList<*>?,
+                  value: Any?,
+                  index: Int,
+                  isSelected: Boolean,
+                  cellHasFocus: Boolean,
+              ) =
+                  super.getListCellRendererComponent(
+                          list,
+                          value,
+                          index,
+                          isSelected,
+                          cellHasFocus,
+                      )
+                      .also { component ->
+                        val candidate = value as RomSourceSnapshot.ArchiveCandidate
+                        (component as JLabel).text = archiveCandidateLabel(candidate)
+                        component.putClientProperty("html.disable", true)
+                        component.toolTipText =
+                            "<html>${escapeHtml(candidate.entryName())}</html>"
+                        component.accessibleContext.accessibleName =
+                            archiveCandidateAccessibleLabel(candidate)
+                      }
+            }
+      }
+  val content =
+      JScrollPane(list).apply {
+        preferredSize = Dimension(540, minOf(360, 75 + candidates.size * 28))
+        getAccessibleContext().accessibleName = "ROMs available in the archive"
+      }
+  val outcome =
+      dialogFactory.showForm(
+          owner,
+          DesktopFormSpec(
+              title = "Choose ROM — Coffee GB",
+              heading = "Choose a game from this archive",
+              description =
+                  "The archive contains more than one supported ROM. Select the game to open.",
+              contentAccessibleName = "ROM archive contents",
+              buttons =
+                  DesktopDialogButtons(
+                      primary =
+                          DesktopDialogAction(
+                              "Open selected ROM",
+                              ArchiveSelectionDecision.OPEN,
+                              mnemonic = KeyEvent.VK_O,
+                          ),
+                      cancel =
+                          DesktopDialogAction(
+                              "Cancel",
+                              ArchiveSelectionDecision.CANCEL,
+                          ),
+                      defaultButton = DesktopDialogDefaultButton.PRIMARY,
+                  ),
+              modality = DesktopOwnedDialogModality.DOCUMENT,
+          ),
+          content,
+      )
+  return list.selectedValue.takeIf { outcome == ArchiveSelectionDecision.OPEN }
+}
+
+private enum class ArchiveSelectionDecision {
+  OPEN,
+  CANCEL,
 }
 
 internal fun archiveCandidateLabel(candidate: RomSourceSnapshot.ArchiveCandidate): String {
@@ -989,6 +1080,9 @@ internal fun formatByteCount(bytes: Long): String =
       bytes < 1024 * 1024 -> String.format(Locale.ROOT, "%.1f KiB", bytes / 1024.0)
       else -> String.format(Locale.ROOT, "%.1f MiB", bytes / (1024.0 * 1024.0))
     }
+
+private fun escapeHtml(value: String): String =
+    value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 private val LOG = LoggerFactory.getLogger("DesktopRomOpen")
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -189,6 +189,7 @@ class SwingGui private constructor(
   }
 
   private fun startGui() {
+    val proposal3MenuEnabled = DesktopFeatureFlags.proposal3MenuEnabled()
     mainWindow = JFrame("Coffee GB")
     mainWindow.iconImages = listOf(16, 32, 48, 128, 256).map(CoffeeGbIcon::image)
     val minimumContentSize = emulator.minimumContentSize()
@@ -395,15 +396,19 @@ class SwingGui private constructor(
                 },
                 preferencesForCategory = { category -> showPreferences(category) },
                 openAbout = { menu.showAbout() },
-            ))
+            ),
+            proposal3MenuAvailable = proposal3MenuEnabled,
+        )
     desktopActions.applyShortcuts(
         DesktopShortcutRegistry(
             DesktopKeyboardKeyAdapter.keyCodes(properties.applicationSettings.input.keyboard.values)))
     val portableMenu =
-        emulator.installPortableMenu(desktopActions) { visible ->
-          if (visible && ::dropFeedback.isInitialized) dropFeedback.update(false)
+        installDesktopProposal3Menu(proposal3MenuEnabled) {
+          emulator.installPortableMenu(desktopActions) { visible ->
+            if (visible && ::dropFeedback.isInitialized) dropFeedback.update(false)
+          }
         }
-    romOpen.setArchiveSelectionHost(portableMenu)
+    portableMenu?.let(romOpen::setArchiveSelectionHost)
     menu =
         SwingMenu(
             properties,
@@ -420,6 +425,7 @@ class SwingGui private constructor(
             desktopActions,
             emulator::isLinkedControllerActive,
             mobileAdapterWindow::show,
+            proposal3MenuEnabled,
             { themeManager.current?.tokens ?: initialTheme.tokens },
             { message ->
               desktopUiCoordinator.warning(message, DesktopCommand.PREFERENCES)
@@ -564,7 +570,7 @@ class SwingGui private constructor(
           }
         })
 
-    installRomDropTarget(portableMenu::visible)
+    installRomDropTarget { portableMenu?.visible() == true }
     mainWindow.pack()
     mainWindow.minimumSize =
         minimumFrameSize(
@@ -1147,6 +1153,10 @@ class SwingGui private constructor(
     }
   }
 }
+
+/** Keeps Proposal 3 construction and its input capture out of the default desktop startup path. */
+internal fun <T> installDesktopProposal3Menu(enabled: Boolean, install: () -> T): T? =
+    if (enabled) install() else null
 
 internal fun ApplicationSettings.Appearance.toDesktopAppearance(): DesktopAppearance =
     when (this) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -47,6 +47,12 @@ internal data class DebuggerMenuActions(
 /** A dynamic Pause/Resume label is a command, not a checked state in the platform menu. */
 internal fun pauseResumeMenuItem(action: Action): JMenuItem = JMenuItem(action)
 
+internal fun addProposal3MenuItem(menu: JMenu, openMenuAction: Action, enabled: Boolean) {
+  if (!enabled) return
+  menu.add(JMenuItem(openMenuAction))
+  menu.addSeparator()
+}
+
 internal fun mobileAdapterConfigurationMenuItem(onShow: () -> Unit): JMenuItem =
     JMenuItem("Configure Mobile Adapter…").apply {
       accessibleContext.accessibleDescription =
@@ -134,6 +140,7 @@ internal class SwingMenu(
     private val desktopActions: DesktopActionRegistry,
     private val isLinkedControllerActive: () -> Boolean,
     private val onMobileAdapterConfiguration: () -> Unit,
+    private val proposal3MenuEnabled: Boolean,
     currentThemeTokens: () -> DesktopThemeTokens,
     private val onDesktopStatus: (String) -> Unit = {},
 ) {
@@ -356,8 +363,11 @@ internal class SwingMenu(
   private fun createGameMenu(): JMenu {
     val gameMenu = JMenu("Game")
 
-    gameMenu.add(JMenuItem(desktopActions[DesktopCommand.OPEN_MENU]))
-    gameMenu.addSeparator()
+    addProposal3MenuItem(
+        gameMenu,
+        desktopActions[DesktopCommand.OPEN_MENU],
+        proposal3MenuEnabled,
+    )
     gameMenu.add(pauseResumeMenuItem(desktopActions[DesktopCommand.PAUSE]))
     gameMenu.add(JMenuItem(desktopActions[DesktopCommand.RESET]))
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -107,6 +107,20 @@ class DesktopActionsTest {
   }
 
   @Test
+  fun `Proposal 3 command is unavailable unless the desktop feature is enabled`() {
+    val handlers = handlers(mutableListOf())
+    val hidden = DesktopActionRegistry(handlers, proposal3MenuAvailable = false)
+    val enabled = DesktopActionRegistry(handlers, proposal3MenuAvailable = true)
+    val playing = DesktopCommandPresentation(gameLoaded = true)
+
+    hidden.update(playing)
+    enabled.update(playing)
+
+    assertFalse(hidden[DesktopCommand.OPEN_MENU].isEnabled)
+    assertTrue(enabled[DesktopCommand.OPEN_MENU].isEnabled)
+  }
+
+  @Test
   fun `gameplay bindings withdraw only matching unmodified application shortcuts`() {
     val shortcuts =
         DesktopShortcutRegistry(
@@ -127,8 +141,10 @@ class DesktopActionsTest {
   }
 
   private fun registry(calls: MutableList<String>): DesktopActionRegistry =
-      DesktopActionRegistry(
-          DesktopCommandHandlers(
+      DesktopActionRegistry(handlers(calls))
+
+  private fun handlers(calls: MutableList<String>): DesktopCommandHandlers =
+      DesktopCommandHandlers(
               openRom = { calls += "open" },
               closeGame = { calls += "close" },
               preferences = { calls += "preferences" },
@@ -145,7 +161,7 @@ class DesktopActionsTest {
               screenshot = { calls += "screenshot" },
               setCommandBarVisible = { calls += "bar=$it" },
               selectStateSlot = { calls += "slot=$it" },
-          ))
+          )
 
   private fun event() = ActionEvent(this, ActionEvent.ACTION_PERFORMED, "test")
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopFeatureFlagsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopFeatureFlagsTest.kt
@@ -1,0 +1,39 @@
+package eu.rekawek.coffeegb.swing
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class DesktopFeatureFlagsTest {
+  @Test
+  fun `Proposal 3 desktop menu is opt-in`() {
+    assertFalse(DesktopFeatureFlags.proposal3MenuEnabled(null))
+    assertFalse(DesktopFeatureFlags.proposal3MenuEnabled(""))
+    assertFalse(DesktopFeatureFlags.proposal3MenuEnabled("false"))
+    assertFalse(DesktopFeatureFlags.proposal3MenuEnabled("yes"))
+    assertTrue(DesktopFeatureFlags.proposal3MenuEnabled("true"))
+    assertTrue(DesktopFeatureFlags.proposal3MenuEnabled("TRUE"))
+  }
+
+  @Test
+  fun `default desktop startup does not construct the Proposal 3 overlay`() {
+    var installs = 0
+
+    val hidden =
+        installDesktopProposal3Menu(enabled = false) {
+          installs++
+          "hidden"
+        }
+    val enabled =
+        installDesktopProposal3Menu(enabled = true) {
+          installs++
+          "installed"
+        }
+
+    assertNull(hidden)
+    assertEquals("installed", enabled)
+    assertEquals(1, installs)
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopRomOpenTest.kt
@@ -165,6 +165,73 @@ class DesktopRomOpenTest {
   }
 
   @Test
+  fun `archive selection keeps the native chooser when no portable host is installed`() {
+    val candidate =
+        RomSourceSnapshot.ArchiveCandidate(7, "games/game.gbc", 1, 32 * 1024, "GAME")
+    var chooserCandidates = emptyList<RomSourceSnapshot.ArchiveCandidate>()
+    val decisions = mutableListOf<RomSourceSnapshot.ArchiveCandidate?>()
+
+    presentArchiveSelection(
+        host = null,
+        requestId = 41,
+        candidates = listOf(candidate),
+        chooseNative = {
+          chooserCandidates = it
+          candidate
+        },
+        onDecision = decisions::add,
+    )
+
+    assertEquals(listOf(candidate), chooserCandidates)
+    assertEquals(listOf<RomSourceSnapshot.ArchiveCandidate?>(candidate), decisions)
+  }
+
+  @Test
+  fun `archive selection uses the portable host only when it is installed`() {
+    val candidate =
+        RomSourceSnapshot.ArchiveCandidate(9, "games/alternate.gb", 0, 16 * 1024, "ALT")
+    var nativeChooserInvoked = false
+    var selectedCallback: ((RomSourceSnapshot.ArchiveCandidate) -> Unit)? = null
+    var cancelledCallback: (() -> Unit)? = null
+    val decisions = mutableListOf<RomSourceSnapshot.ArchiveCandidate?>()
+    val host =
+        object : DesktopArchiveSelectionHost {
+          override fun showArchiveSelection(
+              requestId: Long,
+              candidates: List<RomSourceSnapshot.ArchiveCandidate>,
+              onSelected: (RomSourceSnapshot.ArchiveCandidate) -> Unit,
+              onCancelled: () -> Unit,
+          ) {
+            assertEquals(42, requestId)
+            assertEquals(listOf(candidate), candidates)
+            selectedCallback = onSelected
+            cancelledCallback = onCancelled
+          }
+
+          override fun closeArchiveSelection(requestId: Long) = Unit
+        }
+
+    presentArchiveSelection(
+        host,
+        requestId = 42,
+        candidates = listOf(candidate),
+        chooseNative = {
+          nativeChooserInvoked = true
+          null
+        },
+        onDecision = decisions::add,
+    )
+
+    assertFalse(nativeChooserInvoked)
+    assertTrue(decisions.isEmpty())
+    selectedCallback?.invoke(candidate)
+    assertEquals(listOf<RomSourceSnapshot.ArchiveCandidate?>(candidate), decisions)
+    decisions.clear()
+    cancelledCallback?.invoke()
+    assertEquals(listOf<RomSourceSnapshot.ArchiveCandidate?>(null), decisions)
+  }
+
+  @Test
   fun `error presentation starts concise with accessible expandable diagnostics`() {
     val panel =
         createRomOpenErrorPanel(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingMenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingMenuTest.kt
@@ -1,7 +1,11 @@
 package eu.rekawek.coffeegb.swing
 
+import java.awt.event.ActionEvent
+import javax.swing.AbstractAction
 import javax.swing.JMenu
 import javax.swing.JMenuBar
+import javax.swing.JMenuItem
+import javax.swing.JSeparator
 import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -9,6 +13,27 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class SwingMenuTest {
+
+  @Test
+  fun `Proposal 3 menu insertion follows the feature flag`() {
+    val openMenuAction =
+        object : AbstractAction("On-screen Menu") {
+          override fun actionPerformed(event: ActionEvent) = Unit
+        }
+    val disabledMenu = JMenu("Game")
+
+    addProposal3MenuItem(disabledMenu, openMenuAction, enabled = false)
+
+    assertEquals(0, disabledMenu.menuComponentCount)
+
+    val enabledMenu = JMenu("Game")
+    addProposal3MenuItem(enabledMenu, openMenuAction, enabled = true)
+
+    assertEquals(2, enabledMenu.menuComponentCount)
+    assertEquals(openMenuAction, (enabledMenu.getMenuComponent(0) as JMenuItem).action)
+    assertEquals("On-screen Menu", (enabledMenu.getMenuComponent(0) as JMenuItem).text)
+    assertTrue(enabledMenu.getMenuComponent(1) is JSeparator)
+  }
 
   @Test
   fun `mobile adapter configuration action opens the retained window`() {


### PR DESCRIPTION
## Summary

- keep the portable Proposal 3 on-screen menu disabled in desktop builds by default
- enable it only with `-Dcoffee-gb.desktop.proposal3-menu=true`
- omit its native Game-menu entry and controller/input capture while disabled
- preserve the native Swing archive chooser when the portable menu is unavailable
- leave Android behavior unchanged

## Why

The portable UI is still being refined against the approved mockups. Desktop users should retain the established native interface unless they explicitly opt into the new controller-friendly overlay.

## Validation

- `/opt/maven/bin/mvn -B -pl swing -Dtest=DesktopFeatureFlagsTest,DesktopActionsTest,DesktopRomOpenTest,SwingMenuTest test` (30 tests)
- `/opt/maven/bin/mvn -B -pl swing test` (732 tests, 0 failures, 1 existing skip)
- Sol Ultra activation-path review; Luna Max implemented the headless-safe Game-menu regression seam
