### PR TITLE
Restore Windows MSI installer

### DIFF
--- a/.github/workflows/native-packages.yml
+++ b/.github/workflows/native-packages.yml
@@ -22,13 +22,6 @@ on:
 permissions:
   contents: read
 
-env:
-  COFFEE_GB_LZMA_SDK_URL: >-
-    https://github.com/ip7z/7zip/releases/download/26.02/lzma2602.7z
-  COFFEE_GB_LZMA_SDK_SHA256: 2878c85f5f43a4a4e0952b1fd4e5fe097c1c143997a8047c7e1e788892aa9357
-  COFFEE_GB_7ZR_X64_SHA256: 89645457d40b0e6731014a61ee6ebedd22c01a92fc38618480d385461c4347bb
-  COFFEE_GB_7ZSD_SFX_SHA256: 0fc21d175a0e4c7e4f10521f35f6e6effa9dbd3c0ea80895cc79e72a9fdde088
-
 concurrency:
   group: native-packages-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
@@ -93,7 +86,7 @@ jobs:
             package_type: deb
             runner: ubuntu-24.04
           - target: windows-x86-64
-            package_type: exe
+            package_type: msi
             runner: windows-2025
           - target: macos-x86-64
             package_type: dmg
@@ -176,54 +169,25 @@ jobs:
               ;;
           esac
 
-      - name: Prepare pinned Windows portable-EXE tooling
+      - name: Install WiX toolset for Windows MSI packaging
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
             throw "windows-x86-64 requires an X64 runner"
           }
