### PR TITLE
Fix Super Mario Special 3 mapper detection

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -431,7 +431,20 @@ public final class CartridgeProperties {
                 || headerCrc == 0x0b1b808a // Super Donkey Kong 5 (rumble)
                 || info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
-                && info.byteAt(0x0102) == 0xe0;
+                && info.byteAt(0x0102) == 0xe0
+                || isSuperMarioSpecial3(info);
+    }
+
+    private static boolean isSuperMarioSpecial3(RomInfo info) {
+        return info.data.length == 0x80000
+                && "SUPER MARIO 3".equals(info.title())
+                && info.byteAt(0x0143) == 0x80
+                && info.byteAt(0x0144) == 'M'
+                && info.byteAt(0x0145) == 'K'
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x03
+                && info.byteAt(0x0149) == 0x00;
     }
 
     private static boolean isMakonNtNew(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/MakonNtOld2Test.java
@@ -66,6 +66,24 @@ public class MakonNtOld2Test {
     }
 
     @Test
+    public void detectsSuperMarioSpecial3SingleCart() throws IOException {
+        Rom rom = new Rom(superMarioSpecial3Rom("SUPER MARIO 3"));
+
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_OLD_2,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(new Cartridge(rom, Battery.NULL_BATTERY)
+                .getMemoryController() instanceof MakonNtOld2);
+    }
+
+    @Test
+    public void doesNotDetectSuperMarioSpecial3FromLicenseeAlone() throws IOException {
+        byte[] data = superMarioSpecial3Rom("ANOTHER GAME");
+
+        assertEquals(CartridgeProperties.Mapper.STANDARD,
+                new Rom(data).getCartridgeProperties().getMapper());
+    }
+
+    @Test
     public void masksBanksToTheSelectedGameSizeAndSupportsAlternateWiring()
             throws IOException {
         MemoryController mapper = new MakonNtOld2(
@@ -163,6 +181,18 @@ public class MakonNtOld2Test {
         data[0x0143] = (byte) 0x80;
         data[0x0147] = 0x19; // MBC5 in the menu's standard header
         data[0x0148] = 0x06; // 2 MiB
+        return data;
+    }
+
+    private static byte[] superMarioSpecial3Rom(String title) {
+        byte[] data = new byte[32 * 0x4000];
+        byte[] titleBytes = title.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(titleBytes, 0, data, 0x0134, titleBytes.length);
+        data[0x0143] = (byte) 0x80;
+        data[0x0144] = 'M';
+        data[0x0145] = 'K';
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x03;
         return data;
     }
 


### PR DESCRIPTION
## Compatibility symptom

The supplied `Super Mario Special 3 (Taiwan) (En) (Unl).gbc` image reaches its title scene in CGB-compatible mode, but the stage-map graphics fail after pressing START. On Coffee GB master (`3f0804a2`), a deterministic SKIP-bootstrap replay with START pressed at frame 650 reached frame 700 with only two sprite fragments on an otherwise cyan field; the map background and UI were absent.

## Root cause

The cartridge header advertises ordinary MBC1 hardware, so Coffee GB selected the standard mapper. This release actually uses the Makon/NT old type-2 banking layout; the mismatched bank mapping reads the wrong character data. The same title is classified in the Makon/NT old type-2 group by [hhugboy's cartridge detector](https://github.com/tzlion/hhugboy/blob/b54549b70faf49ff73029f3cf7861d82e1a24543/src/memory/CartDetection.cpp).

Coffee GB already implements this mapper. The patch adds a narrow fingerprint using the supplied image's stable header metadata (physical size, internal title, CGB flag, licensee, SGB flag, declared mapper/ROM/RAM sizes), then routes only that fingerprint to the existing mapper. A near-miss regression test verifies that the licensee metadata alone does not broaden detection.

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=MakonNtOld2Test test` — 10 tests passed.
- `/opt/maven/bin/mvn -pl core test` — 1,599 tests run; 0 failures, 0 errors, 8 skipped.
- Deterministic matched-input reproduction with `ShotMain`, CGB-compatible SKIP bootstrap, battery saves disabled, and `START` held from frame 650 through 654:
  - before: frame 700 showed only two sprite fragments on a cyan field; the stage-map background and UI were absent;
  - after: frame 700 showed the complete stage map, paths, scenery, labels, and character marker.
- The master frame reproduced byte-identically, and a fresh fixed run matched the original after-fix capture.

## Visual evidence

Same CGB-compatible SKIP configuration and START-at-frame-650 input, captured at frame 700:

| Before | After |
| --- | --- |
| ![Before: stage-map background and UI are missing](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Super_Mario_Special_3_Taiwan_En_Unl_gbc_f700-221c26df.png) | ![After: complete stage map renders](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Super_Mario_Special_3_Taiwan_En_Unl_gbc_f700-1ae537cb.png) |
| Only two sprite fragments remain on a cyan field. | The complete map, paths, scenery, labels, and marker render correctly. |

Fixes #557

