### PR TITLE
Map DMG schematics to Coffee GB and correct bounded behavior

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -380,6 +380,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
         interruptManager.disableInterrupts(false);
         if (configuration.bootstrapMode != BootstrapMode.SKIP) {
+            // Component constructors retain the post-boot defaults used by direct fixtures
+            // and SKIP bootstrap. An authentic boot starts before the boot ROM has asserted
+            // VBlank IF or powered the APU, so drive those existing register boundaries to
+            // raw reset before the first CPU tick.
+            interruptManager.setByte(0xff0f, 0x00);
+            sound.setByte(0xff26, 0x00);
             // at power-on the LCD is off; the boot ROM enables it, anchoring the PPU
             // line grid to that write; the CGB divider phase accounts for the boot
             // ROM's accurately paced HDMA setup. Later revisions start 10 T into the
@@ -507,7 +513,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private void applyPostBootState(boolean nonCgbCart) {
         speedMode.setDmgCompat(gbc && nonCgbCart);
         gpu.prepareForTick();
-        biosShadow.setByte(0xff50, 0);
+        biosShadow.setByte(0xff50, 1);
         // DIV counter value at PC=0x0100 after the boot ROM (mooneye boot_div tests)
         timer.presetDiv(hardwareProfile.bootSpec().postBootDivPreset());
         var r = cpu.getRegisters();
@@ -773,9 +779,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             if (dmaCpuState == Cpu.State.HALTED
                     || dmaCpuState == Cpu.State.STOPPED) {
                 // HBlank DMA is suspended while the CPU clock is halted or
-                // stopped. Keep ticking the CPU so an interrupt or asserted joypad
-                // line can wake it; the HDMA request is restored according to the
-                // request level captured when HALT was entered.
+                // stopped. Keep ticking the CPU so an asserted joypad line can wake
+                // STOP; the separately calibrated CGB path can also accept an interrupt.
+                // The HDMA request is restored according to the request level captured
+                // when HALT was entered.
                 if (dmaCpuState == Cpu.State.STOPPED) {
                     hdma.onStoppedCpuRequest();
                 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -221,7 +221,14 @@ public class Cpu implements StatefulComponent<Cpu> {
             display.enableLcd();
         }
 
-        if (state == State.OPCODE || state == State.STOPPED) {
+        // On DMG the ZUMN STOP latch is reset only by ZWLM/WAKE, whose AWOB
+        // source is the physical JOYP input. An enabled IF source therefore
+        // cannot release STOP or re-enable the LCD. Keep the existing CGB
+        // interrupt-wake path; its STOP/speed-switch machine is separate from
+        // the DMG circuit represented by that cone.
+        boolean mayAcceptInterrupt = state == State.OPCODE
+                || (state == State.STOPPED && speedMode.isGbc());
+        if (mayAcceptInterrupt) {
             // A request restored while mode 3 owns the shared VRAM-DMA arbitration
             // slot before interrupt dispatch. Retire HALT's sampled opcode first;
             // mode-2 wake-up still lets interrupt acceptance preempt that sample.
@@ -1266,8 +1273,10 @@ public class Cpu implements StatefulComponent<Cpu> {
         this.stopFrameBlankRequested = false;
         this.debugInstructionKnown = false;
 
-        setCurrentOpcode((opcode1 == 0xcb)
-                ? Opcodes.EXT_COMMANDS.get(opcode2) : Opcodes.COMMANDS.get(opcode1));
+        // EXT_OPCODE after CB means the second byte has not reached the decoder yet.
+        boolean extendedOpcodePending = opcode1 == 0xcb && this.state == State.EXT_OPCODE;
+        setCurrentOpcode(extendedOpcodePending ? null : (opcode1 == 0xcb
+                ? Opcodes.EXT_COMMANDS.get(opcode2) : Opcodes.COMMANDS.get(opcode1)));
         this.ops = (currentOpcode == null) ? null : currentOpcode.getOps();
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -34,6 +34,9 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     private static final int INPUT_FILTER_MASK = (1 << INPUT_FILTER_SAMPLES) - 1;
 
+    /** BOGA clocks the DMG JOYP receiver once per four 4.194304 MHz master ticks. */
+    static final int JOYP_CLOCK_TICKS = 4;
+
     /**
      * Host input is stable between GUI updates, so the thread-safe live hub needs polling only at
      * this master-tick cadence. The initial tick is a poll boundary and later boundaries reuse the
@@ -282,9 +285,8 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
             }
         }
         // JOYP writes happen after the joypad clock edge represented by this emulator
-        // tick. Start sampling a changed input on the following tick, then require four
-        // consecutive samples. This models the four flip-flop input filter visible in
-        // the DMG joypad circuit and keeps short selector glitches from raising IF.
+        // tick. Start sampling a changed input on the following tick. BATU, ACEF, AGEM,
+        // and APUG are all clocked by BOGA's 1 MHz output, rather than by every master tick.
         if (inputChangedSinceLastTick) {
             inputChangedSinceLastTick = false;
             refreshReleasedInputFastPathEligibility();
@@ -310,32 +312,73 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 inputLines = applyButtons(inputLines, buttons);
             }
         }
+        if (!isJoypadClockRising()) {
+            refreshReleasedInputFastPathEligibility();
+            refreshPlayerInputHubFastPathEligibility(inputLines);
+            return;
+        }
         if (inputHistory == SETTLED_HISTORY[inputLines]
                 && filteredInputLines == inputLines) {
             refreshReleasedInputFastPathEligibility();
             refreshPlayerInputHubFastPathEligibility(inputLines);
             return;
         }
+        boolean oldInterruptLine = joypadInterruptLine(inputHistory);
         int nextFilteredInputLines = filteredInputLines;
+        inputHistory = sampleInputHistory(inputHistory, inputLines);
         for (int line = 0; line < 4; line++) {
             int shift = line * INPUT_FILTER_SAMPLES;
             int history = (inputHistory >>> shift) & INPUT_FILTER_MASK;
-            boolean inputLow = (inputLines & (1 << line)) == 0;
-            history = ((history << 1) | (inputLow ? 1 : 0)) & INPUT_FILTER_MASK;
-            inputHistory = (inputHistory & ~(INPUT_FILTER_MASK << shift)) | (history << shift);
             if (history == INPUT_FILTER_MASK) {
                 nextFilteredInputLines &= ~(1 << line);
             } else if (history == 0) {
                 nextFilteredInputLines |= 1 << line;
             }
         }
-        int fallingEdges = filteredInputLines & ~nextFilteredInputLines & 0x0f;
         filteredInputLines = nextFilteredInputLines;
-        if (fallingEdges != 0) {
+        // KERY ORs all four active-low pad inputs before the four-stage receiver. ASOK is
+        // BATU & APUG, so pad identity is gone before interrupt filtering and the middle
+        // two samples are not part of its Boolean equation. ORing the four packed per-line
+        // histories reconstructs that aggregate receiver without changing portable state.
+        boolean interruptLine = joypadInterruptLine(inputHistory);
+        if (!oldInterruptLine && interruptLine) {
             interruptManager.requestInterrupt(InterruptManager.InterruptType.P10_13);
         }
         refreshReleasedInputFastPathEligibility();
         refreshPlayerInputHubFastPathEligibility(inputLines);
+    }
+
+    private boolean isJoypadClockRising() {
+        // BOGA/CLK_1MHz is anchored to the fixed master-clock/reset grid. Do not derive this
+        // phase from Cpu.clockCycle: interrupt-entry and CGB clock-mux compensation can rephase
+        // Coffee's semantic CPU boundary without moving the physical JOYP receiver clock.
+        return (tick & (JOYP_CLOCK_TICKS - 1L)) == 0;
+    }
+
+    static int sampleInputHistory(int histories, int inputLines) {
+        int sampled = histories;
+        for (int line = 0; line < 4; line++) {
+            int shift = line * INPUT_FILTER_SAMPLES;
+            int history = (histories >>> shift) & INPUT_FILTER_MASK;
+            boolean inputLow = (inputLines & (1 << line)) == 0;
+            history = ((history << 1) | (inputLow ? 1 : 0)) & INPUT_FILTER_MASK;
+            sampled = (sampled & ~(INPUT_FILTER_MASK << shift)) | (history << shift);
+        }
+        return sampled;
+    }
+
+    static int aggregateInputHistory(int histories) {
+        int aggregateHistory = histories
+                | histories >>> INPUT_FILTER_SAMPLES
+                | histories >>> (2 * INPUT_FILTER_SAMPLES)
+                | histories >>> (3 * INPUT_FILTER_SAMPLES);
+        return aggregateHistory & INPUT_FILTER_MASK;
+    }
+
+    static boolean joypadInterruptLine(int histories) {
+        int aggregateHistory = aggregateInputHistory(histories);
+        // Bit 0 is BATU's current KERY sample; bit 3 is APUG's three-edge-old sample.
+        return (aggregateHistory & 0b1001) == 0b1001;
     }
 
     private PlayerInputSnapshot sampleInputForTick() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java
@@ -15,6 +15,14 @@ public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow> {
 
     private boolean isEnabled = true;
 
+    /**
+     * Constructs the boot-ROM overlay and its sticky FF50 disable latch.
+     *
+     * <p>On DMG, {@code dmg_cpu_b/sys_decode.kicad_sch} nodes SATO, TEPU, and TUGE implement
+     * {@code TEPU.D = TEPU.Q | D0} on an FF50 write. Consequently only a set D0 can disable the
+     * boot ROM and the disable remains sticky. SameBoy independently applies the same D0 rule to
+     * CGB hardware.
+     */
     public BiosShadow(Bios bios, Cartridge cartridge) {
         this.bios = bios;
         this.cartridge = cartridge;
@@ -35,7 +43,9 @@ public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow> {
     @Override
     public void setByte(int address, int value) {
         if (address == 0xff50) {
-            isEnabled = false;
+            if ((value & 0x01) != 0) {
+                isEnabled = false;
+            }
         } else if (cartridge.accepts(address)) {
             cartridge.setByte(address, value);
         }
@@ -44,7 +54,7 @@ public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow> {
     @Override
     public int getByte(int address) {
         if (address == 0xff50) {
-            return 0xff;
+            return isEnabled ? 0xfe : 0xff;
         } else if (isEnabled && bios.accepts(address)) {
             return bios.getByte(address);
         } else {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode3.java
@@ -191,6 +191,10 @@ public class SoundMode3 extends AbstractSoundMode {
     @Override
     public void trigger() {
         i = 0;
+        // CH3_RESTART asynchronously resets the wave nibble selector.  The sample
+        // buffer itself remains stale, but its high nibble is immediately routed
+        // through the current NR32 volume shifter.
+        lastOutput = applyVolume((buffer >> 4) & 0x0f);
         // the first wave position advance is delayed by 3 extra APU cycles and does not
         // fetch a sample; the stale buffer keeps playing until the second advance
         freqDivider = frequencyPeriod + 3;
@@ -208,7 +212,7 @@ public class SoundMode3 extends AbstractSoundMode {
         ticksSinceRead++;
         clock2Mhz = !clock2Mhz;
         if (!channelEnabled) {
-            return lastOutput;
+            return 0;
         }
         if (clock2Mhz && --freqDivider == 0) {
             resetFreqDivider();
@@ -225,7 +229,7 @@ public class SoundMode3 extends AbstractSoundMode {
 
     @Override
     public int getCurrentOutput() {
-        return lastOutput;
+        return channelEnabled ? lastOutput : 0;
     }
 
     private int getWaveEntry() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
@@ -8,10 +8,45 @@ import org.junit.Test;
 
 import java.util.concurrent.CancellationException;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class GameboyBootStateTest {
+
+    @Test
+    public void authenticBootStartsFromRawInterruptAndSoundPowerState() throws Exception {
+        Rom rom = new Rom(mbc1BatteryRom());
+        for (GameboyType type : new GameboyType[]{GameboyType.DMG, GameboyType.CGB}) {
+            try (Gameboy gameboy = new GameboyConfiguration(rom)
+                    .setGameboyType(type)
+                    .setBootstrapMode(BootstrapMode.NORMAL)
+                    .build()) {
+                AddressSpace bus = gameboy.getAddressSpace();
+
+                assertArrayEquals(
+                        new int[]{0xe0, 0x00, 0x00, 0x70},
+                        new int[]{bus.getByte(0xff0f), bus.getByte(0xff24),
+                                bus.getByte(0xff25), bus.getByte(0xff26)});
+            }
+        }
+    }
+
+    @Test
+    public void skippedBootKeepsPostBootInterruptAndSoundPresets() throws Exception {
+        Rom rom = new Rom(mbc1BatteryRom());
+        try (Gameboy gameboy = new GameboyConfiguration(rom)
+                .setGameboyType(GameboyType.DMG)
+                .setBootstrapMode(BootstrapMode.SKIP)
+                .build()) {
+            AddressSpace bus = gameboy.getAddressSpace();
+
+            assertArrayEquals(
+                    new int[]{0xe1, 0x77, 0x00, 0xf0},
+                    new int[]{bus.getByte(0xff0f), bus.getByte(0xff24),
+                            bus.getByte(0xff25), bus.getByte(0xff26)});
+        }
+    }
 
     @Test
     public void bootStateRestoresMachineButKeepsFreshCartridgeData() throws Exception {
@@ -51,6 +86,20 @@ public class GameboyBootStateTest {
                 .setBootCancellation(() -> true);
 
         assertThrows(CancellationException.class, configuration::build);
+    }
+
+    @Test
+    public void dmgSkipBootExplicitlyDisablesTheBootRom() throws Exception {
+        byte[] bytes = new byte[0x8000];
+        bytes[0] = 0x42;
+        Rom rom = new Rom(bytes);
+
+        try (Gameboy gameboy = new GameboyConfiguration(rom)
+                .setGameboyType(GameboyType.DMG)
+                .setBootstrapMode(BootstrapMode.SKIP)
+                .build()) {
+            assertEquals(0x42, gameboy.getAddressSpace().getByte(0x0000));
+        }
     }
 
     private static Gameboy skipped(Rom rom) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStateRestoreTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStateRestoreTest.java
@@ -1,0 +1,54 @@
+package eu.rekawek.coffeegb.core.cpu;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.Ram;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CpuStateRestoreTest {
+
+    private static final int PROGRAM = 0xc000;
+
+    @Test
+    public void restoredCbPrefixFetchStillDecodesTheFollowingByte() {
+        AddressSpace memory = new Ram(0x0000, 0x10000);
+        memory.setByte(PROGRAM, 0xcb);
+        memory.setByte(PROGRAM + 1, 0x11); // RL C
+
+        Cpu source = cpu(memory);
+        source.getRegisters().setPC(PROGRAM);
+        source.getRegisters().setB(0x80);
+        source.getRegisters().setC(0x80);
+        source.getRegisters().getFlags().setC(false);
+
+        tick(source, 4);
+        assertEquals(Cpu.State.EXT_OPCODE, source.getState());
+        assertEquals(PROGRAM + 1, source.getRegisters().getPC());
+
+        var prefixFetched = source.captureState();
+        Cpu restored = cpu(memory);
+        restored.restoreState(prefixFetched);
+        tick(restored, 4);
+
+        assertEquals(Cpu.State.OPCODE, restored.getState());
+        assertEquals(PROGRAM + 2, restored.getRegisters().getPC());
+        assertEquals(0x80, restored.getRegisters().getB());
+        assertEquals(0x00, restored.getRegisters().getC());
+        assertTrue(restored.getRegisters().getFlags().isZ());
+        assertTrue(restored.getRegisters().getFlags().isC());
+    }
+
+    private static Cpu cpu(AddressSpace memory) {
+        return new Cpu(memory, new InterruptManager(false), null,
+                new SpeedMode(false), new Display(false));
+    }
+
+    private static void tick(Cpu cpu, int count) {
+        for (int i = 0; i < count; i++) {
+            cpu.tick();
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStopTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuStopTest.java
@@ -11,6 +11,7 @@ import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class CpuStopTest {
@@ -35,17 +36,44 @@ public class CpuStopTest {
     @Test
     public void joypadLineWakesStoppedCpuEvenWithInterruptsDisabled() {
         Ram memory = stopProgram(0xcf);
-        Cpu cpu = cpu(memory, new SpeedMode(false));
+        TrackingDisplay display = new TrackingDisplay(false);
+        Cpu cpu = cpu(memory, new InterruptManager(false), new SpeedMode(false), display);
 
         runUntilNotExecutingStop(cpu);
         assertEquals(Cpu.State.STOPPED, cpu.getState());
+        assertFalse(display.isLcdEnabled());
 
         memory.setByte(0xff00, 0xce);
         tickMachineCycle(cpu);
 
         assertEquals(Cpu.State.OPCODE, cpu.getState());
+        assertTrue(display.isLcdEnabled());
         // The wake-up cycle immediately executes the following NOP.
         assertEquals(PROGRAM + 3, cpu.getRegisters().getPC());
+    }
+
+    @Test
+    public void dmgTimerAndSerialInterruptsDoNotWakeStoppedCpu() {
+        assertDmgInterruptDoesNotWake(InterruptManager.InterruptType.Timer);
+        assertDmgInterruptDoesNotWake(InterruptManager.InterruptType.Serial);
+    }
+
+    @Test
+    public void cgbInterruptWakeBehaviorIsPreserved() {
+        Ram memory = stopProgram(0xcf);
+        InterruptManager interrupts = new InterruptManager(true);
+        TrackingDisplay display = new TrackingDisplay(true);
+        Cpu cpu = cpu(memory, interrupts, new SpeedMode(true), display);
+
+        runUntilNotExecutingStop(cpu);
+        assertEquals(Cpu.State.STOPPED, cpu.getState());
+        assertFalse(display.isLcdEnabled());
+
+        requestEnabledInterrupt(interrupts, InterruptManager.InterruptType.Timer);
+        tickMachineCycle(cpu);
+
+        assertEquals(Cpu.State.IRQ_WAIT_2, cpu.getState());
+        assertTrue(display.isLcdEnabled());
     }
 
     @Test
@@ -71,9 +99,43 @@ public class CpuStopTest {
     }
 
     private static Cpu cpu(AddressSpace memory, SpeedMode speedMode) {
-        Cpu cpu = new Cpu(memory, new InterruptManager(false), null, speedMode, new Display(false));
+        return cpu(memory, new InterruptManager(false), speedMode, new Display(false));
+    }
+
+    private static Cpu cpu(AddressSpace memory, InterruptManager interrupts, SpeedMode speedMode,
+                           Display display) {
+        Cpu cpu = new Cpu(memory, interrupts, null, speedMode, display);
         cpu.getRegisters().setPC(PROGRAM);
         return cpu;
+    }
+
+    private static void assertDmgInterruptDoesNotWake(InterruptManager.InterruptType type) {
+        Ram memory = stopProgram(0xcf);
+        InterruptManager interrupts = new InterruptManager(false);
+        TrackingDisplay display = new TrackingDisplay(false);
+        Cpu cpu = cpu(memory, interrupts, new SpeedMode(false), display);
+
+        runUntilNotExecutingStop(cpu);
+        assertEquals(Cpu.State.STOPPED, cpu.getState());
+        assertFalse(display.isLcdEnabled());
+
+        requestEnabledInterrupt(interrupts, type);
+        for (int i = 0; i < 4; i++) {
+            tickMachineCycle(cpu);
+        }
+
+        assertEquals(Cpu.State.STOPPED, cpu.getState());
+        assertEquals(PROGRAM + 2, cpu.getRegisters().getPC());
+        assertFalse(display.isLcdEnabled());
+        assertTrue(interrupts.isInterruptFlagSet(type));
+    }
+
+    private static void requestEnabledInterrupt(InterruptManager interrupts,
+                                                InterruptManager.InterruptType type) {
+        interrupts.setByte(0xff0f, 0);
+        interrupts.setByte(0xffff, 1 << type.ordinal());
+        interrupts.enableInterrupts(false);
+        interrupts.requestInterrupt(type);
     }
 
     private static Gpu gpu(SpeedMode speedMode) {
@@ -100,6 +162,31 @@ public class CpuStopTest {
     private static void tickMachineCycle(Cpu cpu) {
         for (int i = 0; i < 4; i++) {
             cpu.tick();
+        }
+    }
+
+    private static final class TrackingDisplay extends Display {
+
+        private boolean lcdEnabled = true;
+
+        private TrackingDisplay(boolean gbc) {
+            super(gbc);
+        }
+
+        @Override
+        public void enableLcd() {
+            super.enableLcd();
+            lcdEnabled = true;
+        }
+
+        @Override
+        public void disableLcd() {
+            super.disableLcd();
+            lcdEnabled = false;
+        }
+
+        private boolean isLcdEnabled() {
+            return lcdEnabled;
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/experimental/joypad/DmgJoypadInterruptGateCone.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/experimental/joypad/DmgJoypadInterruptGateCone.java
@@ -1,0 +1,88 @@
+package eu.rekawek.coffeegb.core.experimental.joypad;
+
+import eu.rekawek.coffeegb.core.signal.Dff;
+
+import static eu.rekawek.coffeegb.core.signal.SrLatch.Dominance.CLEAR;
+
+/**
+ * Test-only transcription of the DMG-CPU-B JOYP interrupt and wake-up cone.
+ *
+ * <p><strong>Evidence label: static schematic/netlist connectivity.</strong> In
+ * {@code dmg_cpu_b/ff00_joyp.kicad_sch}, KERY ORs the four active-low P10-P13 pad inputs.
+ * BATU, ACEF, AGEM, and APUG are resettable D flip-flops clocked in parallel by BOGA's
+ * {@code CLK_1MHz}; their data path is KERY -> BATU -> ACEF -> AGEM -> APUG. ASOK computes
+ * {@code BATU & APUG}, and its rising edge clocks the Joypad IF latch ULak. AWOB is a separate
+ * transparent latch enabled by {@code CLK_1MHz} and drives the CPU wake input directly.
+ *
+ * <p>The source snapshot is the {@code dmg-schematics} repository at revision
+ * {@value #SCHEMATIC_REVISION}. The matching raw-netlist statements are in
+ * {@code netlist/io/right.nl}, {@code netlist/right-col/{a,b,k}.nl}, and
+ * {@code netlist/top-center-row/b.nl}. This cone intentionally stops at the rising ASOK wire;
+ * FF0F bus arbitration and CPU STOP/HALT behavior belong to other islands.</p>
+ */
+final class DmgJoypadInterruptGateCone {
+
+    static final String SCHEMATIC_REVISION =
+            "02399f96e0893783c130cf6f03fad7a1148ae60a";
+
+    record Observation(
+            boolean kery,
+            boolean batu,
+            boolean acef,
+            boolean agem,
+            boolean apug,
+            boolean asok,
+            boolean asokRising,
+            boolean cpuWakeup) {
+    }
+
+    private final Dff batu = new Dff(CLEAR, false);
+    private final Dff acef = new Dff(CLEAR, false);
+    private final Dff agem = new Dff(CLEAR, false);
+    private final Dff apug = new Dff(CLEAR, false);
+
+    /** AWOB.q; unlike the interrupt filter this is a transparent, unreset latch. */
+    private boolean cpuWakeup;
+
+    /**
+     * Resolves one settled input vector.
+     *
+     * @param lowInputLines bit {@code n} is one when physical P1n is low
+     * @param clk1MhzHigh current BOGA output level, used as AWOB's transparent enable
+     * @param clk1MhzRising whether this vector contains BOGA's rising edge
+     */
+    Observation step(int lowInputLines, boolean clk1MhzHigh, boolean clk1MhzRising) {
+        if ((lowInputLines & ~0x0f) != 0) {
+            throw new IllegalArgumentException("P10-P13 mask exceeds four bits");
+        }
+        if (clk1MhzRising && !clk1MhzHigh) {
+            throw new IllegalArgumentException("a rising edge must finish high");
+        }
+
+        boolean kery = lowInputLines != 0;
+        boolean oldAsok = asok();
+
+        // All four DFFs see the same edge and therefore capture the pre-edge Q vector.
+        batu.resolve(kery, clk1MhzRising, false, false);
+        acef.resolve(batu.q(), clk1MhzRising, false, false);
+        agem.resolve(acef.q(), clk1MhzRising, false, false);
+        apug.resolve(agem.q(), clk1MhzRising, false, false);
+        batu.commit();
+        acef.commit();
+        agem.commit();
+        apug.commit();
+
+        // AWOB follows KERY throughout BOGA's high level, then retains while it is low.
+        if (clk1MhzHigh) {
+            cpuWakeup = kery;
+        }
+
+        boolean newAsok = asok();
+        return new Observation(kery, batu.q(), acef.q(), agem.q(), apug.q(),
+                newAsok, !oldAsok && newAsok, cpuWakeup);
+    }
+
+    private boolean asok() {
+        return batu.q() && apug.q();
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/experimental/joypad/DmgJoypadInterruptGateConeTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/experimental/joypad/DmgJoypadInterruptGateConeTest.java
@@ -1,0 +1,130 @@
+package eu.rekawek.coffeegb.core.experimental.joypad;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DmgJoypadInterruptGateConeTest {
+
+    @Test
+    public void heldInputRaisesAsokOnTheFourthOneMegahertzEdge() {
+        DmgJoypadInterruptGateCone cone = new DmgJoypadInterruptGateCone();
+
+        var first = edge(cone, 0x1);
+        assertBits(first, true, false, false, false);
+        assertFalse(first.asok());
+        assertFalse(first.asokRising());
+
+        var second = edge(cone, 0x1);
+        assertBits(second, true, true, false, false);
+        assertFalse(second.asok());
+
+        var third = edge(cone, 0x1);
+        assertBits(third, true, true, true, false);
+        assertFalse(third.asok());
+
+        var fourth = edge(cone, 0x1);
+        assertBits(fourth, true, true, true, true);
+        assertTrue(fourth.asok());
+        assertTrue(fourth.asokRising());
+    }
+
+    @Test
+    public void aSecondLowPadCannotRetriggerWhileTheAggregateRemainsHigh() {
+        DmgJoypadInterruptGateCone cone = new DmgJoypadInterruptGateCone();
+        for (int edge = 0; edge < 4; edge++) {
+            edge(cone, 0x1);
+        }
+
+        for (int edge = 0; edge < 8; edge++) {
+            var observation = edge(cone, edge < 4 ? 0x3 : 0x2);
+            assertTrue(observation.asok());
+            assertFalse(observation.asokRising());
+        }
+    }
+
+    @Test
+    public void asokChecksTheCurrentAndThreeEdgeOldSamplesRatherThanConsecutiveness() {
+        DmgJoypadInterruptGateCone rejected = new DmgJoypadInterruptGateCone();
+        edge(rejected, 0x1);
+        edge(rejected, 0x0);
+        edge(rejected, 0x0);
+        var narrowPulse = edge(rejected, 0x0);
+        assertFalse(narrowPulse.asok());
+        assertFalse(narrowPulse.asokRising());
+
+        DmgJoypadInterruptGateCone endpointMatch = new DmgJoypadInterruptGateCone();
+        edge(endpointMatch, 0x1);
+        edge(endpointMatch, 0x0);
+        edge(endpointMatch, 0x0);
+        var nonConsecutive = edge(endpointMatch, 0x8);
+        assertTrue(nonConsecutive.asok());
+        assertTrue(nonConsecutive.asokRising());
+    }
+
+    @Test
+    public void allEightSampleSequencesMatchTheBatuAndApugEndpointEquation() {
+        for (int sequence = 0; sequence < 1 << 8; sequence++) {
+            DmgJoypadInterruptGateCone cone = new DmgJoypadInterruptGateCone();
+            boolean expectedPreviousAsok = false;
+            int history = 0;
+
+            for (int sample = 0; sample < 8; sample++) {
+                boolean anyLow = (sequence & 1 << sample) != 0;
+                // Pad identity deliberately varies: KERY must erase it before BATU.
+                int lowLines = anyLow ? 1 << (sample & 3) : 0;
+                var observation = edge(cone, lowLines);
+
+                history = (history << 1 | (anyLow ? 1 : 0)) & 0x0f;
+                boolean expectedAsok = (history & 0x09) == 0x09;
+                assertEquals(expectedAsok, observation.asok());
+                assertEquals(!expectedPreviousAsok && expectedAsok,
+                        observation.asokRising());
+                expectedPreviousAsok = expectedAsok;
+            }
+        }
+    }
+
+    @Test
+    public void awobIsAnEarlierTransparentWakePathIndependentOfAsok() {
+        DmgJoypadInterruptGateCone cone = new DmgJoypadInterruptGateCone();
+
+        var opened = cone.step(0x4, true, false);
+        assertTrue(opened.cpuWakeup());
+        assertFalse(opened.asok());
+
+        var followsRelease = cone.step(0, true, false);
+        assertFalse(followsRelease.cpuWakeup());
+
+        var retainedWhileLow = cone.step(0x8, false, false);
+        assertFalse(retainedWhileLow.cpuWakeup());
+
+        var nextHigh = cone.step(0x8, true, true);
+        assertTrue(nextHigh.cpuWakeup());
+        assertFalse(nextHigh.asok());
+    }
+
+    @Test
+    public void provenancePinsTheAuditedSchematicSnapshot() {
+        assertEquals("02399f96e0893783c130cf6f03fad7a1148ae60a",
+                DmgJoypadInterruptGateCone.SCHEMATIC_REVISION);
+    }
+
+    private static DmgJoypadInterruptGateCone.Observation edge(
+            DmgJoypadInterruptGateCone cone, int lowInputLines) {
+        // The low half is relevant to AWOB retention; only the high transition clocks the DFFs.
+        cone.step(lowInputLines, false, false);
+        return cone.step(lowInputLines, true, true);
+    }
+
+    private static void assertBits(
+            DmgJoypadInterruptGateCone.Observation observation,
+            boolean batu, boolean acef, boolean agem, boolean apug) {
+        assertEquals(batu, observation.batu());
+        assertEquals(acef, observation.acef());
+        assertEquals(agem, observation.agem());
+        assertEquals(apug, observation.apug());
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
@@ -147,7 +147,7 @@ public class JoypadHotPathTest {
     }
 
     @Test
-    public void playerInputHubChangesAreBoundedAndRetainFourSampleFilterTiming() {
+    public void playerInputHubChangesAreBoundedAndRetainOneMegahertzFilterTiming() {
         InterruptManager interrupts = new InterruptManager(false);
         interrupts.setByte(0xff0f, 0);
         PlayerInputHub hub = new PlayerInputHub();
@@ -168,7 +168,8 @@ public class JoypadHotPathTest {
         joypad.tick(); // next 64-tick poll adopts the new physical latch
         assertSame(pressed, joypad.getSampledInput());
         assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
-        for (int sample = 0; sample < 3; sample++) {
+        int fourthReceiverEdgeOffset = 4 * Joypad.JOYP_CLOCK_TICKS - 1;
+        for (int elapsed = 1; elapsed < fourthReceiverEdgeOffset; elapsed++) {
             joypad.tick();
             assertFalse(interrupts.isInterruptFlagSet(InterruptManager.InterruptType.P10_13));
         }
@@ -185,7 +186,7 @@ public class JoypadHotPathTest {
         assertSame(pressed, joypad.getSampledInput());
         joypad.tick(); // next poll adopts release; the filter starts on its following tick
         assertSame(released, joypad.getSampledInput());
-        for (int sample = 0; sample < 3; sample++) {
+        for (int elapsed = 1; elapsed < fourthReceiverEdgeOffset; elapsed++) {
             joypad.tick();
             assertEquals(0x0e, filteredInputLines(joypad.captureState()));
         }
@@ -291,7 +292,9 @@ public class JoypadHotPathTest {
         joypad.seedDeterministicReplayInput(Set.of(Button.A), PlayerInputSnapshot.RELEASED);
         assertFalse(releasedInputFastPathEligible(joypad));
 
-        joypad.tick();
+        for (int tick = 0; tick < Joypad.JOYP_CLOCK_TICKS; tick++) {
+            joypad.tick();
+        }
 
         assertEquals(1, inputHistory(joypad.captureState()));
     }
@@ -307,7 +310,9 @@ public class JoypadHotPathTest {
             joypad.setByte(JOYP, 0x30);
             joypad.tick(); // consume the selector transition
 
-            joypad.tick();
+            for (int tick = 1; tick < Joypad.JOYP_CLOCK_TICKS; tick++) {
+                joypad.tick();
+            }
 
             assertEquals(1, inputHistory(joypad.captureState()));
         }
@@ -336,7 +341,9 @@ public class JoypadHotPathTest {
                 new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
         original.setPressedButtons(Set.of(Button.A));
         original.tick(); // consume the input transition
-        original.tick(); // first pressed sample
+        for (int tick = 1; tick < Joypad.JOYP_CLOCK_TICKS; tick++) {
+            original.tick();
+        }
         ComponentState<Joypad> partialFilter = original.captureState();
         assertEquals(1, inputHistory(partialFilter));
 
@@ -344,7 +351,9 @@ public class JoypadHotPathTest {
                 new InterruptManager(false), EventBus.NULL_EVENT_BUS, false);
         restored.restoreState(partialFilter);
         assertFalse(releasedInputFastPathEligible(restored));
-        restored.tick();
+        for (int tick = 0; tick < Joypad.JOYP_CLOCK_TICKS; tick++) {
+            restored.tick();
+        }
 
         assertEquals(2, inputHistory(restored.captureState()));
     }
@@ -555,7 +564,7 @@ public class JoypadHotPathTest {
 
     private static void settlePlayerInputHub(Joypad joypad) {
         joypad.tick(); // initial hub poll adopts the source and consumes its change flag
-        for (int sample = 0; sample < 4; sample++) {
+        for (int tick = 1; tick < 4 * Joypad.JOYP_CLOCK_TICKS; tick++) {
             joypad.tick();
         }
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadInterruptTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadInterruptTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static eu.rekawek.coffeegb.core.cpu.InterruptManager.InterruptType.P10_13;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -34,7 +35,7 @@ public class JoypadInterruptTest {
         joypad.setByte(0xff00, 0x10);
 
         eventBus.post(new ButtonPressEvent(Button.A));
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4 * Joypad.JOYP_CLOCK_TICKS - 1; i++) {
             joypad.tick();
         }
         assertFalse(interrupts.isInterruptFlagSet(P10_13));
@@ -103,7 +104,7 @@ public class JoypadInterruptTest {
     }
 
     @Test
-    public void pressingASecondInputLineRequestsAnotherInterrupt() {
+    public void pressingASecondInputLineDoesNotRetriggerTheAggregateInterrupt() {
         joypad.setByte(0xff00, 0x10);
         eventBus.post(new ButtonPressEvent(Button.A));
         tickThroughInputFilter();
@@ -112,7 +113,43 @@ public class JoypadInterruptTest {
         eventBus.post(new ButtonPressEvent(Button.B));
         tickThroughInputFilter();
 
+        assertFalse(interrupts.isInterruptFlagSet(P10_13));
+    }
+
+    @Test
+    public void aggregateEndpointGateDoesNotRequireFourConsecutiveLowSamples() {
+        joypad.setByte(0xff00, 0x10);
+        eventBus.post(new ButtonPressEvent(Button.A));
+        tickOneJoypadClock(); // BATU samples one low aggregate level.
+
+        eventBus.post(new ButtonReleaseEvent(Button.A));
+        tickOneJoypadClock();
+        tickOneJoypadClock();
+
+        eventBus.post(new ButtonPressEvent(Button.B));
+        tickOneJoypadClock(); // APUG has the first low while BATU samples the fourth.
+
         assertTrue(interrupts.isInterruptFlagSet(P10_13));
+    }
+
+    @Test
+    public void packedPerLineStateReconstructsEveryAggregateReceiverTransition() {
+        for (int histories = 0; histories <= 0xffff; histories++) {
+            int expectedAggregate = 0;
+            for (int line = 0; line < 4; line++) {
+                expectedAggregate |= histories >>> (line * 4) & 0x0f;
+            }
+            assertEquals(expectedAggregate, Joypad.aggregateInputHistory(histories));
+
+            for (int inputLines = 0; inputLines < 0x10; inputLines++) {
+                int nextHistories = Joypad.sampleInputHistory(histories, inputLines);
+                int nextAggregate = (expectedAggregate << 1
+                        | (inputLines == 0x0f ? 0 : 1)) & 0x0f;
+                assertEquals(nextAggregate, Joypad.aggregateInputHistory(nextHistories));
+                assertEquals((nextAggregate & 0b1001) == 0b1001,
+                        Joypad.joypadInterruptLine(nextHistories));
+            }
+        }
     }
 
     @Test
@@ -121,8 +158,10 @@ public class JoypadInterruptTest {
         joypad.setPressedButtons(Collections.singleton(Button.A));
 
         joypad.setByte(0xff00, 0x10);
-        joypad.tick();
-        joypad.tick();
+        // Three low samples do not reach APUG. The fourth 1 MHz edge sees the row released.
+        for (int tick = 0; tick < 3 * Joypad.JOYP_CLOCK_TICKS; tick++) {
+            joypad.tick();
+        }
         joypad.setByte(0xff00, 0x30);
         tickThroughInputFilter();
 
@@ -134,25 +173,33 @@ public class JoypadInterruptTest {
         joypad.setByte(0xff00, 0x30);
         joypad.setPressedButtons(Collections.singleton(Button.A));
         joypad.setByte(0xff00, 0x10);
-        joypad.tick(); // skip the clock edge on which JOYP changed
-        joypad.tick();
-        joypad.tick();
+        for (int tick = 0; tick < 2 * Joypad.JOYP_CLOCK_TICKS; tick++) {
+            joypad.tick();
+        }
         var memento = joypad.captureState();
 
-        joypad.tick();
-        joypad.tick();
+        for (int tick = 0; tick < 2 * Joypad.JOYP_CLOCK_TICKS; tick++) {
+            joypad.tick();
+        }
         assertTrue(interrupts.isInterruptFlagSet(P10_13));
         interrupts.setByte(0xff0f, 0);
 
         joypad.restoreState(memento);
-        joypad.tick();
-        joypad.tick();
+        for (int tick = 0; tick < 2 * Joypad.JOYP_CLOCK_TICKS; tick++) {
+            joypad.tick();
+        }
 
         assertTrue(interrupts.isInterruptFlagSet(P10_13));
     }
 
     private void tickThroughInputFilter() {
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 4 * Joypad.JOYP_CLOCK_TICKS; i++) {
+            joypad.tick();
+        }
+    }
+
+    private void tickOneJoypadClock() {
+        for (int tick = 0; tick < Joypad.JOYP_CLOCK_TICKS; tick++) {
             joypad.tick();
         }
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/BiosShadowTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/BiosShadowTest.java
@@ -1,0 +1,67 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BiosShadowTest {
+
+    @Test
+    public void dmgFf50IgnoresWritesWithD0Clear() throws IOException {
+        BiosShadow shadow = shadow(HardwareProfileRegistry.DMG);
+
+        assertEquals(0xfe, shadow.getByte(0xff50));
+        shadow.setByte(0xff50, 0x00);
+        shadow.setByte(0xff50, 0xfe);
+
+        assertFalse(shadow.isBootFinished());
+        assertEquals(0xfe, shadow.getByte(0xff50));
+    }
+
+    @Test
+    public void dmgFf50D0SetsAStickyDisableLatch() throws IOException {
+        BiosShadow shadow = shadow(HardwareProfileRegistry.DMG);
+
+        shadow.setByte(0xff50, 0x01);
+        assertTrue(shadow.isBootFinished());
+        assertEquals(0xff, shadow.getByte(0xff50));
+
+        shadow.setByte(0xff50, 0x00);
+        assertTrue(shadow.isBootFinished());
+        assertEquals(0xff, shadow.getByte(0xff50));
+    }
+
+    @Test
+    public void cgbUsesTheSameStickyD0Rule() throws IOException {
+        BiosShadow shadow = shadow(HardwareProfileRegistry.CGB);
+
+        shadow.setByte(0xff50, 0x00);
+        assertFalse(shadow.isBootFinished());
+        assertEquals(0xfe, shadow.getByte(0xff50));
+
+        shadow.setByte(0xff50, 0x01);
+        assertTrue(shadow.isBootFinished());
+        assertEquals(0xff, shadow.getByte(0xff50));
+    }
+
+    private static BiosShadow shadow(HardwareProfile hardwareProfile) throws IOException {
+        return new BiosShadow(
+                new Bios(hardwareProfile),
+                cartridge());
+    }
+
+    private static Cartridge cartridge() throws IOException {
+        byte[] rom = new byte[0x8000];
+        rom[0x0147] = 0x00;
+        return new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMode3Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundMode3Test.java
@@ -6,6 +6,8 @@ import eu.rekawek.coffeegb.core.timer.Timer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SoundMode3Test {
 
@@ -117,6 +119,49 @@ public class SoundMode3Test {
         mode.setByte(0xff1e, 0x87);
         for (int i = 0; i < 12; i++) {
             assertEquals(0, mode.tick());
+        }
+    }
+
+    @Test
+    public void lengthExpiryGatesTheRetainedSampleWhileTheDacStaysOn() {
+        SoundMode3 mode = newDmgMode();
+        mode.setByte(0xff31, 0xf0);
+        mode.setByte(0xff1a, 0x80);
+        mode.setByte(0xff1c, 0x20);
+        mode.setByte(0xff1d, 0xff);
+        mode.setByte(0xff1e, 0x87);
+        assertTicks(mode, 8, 0);
+        assertEquals(15, mode.tick());
+
+        mode.setByte(0xff1b, 0xff); // length = 1
+        mode.setByte(0xff1e, 0x47); // enable length without retriggering
+        mode.tickLength();
+
+        assertTrue(mode.isDacEnabled());
+        assertFalse(mode.isEnabled());
+        assertEquals(0, mode.getCurrentOutput());
+        assertEquals(0, mode.tick());
+    }
+
+    @Test
+    public void retriggerReprojectsTheStaleHighNibbleAtBoth2MhzPhases() {
+        for (int phase = 0; phase < 2; phase++) {
+            SoundMode3 mode = newDmgMode();
+            mode.setByte(0xff30, 0xe3);
+            mode.setByte(0xff1a, 0x80);
+            mode.setByte(0xff1c, 0x20);
+            mode.setByte(0xff1d, 0xfe); // period = 2 APU cycles
+            mode.setByte(0xff1e, 0x87);
+
+            // The first post-trigger advance opens the port and latches E3, while
+            // continuing to play the pre-trigger buffer.
+            assertTicks(mode, 9 + phase, 0);
+            mode.setByte(0xff1c, 0x40);
+            assertEquals(1, mode.getCurrentOutput()); // low nibble at half volume
+
+            mode.setByte(0xff1e, 0x87);
+            assertEquals(7, mode.getCurrentOutput()); // reset selector: high nibble
+            assertEquals(7, mode.tick());
         }
     }
 

--- a/doc/derived/apu-model.md
+++ b/doc/derived/apu-model.md
@@ -254,6 +254,12 @@ Hardware: NR52 bit 7 write strobe is `HAWU` = NAND(`APU_WR`, `FF26`, `D7`); the 
 drives `APU_RESET` (buffer `KEBA`) plus the per-sheet copies `~{APU_RESET2..6}` and
 `~{FF24_FF25_FF26_RESET}` (which also resets NR50/NR51 in `ff24_ff25.kicad_sch`).
 
+At raw console reset, `~RESET2` clears the NR52 master latch before the boot ROM runs. The APU
+therefore starts powered off with NR50=`00`, NR51=`00`, and NR52=`70`; the boot ROM later writes
+NR52 bit 7. Coffee retains post-boot defaults in standalone component construction, but a full
+NORMAL/FAST_FORWARD `Gameboy` now drives this raw boundary before its first CPU tick. SKIP bootstrap
+continues to install the post-boot preset directly.
+
 **Powering off (write NR52 with bit 7 = 0):**
 - All registers NR10-NR51 are reset to 0x00; subsequent reads return the OR-mask values of §5.1
   (i.e. as if the register were 0).
@@ -344,8 +350,14 @@ trigger actions. This happens *only* on DMG.
 
 ### 6.4 Position / buffer semantics
 
-- `wavePosition` (0..31 nibbles) resets to 0 on trigger; the **sample buffer keeps its old
-  value** and is what the DAC outputs until the first fetch (period + ~6 T after trigger, §3).
+- `wavePosition` (0..31 nibbles) and the `WAVE_NIBBLE_SEL` flip-flop reset to 0 on trigger; the
+  **sample buffer keeps its old byte**, but its high nibble is selected immediately and passes
+  through the current NR32 shift. That stale high-nibble value is what the DAC outputs until the
+  first fetch (period + ~6 T after trigger, §3). In the pinned netlist `CH3_RESTART` resets `EFAR`,
+  whose Q selects the four stale-buffer nibble muxes.
+- The four digital CH3 output bits are each AND-gated by `CH3_ACTIVE`. When length expiry or
+  another stop path clears the active latch, the digital DAC input becomes zero even if NR30 keeps
+  the DAC enabled; a retained sample byte is not audible while the channel is inactive.
 - On each timer expiry: `wavePosition = (wavePosition + 1) & 31`, then the byte
   `waveRam[wavePosition >> 1]` is fetched into the buffer; the output nibble is the high nibble
   for even positions, low nibble for odd (`WAVE_NIBBLE_SEL`), then shifted per NR32

--- a/doc/derived/cpu-interrupt-model.md
+++ b/doc/derived/cpu-interrupt-model.md
@@ -1,12 +1,16 @@
-# SM83 interrupt / HALT model
+# SM83 interrupt / HALT / STOP model
 
-Behavioral model of the SM83 CPU's interrupt dispatch and HALT, derived from the SM83
+Behavioral model of the SM83 CPU's interrupt dispatch, HALT, and STOP, derived from the SM83
 schematics (`dmg-schematics/sm83/intr.kicad_sch`, `sequencer.kicad_sch`) and calibrated
 cycle-exactly against the mooneye acceptance tests. This is the specification implemented by
 `Cpu` and `InterruptManager`.
 
 ## Interrupt sampling and dispatch
 
+- Raw console reset clears all five SoC IF latches, so FF0F initially reads `E0`; the boot process
+  later produces the familiar post-boot `E1`. Standalone `InterruptManager` construction retains
+  the post-boot fixture default, while a full NORMAL/FAST_FORWARD `Gameboy` drives FF0F to the raw
+  reset value before its first CPU tick. SKIP bootstrap keeps the post-boot preset.
 - At every machine-cycle boundary where the CPU would fetch an opcode, it samples
   `IME && (IE & IF & 0x1F) != 0`; if set, the 5 M-cycle dispatch starts instead of the fetch:
 
@@ -55,6 +59,16 @@ keeps cycling. Consequently **a halted CPU behaves exactly as if it were executi
 - Halt bug: executing HALT with IME=0 and a wake-synchronized `(IE & IF) != 0` prevents the sleep
   latch from setting after HALT's own missing IDU increment. The next opcode has already been
   sampled from the unchanged address and is fetched/executed again (`halt_bug`).
+
+## STOP
+
+On DMG, STOP and HALT do not share a wake condition. The sequencer's retained STOP latch is cleared
+only by reset or the WAKE port. The DMG wrapper drives WAKE from the JOYP `AWOB` latch, so an
+ordinary enabled IF source cannot release STOP even when IME is set. Coffee therefore leaves a DMG
+CPU stopped, keeps the LCD disabled, and retains the IF bit until a physical P10-P13 line goes low.
+That JOYP-low transition releases STOP independently of IE/IME and restores the LCD before normal
+fetch/interrupt selection resumes. The CGB STOP/speed-switch projection retains its separately
+calibrated behavior because its circuitry is outside the DMG source corpus.
 
 ## RST
 

--- a/doc/dmg-schematic-class-map.md
+++ b/doc/dmg-schematic-class-map.md
@@ -1,0 +1,486 @@
+# DMG-CPU-B schematic to Coffee GB class map
+
+This document maps the complete internal DMG circuit source in the sibling
+`/home/newton/dev/dmg-schematics` checkout to Coffee GB's production model. It is an architecture
+cross-reference, not a claim that Coffee GB is a gate-level transcription.
+
+The source examined here is the clean [dmg-schematics repository](https://github.com/msinger/dmg-schematics)
+at revision `02399f96e0893783c130cf6f03fad7a1148ae60a` (2026-05-18). Régis Galland and
+Michael Singer are credited in its source title blocks; its README records derivation from
+Furrtek's DMG-CPU-Inside work. The source is licensed
+[CC BY-SA 4.0](https://github.com/msinger/dmg-schematics/blob/02399f96e0893783c130cf6f03fad7a1148ae60a/LICENSE), while Coffee GB
+remains MIT. No schematic geometry, cell-level wire graph, generated RTL, or copied circuit
+implementation is stored here. The repository-local `scripts/index-dmg-schematics.py` reader emits
+only structural metadata, including sheet hierarchy and interface labels, and can reproduce the
+inventory:
+
+```sh
+scripts/index-dmg-schematics.py /home/newton/dev/dmg-schematics --check
+scripts/index-dmg-schematics.py /home/newton/dev/dmg-schematics > /tmp/dmg-schematic-index.json
+```
+
+Where this document cites SameBoy, the independent source is
+[SameBoy `213a12ce`](https://github.com/LIJI32/SameBoy/tree/213a12ce93d66b105a113debd9396306066a7cfc):
+`Core/memory.c` supplies the FF50 rule/readback and `Core/apu.c` supplies the CH3 output behavior.
+
+The evidence labels used below are:
+
+- **direct**: the Coffee class owns the same externally visible register, state, or data path;
+- **composed**: several Coffee classes divide one physical sheet, or one class spans sheets;
+- **projection**: behavior is calibrated to the circuit or hardware, but state/timing is represented
+  differently;
+- **absent**: the circuit behavior is deliberately not modeled;
+- **outside DMG**: the Coffee class represents CGB, SGB, cartridge, host, persistence, debug, or
+  service behavior that does not exist inside the DMG-CPU-B source.
+
+## Complete source inventory
+
+The checkout contains 65 KiCad sheets: 49 under `dmg_cpu_b`, 14 under `sm83`, and two
+standard-cell reference/catalog sheets. The DMG hierarchy reaches 47 of its 49 sheets. The empty
+`ff04_div.kicad_sch` is an unused placeholder; current DIV circuitry is in `clocks_and_reset`.
+The unreferenced `sprite_store.kicad_sch` is an unused older/draft sprite-store sheet that overlaps
+active part 1; the active hierarchy uses parts 1 and 2. All 14 SM83 sheets are reachable. The
+catalog sheets are
+`dmg_cells/dmg_cells.kicad_sch` and `sm83_cells/sm83_cells.kicad_sch`; they are library/reference
+circuits, not runtime hierarchy instances.
+
+All 82 raw `.nl` files are included by the single `netlist/Makefile`: 66 in `NETLIST_FILES` and 16
+in `SM83_NETLIST_FILES`. Their declarations describe 4,756 cells, 5,114 wires, 221 type
+declarations (77 DMG and 144 SM83; 214 unique spellings across the separate namespaces), 63 logical
+categories, and 72 aliases. Wave RAM, boot ROM, high RAM, and two OAM banks are opaque macro cells.
+The DMG top-level CPU is a macro boundary, but the same checkout separately expands the SM83 in its
+14 sheets and 16 raw files. Physical analog cells and connectivity are present under the
+`-codegen` condition; only generated digital RTL substitutes an `audio` black box. Consequently,
+generated SystemVerilog is not a transistor-complete or analog-behavioral chip model.
+
+The checkout also carries `dmg_cells/dmg-cpu.jelib`, `sm83_cells/sm83.jelib`, and
+`dmg_cpu_b/overlay/dmg-cpu-b_overlay.svg`. The supporting `doc/wave_diagrams.html` illustrates
+clock, APU, LCD, and BG/window waveforms. These layout/library, overlay, and explanatory artifacts
+are acknowledged but not separately class-mapped: this audit maps logical behavior, and their
+corresponding cells/nets are represented by the indexed schematic/netlist corpus.
+
+One source-interface anomaly was found during hierarchy validation: the child
+`dmg_cpu_b/oam.kicad_sch` declares `DMA_PHI`, but the OAM sheet instance in
+`dmg_cpu_b/ppu.kicad_sch` has no corresponding sheet pin. The other 58 parent/child unique
+pin-name sets match. This is an upstream schematic metadata issue, not a Coffee GB behavior claim.
+
+The raw files are physical regions rather than subsystem modules. This manifest accounts for every
+one; the index JSON supplies each individual filename and its category histogram.
+
+| Raw-netlist group | Files | Cells | Wires | Contents |
+| --- | ---: | ---: | ---: | --- |
+| DMG metadata/glue (`defines`, `types`, `categories`, `labels`, `bus`, `port`, `pwr`) | 7 | 6 | 161 | declarations, shared signals and ports |
+| DMG `io/{top,bottom,left,right}` | 4 | 78 | 49 | package pads and input/output cells |
+| DMG macro memory/CPU (`cpu-mem`, `ram-col-a`, `ram-row-w`) | 3 | 55 | 79 | opaque cores/arrays and their glue |
+| DMG analog (`analog-audio`, `analog-col-t`) | 2 | 54 | 26 | audio macro/physical analog and spare cells |
+| DMG `top-left-col/{r,s,t}` | 3 | 207 | 158 | VRAM, external buses, boot-ROM decode |
+| DMG `top-center-col/{l,m,n,p,r,s,t,u}` | 8 | 311 | 302 | timer, DMA, IF, clocks and address paths |
+| DMG `top-center-row/{a,b,c,d,e,y,z}` | 7 | 189 | 163 | clocks, serial, boot ROM and wave RAM |
+| DMG `bottom-left-col/{k,l,m,n,p,r,s,t,v,w,x}` | 11 | 929 | 918 | BG/window/STAT/palette/FIFO circuits |
+| DMG `bottom-center-col/{a,b,c,d,e,f,g,w,x,y,z}` | 11 | 973 | 769 | OAM, sprite storage/match/priority/control |
+| DMG `right-col/{a,b,c,d,e,f,g,h,j,k}` | 10 | 1,329 | 1,329 | APU, JOYP and test circuits |
+| SM83 declarations and `reg`/`alu`/`dec`/`seq`/`dbus` groups | 16 | 625 | 1,160 | complete CPU-core raw model |
+| **Total** | **82** | **4,756** | **5,114** | |
+
+## DMG top level and common I/O
+
+Across this table and the APU/PPU subsystem tables below, every reachable DMG sheet is represented.
+A class in the last column is the closest behavioral owner, not necessarily a one-to-one
+implementation.
+
+| Schematic sheet | Circuit responsibility | Coffee GB owner(s) | Mapping |
+| --- | --- | --- | --- |
+| `dmg_cpu_b/dmg_cpu_b.kicad_sch` | Chip hierarchy, pads, shared buses | `Gameboy`, `Mmu`, `AddressSpace` | composed/projection |
+| `dmg_cpu_b/cpu.kicad_sch` | SM83 wrapper, CPU bus and clocks | `Cpu`, `Registers`, `InterruptManager`, `Mmu` | composed/projection |
+| `dmg_cpu_b/clocks_and_reset.kicad_sch` | Master clocks, phase clocks, divider, reset tree | `Gameboy`, `Timer`, `FrameSequencer`, `SerialPort` | projection |
+| `dmg_cpu_b/ext_addr_buses.kicad_sch` | CPU/PPU/DMA address-bus arbitration | `Mmu`, `Cpu`, `Dma`, `Gpu` | projection |
+| `dmg_cpu_b/ext_data_buses.kicad_sch` | Shared data buses and direction gates | `Mmu`, `AddressSpace`, `DmaAddressSpace`, `DmaCpuAddressSpace`, `DmaOamAddressSpace` | projection |
+| `dmg_cpu_b/sys_decode.kicad_sch` | Address decode, boot ROM, high RAM, FF50 latch | `Mmu`, `Bios`, `BiosShadow`, `Ram` | direct/projection |
+| `dmg_cpu_b/ff00_joyp.kicad_sch` | JOYP selectors, input filter, wake and IF pulse | `Joypad`, `Cpu`, `InterruptManager` | projection |
+| `dmg_cpu_b/ff01-02_serial.kicad_sch` | SB/SC, internal clock, SCK/SIN/SOUT and serial IF | `SerialPort`, `SerialEndpoint`, `InterruptManager` | direct/projection |
+| `dmg_cpu_b/ff05-07_timer.kicad_sch` | TIMA/TMA/TAC, selected DIV wire, overflow/reload | `Timer`, `InterruptManager` | projection |
+| `dmg_cpu_b/ff0f_int.kicad_sch` | Five IF latches and source set/reset paths | `InterruptManager` plus all interrupt producers | projection |
+| `dmg_cpu_b/ff04_div.kicad_sch` | Empty unused DIV placeholder | `Timer` through `clocks_and_reset` | orphaned source |
+
+The two remaining KiCad files are reference catalogs rather than hierarchy instances:
+
+| Catalog sheet | Content | Coffee GB owner | Mapping |
+| --- | --- | --- | --- |
+| `dmg_cells/dmg_cells.kicad_sch` | DMG standard-cell reference circuits | none | source reference, no runtime class |
+| `sm83_cells/sm83_cells.kicad_sch` | SM83 standard-cell reference circuits | none | source reference, no runtime class |
+
+`SpeedMode`, `Hdma`, `GbcRam`, `UndocumentedGbcRegisters`, `InfraredPort`, and the CGB portions of
+`Gpu`, `Timer`, `SerialPort`, and `Sound` are outside this DMG source. SGB packet reception is also
+not on the DMG die: `Joypad` combines the DMG JOYP behavior with an external ICD2-facing model.
+
+The corresponding DMG-visible ownership is complete at the register boundary:
+
+| Address/range | Circuit sheet | Coffee GB owner |
+| --- | --- | --- |
+| 0000-00FF during boot | `sys_decode` opaque boot-ROM macro and `BOOT_SEL` | `Bios`, `BiosShadow` |
+| FF00 | `ff00_joyp` | `Joypad` |
+| FF01-FF02 | `ff01-02_serial` | `SerialPort` |
+| FF04-FF07 | clocks/reset plus `ff05-07_timer` | `Timer` |
+| FF0F, FFFF | `ff0f_int`, SM83 `intr` | `InterruptManager` |
+| FF10-FF26, FF30-FF3F | APU sheets | `Sound` and its channel classes |
+| FF40-FF45, FF47-FF4B | PPU decode/background/window/STAT/palettes | `Lcdc`, `Gpu`, `GpuRegisterValues`, `StatRegister` |
+| FF46 | `ff46_dma` | `Dma` |
+| FF50 | `sys_decode` | `BiosShadow` |
+| FF60 | `ff00_joyp` test-mode cone | intentionally absent |
+| 8000-9FFF | VRAM interface and external buses; storage is off-die | `Gpu`, `Ram`, DMA address-space wrappers |
+| C000-DFFF, E000-FDFF | External WRAM decode/buses and echo selection; storage is off-die | `Ram`, `ShadowAddressSpace`, `Mmu` |
+| FE00-FE9F | OAM sheets and external buses | `Gpu`, `Ram`, DMA address-space wrappers |
+| FF80-FFFE | `sys_decode` opaque high-RAM macro | `Ram` registered in `Mmu` |
+
+Unused/unmapped addresses, external cartridge RAM/ROM control, and CGB-only registers are outside
+that internal DMG register inventory. DMG work RAM at C000-DFFF and video RAM storage at
+8000-9FFF are off-die; the source contains their bus decode/interface rather than their storage.
+Coffee reuses the generic `Ram` class for these off-die arrays as well as the on-die HRAM/OAM/wave
+storage projections. `ShadowAddressSpace` is on-die echo decode over the off-die work RAM.
+
+## SM83 CPU core
+
+| Schematic sheet | Circuit responsibility | Coffee GB owner(s) | Mapping |
+| --- | --- | --- | --- |
+| `sm83/sm83.kicad_sch` | CPU-core hierarchy | `Cpu`, `Registers`, `Flags`, `InterruptManager`, opcode classes; `Mmu`/`AddressSpace` bus boundary | composed/projection |
+| `sm83/register_bank.kicad_sch` | GP/SP-PC/WZ/IDU/ALU hierarchy and buses | `Registers`, `Flags`, `AluFunctions`, `Cpu` operand/context state | composed/projection |
+| `sm83/reg_gp.kicad_sch` | A, B/C, D/E, H/L and IR storage; F-bus and DAA-comparator interface | `Registers`, `Cpu`, `Flags`, `AluFunctions` | direct/projection |
+| `sm83/reg_sp_pc.kicad_sch` | SP and PC storage | `Registers`, `Cpu`, `OpcodeBuilder` | direct/projection |
+| `sm83/reg_wz.kicad_sch` | Internal W/Z temporary registers | `Cpu`, `Argument`, `OpcodeBuilder` | projection |
+| `sm83/idu.kicad_sch` | 16-bit increment/decrement and signed-offset address unit | `AluFunctions` D16 operations, `OpcodeBuilder`, `Registers`, `Cpu` | projection |
+| `sm83/alu.kicad_sch` | ALU core, flags, DAA path | `AluFunctions`, `Flags`, `BitUtils` | direct/projection |
+| `sm83/alu_decoder.kicad_sch` | ALU control decode | `Opcodes`, `OpcodeBuilder`, `AluFunctions` | projection |
+| `sm83/decoder1.kicad_sch` | Opcode/control decoder bank 1 | `Opcodes`, `OpcodeBuilder`, `Opcode`, `Op`, `Cpu` phase metadata | projection |
+| `sm83/decoder2.kicad_sch` | Opcode/control decoder bank 2 | `Opcodes`, `OpcodeBuilder`, `Opcode`, `Op`, `Cpu` phase metadata | projection |
+| `sm83/decoder3.kicad_sch` | Opcode/control decoder bank 3 | `Opcodes`, `OpcodeBuilder`, `Opcode`, `Op`, `Cpu` phase metadata | projection |
+| `sm83/sequencer.kicad_sch` | T/M-cycle state, IME/EI/DI/RETI, HALT/STOP/NMI and interrupt-entry sequencing | `Cpu`, `Opcode`, `Op`, `InterruptManager`; `Gameboy`/`SpeedMode`/`Display` clock boundary | projection |
+| `sm83/intr.kicad_sch` | IE storage, transparent IE&IF aperture bank, priority/vector and one-hot acknowledge | `InterruptManager`, `Cpu` interrupt/wake boundary, `Mmu` FFFF boundary | projection |
+| `sm83/dbus_bridge.kicad_sch` | Internal/external CPU data-bus gates | `Cpu`, `Mmu`, `AddressSpace` | projection |
+
+Coffee's instruction model preserves architectural register and ALU results, but it does not
+instantiate the decoder product terms, transparent register buses, or persistent T1-T4 bus cycle.
+In particular, an operation currently reads memory one Coffee machine-cycle later than the
+corresponding SM83 transaction. Boot-DIV, PPU, interrupt, and DMA timings are calibrated around
+that known skew. Fixing it is a cross-subsystem migration, not a local decoder rewrite.
+
+## APU and analog audio
+
+| Schematic sheet | Circuit responsibility | Coffee GB owner(s) | Mapping |
+| --- | --- | --- | --- |
+| `dmg_cpu_b/apu.kicad_sch` | APU hierarchy | `Sound` | composed/projection |
+| `dmg_cpu_b/apu_control.kicad_sch` | NR52 power/status, APU clocks and frame taps | `Sound`, `FrameSequencer`, channel `start`/`stop` paths | projection |
+| `dmg_cpu_b/apu_decode.kicad_sch` | NR10-NR52 and wave-RAM bus decode | `Sound` address dispatch | direct/projection |
+| `dmg_cpu_b/ff24_ff25.kicad_sch` | NR50 volume/VIN and NR51 routing | `Sound` mixer/routing | partial |
+| `dmg_cpu_b/ch1_regs.kicad_sch` | CH1 frequency, duty, length, envelope registers | `SoundMode1`, `AbstractSoundMode`, `LengthCounter`, `VolumeEnvelope` | direct/projection |
+| `dmg_cpu_b/ch1_sweep.kicad_sch` | CH1 sweep timer/shift/adder | `FrequencySweep` | direct/projection |
+| `dmg_cpu_b/channel1.kicad_sch` | CH1 oscillator, duty, trigger and output | `SoundMode1`, `AbstractSoundMode` | direct/projection |
+| `dmg_cpu_b/ch2_regs.kicad_sch` | CH2 duty, length, envelope and frequency registers | `SoundMode2`, `AbstractSoundMode`, `LengthCounter`, `VolumeEnvelope` | direct/projection |
+| `dmg_cpu_b/channel2.kicad_sch` | CH2 oscillator, duty, trigger and output | `SoundMode2`, `AbstractSoundMode` | direct/projection |
+| `dmg_cpu_b/ch3_regs.kicad_sch` | NR30-NR34, CH3 trigger/status/level | `SoundMode3`, `LengthCounter` | direct/projection |
+| `dmg_cpu_b/ch3_wave_ram.kicad_sch` | Wave RAM port, byte buffer, nibble mux, CH3 output | `SoundMode3` | direct/projection |
+| `dmg_cpu_b/ch4_regs.kicad_sch` | NR41-NR44, envelope, trigger and divisor controls | `SoundMode4`, `LengthCounter`, `VolumeEnvelope`, `PolynomialCounter` | direct/projection |
+| `dmg_cpu_b/channel4.kicad_sch` | CH4 clock divider, LFSR and output | `SoundMode4`, `PolynomialCounter`, `Lfsr` | projection |
+| `dmg_cpu_b/analog.kicad_sch` | Four DACs, VIN, mixer, amplifiers and pins | `Sound`, `StereoPcmConverter`, `DcBlocker`, `SoundOutputObserver` | partial/absent |
+
+Coffee keeps the four digital channels and a linear stereo projection. It does not accept an
+external VIN signal, despite the physical NR50 VIN gates, and it does not model DAC voltage curves,
+the analog mixer/amplifier, power ramps, or output-pin loading. `StereoPcmConverter` and
+`DcBlocker` are host-output approximations rather than mapped cells.
+
+## PPU, OAM, VRAM, and LCD
+
+| Schematic sheet | Circuit responsibility | Coffee GB owner(s) | Mapping |
+| --- | --- | --- | --- |
+| `dmg_cpu_b/ppu.kicad_sch` | PPU hierarchy and shared control | `Gpu`, `Lcdc`, `StatRegister` | composed/projection |
+| `dmg_cpu_b/ppu_decode.kicad_sch` | PPU register and cycle decode | `Gpu`, `Lcdc`, `GpuRegisterValues` | projection |
+| `dmg_cpu_b/background.kicad_sch` | SCX/SCY latches and background controls | `GpuRegisterValues`, `Fetcher`, `PixelTransfer` | direct/projection |
+| `dmg_cpu_b/win_detect.kicad_sch` | WY/WX compare, window start/source latch | `GpuRegisterValues`, `PixelTransfer`, `Fetcher` | projection |
+| `dmg_cpu_b/bg_win_cycles.kicad_sch` | Tile-map/data fetch sequencing | `Fetcher`, `PixelTransfer` | projection |
+| `dmg_cpu_b/bg_px_shifter.kicad_sch` | Background pixel load and shift bank | `DmgPixelFifo`, `Fetcher`, `PixelTransfer` | projection |
+| `dmg_cpu_b/palettes.kicad_sch` | FF47-FF49 palette latches | `GpuRegisterValues`, `DmgPixelFifo` | direct/projection |
+| `dmg_cpu_b/pixel_mux.kicad_sch` | BG/OBJ priority, LCDC masks, final DMG pixels | `DmgPixelFifo`, `SpriteFifo`, `Lcdc`, `Display` | projection |
+| `dmg_cpu_b/ff41_stat.kicad_sch` | STAT enables/sources, LY, LYC and coincidence | `StatRegister`, `Gpu` | projection |
+| `dmg_cpu_b/lcd.kicad_sch` | LCD clocks, line/frame output and mode-related latches | `Gpu`, `Display`, `GpuTimingSnapshot` | projection |
+| `dmg_cpu_b/oam.kicad_sch` | OAM bus, precharge, scan and memory control | `Gpu`, `OamSearch`, `Dma`, `SpriteBug`, `Ram` | projection |
+| `dmg_cpu_b/oam_mem.kicad_sch` | Two physical OAM SRAM macros | `Ram`, `Gpu`, `DmaOamAddressSpace` | opaque/projection |
+| `dmg_cpu_b/sprite_y_comparator.kicad_sch` | Ten-row OAM search/Y matching | `OamSearch` | direct/projection |
+| `dmg_cpu_b/sprite_store_part1.kicad_sch` | First half of ten selected sprite registers | `OamSearch`, `PixelTransfer` sprite records | projection |
+| `dmg_cpu_b/sprite_store_part2.kicad_sch` | Second half of selected sprite registers | `OamSearch`, `PixelTransfer` sprite records | projection |
+| `dmg_cpu_b/sprite_store.kicad_sch` | Unused older/draft sprite-store sheet overlapping active part 1 | `OamSearch`, `PixelTransfer` only through the active part 1/2 sheets | orphaned source |
+| `dmg_cpu_b/sprite_x_match.kicad_sch` | OBJ-enable/X-match aggregation | `PixelTransfer` object-start logic | projection |
+| `dmg_cpu_b/sprite_x_matchers_part1.kicad_sch` | First five sprite X comparators | `PixelTransfer` | projection |
+| `dmg_cpu_b/sprite_x_matchers_part2.kicad_sch` | Last five sprite X comparators | `PixelTransfer` | projection |
+| `dmg_cpu_b/sprite_x_prio.kicad_sch` | DMG sprite X/OAM priority selection | `OamSearch`, `SpriteFifo` | direct/projection |
+| `dmg_cpu_b/sprite_control.kicad_sch` | Object fetch/control state | `OamSearch`, `PixelTransfer`, `Fetcher` | projection |
+| `dmg_cpu_b/sp_px_shifter.kicad_sch` | Object bitplane load/shift bank | `SpriteFifo`, `PixelTransfer` | projection |
+| `dmg_cpu_b/vram_interface.kicad_sch` | VRAM address/data arbitration and read strobes | `Gpu`, `Fetcher`, `Mmu` | projection |
+| `dmg_cpu_b/ff46_dma.kicad_sch` | OAM DMA register, counter, source and grants | `Dma`, `DmaAddressSpace`, `DmaCpuAddressSpace`, `DmaOamAddressSpace` | projection |
+
+`ColorPalette`, `ColorPixelFifo`, `TileAttributes`, `Hdma`, CGB VRAM banking, and CGB priority
+rules are outside the DMG-CPU-B source. `SpriteBug` is a behavioral model fitted to physical DMG
+captures; the checked-in raw netlist exposes symmetric generic SRAM macros and cannot validate the
+directional bitline corruption algorithm.
+
+The largest topological difference is deliberate: the die has one forward address/latch/shifter/LCD
+path. Coffee runs one unshifted `PixelTransfer` for timing and a second renderer four dots behind,
+then uses reread, refresh, rewind, and catch-up operations to reproduce hardware images. Existing
+ROM results validate that projection, but it is not the physical pipeline and cannot be simplified
+one local special case at a time.
+
+## Raw netlist categories
+
+The 63 declared logical categories classify 4,674 of the 4,756 raw cells. The remaining 82 are
+spares, trivial/virtual supply and port cells, uncategorized pads/glue, or the top-level opaque CPU
+and generated-audio wrappers. This table maps every declared category to the sheet/class groups
+above; physical region files intentionally contain several categories.
+
+| Raw category set | KiCad sheet group | Coffee GB owner(s) |
+| --- | --- | --- |
+| `sys-decode`, `bootrom`, `hram` | `sys_decode` | `Mmu`, `Bios`, `BiosShadow`, `Ram` |
+| `bus-adr` | `ext_addr_buses` | `Mmu`, `Cpu`, `Gpu`, `Dma` |
+| `bus-data` | `ext_data_buses`, CPU/DMA glue | `Mmu`, `AddressSpace`, CPU/GPU/DMA owners |
+| `clocks` | `clocks_and_reset` | `Gameboy`, `Timer`, `FrameSequencer`, `SerialPort` |
+| `joypad` | `ff00_joyp` | `Joypad` |
+| `test` | distributed FF60/test/reset/bus cone across the root, `ff00_joyp`, `sys_decode`, `clocks_and_reset`, and bus/VRAM sheets | no production owner; package-test pads, shadow overrides, and FF60 test mode are absent |
+| `serial` | `ff01-02_serial` | `SerialPort` |
+| `timer` | `ff05-07_timer` | `Timer` |
+| `int` | `ff0f_int` | `InterruptManager` |
+| `apu-decode`, `apu-control` | APU decode/control and `ff24_ff25` | `Sound`, `FrameSequencer` |
+| `apu-ch1`, `apu-ch2`, `apu-ch3`, `apu-ch4` | corresponding channel/register sheets | `SoundMode1`-`SoundMode4` and helper classes |
+| `apu-analog` | `analog` | `Sound` host projection; physical analog/VIN absent |
+| `ppu-control`, `ppu-decode` | `ppu`, `ppu_decode` | `Gpu`, `Lcdc`, `GpuRegisterValues` |
+| `ppu-bgscroll`, `ppu-window` | `background`, `win_detect` | `GpuRegisterValues`, `PixelTransfer`, `Fetcher` |
+| `ppu-stat`, `ppu-lcd` | `ff41_stat`, `lcd` | `StatRegister`, `Gpu`, `Display` |
+| `ppu-bgfifo`, `ppu-cycles` | BG shifter and fetch-cycle sheets | `Fetcher`, `DmgPixelFifo`, `PixelTransfer` |
+| `ppu-oam`, `ppu-ycomp` | `oam`, `oam_mem`, Y comparator | `OamSearch`, `Gpu`, `Dma`, `DmaOamAddressSpace`, `Ram`, `SpriteBug` |
+| `ppu-pal`, `ppu-mux` | `palettes`, `pixel_mux` | `GpuRegisterValues`, `DmgPixelFifo`, `SpriteFifo`, `Display` |
+| `ppu-objctl`, `ppu-xprio`, `ppu-xcomp`, `ppu-objfifo`, `ppu-objreg` | sprite control/matcher/store/shifter sheets | `OamSearch`, `PixelTransfer`, `SpriteFifo` |
+| `ppu-vram`, `ppu-dma` | `vram_interface`, `ff46_dma` | `Gpu`, `Fetcher`, `Dma` |
+| `reg`, `reg-bus`, `reg-ir`, `reg-a`, `reg-hl`, `reg-de`, `reg-bc`, `reg-wz`, `reg-sp`, `reg-pc` | SM83 register sheets | `Registers`, `Cpu` |
+| `idu` | `idu` | `AluFunctions` D16 operations, `OpcodeBuilder`, `Registers`, `Cpu` |
+| `irq`, `irq-ie` | `intr` | `Cpu`, `InterruptManager` |
+| `alu`, `alu-flag`, `alu-dec`, `alu-core`, `alu-daa` | `alu`, `alu_decoder` | `AluFunctions`, `Flags`, opcode construction |
+| `dec1`, `dec2`, `dec3` | decoder sheets | `Opcodes`, `OpcodeBuilder`, `Opcode`, `Op` |
+| `seq`, `seq-irq` | `sequencer` | `Cpu`, interrupt microprogram |
+| `dbus`, `dbus-rd`, `dbus-mreq` | `dbus_bridge` | `Cpu`, `Mmu`, `AddressSpace` |
+
+## Reverse map: Coffee GB core production classes
+
+The following rows cover every class under `core/src/main/java` by either naming its exact circuit
+sheets or placing its entire package in an explicit no-die category. Small data records/enums
+inherit the mapping of their owning row. The Swing, CLI, controller, portable-UI, and Android
+modules are host front ends/services and therefore do not own DMG-die circuits. This grouping was
+mechanically checked against all 293 core production Java files across 32 packages.
+
+| Coffee GB class or class family | Schematic source | Boundary |
+| --- | --- | --- |
+| `Gameboy`, `AddressSpace` | DMG root, clocks, buses, CPU/PPU/APU roots | orchestration/projection |
+| `Cpu`, `Registers`, `Flags`, `AluFunctions`, `BitUtils`, `Opcodes`, `Argument`, `DataType`, `Op`, `Opcode`, `OpcodeBuilder` | all SM83 sheets plus DMG `cpu` wrapper | CPU architecture/projection |
+| `DebugCpuAddressSpace`, `DebugPpuAddressSpace` | CPU/PPU bus observation boundaries | debugger adapters, not die logic |
+| `InterruptManager` | `ff0f_int`, SM83 `intr`/`sequencer` | IF/IE/IME/entry projection |
+| `Timer` | `ff05-07_timer`, `clocks_and_reset` | timer projection |
+| `Joypad`, `Button`, `JoypadButtonMask` | `ff00_joyp` | DMG electrical path plus host/SGB extensions |
+| remaining `joypad` input-source, snapshot, timeline, and event classes | none beyond the `Joypad` port boundary | host input/replay services |
+| `SerialPort`, `NaiveSerialPort`, `ClockType` | `ff01-02_serial`, clocks | on-die SB/SC state and clock projection |
+| `SerialEndpoint` | serial pins at the `ff01-02_serial` boundary | external-device/pin contract; implementations are outside the die |
+| `Sound`, `FrameSequencer`, `AbstractSoundMode`, `SoundMode1`-`SoundMode4`, `LengthCounter`, `VolumeEnvelope`, `FrequencySweep`, `PolynomialCounter`, `Lfsr` | all APU sheets | digital APU projection |
+| `StereoPcmConverter`, `DcBlocker`, `SoundOutputObserver` | `analog` only at functional boundary | host approximation, not analog transcription |
+| `Gpu`, `Lcdc`, `StatRegister`, `GpuRegister`, `GpuRegisterValues`, `Mode`, `GpuTimingSnapshot` | PPU root/decode/STAT/LCD/register sheets | control projection |
+| `Fetcher`, `PixelTransfer`, `DmgPixelFifo`, `SpriteFifo`, `PixelFifo`, `IntQueue`, `OamSearch` | PPU fetch/shifter/sprite sheets | data-path projection |
+| `GpuPhase` | PPU sequencing sheets | Java phase vocabulary for the projection |
+| `HBlankPhase`, `VBlankPhase` | none as active runtime owners | retained public/state-registry compatibility types; no current production references |
+| `Display` | PPU `lcd`/`pixel_mux` output boundary | host LCD sink |
+| `SpriteBug` | OAM sheets plus hardware-fitted external captures | behavioral compatibility model |
+| `VRamTransfer` | none | SGB ICD2-facing rendered-pixel/tile capture service, despite its historical name |
+| `Bios`, `BiosShadow`, `Mmu`, `ShadowAddressSpace` | `sys_decode` and external buses | decode/direct projection; echo decode fronts off-die WRAM |
+| `Ram` | opaque on-die HRAM/OAM/wave macros where used; no DMG die storage for Coffee's WRAM/VRAM instances | generic storage reused across on-die projections and off-die arrays |
+| `Dma`, `DmaAddressSpace`, `DmaCpuAddressSpace`, `DmaOamAddressSpace` | `ff46_dma`, OAM, external buses | projection |
+| `OamEchoRam` | only the post-OAM decode boundary is DMG-relevant | model-dependent FEA0-FEFF projection; writable RAM/alias behavior is CGB-only |
+| `SpeedMode`, `Hdma`, `GbcRam`, `UndocumentedGbcRegisters`, `ColorPalette`, `ColorPixelFifo`, `TileAttributes` | none | outside DMG: CGB hardware |
+| `InfraredPort`, `InfraredEndpoint`, `FullChanger`, `Peer2PeerInfraredEndpoint` | none | outside DMG: CGB/host device |
+| `SuperGameboy`, `SgbDisplay`, `Background`, `Commands`, `DefinedPalettes` | none | outside DMG: SGB/SNES-side hardware |
+| remaining serial peripherals/helpers and `serial.mobile` | only `SerialEndpoint` meets the on-die port | external accessories/services |
+| every class under `memory.cart` (mappers, RTC, battery, camera, ROM/source, and archive helpers) | only cartridge-bus pads at DMG root | outside die/cartridge/host persistence |
+| `hardware` profiles and `GameboyType` | none | model configuration and non-DMG variants |
+| `debug`, `events`, `genie`, `rumble`, `persistence`, `memento`, and `state` packages | none | debugger, services, cheats, host I/O, persistence |
+| `Dumper`, `InputStreams` | none | host utilities |
+
+## Circuit/model differences found by this audit
+
+These are separated from ordinary abstraction differences. “Circuit mismatch” means the checked
+DMG-B source has a concrete different dependency or transition. It does not by itself outrank
+physical measurements, hardware-verified ROMs, or a known game regression.
+
+| Area | Circuit | Coffee GB | Classification and action |
+| --- | --- | --- | --- |
+| FF50 boot disable/readback | Sticky `TEPU` samples `D0 OR TEPU` only on an FF50 write; D0 reads as `TEPU` | Any FF50 write disabled the boot ROM and FF50 always read `FF` | direct DMG-B mismatch; corrected to sticky D0 and `FE`/`FF` readback, with the CGB rule independently corroborated by SameBoy |
+| Raw IF reset | `~RESET2` clears all five FF0F latches, so the pulled-up register reads `E0` | `InterruptManager` construction carries the SKIP/post-boot `E1` preset | raw-reset/post-boot conflation; authentic boot now drives the existing FF0F boundary to `E0` before its first tick |
+| Raw APU power | Reset clears NR52 master `HADA`; its complement holds NR50/NR51 reset, giving `00/00/70` | `Sound` construction carries the SKIP/post-boot `77/00/F0` preset | raw-reset/post-boot conflation; authentic boot now drives NR52 off before its first tick |
+| JOYP IF | Four 1 MHz stages sample the **aggregate** selected P10-P13 low level; IF rises when the current and three-edge-old samples are both high | Four histories advanced every 4.19 MHz tick and each filtered line had its own edge | direct topology/phase mismatch; corrected with an executable cone and exhaustive state test |
+| JOYP wake | A separate earlier latch observes the aggregate low level | STOP polls readable FF00 directly | similar intent, different phase; do not merge with the IF correction |
+| DMG STOP release | Sequencer latch `ZUMN` is reset only by reset or `ZWLM`/WAKE from the JOYP `AWOB` latch; ordinary IF has no path | IME plus enabled Timer/Serial IF could dispatch directly from `STOPPED` and re-enable LCD | direct DMG wake-source mismatch; corrected while retaining the separately calibrated CGB policy |
+| CH3 inactive output | Every CH3 output bit is AND-gated by `CH3_ACTIVE` | A disabled channel could return retained `lastOutput` while DAC remained on | direct circuit and SameBoy mismatch; corrected, with a bounded game-level risk check |
+| CH3 trigger sample | Restart resets nibble select, exposing stale buffer high nibble at current NR32 level | Trigger reset position but left prior `lastOutput` until the first frequency event | direct circuit and SameBoy mismatch; corrected at both 2 MHz phases |
+| VIN/analog | Fifth VIN input and voltage-domain DAC/mixer/amplifier exist | Four-channel linear PCM only | deliberate absent feature |
+| Clock/reset power-up | Oscillator, clock buffers, reset latches and ripple stages establish electrical phase | Constructors and profile-specific DIV/PPU presets establish a calibrated phase | deliberate projection; absolute reset propagation is not modeled |
+| Shared buses | Tri-state/open-drain drivers, precharge, keepers and multiple simultaneous masters | `Mmu` indexes the first accepting `AddressSpace`; collision wrappers add selected exceptions | architectural projection; a persistent resolved-bus fabric remains future work |
+| NMI/test hardware | An NMI pad and FF60/test/ECO cone exist in the raw source | No production owner | deliberately absent undocumented/test behavior |
+| SM83 register reset | Reset seeds physical PC latches to `FFFF`; the first fetch/IDU path presents `0000`, while most GP/SP/WZ/IR/flag cells have no reset fanout | Constructors expose zeroed architectural registers and PC=`0000` directly | externally equivalent boot entry but structurally different; compare the first address/fetch phase, not an instantaneous register scalar |
+| CPU bus timing | Persistent T1-T4 bus/control cycles | Atomic operation callbacks, with known one-M-cycle-late reads | architectural projection debt |
+| CB-prefix restore | Physical IR storage and `TABLE_CB` sequencing distinguish a fetched prefix from a decoded second byte | Restore decoded stale `opcode2` even when the saved phase was still waiting for that byte | released-state projection bug; corrected by retaining the pending decoder phase without changing the state record |
+| Timer/IF | Ripple counter, sampled overflow/reload stages, local set/reset IF latch | Semantic countdowns plus scheduler-aligned request suppression | calibrated projection; prior local rewrite was falsified by missing shared phase |
+| Interrupt selection | Transparent pending bank closes before T4; held owner drives ACK and vector | Callback/state projections and peripheral forecasts | calibrated scheduler debt; must migrate as one sub-cycle island |
+| HALT bug | HALT decode suppresses its own IDU increment; delayed HALT feeds the sleep latch | Architectural outcome is modeled through semantic CPU state | outcome-compatible, internal control differs |
+| DMG pixel pipeline | One forward source/fetch/latch/shifter/LCD path | Two `PixelTransfer` timelines plus refresh/rewind/catch-up | calibrated but topologically different |
+| LCDC.5 window disable | Source resets asynchronously; at most committed flight retires | Delayed renderer launches an additional post-reset window map transaction | concrete internal mismatch hidden by output-equivalent repair |
+| LCDC.1 object disable | Future match/output mask changes immediately; committed byte/shifter flight retires | Three-dot catch-up repays duplicated-timeline phase debt | local mechanism differs; deletion alone fails a hardware image |
+| OAM corruption | Physical direction/bitline behavior is below the desired abstraction | `SpriteBug` implements hardware-fitted formulas; raw model uses symmetric SRAM macros | raw source cannot validate this behavior |
+| CH1 restart/sweep | Active status is downstream of the restart/adder request cone | retained production now ignores compatibility `wasActive` timing input | corrected, DMG-grounded; CGB differential only |
+| CH4 trigger timing | Raw write/clock/retained phase selects restart alignment | Semantic countdown/alignment cases | unresolved projection; faithful and lean replacements failed 8/13 CH4 SameSuite ROMs |
+
+## Bounded corrections retained by this audit
+
+Six production slices were small enough to correct without importing a gate simulator or changing
+a released state record.
+
+### FF50 boot-ROM disable
+
+In the flattened source, `SATO` combines CPU `D0` with the retained `TEPU.Q`; the result drives
+`TEPU.D`, while `TUGE` supplies the FF50-write clock. The DMG equation is therefore
+`TEPU.next = TEPU.Q OR D0`, not “disable on any write.” `SYPU` exposes the retained latch on D0,
+so FF50 reads as `FE` while the boot ROM is mapped and `FF` after it is disabled. `BiosShadow` now
+implements both behaviors. CGB is outside this schematic corpus, but pinned SameBoy independently
+uses the same sticky-D0 rule and `FE`/`FF` readback for every model. SKIP boot writes one explicitly.
+
+The state record remains exactly one `isEnabled` bit.
+
+### Raw reset versus post-boot presets
+
+`~RESET2` clears the five SoC IF latches `LOPE`, `LALU`, `NYBO`, `UBUL`, and `ULAK`; their pulled-up
+FF0F read therefore starts at `E0`, not the VBlank-posted `E1` used after boot. The same reset tree
+clears the NR52 master latch `HADA`. `HADA.~Q` propagates through `JYRO`/`KEPY` and holds NR50/NR51
+reset, yielding `FF24=00`, `FF25=00`, and `FF26=70` before the boot ROM powers the APU.
+
+Coffee's component constructors intentionally remain convenient post-boot defaults for direct
+fixtures and SKIP bootstrap. `Gameboy` now separates the full-machine boundary: NORMAL and
+FAST_FORWARD drive FF0F=`00` and NR52=`00` before the first CPU tick, while SKIP retains
+`E1/77/00/F0`. The DMG values come directly from the reset cones. Pinned SameBoy's zeroed machine
+reset and APU initialization independently corroborate the same pre-boot boundary for CGB. No
+component field, constructor, public API, or state record changed.
+
+### CB-prefix decoder phase on restore
+
+The SM83 register bank retains an eight-bit instruction register, while the sequencer's
+`TABLE_CB` phase distinguishes a fetched `CB` prefix from a decoded extended opcode. Coffee already
+retains the equivalent `EXT_OPCODE` phase, but restore previously rebuilt `currentOpcode` from the
+still-stale `opcode2` field. A checkpoint taken immediately after the prefix therefore installed
+`CB 00`; when execution resumed, the real second byte was read but could not replace that non-null
+placeholder. Restore now leaves the decoder empty only for `opcode1=CB` in `EXT_OPCODE`, allowing
+the following byte to select the instruction exactly as uninterrupted execution does. STOP's
+separate two-byte path is unchanged. A regression captures at the prefix boundary and proves that
+`CB 11` executes `RL C`, not `RLC B`; the public API and `CpuState`/`CpuMemento` shapes are unchanged.
+
+### JOYP interrupt qualifier
+
+The physical pad-low inputs first lose their identity in the `KERY` OR gate. `BATU`, `ACEF`,
+`AGEM`, and `APUG` then sample that one signal on BOGA/`CLK_1MHz`; `ASOK = BATU AND APUG` clocks
+the joypad IF latch. This has three consequences that the former implementation missed:
+
+- histories advance once per four master ticks, not once per master tick;
+- pressing a second selected key while one remains held cannot retrigger the aggregate line; and
+- the two middle receiver samples need not be low, because ASOK compares only the current and
+  three-edge-old samples.
+
+`Joypad` retains the existing four packed per-line history field and ORs its nibbles to reconstruct
+the single physical aggregate receiver. A test-only gate cone models the four simultaneous DFF
+captures and the separate transparent `AWOB` wake latch. Tests exhaust all 256 eight-edge aggregate
+sequences and all 65,536 packed histories by 16 input vectors. The focused Joypad/SGB suites pass
+62/62, the core unit suite passes 1,584 tests with eight skipped, and the GBC-HW profile passes
+221/221. The shared CGB behavior is therefore a tested fit, not a topology claim; the DMG sheets do
+not establish the CGB receiver. SGB/SGB2 also share this receiver model around their external ICD2
+protocol, without a separate sourced receiver trace.
+
+The released state-record shape is unchanged, but the packed history's temporal unit changed from
+one master tick to one 1 MHz receiver edge. Current snapshots and restores are exact because the
+record also retains the master-grid `tick` phase. A partially settled snapshot written by an older
+Coffee GB build has no four-edge DMG history from which to reconstruct the new receiver exactly;
+it loads structurally and treats the stored nibbles as the best available receiver state.
+
+STOP wake remains a bounded difference. Hardware drives CPU wake through the earlier transparent
+`AWOB` latch, while Coffee samples the readable FF00 level directly. That phase should move only
+with an explicit common clock fabric, not be folded into the IF correction.
+
+### DMG STOP wake ownership
+
+The SM83 sequencer retains STOP in `ZUMN`. Its only functional clear is `ZWLM`, whose non-reset
+input is the CPU WAKE port; in the DMG wrapper that port is driven solely by JOYP's transparent
+`AWOB` latch. Timer, Serial, and the other maskable IF sources have no path to that clear. Coffee
+previously considered `STOPPED` an interrupt-acceptance state, so IME plus an enabled IF bit could
+start dispatch and re-enable the LCD without a P10-P13 line going low. DMG interrupt acceptance is
+now blocked until the existing JOYP-low path first releases STOP. Focused tests hold enabled Timer
+and Serial requests across several machine cycles, then separately prove that a real low JOYP line
+wakes and restores the LCD. The CGB interrupt-wake path is intentionally unchanged: CGB is outside
+this schematic corpus and retains its existing ROM-calibrated policy. SGB/SGB2 use the DMG-family
+gate because their handheld CPU is non-CGB; no separate SGB STOP receiver trace was available.
+
+### CH3 output ownership and restart projection
+
+In `ch3_wave_ram`, `BARY`, `BYKA`, `BOPA`, and `BELY` AND every digital CH3 output bit with
+`CH3_ACTIVE`. `CH3_RESTART` also resets `EFAR`, the wave-nibble selector, so the stale sample
+buffer's high nibble reaches the output immediately through the current NR32 shift. A pinned
+SameBoy source cross-check independently implements both transitions. `SoundMode3` now returns
+zero when the active latch clears and reprojects the stale high nibble/current volume at trigger.
+
+The focused CH3 tests pass 8/8; Blargg individual passes 46/46 (including both 12-case DMG/CGB
+sound groups), and SameSuite passes 77/77. The historical retained-output workaround was exercised
+with an authorized local 3D Pocket Pool run rather than dismissed: during a scripted 1,800-frame
+run it encountered 195,446 master ticks with NR30 on and CH3 inactive. After Coffee's real
+48 kHz/DC-block output path the aggregate absolute-sample change was 0.1233% and squared-energy
+change 0.0374%.
+That bounds this replay, but it is not a listening test or proof that every route through the game
+is unaffected.
+
+## Final verification
+
+The combined tree was verified after all six corrections, rather than by adding isolated-worktree
+results. The unit and integration reports contain no failures or errors:
+
+| Suite | Result |
+| --- | ---: |
+| Core unit tests | 1,584 run, 8 skipped |
+| Controller unit tests | 904 run, 2 skipped |
+| Mooneye + dmg-acid2 + cgb-acid2 | 132/132 |
+| Blargg aggregate + individual | 54/54 |
+| SameSuite + Mealybug strict images | 103/103 |
+| Gambatte hardware + GBMicrotest | 5,156/5,156 |
+| GBC hardware + misc-gb + Daid | 247/247 |
+| RTC3 + MBC30 + cgb-acid-hell + Strikethrough + CasualPokePlayer + BullyGB | 15/15 |
+
+The integration rows total 5,707/5,707. They establish regression safety for the bounded Coffee GB
+changes; they do not upgrade the schematic source into CGB, SGB, analog-timing, or physical-silicon
+evidence. Relative to the pre-audit baseline, `javap -public -s` is identical for all five changed
+production classes, and `javap -p -s` is identical for their ten `State`/`Memento` records. The
+behavioral corrections therefore do not change the public Java descriptors or released record
+component order.
+
+## Architectural conclusion
+
+The mapping supports a hybrid architecture, not a whole-chip simulator. CPU bus intent, clock
+selection, IF latches, DMA ownership, and the PPU control/front-end are the places where physical
+storage and edge ownership would delete the most semantic forecasting. ALU math, pixel values,
+waveforms, RAM contents, and host output remain better as behavioral data planes.
+
+The source is strongest for topology and relative ordering and weaker for absolute delay. Memories
+remain opaque macros. Analog connectivity is present, but it is not a digital behavioral oracle and
+the generated RTL replaces it with a black box. CGB, SGB, cartridge logic, and peripherals require
+separate evidence. Production changes should therefore satisfy all of these gates:
+
+1. a bounded circuit cone names the actual inputs, storage and outputs;
+2. an executable test distinguishes it from the old semantic dependency;
+3. hardware-verified ROMs or an independent emulator do not contradict it;
+4. public API and released state shapes remain compatible, or a migration is explicit; and
+5. the change deletes more live timing/provenance/repair complexity than it adds.
+
+The deeper signal-fabric proposal, previously executed external traces, rejected cuts, and full
+regression baseline remain in `signal-driven-core.md`, `signal-driven-core-experiments.md`, and
+`signal-oracle-repro.md`.

--- a/doc/emulation-performance-next-pass.md
+++ b/doc/emulation-performance-next-pass.md
@@ -767,6 +767,11 @@ Acceptance:
 
 ### PR 10: add a settled-input joypad path
 
+> Historical note: the later DMG schematic audit retained this settled-input optimization but
+> corrected the receiver to one aggregate BATU/ACEF/AGEM/APUG pipeline clocked at 1 MHz. The
+> four-sample timing statements below describe this PR's pre-audit baseline, not current master-tick
+> latency; see `dmg-schematic-class-map.md`.
+
 Branch: `codex/perf-joypad-settled-input`
 
 Risk: medium. Primary purpose: real throughput; expected exact-count reduction in headless runs is

--- a/doc/signal-driven-core-experiments.md
+++ b/doc/signal-driven-core-experiments.md
@@ -1356,12 +1356,15 @@ electrical collision and copy sequencers stay in production until each named pro
 
 ## Existing positive controls
 
-The architectural diagnosis is selective. The DMG-facing part of `Joypad` already has the desired
-shape: four packed sample stages per P10-P13 line, one retained filtered level, and a falling-edge
-request. Its remaining size is mostly host-input ownership, deterministic replay, debugger hooks,
-fast paths, and the separate SGB ICD2 packet protocol. `InfraredPort` is similarly a small stored RP
-output feeding a combinational input mux; its external Full Changer protocol is behavioral device
-logic. Neither needs to be rewritten into a general gate graph.
+The architectural diagnosis is selective. The DMG-facing part of `Joypad` now has a bounded
+circuit-shaped interrupt boundary: the released record's four packed per-line history nibbles
+remain as a structural compatibility projection, but their OR reconstructs the single physical KERY aggregate sampled by the
+BATU/ACEF/AGEM/APUG 1 MHz receiver, and IF is requested only on the ASOK rising edge. Its remaining
+size is mostly host-input ownership, deterministic replay, debugger hooks, fast paths, and the
+separate SGB ICD2 packet protocol. The independent AWOB STOP-wake phase remains a future shared-clock
+task. `InfraredPort` is similarly a small stored RP output feeding a combinational input mux; its
+external Full Changer protocol is behavioral device logic. Neither needs to be rewritten into a
+general gate graph.
 
 These are useful controls for the proposal. A large source file is not itself evidence of a bad
 hardware abstraction, and behavioral algorithms are not targets merely because they live in

--- a/doc/signal-driven-core.md
+++ b/doc/signal-driven-core.md
@@ -477,14 +477,23 @@ The sibling `/home/newton/dev/dmg-schematics` checkout contains parsable cells/w
 SystemVerilog through `nlconv`. It is unusually useful, but it should not become a naively
 interpreted production core.
 
-Approximate netlist sizes are:
+The complete pinned sheet/category inventory and bidirectional Coffee GB class cross-reference are
+maintained in [`dmg-schematic-class-map.md`](dmg-schematic-class-map.md). Its repository-local
+indexer also makes the source count and hierarchy checks reproducible without copying the
+CC BY-SA connectivity graph into this MIT tree.
 
-| Scope | Cells | Naive full scan at 4.194 MHz |
+The repository-local indexer reports these reviewed source-declaration sizes (the subsystem rows
+are declared logical-category sums, while the whole-chip row also includes uncategorized pads,
+wrappers, and spare/virtual cells). Conditional `codegen` and `-codegen` declarations are mutually
+exclusive, so the rate column is a deliberately conservative declaration-count upper bound rather
+than the number of simultaneously active cells:
+
+| Scope | Source cell declarations | Upper-bound scan at 4.194 MHz |
 | --- | ---: | ---: |
-| Whole chip | 4,736 | 19.9 billion cell evaluations/s |
+| Whole chip | 4,756 | 19.95 billion cell evaluations/s |
 | Clock + timer + interrupt | 228 | 0.96 billion/s |
-| PPU | 2,116 | 8.88 billion/s |
-| APU | 1,237 | 5.19 billion/s |
+| PPU | 2,118 | 8.88 billion/s |
+| APU | 1,257 | 5.27 billion/s |
 
 A raw evaluator also needs four-state/tri-state resolution, transparent latches, asynchronous
 resets, combinational feedback settling, held/bidirectional buses, and custom RAM behavior. Analog

--- a/scripts/index-dmg-schematics.py
+++ b/scripts/index-dmg-schematics.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build a compact, factual index of the sibling dmg-schematics checkout.
+
+The source checkout is CC BY-SA 4.0.  This independently authored reader emits
+only structural metadata (sheet relationships, interface label names, symbol
+counts, and netlist category counts); it does not copy schematic geometry or
+cell-level wire connectivity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Iterator
+
+
+STRING = r'"(?:\\.|[^"\\])*"'
+
+REFERENCE_COUNTS = {
+    "schematic_count": 65,
+    "hierarchy_interface_count": 59,
+    "hierarchy_interface_mismatch_count": 1,
+    "netlist_file_count": 82,
+    "cell_count": 4_756,
+    "wire_count": 5_114,
+    "type_count": 221,
+    "unique_type_name_count": 214,
+    "declared_category_count": 63,
+    "alias_count": 72,
+    "classified_cell_count": 4_674,
+    "unclassified_cell_count": 82,
+}
+
+REFERENCE_COMMIT = "02399f96e0893783c130cf6f03fad7a1148ae60a"
+
+REFERENCE_CATEGORIES = (
+    "alu", "alu-core", "alu-daa", "alu-dec", "alu-flag", "apu-analog",
+    "apu-ch1", "apu-ch2", "apu-ch3", "apu-ch4", "apu-control", "apu-decode",
+    "bootrom", "bus-adr", "bus-data", "clocks", "dbus", "dbus-mreq", "dbus-rd",
+    "dec1", "dec2", "dec3", "hram", "idu", "int", "irq", "irq-ie", "joypad",
+    "ppu-bgfifo", "ppu-bgscroll", "ppu-control", "ppu-cycles", "ppu-decode",
+    "ppu-dma", "ppu-lcd", "ppu-mux", "ppu-oam", "ppu-objctl", "ppu-objfifo",
+    "ppu-objreg", "ppu-pal", "ppu-stat", "ppu-vram", "ppu-window", "ppu-xcomp",
+    "ppu-xprio", "ppu-ycomp", "reg", "reg-a", "reg-bc", "reg-bus", "reg-de",
+    "reg-hl", "reg-ir", "reg-pc", "reg-sp", "reg-wz", "seq", "seq-irq",
+    "serial", "sys-decode", "test", "timer",
+)
+
+REFERENCE_ORPHANS = {
+    "dmg_cpu_b": (
+        "dmg_cpu_b/ff04_div.kicad_sch",
+        "dmg_cpu_b/sprite_store.kicad_sch",
+    ),
+    "sm83": (),
+}
+
+REFERENCE_INTERFACE_MISMATCH = {
+    "parent": "dmg_cpu_b/ppu.kicad_sch",
+    "child": "dmg_cpu_b/oam.kicad_sch",
+    "resolved": True,
+    "parent_only_pins": [],
+    "child_only_labels": ["DMA_PHI"],
+}
+
+
+def decode_string(value: str) -> str:
+    return json.loads(value)
+
+
+def first_string(form: str, key: str) -> str | None:
+    match = re.search(r"\(" + re.escape(key) + r"\s+(" + STRING + r")", form)
+    return decode_string(match.group(1)) if match else None
+
+
+def properties(form: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    pattern = re.compile(r"\(property\s+(" + STRING + r")\s+(" + STRING + r")")
+    for match in pattern.finditer(form):
+        result[decode_string(match.group(1))] = decode_string(match.group(2))
+    return result
+
+
+def top_level_forms(path: pathlib.Path) -> Iterator[tuple[str, str]]:
+    """Yield direct children of the kicad_sch root without building a huge AST."""
+    data = path.read_text(encoding="utf-8")
+    depth = 0
+    start: int | None = None
+    quoted = False
+    escaped = False
+    for offset, char in enumerate(data):
+        if quoted:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quoted = False
+            continue
+        if char == '"':
+            quoted = True
+        elif char == "(":
+            if depth == 1:
+                start = offset
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 1 and start is not None:
+                form = data[start : offset + 1]
+                match = re.match(r"\(\s*([^\s()]+)", form)
+                if match:
+                    yield match.group(1), form
+                start = None
+        if depth < 0:
+            raise ValueError(f"unbalanced closing parenthesis in {path}")
+    if depth != 0 or quoted:
+        raise ValueError(f"unterminated expression or string in {path}")
+
+
+def schematic_index(path: pathlib.Path, root: pathlib.Path) -> dict[str, object]:
+    counts: collections.Counter[str] = collections.Counter()
+    labels: dict[str, set[str]] = {
+        "hierarchical": set(),
+        "global": set(),
+        "local": set(),
+    }
+    symbols: collections.Counter[str] = collections.Counter()
+    references: list[dict[str, str]] = []
+    children: list[dict[str, object]] = []
+    title: dict[str, str] = {}
+
+    for kind, form in top_level_forms(path):
+        counts[kind] += 1
+        if kind == "title_block":
+            for key in ("title", "date", "rev", "company"):
+                value = first_string(form, key)
+                if value is not None:
+                    title[key] = value
+        elif kind == "sheet":
+            props = properties(form)
+            pins = [decode_string(value) for value in re.findall(r"\(pin\s+(" + STRING + r")", form)]
+            children.append(
+                {
+                    "name": props.get("Sheetname", ""),
+                    "file": props.get("Sheetfile", ""),
+                    "pins": sorted(set(pins)),
+                }
+            )
+        elif kind in ("hierarchical_label", "global_label", "label"):
+            value = first_string(form, kind)
+            if value is not None:
+                bucket = {
+                    "hierarchical_label": "hierarchical",
+                    "global_label": "global",
+                    "label": "local",
+                }[kind]
+                labels[bucket].add(value)
+        elif kind == "symbol":
+            lib_id = first_string(form, "lib_id")
+            props = properties(form)
+            if lib_id:
+                symbols[lib_id] += 1
+                reference = props.get("Reference")
+                value = props.get("Value")
+                if reference and not reference.startswith("#"):
+                    references.append(
+                        {"reference": reference, "value": value or "", "lib_id": lib_id}
+                    )
+
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "title": title,
+        "children": sorted(children, key=lambda child: (str(child["file"]), str(child["name"]))),
+        "labels": {key: sorted(values) for key, values in labels.items()},
+        "symbols": dict(sorted(symbols.items())),
+        "references": sorted(references, key=lambda item: item["reference"]),
+        "object_counts": dict(sorted(counts.items())),
+    }
+
+
+def netlist_statements(data: str, source: pathlib.Path) -> Iterator[str]:
+    """Yield semicolon-terminated nlconv statements.
+
+    Statements may span lines and command names may carry a condition suffix,
+    for example ``cell:-codegen``.  Hash comments and semicolons only have
+    syntax outside quoted strings.
+    """
+    buffer: list[str] = []
+    quoted = False
+    escaped = False
+    commented = False
+
+    for char in data:
+        if commented:
+            if char == "\n":
+                commented = False
+                buffer.append(char)
+            continue
+        if quoted:
+            buffer.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quoted = False
+            continue
+        if char == "#":
+            commented = True
+        elif char == '"':
+            quoted = True
+            buffer.append(char)
+        elif char == ";":
+            statement = "".join(buffer).strip()
+            buffer.clear()
+            if statement:
+                yield statement
+        else:
+            buffer.append(char)
+
+    if quoted:
+        raise ValueError(f"unterminated string in {source}")
+    remainder = "".join(buffer).strip()
+    if remainder:
+        raise ValueError(f"unterminated netlist statement in {source}: {remainder[:80]!r}")
+
+
+def netlist_command(statement: str) -> tuple[str, str | None]:
+    match = re.match(r"([A-Za-z][A-Za-z0-9_-]*)(?::([^\s]+))?(?:\s|$)", statement)
+    if not match:
+        raise ValueError(f"unrecognized netlist statement: {statement[:80]!r}")
+    return match.group(1), match.group(2)
+
+
+def makefile_file_list(path: pathlib.Path, variable: str) -> list[str]:
+    """Read one simple backslash-continued file-list assignment."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    prefix = f"{variable} ="
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        values: list[str] = []
+        current = line[len(prefix) :].strip()
+        while True:
+            continued = current.endswith("\\")
+            if continued:
+                current = current[:-1].strip()
+            values.extend(current.split())
+            if not continued:
+                return values
+            index += 1
+            if index >= len(lines):
+                raise ValueError(f"unterminated {variable} assignment in {path}")
+            current = lines[index].strip()
+    raise ValueError(f"missing {variable} assignment in {path}")
+
+
+def netlist_index(root: pathlib.Path) -> dict[str, object]:
+    netlist_root = root / "netlist"
+    declared_categories: set[str] = set()
+    cells: collections.Counter[str] = collections.Counter()
+    signal_classes: collections.Counter[str] = collections.Counter()
+    cells_by_file: dict[str, collections.Counter[str]] = {}
+    wires_by_file: dict[str, collections.Counter[str]] = {}
+    statement_counts_by_file: dict[str, collections.Counter[str]] = {}
+    unclassified_cells_by_file: collections.Counter[str] = collections.Counter()
+    unclassified_wires_by_file: collections.Counter[str] = collections.Counter()
+    statement_counts: collections.Counter[str] = collections.Counter()
+    qualified_statements: collections.Counter[str] = collections.Counter()
+    cell_names: set[str] = set()
+    wire_names: set[str] = set()
+    type_names: set[str] = set()
+    cell_aliases = 0
+    wire_aliases = 0
+
+    cell_re = re.compile(
+        r"^cell(?::(?P<condition>[^\s]+))?\s+"
+        r"(?P<name>[^:\s]+):(?P<type>[^\s;]+)"
+    )
+    wire_re = re.compile(
+        r"^wire(?::(?P<condition>[^\s]+))?\s+"
+        r"(?P<name>[^:\s]+)(?::(?P<signal>[^\s;]+))?(?:\s|$)"
+    )
+    category_statement_re = re.compile(r"^category\s+([^\s:]+)\s*:")
+    alias_re = re.compile(r"^alias\s+(cell|wire)\s+")
+    type_re = re.compile(r"^type(?::[^\s]+)?\s+([^\s;]+)")
+
+    files = sorted(netlist_root.rglob("*.nl"))
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        file_cells: collections.Counter[str] = collections.Counter()
+        file_wires: collections.Counter[str] = collections.Counter()
+        file_statement_counts: collections.Counter[str] = collections.Counter()
+        data = path.read_text(encoding="utf-8")
+
+        for statement in netlist_statements(data, path):
+            command, condition = netlist_command(statement)
+            statement_counts[command] += 1
+            file_statement_counts[command] += 1
+            if condition:
+                qualified_statements[f"{command}:{condition}"] += 1
+
+            if command == "category":
+                match = category_statement_re.match(statement)
+                if not match:
+                    raise ValueError(f"malformed category in {path}: {statement[:80]!r}")
+                declared_categories.add(match.group(1))
+            elif command == "cell":
+                match = cell_re.match(statement)
+                if not match:
+                    raise ValueError(f"malformed cell in {path}: {statement[:80]!r}")
+                cell_names.add(match.group("name"))
+                category_match = re.search(r"->\s*([A-Za-z0-9_-]+)", statement)
+                if category_match:
+                    category = category_match.group(1)
+                    cells[category] += 1
+                    file_cells[category] += 1
+                else:
+                    unclassified_cells_by_file[relative] += 1
+            elif command == "wire":
+                match = wire_re.match(statement)
+                if not match:
+                    raise ValueError(f"malformed wire in {path}: {statement[:80]!r}")
+                wire_names.add(match.group("name"))
+                signal = match.group("signal")
+                if signal:
+                    signal_classes[signal] += 1
+                    file_wires[signal] += 1
+                else:
+                    unclassified_wires_by_file[relative] += 1
+            elif command == "type":
+                match = type_re.match(statement)
+                if not match:
+                    raise ValueError(f"malformed type in {path}: {statement[:80]!r}")
+                type_names.add(match.group(1))
+            elif command == "alias":
+                match = alias_re.match(statement)
+                if not match:
+                    raise ValueError(f"malformed alias in {path}: {statement[:80]!r}")
+                if match.group(1) == "cell":
+                    cell_aliases += 1
+                else:
+                    wire_aliases += 1
+        if file_cells:
+            cells_by_file[relative] = file_cells
+        if file_wires:
+            wires_by_file[relative] = file_wires
+        statement_counts_by_file[relative] = file_statement_counts
+
+    undeclared_cell_categories = sorted(set(cells) - declared_categories)
+    if undeclared_cell_categories:
+        raise ValueError(f"undeclared cell categories: {undeclared_cell_categories}")
+
+    all_categories = sorted(declared_categories)
+    makefile = netlist_root / "Makefile"
+    dmg_makefile_files = [
+        f"netlist/{value}" for value in makefile_file_list(makefile, "NETLIST_FILES")
+    ]
+    sm83_makefile_files = [
+        f"netlist/{value}" for value in makefile_file_list(makefile, "SM83_NETLIST_FILES")
+    ]
+    return {
+        "files": [path.relative_to(root).as_posix() for path in files],
+        "file_count": len(files),
+        "statement_counts": dict(sorted(statement_counts.items())),
+        "statement_counts_by_file": {
+            path: dict(sorted(counter.items()))
+            for path, counter in sorted(statement_counts_by_file.items())
+        },
+        "qualified_statements": dict(sorted(qualified_statements.items())),
+        "cell_count": statement_counts["cell"],
+        "wire_count": statement_counts["wire"],
+        "type_count": statement_counts["type"],
+        "unique_type_name_count": len(type_names),
+        "declared_category_count": statement_counts["category"],
+        "signal_count": statement_counts["signal"],
+        "define_count": statement_counts["define"],
+        "label_count": statement_counts["label"],
+        "alias_count": statement_counts["alias"],
+        "unique_cell_names": len(cell_names),
+        "unique_wire_names": len(wire_names),
+        "cell_alias_statements": cell_aliases,
+        "wire_alias_statements": wire_aliases,
+        "makefile_groups": {
+            "NETLIST_FILES": dmg_makefile_files,
+            "SM83_NETLIST_FILES": sm83_makefile_files,
+        },
+        "classified_cell_count": sum(cells.values()),
+        "unclassified_cell_count": sum(unclassified_cells_by_file.values()),
+        "unclassified_cells_by_file": dict(sorted(unclassified_cells_by_file.items())),
+        "classified_wire_count": sum(signal_classes.values()),
+        "unclassified_wire_count": sum(unclassified_wires_by_file.values()),
+        "unclassified_wires_by_file": dict(sorted(unclassified_wires_by_file.items())),
+        "categories": [
+            {
+                "name": category,
+                "cells": cells[category],
+            }
+            for category in all_categories
+        ],
+        "signal_classes": [
+            {"name": signal, "wires": signal_classes[signal]}
+            for signal in sorted(signal_classes)
+        ],
+        "cells_by_file": {
+            path: dict(sorted(counter.items()))
+            for path, counter in sorted(cells_by_file.items())
+        },
+        "wires_by_file": {
+            path: dict(sorted(counter.items())) for path, counter in sorted(wires_by_file.items())
+        },
+    }
+
+
+def git_metadata(root: pathlib.Path) -> dict[str, object]:
+    def git(*args: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(root), *args], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+
+    try:
+        return {
+            "commit": git("rev-parse", "HEAD"),
+            "commit_date": git("show", "-s", "--format=%cI", "HEAD"),
+            "status": git("status", "--short").splitlines(),
+        }
+    except (OSError, subprocess.CalledProcessError):
+        return {"commit": None, "commit_date": None, "status": []}
+
+
+def build_index(root: pathlib.Path) -> dict[str, object]:
+    projects = ("dmg_cpu_b", "sm83", "dmg_cells", "sm83_cells")
+    schematics = [
+        schematic_index(path, root)
+        for project in projects
+        for path in sorted((root / project).glob("*.kicad_sch"))
+    ]
+    by_path = {str(item["path"]): item for item in schematics}
+    roots = {
+        "dmg_cpu_b": "dmg_cpu_b/dmg_cpu_b.kicad_sch",
+        "sm83": "sm83/sm83.kicad_sch",
+    }
+    hierarchy: dict[str, object] = {}
+    for project, project_root in roots.items():
+        reachable: set[str] = set()
+        pending = [project_root]
+        while pending:
+            current = pending.pop()
+            if current in reachable:
+                continue
+            reachable.add(current)
+            for child in by_path[current]["children"]:  # type: ignore[index]
+                child_path = f"{project}/{child['file']}"
+                if child_path in by_path:
+                    pending.append(child_path)
+        project_files = {
+            path for path in by_path if path.startswith(f"{project}/")
+        }
+        hierarchy[project] = {
+            "root": project_root,
+            "reachable": sorted(reachable),
+            "orphans": sorted(project_files - reachable),
+        }
+
+    interfaces: list[dict[str, object]] = []
+    for parent_path, parent in sorted(by_path.items()):
+        parent_dir = pathlib.PurePosixPath(parent_path).parent
+        for child in parent["children"]:  # type: ignore[index]
+            child_path = (parent_dir / str(child["file"])).as_posix()
+            target = by_path.get(child_path)
+            if target is None:
+                interfaces.append(
+                    {
+                        "parent": parent_path,
+                        "child": child_path,
+                        "resolved": False,
+                        "parent_only_pins": sorted(set(child["pins"])),
+                        "child_only_labels": [],
+                    }
+                )
+                continue
+            parent_pins = set(child["pins"])
+            child_labels = set(target["labels"]["hierarchical"])  # type: ignore[index]
+            interfaces.append(
+                {
+                    "parent": parent_path,
+                    "child": child_path,
+                    "resolved": True,
+                    "parent_only_pins": sorted(parent_pins - child_labels),
+                    "child_only_labels": sorted(child_labels - parent_pins),
+                }
+            )
+
+    return {
+        "source": str(root),
+        "git": git_metadata(root),
+        "schematic_count": len(schematics),
+        "schematics": schematics,
+        "hierarchy": hierarchy,
+        "hierarchy_interfaces": interfaces,
+        "netlist": netlist_index(root),
+    }
+
+
+def scanner_self_check() -> list[str]:
+    fixture = '''
+# A qualified, multiline cell with an attribute after its category.
+cell:-codegen lmix:mixer
+    in1@-1,2,3,4
+    ->apu-analog attrib "sv:note=contains;a-semicolon";
+cell:codegen audio:audio;
+wire:-codegen mixed:analog
+    lmix.out -> audio.lout;
+alias cell audio_alias -> audio;
+type:codegen audio in out:out "description; still one statement";
+'''
+    errors: list[str] = []
+    source = pathlib.Path("<self-check>")
+    statements = list(netlist_statements(fixture, source))
+    commands = [netlist_command(statement) for statement in statements]
+    expected = [
+        ("cell", "-codegen"),
+        ("cell", "codegen"),
+        ("wire", "-codegen"),
+        ("alias", None),
+        ("type", "codegen"),
+    ]
+    if commands != expected:
+        errors.append(f"statement scanner fixture: expected {expected}, got {commands}")
+    if not re.search(r"->\s*apu-analog\b", statements[0]):
+        errors.append("statement scanner fixture lost the multiline cell category")
+    return errors
+
+
+def validate_index(index: dict[str, object], reference_counts: bool) -> list[str]:
+    errors = scanner_self_check()
+    netlist = index["netlist"]
+    interfaces = index["hierarchy_interfaces"]
+    assert isinstance(netlist, dict)
+    assert isinstance(interfaces, list)
+
+    categories = netlist["categories"]
+    signal_classes = netlist["signal_classes"]
+    cells_by_file = netlist["cells_by_file"]
+    wires_by_file = netlist["wires_by_file"]
+    assert isinstance(categories, list)
+    assert isinstance(signal_classes, list)
+    assert isinstance(cells_by_file, dict)
+    assert isinstance(wires_by_file, dict)
+
+    invariants = {
+        "declared category records": (
+            len(categories),
+            netlist["declared_category_count"],
+        ),
+        "classified plus unclassified cells": (
+            int(netlist["classified_cell_count"]) + int(netlist["unclassified_cell_count"]),
+            netlist["cell_count"],
+        ),
+        "per-file classified cells": (
+            sum(sum(counter.values()) for counter in cells_by_file.values()),
+            netlist["classified_cell_count"],
+        ),
+        "signal-class wires": (
+            sum(int(item["wires"]) for item in signal_classes)
+            + int(netlist["unclassified_wire_count"]),
+            netlist["wire_count"],
+        ),
+        "per-file wires": (
+            sum(sum(counter.values()) for counter in wires_by_file.values())
+            + int(netlist["unclassified_wire_count"]),
+            netlist["wire_count"],
+        ),
+        "cell plus wire aliases": (
+            int(netlist["cell_alias_statements"]) + int(netlist["wire_alias_statements"]),
+            netlist["alias_count"],
+        ),
+    }
+    for name, (actual, expected) in invariants.items():
+        if actual != expected:
+            errors.append(f"{name}: expected {expected}, got {actual}")
+
+    if reference_counts:
+        git = index["git"]
+        hierarchy = index["hierarchy"]
+        schematics = index["schematics"]
+        assert isinstance(git, dict)
+        assert isinstance(hierarchy, dict)
+        assert isinstance(schematics, list)
+        mismatched_interfaces = [
+            item
+            for item in interfaces
+            if not item["resolved"]
+            or item["parent_only_pins"]
+            or item["child_only_labels"]
+        ]
+        actual_counts = {
+            "schematic_count": index["schematic_count"],
+            "hierarchy_interface_count": len(interfaces),
+            "hierarchy_interface_mismatch_count": len(mismatched_interfaces),
+            "netlist_file_count": netlist["file_count"],
+            **{name: netlist[name] for name in REFERENCE_COUNTS if name in netlist},
+        }
+        for name, expected in REFERENCE_COUNTS.items():
+            actual = actual_counts[name]
+            if actual != expected:
+                errors.append(f"reference {name}: expected {expected}, got {actual}")
+
+        if git["commit"] != REFERENCE_COMMIT:
+            errors.append(
+                f"reference commit: expected {REFERENCE_COMMIT}, got {git['commit']}"
+            )
+        if git["status"]:
+            errors.append(f"reference checkout is dirty: {git['status']}")
+
+        project_sheet_counts = collections.Counter(
+            str(item["path"]).split("/", 1)[0] for item in schematics
+        )
+        expected_project_sheet_counts = {
+            "dmg_cpu_b": 49,
+            "sm83": 14,
+            "dmg_cells": 1,
+            "sm83_cells": 1,
+        }
+        if dict(project_sheet_counts) != expected_project_sheet_counts:
+            errors.append(
+                "reference schematic split: expected "
+                f"{expected_project_sheet_counts}, got {dict(project_sheet_counts)}"
+            )
+
+        for project, expected_orphans in REFERENCE_ORPHANS.items():
+            project_hierarchy = hierarchy[project]
+            assert isinstance(project_hierarchy, dict)
+            actual_orphans = tuple(project_hierarchy["orphans"])
+            if actual_orphans != expected_orphans:
+                errors.append(
+                    f"reference {project} orphans: expected {expected_orphans}, "
+                    f"got {actual_orphans}"
+                )
+        reachable_counts = {
+            project: len(hierarchy[project]["reachable"])  # type: ignore[index]
+            for project in REFERENCE_ORPHANS
+        }
+        if reachable_counts != {"dmg_cpu_b": 47, "sm83": 14}:
+            errors.append(
+                "reference reachable sheets: expected {'dmg_cpu_b': 47, 'sm83': 14}, "
+                f"got {reachable_counts}"
+            )
+
+        if mismatched_interfaces != [REFERENCE_INTERFACE_MISMATCH]:
+            errors.append(
+                "reference interface mismatch: expected "
+                f"{REFERENCE_INTERFACE_MISMATCH}, got {mismatched_interfaces}"
+            )
+
+        category_names = tuple(item["name"] for item in categories)
+        if category_names != REFERENCE_CATEGORIES:
+            errors.append(
+                f"reference categories: expected {REFERENCE_CATEGORIES}, got {category_names}"
+            )
+
+        makefile_groups = netlist["makefile_groups"]
+        assert isinstance(makefile_groups, dict)
+        makefile_files = [
+            path
+            for group in ("NETLIST_FILES", "SM83_NETLIST_FILES")
+            for path in makefile_groups[group]
+        ]
+        discovered_files = netlist["files"]
+        if sorted(makefile_files) != sorted(discovered_files):
+            errors.append("reference Makefile membership differs from discovered .nl files")
+        makefile_group_counts = {
+            group: len(makefile_groups[group])
+            for group in ("NETLIST_FILES", "SM83_NETLIST_FILES")
+        }
+        if makefile_group_counts != {"NETLIST_FILES": 66, "SM83_NETLIST_FILES": 16}:
+            errors.append(
+                "reference Makefile split: expected 66/16, "
+                f"got {makefile_group_counts}"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "root",
+        nargs="?",
+        type=pathlib.Path,
+        default=pathlib.Path("../dmg-schematics"),
+        help="path to the dmg-schematics checkout",
+    )
+    parser.add_argument("--compact", action="store_true", help="emit compact JSON")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate parser invariants and the reviewed source snapshot counts",
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    if not (root / "dmg_cpu_b" / "dmg_cpu_b.kicad_sch").is_file():
+        parser.error(f"not a dmg-schematics checkout: {root}")
+    index = build_index(root)
+    errors = validate_index(index, reference_counts=args.check)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    if args.check:
+        netlist = index["netlist"]
+        assert isinstance(netlist, dict)
+        print(
+            "OK: "
+            f"{len(index['hierarchy_interfaces'])} hierarchy interfaces, "
+            f"{netlist['file_count']} netlist files, "
+            f"{netlist['cell_count']} cells, "
+            f"{netlist['wire_count']} wires, "
+            f"{netlist['type_count']} type declarations, "
+            f"{netlist['declared_category_count']} categories, "
+            f"{netlist['alias_count']} aliases"
+        )
+        return 0
+    json.dump(
+        index,
+        sys.stdout,
+        indent=None if args.compact else 2,
+        sort_keys=False,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Inventory and cross-reference all DMG/SM83 schematic sheets, netlists, logical categories, and Coffee GB core classes.
- Add a reproducible structural indexer and the complete mapping document.
- Correct six bounded circuit mismatches: FF50 sticky D0, raw IF/APU reset, CB-prefix restore, aggregate 1 MHz JOYP filtering, DMG STOP wake ownership, and CH3 output/retrigger behavior.

## Verification
- Core: 1,584 tests, 8 skipped
- Controller: 904 tests, 2 skipped
- Integration: 5,707/5,707
- Public API and affected State/Memento descriptors remain unchanged.

The mapping documents remaining projection boundaries for PPU timing, CPU bus/IRQ/DMA scheduling, memories, analog behavior, and CGB/SGB evidence.