### PR TITLE
Fix Windows gamepad RawInput polling

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SdlGamepadBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SdlGamepadBackend.java
@@ -15,6 +15,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.function.BiPredicate;
 
 import static io.github.libsdl4j.api.Sdl.SDL_Init;
 import static io.github.libsdl4j.api.Sdl.SDL_QuitSubSystem;
@@ -22,6 +24,8 @@ import static io.github.libsdl4j.api.SdlSubSystemConst.SDL_INIT_GAMECONTROLLER;
 import static io.github.libsdl4j.api.gamecontroller.SDL_GameControllerAxis.*;
 import static io.github.libsdl4j.api.gamecontroller.SDL_GameControllerButton.*;
 import static io.github.libsdl4j.api.gamecontroller.SdlGamecontroller.*;
+import static io.github.libsdl4j.api.hints.SdlHints.SDL_SetHint;
+import static io.github.libsdl4j.api.hints.SdlHintsConst.SDL_HINT_JOYSTICK_THREAD;
 import static io.github.libsdl4j.api.joystick.SdlJoystick.*;
 
 /** Real SDL2 implementation kept behind the no-native test seam. */
@@ -33,6 +37,9 @@ final class SdlGamepadBackend implements GamepadBackend {
     @Override
     public void initialize() {
         locateSystemSdl();
+        configurePlatformHints(
+                System.getProperty("os.name", ""),
+                (name, value) -> SDL_SetHint(name, value));
         // SDL_JoystickGetDeviceGUID returns SDL_JoystickGUID by value.  The direct JNA mapping
         // used by libsdl4j corrupts the following native call for this struct-return ABI on
         // macOS arm64 when SDL2 is provided by Homebrew's sdl2-compat layer.  Use JNA's proxy
@@ -43,6 +50,16 @@ final class SdlGamepadBackend implements GamepadBackend {
             throw new IllegalStateException("SDL game-controller initialization failed");
         }
         initialized = true;
+    }
+
+    static void configurePlatformHints(
+            String osName, BiPredicate<String, String> hintSetter) {
+        if (nullToEmpty(osName).toLowerCase(Locale.ROOT).startsWith("windows")) {
+            // The Windows RawInput backend receives controller reports through WM_INPUT.
+            // Coffee GB does not own an SDL video event loop, so let SDL own the message-only
+            // window and dispatch those reports on its dedicated joystick thread.
+            hintSetter.test(SDL_HINT_JOYSTICK_THREAD, "1");
+        }
     }
 
     @Override

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
@@ -343,6 +343,25 @@ public class SwingGamepadTest {
     }
 
     @Test
+    public void sdlBackendEnablesItsRawInputMessageThreadOnlyOnWindows() {
+        List<Map.Entry<String, String>> hints = new ArrayList<>();
+        SdlGamepadBackend.configurePlatformHints("Windows 11", (name, value) -> {
+            hints.add(Map.entry(name, value));
+            return true;
+        });
+        assertEquals(List.of(Map.entry("SDL_JOYSTICK_THREAD", "1")), hints);
+
+        for (String osName : List.of("Mac OS X", "Darwin", "Linux")) {
+            hints.clear();
+            SdlGamepadBackend.configurePlatformHints(osName, (name, value) -> {
+                hints.add(Map.entry(name, value));
+                return true;
+            });
+            assertTrue(osName + " must not enable the Windows joystick thread", hints.isEmpty());
+        }
+    }
+
+    @Test
     public void pollerThreadExitReleasesSourcesAndClosesBackend() throws Exception {
         Rig rig = new Rig(mapping(new ControllerProperties.GamepadAssignment(0, ID_A)));
         FakeDevice device = rig.backend.add(ID_A, "primary");


### PR DESCRIPTION
## Summary

- enable SDL's dedicated joystick thread before controller initialization on Windows
- preserve the existing SDL backend behavior on macOS and Linux
- add regression coverage for the platform-specific hint

## Root cause

Coffee GB uses a Swing window and initializes only SDL's game-controller subsystem. SDL2's Windows RawInput backend receives controller reports through `WM_INPUT`, but without an SDL video event pump or the dedicated joystick thread those messages are not dispatched. Controllers therefore enumerate and open successfully while every cached axis and button remains neutral.

Setting `SDL_JOYSTICK_THREAD=1` before `SDL_Init` makes SDL own the message-only window and dispatch RawInput reports on its joystick thread.

## Impact

Xbox and other RawInput-backed controllers now deliver input in the Windows desktop emulator. Other platforms are unchanged.

## Validation

- `mvn -pl swing -Dtest=SwingGamepadTest test` — 16 tests passed
- `mvn -pl swing -am package -DskipTests` — build succeeded
- Windows 11 runtime trace with two detected Xbox controllers recorded START, A, B, and stick directions at the SDL, desktop routing, and emulator-core checkpoints with zero polling failures
