### PR TITLE
Fix Super Color 26-in-1 multicart protocol

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -119,6 +119,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.memory.cart.type.Gowin\$GowinState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$LoaderMbc5\$LoaderMbc5State",
+          "eu.rekawek.coffeegb.core.memory.cart.type.NtNew\$NtNewState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -117,6 +117,8 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint\$MobileAdapterSerialEndpointWireState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Hitek\$HitekState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Gowin\$GowinState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$LoaderMbc5\$LoaderMbc5State",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -584,7 +584,7 @@ internal object DetachedStateAdapter {
     val current = StateGraph.captureRoot(gameboy.captureStateWithoutTimeSource(), GAMEBOY_ROOT)
     StateGraph.validateCompatible(state.root, current, "machine")
     try {
-      gameboy.validateRtcRuntimeState(state.rtcRuntime.toCore())
+      gameboy.validateRtcRuntimeStateForRestoreCandidate(state.rtcRuntime.toCore())
       gameboy.validateDmgFifoRuntimeState(state.dmgFifoRuntime.toCore())
     } catch (failure: IllegalArgumentException) {
       throw StateApplyException("Detached machine runtime layout is incompatible", failure)
@@ -1129,7 +1129,9 @@ internal object StateGraph {
         element: Boolean = false,
     ) {
       if (candidate === NullState || target === NullState) {
-        if (candidate !== target && !isAuditedNullable(owner, field, element)) {
+        if (candidate !== target &&
+            !isAuditedNullable(owner, field, element) &&
+            !isDynamicMbc5MulticartGameState(owner, field)) {
           throw StateApplyException("$path has incompatible state presence")
         }
         return
@@ -1144,6 +1146,12 @@ internal object StateGraph {
             return
           }
           if (candidate.typeId != target.typeId) {
+            if (isDynamicMbc5MulticartGameState(owner, field)) {
+              // This board commits a selected game by replacing its virtual child mapper. The
+              // candidate record has already passed the child-mapper policy; its type is not a
+              // target-owned invariant of the surrounding physical cartridge.
+              return
+            }
             if (isMobileAdapterEndpointStatePair(candidate, target)) {
               // One Mobile Adapter endpoint legitimately alternates between released, active-wire,
               // and external-I/O-aborted records. The candidate's own record semantics are checked
@@ -1311,6 +1319,10 @@ internal object StateGraph {
   private fun isAuditedNullable(owner: String?, field: String?, element: Boolean): Boolean =
       owner to field in if (element) AUDITED_NULLABLE_ELEMENTS else AUDITED_NULLABLE_FIELDS
 
+  /** The board's committed child mapper can be absent or one of several native MBC records. */
+  private fun isDynamicMbc5MulticartGameState(owner: String?, field: String?): Boolean =
+      owner == MBC5_MULTICART_STATE && field == "selectedGameState"
+
   private val VARIABLE_ARRAY_FIELDS =
       setOf(
           "eu.rekawek.coffeegb.core.sound.Sound\$SoundState" to "buffer",
@@ -1360,6 +1372,9 @@ internal object StateGraph {
 
   private const val FILE_BATTERY_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
+
+  private const val MBC5_MULTICART_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
 
   /**
    * Exact nullable locations in the pinned legacy graph. Nullability is a field contract, not a

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -76,7 +76,7 @@ internal class MachineSnapshot private constructor(
     val candidateWallClock = wallClockRuntime.toCore()
     val candidateFifo = dmgFifoRuntime?.toCore()
     try {
-      gameboy.validateRtcRuntimeState(candidateRtc)
+      gameboy.validateRtcRuntimeStateForRestoreCandidate(candidateRtc)
       gameboy.validateWallClockRuntimeState(candidateWallClock)
       gameboy.validateDmgFifoRuntimeState(candidateFifo)
     } catch (failure: IllegalArgumentException) {
@@ -719,9 +719,23 @@ private object SnapshotGraph {
 
   fun ownershipSignature(root: SnapshotRecord): List<Int> {
     val signature = ArrayList<Int>()
-    root.visitRecords { record ->
-      if (isOwnershipRecord(recordClassName(record.typeId))) signature += record.typeId
+    val seen = IdentityHashMap<SnapshotValue, Boolean>()
+    fun visit(value: SnapshotValue) {
+      if (seen.put(value, true) != null) return
+      when (value) {
+        is SnapshotRecord -> {
+          val type = recordClassName(value.typeId)
+          if (isOwnershipRecord(type)) signature += value.typeId
+          value.fields.forEach { field ->
+            if (!isDynamicMbc5MulticartGameState(type, field.name)) visit(field.value)
+          }
+        }
+        is SnapshotValues -> value.values.forEach(::visit)
+        is SnapshotIntMap -> value.entries.forEach { visit(it.value) }
+        else -> Unit
+      }
     }
+    visit(root)
     return signature
   }
 
@@ -733,9 +747,12 @@ private object SnapshotGraph {
         StateTypeRegistry.isAuditedStateType(value.javaClass) -> {
           val typeId = recordIds[value.javaClass]
               ?: throw StateApplyException("Unregistered internal record ${value.javaClass.name}")
-          if (isOwnershipRecord(value.javaClass.name)) signature += typeId
+          val type = value.javaClass.name
+          if (isOwnershipRecord(type)) signature += typeId
           StateRecordIntrospection.components(value.javaClass).forEach { component ->
-            visit(component.value(value))
+            if (!isDynamicMbc5MulticartGameState(type, component.name)) {
+              visit(component.value(value))
+            }
           }
         }
         value.javaClass.isArray && !value.javaClass.componentType.isPrimitive ->
@@ -755,6 +772,12 @@ private object SnapshotGraph {
   private fun isOwnershipRecord(name: String): Boolean =
       name.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.") ||
           name.startsWith("eu.rekawek.coffeegb.core.memory.cart.battery.")
+
+  private fun isDynamicMbc5MulticartGameState(owner: String, field: String): Boolean =
+      owner == MBC5_MULTICART_STATE && field == "selectedGameState"
+
+  private const val MBC5_MULTICART_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
 
   private class Restore {
     private var references = 0L

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1611,17 +1611,29 @@ internal object StateSemantics {
         constrained("The multi-MBC board retains byte-sized configuration registers and an explicit child mapper state.") {
           it.requiredRecordType("menuState", MBC5_MULTICART_LOADER_STATE)
           it.range("selectedPage", 0, 0xff); it.range("pageMask", 0, 0xff)
-          when (it.int("selectedMapperMode")) {
+          val mapperMode = it.int("selectedMapperMode")
+          it.require(mapperMode == -1 || mapperMode in 0..0xff,
+              "has an invalid selected mapper mode $mapperMode")
+          when (mapperMode) {
             -1 -> it.require(it.value("selectedGameState") == null,
                 "has a selected game without a mapper mode")
-            MBC5_MULTICART_MBC1_MODE ->
-                it.requiredRecordType("selectedGameState", MBC1_STATE)
-            MBC5_MULTICART_MBC2_OR_MBC3_MODE ->
-                it.requiredRecordType("selectedGameState", MBC2_STATE, MBC3_STATE)
-            MBC5_MULTICART_MBC5_MODE ->
-                it.requiredRecordType("selectedGameState", MBC5_STATE)
-            else -> it.require(false, "has an invalid selected mapper mode")
+            else -> when (mapperMode and 0xe0) {
+              MBC5_MULTICART_MBC1_MODE -> it.requiredRecordType(
+                  "selectedGameState", NTNEW_STATE, MBC1_STATE, BASIC_ROM_STATE)
+              MBC5_MULTICART_MBC2_OR_MBC3_MODE ->
+                  it.requiredRecordType("selectedGameState", MBC2_STATE, MBC3_STATE)
+              MBC5_MULTICART_MBC5_MODE ->
+                  it.requiredRecordType("selectedGameState", NTNEW_STATE, MBC5_STATE)
+              else -> it.require(false, "has an invalid selected mapper mode")
+            }
           }
+        }
+    target[NTNEW_STATE] =
+        constrained("Newer N&T/Makon banking retains two byte-sized 8 KiB selectors and one RAM page.") {
+          it.recordType("batteryMemento", MEMORY_BATTERY_STATE, FILE_BATTERY_STATE)
+          it.require(it.intArray("ram").size == 0x2000, "must have one 8 KiB RAM page")
+          it.intValues("ram", 0, 0xff)
+          it.range("lowRomBank", 0, 0xff); it.range("highRomBank", 0, 0xff)
         }
     target[MBC5_MULTICART_LOADER_STATE] =
         constrained("The MBC5 menu loader preserves a bounded two-bank transition window.") {
@@ -1838,6 +1850,8 @@ internal object StateSemantics {
   private const val MBC2_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc2\$Mbc2State"
   private const val MBC3_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3State"
   private const val MBC5_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
+  private const val BASIC_ROM_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomState"
+  private const val NTNEW_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.NtNew\$NtNewState"
   private const val MBC5_MULTICART_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
   private const val MBC5_MULTICART_LOADER_STATE =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1607,6 +1607,29 @@ internal object StateSemantics {
         constrained("MBC5 exposes a nine-bit ROM bank and four-bit RAM/rumble register.") {
           it.range("selectedRamBank", 0, 0x0f); it.range("selectedRomBank", 0, 0x1ff)
         }
+    target[MBC5_MULTICART_STATE] =
+        constrained("The multi-MBC board retains byte-sized configuration registers and an explicit child mapper state.") {
+          it.requiredRecordType("menuState", MBC5_MULTICART_LOADER_STATE)
+          it.range("selectedPage", 0, 0xff); it.range("pageMask", 0, 0xff)
+          when (it.int("selectedMapperMode")) {
+            -1 -> it.require(it.value("selectedGameState") == null,
+                "has a selected game without a mapper mode")
+            MBC5_MULTICART_MBC1_MODE ->
+                it.requiredRecordType("selectedGameState", MBC1_STATE)
+            MBC5_MULTICART_MBC2_OR_MBC3_MODE ->
+                it.requiredRecordType("selectedGameState", MBC2_STATE, MBC3_STATE)
+            MBC5_MULTICART_MBC5_MODE ->
+                it.requiredRecordType("selectedGameState", MBC5_STATE)
+            else -> it.require(false, "has an invalid selected mapper mode")
+          }
+        }
+    target[MBC5_MULTICART_LOADER_STATE] =
+        constrained("The MBC5 menu loader preserves a bounded two-bank transition window.") {
+          it.requiredRecordType("mbc5State", MBC5_STATE)
+          val base = it.int("loaderBaseBank")
+          it.require(base == -1 || base in 0x14..0x212 && base and 1 == 0,
+              "has an invalid loader base bank $base")
+        }
     target["eu.rekawek.coffeegb.core.memory.cart.type.XploderGb\$XploderGbState"] =
         constrained("Xploder exposes byte ROM banking, sixteen RAM banks, and a fixed 128 KiB RAM image.") {
           it.recordType("batteryMemento", MEMORY_BATTERY_STATE, FILE_BATTERY_STATE)
@@ -1812,7 +1835,16 @@ internal object StateSemantics {
   private const val FILE_BATTERY_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
   private const val MBC1_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc1\$Mbc1State"
+  private const val MBC2_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc2\$Mbc2State"
+  private const val MBC3_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc3\$Mbc3State"
   private const val MBC5_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
+  private const val MBC5_MULTICART_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
+  private const val MBC5_MULTICART_LOADER_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$LoaderMbc5\$LoaderMbc5State"
+  private const val MBC5_MULTICART_MBC2_OR_MBC3_MODE = 0xa0
+  private const val MBC5_MULTICART_MBC5_MODE = 0xc0
+  private const val MBC5_MULTICART_MBC1_MODE = 0xe0
   private const val MBC7_EEPROM_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromState"
   private const val MOBILE_ADAPTER_ENGINE_STATE =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Mbc5MulticartStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Mbc5MulticartStateTest.kt
@@ -1,0 +1,82 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.junit.Test
+
+class Mbc5MulticartStateTest {
+
+  @Test
+  fun portableAndInProcessSnapshotsRestoreAcrossMenuAndNativeChildMappers() {
+    val configuration =
+        StateCodecTestSupport.configuration(multicartRom(), GameboyType.CGB)
+            .setRtcTimeSource(VirtualTimeSource())
+    StateCodecTestSupport.session(configuration).use { session ->
+      val gameboy = session.gameboy
+      val menuSnapshot = MachineSnapshot.capture(gameboy)
+      val menuState = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      select(gameboy, 0x20, 0xe0, 0xa0)
+      gameboy.addressSpace.setByte(0x2000, 3)
+      assertEquals(0x43, gameboy.addressSpace.getByte(0x4000))
+      assertNotNull(gameboy.captureRtcRuntimeState().primary())
+      val mbc3Snapshot = MachineSnapshot.capture(gameboy, menuSnapshot)
+      val mbc3State = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      menuSnapshot.restore(gameboy)
+      select(gameboy, 0x10, 0xf0, 0xe0)
+      assertNull(gameboy.captureRtcRuntimeState().primary())
+      mbc3Snapshot.restore(gameboy)
+      assertEquals(0x43, gameboy.addressSpace.getByte(0x4000))
+      assertNotNull(gameboy.captureRtcRuntimeState().primary())
+
+      StateCodec.decodeAndApply(menuState, configuration, gameboy)
+      assertNull(gameboy.captureRtcRuntimeState().primary())
+      select(gameboy, 0x10, 0xf0, 0xe0)
+      StateCodec.decodeAndApply(mbc3State, configuration, gameboy)
+      assertEquals(0x43, gameboy.addressSpace.getByte(0x4000))
+      assertNotNull(gameboy.captureRtcRuntimeState().primary())
+    }
+  }
+
+  private fun select(gameboy: Gameboy, page: Int, invertedMask: Int, mapperMode: Int) {
+    gameboy.addressSpace.setByte(0xb000, page)
+    gameboy.addressSpace.setByte(0xb100, invertedMask)
+    gameboy.addressSpace.setByte(0xb200, mapperMode)
+  }
+
+  private fun multicartRom(): ByteArray = ByteArray(256 * 0x4000).also { data ->
+    repeat(256) { bank -> data[bank * 0x4000] = bank.toByte() }
+    putHeader(data, 0, 0x19, 0x05)
+    for (bank in 0x16..0x20 step 2) {
+      putHeader(data, bank, 0x19, 0x05)
+    }
+    putHeader(data, 0x20, 0x01, 0x04)
+    putHeader(data, 0x40, 0x10, 0x05)
+  }
+
+  private fun putHeader(data: ByteArray, bank: Int, type: Int, size: Int) {
+    val base = bank * 0x4000
+    NINTENDO_LOGO.forEachIndexed { index, byte -> data[base + 0x104 + index] = byte }
+    data[base + 0x143] = 0x80.toByte()
+    data[base + 0x147] = type.toByte()
+    data[base + 0x148] = size.toByte()
+  }
+
+  private companion object {
+    val NINTENDO_LOGO =
+        byteArrayOf(
+            0xce.toByte(), 0xed.toByte(), 0x66, 0x66, 0xcc.toByte(), 0x0d, 0, 0x0b,
+            0x03, 0x73, 0, 0x83.toByte(), 0, 0x0c, 0, 0x0d,
+            0, 0x08, 0x11, 0x1f, 0x88.toByte(), 0x89.toByte(), 0, 0x0e,
+            0xdc.toByte(), 0xcc.toByte(), 0x6e, 0xe6.toByte(), 0xdd.toByte(), 0xdd.toByte(),
+            0xd9.toByte(), 0x99.toByte(), 0xbb.toByte(), 0xbb.toByte(), 0x67, 0x63, 0x6e,
+            0x0e, 0xec.toByte(), 0xcc.toByte(), 0xdd.toByte(), 0xdc.toByte(), 0x99.toByte(),
+            0x9f.toByte(), 0xbb.toByte(), 0xb9.toByte(), 0x33, 0x3e,
+        )
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Mbc5MulticartStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Mbc5MulticartStateTest.kt
@@ -34,12 +34,33 @@ class Mbc5MulticartStateTest {
       assertEquals(0x43, gameboy.addressSpace.getByte(0x4000))
       assertNotNull(gameboy.captureRtcRuntimeState().primary())
 
+      menuSnapshot.restore(gameboy)
+      select(gameboy, 0x10, 0xf0, 0xe0)
+      gameboy.addressSpace.setByte(0x1400, 0x55)
+      gameboy.addressSpace.setByte(0x2000, 0x04)
+      gameboy.addressSpace.setByte(0x2400, 0x05)
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x6000))
+      val ntNewSnapshot = MachineSnapshot.capture(gameboy, mbc3Snapshot)
+      val ntNewState = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      gameboy.addressSpace.setByte(0x2000, 0x06)
+      mbc3Snapshot.restore(gameboy)
+      assertNotNull(gameboy.captureRtcRuntimeState().primary())
+      ntNewSnapshot.restore(gameboy)
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x6000))
+
       StateCodec.decodeAndApply(menuState, configuration, gameboy)
       assertNull(gameboy.captureRtcRuntimeState().primary())
       select(gameboy, 0x10, 0xf0, 0xe0)
       StateCodec.decodeAndApply(mbc3State, configuration, gameboy)
       assertEquals(0x43, gameboy.addressSpace.getByte(0x4000))
       assertNotNull(gameboy.captureRtcRuntimeState().primary())
+
+      StateCodec.decodeAndApply(ntNewState, configuration, gameboy)
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x22, gameboy.addressSpace.getByte(0x6000))
     }
   }
 
@@ -50,7 +71,10 @@ class Mbc5MulticartStateTest {
   }
 
   private fun multicartRom(): ByteArray = ByteArray(256 * 0x4000).also { data ->
-    repeat(256) { bank -> data[bank * 0x4000] = bank.toByte() }
+    repeat(256) { bank ->
+      data[bank * 0x4000] = bank.toByte()
+      data[bank * 0x4000 + 0x2000] = bank.toByte()
+    }
     putHeader(data, 0, 0x19, 0x05)
     for (bank in 0x16..0x20 step 2) {
       putHeader(data, bank, 0x19, 0x05)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -50,6 +50,25 @@ class StateCoverageMatrixTest {
               Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
             },
             mapper(
+                "Mbc5Multicart",
+                listOf(
+                    0xb000 to 0x20,
+                    0xb100 to 0xe0,
+                    0xb200 to 0xa0,
+                    0x0000 to 0x0a,
+                    0x4000 to 0x08,
+                    0xa000 to 0x2a,
+                ),
+                listOf(0x0100, 0x4000, 0xa000),
+            ) {
+              Mbc5Multicart(
+                  multicartFixture(),
+                  Battery.NULL_BATTERY,
+                  VirtualTimeSource(120_000),
+                  ClockSpec.LEGACY,
+              )
+            },
+            mapper(
                 "LiCheng",
                 listOf(
                     0x0000 to 0x0a,
@@ -192,7 +211,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(29, registeredMapperRecords.size)
+    assertEquals(31, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -772,6 +791,15 @@ class StateCoverageMatrixTest {
     return Rom(bytes)
   }
 
+  private fun multicartFixture(): Rom {
+    val bytes = ByteArray(128 * 0x4000)
+    val selected = 0x40 * 0x4000
+    bytes[selected + 0x143] = 0x80.toByte()
+    bytes[selected + 0x147] = 0x10
+    bytes[selected + 0x148] = 0x05
+    return Rom(bytes)
+  }
+
   private companion object {
     const val MBC5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
     const val MBC6_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc6\$Mbc6State"
@@ -789,6 +817,7 @@ class StateCoverageMatrixTest {
             "Mbc2",
             "Mbc3",
             "Mbc5",
+            "Mbc5Multicart",
             "LiCheng",
             "XploderGb",
             "Vf001Zook",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -36,6 +36,17 @@ class StateCoverageMatrixTest {
               Mbc1(it, Battery.NULL_BATTERY)
             },
             mapper(
+                "NtNew",
+                listOf(
+                    0x1400 to 0x55,
+                    0x2000 to 0x0a,
+                    0x2400 to 0x0b,
+                    0x0000 to 0x0a,
+                    0xa000 to 0x33,
+                ),
+                listOf(0x4000, 0x6000, 0xa000),
+            ) { NtNew(mutableRom(0x01), Battery.NULL_BATTERY) },
+            mapper(
                 "Gowin",
                 listOf(0x2000 to 0x03, 0x6080 to 0x65),
                 listOf(0x4000, 0xa080),
@@ -211,7 +222,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(31, registeredMapperRecords.size)
+    assertEquals(32, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -813,6 +824,7 @@ class StateCoverageMatrixTest {
         setOf(
             "BasicRom",
             "Mbc1",
+            "NtNew",
             "Gowin",
             "Mbc2",
             "Mbc3",

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1357,6 +1357,23 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
     }
 
+    /**
+     * Preflights an RTC supplement before the candidate cartridge mapper state has been restored.
+     */
+    public void validateRtcRuntimeStateForRestoreCandidate(RtcRuntimeState state) {
+        if (state == null) {
+            throw new IllegalArgumentException("Cartridge RTC runtime state is missing");
+        }
+        cartridge.validateRtcRuntimeStateForRestoreCandidate(state.primary());
+        if (slotCartridge == null) {
+            if (state.slot() != null) {
+                throw new IllegalArgumentException("Slot RTC runtime state supplied without a slot cartridge");
+            }
+        } else {
+            slotCartridge.validateRtcRuntimeStateForRestoreCandidate(state.slot());
+        }
+    }
+
     public void restoreRtcRuntimeState(RtcRuntimeState state) {
         validateRtcRuntimeState(state);
         cartridge.restoreRtcRuntimeState(state.primary());

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -113,6 +113,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case MBC1 -> new Mbc1(rom, battery);
             case POCKET_CAMERA -> new PocketCamera(rom, battery);
             case MBC5 -> new Mbc5(rom, battery);
+            case MBC5_MULTICART -> new Mbc5Multicart(rom, battery, rtcTimeSource, clockSpec);
             case STANDARD -> createStandardMemoryController(rom, battery, rtcTimeSource, clockSpec);
         };
     }
@@ -258,16 +259,19 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
 
     /** Returns detached MBC3 pause bookkeeping, or null for mappers without that clock. */
     public RealTimeClock.RuntimeState captureRtcRuntimeState() {
-        return addressSpace instanceof Mbc3 mbc3 ? mbc3.captureRtcRuntimeState() : null;
+        Mbc3 mbc3 = getMbc3Controller();
+        return mbc3 == null ? null : mbc3.captureRtcRuntimeState();
     }
 
     /** Checks the MBC3 pause boundary without applying elapsed host time. */
     public boolean isRtcEmulationPaused() {
-        return addressSpace instanceof Mbc3 mbc3 && mbc3.isRtcEmulationPaused();
+        Mbc3 mbc3 = getMbc3Controller();
+        return mbc3 != null && mbc3.isRtcEmulationPaused();
     }
 
     public void validateRtcRuntimeState(RealTimeClock.RuntimeState state) {
-        if (!(addressSpace instanceof Mbc3 mbc3)) {
+        Mbc3 mbc3 = getMbc3Controller();
+        if (mbc3 == null) {
             if (state != null) {
                 throw new IllegalArgumentException("RTC runtime state supplied for a non-MBC3 cartridge");
             }
@@ -276,6 +280,24 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
         if (state == null) {
             throw new IllegalArgumentException("MBC3 RTC runtime state is missing");
         }
+        validateRtcPauseBoundary(state);
+    }
+
+    /**
+     * Preflights an RTC supplement before a dynamic multicart has installed the candidate game.
+     * The regular validation remains strict once the mapper state has been restored.
+     */
+    public void validateRtcRuntimeStateForRestoreCandidate(RealTimeClock.RuntimeState state) {
+        if (addressSpace instanceof Mbc5Multicart) {
+            if (state != null) {
+                validateRtcPauseBoundary(state);
+            }
+            return;
+        }
+        validateRtcRuntimeState(state);
+    }
+
+    private static void validateRtcPauseBoundary(RealTimeClock.RuntimeState state) {
         if (!state.emulationPaused() && state.pauseStartedMillis() != 0) {
             throw new IllegalArgumentException("Running MBC3 RTC has a stale pause reference");
         }
@@ -283,9 +305,20 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
 
     public void restoreRtcRuntimeState(RealTimeClock.RuntimeState state) {
         validateRtcRuntimeState(state);
-        if (addressSpace instanceof Mbc3 mbc3) {
+        Mbc3 mbc3 = getMbc3Controller();
+        if (mbc3 != null) {
             mbc3.restoreRtcRuntimeState(state);
         }
+    }
+
+    private Mbc3 getMbc3Controller() {
+        if (addressSpace instanceof Mbc3 mbc3) {
+            return mbc3;
+        }
+        if (addressSpace instanceof Mbc5Multicart multicart) {
+            return multicart.getActiveMbc3();
+        }
+        return null;
     }
 
     /** The Sachen MMC2 needs to observe reads on the upper half of the bus (see Mmu). */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -41,7 +41,8 @@ public final class CartridgeProperties {
         WISDOM_TREE,
         MBC1,
         POCKET_CAMERA,
-        MBC5
+        MBC5,
+        MBC5_MULTICART
     }
 
     public enum Feature {
@@ -106,6 +107,8 @@ public final class CartridgeProperties {
                     Mapper.POCKET_CAMERA),
             mapper("Bung/EMS flash cartridge", CartridgeProperties::isBungEms,
                     Mapper.BUNG_EMS),
+            mapper("MBC5 multi-MBC multicart", CartridgeProperties::isMbc5Multicart,
+                    Mapper.MBC5_MULTICART),
             mapper("hidden MMM01 multicart", CartridgeProperties::isHiddenMmm01,
                     Mapper.HIDDEN_MMM01),
             mapper("Mani 32 KiB multicart", CartridgeProperties::isMani32kMulticart,
@@ -310,6 +313,24 @@ public final class CartridgeProperties {
                 || info.hasNullTerminatedTitle("GB16M")
                 || info.rawType() == 0xbe
                 || (info.rawType() == 0x1b && info.byteAt(0x014a) == 0xe1);
+    }
+
+    private static boolean isMbc5Multicart(RomInfo info) {
+        if (info.data.length != 0x400000
+                || !info.hasValidLogo()
+                || info.byteAt(0x0143) != 0x80
+                || info.rawType() != 0x19
+                || info.declaredRomBanks() != 64
+                || info.physicalRomBanks() != 256
+                || info.byteAt(0x0149) != 0) {
+            return false;
+        }
+        for (int bank = 0x16; bank <= 0x20; bank += 2) {
+            if (!hasLogoAt(info.data, bank * 0x4000 + 0x0104)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isHiddenMmm01(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -139,9 +139,9 @@ public class Mbc5 implements MemoryController {
     @Override
     public int getByte(int address) {
         if (address >= 0x0000 && address < 0x4000) {
-            return getRomByte(0, address);
+            return getRomByte(getRomBankFor0x0000(), address);
         } else if (address >= 0x4000 && address < 0x8000) {
-            return getRomByte(selectedRomBank % romBanks, address - 0x4000);
+            return getRomByte(getRomBankFor0x4000(), address - 0x4000);
         } else if (address >= 0xa000 && address < 0xc000) {
             int ramAddress = getRamAddress(address);
             if (ramAddress < ram.length) {
@@ -162,7 +162,29 @@ public class Mbc5 implements MemoryController {
         }
     }
 
-    private int getRomByte(int bank, int address) {
+    /** Hook for MBC5-derived boards that can remap the normally fixed ROM window. */
+    protected int getRomBankFor0x0000() {
+        return 0;
+    }
+
+    /** Hook for MBC5-derived boards that offset the switchable ROM window. */
+    protected int getRomBankFor0x4000() {
+        return selectedRomBank % romBanks;
+    }
+
+    protected final int getSelectedRomBank() {
+        return selectedRomBank;
+    }
+
+    protected final void setSelectedRomBank(int bank) {
+        selectedRomBank = bank;
+    }
+
+    protected final int normalizeRomBank(int bank) {
+        return Math.floorMod(bank, romBanks);
+    }
+
+    protected int getRomByte(int bank, int address) {
         int cartOffset = bank * 0x4000 + address;
         if (cartOffset < cartridge.length) {
             return cartridge[cartOffset];

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
@@ -19,9 +19,9 @@ import java.util.Arrays;
  * A multi-MBC board with an MBC5 menu and a configuration port in external-RAM space.
  *
  * <p>The menu runs through ordinary MBC5 banking. Before jumping to a selected game it writes a
- * 32 KiB page number, an inverted page mask and a mapper kind to {@code b000}, {@code b100} and
- * {@code b200}. The last write commits a virtual cartridge view; the game then sees its own MBC1,
- * MBC2, MBC3 or MBC5 controller from address zero.</p>
+ * 32 KiB page number, an inverted page mask and a mapper configuration byte to {@code b000},
+ * {@code b100} and {@code b200}. The last write commits a virtual cartridge view; the game then
+ * sees its own controller from address zero.</p>
  */
 public class Mbc5Multicart implements MemoryController {
 
@@ -196,9 +196,10 @@ public class Mbc5Multicart implements MemoryController {
     }
 
     private MemoryController createGame(int mapperMode) {
-        if (mapperMode != MBC1_MODE
-                && mapperMode != MBC2_OR_MBC3_MODE
-                && mapperMode != MBC5_MODE) {
+        int mapperFamily = mapperMode & 0xe0;
+        if (mapperFamily != MBC1_MODE
+                && mapperFamily != MBC2_OR_MBC3_MODE
+                && mapperFamily != MBC5_MODE) {
             return null;
         }
         int romBanks = (pageMask + 1) << 1;
@@ -209,14 +210,17 @@ public class Mbc5Multicart implements MemoryController {
         } catch (IOException e) {
             throw new IllegalStateException("Unable to create selected multicart view", e);
         }
-        return switch (mapperMode) {
-            case MBC1_MODE -> new Mbc1(gameRom, Battery.NULL_BATTERY);
-            case MBC2_OR_MBC3_MODE -> gameRom.getType().isMbc2()
-                    ? new Mbc2(gameRom, Battery.NULL_BATTERY)
-                    : new Mbc3(gameRom, Battery.NULL_BATTERY, guardedTimeSource, clockSpec);
-            case MBC5_MODE -> new Mbc5(gameRom, Battery.NULL_BATTERY);
-            default -> throw new IllegalStateException("Checked mapper mode is unsupported");
-        };
+        if (gameRom.getType().isMbc1()) {
+            return new NtNew(gameRom, Battery.NULL_BATTERY);
+        } else if (gameRom.getType().isMbc2()) {
+            return new Mbc2(gameRom, Battery.NULL_BATTERY);
+        } else if (gameRom.getType().isMbc3()) {
+            return new Mbc3(gameRom, Battery.NULL_BATTERY, guardedTimeSource, clockSpec);
+        } else if (gameRom.getType().isMbc5()) {
+            return new NtNew(gameRom, Battery.NULL_BATTERY);
+        } else {
+            return new BasicRom(gameRom, Battery.NULL_BATTERY);
+        }
     }
 
     private byte[] createGameImage(int baseRomBank, int romBanks) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
@@ -1,0 +1,382 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A multi-MBC board with an MBC5 menu and a configuration port in external-RAM space.
+ *
+ * <p>The menu runs through ordinary MBC5 banking. Before jumping to a selected game it writes a
+ * 32 KiB page number, an inverted page mask and a mapper kind to {@code b000}, {@code b100} and
+ * {@code b200}. The last write commits a virtual cartridge view; the game then sees its own MBC1,
+ * MBC2, MBC3 or MBC5 controller from address zero.</p>
+ */
+public class Mbc5Multicart implements MemoryController {
+
+    private static final int MBC2_OR_MBC3_MODE = 0xa0;
+
+    private static final int MBC5_MODE = 0xc0;
+
+    private static final int MBC1_MODE = 0xe0;
+
+    private final int[] cartridge;
+
+    private final LoaderMbc5 menu;
+
+    private final TimeSource timeSource;
+
+    private final ClockSpec clockSpec;
+
+    private final TimeSource guardedTimeSource;
+
+    private int selectedPage;
+
+    private int pageMask;
+
+    private int selectedMapperMode = -1;
+
+    private MemoryController selectedGame;
+
+    private boolean clockPaused;
+
+    private boolean stateTimeSourceAccessSuppressed;
+
+    private transient EventBus eventBus = EventBus.NULL_EVENT_BUS;
+
+    private transient DebugHooks debugHooks;
+
+    public Mbc5Multicart(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource(), ClockSpec.LEGACY);
+    }
+
+    public Mbc5Multicart(Rom rom, Battery battery, TimeSource timeSource, ClockSpec clockSpec) {
+        this.cartridge = rom.getRom();
+        this.menu = new LoaderMbc5(rom, battery);
+        this.timeSource = timeSource;
+        this.clockSpec = clockSpec;
+        this.guardedTimeSource = () -> stateTimeSourceAccessSuppressed
+                ? 0 : this.timeSource.currentTimeMillis();
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return menu.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (selectedGame != null) {
+            selectedGame.setByte(address, value);
+            return;
+        }
+
+        if (address == 0xb000) {
+            selectedPage = value;
+        } else if (address == 0xb100) {
+            pageMask = ~value & 0xff;
+        } else if (address == 0xb200) {
+            selectGame(value);
+        } else {
+            menu.setByte(address, value);
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        return selectedGame == null ? menu.getByte(address) : selectedGame.getByte(address);
+    }
+
+    /**
+     * This controller may switch to MBC3 after the {@link Cartridge} has cached this value, so it
+     * must remain clocked from power-on even while the menu is active.
+     */
+    @Override
+    public boolean isClocked() {
+        return true;
+    }
+
+    @Override
+    public void tick() {
+        if (selectedGame != null) {
+            selectedGame.tick();
+        }
+    }
+
+    @Override
+    public void setClockPaused(boolean paused) {
+        clockPaused = paused;
+        if (selectedGame != null) {
+            selectedGame.setClockPaused(paused);
+        }
+    }
+
+    @Override
+    public void reanchorClockAfterRestore(boolean paused) {
+        if (selectedGame != null) {
+            selectedGame.reanchorClockAfterRestore(paused);
+        }
+    }
+
+    @Override
+    public void setStateTimeSourceAccessSuppressed(boolean suppressed) {
+        stateTimeSourceAccessSuppressed = suppressed;
+        if (selectedGame != null) {
+            selectedGame.setStateTimeSourceAccessSuppressed(suppressed);
+        }
+    }
+
+    @Override
+    public boolean isRumbleActive() {
+        return selectedGame == null ? menu.isRumbleActive() : selectedGame.isRumbleActive();
+    }
+
+    @Override
+    public void skipBoot() {
+        menu.skipBoot();
+        if (selectedGame != null) {
+            selectedGame.skipBoot();
+        }
+    }
+
+    @Override
+    public void flushRam() {
+        menu.flushRam();
+        if (selectedGame != null) {
+            selectedGame.flushRam();
+        }
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus == null ? EventBus.NULL_EVENT_BUS : eventBus;
+        menu.init(this.eventBus);
+        if (selectedGame != null) {
+            selectedGame.init(this.eventBus);
+        }
+    }
+
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        debugHooks = hooks;
+        menu.setDebugHooks(hooks);
+        if (selectedGame != null) {
+            selectedGame.setDebugHooks(hooks);
+        }
+    }
+
+    /** Returns the selected MBC3 controller when the active game uses one. */
+    public Mbc3 getActiveMbc3() {
+        return selectedGame instanceof Mbc3 mbc3 ? mbc3 : null;
+    }
+
+    private void selectGame(int mapperMode) {
+        MemoryController game = createGame(mapperMode);
+        if (game == null) {
+            return;
+        }
+        selectedMapperMode = mapperMode;
+        selectedGame = game;
+        selectedGame.init(eventBus);
+        selectedGame.setDebugHooks(debugHooks);
+        selectedGame.setStateTimeSourceAccessSuppressed(stateTimeSourceAccessSuppressed);
+        selectedGame.setClockPaused(clockPaused);
+    }
+
+    private MemoryController createGame(int mapperMode) {
+        if (mapperMode != MBC1_MODE
+                && mapperMode != MBC2_OR_MBC3_MODE
+                && mapperMode != MBC5_MODE) {
+            return null;
+        }
+        int romBanks = (pageMask + 1) << 1;
+        int baseRomBank = selectedPage << 1;
+        Rom gameRom;
+        try {
+            gameRom = new Rom(createGameImage(baseRomBank, romBanks));
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create selected multicart view", e);
+        }
+        return switch (mapperMode) {
+            case MBC1_MODE -> new Mbc1(gameRom, Battery.NULL_BATTERY);
+            case MBC2_OR_MBC3_MODE -> gameRom.getType().isMbc2()
+                    ? new Mbc2(gameRom, Battery.NULL_BATTERY)
+                    : new Mbc3(gameRom, Battery.NULL_BATTERY, guardedTimeSource, clockSpec);
+            case MBC5_MODE -> new Mbc5(gameRom, Battery.NULL_BATTERY);
+            default -> throw new IllegalStateException("Checked mapper mode is unsupported");
+        };
+    }
+
+    private byte[] createGameImage(int baseRomBank, int romBanks) {
+        byte[] image = new byte[romBanks * 0x4000];
+        Arrays.fill(image, (byte) 0xff);
+        int source = baseRomBank * 0x4000;
+        int copied = Math.max(0, Math.min(image.length, cartridge.length - source));
+        for (int i = 0; i < copied; i++) {
+            image[i] = (byte) cartridge[source + i];
+        }
+        Integer sizeCode = romSizeCode(romBanks);
+        if (sizeCode != null) {
+            image[0x0148] = sizeCode.byteValue();
+        }
+        return image;
+    }
+
+    private static Integer romSizeCode(int banks) {
+        if (banks < 2 || banks > 512 || Integer.bitCount(banks) != 1) {
+            return null;
+        }
+        return Integer.numberOfTrailingZeros(banks) - 1;
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new Mbc5MulticartState(
+                menu.captureState(),
+                selectedPage,
+                pageMask,
+                selectedMapperMode,
+                selectedGame == null ? null : selectedGame.captureState());
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new Mbc5MulticartState(
+                menu.captureState(capture),
+                selectedPage,
+                pageMask,
+                selectedMapperMode,
+                selectedGame == null ? null : selectedGame.captureState(capture));
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        menu.declareMachineStatePayloads(capture);
+        if (selectedGame != null) {
+            selectedGame.declareMachineStatePayloads(capture);
+        }
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof Mbc5MulticartState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        menu.restoreState(mem.menuState);
+        selectedPage = mem.selectedPage;
+        pageMask = mem.pageMask;
+        selectedMapperMode = mem.selectedMapperMode;
+        if (mem.selectedGameState == null) {
+            selectedGame = null;
+            return;
+        }
+        selectedGame = createGame(selectedMapperMode);
+        if (selectedGame == null) {
+            throw new IllegalArgumentException("Invalid selected multicart mapper mode");
+        }
+        selectedGame.init(eventBus);
+        selectedGame.setDebugHooks(debugHooks);
+        selectedGame.setStateTimeSourceAccessSuppressed(stateTimeSourceAccessSuppressed);
+        selectedGame.setClockPaused(clockPaused);
+        selectedGame.restoreState(mem.selectedGameState);
+    }
+
+    private record Mbc5MulticartState(
+            ComponentState<MemoryController> menuState,
+            int selectedPage,
+            int pageMask,
+            int selectedMapperMode,
+            ComponentState<MemoryController> selectedGameState)
+            implements ComponentState<MemoryController> {
+    }
+
+    /**
+     * The menu first switches a two-bank loader window before that loader writes the external
+     * configuration registers. It remains ordinary MBC5 until the {@code aa} strobe arms it.
+     */
+    private static final class LoaderMbc5 extends Mbc5 {
+
+        private static final int LOADER_BASE_BANK = 0x14;
+
+        private boolean loaderSelectArmed;
+
+        private int loaderBaseBank = -1;
+
+        private LoaderMbc5(Rom rom, Battery battery) {
+            super(rom, battery);
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            value &= 0xff;
+            if (address >= 0x7000 && address < 0x8000 && value == 0xaa) {
+                loaderSelectArmed = true;
+                return;
+            }
+            if (loaderSelectArmed && address >= 0x2000 && address < 0x3000) {
+                loaderBaseBank = LOADER_BASE_BANK + (value << 1);
+                setSelectedRomBank(1);
+                loaderSelectArmed = false;
+                return;
+            }
+            super.setByte(address, value);
+        }
+
+        @Override
+        protected int getRomBankFor0x0000() {
+            return loaderBaseBank < 0 ? 0 : normalizeRomBank(loaderBaseBank);
+        }
+
+        @Override
+        protected int getRomBankFor0x4000() {
+            return loaderBaseBank < 0
+                    ? super.getRomBankFor0x4000()
+                    : normalizeRomBank(loaderBaseBank + getSelectedRomBank());
+        }
+
+        @Override
+        public ComponentState<MemoryController> captureState() {
+            return new LoaderMbc5State(super.captureState(), loaderSelectArmed, loaderBaseBank);
+        }
+
+        @Override
+        public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+            return new LoaderMbc5State(
+                    super.captureState(capture), loaderSelectArmed, loaderBaseBank);
+        }
+
+        @Override
+        public void declareMachineStatePayloads(MachineStateCapture capture) {
+            super.declareMachineStatePayloads(capture);
+        }
+
+        @Override
+        public void restoreState(ComponentState<MemoryController> state) {
+            if (!(state instanceof LoaderMbc5State mem)) {
+                throw new IllegalArgumentException("Invalid state type");
+            }
+            super.restoreState(mem.mbc5State);
+            loaderSelectArmed = mem.loaderSelectArmed;
+            loaderBaseBank = mem.loaderBaseBank;
+        }
+
+        private record LoaderMbc5State(
+                ComponentState<MemoryController> mbc5State,
+                boolean loaderSelectArmed,
+                int loaderBaseBank)
+                implements ComponentState<MemoryController> {
+        }
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNew.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNew.java
@@ -1,0 +1,161 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+import java.util.Arrays;
+
+/**
+ * Newer N&amp;T/Makon mapper used by selected games on multi-game boards.
+ *
+ * <p>It begins with an MBC3-like, 16 KiB switchable ROM window. Writing {@code 55} to
+ * {@code 1400-1fff} changes that window into independently switchable 8 KiB halves, selected
+ * through {@code 2000} and {@code 2400}. This is the board protocol, rather than MBC1's upper
+ * ROM-bank register.</p>
+ */
+public class NtNew implements MemoryController {
+
+    private final int[] rom;
+
+    private final int rom8kBanks;
+
+    private final int[] ram = new int[0x2000];
+
+    private final Battery battery;
+
+    private int lowRomBank = 2;
+
+    private int highRomBank = 3;
+
+    private boolean bank8kMode;
+
+    private boolean ramWriteEnabled;
+
+    private boolean ramUpdated;
+
+    public NtNew(Rom rom, Battery battery) {
+        this.rom = rom.getRom();
+        this.rom8kBanks = Math.max(2, (this.rom.length + 0x1fff) / 0x2000);
+        this.battery = battery;
+        Arrays.fill(ram, 0xff);
+        battery.loadRam(ram);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return (address >= 0x0000 && address < 0x8000)
+                || (address >= 0xa000 && address < 0xc000);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (address >= 0x0000 && address < 0x2000) {
+            if ((address & 0x1f00) == 0x1400 && value == 0x55) {
+                bank8kMode = true;
+            }
+            ramWriteEnabled = (value & 0x0f) == 0x0a;
+        } else if (address >= 0x2000 && address < 0x3000) {
+            selectRomBank(address, value);
+        } else if (address >= 0xa000 && address < 0xc000 && ramWriteEnabled) {
+            ram[address - 0xa000] = value;
+            ramUpdated = true;
+        }
+    }
+
+    private void selectRomBank(int address, int value) {
+        if (!bank8kMode) {
+            int bank = sanitize8kBank(value << 1);
+            lowRomBank = bank;
+            highRomBank = bank | 1;
+            return;
+        }
+        switch (address & 0x0f00) {
+            case 0x0000 -> lowRomBank = sanitize8kBank(value);
+            case 0x0400 -> highRomBank = sanitize8kBank(value);
+            default -> {
+                // Other addresses in the range are not decoded by this board.
+            }
+        }
+    }
+
+    private static int sanitize8kBank(int bank) {
+        return (bank & 0xfe) == 0 ? bank | 2 : bank;
+    }
+
+    @Override
+    public int getByte(int address) {
+        if (address >= 0x0000 && address < 0x4000) {
+            return getRomByte(0, address);
+        } else if (address >= 0x4000 && address < 0x6000) {
+            return getRomByte(lowRomBank, address - 0x4000);
+        } else if (address >= 0x6000 && address < 0x8000) {
+            return getRomByte(highRomBank, address - 0x6000);
+        } else if (address >= 0xa000 && address < 0xc000) {
+            return ramWriteEnabled ? ram[address - 0xa000] : 0xff;
+        }
+        throw new IllegalArgumentException(Integer.toHexString(address));
+    }
+
+    private int getRomByte(int bank, int offset) {
+        int address = Math.floorMod(bank, rom8kBanks) * 0x2000 + offset;
+        return address < rom.length ? rom[address] : 0xff;
+    }
+
+    @Override
+    public void flushRam() {
+        if (ramUpdated) {
+            battery.saveRam(ram);
+            battery.flush();
+        }
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new NtNewState(battery.captureState(), ram.clone(), lowRomBank, highRomBank,
+                bank8kMode, ramWriteEnabled, ramUpdated);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new NtNewState(battery.captureState(capture), capture.ints(ram), lowRomBank,
+                highRomBank, bank8kMode, ramWriteEnabled, ramUpdated);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        battery.declareMachineStatePayloads(capture);
+        capture.declareInts(ram);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof NtNewState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        battery.restoreState(mem.batteryMemento);
+        System.arraycopy(mem.ram, 0, ram, 0, ram.length);
+        lowRomBank = mem.lowRomBank;
+        highRomBank = mem.highRomBank;
+        bank8kMode = mem.bank8kMode;
+        ramWriteEnabled = mem.ramWriteEnabled;
+        ramUpdated = mem.ramUpdated;
+    }
+
+    private record NtNewState(ComponentState<Battery> batteryMemento, int[] ram,
+                              int lowRomBank, int highRomBank, boolean bank8kMode,
+                              boolean ramWriteEnabled, boolean ramUpdated)
+            implements ComponentState<MemoryController> {
+    }
+
+    /** Importer-only compatibility record for released local snapshots. */
+    private record NtNewMemento(Memento<Battery> batteryMemento, int[] ram,
+                                int lowRomBank, int highRomBank, boolean bank8kMode,
+                                boolean ramWriteEnabled, boolean ramUpdated)
+            implements Memento<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5MulticartTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5MulticartTest.java
@@ -1,0 +1,209 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class Mbc5MulticartTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void detectsTheMultiMbcLayout() throws IOException {
+        Rom rom = new Rom(multicartRom());
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.MBC5_MULTICART,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof Mbc5Multicart);
+    }
+
+    @Test
+    public void doesNotDetectTheBoardWithoutItsEmbeddedGameHeaderLayout() throws IOException {
+        byte[] data = multicartRom();
+        data[0x16 * 0x4000 + 0x0104] ^= 1;
+
+        assertFalse(new Rom(data).getCartridgeProperties().getMapper()
+                == CartridgeProperties.Mapper.MBC5_MULTICART);
+    }
+
+    @Test
+    public void keepsTheMenuOnMbc5UntilExternalConfigurationCommitsAGame() throws IOException {
+        MemoryController mapper = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2000, 0x15);
+        assertEquals(0, mapper.getByte(0x0000));
+        assertEquals(0x15, mapper.getByte(0x4000));
+
+        mapper.setByte(0x7000, 0xaa);
+        mapper.setByte(0x2000, 1);
+        assertEquals(0x16, mapper.getByte(0x0000));
+        assertEquals(0x17, mapper.getByte(0x4000));
+
+        mapper.setByte(0xb000, 0x10);
+        mapper.setByte(0xb100, 0xf0);
+        assertEquals(0x16, mapper.getByte(0x0000));
+        assertEquals(0x17, mapper.getByte(0x4000));
+
+        mapper.setByte(0xb200, 0xe1);
+        assertEquals(0x16, mapper.getByte(0x0000));
+
+        mapper.setByte(0xb200, 0xe0);
+        assertEquals(0x20, mapper.getByte(0x0000));
+        assertEquals(0x21, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 0);
+        assertEquals(0x21, mapper.getByte(0x4000));
+
+        mapper.setByte(0x2000, 3);
+        assertEquals(0x20, mapper.getByte(0x0000));
+        assertEquals(0x23, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void selectsMbc3AndMbc5GamesUsingTheBoardMapperMode() throws IOException {
+        MemoryController mbc3 = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mbc3, 0x20, 0xe0, 0xa0);
+        assertEquals(0x40, mbc3.getByte(0x0000));
+        mbc3.setByte(0x2000, 3);
+        assertEquals(0x43, mbc3.getByte(0x4000));
+
+        MemoryController mbc5 = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mbc5, 0x40, 0xe0, 0xc0);
+        assertEquals(0x80, mbc5.getByte(0x0000));
+        mbc5.setByte(0x2000, 3);
+        assertEquals(0x83, mbc5.getByte(0x4000));
+    }
+
+    @Test
+    public void refinesTheSharedMbc3ModeFromTheSelectedGameHeader() throws IOException {
+        MemoryController mbc2 = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mbc2, 0x60, 0xfc, 0xa0);
+        assertEquals(0xc0, mbc2.getByte(0x0000));
+
+        mbc2.setByte(0x2000, 2);
+        assertEquals(0xc1, mbc2.getByte(0x4000));
+        mbc2.setByte(0x2100, 3);
+        assertEquals(0xc3, mbc2.getByte(0x4000));
+        mbc2.setByte(0x0000, 0x0a);
+        mbc2.setByte(0xa000, 0xab);
+        assertEquals(0xfb, mbc2.getByte(0xa000));
+    }
+
+    @Test
+    public void appliesThePageMaskEvenWhenTheEmbeddedHeaderOverstatesItsSize() throws IOException {
+        MemoryController mapper = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mapper, 0, 0xf0, 0xc0);
+
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(1, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void restoresTheSelectedGameAndItsMapperState() throws IOException {
+        Mbc5Multicart mapper = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mapper, 0x68, 0xfc, 0xe0);
+        mapper.setByte(0x2000, 4);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 7);
+        mapper.restoreState(state);
+
+        assertEquals(0xd0, mapper.getByte(0x0000));
+        assertEquals(0xd4, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void exposesAnMbc3RuntimeAfterTheMbc3GameIsSelected() throws IOException {
+        VirtualTimeSource timeSource = new VirtualTimeSource();
+        Cartridge cartridge = new Cartridge(
+                new Rom(multicartRom()), Battery.NULL_BATTERY, timeSource, ClockSpec.LEGACY);
+
+        assertTrue(cartridge.isClocked());
+        configure(cartridge.getMemoryController(), 0x20, 0xe0, 0xa0);
+        assertNotNull(cartridge.captureRtcRuntimeState());
+    }
+
+    @Test
+    public void restoresAnMbc3GameWithoutConsultingTheClockDuringASuppressedTransaction()
+            throws IOException {
+        FailingTimeSource timeSource = new FailingTimeSource();
+        Mbc5Multicart mapper = new Mbc5Multicart(
+                new Rom(multicartRom()), Battery.NULL_BATTERY, timeSource, ClockSpec.LEGACY);
+        configure(mapper, 0x20, 0xe0, 0xa0);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        timeSource.failOnRead = true;
+        mapper.setStateTimeSourceAccessSuppressed(true);
+        mapper.restoreState(state);
+
+        assertEquals(0x40, mapper.getByte(0x0000));
+    }
+
+    private static void configure(MemoryController mapper, int page, int invertedMask, int mode) {
+        mapper.setByte(0xb000, page);
+        mapper.setByte(0xb100, invertedMask);
+        mapper.setByte(0xb200, mode);
+    }
+
+    private static byte[] multicartRom() {
+        byte[] data = new byte[256 * 0x4000];
+        for (int bank = 0; bank < 256; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        putHeader(data, 0, 0x19, 0x05);
+        for (int bank = 0x16; bank <= 0x20; bank += 2) {
+            putHeader(data, bank, 0x19, 0x05);
+        }
+        putHeader(data, 0x20, 0x01, 0x04);
+        putHeader(data, 0x40, 0x10, 0x05);
+        putHeader(data, 0x80, 0x1c, 0x05);
+        putHeader(data, 0xc0, 0x06, 0x02);
+        putHeader(data, 0xd0, 0x01, 0x02);
+        return data;
+    }
+
+    private static void putHeader(byte[] data, int bank, int type, int size) {
+        int base = bank * 0x4000;
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[base + 0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        data[base + 0x0143] = (byte) 0x80;
+        data[base + 0x0147] = (byte) type;
+        data[base + 0x0148] = (byte) size;
+    }
+
+    private static final class FailingTimeSource implements TimeSource {
+
+        private boolean failOnRead;
+
+        @Override
+        public long currentTimeMillis() {
+            if (failOnRead) {
+                throw new AssertionError("unexpected wall-clock read");
+            }
+            return 1;
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5MulticartTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5MulticartTest.java
@@ -66,7 +66,7 @@ public class Mbc5MulticartTest {
         assertEquals(0x16, mapper.getByte(0x0000));
         assertEquals(0x17, mapper.getByte(0x4000));
 
-        mapper.setByte(0xb200, 0xe1);
+        mapper.setByte(0xb200, 0x80);
         assertEquals(0x16, mapper.getByte(0x0000));
 
         mapper.setByte(0xb200, 0xe0);
@@ -82,6 +82,16 @@ public class Mbc5MulticartTest {
     }
 
     @Test
+    public void acceptsLowConfigurationBitsForPlainRomGames() throws IOException {
+        MemoryController mapper = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+
+        configure(mapper, 0x0c, 0xff, 0xe8);
+
+        assertEquals(0x18, mapper.getByte(0x0000));
+        assertEquals(0x19, mapper.getByte(0x4000));
+    }
+
+    @Test
     public void selectsMbc3AndMbc5GamesUsingTheBoardMapperMode() throws IOException {
         MemoryController mbc3 = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
         configure(mbc3, 0x20, 0xe0, 0xa0);
@@ -94,6 +104,19 @@ public class Mbc5MulticartTest {
         assertEquals(0x80, mbc5.getByte(0x0000));
         mbc5.setByte(0x2000, 3);
         assertEquals(0x83, mbc5.getByte(0x4000));
+    }
+
+    @Test
+    public void usesTheNAndT8KiBProtocolForMbc5HeaderGames() throws IOException {
+        MemoryController mapper = new Mbc5Multicart(new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mapper, 0x40, 0xe0, 0xc0);
+
+        mapper.setByte(0x1400, 0x55);
+        mapper.setByte(0x2000, 0x06);
+        mapper.setByte(0x2400, 0x07);
+
+        assertEquals(0x83, mapper.getByte(0x4000));
+        assertEquals(0x83, mapper.getByte(0x6000));
     }
 
     @Test
@@ -171,11 +194,13 @@ public class Mbc5MulticartTest {
         byte[] data = new byte[256 * 0x4000];
         for (int bank = 0; bank < 256; bank++) {
             data[bank * 0x4000] = (byte) bank;
+            data[bank * 0x4000 + 0x2000] = (byte) bank;
         }
         putHeader(data, 0, 0x19, 0x05);
         for (int bank = 0x16; bank <= 0x20; bank += 2) {
             putHeader(data, bank, 0x19, 0x05);
         }
+        putHeader(data, 0x18, 0x00, 0x00);
         putHeader(data, 0x20, 0x01, 0x04);
         putHeader(data, 0x40, 0x10, 0x05);
         putHeader(data, 0x80, 0x1c, 0x05);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
@@ -1,0 +1,60 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class NtNewTest {
+
+    @Test
+    public void changesFromA16KiBWindowToIndependent8KiBWindows() throws IOException {
+        NtNew mapper = new NtNew(new Rom(romWith8kPageMarkers()), Battery.NULL_BATTERY);
+
+        assertEquals(0, mapper.getByte(0x0000));
+        assertEquals(2, mapper.getByte(0x4000));
+        assertEquals(3, mapper.getByte(0x6000));
+
+        mapper.setByte(0x2000, 0x10);
+        assertEquals(0x20, mapper.getByte(0x4000));
+        assertEquals(0x21, mapper.getByte(0x6000));
+
+        mapper.setByte(0x1400, 0x55);
+        mapper.setByte(0x2000, 0x04);
+        mapper.setByte(0x2400, 0x05);
+        assertEquals(0x04, mapper.getByte(0x4000));
+        assertEquals(0x05, mapper.getByte(0x6000));
+    }
+
+    @Test
+    public void restoresTheIndependent8KiBWindowState() throws IOException {
+        NtNew mapper = new NtNew(new Rom(romWith8kPageMarkers()), Battery.NULL_BATTERY);
+        mapper.setByte(0x1400, 0x55);
+        mapper.setByte(0x2000, 0x0a);
+        mapper.setByte(0x2400, 0x0b);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 0x12);
+        mapper.setByte(0x2400, 0x13);
+        mapper.restoreState(state);
+
+        assertEquals(0x0a, mapper.getByte(0x4000));
+        assertEquals(0x0b, mapper.getByte(0x6000));
+    }
+
+    private static byte[] romWith8kPageMarkers() {
+        byte[] data = new byte[64 * 0x2000];
+        for (int page = 0; page < 64; page++) {
+            Arrays.fill(data, page * 0x2000, (page + 1) * 0x2000, (byte) page);
+        }
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x04;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #538

## Symptom

In CGB mode, multiple menu entries on the reported Super Color 26-in-1 multicart either reached a white screen or started the wrong game. For example, Pokémon Golden 2 showed white and the second-page Alleyway entry started Tetris.

## Cause

The menu configuration byte contains flag bits, so valid values such as `E8` were incorrectly rejected. More importantly, selected MBC1- and MBC5-header games use the newer N&T/Makon protocol: after `1400=55`, the `2000` and `2400` ports independently select the two 8 KiB halves of the switchable ROM window. Treating those writes as ordinary MBC1/MBC5 banking maps the wrong code page.

## Change

- Accept the configuration-byte family while retaining its low flag bits, including the plain-ROM entries.
- Add the N&T/Makon 8 KiB split-window mapper and use it for the affected selected-game headers.
- Preserve its state through rewind and portable snapshots.

## Regression coverage

Added mapper tests for the 8 KiB handoff, MBC5-header descendants, flag-bearing plain-ROM entries, and state restoration across menu, RTC, and N&T/Makon child mappers.

## Validation

- `/opt/maven/bin/mvn -pl core test`
- `/opt/maven/bin/mvn -q -pl controller -am -Dtest=Mbc5MulticartStateTest,StateCoverageMatrixTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2`
- Local CGB replay of the supplied attachment: all 26 entries across all three menu pages reached their title or intro screens. Pokémon Golden 2, Street Fighter II, and Alleyway were specifically rechecked.

No screenshot is attached because it would be derived from the supplied commercial ROM.