### PR TITLE
Detect Vast Fame SL multicarts

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -387,11 +387,15 @@ public final class CartridgeProperties {
                 'P', 'O', 'K', 'E', 'M', 'O', 'N', '_',
                 'G', 'L', 'D', 'A', 'A', 'U', 'J'
         };
-        return info.data.length == 0x400000
+        boolean pokemon36In1 = info.data.length == 0x400000
                 && matches(info.data, 0x0134, title)
                 && info.byteAt(0x0143) == 0x80
                 && info.rawType() == 0x10
                 && info.byteAt(0x0148) == 0x06;
+        boolean vastFameMulticart = (info.data.length == 0x800000
+                || info.data.length == 0x1000000)
+                && info.title().startsWith("TIMER MONSTER");
+        return pokemon36In1 || vastFameMulticart;
     }
 
     private static boolean isBhgosMulticart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticartTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/SlMulticartTest.java
@@ -57,6 +57,25 @@ public class SlMulticartTest {
     }
 
     @Test
+    public void detectsVastFameTimerMonsterMulticarts() throws IOException {
+        assertEquals(CartridgeProperties.Mapper.SL_MULTICART,
+                new Rom(timerMonsterRom(0x800000)).getCartridgeProperties().getMapper());
+        assertEquals(CartridgeProperties.Mapper.SL_MULTICART,
+                new Rom(timerMonsterRom(0x1000000)).getCartridgeProperties().getMapper());
+    }
+
+    private static byte[] timerMonsterRom(int size) {
+        byte[] rom = new byte[size];
+        byte[] title = "TIMER MONSTER  ".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, rom, 0x0134, title.length);
+        rom[0x0143] = (byte) 0x80;
+        rom[0x0147] = 0x1b;
+        rom[0x0148] = 0x06;
+        rom[0x0149] = 0x01;
+        return rom;
+    }
+
+    @Test
     public void configurationRelocatesBothRomWindowsAndUsesMbc1ZeroRemap()
             throws IOException {
         Cartridge cart = cartridge();


### PR DESCRIPTION
## Summary

The supplied **Yin Ban Zhongwen RPG Zhanlve + Dongzuo + Yizhi 12 in 1** CGB image booted the first embedded game instead of showing its 12-item menu.

The cartridge is part of the Vast Fame `TIMER MONSTER` family that uses the SL/"Last Bible" multicart command protocol. Coffee GB already implements that controller, but its detector only recognized the separate 4 MiB `POKEMON_GLDAAUJ` SL signature. This 8 MiB image therefore fell back to ordinary MBC5, which ignored the menu-selection command ports and continued executing game 1.

Recognize the known 8 MiB and 16 MiB `TIMER MONSTER` family as `SL_MULTICART`. No mapper behavior or timing code changes.

## Regression coverage

- Added synthetic detection coverage for both known physical sizes.
- Before the fix, `SlMulticartTest` failed because the image was classified as `STANDARD`.
- After the fix, the focused mapper suite passes.
- The complete core unit suite passes.

Commands:

```
/opt/maven/bin/mvn -pl core -Dtest=SlMulticartTest test
/opt/maven/bin/mvn -pl core test
```

Results:

- Focused: 6 tests, 0 failures
- Core: 1,598 tests, 0 failures, 8 skipped

## Reproduction

Using the exact ROM attached to #551 with normal CGB boot:

- Master, frame 220: the first embedded game's opening text is displayed; no menu appears.
- This branch, frame 220: the 12-item Chinese multicart menu is displayed.
- Pressing A on item 1 at frame 220 successfully resets into that selected game.

## Visual evidence

Same normal-CGB configuration at frame 220:

| Before | After |
| --- | --- |
| ![Before: game 1 boots directly](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Yin_Ban_Zhongwen_RPG_Zhanlve_Dongzuo_Yizhi_12_in_1_Unl_gbc_f220-c8a4c58a.png) | ![After: the 12-item multicart menu appears](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Yin_Ban_Zhongwen_RPG_Zhanlve_Dongzuo_Yizhi_12_in_1_Unl_gbc_f220-03c3ba2d.png) |
| The cartridge skips its menu and boots game 1 directly. | The 12-item multicart menu is available. |

Fixes #551

