### PR TITLE
Fix Gowin first-level protection freeze

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -116,6 +116,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint\$MobileAdapterSerialEndpointNetworkState",
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint\$MobileAdapterSerialEndpointWireState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Hitek\$HitekState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Gowin\$GowinState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1554,6 +1554,13 @@ internal object StateSemantics {
           it.range("cachedRomBankFor0x0000", -1, 0x7f)
           it.range("cachedRomBankFor0x4000", -1, 0x7f)
         }
+    target["eu.rekawek.coffeegb.core.memory.cart.type.Gowin\$GowinState"] =
+        constrained("Gowin retains a high-set protection response with its nested MBC1 state.") {
+          it.recordType("delegateMemento", MBC1_STATE)
+          val response = it.int("protectionResponse")
+          it.require(response in 0..0xff && response and 0xf0 == 0xf0,
+              "has an invalid protection response $response")
+        }
     target["eu.rekawek.coffeegb.core.memory.cart.type.BungEms\$BungEmsState"] =
         constrained("Bung/EMS ROM latches are bytes, its high bit is binary, and RAM has four banks.") {
           listOf("romBankLow", "romBankMask", "romBankLatch").forEach { name -> it.range(name, 0, 0xff) }
@@ -1775,6 +1782,7 @@ internal object StateSemantics {
       "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"
   private const val FILE_BATTERY_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
+  private const val MBC1_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc1\$Mbc1State"
   private const val MBC5_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
   private const val MBC7_EEPROM_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromState"

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -35,6 +35,11 @@ class StateCoverageMatrixTest {
             mapper("Mbc1", listOf(0x0000 to 0x0a, 0x2000 to 0x03, 0xa000 to 0x32)) {
               Mbc1(it, Battery.NULL_BATTERY)
             },
+            mapper(
+                "Gowin",
+                listOf(0x2000 to 0x03, 0x6080 to 0x65),
+                listOf(0x4000, 0xa080),
+            ) { Gowin(it, Battery.NULL_BATTERY) },
             mapper("Mbc2", listOf(0x0000 to 0x0a, 0x2100 to 0x05, 0xa000 to 0x03)) {
               Mbc2(it, Battery.NULL_BATTERY)
             },
@@ -187,7 +192,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(28, registeredMapperRecords.size)
+    assertEquals(29, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -625,6 +630,7 @@ class StateCoverageMatrixTest {
       controller.setByte(0x0006, 0x7d)
       controller.setByte(0x0007, 0x0f)
     }
+    if (controller is Gowin) controller.setByte(0x6080, 0x20)
     repeat(3) { controller.tick() }
   }
 
@@ -779,6 +785,7 @@ class StateCoverageMatrixTest {
         setOf(
             "BasicRom",
             "Mbc1",
+            "Gowin",
             "Mbc2",
             "Mbc3",
             "Mbc5",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateInventoryTest.kt
@@ -40,6 +40,16 @@ class StateInventoryTest {
             1,
     )
     assertEquals(
+        100,
+        StateTypeRegistry.recordClassNames.indexOf(
+            "eu.rekawek.coffeegb.core.memory.cart.type.Hitek\$HitekState") + 1,
+    )
+    assertEquals(
+        101,
+        StateTypeRegistry.recordClassNames.indexOf(
+            "eu.rekawek.coffeegb.core.memory.cart.type.Gowin\$GowinState") + 1,
+    )
+    assertEquals(
         8,
         StatePayloadSectionCodec.serialPeripheralId(SerialPeripheralState.MOBILE_ADAPTER_GB),
     )

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -97,6 +97,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
             case LI_CHENG -> new LiCheng(rom, battery);
+            case GOWIN -> new Gowin(rom, battery);
             case VF001_ZOOK -> new Vf001Zook(rom, battery);
             case VF001_GENERAL -> new Vf001General(rom, battery);
             case HITEK -> new Hitek(rom, battery);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -26,6 +26,7 @@ public final class CartridgeProperties {
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
         LI_CHENG,
+        GOWIN,
         VF001_ZOOK,
         VF001_GENERAL,
         HITEK,
@@ -119,6 +120,8 @@ public final class CartridgeProperties {
                     Mapper.MAKON_NT_OLD_2),
             mapper("Li Cheng unlicensed mapper", CartridgeProperties::isLiCheng,
                     Mapper.LI_CHENG),
+            mapper("Gowin protection mapper", CartridgeProperties::isGowin,
+                    Mapper.GOWIN),
             mapper("Vast Fame VF001 Zook protection", CartridgeProperties::isVf001Zook,
                     Mapper.VF001_ZOOK),
             mapper("Vast Fame VF001 protection", CartridgeProperties::isVf001General,
@@ -395,6 +398,16 @@ public final class CartridgeProperties {
                 // Yingxiong Tianxia / Pokemon Jade (Telefang bootleg) uses a normal
                 // secondary logo, so its header is the stable mapper fingerprint.
                 || info.crc32(0x0100, 0x50) == 0x3ef5afb2;
+    }
+
+    private static boolean isGowin(RomInfo info) {
+        return info.data.length == 0x80000
+                && info.title().startsWith("SCHOOL FIGHTER1")
+                && info.hasValidLogo()
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x04
+                && info.byteAt(0x0149) == 0x00;
     }
 
     private static boolean isVf001Zook(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Gowin.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Gowin.java
@@ -1,0 +1,105 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+/**
+ * Gowin's MBC1-compatible protection mapper. A write to its protection latch is exposed through
+ * a four-bit combinational network in the otherwise absent external-RAM window. The response
+ * function is an inferred model constrained by every known challenge, not a physical schematic.
+ */
+public class Gowin implements MemoryController {
+
+    private static final int PROTECTION_WRITE = 0x6080;
+
+    private static final int PROTECTION_READ = 0xa080;
+
+    private final Mbc1 delegate;
+
+    private int protectionResponse = 0xff;
+
+    public Gowin(Rom rom, Battery battery) {
+        delegate = new Mbc1(rom, battery);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if (address == PROTECTION_WRITE) {
+            protectionResponse = protectionResponse(value);
+        }
+        delegate.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address == PROTECTION_READ) {
+            return protectionResponse;
+        }
+        return delegate.getByte(address);
+    }
+
+    private static int protectionResponse(int value) {
+        int bit0 = value & 1;
+        int bit1 = (value >> 1) & 1;
+        int bit2 = (value >> 2) & 1;
+        int bit3 = (value >> 3) & 1;
+        int bit5 = (value >> 5) & 1;
+
+        int responseBit3 = 1 ^ bit5;
+        int responseBit2 = (bit3 & bit2) | bit0;
+        int responseBit1 = 1 ^ ((bit1 & bit5) | responseBit2);
+        int responseBit0 = (1 ^ (bit3 | bit2)) | bit5;
+        return 0xf0
+                | responseBit0
+                | (responseBit1 << 1)
+                | (responseBit2 << 2)
+                | (responseBit3 << 3);
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        delegate.setDebugHooks(hooks);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new GowinState(delegate.captureState(), protectionResponse);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new GowinState(delegate.captureState(capture), protectionResponse);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof GowinState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        delegate.restoreState(mem.delegateMemento);
+        protectionResponse = mem.protectionResponse;
+    }
+
+    private record GowinState(ComponentState<MemoryController> delegateMemento,
+                              int protectionResponse) implements ComponentState<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/GowinTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/GowinTest.java
@@ -1,0 +1,121 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GowinTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void detectsSchoolFighterBoardWithoutAWholeRomFingerprint() throws IOException {
+        Rom rom = new Rom(gowinRom());
+
+        assertEquals(CartridgeProperties.Mapper.GOWIN,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof Gowin);
+    }
+
+    @Test
+    public void doesNotClassifyOtherMbc1SoftwareByTitleAlone() throws IOException {
+        byte[] data = gowinRom();
+        data[0x0147] = 0x19;
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                new Rom(data).getCartridgeProperties().getMapper());
+    }
+
+    @Test
+    public void answersEveryKnownSchoolFighterChallenge() throws IOException {
+        Gowin mapper = mapper();
+
+        assertEquals(0xff, mapper.getByte(0xa080));
+        assertResponse(mapper, 0x42, 0xfb);
+        assertResponse(mapper, 0x44, 0xfa);
+        assertResponse(mapper, 0x4a, 0xfa);
+        assertResponse(mapper, 0x4c, 0xfc);
+        assertResponse(mapper, 0x57, 0xfc);
+        assertResponse(mapper, 0x62, 0xf1);
+        assertResponse(mapper, 0x65, 0xf5);
+        assertResponse(mapper, 0x78, 0xf3);
+    }
+
+    @Test
+    public void preservesMbc1BankingAndProtectionState() throws IOException {
+        Gowin mapper = mapper();
+        mapper.setByte(0x2000, 5);
+        mapper.setByte(0x6080, 0x44);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 2);
+        mapper.setByte(0x6080, 0x20);
+        mapper.restoreState(state);
+
+        assertEquals(5, mapper.getByte(0x4000));
+        assertEquals(0xfa, mapper.getByte(0xa080));
+    }
+
+    @Test
+    public void protectionWritesAlsoReachTheUnderlyingMbc1ModeRegister() throws IOException {
+        byte[] data = gowinRom(0x100000, 0x05);
+        Gowin mapper = new Gowin(new Rom(data), Battery.NULL_BATTERY);
+        mapper.setByte(0x6080, 0x65);
+        mapper.setByte(0x4000, 1);
+        assertEquals(32, mapper.getByte(0x0000));
+
+        mapper.setByte(0x6080, 0x44);
+        assertEquals(0, mapper.getByte(0x0000));
+        mapper.setByte(0x6080, 0x65);
+        assertEquals(32, mapper.getByte(0x0000));
+        assertEquals(0xf5, mapper.getByte(0xa080));
+    }
+
+    private static void assertResponse(Gowin mapper, int value, int response) {
+        mapper.setByte(0x6080, value);
+        assertEquals(response, mapper.getByte(0xa080));
+    }
+
+    private static Gowin mapper() throws IOException {
+        return new Gowin(new Rom(gowinRom()), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] gowinRom() {
+        return gowinRom(0x80000, 0x04);
+    }
+
+    private static byte[] gowinRom(int size, int sizeCode) {
+        byte[] data = new byte[size];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        byte[] title = "SCHOOL FIGHTER1".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0147] = 0x01;
+        data[0x0148] = (byte) sizeCode;
+        data[0x0149] = 0x00;
+        return data;
+    }
+}

--- a/docs/legacy-state-retirement.md
+++ b/docs/legacy-state-retirement.md
@@ -51,7 +51,7 @@ carries the compatibility leaves.
 The architecture test strips the marked compatibility declarations and proves that the remaining
 live owner source has no `Memento<T>` or compatibility-leaf dependency. It also proves that every
 normal record is non-serializable, the normal and compatibility registries are disjoint, and the
-100 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
+101 normal IDs, 91 compatibility IDs, exact native-serialization allowlist, and network prohibition
 remain pinned.
 
 ## Supported migration inputs and limits

--- a/docs/state-file-v1.md
+++ b/docs/state-file-v1.md
@@ -165,12 +165,12 @@ Every value starts with a one-byte tag:
 
 Float NaN payloads and signed zero are preserved with `doubleToRawLongBits`. Int32-map keys are
 strictly increasing and unique. Record type IDs are the one-based stable entries of the audited
-100-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
+101-record `StateTypeRegistry`; field count, name, and declaration order are encoded and checked.
 The 11 enum type IDs use the same audited ordering, while enum value IDs are an explicit v1
 one-based registry verified against the production enum names. Class names from input are never
 loaded or instantiated.
 
-The record ID/name/field registry is the exact ordered 100-record appendix in
+The record ID/name/field registry is the exact ordered 101-record appendix in
 [state-memento-schema.md](state-memento-schema.md), where each bullet's one-based position is its
 ID. IDs 88 through 91 deliberately name non-serializable normal-state leaves; the local legacy
 importer has ID-aligned historical descriptor classes with the same field schemas. StateFile does
@@ -188,9 +188,9 @@ parser/configuration/timing state, and restore as externally
 disconnected. An in-flight deterministic request byte may pair ID 99 with nested ID 97 so its
 latched reply finishes before the normalized disconnect takes effect. Other mid-byte external-I/O
 captures use ID 99 wire phase 11, retain only the already-latched reply byte, and reset the wire at
-that byte boundary. ID 100 appends the HiTek mapper state. None of IDs 92 through 100 has a legacy
-descriptor because no released
-Java-serialized snapshot could contain them. The v1 enum registry is:
+that byte boundary. ID 100 appends the HiTek mapper state. ID 101 appends the Gowin mapper's nested
+MBC1 state and protection response. None of IDs 92 through 101 has a legacy descriptor because no
+released Java-serialized snapshot could contain them. The v1 enum registry is:
 
 | Type ID | Enum | Value IDs in order starting at 1 |
 |---:|---|---|

--- a/docs/state-machine-inventory.md
+++ b/docs/state-machine-inventory.md
@@ -8,7 +8,7 @@ Before mutation, apply checks the hardware tag, nested record/mapper tree, invar
 serial endpoint and component-state root, cartridge RTC locations, runtime DTO, held input, and linked
 topology against the already-configured target. Null is admitted only for audited owner/field or
 array-element positions, not inferred from the non-null value's type. The adapter then reconstructs
-the complete replacement and applies the semantic policy registered for each of the 100 admitted
+the complete replacement and applies the semantic policy registered for each of the 101 admitted
 record types. Those policies reject invalid indices, counts, capacities, command phases, and scalar
 relationships before the first live mutation. If an unexpected component apply nevertheless
 throws, the adapter restores the machine, both RTC locations, serial endpoint/runtime, held
@@ -32,7 +32,7 @@ Protocol v8 remains StateFile-v1-only and rejects MGB before linked construction
 The exact remaining compatibility surface and removal policy are documented in
 [legacy-state-retirement.md](legacy-state-retirement.md).
 
-The exact field-by-field portable schema for all 100 admitted production record types is documented
+The exact field-by-field portable schema for all 101 admitted production record types is documented
 in [state-memento-schema.md](state-memento-schema.md), while `StateTypeRegistry` is the executable
 type allowlist. `StateCoverageMatrixTest` gives every mutable mapper and stateful serial peripheral
 an explicit non-idle setup and compares a fixed continuation trace plus final state;
@@ -99,12 +99,12 @@ component state; the six fields named above are in the detached supplement; and 
 
 ## Mapper coverage matrix
 
-Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Mbc2`,
+Every supported mutable mapper family is explicit and executable: `BasicRom`, `Mbc1`, `Gowin`, `Mbc2`,
 `Mbc3`/RTC, `Mbc5`, `LiCheng`, `XploderGb`, `Vf001Zook`, `Vf001General`, `Mbc6` RAM/flash,
 `Mbc7`/EEPROM, `Mmm01`,
 `PocketCamera`, `Huc1`, `Huc3`,
 `Tama5`, `BungEms`, `BhgosMulticart`, `MakonNtOld2`, `DuzMulticart`, `Mani32kMulticart`,
-`SlMulticart`, `Sintax`, `Bbd`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
+`SlMulticart`, `Sintax`, `Bbd`, `Hitek`, both `SachenMmc` modes, `WisdomTree`, and `Datel` with a real MBC3
 pass-through slot. For each family the matrix captures a non-idle setup, runs address/tick probes,
 restores through the detached graph, reruns the same probes, and compares both observable trace and
 final state. Dedicated mid-operation cases capture MBC6 during JEDEC unlock/ID/program sequences,
@@ -147,7 +147,7 @@ Records whose fields are deliberately not range-constrained still have an explic
 rationale in that registry. Examples are raw bus/address/register latches, signed emulated clocks,
 documented `-1`/minimum-value sentinels, and parent records whose only relationship-bearing values
 are validated by nested records. Runtime semantic preflight requires the policy-key set to equal
-all 100 admitted record types, so a new state record cannot enter the model without an explicit
+all 101 admitted record types, so a new state record cannot enter the model without an explicit
 choice. Rollback is retained for unexpected failures in legacy restore code; it is not the validation path for a
 deterministically malformed detached candidate.
 

--- a/docs/state-memento-schema.md
+++ b/docs/state-memento-schema.md
@@ -1,6 +1,6 @@
 # Audited state-record schema
 
-This documents the captured fields for all 100 production record types admitted by
+This documents the captured fields for all 101 production record types admitted by
 `StateTypeRegistry`. Each bullet's one-based position is its stable StateFile-v1 record type ID;
 each line names the non-serializable `ComponentState` record and every component captured by
 `captureState`. `StateTypeRegistry`, the StateFile golden/schema tests, and capture/apply behavior
@@ -141,3 +141,4 @@ altering the 1.7.13/1.7.14 migration schema listed below.
 - `eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint$MobileAdapterSerialEndpointNetworkState`: engineState, sb, sendBitIndex
 - `eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint$MobileAdapterSerialEndpointWireState`: engineState, sb, sendBitIndex, byteTransferActive, wirePhaseId, currentReply, requestAcknowledgement, responsePacket, responseByteIndex, awaitingResponse, responseRetryCount
 - `eu.rekawek.coffeegb.core.memory.cart.type.Hitek$HitekState`: delegateMemento, dataSwapMode, bankSwapMode
+- `eu.rekawek.coffeegb.core.memory.cart.type.Gowin$GowinState`: delegateMemento, protectionResponse


### PR DESCRIPTION
## Summary

Remen Gaoxiao - Shuma Guaishou III reaches its first level through a custom Gowin cartridge protection exchange. Coffee GB previously treated the image as ordinary MBC1 with no external RAM, so reads from the protection response address returned `FF`; the game's protection checks and protected bank-selection path could then loop or select the wrong code bank.

This change adds an MBC1-compatible Gowin mapper that:

- latches writes to the protection address and exposes a transformed four-bit response at the board's read address;
- keeps the underlying MBC1 decode active for the same writes;
- uses an inferred combinational response constrained by all eight known challenge/response observations (seven in this board image and one documented publicly), rather than claiming a recovered hardware schematic;
- detects the known board from its stable header characteristics without a whole-ROM fingerprint; and
- captures the protection latch in portable save states, including registry, semantic validation, coverage, and schema documentation.

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=GowinTest,Mbc1Test test` — 10 passed
- `/opt/maven/bin/mvn -pl controller -am -Dtest=StateCoverageMatrixTest,StateInventoryTest,StateRecordIntrospectionTest -Dsurefire.failIfNoSpecifiedTests=false test` — 9 passed
- `/opt/maven/bin/mvn -pl core test` — 1,221 passed, 8 skipped
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` — 132 passed
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` — 54 passed

The original ROM was replayed privately in CGB mode. It entered active first-level gameplay and remained responsive through movement and both action buttons at frame 4,772 / tick 334,757,403. The stage-title interstitial is START-gated and was not treated as a hang. No screenshot is attached because the reproduction uses a commercial ROM.

Fixes #524
