### PR TITLE
Support HiTek mapper for Terrifying 911

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -115,6 +115,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterEngine\$MobileAdapterEngineNetworkState",
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint\$MobileAdapterSerialEndpointNetworkState",
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint\$MobileAdapterSerialEndpointWireState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Hitek\$HitekState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1645,6 +1645,11 @@ internal object StateSemantics {
           it.recordType("delegateMemento", MBC5_STATE)
           it.range("dataSwapMode", 0, 7); it.range("bankSwapMode", 0, 7)
         }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Hitek\$HitekState"] =
+        constrained("HiTek data/bank permutation selectors index eight-entry tables.") {
+          it.recordType("delegateMemento", MBC5_STATE)
+          it.range("dataSwapMode", 0, 7); it.range("bankSwapMode", 0, 7)
+        }
     target["eu.rekawek.coffeegb.core.memory.cart.type.Mmm01\$Mmm01State"] =
         constrained("MMM01 bank fields and masks retain their documented hardware bit widths.") {
           it.range("romBankLow", 0, 0x1f); it.range("romBankMid", 0, 3)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -123,6 +123,9 @@ class StateCoverageMatrixTest {
             mapper("Bbd", listOf(0x2000 to 0x11, 0x4000 to 0x03)) {
               Bbd(it, Battery.NULL_BATTERY)
             },
+            mapper("Hitek", listOf(0x2001 to 0x04, 0x2080 to 0x03, 0x2000 to 0x11)) {
+              Hitek(it, Battery.NULL_BATTERY)
+            },
             mapper("SachenMmc1", listOf(0x0000 to 0x0a, 0x2000 to 0x12, 0x4000 to 0x02)) {
               SachenMmc(it, false, false)
             },
@@ -184,7 +187,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(27, registeredMapperRecords.size)
+    assertEquals(28, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -798,6 +801,7 @@ class StateCoverageMatrixTest {
             "SlMulticart",
             "Sintax",
             "Bbd",
+            "Hitek",
             "SachenMmc1",
             "SachenMmc2",
             "WisdomTree",

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -99,6 +99,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case LI_CHENG -> new LiCheng(rom, battery);
             case VF001_ZOOK -> new Vf001Zook(rom, battery);
             case VF001_GENERAL -> new Vf001General(rom, battery);
+            case HITEK -> new Hitek(rom, battery);
             case BBD -> new Bbd(rom, battery);
             case SINTAX -> new Sintax(rom, battery);
             case SACHEN_MMC1 -> new SachenMmc(rom, false, true);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -28,6 +28,7 @@ public final class CartridgeProperties {
         LI_CHENG,
         VF001_ZOOK,
         VF001_GENERAL,
+        HITEK,
         BBD,
         SINTAX,
         SACHEN_MMC1,
@@ -122,6 +123,8 @@ public final class CartridgeProperties {
                     Mapper.VF001_ZOOK),
             mapper("Vast Fame VF001 protection", CartridgeProperties::isVf001General,
                     Mapper.VF001_GENERAL),
+            mapper("HiTek unlicensed mapper", CartridgeProperties::isHitek,
+                    Mapper.HITEK),
             mapper("BBD unlicensed mapper", CartridgeProperties::isBbd,
                     Mapper.BBD),
             mapper("Sintax unlicensed mapper", CartridgeProperties::isSintax,
@@ -413,6 +416,10 @@ public final class CartridgeProperties {
         int secondaryLogo = info.crc32(0x0184, 0x30);
         return (secondaryLogo == 0xc7d8c1df || secondaryLogo == 0x6d1ea662)
                 && info.byteAt(0x7fff) != 0x01;
+    }
+
+    private static boolean isHitek(RomInfo info) {
+        return info.crc32(0x0184, 0x30) == 0x4fdab691;
     }
 
     private static boolean isSintax(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Hitek.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Hitek.java
@@ -1,0 +1,138 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+/**
+ * The unlicensed HiTek mapper used by Gaoke/Ruanxin cartridges. It is MBC5-compatible,
+ * with power-on data and bank permutations that the game reprograms through BBD-like
+ * protection registers.
+ */
+public class Hitek implements MemoryController {
+
+    private static final int[] IDENTITY = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    private static final int[][] DATA_REORDERING = {
+            IDENTITY,
+            {0, 6, 5, 3, 4, 1, 2, 7},
+            {0, 5, 6, 3, 4, 2, 1, 7},
+            {0, 6, 2, 3, 4, 5, 1, 7},
+            {0, 6, 1, 3, 4, 5, 2, 7},
+            {0, 1, 6, 3, 4, 5, 2, 7},
+            {0, 2, 6, 3, 4, 1, 5, 7},
+            {0, 6, 2, 3, 4, 1, 5, 7}
+    };
+
+    private static final int[][] BANK_REORDERING = {
+            IDENTITY,
+            {3, 2, 1, 0, 4, 5, 6, 7},
+            {2, 1, 0, 3, 4, 5, 6, 7},
+            {1, 0, 3, 2, 4, 5, 6, 7},
+            {0, 3, 2, 1, 4, 5, 6, 7},
+            {2, 3, 0, 1, 4, 5, 6, 7},
+            {3, 0, 1, 2, 4, 5, 6, 7},
+            {2, 0, 3, 1, 4, 5, 6, 7}
+    };
+
+    private final Mbc5 delegate;
+
+    private int dataSwapMode = 7;
+
+    private int bankSwapMode = 7;
+
+    public Hitek(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (address >= 0x3000 && address < 0x4000) {
+            return;
+        }
+        switch (address & 0xf0ff) {
+            case 0x2000 -> value = reorderBits(value, BANK_REORDERING[bankSwapMode]);
+            case 0x2001 -> dataSwapMode = value & 0x07;
+            case 0x2080 -> bankSwapMode = value & 0x07;
+            default -> {
+            }
+        }
+        delegate.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        int value = delegate.getByte(address);
+        if (address >= 0x4000 && address < 0x8000) {
+            return reorderBits(value, DATA_REORDERING[dataSwapMode]);
+        }
+        return value;
+    }
+
+    private static int reorderBits(int value, int[] reorder) {
+        int result = 0;
+        for (int newBit = 0; newBit < 8; newBit++) {
+            result |= ((value >> reorder[newBit]) & 1) << newBit;
+        }
+        return result;
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public boolean isRumbleActive() {
+        return delegate.isRumbleActive();
+    }
+
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        delegate.setDebugHooks(hooks);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new HitekState(delegate.captureState(), dataSwapMode, bankSwapMode);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new HitekState(
+                delegate.captureState(capture), dataSwapMode, bankSwapMode);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof HitekState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        delegate.restoreState(mem.delegateMemento);
+        dataSwapMode = mem.dataSwapMode;
+        bankSwapMode = mem.bankSwapMode;
+    }
+
+    private record HitekState(ComponentState<MemoryController> delegateMemento, int dataSwapMode,
+                              int bankSwapMode) implements ComponentState<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/HitekTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/HitekTest.java
@@ -1,0 +1,173 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HitekTest {
+
+    private static final int[][] DATA_REORDERING = {
+            {0, 1, 2, 3, 4, 5, 6, 7},
+            {0, 6, 5, 3, 4, 1, 2, 7},
+            {0, 5, 6, 3, 4, 2, 1, 7},
+            {0, 6, 2, 3, 4, 5, 1, 7},
+            {0, 6, 1, 3, 4, 5, 2, 7},
+            {0, 1, 6, 3, 4, 5, 2, 7},
+            {0, 2, 6, 3, 4, 1, 5, 7},
+            {0, 6, 2, 3, 4, 1, 5, 7}
+    };
+
+    private static final int[][] BANK_REORDERING = {
+            {0, 1, 2, 3, 4, 5, 6, 7},
+            {3, 2, 1, 0, 4, 5, 6, 7},
+            {2, 1, 0, 3, 4, 5, 6, 7},
+            {1, 0, 3, 2, 4, 5, 6, 7},
+            {0, 3, 2, 1, 4, 5, 6, 7},
+            {2, 3, 0, 1, 4, 5, 6, 7},
+            {3, 0, 1, 2, 4, 5, 6, 7},
+            {2, 0, 3, 1, 4, 5, 6, 7}
+    };
+
+    @Test
+    public void detectsHitekSecondaryLogo() throws IOException {
+        Rom rom = new Rom(hitekRom());
+
+        assertEquals(CartridgeProperties.Mapper.HITEK,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof Hitek);
+    }
+
+    @Test
+    public void appliesPowerOnAndProgrammedPermutations() throws IOException {
+        byte[] data = hitekRom();
+        data[1 * 0x4000 + 0x0123] = 0x02;
+        data[2 * 0x4000 + 0x0123] = 0x40;
+        data[4 * 0x4000 + 0x0123] = 0x04;
+        Hitek mapper = new Hitek(new Rom(data), Battery.NULL_BATTERY);
+
+        // Power-on bank mode 7 routes bank bit 0 to bit 1, and data mode 7
+        // routes input bit 6 to output bit 1.
+        mapper.setByte(0x2000, 0x01);
+        assertEquals(0x02, mapper.getByte(0x4123));
+
+        // Programming the control ports also performs their underlying MBC5
+        // bank writes, so mode 1 selects bank 1 before the next explicit write.
+        mapper.setByte(0x2001, 0x01);
+        assertEquals(0x20, mapper.getByte(0x4123));
+        mapper.setByte(0x2080, 0x01);
+        assertEquals(0x20, mapper.getByte(0x4123));
+        mapper.setByte(0x2000, 0x02);
+        assertEquals(0x40, mapper.getByte(0x4123));
+    }
+
+    @Test
+    public void ignoresMbc5HighBankWrites() throws IOException {
+        byte[] data = hitekRom(129, 0x06);
+        data[0x4000] = 0x11;
+        data[128 * 0x4000] = 0x22;
+        Hitek mapper = new Hitek(new Rom(data), Battery.NULL_BATTERY);
+        mapper.setByte(0x2001, 0x00);
+        mapper.setByte(0x2080, 0x00);
+        mapper.setByte(0x2000, 0x01);
+
+        mapper.setByte(0x3001, 0x01);
+
+        assertEquals(0x11, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void supportsEveryDataAndBankPermutationMode() throws IOException {
+        byte[] data = hitekRom(256, 0x07);
+        int markerOffset = 0x0123;
+        for (int mode = 0; mode < 8; mode++) {
+            for (int bit = 0; bit < 8; bit++) {
+                data[mode * 0x4000 + markerOffset + bit] = (byte) (1 << bit);
+            }
+        }
+        int bankMarkerOffset = 0x0200;
+        for (int bank = 0; bank < 256; bank++) {
+            data[bank * 0x4000 + bankMarkerOffset] = (byte) bank;
+        }
+        Hitek mapper = new Hitek(new Rom(data), Battery.NULL_BATTERY);
+
+        for (int mode = 0; mode < 8; mode++) {
+            mapper.setByte(0x2001, mode);
+            for (int bit = 0; bit < 8; bit++) {
+                int oneHot = 1 << bit;
+                assertEquals(reorderBits(oneHot, DATA_REORDERING[mode]),
+                        mapper.getByte(0x4000 + markerOffset + bit));
+            }
+        }
+
+        mapper.setByte(0x2001, 0x00);
+        for (int mode = 0; mode < 8; mode++) {
+            mapper.setByte(0x2080, mode);
+            for (int bit = 0; bit < 8; bit++) {
+                int oneHot = 1 << bit;
+                mapper.setByte(0x2000, oneHot);
+                assertEquals(reorderBits(oneHot, BANK_REORDERING[mode]),
+                        mapper.getByte(0x4000 + bankMarkerOffset));
+            }
+        }
+    }
+
+    @Test
+    public void stateRoundTripPreservesProtectionModes() throws IOException {
+        byte[] data = hitekRom();
+        data[4 * 0x4000 + 0x0123] = 0x02;
+        Hitek mapper = new Hitek(new Rom(data), Battery.NULL_BATTERY);
+        mapper.setByte(0x2001, 0x04);
+        mapper.setByte(0x2080, 0x01);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2001, 0x00);
+        mapper.setByte(0x2080, 0x00);
+        mapper.restoreState(state);
+        mapper.setByte(0x2000, 0x02);
+
+        assertEquals(0x04, mapper.getByte(0x4123));
+    }
+
+    private static byte[] hitekRom() {
+        return hitekRom(128, 0x06);
+    }
+
+    private static byte[] hitekRom(int banks, int sizeCode) {
+        byte[] data = new byte[banks * 0x4000];
+        data[0x0147] = 0x1b;
+        data[0x0148] = (byte) sizeCode;
+        data[0x0149] = 0x03;
+        // Synthetic 48-byte block whose CRC-32 is the public HiTek secondary-logo
+        // fingerprint. It contains no commercial ROM or logo bytes.
+        byte[] prefix = "COFFEE GB HITEK CLEANROOM REGRESSION FIXTURE"
+                .getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(prefix, 0, data, 0x0184, prefix.length);
+        for (int i = prefix.length; i < 44; i++) {
+            data[0x0184 + i] = '.';
+        }
+        data[0x01b0] = (byte) 0xa5;
+        data[0x01b1] = 0x42;
+        data[0x01b2] = (byte) 0xcf;
+        data[0x01b3] = 0x17;
+        return data;
+    }
+
+    private static int reorderBits(int value, int[] reorder) {
+        int result = 0;
+        for (int newBit = 0; newBit < 8; newBit++) {
+            result |= ((value >> reorder[newBit]) & 1) << newBit;
+        }
+        return result;
+    }
+}

--- a/docs/legacy-state-retirement.md
+++ b/docs/legacy-state-retirement.md
@@ -51,7 +51,7 @@ carries the compatibility leaves.
 The architecture test strips the marked compatibility declarations and proves that the remaining
 live owner source has no `Memento<T>` or compatibility-leaf dependency. It also proves that every
 normal record is non-serializable, the normal and compatibility registries are disjoint, and the
-99 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
+100 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
 remain pinned.
 
 ## Supported migration inputs and limits

--- a/docs/state-file-v1.md
+++ b/docs/state-file-v1.md
@@ -165,12 +165,12 @@ Every value starts with a one-byte tag:
 
 Float NaN payloads and signed zero are preserved with `doubleToRawLongBits`. Int32-map keys are
 strictly increasing and unique. Record type IDs are the one-based stable entries of the audited
-99-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
+100-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
 The 11 enum type IDs use the same audited ordering, while enum value IDs are an explicit v1
 one-based registry verified against the production enum names. Class names from input are never
 loaded or instantiated.
 
-The record ID/name/field registry is the exact ordered 99-record appendix in
+The record ID/name/field registry is the exact ordered 100-record appendix in
 [state-memento-schema.md](state-memento-schema.md), where each bullet's one-based position is its
 ID. IDs 88 through 91 deliberately name non-serializable normal-state leaves; the local legacy
 importer has ID-aligned historical descriptor classes with the same field schemas. StateFile does
@@ -188,7 +188,8 @@ parser/configuration/timing state, and restore as externally
 disconnected. An in-flight deterministic request byte may pair ID 99 with nested ID 97 so its
 latched reply finishes before the normalized disconnect takes effect. Other mid-byte external-I/O
 captures use ID 99 wire phase 11, retain only the already-latched reply byte, and reset the wire at
-that byte boundary. None of IDs 92 through 99 has a legacy descriptor because no released
+that byte boundary. ID 100 appends the HiTek mapper state. None of IDs 92 through 100 has a legacy
+descriptor because no released
 Java-serialized snapshot could contain them. The v1 enum registry is:
 
 | Type ID | Enum | Value IDs in order starting at 1 |

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -8,7 +8,7 @@ Before mutation, apply checks the hardware tag, nested record/mapper tree, invar
 serial endpoint and component-state root, cartridge RTC locations, runtime DTO, held input, and linked
 topology against the already-configured target. Null is admitted only for audited owner/field or
 array-element positions, not inferred from the non-null value's type. The adapter then reconstructs
-the complete replacement and applies the semantic policy registered for each of the 99 admitted
+the complete replacement and applies the semantic policy registered for each of the 100 admitted
 record types. Those policies reject invalid indices, counts, capacities, command phases, and scalar
 relationships before the first live mutation. If an unexpected component apply nevertheless
 throws, the adapter restores the machine, both RTC locations, serial endpoint/runtime, held
@@ -32,7 +32,7 @@ Protocol v8 remains StateFile-v1-only and rejects MGB before linked construction
 The exact remaining compatibility surface and removal policy are documented in
 [legacy-state-retirement.md](legacy-state-retirement.md).
 
-The exact field-by-field portable schema for all 99 admitted production record types is documented
+The exact field-by-field portable schema for all 100 admitted production record types is documented
 in [state-memento-schema.md](state-memento-schema.md), while `StateTypeRegistry` is the executable
 type allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral
 an explicit non-idle setup and compares a fixed continuation trace plus final state;
@@ -147,7 +147,7 @@ Records whose fields are deliberately not range-constrained still have an explic
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
 documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
 are validated by nested records. Runtime semantic preflight requires the policy-key set to equal
-all 99 admitted record types, so a new state record cannot enter the model without an explicit
+all 100 admitted record types, so a new state record cannot enter the model without an explicit
 choice. Rollback is retained for unexpected failures in legacy restore code; it is not the validation path for a
 deterministically malformed detached candidate.
 

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -1,6 +1,6 @@
 # Audited state-record schema
 
-This documents the captured fields for all 99 production record types admitted by
+This documents the captured fields for all 100 production record types admitted by
 `StateTypeRegistry`. Each bullet's one-based position is its stable StateFile-v1 record type ID;
 each line names the non-serializable `ComponentState` record and every component captured by
 `captureState`. `StateTypeRegistry`, the StateFile golden/schema tests, and capture/apply behavior
@@ -140,3 +140,4 @@ altering the 1.7.13/1.7.14 migration schema listed below.
 - `eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterEngine$MobileAdapterEngineNetworkState`: phaseId, outcomeId, errorId, deviceId, packetBuffer, packetCount, expectedPacketBytes, configuration, responsePacket, acknowledgement, idlePhaseUnits, serialByteObserved, pendingPacketSlots, externalIoAtCapture
 - `eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint$MobileAdapterSerialEndpointNetworkState`: engineState, sb, sendBitIndex
 - `eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint$MobileAdapterSerialEndpointWireState`: engineState, sb, sendBitIndex, byteTransferActive, wirePhaseId, currentReply, requestAcknowledgement, responsePacket, responseByteIndex, awaitingResponse, responseRetryCount
+- `eu.rekawek.coffeegb.core.memory.cart.type.Hitek$HitekState`: delegateMemento, dataSwapMode, bankSwapMode


### PR DESCRIPTION
## Summary

Terrifying 911 (China) (En) (Unl) remained on a black screen in CGB mode because Coffee GB treated the cartridge as plain MBC5. The cartridge uses the unlicensed HiTek protection mapper: bank and ROM-data bits start in scrambled modes, can be reprogrammed through the 0x2001 and 0x2080 control ports, and do not expose the normal MBC5 high-bank register in the 0x3000-0x3fff range.

This change:

- detects the public HiTek secondary-logo fingerprint before the broader unlicensed mapper profiles;
- adds the complete eight-mode HiTek bank and data permutations with the documented power-on modes and control-port forwarding;
- preserves the protection modes in save states and registers the new append-only portable state record with semantic validation;
- adds clean-room unit fixtures covering detection, every one-hot permutation, ignored high-bank writes, and state restoration;
- extends the controller mapper state round-trip coverage and schema documentation.

The implementation follows the public HiTek mapper behavior documented by hhugboy and independently implemented by mGBA:

- https://github.com/tzlion/hhugboy/blob/b54549b70faf49ff73029f3cf7861d82e1a24543/src/memory/mbc/MbcUnlHitek.cpp
- https://github.com/mgba-emu/mgba/blob/afd6f14eaf8bd35214ed3fb9dc69a92bfc3877a9/src/gb/mbc/unlicensed.c

## Verification

Before the change, the exact supplied ROM stayed black beyond frame 2,000. After the change, a persistent private run reached the HiTek logo, story, title/menu, mission start, and playable first stage; directional and action inputs produced normal gameplay.

Passed:

- `/opt/maven/bin/mvn -q -pl core -Dtest=HitekTest,BbdTest test`
- `/opt/maven/bin/mvn -q -pl core test`
- `/opt/maven/bin/mvn -q -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2`
- `/opt/maven/bin/mvn -q -pl core test -Ptest-blargg-individual,test-blargg`
- `/opt/maven/bin/mvn -q -pl controller -am -Dtest=StateCoverageMatrixTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `/opt/maven/bin/mvn -q -pl controller -am test`

Private before/after captures were reviewed but are not uploaded because publication of screenshots derived from the supplied commercial ROM was not authorized.

Fixes #528
