### PR TITLE
Show save-state timestamps and feedback

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -48,7 +48,23 @@ public class AndroidRuntimeEndToEndSmokeTest {
             CountDownLatch stateSaved = new CountDownLatch(1);
             CountDownLatch stateRestored = new CountDownLatch(1);
             CountDownLatch stateSaveRequested = new CountDownLatch(1);
+            CountDownLatch stateSavedMessage = new CountDownLatch(1);
+            CountDownLatch stateLoadedMessage = new CountDownLatch(1);
             AtomicReference<StateOperationFailedEvent> stateFailure = new AtomicReference<>();
+            runtime.addObserver(new RuntimeObserver() {
+                @Override
+                public void onStateChanged(RuntimeState state) {
+                }
+
+                @Override
+                public void onTransientMessage(String message) {
+                    if (message.startsWith("State saved")) {
+                        stateSavedMessage.countDown();
+                    } else if (message.startsWith("State loaded")) {
+                        stateLoadedMessage.countDown();
+                    }
+                }
+            });
             events.register(event -> {
                 if (event.getRef() instanceof StateRef.Slot
                         && ((StateRef.Slot) event.getRef()).getIndex() == 0) {
@@ -89,9 +105,13 @@ public class AndroidRuntimeEndToEndSmokeTest {
             assertTrue("state save request", stateSaveRequested.await(
                     STATE_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             awaitStateOperation("state save", stateSaved, stateFailure);
+            assertTrue("state saved flash message", stateSavedMessage.await(
+                    STATE_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             awaitSavedState(runtime, 0);
             runtime.restoreSnapshot(0);
             awaitStateOperation("state restore", stateRestored, stateFailure);
+            assertTrue("state loaded flash message", stateLoadedMessage.await(
+                    STATE_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             assertFrame(runtime, "after state restore");
 
             runtime.onHostNotVisible();

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -41,6 +41,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -49,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -79,6 +81,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 return thread;
             });
     private final CopyOnWriteArraySet<RuntimeObserver> observers = new CopyOnWriteArraySet<>();
+    /** Registration epochs prevent a queued message from a prior Activity attachment resurfacing. */
+    private final ConcurrentHashMap<RuntimeObserver, Long> observerRegistrations =
+            new ConcurrentHashMap<>();
+    private final AtomicLong nextObserverRegistration = new AtomicLong();
     private final AtomicBoolean closed = new AtomicBoolean();
     /** Serializes a UI-thread pause capture with owner-thread presentation publication. */
     private final Object presentationLock = new Object();
@@ -394,6 +400,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     public void addObserver(RuntimeObserver observer) {
         RuntimeObserver checked = Objects.requireNonNull(observer, "observer");
         observers.add(checked);
+        observerRegistrations.put(checked, nextObserverRegistration.incrementAndGet());
         RuntimeState replay = state;
         mainHandler.post(() -> {
             if (observers.contains(checked)) {
@@ -405,6 +412,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Must be paired with {@link #addObserver(RuntimeObserver)} from Activity/service teardown. */
     public void removeObserver(RuntimeObserver observer) {
         observers.remove(observer);
+        observerRegistrations.remove(observer);
     }
 
     /** Opens the user-selected SAF document; all metadata, archive and ROM work stays off-main. */
@@ -711,6 +719,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
+        observers.clear();
+        observerRegistrations.clear();
         deadlines.shutdownNow();
         try {
             owner.execute(() -> {
@@ -744,8 +754,16 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus = new EventBusImpl();
         eventBus.register(
                 (StateOperationCompletedEvent event) -> {
-                    if (event.getOperation() == StateOperation.SAVE) {
-                        submit(() -> completeStateSave(event.getRequestId()));
+                    if (event.getOperation() == StateOperation.SAVE
+                            || event.getOperation() == StateOperation.LOAD) {
+                        // Controller callbacks run on the emulation thread. Keep runtime-owned
+                        // layout/session checks and save callback bookkeeping on the owner.
+                        submit(() -> {
+                            if (event.getOperation() == StateOperation.SAVE) {
+                                completeStateSave(event.getRequestId());
+                            }
+                            publishStateCompletionMessage(event);
+                        });
                     }
                 },
                 StateOperationCompletedEvent.class);
@@ -1080,6 +1098,40 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
+    /** Forwards only successful SAVE/LOAD completions belonging to the active managed session. */
+    private void publishStateCompletionMessage(StateOperationCompletedEvent event) {
+        long sessionId = event.getSessionId();
+        if (closed.get() || activeLayout == null || sessionId <= 0L
+                || sessionId != activeStateSessionId) {
+            return;
+        }
+        String message = event.getMessage();
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        List<ObserverRegistration> recipients = observers.stream()
+                .map(observer -> new ObserverRegistration(observer,
+                        observerRegistrations.get(observer)))
+                .filter(recipient -> recipient.registrationId() != null)
+                .collect(Collectors.toList());
+        mainHandler.post(() -> {
+            // Activity/service lifecycle changes can remove and later re-add the same observer;
+            // re-check both ownership and the state-session edge before delivering this queued
+            // callback so an old completion cannot flash in a replacement session.
+            if (closed.get() || activeStateSessionId != sessionId) {
+                return;
+            }
+            for (ObserverRegistration recipient : recipients) {
+                Long currentRegistration = observerRegistrations.get(recipient.observer());
+                if (currentRegistration != null
+                        && currentRegistration.equals(recipient.registrationId())
+                        && observers.contains(recipient.observer())) {
+                    recipient.observer().onTransientMessage(message);
+                }
+            }
+        });
+    }
+
     private void onFlushDeadline(long requestId) {
         if (pendingFlushRequestId != requestId) {
             return;
@@ -1404,6 +1456,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             this.thumbnail = thumbnail;
             this.onCompleted = onCompleted;
         }
+    }
+
+    private record ObserverRegistration(RuntimeObserver observer, Long registrationId) {
     }
 
     @FunctionalInterface

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidStateSlot.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidStateSlot.java
@@ -3,9 +3,11 @@ package eu.rekawek.coffeegb.android;
 import eu.rekawek.coffeegb.controller.state.StateCatalogEntry;
 import eu.rekawek.coffeegb.controller.state.StateCatalogStatus;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
+import java.time.Instant;
 
 /** Immutable, path-free state-slot row for Android UI presentation. */
-record AndroidStateSlot(int index, String detail, boolean loadable, MenuPreview preview) {
+record AndroidStateSlot(int index, String detail, boolean loadable, MenuPreview preview,
+        Instant savedAt) {
 
     AndroidStateSlot {
         if (preview == null) {
@@ -19,19 +21,18 @@ record AndroidStateSlot(int index, String detail, boolean loadable, MenuPreview 
 
     static AndroidStateSlot from(int index, StateCatalogEntry entry, MenuPreview preview) {
         if (entry == null) {
-            return new AndroidStateSlot(index, "Empty", false, MenuPreview.empty());
+            return new AndroidStateSlot(index, "Empty", false, MenuPreview.empty(), null);
         }
         StateCatalogStatus status = entry.getStatus();
         if (status != StateCatalogStatus.AVAILABLE) {
             String reason = entry.getDetail();
             return new AndroidStateSlot(index,
                     reason == null || reason.isBlank() ? "Unavailable: " + status : reason, false,
-                    MenuPreview.empty());
+                    MenuPreview.empty(), null);
         }
-        String saved = entry.getMetadata() == null
-                ? "Saved state"
-                : "Saved " + entry.getMetadata().getSavedAt();
-        return new AndroidStateSlot(index, saved, true, preview);
+        Instant savedAt = entry.getMetadata() == null ? null : entry.getMetadata().getSavedAt();
+        String saved = savedAt == null ? "Saved state" : "Saved " + savedAt;
+        return new AndroidStateSlot(index, saved, true, preview, savedAt);
     }
 
     String label() {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -8,6 +8,9 @@ import android.graphics.Paint;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
 import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
@@ -22,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Dedicated nearest-neighbour native-frame surface.
@@ -39,6 +43,8 @@ public final class CoffeeGbSurfaceView extends SurfaceView
     private final Paint videoPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint displayPaint = new Paint();
     private final Paint skinPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint transientPanelPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint transientTextPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Rect source = new Rect();
     private final Rect destination = new Rect();
     private final Bitmap bitmap = Bitmap.createBitmap(
@@ -47,12 +53,16 @@ public final class CoffeeGbSurfaceView extends SurfaceView
     private final RasterSkin landscapeSkin;
     private final MenuRenderer menuRenderer = new MenuRenderer();
     private final Set<Integer> menuTouchPointers = new HashSet<>();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicLong transientRevision = new AtomicLong();
 
     private volatile NativeFrameStore frames;
     private volatile MenuPresentation menuPresentation;
     private volatile MenuTouchInput menuInput;
     private final TouchControlsPreferences touchPreferences;
     private volatile TouchControlsLayout touchLayout;
+    private volatile String transientMessage;
+    private volatile long transientExpiresAt;
     private AndroidInputRouter input;
     private RenderThread renderThread;
     private volatile boolean surfaceReady;
@@ -62,6 +72,10 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         videoPaint.setFilterBitmap(false);
         displayPaint.setColor(Color.BLACK);
         skinPaint.setFilterBitmap(true);
+        transientPanelPaint.setColor(Color.argb(210, 0, 0, 0));
+        transientTextPaint.setColor(Color.WHITE);
+        transientTextPaint.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        transientTextPaint.setTextAlign(Paint.Align.LEFT);
         portraitSkin = RasterSkin.portrait(context);
         landscapeSkin = RasterSkin.landscape(context);
         touchPreferences = new TouchControlsPreferences(context);
@@ -106,6 +120,34 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         onFrameAvailable();
     }
 
+    /** Displays host feedback over gameplay or the opaque menu for the standard short duration. */
+    void showTransientMessage(String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        long revision = transientRevision.incrementAndGet();
+        transientMessage = message;
+        transientExpiresAt = SystemClock.uptimeMillis()
+                + TransientMessage.DURATION_MILLIS;
+        onFrameAvailable();
+        mainHandler.postDelayed(() -> {
+            if (transientRevision.get() != revision) {
+                return;
+            }
+            transientMessage = null;
+            transientExpiresAt = 0L;
+            onFrameAvailable();
+        }, TransientMessage.DURATION_MILLIS);
+    }
+
+    /** Clears feedback during surface/lifecycle teardown and invalidates pending expiry callbacks. */
+    void clearTransientMessage() {
+        transientRevision.incrementAndGet();
+        transientMessage = null;
+        transientExpiresAt = 0L;
+        onFrameAvailable();
+    }
+
     /** Installs the input bridge used to consume skin controls while the menu is visible. */
     public void setMenuInput(MenuTouchInput input) {
         MenuTouchInput previous = menuInput;
@@ -135,6 +177,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
 
     /** Releases only the Surface subscription; the active emulator keeps running in its service. */
     public void detach() {
+        clearTransientMessage();
         NativeFrameStore active = frames;
         if (active != null) {
             active.removeListener(this);
@@ -437,9 +480,41 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                 if (menu != null) {
                     menuRenderer.draw(canvas, menu, display);
                 }
+                drawTransientMessage(canvas, display);
                 skin.draw(canvas, skinPaint, transform);
             } finally {
                 holder.unlockCanvasAndPost(canvas);
+            }
+        }
+
+        private void drawTransientMessage(Canvas canvas, RectF display) {
+            String text = transientMessage;
+            if (text == null || text.isBlank()
+                    || SystemClock.uptimeMillis() >= transientExpiresAt) {
+                return;
+            }
+            float scale = Math.max(1.0f, display.width() / 160.0f);
+            float textSize = Math.max(12.0f, 7.0f * scale);
+            transientTextPaint.setTextSize(textSize);
+            Paint.FontMetrics metrics = transientTextPaint.getFontMetrics();
+            float paddingX = Math.max(6.0f, 4.0f * scale);
+            float paddingY = Math.max(4.0f, 2.0f * scale);
+            float boxWidth = transientTextPaint.measureText(text) + 2.0f * paddingX;
+            float boxHeight = metrics.descent - metrics.ascent + 2.0f * paddingY;
+            float x = display.centerX() - boxWidth / 2.0f;
+            float y = display.bottom - boxHeight - Math.max(4.0f, 4.0f * scale);
+            int save = canvas.save();
+            try {
+                // The menu and message are host overlays, but neither may escape the exact
+                // display aperture into the raster skin or letterbox.
+                canvas.clipRect(display);
+                float radius = Math.max(6.0f, 4.0f * scale);
+                canvas.drawRoundRect(x, y, x + boxWidth, y + boxHeight, radius, radius,
+                        transientPanelPaint);
+                canvas.drawText(text, x + paddingX, y + paddingY - metrics.ascent,
+                        transientTextPaint);
+            } finally {
+                canvas.restoreToCount(save);
             }
         }
 
@@ -449,6 +524,13 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                 return !running || renderThread != this || !surfaceReady
                         || !holder.getSurface().isValid();
             }
+        }
+    }
+
+    private static final class TransientMessage {
+        private static final long DURATION_MILLIS = 1_500L;
+
+        private TransientMessage() {
         }
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -40,6 +40,10 @@ import eu.rekawek.coffeegb.ui.menu.MenuStackSnapshot;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 
 import java.lang.ref.WeakReference;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +98,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final String PRINTER_CONTINUATION_URI = "uri";
     private static final String PRINTER_CONTINUATION_PHASE = "phase";
     private static final String SOURCE_URL = "https://github.com/trekawek/coffee-gb";
+    private static final DateTimeFormatter STATE_TIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
 
     private CoffeeGbSurfaceView video;
     private View menuButton;
@@ -359,6 +365,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     protected void onPause() {
         armLegacyCameraPermissionFallback(externalSurface);
         activityResumed = false;
+        if (video != null) {
+            video.clearTransientMessage();
+        }
         super.onPause();
     }
 
@@ -514,6 +523,19 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         applyState(state);
     }
 
+    /** Shows current-session SAVE/LOAD completion feedback above gameplay or the menu. */
+    @Override
+    public void onTransientMessage(String message) {
+        // Runtime callbacks are posted to the main thread, but an Activity can be between
+        // onPause/onStop or service rebinding when a queued callback arrives. Do not let an old
+        // lifecycle paint feedback into a newly attached surface.
+        if (!activityResumed || !bound || runtime == null || video == null
+                || message == null || message.isBlank()) {
+            return;
+        }
+        video.showTransientMessage(message);
+    }
+
     private void toggleMenu() {
         if (menuController == null || externalSurface.active()) {
             return;
@@ -646,7 +668,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         int slot = parseSlot(focused.id().replace("slot:", ""));
         AndroidStateSlot selected = stateSlot(slot);
         MenuPreview preview = selected == null ? MenuPreview.empty() : selected.preview();
-        if (presentation.preview() == preview) {
+        List<String> sideLines = stateSavedAtLines(selected);
+        if (presentation.preview() == preview && presentation.sideLines().equals(sideLines)) {
             return false;
         }
         String focusId = focused.id();
@@ -1790,9 +1813,28 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
         String mode = stateMenuMode == StateMenuMode.SAVE ? "SAVE" : "LOAD";
         return new MenuPageSpec(MenuRoute.SAVE_STATES, "COFFEE GB", mode + " STATES", "", "",
-                List.of(), items, 1,
+                stateSavedAtLines(stateSlot(preferredFocus == null
+                        ? StateRef.MIN_SLOT : parseSlot(preferredFocus.replace("slot:", "")))),
+                items, 1,
                 List.of("D-PAD MOVE", "A " + mode, "B BACK"),
                 preferredFocus == null ? "slot:" + StateRef.MIN_SLOT : preferredFocus, preview);
+    }
+
+    private static List<String> stateSavedAtLines(AndroidStateSlot slot) {
+        String formatted = formatStateSavedAt(slot == null ? null : slot.savedAt());
+        return formatted == null ? List.of() : List.of(formatted);
+    }
+
+    static String formatStateSavedAt(Instant savedAt) {
+        if (savedAt == null) {
+            return null;
+        }
+        try {
+            return "SAVED " + STATE_TIME_FORMAT.format(savedAt);
+        } catch (DateTimeException | ArithmeticException ignored) {
+            // Metadata is optional; unsupported/corrupt values must not become a fake date.
+            return null;
+        }
     }
 
     private MenuPageSpec libraryPage() {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeObserver.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeObserver.java
@@ -5,4 +5,12 @@ package eu.rekawek.coffeegb.android;
 public interface RuntimeObserver {
 
     void onStateChanged(RuntimeState state);
+
+    /**
+     * Receives a short-lived host message for a successful current-session state operation.
+     * Implementations may ignore it when their surface is not attached or visible.
+     */
+    default void onTransientMessage(String message) {
+        // Optional host feedback; state snapshots remain the required observer contract.
+    }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
@@ -3,12 +3,17 @@ package eu.rekawek.coffeegb.android;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
 import eu.rekawek.coffeegb.controller.state.StateCatalogEntry;
 import eu.rekawek.coffeegb.controller.state.StateCatalogStatus;
+import eu.rekawek.coffeegb.controller.state.StateMetadata;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 import org.junit.Test;
 
+import java.time.Instant;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class AndroidStateSlotTest {
 
@@ -19,6 +24,7 @@ public class AndroidStateSlotTest {
         assertEquals("Slot 3: Empty", slot.label());
         assertFalse(slot.loadable());
         assertSame(MenuPreview.empty(), slot.preview());
+        assertNull(slot.savedAt());
     }
 
     @Test
@@ -35,5 +41,21 @@ public class AndroidStateSlotTest {
         assertEquals(true, slot.loadable());
         assertSame(preview, slot.preview());
         assertEquals(color, slot.preview().copyPixels()[0]);
+    }
+
+    @Test
+    public void availableSlotCarriesItsValidatedCatalogSavedTime() {
+        Instant savedAt = Instant.parse("2026-08-13T12:34:00Z");
+        String hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        StateMetadata metadata = new StateMetadata(new StateRef.Slot(2), null, savedAt,
+                null, 128, hash, null);
+        StateCatalogEntry entry = new StateCatalogEntry(
+                new StateRef.Slot(2), StateCatalogStatus.AVAILABLE, null, null,
+                hash, metadata, null, null, null);
+
+        AndroidStateSlot slot = AndroidStateSlot.from(2, entry, MenuPreview.empty());
+
+        assertEquals(savedAt, slot.savedAt());
+        assertTrue(MainActivity.formatStateSavedAt(savedAt).startsWith("SAVED "));
     }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -6,6 +6,9 @@ import java.awt.Toolkit
 import java.awt.event.ActionEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import javax.swing.AbstractAction
 import javax.swing.Action
 import javax.swing.KeyStroke
@@ -74,10 +77,26 @@ internal data class DesktopCommandHandlers(
 
 /** Detached quick-state data consumed by the portable menu renderer. */
 internal data class PortableMenuStateSlot(
-    val index: Int,
-    val loadable: Boolean,
-    val preview: MenuPreview = MenuPreview.empty(),
+  val index: Int,
+  val loadable: Boolean,
+  val preview: MenuPreview = MenuPreview.empty(),
+  /** Authoritative managed-state metadata; null means the slot has no trustworthy saved time. */
+  val savedAt: Instant? = null,
 )
+
+private val PORTABLE_STATE_TIME_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault())
+
+/** Formats only the persisted instant supplied by the state catalog. */
+internal fun portableStateSavedAt(instant: Instant?): String? {
+  if (instant == null) return null
+  return try {
+    "SAVED ${PORTABLE_STATE_TIME_FORMAT.format(instant)}"
+  } catch (_: RuntimeException) {
+    // A malformed/unsupported metadata instant must never become a misleading UI date.
+    null
+  }
+}
 
 /**
  * Creates every general desktop action exactly once and applies one immutable command snapshot.

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -292,7 +292,13 @@ class SwingGui private constructor(
                             val argb = IntArray(rgb.size) { index -> 0xff000000.toInt() or rgb[index] }
                             eu.rekawek.coffeegb.ui.menu.MenuPreview.ready(image.width, image.height, argb)
                           }
-                          PortableMenuStateSlot(ref.index, entry.canLoad, preview)
+                          PortableMenuStateSlot(
+                              ref.index,
+                              entry.canLoad,
+                              preview,
+                              entry.catalogEntry?.metadata?.savedAt
+                                  ?.takeIf { entry.canLoad },
+                          )
                         })
               }
             },

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -371,13 +371,15 @@ internal class SwingProposal3Menu(
             }
         val mode = if (stateMenuMode == StateMenuMode.SAVE) "SAVE" else "LOAD"
         val focused = stateFocusedItemId ?: "slot-0"
+        val focusedSlot =
+            commands.stateSlots().firstOrNull { "slot-${it.index}" == focused }
         val preview =
-            commands.stateSlots().firstOrNull { "slot-${it.index}" == focused }?.preview
-                ?: MenuPreview.empty()
+            focusedSlot?.preview ?: MenuPreview.empty()
+        val savedAt = portableStateSavedAt(focusedSlot?.savedAt)
         page(
             "${mode} STATES",
             "",
-            emptyList(),
+            if (savedAt == null) emptyList() else listOf(savedAt),
             slots,
             preferredFocus = focused,
             headerAction = "",
@@ -859,7 +861,12 @@ internal class SwingProposal3Menu(
       val desiredPreview =
           commands.stateSlots().firstOrNull { "slot-${it.index}" == focusedId }?.preview
               ?: MenuPreview.empty()
-      if (presentation.preview() !== desiredPreview) {
+      val focusedSlot =
+          commands.stateSlots().firstOrNull { "slot-${it.index}" == focusedId }
+      val desiredSideLines = portableStateSavedAt(focusedSlot?.savedAt)
+          ?.let { listOf(it) }
+          ?: emptyList()
+      if (presentation.preview() !== desiredPreview || presentation.sideLines() != desiredSideLines) {
         controller.setPage(pageFor(MenuRoute.SAVE_STATES, commands.menuState()))
         return
       }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -14,6 +14,8 @@ import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuRect;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
 
 import javax.swing.*;
 import java.awt.*;
@@ -154,8 +156,11 @@ public class SwingDisplay extends JPanel implements Runnable {
     /** Resets host-only output state before a controller can quiesce or close its event bus. */
     public void releaseForLifecycleChange() {
         rumbling = false;
+        notificationText = null;
+        notificationExpiresAt = 0L;
         invalidateFrameForLifecycle();
         resetPresentationFrameRate();
+        repaintNotification(0);
     }
 
     /**
@@ -432,10 +437,6 @@ public class SwingDisplay extends JPanel implements Runnable {
         frame.paint(frameGraphics);
         frameGraphics.dispose();
 
-        Graphics2D notificationGraphics = (Graphics2D) g.create();
-        paintNotification(notificationGraphics, viewport);
-        notificationGraphics.dispose();
-
         if (menuOverlay.visible()) {
             // The aspect-fit bars belong to the menu presentation, not the game frame beneath it.
             // Clearing the component first prevents a narrow/tall host from leaking gameplay
@@ -444,6 +445,24 @@ public class SwingDisplay extends JPanel implements Runnable {
             g.fillRect(0, 0, getWidth(), getHeight());
             menuOverlay.paint((Graphics2D) g, getWidth(), getHeight());
         }
+
+        // Notifications are host feedback, so they must remain visible above the opaque portable
+        // menu overlay as well as above gameplay. State-operation completion messages retain their
+        // existing duration and wording on both surfaces.
+        Rectangle notificationBounds = viewport.paintBounds();
+        double notificationScale = viewport.scale();
+        if (menuOverlay.visible()) {
+            MenuRect menuBounds = MenuViewport.fit(getWidth(), getHeight()).contentBounds();
+            notificationBounds = new Rectangle(
+                    menuBounds.x(), menuBounds.y(), menuBounds.width(), menuBounds.height());
+            notificationScale = Math.min(
+                    (double) menuBounds.width() / MenuViewport.SOURCE_WIDTH,
+                    (double) menuBounds.height() / MenuViewport.SOURCE_HEIGHT);
+        }
+        Graphics2D notificationGraphics = (Graphics2D) g.create();
+        notificationGraphics.clip(notificationBounds);
+        paintNotification(notificationGraphics, notificationBounds, notificationScale);
+        notificationGraphics.dispose();
     }
 
     private void showNotification(String text) {
@@ -486,15 +505,14 @@ public class SwingDisplay extends JPanel implements Runnable {
         });
     }
 
-    private void paintNotification(Graphics2D g, DisplayViewport viewport) {
+    private void paintNotification(Graphics2D g, Rectangle bounds, double scale) {
         String persistentText = persistentNotificationText;
         String text = persistentText != null ? persistentText : notificationText;
         if (text == null || (persistentText == null && System.nanoTime() >= notificationExpiresAt)) {
             return;
         }
 
-        Rectangle bounds = viewport.paintBounds();
-        int localScale = Math.max(1, (int) Math.floor(viewport.scale()));
+        int localScale = Math.max(1, (int) Math.floor(scale));
         int fontSize = Math.max(12, 7 * localScale);
         g.setFont(new Font(Font.SANS_SERIF, Font.BOLD, fontSize));
         FontMetrics metrics = g.getFontMetrics();

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.ui.menu.MenuKey
 import eu.rekawek.coffeegb.ui.menu.MenuRoute
 import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame
+import java.time.Instant
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicInteger
 import javax.swing.JRootPane
@@ -490,6 +491,49 @@ class SwingProposal3MenuTest {
       press(emptyMenu, MenuKey.A)
       assertEquals(null, bridge.loadedSlot)
       assertTrue(emptyMenu.visible())
+    }
+  }
+
+  @Test
+  fun `state date follows focus even when slots share the empty preview`() {
+    val bridge =
+        FakeBridge().also {
+          it.stateCatalog =
+              listOf(
+                  PortableMenuStateSlot(
+                      0,
+                      true,
+                      MenuPreview.empty(),
+                      Instant.parse("2026-08-13T12:34:00Z"),
+                  ),
+                  PortableMenuStateSlot(1, false, MenuPreview.empty(), null),
+              )
+        }
+    val frames = mutableListOf<MenuArgbFrame?>()
+    val menu =
+        SwingProposal3Menu(
+            frameSink = { frames += it },
+            commands = bridge,
+            releaseGameplay = {},
+        )
+
+    javax.swing.SwingUtilities.invokeAndWait {
+      menu.openFromDesktop()
+      press(menu, MenuKey.DOWN)
+      press(menu, MenuKey.A)
+      val dated = frames.filterNotNull().last()
+      press(menu, MenuKey.DOWN)
+      val empty = frames.filterNotNull().last()
+      assertFalse(savedDatePixels(dated).contentEquals(savedDatePixels(empty)))
+    }
+  }
+
+  private fun savedDatePixels(frame: MenuArgbFrame): IntArray {
+    val pixels = frame.copyPixels()
+    return IntArray(352 * 44) { offset ->
+      val x = 30 + offset % 352
+      val y = 505 + offset / 352
+      pixels[y * frame.width() + x]
     }
   }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -2,12 +2,22 @@ package eu.rekawek.coffeegb.swing.io;
 
 import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.controller.state.StateOperation;
+import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent;
+import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
+import eu.rekawek.coffeegb.ui.menu.MenuRoute;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuRect;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor;
 import org.junit.Test;
 
 import javax.swing.SwingUtilities;
@@ -19,6 +29,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
@@ -115,6 +126,67 @@ public class SwingDisplayTest {
 
         session.post(new Controller.SnapshotRestoredEvent(7));
         assertEquals("State loaded (slot 7)", textField.get(display));
+        root.close();
+    }
+
+    @Test
+    public void stateCompletionFlashStaysAboveAndInsideTheVisibleMenu() throws Exception {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        EventBus session = root.fork("test");
+        SwingDisplay display = newDisplay(root);
+        root.post(new SwingDisplay.SetRotationEvent(90));
+        onEdt(() -> {
+            display.setSize(400, 1_000);
+            display.setMenuOverlay(composePauseFrame());
+        });
+        BufferedImage baseline = paintAtSize(display, 400, 1_000);
+
+        session.post(new StateOperationCompletedEvent(
+                1L,
+                1L,
+                StateOperation.SAVE,
+                new StateRef.Slot(0),
+                null,
+                "State saved (slot 0)",
+                List.of(),
+                null));
+        BufferedImage flashed = paintAtSize(display, 400, 1_000);
+
+        MenuRect menuBounds = MenuViewport.fit(400, 1_000).contentBounds();
+        int changedPixels = 0;
+        for (int y = 0; y < flashed.getHeight(); y++) {
+            for (int x = 0; x < flashed.getWidth(); x++) {
+                if (baseline.getRGB(x, y) != flashed.getRGB(x, y)) {
+                    changedPixels++;
+                    assertTrue("flash escaped menu viewport at " + x + "," + y,
+                            menuBounds.contains(x, y));
+                }
+            }
+        }
+        assertTrue("state completion was hidden behind the menu", changedPixels > 0);
+        root.close();
+    }
+
+    @Test
+    public void lifecycleReleaseClearsTransientStateFeedback() throws Exception {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        EventBus session = root.fork("test");
+        SwingDisplay display = newDisplay(root);
+        Field textField = SwingDisplay.class.getDeclaredField("notificationText");
+        textField.setAccessible(true);
+        Field expiryField = SwingDisplay.class.getDeclaredField("notificationExpiresAt");
+        expiryField.setAccessible(true);
+
+        session.post(new Controller.SnapshotSavedEvent(2));
+        assertEquals("State saved (slot 2)", textField.get(display));
+
+        display.releaseForLifecycleChange();
+        assertNull(textField.get(display));
+        assertEquals(0L, expiryField.getLong(display));
+
+        session.post(new Controller.RomLoadingEvent(new File("next.gb")));
+        session.post(new Controller.EmulationStartedEvent("NEXT"));
+        assertNull("old state feedback resurfaced after loading", textField.get(display));
         root.close();
     }
 
@@ -577,6 +649,43 @@ public class SwingDisplayTest {
             }
             return target;
         });
+    }
+
+    private static BufferedImage paintAtSize(SwingDisplay display, int width, int height)
+            throws Exception {
+        return onEdt(() -> {
+            display.setSize(width, height);
+            BufferedImage target = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            Graphics graphics = target.getGraphics();
+            try {
+                display.paintComponent(graphics);
+            } finally {
+                graphics.dispose();
+            }
+            return target;
+        });
+    }
+
+    private static MenuArgbFrame composePauseFrame() {
+        AtomicReference<MenuPresentation> presentation = new AtomicReference<>();
+        MenuController controller = new MenuController(new MenuController.Listener() {
+            @Override
+            public void onPresentation(MenuPresentation next) {
+                presentation.set(next);
+            }
+
+            @Override
+            public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+            }
+
+            @Override
+            public void onHeaderSelected(MenuRoute route) {
+            }
+        });
+        controller.show(MenuRoute.PAUSE_CONSOLE);
+        return new Proposal3MenuCompositor()
+                .compose(presentation.get())
+                .orElseThrow(() -> new AssertionError("pause frame was not composed"));
     }
 
     private static Thread daemonThread(Runnable runnable) {

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3TextCatalog.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3TextCatalog.java
@@ -101,8 +101,11 @@ final class Proposal3TextCatalog {
     }
 
     private static void saveStates(List<TextRegion> regions) {
-        // Save/load state pages deliberately contain only the selected thumbnail on the left.
-        // Slot status, metadata and action copy belong neither below nor beside the preview.
+        // The blank area below the selected thumbnail is reserved for authoritative managed-state
+        // metadata. Empty/loading/unavailable slots simply provide no side line, leaving the
+        // approved artwork untouched.
+        regions.add(region(Key.SIDE_LINE, 0, new MenuRect(30, 505, 352, 44), Surface.PAPER,
+                align(Horizontal.CENTER), Proposal3GlyphAtlas.Role.SMALL));
     }
 
     private static void settings(List<TextRegion> regions) {

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositorTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositorTest.java
@@ -172,6 +172,33 @@ public class Proposal3MenuCompositorTest {
     }
 
     @Test
+    public void stateSavedDateUsesOnlyTheBlankAreaBelowTheFocusedPreview() {
+        MenuPresentation empty = defaultPresentation(MenuRoute.SAVE_STATES);
+        MenuPresentation dated = presentation(new MenuPageSpec(
+                empty.route(), empty.title(), empty.context(), empty.headerAction(),
+                empty.sideHeading(), List.of("SAVED 2026-08-13 17:15"),
+                copyItems(empty.items()), empty.columns(), empty.footerHints(), "slot-0",
+                empty.preview()));
+        Proposal3MenuCompositor compositor = new Proposal3MenuCompositor();
+        int[] emptyPixels = compositor.compose(empty).orElseThrow().copyPixels();
+        int[] datedPixels = compositor.compose(dated).orElseThrow().copyPixels();
+        MenuRect savedDate = new MenuRect(30, 505, 352, 44);
+        int changed = 0;
+        for (int y = 0; y < MenuArtworkCatalog.PACKAGED_HEIGHT; y++) {
+            for (int x = 0; x < MenuArtworkCatalog.PACKAGED_WIDTH; x++) {
+                int offset = y * MenuArtworkCatalog.PACKAGED_WIDTH + x;
+                if (emptyPixels[offset] != datedPixels[offset]) {
+                    assertTrue("saved date escaped its reserved area at " + x + "," + y,
+                            x >= savedDate.x() && x < savedDate.right()
+                                    && y >= savedDate.y() && y < savedDate.bottom());
+                    changed++;
+                }
+            }
+        }
+        assertTrue("saved date did not render", changed > 0);
+    }
+
+    @Test
     public void pausePreviewClearsTheEntireBezelInnerAperture() throws Exception {
         MenuRect aperture = Proposal3OverlayCatalog.PAUSE_PREVIEW;
         assertEquals(new MenuRect(30, 139, 351, 243), aperture);


### PR DESCRIPTION
## What changed

- show the persisted save timestamp below the focused save-state screenshot
- show short success messages after save and load operations on Swing and Android
- keep feedback above the on-screen menu, clipped to its display aperture, and clear it across lifecycle/session changes
- add portable compositor, Swing focus/layout/lifecycle, Android metadata, and Android end-to-end callback coverage

## Why

The redesigned save/load pages showed the correct state thumbnails but did not identify when a state was captured, and successful controller operations had no visible confirmation while the opaque menu remained open.

## User impact

Players can now see when the focused state was saved and receive immediate confirmation after saving or loading. Empty and unavailable slots remain visually clean because no date is fabricated without authoritative catalog metadata.

## Validation

- `/opt/maven/bin/mvn -pl swing -am test` (2,952 tests passed; 11 skipped)
- `ANDROID_HOME=/opt/android-sdk ./gradlew -PcoffeeGbMavenRepository=../build/android-m2 testDebugUnitTest compileDebugAndroidTestJavaWithJavac`
- `git diff --check`
