### PR TITLE
Stabilize persistence close tests

### DIFF
--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerStateUxTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerStateUxTest.kt
@@ -551,7 +551,7 @@ class BasicControllerStateUxTest {
             RewindManager(enabled = false),
             StateWorkspaceFactory { paths -> workspace(paths, persistence) },
             StateOperationWorkerFactory.DEFAULT,
-            closeTimeoutMillis = 300,
+            closeTimeoutMillis = CLOSE_PERSISTENCE_TIMEOUT_MILLIS,
         )
     var closed = false
     controller.startController()
@@ -1469,6 +1469,9 @@ class BasicControllerStateUxTest {
   private companion object {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
     const val TIMEOUT_SECONDS = 10L
+    // The writer is deliberately held in flight. Leave enough time for the retry's real encode
+    // and file write after it is released on contended CI workers.
+    const val CLOSE_PERSISTENCE_TIMEOUT_MILLIS = 2_000L
   }
 
   private class ToggleFailWriter : AtomicFileWriter() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -248,7 +248,13 @@ class BasicControllerTest {
           PreparedSession.Ready(config, gameboy)
         }
     val controller =
-        BasicController(eventBus, testProperties(), null, preparer, closeTimeoutMillis = 300)
+        BasicController(
+            eventBus,
+            testProperties(),
+            null,
+            preparer,
+            closeTimeoutMillis = CLOSE_PERSISTENCE_TIMEOUT_MILLIS,
+        )
 
     controller.startController()
     try {
@@ -336,7 +342,13 @@ class BasicControllerTest {
           PreparedSession.Ready(config, gameboy)
         }
     val controller =
-        BasicController(eventBus, testProperties(), null, preparer, closeTimeoutMillis = 300)
+        BasicController(
+            eventBus,
+            testProperties(),
+            null,
+            preparer,
+            closeTimeoutMillis = CLOSE_PERSISTENCE_TIMEOUT_MILLIS,
+        )
 
     controller.startController()
     try {
@@ -1623,6 +1635,9 @@ class BasicControllerTest {
     val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
 
     const val TIMEOUT_SECONDS = 10L
+    // These tests intentionally keep a previous physical writer alive. The retry performs a
+    // real autosave, so it needs CI scheduling headroom once that writer is released.
+    const val CLOSE_PERSISTENCE_TIMEOUT_MILLIS = 2_000L
   }
 
   private class ToggleFailWriter : AtomicFileWriter() {


### PR DESCRIPTION
## Summary

Stabilizes the close-autosave concurrency tests by giving the deliberately blocked persistence retry enough time to perform its real encode and file write on contended CI workers.

## Validation

- Repeated focused controller tests
- `mvn -pl controller -am test`
