### PR TITLE
Fix Sonic Adventure 8 mapper detection

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -432,12 +432,25 @@ public final class CartridgeProperties {
                 || info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0
-                || isSuperMarioSpecial3(info);
+                || isSuperMarioSpecial3(info)
+                || isSonicAdventure8(info);
     }
 
     private static boolean isSuperMarioSpecial3(RomInfo info) {
         return info.data.length == 0x80000
                 && "SUPER MARIO 3".equals(info.title())
+                && info.byteAt(0x0143) == 0x80
+                && info.byteAt(0x0144) == 'M'
+                && info.byteAt(0x0145) == 'K'
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x03
+                && info.byteAt(0x0149) == 0x00;
+    }
+
+    private static boolean isSonicAdventure8(RomInfo info) {
+        return info.data.length == 0x80000
+                && "SONIC 7".equals(info.title())
                 && info.byteAt(0x0143) == 0x80
                 && info.byteAt(0x0144) == 'M'
                 && info.byteAt(0x0145) == 'K'

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MakonNtOld2Test {
@@ -83,6 +84,24 @@ public class MakonNtOld2Test {
                 rom.getCartridgeProperties().getMapper());
         assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
                 .getMemoryController() instanceof MakonNtOld2);
+    }
+
+    @Test
+    public void detectedSonicAdventure8ControlsRumble() throws IOException {
+        Cartridge cartridge = new Cartridge(
+                new Rom(sonicAdventure8Rom("SONIC 7")), Battery.NULL_BATTERY);
+        List<Boolean> motorLog = new ArrayList<>();
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        bus.register(event -> motorLog.add(event.on()), RumbleEvent.class);
+        cartridge.init(bus);
+
+        cartridge.setByte(0x5001, 0x80); // enable the Rumble Version's mapper mode
+        cartridge.setByte(0x4000, 0x02); // old mode's motor bit
+        assertTrue(cartridge.isRumbleActive());
+        cartridge.setByte(0x4000, 0x00);
+        assertFalse(cartridge.isRumbleActive());
+
+        assertEquals(List.of(true, false), motorLog);
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -76,8 +76,26 @@ public class MakonNtOld2Test {
     }
 
     @Test
+    public void detectsSonicAdventure8SingleCart() throws IOException {
+        Rom rom = new Rom(sonicAdventure8Rom("SONIC 7"));
+
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_OLD_2,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof MakonNtOld2);
+    }
+
+    @Test
     public void doesNotDetectSuperMarioSpecial3FromLicenseeAlone() throws IOException {
         byte[] data = superMarioSpecial3Rom("ANOTHER GAME");
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                new Rom(data).getCartridgeProperties().getMapper());
+    }
+
+    @Test
+    public void doesNotDetectSonicAdventure8FromLicenseeAlone() throws IOException {
+        byte[] data = sonicAdventure8Rom("ANOTHER GAME");
 
         assertEquals(CartridgeProperties.Mapper.STANDARD,
                 new Rom(data).getCartridgeProperties().getMapper());
@@ -185,6 +203,18 @@ public class MakonNtOld2Test {
     }
 
     private static byte[] superMarioSpecial3Rom(String title) {
+        byte[] data = new byte[32 * 0x4000];
+        byte[] titleBytes = title.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(titleBytes, 0, data, 0x0134, titleBytes.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0144] = 'M';
+        data[0x0145] = 'K';
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x03;
+        return data;
+    }
+
+    private static byte[] sonicAdventure8Rom(String title) {
         byte[] data = new byte[32 * 0x4000];
         byte[] titleBytes = title.getBytes(StandardCharsets.US_ASCII);
         System.arraycopy(titleBytes, 0, data, 0x0134, titleBytes.length);


### PR DESCRIPTION
## Compatibility symptom

The supplied `Sonic Adventure 8 (Taiwan) (En) (Rumble Version) (Unl).gbc` image did not reach a usable title screen in CGB-compatible mode. On Coffee GB master (`3f0804a2`), a deterministic SKIP-bootstrap run remained on red/white horizontally corrupted graphics through frame 600.

## Root cause and fix

The header advertises ordinary MBC1 hardware, so Coffee GB selected the standard mapper. This Rumble Version instead uses the Makon/NT old type-2 banking layout, which Coffee GB already implements, including its mapper-controlled rumble motor. The mismatched bank mapping supplied corrupt graphics and left the rumble protocol unreachable.

The PR adds a narrow fingerprint for this exact header shape and routes it to the Makon/NT old type-2 controller. It also verifies that the detected Sonic cartridge enables the motor through `0x5001`, drives it with the old-mode register bit, emits `RumbleEvent(true)`/`RumbleEvent(false)`, and reports the matching active state. A near-miss test keeps detection narrow.

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=MakonNtOld2Test test` — 13 passed.
- `/opt/maven/bin/mvn -pl core test` — 1,731 run; 0 failures, 0 errors, 8 skipped.
- The original deterministic CGB SKIP-bootstrap reproduction changed from persistent red/white corruption to the complete Sonic artwork and `SONIC 8 ADVENTURE` title screen; scripted input reached Zone 1.

## Visual evidence

Same CGB-compatible SKIP configuration at frame 600:

| Before | After |
| --- | --- |
| ![Before: red horizontal corruption](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Sonic_Adventure_8_Taiwan_En_Rumble_Version_Unl_gbc_f600-98d29cd6.png) | ![After: Sonic title artwork renders correctly](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Sonic_Adventure_8_Taiwan_En_Rumble_Version_Unl_gbc_f600-64dd0b98.png) |
| Red horizontal corruption prevents a usable title screen. | The complete Sonic artwork and title render correctly. |

Fixes #555