-          $SevenZipRoot = Join-Path $env:ProgramFiles "7-Zip"
-          $BootstrapSevenZip = Join-Path $SevenZipRoot "7z.exe"
-          if (-not (Test-Path -LiteralPath $BootstrapSevenZip -PathType Leaf) -or
-              (Get-Item -LiteralPath $BootstrapSevenZip).Length -eq 0) {
-            throw "windows-x86-64 requires the installed 7-Zip executable: $BootstrapSevenZip"
+          $WixBin = Join-Path ${env:ProgramFiles(x86)} "WiX Toolset v3.11\bin"
+          $Candle = Join-Path $WixBin "candle.exe"
+          $Light = Join-Path $WixBin "light.exe"
+          if (-not (Test-Path -LiteralPath $Candle -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $Light -PathType Leaf)) {
+            choco install wixtoolset --version=3.11.2 --yes --no-progress
           }
-
-          $ToolRoot = Join-Path $env:RUNNER_TEMP "coffee-gb-lzma-sdk"
-          $ToolBin = Join-Path $ToolRoot "bin"
-          $Extracted = Join-Path $ToolRoot "extracted"
-          New-Item -ItemType Directory -Path $ToolBin -Force | Out-Null
-          New-Item -ItemType Directory -Path $Extracted -Force | Out-Null
-          $SdkArchive = Join-Path $ToolRoot "lzma-sdk.7z"
-          Invoke-WebRequest -Uri $env:COFFEE_GB_LZMA_SDK_URL -OutFile $SdkArchive
-          $SdkHash = (Get-FileHash -LiteralPath $SdkArchive -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($SdkHash -ne $env:COFFEE_GB_LZMA_SDK_SHA256) {
-            throw "Pinned LZMA SDK archive SHA-256 mismatch: $SdkHash"
+          if (-not (Test-Path -LiteralPath $Candle -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $Light -PathType Leaf)) {
+            throw "WiX 3.11 candle.exe and light.exe are required by JDK 21 jpackage"
           }
-
-          & $BootstrapSevenZip e $SdkArchive `
-            "bin/x64/7zr.exe" `
-            "bin/7zSD.sfx" `
-            "-o$Extracted" `
-            -y
-          if ($LASTEXITCODE -ne 0) {
-            throw "Unable to extract pinned Windows portable-EXE tooling"
-          }
-          $SourceArchiver = Join-Path $Extracted "7zr.exe"
-          $SourceSfx = Join-Path $Extracted "7zSD.sfx"
-          $ArchiverHash = (Get-FileHash -LiteralPath $SourceArchiver -Algorithm SHA256).Hash.ToLowerInvariant()
-          $SfxHash = (Get-FileHash -LiteralPath $SourceSfx -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($ArchiverHash -ne $env:COFFEE_GB_7ZR_X64_SHA256) {
-            throw "Pinned x64 7zr.exe SHA-256 mismatch: $ArchiverHash"
-          }
-          if ($SfxHash -ne $env:COFFEE_GB_7ZSD_SFX_SHA256) {
-            throw "Pinned 7zSD.sfx SHA-256 mismatch: $SfxHash"
-          }
-
-          Copy-Item -LiteralPath $SourceArchiver -Destination (Join-Path $ToolBin "7z.exe")
-          Copy-Item -LiteralPath $SourceSfx -Destination (Join-Path $ToolBin "7z.sfx")
-          $ToolBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $WixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Linux package validation prerequisites
         if: runner.os == 'Linux'
@@ -281,7 +245,7 @@ jobs:
               "swing/target/native-package-${PACKAGE_TARGET}-${PACKAGE_TYPE}"
           fi
 
-      - name: Run the portable EXE and repeat strict launch smokes
+      - name: Install the MSI and repeat strict launch smokes
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -473,7 +437,7 @@ jobs:
             package_type: deb
             runner: ubuntu-24.04
           - target: windows-x86-64
-            package_type: exe
+            package_type: msi
             runner: windows-2025
           - target: macos-x86-64
             package_type: dmg
@@ -550,51 +514,25 @@ jobs:
           "COFFEE_GB_MAVEN_COMMAND=$MavenWrapper" |
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Prepare pinned Windows portable-EXE tooling
+      - name: Install WiX toolset for Windows MSI packaging
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $SevenZipRoot = Join-Path $env:ProgramFiles "7-Zip"
-          $BootstrapSevenZip = Join-Path $SevenZipRoot "7z.exe"
-          if (-not (Test-Path -LiteralPath $BootstrapSevenZip -PathType Leaf) -or
-              (Get-Item -LiteralPath $BootstrapSevenZip).Length -eq 0) {
-            throw "windows-x86-64 requires the installed 7-Zip executable: $BootstrapSevenZip"
+          if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne "X64") {
+            throw "windows-x86-64 requires an X64 runner"
           }
-
-          $ToolRoot = Join-Path $env:RUNNER_TEMP "coffee-gb-lzma-sdk"
-          $ToolBin = Join-Path $ToolRoot "bin"
-          $Extracted = Join-Path $ToolRoot "extracted"
-          New-Item -ItemType Directory -Path $ToolBin -Force | Out-Null
-          New-Item -ItemType Directory -Path $Extracted -Force | Out-Null
-          $SdkArchive = Join-Path $ToolRoot "lzma-sdk.7z"
-          Invoke-WebRequest -Uri $env:COFFEE_GB_LZMA_SDK_URL -OutFile $SdkArchive
-          $SdkHash = (Get-FileHash -LiteralPath $SdkArchive -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($SdkHash -ne $env:COFFEE_GB_LZMA_SDK_SHA256) {
-            throw "Pinned LZMA SDK archive SHA-256 mismatch: $SdkHash"
+          $WixBin = Join-Path ${env:ProgramFiles(x86)} "WiX Toolset v3.11\bin"
+          $Candle = Join-Path $WixBin "candle.exe"
+          $Light = Join-Path $WixBin "light.exe"
+          if (-not (Test-Path -LiteralPath $Candle -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $Light -PathType Leaf)) {
+            choco install wixtoolset --version=3.11.2 --yes --no-progress
           }
-
-          & $BootstrapSevenZip e $SdkArchive `
-            "bin/x64/7zr.exe" `
-            "bin/7zSD.sfx" `
-            "-o$Extracted" `
-            -y
-          if ($LASTEXITCODE -ne 0) {
-            throw "Unable to extract pinned Windows portable-EXE tooling"
+          if (-not (Test-Path -LiteralPath $Candle -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $Light -PathType Leaf)) {
+            throw "WiX 3.11 candle.exe and light.exe are required by JDK 21 jpackage"
           }
-          $SourceArchiver = Join-Path $Extracted "7zr.exe"
-          $SourceSfx = Join-Path $Extracted "7zSD.sfx"
-          $ArchiverHash = (Get-FileHash -LiteralPath $SourceArchiver -Algorithm SHA256).Hash.ToLowerInvariant()
-          $SfxHash = (Get-FileHash -LiteralPath $SourceSfx -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($ArchiverHash -ne $env:COFFEE_GB_7ZR_X64_SHA256) {
-            throw "Pinned x64 7zr.exe SHA-256 mismatch: $ArchiverHash"
-          }
-          if ($SfxHash -ne $env:COFFEE_GB_7ZSD_SFX_SHA256) {
-            throw "Pinned 7zSD.sfx SHA-256 mismatch: $SfxHash"
-          }
-
-          Copy-Item -LiteralPath $SourceArchiver -Destination (Join-Path $ToolBin "7z.exe")
-          Copy-Item -LiteralPath $SourceSfx -Destination (Join-Path $ToolBin "7z.sfx")
-          $ToolBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $WixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Linux package validation prerequisites
         if: runner.os == 'Linux'

--- a/docs/native-package-ci.md
+++ b/docs/native-package-ci.md
@@ -6,16 +6,14 @@ Linux. Each jpackage invocation runs on its target architecture:
 | Target | GitHub-hosted runner | Deliverable | Final-package check |
 | --- | --- | --- | --- |
 | Linux x64 | `ubuntu-24.04` | DEB | `dpkg-deb --extract` |
-| Windows x64 | `windows-2025` | Portable EXE | run the EXE, then extract into an isolated verification directory |
+| Windows x64 | `windows-2025` | MSI | administrative extraction plus an isolated install and shortcut inspection |
 | macOS x64 | `macos-15-intel` | DMG | read-only `hdiutil` mount |
 | macOS arm64 | `macos-15` | DMG | read-only `hdiutil` mount |
 
-JDK 21 supplies `jdeps`, `jlink`, and `jpackage`. The Windows image bootstraps a digest-pinned LZMA
-SDK archive, then exposes its x64 `7zr.exe` and configuration-aware `7zSD.sfx` installer module
-under the sibling names expected by the package interface. The archive and both extracted files
-must match reviewed SHA-256 values before building. Each job also fails if its architecture or
-required host tool is wrong. Oracle jpackage cannot cross-build these formats, so a missing target
-runner is a release blocker rather than permission to relabel another architecture.
+JDK 21 supplies `jdeps`, `jlink`, and `jpackage`. The Windows image provisions WiX 3.11 and exposes
+its `candle.exe` and `light.exe` tools to the subsequent package steps. Each job also fails if its
+architecture or required host tool is wrong. Oracle jpackage cannot cross-build these formats, so a
+missing target runner is a release blocker rather than permission to relabel another architecture.
 
 ## What CI proves
 
@@ -34,9 +32,9 @@ and launch gates. The package tool then:
 4. writes `PACKAGE-RESULT.properties`, one canonical byte-identical Maven dependency CycloneDX
    SBOM, one exact target-native CycloneDX SBOM generated from the locked inventory, and exhaustive
    `SHA256SUMS`;
-5. unpacks, extracts, or mounts the final package and repeats strict inspection and both launch smokes from
-   an isolated temporary home; and
-6. proves the final DEB desktop entry, portable-EXE registry state, and DMG application metadata
+5. unpacks, extracts, installs, or mounts the final package and repeats strict inspection and both launch
+   smokes from an isolated temporary home; and
+6. proves the final DEB desktop entry, MSI registry and shortcut state, and DMG application metadata
    do not register `.gb`, `.gbc`, or `.rom` with Coffee GB; and
 7. uploads the short-lived target validation inputs, including both SBOMs, checksums, result
    manifest, and (once, from Linux) the unchanged portable Maven JAR. The final gated release
@@ -62,9 +60,10 @@ Windows keeps the primary `Coffee GB.exe` GUI launcher console-free and uses the
 The no-registration gate inspects the exact final artifacts. Linux rejects any `MimeType` in the
 packaged Coffee GB desktop entry. macOS rejects `CFBundleDocumentTypes`,
 `UTExportedTypeDeclarations`, and `UTImportedTypeDeclarations` in the mounted application. Windows
-runs the portable EXE, extracts it into an isolated directory, and rejects any `.gb`, `.gbc`, or
-`.rom` extension class, `OpenWithProgids`, or `OpenWithList` entry that resolves to Coffee GB.
-These checks run again for protected signed builds.
+installs the MSI into an isolated directory, rejects any `.gb`, `.gbc`, or `.rom` extension class,
+`OpenWithProgids`, or `OpenWithList` entry that resolves to Coffee GB, and requires the desktop and
+Start Menu links to target only `Coffee GB.exe`, never `Coffee GB Console.exe`. These checks run again
+for protected signed builds.
 
 The content verifier bounds traversal and rejects symlinks in application input, a second runtime,
 foreign or altered target natives, ROM-like files, signing-store exports, private-key/token-shaped

--- a/docs/native-packaging.md
+++ b/docs/native-packaging.md
@@ -3,8 +3,8 @@
 This document defines the native packaging and release-validation contract. Maven remains the
 authoritative application build. Target staging, minimized runtimes, application images, and native
 installers consume Maven outputs; they never compile a second application copy or resolve a second
-dependency graph. Windows release EXEs are self-extracting portable application images, not
-installers.
+dependency graph. Windows releases use MSI installers by default; self-extracting portable EXEs
+remain an explicit optional package type.
 
 ## Desktop artifacts
 
@@ -127,8 +127,8 @@ neutral JAR, universal JAR, and CycloneDX SBOM, and then invoke the same Java pa
 ```
 
 ```powershell
-# Windows x86-64 portable EXE (the target's default package)
-.\packaging\package-native.ps1 windows-x86-64 exe
+# Windows x86-64 MSI (the target's default installer)
+.\packaging\package-native.ps1 windows-x86-64 msi
 ```
 
 Both wrappers use the portable `mvn` command from `PATH`. Set `COFFEE_GB_MAVEN_COMMAND` to an
@@ -141,7 +141,7 @@ the host; after selection, the tool rejects a mismatched host OS or architecture
 | Target | Host | Default package | Other validated type | Host prerequisites |
 | --- | --- | --- | --- | --- |
 | `linux-x86-64` | Linux x86-64 | DEB | RPM, app-image | JDK 21+, `dpkg-deb` and `desktop-file-validate` for DEB, or `rpmbuild` for RPM |
-| `windows-x86-64` | Windows x86-64 | Portable EXE | MSI, app-image | JDK 21+, 7-Zip with `7z.sfx` |
+| `windows-x86-64` | Windows x86-64 | MSI | Portable EXE, app-image | JDK 21+, WiX 3.11 (`candle.exe`, `light.exe`) for MSI; 7-Zip with `7z.sfx` for the optional portable EXE |
 | `macos-x86-64` | macOS x86-64 | DMG | PKG, app-image | JDK 21+, Xcode command-line packaging tools |
 | `macos-aarch64` | macOS arm64 | DMG | PKG, app-image | arm64 JDK 21+, Xcode command-line packaging tools |
 
@@ -231,11 +231,13 @@ type. Linux packages install a freedesktop `Game;` menu shortcut while retaining
 section `games`. A DEB build extracts the package-owned
 `/opt/coffee-gb/lib/coffee-gb-Coffee_GB.desktop` payload, runs `desktop-file-validate`, and proves
 the bounded `postinst` script registers that exact file. It also verifies the section and expected
-`libasound2t64` dependency. The Windows portable EXE extracts to a temporary directory, launches
-Coffee GB, and creates no shortcut, uninstall identity, or registry entry; the optional MSI retains
-the fixed upgrade UUID, help/update URLs, and install-directory chooser. macOS packages set the Games
-application category and bundle identifier. The desktop ROM-open service remains available for
-explicit application-directed open-file events; packaging never claims those file types.
+`libasound2t64` dependency. The Windows MSI retains the fixed upgrade UUID, help/update URLs, and
+install-directory chooser, and installs Coffee GB's desktop and Start Menu shortcuts. Its secondary
+console launcher is intentionally not shortcut-eligible. The optional portable EXE extracts to a
+temporary directory, launches Coffee GB, and creates no shortcut, uninstall identity, or registry
+entry. macOS packages set the Games application category and bundle identifier. The desktop ROM-open
+service remains available for explicit application-directed open-file events; packaging never claims
+those file types.
 
 ## SBOM, checksums, and release signing
 
@@ -302,14 +304,14 @@ Protected release signing uses a two-stage image flow before any digest is final
 6. only then copy the verified Maven dependency SBOM and target-native SBOM and write the result
    manifest and checksums.
 
-On Windows the policy is deliberately EXE-only. It deterministically Authenticode-signs every
-visible executable/DLL in the app image with SHA-256 and an RFC 3161 HTTPS timestamp, appending
-rather than replacing an existing vendor signature, and requires `/pa /all /tw` verification
-before portable-EXE creation, in jpackage's app image, and after extraction. Digest-locked
-third-party native-source binaries are stored rather than compressed inside a deterministic ZIP;
-platform signing seals that resource without rewriting the upstream bytes later checked during
-runtime extraction. The policy then signs and verifies the outer EXE. On macOS the protected path
-is deliberately DMG-only: jpackage signs the `.app` with its JDK-enabling default entitlements,
+On Windows the policy supports MSI and portable EXE installers. It deterministically
+Authenticode-signs every visible executable/DLL in the app image with SHA-256 and an RFC 3161 HTTPS
+timestamp, appending rather than replacing an existing vendor signature, and requires `/pa /all /tw`
+verification before installer construction, in jpackage's app image, and after extraction.
+Digest-locked third-party native-source binaries are stored rather than compressed inside a
+deterministic ZIP; platform signing seals that resource without rewriting the upstream bytes later
+checked during runtime extraction. The policy then signs and verifies the outer MSI or EXE. On macOS
+the protected path is deliberately DMG-only: jpackage signs the `.app` with its JDK-enabling default entitlements,
 `codesign --deep --strict` verifies the complete bundle, and an explicit code requirement proves
 that the application signature contains
 `com.apple.security.cs.disable-library-validation=true`, which is required to load the separately
@@ -337,8 +339,8 @@ libraries have additional ABI and package requirements. Windows 10 x86-64 or new
 newer on the packaged architecture remain the other project release floors. These are conservative
 tested floors, not a claim that every older machine fails. Each native package bundles its Java
 runtime, so users do not install Java separately. Linux desktop integration depends on the
-distribution's ordinary menu/MIME tools, Windows portable-EXE creation depends on 7-Zip's SFX
-module, and macOS
+distribution's ordinary menu/MIME tools, Windows MSI creation depends on WiX 3.11, optional
+portable-EXE creation depends on 7-Zip's SFX module, and macOS
 Gatekeeper warns for unsigned local/PR builds; only protected release builds may be signed and
 notarized.
 
@@ -435,8 +437,8 @@ keyed by the POMs; `target/`, native caches, settings, ROMs, batteries, and stat
 never cached. Target artifacts expire after seven days and the complete gated bundle after
 fourteen.
 
-Every host verifies jpackage's pre-package payload, then extracts the actual DEB/portable EXE or
-mounts the actual DMG and repeats the checks. Inspection requires:
+Every host verifies jpackage's pre-package payload, then extracts the actual DEB, administratively
+extracts and installs the MSI, or mounts the actual DMG and repeats the checks. Inspection requires:
 
 - exactly one linked runtime and the locked ten-module closure;
 - the exact target-native allowlist and digests, with no foreign native;

--- a/docs/native-release-checklist.md
+++ b/docs/native-release-checklist.md
@@ -15,16 +15,16 @@ has a named tester, target/architecture, date, and result. A tag push alone must
   package manifest and `--version`; its fully qualified ref peels to the full `source.commit`
   recorded in `NATIVE-PACKAGE-MATRIX.properties`.
 - [ ] All four required targets passed their unit/integration build, pre-package inspection,
-  final package extract/mount, packaged `--version`, `--package-smoke`, normal and `--debug`
+  final package extract/install/mount, packaged `--version`, `--package-smoke`, normal and `--debug`
   production desktop launches, no-registration checks for `.gb`, `.gbc`, and `.rom`, bounded
-  shutdown, and portable-EXE cleanup where applicable. Each package smoke named the exact configured target after
+  shutdown, and MSI cleanup where applicable. Each package smoke named the exact configured target after
   starting from its own empty extraction cache.
 - [ ] If protected signing was requested, every target was rebuilt from the same immutable source
-  after the unsigned gate. Windows app-image executables and the portable EXE, macOS app bundles and DMGs,
+  after the unsigned gate. Windows app-image executables and the MSI, macOS app bundles and DMGs,
   and Linux detached signatures all passed their independent platform verification. The extracted
   macOS app retained `com.apple.security.cs.disable-library-validation=true`, passed Gatekeeper,
   and launched with its extracted locked natives; checksums were generated afterward.
-- [ ] The release bundle contains the portable JAR, Linux x64 DEB, Windows x64 EXE, macOS x64 DMG,
+- [ ] The release bundle contains the portable JAR, Linux x64 DEB, Windows x64 MSI, macOS x64 DMG,
   macOS arm64 DMG, `NATIVE-PACKAGE-MATRIX.properties`, and `SHA256SUMS`, plus every detached
   signature named by the matrix. It contains no `*.json` files; the matrix records the Maven and
   target-native SBOM digests validated before assembly.
@@ -65,9 +65,9 @@ has a named tester, target/architecture, date, and result. A tag push alone must
 - [ ] Launch through the packaged `--debug` path (the secondary console launcher on Windows) and
   confirm the production window starts and package-native fallback diagnostics contain no ROM,
   state, credential, or private path.
-- [ ] For the Windows portable EXE, confirm it starts directly without an installer, creates no
-  shortcuts or Installed Apps entry, and leaves no Coffee GB ROM association. For installable
-  packages, uninstall/remove the application and confirm launchers and shortcuts are removed.
+- [ ] For the Windows MSI, confirm that the Coffee GB desktop and Start Menu links launch
+  `Coffee GB.exe`, no `Coffee GB Console.exe` shortcut exists, and no Coffee GB ROM association was
+  added. Uninstall it and confirm the application and both Coffee GB shortcuts are removed.
 - [ ] Confirm ROMs, batteries, states, settings, screenshots, and other user data remain usable
   after closing and relaunching the package.
 

--- a/docs/release-notes/coffee-gb-2.0.md
+++ b/docs/release-notes/coffee-gb-2.0.md
@@ -120,7 +120,7 @@ directory, and legacy `.sn0`–`.sn9` files remain available as read-only fallba
 
 Choose the package for your platform from the assets below:
 
-- **Windows x64:** portable EXE
+- **Windows x64:** MSI installer
 - **Linux x64:** DEB package
 - **macOS Intel:** x64 DMG
 - **macOS Apple silicon:** arm64 DMG

--- a/packaging/package-native.ps1
+++ b/packaging/package-native.ps1
@@ -52,7 +52,7 @@ if (-not (Test-Path -LiteralPath $Sbom -PathType Leaf)) {
     throw "CycloneDX SBOM is missing: $Sbom"
 }
 
-if ($Target -eq "windows-x86-64" -and (-not $Type -or $Type -eq "exe")) {
+if ($Target -eq "windows-x86-64" -and $Type -eq "exe") {
     $SevenZip = Get-Command "7z.exe" -ErrorAction SilentlyContinue
     if (-not $SevenZip) {
         throw "Windows portable EXE packaging requires 7z.exe"

--- a/packaging/verify-native-package.ps1
+++ b/packaging/verify-native-package.ps1
@@ -16,16 +16,19 @@ $BuildRoot = if ([System.IO.Path]::IsPathRooted($BuildRoot)) {
     [System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $BuildRoot))
 }
 $Dist = Join-Path $BuildRoot "dist"
-$UnpackedRoot = Join-Path $BuildRoot "unpacked-portable-exe"
+$Extracted = Join-Path $BuildRoot "extracted-installer"
+$InstalledRoot = Join-Path $BuildRoot "installed-msi"
 $SmokeHome = Join-Path $BuildRoot "unpacked-smoke-home"
 
-if (Test-Path -LiteralPath $UnpackedRoot) {
-    throw "Portable EXE extraction output already exists: $UnpackedRoot"
+foreach ($Path in @($Extracted, $InstalledRoot)) {
+    if (Test-Path -LiteralPath $Path) {
+        throw "MSI verification output already exists: $Path"
+    }
 }
 
 $AppJars = @(Get-ChildItem -Path $SwingTarget -Filter "coffee-gb-*-app.jar" -File)
 $Sboms = @(Get-ChildItem -Path $SwingTarget -Filter "coffee-gb-*-sbom.cdx.json" -File)
-$Packages = @(Get-ChildItem -Path $Dist -Filter "*.exe" -File)
+$Packages = @(Get-ChildItem -Path $Dist -Filter "*.msi" -File)
 if ($AppJars.Count -ne 1) {
     throw "Expected exactly one Maven -app.jar, found $($AppJars.Count)"
 }
@@ -33,10 +36,35 @@ if ($Sboms.Count -ne 1) {
     throw "Expected exactly one Maven SBOM, found $($Sboms.Count)"
 }
 if ($Packages.Count -ne 1) {
-    throw "Expected exactly one Windows portable EXE, found $($Packages.Count)"
+    throw "Expected exactly one MSI installer, found $($Packages.Count)"
 }
 
-function Assert-NoRomAssociations {
+function Show-MsiLogTail([string] $Log, [string] $Operation) {
+    try {
+        if (Test-Path -LiteralPath $Log -PathType Leaf) {
+            Write-Host "$Operation log tail:"
+            Get-Content -LiteralPath $Log -Tail 250
+        } else {
+            Write-Warning "$Operation log was not created: $Log"
+        }
+    } catch {
+        Write-Warning "Unable to read $Operation log ${Log}: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-Msi([string] $Operation, [string[]] $Arguments, [string] $Log) {
+    $Msi = Start-Process `
+        -FilePath "msiexec.exe" `
+        -ArgumentList $Arguments `
+        -Wait `
+        -PassThru
+    if ($Msi.ExitCode -notin @(0, 3010)) {
+        Show-MsiLogTail $Log $Operation
+        throw "$Operation failed with exit code $($Msi.ExitCode); see $Log"
+    }
+}
+
+function Assert-NoRomAssociations([string] $InstallationRoot) {
     foreach ($Extension in @(".gb", ".gbc", ".rom")) {
         $ExtensionKey = "Registry::HKEY_CLASSES_ROOT\$Extension"
         if (-not (Test-Path -LiteralPath $ExtensionKey)) {
@@ -52,7 +80,7 @@ function Assert-NoRomAssociations {
         if (Test-Path -LiteralPath $OpenWithList) {
             foreach ($Application in (Get-Item -LiteralPath $OpenWithList).GetValueNames()) {
                 if ($Application -match '(?i)Coffee GB(?: Console)?\.exe') {
-                    throw "The portable EXE registered $Application for $Extension"
+                    throw "The MSI registered $Application for $Extension"
                 }
             }
         }
@@ -63,56 +91,80 @@ function Assert-NoRomAssociations {
             }
             $Command = (Get-Item -LiteralPath $CommandKey).GetValue("")
             if ($Command -match '(?i)Coffee GB(?: Console)?\.exe' -or
-                $Command -like "*$UnpackedRoot*") {
-                throw "The portable EXE registered $Extension through $ProgId`: $Command"
+                $Command -like "*$InstallationRoot*") {
+                throw "The MSI registered $Extension through $ProgId`: $Command"
             }
         }
     }
 }
 
-$SevenZip = Get-Command "7z.exe" -ErrorAction SilentlyContinue
-if (-not $SevenZip) {
-    throw "7z.exe is required to inspect the Windows portable EXE"
+function Assert-OnlyCoffeeGbShortcuts([string] $InstallationRoot) {
+    $Desktop = Join-Path $env:PUBLIC "Desktop"
+    $StartMenuGroup = Join-Path `
+        $env:ProgramData `
+        "Microsoft\Windows\Start Menu\Programs\Coffee GB"
+    $ExpectedShortcuts = @(
+        Join-Path $Desktop "Coffee GB.lnk",
+        Join-Path $StartMenuGroup "Coffee GB.lnk"
+    )
+    $PrimaryLauncher = [System.IO.Path]::GetFullPath(
+        (Join-Path $InstallationRoot "Coffee GB.exe"))
+    $ConsoleLauncher = [System.IO.Path]::GetFullPath(
+        (Join-Path $InstallationRoot "Coffee GB Console.exe"))
+    $InstallationPrefix = [System.IO.Path]::GetFullPath($InstallationRoot).TrimEnd('\') + '\'
+    $Shell = New-Object -ComObject WScript.Shell
+
+    foreach ($ShortcutPath in $ExpectedShortcuts) {
+        if (-not (Test-Path -LiteralPath $ShortcutPath -PathType Leaf)) {
+            throw "MSI did not create the Coffee GB shortcut: $ShortcutPath"
+        }
+        $TargetPath = $Shell.CreateShortcut($ShortcutPath).TargetPath
+        if ([System.IO.Path]::GetFullPath($TargetPath) -ine $PrimaryLauncher) {
+            throw "Coffee GB shortcut has an unexpected target: $ShortcutPath -> $TargetPath"
+        }
+    }
+
+    foreach ($Directory in @($Desktop, $StartMenuGroup)) {
+        if (-not (Test-Path -LiteralPath $Directory -PathType Container)) {
+            continue
+        }
+        foreach ($Shortcut in (Get-ChildItem -LiteralPath $Directory -Filter "*.lnk" -File -Recurse)) {
+            $TargetPath = $Shell.CreateShortcut($Shortcut.FullName).TargetPath
+            if ([string]::IsNullOrWhiteSpace($TargetPath)) {
+                continue
+            }
+            $ResolvedTarget = [System.IO.Path]::GetFullPath($TargetPath)
+            if ($ResolvedTarget -ieq $ConsoleLauncher) {
+                throw "MSI installed a misleading console shortcut: $($Shortcut.FullName)"
+            }
+            if ($ResolvedTarget.StartsWith(
+                    $InstallationPrefix,
+                    [System.StringComparison]::OrdinalIgnoreCase) -and
+                    $ResolvedTarget -ine $PrimaryLauncher) {
+                throw "MSI installed an unexpected launcher shortcut: $($Shortcut.FullName)"
+            }
+        }
+    }
 }
 
-$PortableMarker = Join-Path $BuildRoot "portable-exe-ready.marker"
-$PreviousMarker = $env:COFFEE_GB_DESKTOP_SMOKE_MARKER
-try {
-    $env:COFFEE_GB_DESKTOP_SMOKE_MARKER = $PortableMarker
-    $Process = Start-Process -FilePath $Packages[0].FullName -PassThru
-    $Deadline = [DateTime]::UtcNow.AddSeconds(45)
-    while (-not (Test-Path -LiteralPath $PortableMarker -PathType Leaf) -and
-            [DateTime]::UtcNow -lt $Deadline) {
-        Start-Sleep -Milliseconds 100
-    }
-    if (-not (Test-Path -LiteralPath $PortableMarker -PathType Leaf)) {
-        throw "Windows portable EXE did not start Coffee GB"
-    }
-    $Evidence = Get-Content -LiteralPath $PortableMarker -Raw
-    if ($Evidence -notmatch "Coffee GB desktop ready OK:") {
-        throw "Windows portable EXE produced invalid startup evidence: $Evidence"
-    }
-    $Process.WaitForExit(45000) | Out-Null
-    if (-not $Process.HasExited) {
-        $Process.Kill()
-        throw "Windows portable EXE did not exit after the desktop smoke"
-    }
-} finally {
-    $env:COFFEE_GB_DESKTOP_SMOKE_MARKER = $PreviousMarker
-}
+New-Item -ItemType Directory -Path $Extracted | Out-Null
+$ExtractLog = Join-Path $BuildRoot "msi-administrative-extract.log"
+Invoke-Msi -Operation "MSI administrative extraction" -Arguments @(
+    "/a",
+    "`"$($Packages[0].FullName)`"",
+    "/qn",
+    "TARGETDIR=`"$Extracted`"",
+    "/L*V",
+    "`"$ExtractLog`""
+) -Log $ExtractLog
 
-& $SevenZip.Source x "-o$UnpackedRoot" "-y" $Packages[0].FullName
-if ($LASTEXITCODE -ne 0) {
-    throw "Unable to unpack Windows portable EXE with exit code $LASTEXITCODE"
-}
-Assert-NoRomAssociations
 $Arguments = @(
     "-cp", $AppJars[0].FullName,
     "eu.rekawek.coffeegb.swing.packaging.NativePackageVerifier",
     "verify",
     "--target", $Target,
-    "--type", "exe",
-    "--root", $UnpackedRoot,
+    "--type", "msi",
+    "--root", $Extracted,
     "--source-app-jar", $AppJars[0].FullName,
     "--source-sbom", $Sboms[0].FullName,
     "--source-legal", (Join-Path $RepositoryRoot "packaging/resources/legal"),
@@ -122,5 +174,38 @@ $Arguments = @(
 )
 & java @Arguments
 if ($LASTEXITCODE -ne 0) {
-    throw "Portable EXE verification failed with exit code $LASTEXITCODE"
+    throw "Extracted MSI verification failed with exit code $LASTEXITCODE"
+}
+
+$InstallLog = Join-Path $BuildRoot "msi-install.log"
+$UninstallLog = Join-Path $BuildRoot "msi-uninstall.log"
+$Installed = $false
+try {
+    Invoke-Msi -Operation "MSI installation" -Arguments @(
+        "/i",
+        "`"$($Packages[0].FullName)`"",
+        "/qn",
+        "/norestart",
+        "INSTALLDIR=`"$InstalledRoot`"",
+        "/L*V",
+        "`"$InstallLog`""
+    ) -Log $InstallLog
+    $Installed = $true
+
+    if (-not (Test-Path -LiteralPath $InstalledRoot -PathType Container)) {
+        throw "MSI did not install to the requested directory: $InstalledRoot"
+    }
+    Assert-NoRomAssociations $InstalledRoot
+    Assert-OnlyCoffeeGbShortcuts $InstalledRoot
+} finally {
+    if ($Installed) {
+        Invoke-Msi -Operation "MSI uninstall" -Arguments @(
+            "/x",
+            "`"$($Packages[0].FullName)`"",
+            "/qn",
+            "/norestart",
+            "/L*V",
+            "`"$UninstallLog`""
+        ) -Log $UninstallLog
+    }
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageMetadata.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageMetadata.java
@@ -263,7 +263,7 @@ public final class NativePackageMetadata {
                         Architecture.X86_64,
                         "ico",
                         Set.of(PackageType.APP_IMAGE, PackageType.MSI, PackageType.EXE),
-                        PackageType.EXE));
+                        PackageType.MSI));
         targets.put(
                 NativeTarget.MACOS_X86_64,
                 new Target(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageStager.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageStager.java
@@ -128,7 +128,11 @@ public final class NativePackageStager {
         writeUtf8(
                 windowsConsoleLauncher,
                 "arguments=--debug\n"
-                        + "win-console=true\n");
+                        + "win-console=true\n"
+                        // Additional launchers inherit the primary launcher's Windows shortcut
+                        // settings unless they explicitly override them.
+                        + "win-shortcut=false\n"
+                        + "win-menu=false\n");
 
         Map<String, String> inventory = new TreeMap<>();
         inventory.put("schema", "1");

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/ReleaseSigningPolicy.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/ReleaseSigningPolicy.java
@@ -56,9 +56,10 @@ public final class ReleaseSigningPolicy {
                     "Release signing requires an installer artifact, not app-image");
         }
         if (target.hostOs() == NativePackageMetadata.HostOs.WINDOWS
-                && packageType != NativePackageMetadata.PackageType.EXE) {
+                && packageType != NativePackageMetadata.PackageType.EXE
+                && packageType != NativePackageMetadata.PackageType.MSI) {
             throw new IllegalArgumentException(
-                    "Windows release signing supports EXE only");
+                    "Windows release signing supports MSI and EXE installers only");
         }
         if (target.hostOs() == NativePackageMetadata.HostOs.MACOS
                 && packageType != NativePackageMetadata.PackageType.DMG) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageMetadataTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageMetadataTest.java
@@ -38,7 +38,7 @@ public class NativePackageMetadataTest {
         NativePackageMetadata.Target windows =
                 NativePackageMetadata.target(NativeTarget.WINDOWS_X86_64);
         assertEquals("ico", windows.iconSuffix());
-        assertEquals(NativePackageMetadata.PackageType.EXE, windows.defaultPackageType());
+        assertEquals(NativePackageMetadata.PackageType.MSI, windows.defaultPackageType());
 
         NativePackageMetadata.Target macArm =
                 NativePackageMetadata.target(NativeTarget.MACOS_AARCH64);

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageWorkflowTest.java
@@ -44,25 +44,18 @@ public class NativePackageWorkflowTest {
         assertTrue(packages.contains("cache: maven"));
         assertTrue(packages.contains("cache-dependency-path: \"**/pom.xml\""));
         assertTrue(packages.contains("persist-credentials: false"));
-        assertTrue(packages.contains("7z.exe"));
-        assertTrue(packages.contains("7z.sfx"));
-        assertTrue(packages.contains("7zSD.sfx"));
-        assertTrue(packages.contains("lzma2602.7z"));
-        assertTrue(packages.contains(
-                "2878c85f5f43a4a4e0952b1fd4e5fe097c1c143997a8047c7e1e788892aa9357"));
-        assertTrue(packages.contains(
-                "89645457d40b0e6731014a61ee6ebedd22c01a92fc38618480d385461c4347bb"));
-        assertTrue(packages.contains(
-                "0fc21d175a0e4c7e4f10521f35f6e6effa9dbd3c0ea80895cc79e72a9fdde088"));
         assertEquals(2, occurrences(packages,
-                "name: Prepare pinned Windows portable-EXE tooling"));
+                "name: Install WiX toolset for Windows MSI packaging"));
         assertEquals(2, occurrences(packages,
-                "Join-Path $env:ProgramFiles \"7-Zip\""));
+                "choco install wixtoolset --version=3.11.2 --yes --no-progress"));
         assertEquals(2, occurrences(packages, "$env:GITHUB_PATH"));
-        assertFalse(packages.contains("candle.exe"));
-        assertFalse(packages.contains("light.exe"));
-        assertEquals(2, occurrences(packages, "package_type: exe"));
-        assertFalse(packages.contains("package_type: msi"));
+        assertTrue(packages.contains("candle.exe"));
+        assertTrue(packages.contains("light.exe"));
+        assertEquals(0, occurrences(packages, "package_type: exe"));
+        assertEquals(2, occurrences(packages, "package_type: msi"));
+        assertFalse(packages.contains("7z.sfx"));
+        assertFalse(packages.contains("7zSD.sfx"));
+        assertFalse(packages.contains("lzma2602.7z"));
         assertTrue(packages.contains("verify-native-package.sh"));
         assertTrue(packages.contains("verify-native-package.ps1"));
         assertFalse(packages.contains("verify-native-association"));

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
@@ -60,6 +60,7 @@ public class NativePackagingScriptTest {
         assertTrue(ps.contains("COFFEE_GB_MAVEN_COMMAND"));
         assertTrue(ps.contains("COFFEE_GB_7ZIP_COMMAND"));
         assertTrue(ps.contains("7z.sfx"));
+        assertTrue(ps.contains("$Target -eq \"windows-x86-64\" -and $Type -eq \"exe\""));
         assertFalse(sh.contains("/opt/maven"));
 
         for (String contents :
@@ -76,16 +77,18 @@ public class NativePackagingScriptTest {
             assertFalse(contents.contains("wget "));
         }
         assertTrue(verifyPs.contains("Start-Process"));
-        assertTrue(verifyPs.contains("-Filter \"*.exe\""));
-        assertTrue(verifyPs.contains("-FilePath $Packages[0].FullName"));
-        assertTrue(verifyPs.contains("Get-Command \"7z.exe\""));
-        assertTrue(verifyPs.contains("portable-exe-ready.marker"));
-        assertTrue(verifyPs.contains("x \"-o$UnpackedRoot\" \"-y\" $Packages[0].FullName"));
-        assertTrue(verifyPs.contains("\"--type\", \"exe\""));
-        assertTrue(verifyPs.contains("-PassThru"));
-        assertTrue(verifyPs.contains("$Process.WaitForExit(45000)"));
-        assertTrue(verifyPs.contains("\"--root\", $UnpackedRoot"));
-        assertFalse(verifyPs.contains("msiexec.exe"));
+        assertTrue(verifyPs.contains("-Filter \"*.msi\""));
+        assertTrue(verifyPs.contains("msiexec.exe"));
+        assertTrue(verifyPs.contains("\"/a\""));
+        assertTrue(verifyPs.contains("\"/i\""));
+        assertTrue(verifyPs.contains("\"/x\""));
+        assertTrue(verifyPs.contains("INSTALLDIR="));
+        assertTrue(verifyPs.contains("\"--type\", \"msi\""));
+        assertTrue(verifyPs.contains("\"--root\", $Extracted"));
+        assertTrue(verifyPs.contains("Assert-OnlyCoffeeGbShortcuts"));
+        assertTrue(verifyPs.contains("Coffee GB Console.exe"));
+        assertFalse(verifyPs.contains("Get-Command \"7z.exe\""));
+        assertFalse(verifyPs.contains("portable-exe-ready.marker"));
 
         int normalization = verifyPs.indexOf(
                 "$BuildRoot = if ([System.IO.Path]::IsPathRooted($BuildRoot)) {");
@@ -98,7 +101,8 @@ public class NativePackagingScriptTest {
                 "[System.IO.Path]::GetFullPath((Join-Path $RepositoryRoot $BuildRoot))"));
 
         assertFalse(verifyPs.contains("function Invoke-Package"));
-        assertFalse(verifyPs.contains("INSTALLDIR="));
+        assertTrue(verifyPs.contains("function Invoke-Msi"));
+        assertTrue(verifyPs.contains("Invoke-Msi -Operation \"MSI installation\" -Arguments"));
         assertTrue(verifySh.contains("grep -Eq '^MimeType='"));
         assertTrue(verifySh.contains("CFBundleDocumentTypes"));
         assertTrue(verifySh.contains("UTExportedTypeDeclarations"));

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/ReleaseSigningPolicyTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/ReleaseSigningPolicyTest.java
@@ -71,15 +71,15 @@ public class ReleaseSigningPolicyTest {
         windows.put("COFFEE_GB_WINDOWS_TIMESTAMP_URL", "https://timestamp.example");
         ReleaseSigningPolicy windowsPolicy = ReleaseSigningPolicy.require(
                 NativePackageMetadata.target(NativeTarget.WINDOWS_X86_64),
-                NativePackageMetadata.PackageType.EXE,
+                NativePackageMetadata.PackageType.MSI,
                 "1.7.15",
                 windows);
         assertTrue(windowsPolicy.jpackageOptions().isEmpty());
         List<String> installerSigning =
-                windowsPolicy.postPackageCommands(Path.of("coffee-gb.exe")).get(0);
+                windowsPolicy.postPackageCommands(Path.of("coffee-gb.msi")).get(0);
         assertEquals("signtool", installerSigning.get(0));
         assertFalse(installerSigning.contains("/as"));
-        assertTrue(windowsPolicy.verificationCommands(Path.of("coffee-gb.exe"))
+        assertTrue(windowsPolicy.verificationCommands(Path.of("coffee-gb.msi"))
                 .get(0)
                 .contains("/tw"));
         Path appImage = temporaryFolder.newFolder("windows-app").toPath();
@@ -187,13 +187,6 @@ public class ReleaseSigningPolicyTest {
                 () -> ReleaseSigningPolicy.require(
                         NativePackageMetadata.target(NativeTarget.WINDOWS_X86_64),
                         NativePackageMetadata.PackageType.APP_IMAGE,
-                        "1.7.15",
-                        releaseEnvironment()));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> ReleaseSigningPolicy.require(
-                        NativePackageMetadata.target(NativeTarget.WINDOWS_X86_64),
-                        NativePackageMetadata.PackageType.MSI,
                         "1.7.15",
                         releaseEnvironment()));
         assertThrows(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/integration/NativePackageIT.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/integration/NativePackageIT.java
@@ -120,7 +120,10 @@ public class NativePackageIT {
             assertTrue(Files.size(result.icon()) > 5_000);
             assertFalse(Files.exists(result.root().resolve("associations")));
             assertEquals(
-                    "arguments=--debug\nwin-console=true\n",
+                    "arguments=--debug\n"
+                            + "win-console=true\n"
+                            + "win-shortcut=false\n"
+                            + "win-menu=false\n",
                     Files.readString(result.windowsConsoleLauncher()));
             String inventory = Files.readString(result.inventory());
             assertTrue(inventory.contains("native.source-format=stored-zip\n"));


### PR DESCRIPTION
## Summary

Restores the Windows MSI as the default release artifact, provisions WiX in Windows CI, and keeps the console launcher out of the desktop and Start Menu shortcuts.

The MSI verifier now installs the package into an isolated location and proves that only Coffee GB shortcuts target the installed application.

## Validation

- `mvn -pl swing -am test`
- `mvn -pl swing -am -Dskip.unit.tests=true -Dit.test=NativePackageIT verify`
