### PR TITLE
Fix Unlicensed 256M multicart game loading

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -120,6 +120,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState",
           "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$LoaderMbc5\$LoaderMbc5State",
           "eu.rekawek.coffeegb.core.memory.cart.type.NtNew\$NtNewState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Unlicensed256M\$Unlicensed256MState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -1131,7 +1131,7 @@ internal object StateGraph {
       if (candidate === NullState || target === NullState) {
         if (candidate !== target &&
             !isAuditedNullable(owner, field, element) &&
-            !isDynamicMbc5MulticartGameState(owner, field)) {
+            !isDynamicMulticartGameState(owner, field)) {
           throw StateApplyException("$path has incompatible state presence")
         }
         return
@@ -1146,7 +1146,7 @@ internal object StateGraph {
             return
           }
           if (candidate.typeId != target.typeId) {
-            if (isDynamicMbc5MulticartGameState(owner, field)) {
+            if (isDynamicMulticartGameState(owner, field)) {
               // This board commits a selected game by replacing its virtual child mapper. The
               // candidate record has already passed the child-mapper policy; its type is not a
               // target-owned invariant of the surrounding physical cartridge.
@@ -1320,8 +1320,8 @@ internal object StateGraph {
       owner to field in if (element) AUDITED_NULLABLE_ELEMENTS else AUDITED_NULLABLE_FIELDS
 
   /** The board's committed child mapper can be absent or one of several native MBC records. */
-  private fun isDynamicMbc5MulticartGameState(owner: String?, field: String?): Boolean =
-      owner == MBC5_MULTICART_STATE && field == "selectedGameState"
+  private fun isDynamicMulticartGameState(owner: String?, field: String?): Boolean =
+      owner in DYNAMIC_MULTICART_STATES && field == "selectedGameState"
 
   private val VARIABLE_ARRAY_FIELDS =
       setOf(
@@ -1373,8 +1373,11 @@ internal object StateGraph {
   private const val FILE_BATTERY_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
 
-  private const val MBC5_MULTICART_STATE =
-      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
+  private val DYNAMIC_MULTICART_STATES =
+      setOf(
+          "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Unlicensed256M\$Unlicensed256MState",
+      )
 
   /**
    * Exact nullable locations in the pinned legacy graph. Nullability is a field contract, not a

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/MachineSnapshot.kt
@@ -727,7 +727,7 @@ private object SnapshotGraph {
           val type = recordClassName(value.typeId)
           if (isOwnershipRecord(type)) signature += value.typeId
           value.fields.forEach { field ->
-            if (!isDynamicMbc5MulticartGameState(type, field.name)) visit(field.value)
+            if (!isDynamicMulticartGameState(type, field.name)) visit(field.value)
           }
         }
         is SnapshotValues -> value.values.forEach(::visit)
@@ -750,7 +750,7 @@ private object SnapshotGraph {
           val type = value.javaClass.name
           if (isOwnershipRecord(type)) signature += typeId
           StateRecordIntrospection.components(value.javaClass).forEach { component ->
-            if (!isDynamicMbc5MulticartGameState(type, component.name)) {
+            if (!isDynamicMulticartGameState(type, component.name)) {
               visit(component.value(value))
             }
           }
@@ -773,11 +773,14 @@ private object SnapshotGraph {
       name.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.") ||
           name.startsWith("eu.rekawek.coffeegb.core.memory.cart.battery.")
 
-  private fun isDynamicMbc5MulticartGameState(owner: String, field: String): Boolean =
-      owner == MBC5_MULTICART_STATE && field == "selectedGameState"
+  private fun isDynamicMulticartGameState(owner: String, field: String): Boolean =
+      owner in DYNAMIC_MULTICART_STATES && field == "selectedGameState"
 
-  private const val MBC5_MULTICART_STATE =
-      "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
+  private val DYNAMIC_MULTICART_STATES =
+      setOf(
+          "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Unlicensed256M\$Unlicensed256MState",
+      )
 
   private class Restore {
     private var references = 0L

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1628,6 +1628,27 @@ internal object StateSemantics {
             }
           }
         }
+    target[UNLICENSED_256M_STATE] =
+        constrained("The 256 Mbit board retains one shared 512 KiB SRAM image and a dynamically selected native mapper.") {
+          it.requiredRecordType("menuState", MBC5_STATE)
+          it.require(it.intArray("sharedRam").size == 0x80000,
+              "must have the board's full 512 KiB SRAM image")
+          it.intValues("sharedRam", 0, 0xff)
+          it.range("selectedPage", 0, 0x3ff); it.range("pageMask", 0, 0xff)
+          val configuration = it.int("configuration")
+          it.require(configuration == -1 || configuration in 0..0xff,
+              "has an invalid configuration $configuration")
+          if (configuration == -1) {
+            it.require(it.value("selectedGameState") == null,
+                "has a selected game without a committed configuration")
+          } else {
+            it.require((it.int("selectedPage") ushr 8) == (configuration and 0x03),
+                "has page bits inconsistent with its configuration")
+            it.requiredRecordType(
+                "selectedGameState", MBC1_STATE, MBC2_STATE, MBC3_STATE,
+                MBC5_STATE, BASIC_ROM_STATE)
+          }
+        }
     target[NTNEW_STATE] =
         constrained("Newer N&T/Makon banking retains two byte-sized 8 KiB selectors and one RAM page.") {
           it.recordType("batteryMemento", MEMORY_BATTERY_STATE, FILE_BATTERY_STATE)
@@ -1854,6 +1875,8 @@ internal object StateSemantics {
   private const val NTNEW_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.NtNew\$NtNewState"
   private const val MBC5_MULTICART_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
+  private const val UNLICENSED_256M_STATE =
+      "eu.rekawek.coffeegb.core.memory.cart.type.Unlicensed256M\$Unlicensed256MState"
   private const val MBC5_MULTICART_LOADER_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$LoaderMbc5\$LoaderMbc5State"
   private const val MBC5_MULTICART_MBC2_OR_MBC3_MODE = 0xa0

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -61,6 +61,26 @@ class StateCoverageMatrixTest {
               Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
             },
             mapper(
+                "Unlicensed256M",
+                listOf(
+                    0x7000 to 0x60,
+                    0x7001 to 0xe0,
+                    0x7002 to 0x91,
+                    0x2000 to 0x03,
+                    0x0000 to 0x0a,
+                    0x4000 to 0x02,
+                    0xa000 to 0x2a,
+                ),
+                listOf(0x0100, 0x4000, 0xa000),
+            ) {
+              Unlicensed256M(
+                  unlicensed256MFixture(),
+                  Battery.NULL_BATTERY,
+                  VirtualTimeSource(120_000),
+                  ClockSpec.LEGACY,
+              )
+            },
+            mapper(
                 "Mbc5Multicart",
                 listOf(
                     0xb000 to 0x20,
@@ -222,7 +242,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(32, registeredMapperRecords.size)
+    assertEquals(33, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -811,6 +831,17 @@ class StateCoverageMatrixTest {
     return Rom(bytes)
   }
 
+  private fun unlicensed256MFixture(): Rom {
+    val bytes = ByteArray(0x400000)
+    repeat(bytes.size / 0x4000) { bank -> bytes[bank * 0x4000] = bank.toByte() }
+    val selected = 0xc0 * 0x4000
+    bytes[selected + 0x143] = 0x80.toByte()
+    bytes[selected + 0x147] = 0x1b
+    bytes[selected + 0x148] = 0x05
+    bytes[selected + 0x149] = 0x03
+    return Rom(bytes)
+  }
+
   private companion object {
     const val MBC5_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
     const val MBC6_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc6\$Mbc6State"
@@ -829,6 +860,7 @@ class StateCoverageMatrixTest {
             "Mbc2",
             "Mbc3",
             "Mbc5",
+            "Unlicensed256M",
             "Mbc5Multicart",
             "LiCheng",
             "XploderGb",

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Unlicensed256MStateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Unlicensed256MStateTest.kt
@@ -1,0 +1,93 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.GameboyType
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class Unlicensed256MStateTest {
+
+  @Test
+  fun portableAndInProcessSnapshotsRestoreAcrossTheMenuAndSelectedGame() {
+    val configuration = StateCodecTestSupport.configuration(multicartRom(), GameboyType.CGB)
+    StateCodecTestSupport.session(configuration).use { session ->
+      val gameboy = session.gameboy
+      val menuSnapshot = MachineSnapshot.capture(gameboy)
+      val menuState = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      select(gameboy, 0x91)
+      gameboy.addressSpace.setByte(0x2000, 0x03)
+      gameboy.addressSpace.setByte(0x0000, 0x0a)
+      gameboy.addressSpace.setByte(0x4000, 0x02)
+      gameboy.addressSpace.setByte(0xa123, 0x5a)
+      assertEquals(0xc3, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x5a, gameboy.addressSpace.getByte(0xa123))
+      val selectedSnapshot = MachineSnapshot.capture(gameboy, menuSnapshot)
+      val selectedState = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      menuSnapshot.restore(gameboy)
+      assertEquals(0x01, gameboy.addressSpace.getByte(0x4000))
+      selectedSnapshot.restore(gameboy)
+      assertEquals(0xc3, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x5a, gameboy.addressSpace.getByte(0xa123))
+
+      StateCodec.decodeAndApply(menuState, configuration, gameboy)
+      assertEquals(0x01, gameboy.addressSpace.getByte(0x4000))
+      select(gameboy, 0x91)
+      gameboy.addressSpace.setByte(0x0000, 0x0a)
+      gameboy.addressSpace.setByte(0x4000, 0x02)
+      gameboy.addressSpace.setByte(0xa123, 0x2a)
+      StateCodec.decodeAndApply(selectedState, configuration, gameboy)
+      assertEquals(0xc3, gameboy.addressSpace.getByte(0x4000))
+      assertEquals(0x5a, gameboy.addressSpace.getByte(0xa123))
+    }
+  }
+
+  private fun select(gameboy: Gameboy, configuration: Int) {
+    gameboy.addressSpace.setByte(0x7000, 0x60)
+    gameboy.addressSpace.setByte(0x7001, 0xe0)
+    gameboy.addressSpace.setByte(0x7002, configuration)
+  }
+
+  private fun multicartRom(): ByteArray = ByteArray(0x400000).also { data ->
+    repeat(data.size / 0x4000) { bank -> data[bank * 0x4000] = bank.toByte() }
+    putHeader(data, 0, "GB HiCol", 0x03, 0x01, 0x00)
+    data[0x100] = 0x00
+    data[0x101] = 0xc3.toByte()
+    data[0x102] = 0x00
+    data[0x103] = 0x40
+    putHeader(data, 0xc0, "SELECTED", 0x1b, 0x05, 0x03)
+  }
+
+  private fun putHeader(
+      data: ByteArray,
+      bank: Int,
+      title: String,
+      type: Int,
+      romSize: Int,
+      ramSize: Int,
+  ) {
+    val base = bank * 0x4000
+    NINTENDO_LOGO.copyInto(data, base + 0x104)
+    title.forEachIndexed { index, character ->
+      data[base + 0x134 + index] = character.code.toByte()
+    }
+    data[base + 0x143] = 0x80.toByte()
+    data[base + 0x147] = type.toByte()
+    data[base + 0x148] = romSize.toByte()
+    data[base + 0x149] = ramSize.toByte()
+  }
+
+  private companion object {
+    val NINTENDO_LOGO =
+        byteArrayOf(
+            0xce.toByte(), 0xed.toByte(), 0x66, 0x66, 0xcc.toByte(), 0x0d, 0, 0x0b,
+            0x03, 0x73, 0, 0x83.toByte(), 0, 0x0c, 0, 0x0d,
+            0, 0x08, 0x11, 0x1f, 0x88.toByte(), 0x89.toByte(), 0, 0x0e,
+            0xdc.toByte(), 0xcc.toByte(), 0x6e, 0xe6.toByte(), 0xdd.toByte(), 0xdd.toByte(),
+            0xd9.toByte(), 0x99.toByte(), 0xbb.toByte(), 0xbb.toByte(), 0x67, 0x63, 0x6e,
+            0x0e, 0xec.toByte(), 0xcc.toByte(), 0xdd.toByte(), 0xdc.toByte(), 0x99.toByte(),
+            0x9f.toByte(), 0xbb.toByte(), 0xb9.toByte(), 0x33, 0x3e,
+        )
+  }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -395,6 +395,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             if (mapper == CartridgeProperties.Mapper.SL_MULTICART) {
                 ramSize = 0x20000;
             }
+            if (mapper == CartridgeProperties.Mapper.UNLICENSED_256M) {
+                ramSize = 0x80000;
+            }
             if (xploderGb) {
                 ramSize = 0x20000;
             }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -93,6 +93,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case HIDDEN_MMM01 -> new Mmm01(rom, battery, false);
             case MANI_32K_MULTICART -> new Mani32kMulticart(rom);
             case SL_MULTICART -> new SlMulticart(rom, battery);
+            case UNLICENSED_256M -> new Unlicensed256M(
+                    rom, battery, rtcTimeSource, clockSpec);
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
@@ -288,7 +290,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
      * The regular validation remains strict once the mapper state has been restored.
      */
     public void validateRtcRuntimeStateForRestoreCandidate(RealTimeClock.RuntimeState state) {
-        if (addressSpace instanceof Mbc5Multicart) {
+        if (addressSpace instanceof Mbc5Multicart
+                || addressSpace instanceof Unlicensed256M) {
             if (state != null) {
                 validateRtcPauseBoundary(state);
             }
@@ -316,6 +319,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             return mbc3;
         }
         if (addressSpace instanceof Mbc5Multicart multicart) {
+            return multicart.getActiveMbc3();
+        }
+        if (addressSpace instanceof Unlicensed256M multicart) {
             return multicart.getActiveMbc3();
         }
         return null;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -22,6 +22,7 @@ public final class CartridgeProperties {
         HIDDEN_MMM01,
         MANI_32K_MULTICART,
         SL_MULTICART,
+        UNLICENSED_256M,
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
@@ -115,6 +116,8 @@ public final class CartridgeProperties {
                     Mapper.MANI_32K_MULTICART),
             mapper("SL multicart", CartridgeProperties::isSlMulticart,
                     Mapper.SL_MULTICART),
+            mapper("Unlicensed 256M multicart", CartridgeProperties::isUnlicensed256m,
+                    Mapper.UNLICENSED_256M),
             mapper("Duz multicart", CartridgeProperties::isDuzMulticart,
                     Mapper.DUZ_MULTICART),
             mapper("Blue Hippo G.B.O.S. multicart", CartridgeProperties::isBhgosMulticart,
@@ -392,6 +395,18 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0143) == 0x80
                 && info.rawType() == 0x10
                 && info.byteAt(0x0148) == 0x06;
+    }
+
+    private static boolean isUnlicensed256m(RomInfo info) {
+        int[] entry = {0x00, 0xc3, 0x00, 0x40};
+        return info.data.length == 0x400000
+                && "GB HiCol".equals(info.title())
+                && matches(info.data, 0x0100, entry)
+                && info.hasValidLogo()
+                && info.byteAt(0x0143) == 0x80
+                && info.rawType() == 0x03
+                && info.byteAt(0x0148) == 0x01
+                && info.byteAt(0x0149) == 0x00;
     }
 
     private static boolean isBhgosMulticart(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
@@ -1,0 +1,292 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Unlicensed multicart controller sold on 256 Mbit flash cartridges.
+ *
+ * <p>The menu uses MBC5-compatible banking. Before starting a game it writes the low eight bits
+ * of a 32 KiB base page to {@code 7000}, an inverted page-count mask to {@code 7001}, and the
+ * upper base-page bits plus board flags to {@code 7002}. The final write commits a virtual
+ * cartridge view whose header selects the embedded game's mapper.</p>
+ */
+public final class Unlicensed256M implements MemoryController {
+
+    private final int[] cartridge;
+
+    private final Mbc5 menu;
+
+    private final TimeSource timeSource;
+
+    private final ClockSpec clockSpec;
+
+    private final TimeSource guardedTimeSource;
+
+    private int selectedPage;
+
+    private int pageMask;
+
+    private int configuration = -1;
+
+    private MemoryController selectedGame;
+
+    private boolean clockPaused;
+
+    private boolean stateTimeSourceAccessSuppressed;
+
+    private transient EventBus eventBus = EventBus.NULL_EVENT_BUS;
+
+    private transient DebugHooks debugHooks;
+
+    public Unlicensed256M(Rom rom, Battery battery) {
+        this(rom, battery, new SystemTimeSource(), ClockSpec.LEGACY);
+    }
+
+    public Unlicensed256M(
+            Rom rom,
+            Battery battery,
+            TimeSource timeSource,
+            ClockSpec clockSpec) {
+        this.cartridge = rom.getRom();
+        this.menu = new Mbc5(rom, battery);
+        this.timeSource = timeSource;
+        this.clockSpec = clockSpec;
+        this.guardedTimeSource = () -> stateTimeSourceAccessSuppressed
+                ? 0 : this.timeSource.currentTimeMillis();
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return menu.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        value &= 0xff;
+        if (selectedGame != null) {
+            selectedGame.setByte(address, value);
+            return;
+        }
+        if (address == 0x7000) {
+            selectedPage = (selectedPage & 0x300) | value;
+        } else if (address == 0x7001) {
+            pageMask = ~value & 0xff;
+        } else if (address == 0x7002) {
+            selectedPage = (selectedPage & 0xff) | ((value & 0x03) << 8);
+            selectGame(value);
+        } else {
+            menu.setByte(address, value);
+        }
+    }
+
+    @Override
+    public int getByte(int address) {
+        return selectedGame == null ? menu.getByte(address) : selectedGame.getByte(address);
+    }
+
+    @Override
+    public boolean isClocked() {
+        return true;
+    }
+
+    @Override
+    public void tick() {
+        if (selectedGame != null) {
+            selectedGame.tick();
+        }
+    }
+
+    @Override
+    public void setClockPaused(boolean paused) {
+        clockPaused = paused;
+        if (selectedGame != null) {
+            selectedGame.setClockPaused(paused);
+        }
+    }
+
+    @Override
+    public void reanchorClockAfterRestore(boolean paused) {
+        if (selectedGame != null) {
+            selectedGame.reanchorClockAfterRestore(paused);
+        }
+    }
+
+    @Override
+    public void setStateTimeSourceAccessSuppressed(boolean suppressed) {
+        stateTimeSourceAccessSuppressed = suppressed;
+        if (selectedGame != null) {
+            selectedGame.setStateTimeSourceAccessSuppressed(suppressed);
+        }
+    }
+
+    @Override
+    public boolean isRumbleActive() {
+        return selectedGame == null ? menu.isRumbleActive() : selectedGame.isRumbleActive();
+    }
+
+    @Override
+    public void skipBoot() {
+        menu.skipBoot();
+        if (selectedGame != null) {
+            selectedGame.skipBoot();
+        }
+    }
+
+    @Override
+    public void flushRam() {
+        menu.flushRam();
+        if (selectedGame != null) {
+            selectedGame.flushRam();
+        }
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        this.eventBus = eventBus == null ? EventBus.NULL_EVENT_BUS : eventBus;
+        menu.init(this.eventBus);
+        if (selectedGame != null) {
+            selectedGame.init(this.eventBus);
+        }
+    }
+
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        debugHooks = hooks;
+        menu.setDebugHooks(hooks);
+        if (selectedGame != null) {
+            selectedGame.setDebugHooks(hooks);
+        }
+    }
+
+    /** Returns the selected MBC3 controller when the active game uses one. */
+    public Mbc3 getActiveMbc3() {
+        return selectedGame instanceof Mbc3 mbc3 ? mbc3 : null;
+    }
+
+    private void selectGame(int value) {
+        configuration = value;
+        selectedGame = createGame();
+        selectedGame.init(eventBus);
+        selectedGame.setDebugHooks(debugHooks);
+        selectedGame.setStateTimeSourceAccessSuppressed(stateTimeSourceAccessSuppressed);
+        selectedGame.setClockPaused(clockPaused);
+    }
+
+    private MemoryController createGame() {
+        int romBanks = (pageMask + 1) << 1;
+        Rom gameRom;
+        try {
+            gameRom = new Rom(createGameImage(selectedPage << 1, romBanks));
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create selected multicart view", e);
+        }
+        if (gameRom.getType().isMbc1()) {
+            return new Mbc1(gameRom, Battery.NULL_BATTERY);
+        } else if (gameRom.getType().isMbc2()) {
+            return new Mbc2(gameRom, Battery.NULL_BATTERY);
+        } else if (gameRom.getType().isMbc3()) {
+            return new Mbc3(gameRom, Battery.NULL_BATTERY, guardedTimeSource, clockSpec);
+        } else if (gameRom.getType().isMbc5()) {
+            return new Mbc5(gameRom, Battery.NULL_BATTERY);
+        } else {
+            return new BasicRom(gameRom, Battery.NULL_BATTERY);
+        }
+    }
+
+    private byte[] createGameImage(int baseRomBank, int romBanks) {
+        byte[] image = new byte[romBanks * 0x4000];
+        Arrays.fill(image, (byte) 0xff);
+        int physicalBanks = Math.max(1, (cartridge.length + 0x3fff) / 0x4000);
+        for (int bank = 0; bank < romBanks; bank++) {
+            int sourceBank = Math.floorMod(baseRomBank + bank, physicalBanks);
+            int source = sourceBank * 0x4000;
+            int target = bank * 0x4000;
+            int copied = Math.min(0x4000, cartridge.length - source);
+            for (int i = 0; i < copied; i++) {
+                image[target + i] = (byte) cartridge[source + i];
+            }
+        }
+        Integer sizeCode = romSizeCode(romBanks);
+        if (sizeCode != null) {
+            image[0x0148] = sizeCode.byteValue();
+        }
+        return image;
+    }
+
+    private static Integer romSizeCode(int banks) {
+        if (banks < 2 || banks > 512 || Integer.bitCount(banks) != 1) {
+            return null;
+        }
+        return Integer.numberOfTrailingZeros(banks) - 1;
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new Unlicensed256MState(
+                menu.captureState(),
+                selectedPage,
+                pageMask,
+                configuration,
+                selectedGame == null ? null : selectedGame.captureState());
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new Unlicensed256MState(
+                menu.captureState(capture),
+                selectedPage,
+                pageMask,
+                configuration,
+                selectedGame == null ? null : selectedGame.captureState(capture));
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        menu.declareMachineStatePayloads(capture);
+        if (selectedGame != null) {
+            selectedGame.declareMachineStatePayloads(capture);
+        }
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof Unlicensed256MState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        menu.restoreState(mem.menuState);
+        selectedPage = mem.selectedPage;
+        pageMask = mem.pageMask;
+        configuration = mem.configuration;
+        if (mem.selectedGameState == null) {
+            selectedGame = null;
+            return;
+        }
+        selectedGame = createGame();
+        selectedGame.init(eventBus);
+        selectedGame.setDebugHooks(debugHooks);
+        selectedGame.setStateTimeSourceAccessSuppressed(stateTimeSourceAccessSuppressed);
+        selectedGame.setClockPaused(clockPaused);
+        selectedGame.restoreState(mem.selectedGameState);
+    }
+
+    private record Unlicensed256MState(
+            ComponentState<MemoryController> menuState,
+            int selectedPage,
+            int pageMask,
+            int configuration,
+            ComponentState<MemoryController> selectedGameState)
+            implements ComponentState<MemoryController> {
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
@@ -24,9 +24,17 @@ import java.util.Arrays;
  */
 public final class Unlicensed256M implements MemoryController {
 
+    private static final int SRAM_SLOT_SIZE = 0x8000;
+
+    private static final int SRAM_SLOT_COUNT = 16;
+
     private final int[] cartridge;
 
     private final Mbc5 menu;
+
+    private final Battery battery;
+
+    private final int[] sharedRam = new int[SRAM_SLOT_SIZE * SRAM_SLOT_COUNT];
 
     private final TimeSource timeSource;
 
@@ -60,7 +68,10 @@ public final class Unlicensed256M implements MemoryController {
             TimeSource timeSource,
             ClockSpec clockSpec) {
         this.cartridge = rom.getRom();
-        this.menu = new Mbc5(rom, battery);
+        this.menu = new Mbc5(rom, Battery.NULL_BATTERY);
+        this.battery = battery;
+        Arrays.fill(sharedRam, 0xff);
+        battery.loadRam(sharedRam);
         this.timeSource = timeSource;
         this.clockSpec = clockSpec;
         this.guardedTimeSource = () -> stateTimeSourceAccessSuppressed
@@ -76,6 +87,9 @@ public final class Unlicensed256M implements MemoryController {
     public void setByte(int address, int value) {
         value &= 0xff;
         if (selectedGame != null) {
+            if (!isSramEnabled() && address >= 0xa000 && address < 0xc000) {
+                return;
+            }
             selectedGame.setByte(address, value);
             return;
         }
@@ -93,6 +107,12 @@ public final class Unlicensed256M implements MemoryController {
 
     @Override
     public int getByte(int address) {
+        if (selectedGame != null
+                && !isSramEnabled()
+                && address >= 0xa000
+                && address < 0xc000) {
+            return 0xff;
+        }
         return selectedGame == null ? menu.getByte(address) : selectedGame.getByte(address);
     }
 
@@ -146,7 +166,6 @@ public final class Unlicensed256M implements MemoryController {
 
     @Override
     public void flushRam() {
-        menu.flushRam();
         if (selectedGame != null) {
             selectedGame.flushRam();
         }
@@ -192,17 +211,24 @@ public final class Unlicensed256M implements MemoryController {
         } catch (IOException e) {
             throw new IllegalStateException("Unable to create selected multicart view", e);
         }
+        Battery childBattery = isSramEnabled()
+                ? new SlotBattery((selectedPage >>> 6) & 0x0f)
+                : Battery.NULL_BATTERY;
         if (gameRom.getType().isMbc1()) {
-            return new Mbc1(gameRom, Battery.NULL_BATTERY);
+            return new Mbc1(gameRom, childBattery);
         } else if (gameRom.getType().isMbc2()) {
-            return new Mbc2(gameRom, Battery.NULL_BATTERY);
+            return new Mbc2(gameRom, childBattery);
         } else if (gameRom.getType().isMbc3()) {
-            return new Mbc3(gameRom, Battery.NULL_BATTERY, guardedTimeSource, clockSpec);
+            return new Mbc3(gameRom, childBattery, guardedTimeSource, clockSpec);
         } else if (gameRom.getType().isMbc5()) {
-            return new Mbc5(gameRom, Battery.NULL_BATTERY);
+            return new Mbc5(gameRom, childBattery);
         } else {
-            return new BasicRom(gameRom, Battery.NULL_BATTERY);
+            return new BasicRom(gameRom, childBattery);
         }
+    }
+
+    private boolean isSramEnabled() {
+        return (configuration & 0x40) == 0;
     }
 
     private byte[] createGameImage(int baseRomBank, int romBanks) {
@@ -236,6 +262,7 @@ public final class Unlicensed256M implements MemoryController {
     public ComponentState<MemoryController> captureState() {
         return new Unlicensed256MState(
                 menu.captureState(),
+                sharedRam.clone(),
                 selectedPage,
                 pageMask,
                 configuration,
@@ -246,6 +273,7 @@ public final class Unlicensed256M implements MemoryController {
     public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
         return new Unlicensed256MState(
                 menu.captureState(capture),
+                capture.ints(sharedRam),
                 selectedPage,
                 pageMask,
                 configuration,
@@ -254,6 +282,7 @@ public final class Unlicensed256M implements MemoryController {
 
     @Override
     public void declareMachineStatePayloads(MachineStateCapture capture) {
+        capture.declareInts(sharedRam);
         menu.declareMachineStatePayloads(capture);
         if (selectedGame != null) {
             selectedGame.declareMachineStatePayloads(capture);
@@ -266,6 +295,10 @@ public final class Unlicensed256M implements MemoryController {
             throw new IllegalArgumentException("Invalid state type");
         }
         menu.restoreState(mem.menuState);
+        if (mem.sharedRam.length != sharedRam.length) {
+            throw new IllegalArgumentException("ComponentState shared RAM length doesn't match");
+        }
+        System.arraycopy(mem.sharedRam, 0, sharedRam, 0, sharedRam.length);
         selectedPage = mem.selectedPage;
         pageMask = mem.pageMask;
         configuration = mem.configuration;
@@ -283,10 +316,68 @@ public final class Unlicensed256M implements MemoryController {
 
     private record Unlicensed256MState(
             ComponentState<MemoryController> menuState,
+            int[] sharedRam,
             int selectedPage,
             int pageMask,
             int configuration,
             ComponentState<MemoryController> selectedGameState)
             implements ComponentState<MemoryController> {
+    }
+
+    /** A selected game's mapper sees only its 32 KiB slice of the board's shared SRAM. */
+    private final class SlotBattery implements Battery {
+
+        private final int offset;
+
+        private SlotBattery(int slot) {
+            offset = slot * SRAM_SLOT_SIZE;
+        }
+
+        @Override
+        public void loadRam(int[] ram) {
+            Arrays.fill(ram, 0xff);
+            System.arraycopy(sharedRam, offset, ram, 0, Math.min(ram.length, SRAM_SLOT_SIZE));
+        }
+
+        @Override
+        public void saveRam(int[] ram) {
+            System.arraycopy(ram, 0, sharedRam, offset, Math.min(ram.length, SRAM_SLOT_SIZE));
+            battery.saveRam(sharedRam);
+        }
+
+        @Override
+        public void loadRamWithClock(int[] ram, long[] clockData) {
+            loadRam(ram);
+            if (clockData != null) {
+                Arrays.fill(clockData, 0);
+            }
+        }
+
+        @Override
+        public void saveRamWithClock(int[] ram, long[] clockData) {
+            saveRam(ram);
+        }
+
+        @Override
+        public void flush() {
+            battery.flush();
+        }
+
+        @Override
+        public DebugHistoryReplayShape debugHistoryReplayShape() {
+            return new DebugHistoryReplayShape(DebugHistoryReplayKind.NULL, 0);
+        }
+
+        @Override
+        public ComponentState<Battery> captureState() {
+            return null;
+        }
+
+        @Override
+        public void restoreState(ComponentState<Battery> state) {
+            if (state != null) {
+                throw new IllegalArgumentException("Slot battery has no independent state");
+            }
+        }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
@@ -1,15 +1,23 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -71,7 +79,80 @@ public class Unlicensed256MTest {
         assertEquals(0xc3, mapper.getByte(0x4000));
     }
 
-    private static void configure(MemoryController mapper, int page, int invertedMask, int flags) {
+    @Test
+    public void persistsTheSelectedGames32KiBPageInTheShared512KiBImage() throws IOException {
+        Rom rom = new Rom(multicartRom());
+        Path save = Files.createTempFile("unlicensed-256m", ".sav");
+        try {
+            byte[] initial = new byte[0x80000];
+            Arrays.fill(initial, (byte) 0xff);
+            initial[slotRamOffset(5, 2, 0x123)] = 0x5a;
+            initial[slotRamOffset(4, 2, 0x123)] = 0x4a;
+            Files.write(save, initial);
+
+            assertTrue(Cartridge.supportsBatterySave(rom));
+            Cartridge cartridge = persistentCartridge(rom, save);
+            configure(cartridge, 0x60, 0xe0, 0x91);
+            cartridge.setByte(0x0000, 0x0a);
+            cartridge.setByte(0x4000, 0x02);
+            assertEquals(0x5a, cartridge.getByte(0xa123));
+            cartridge.setByte(0xa123, 0x6b);
+            cartridge.flushBattery();
+
+            byte[] saved = Files.readAllBytes(save);
+            assertEquals(0x80000, saved.length);
+            assertEquals(0x6b, saved[slotRamOffset(5, 2, 0x123)] & 0xff);
+            assertEquals(0x4a, saved[slotRamOffset(4, 2, 0x123)] & 0xff);
+
+            Cartridge reloaded = persistentCartridge(rom, save);
+            configure(reloaded, 0x60, 0xe0, 0x91);
+            reloaded.setByte(0x0000, 0x0a);
+            reloaded.setByte(0x4000, 0x02);
+            assertEquals(0x6b, reloaded.getByte(0xa123));
+        } finally {
+            Files.deleteIfExists(save);
+        }
+    }
+
+    @Test
+    public void configurationBitSixDisconnectsSharedSram() throws IOException {
+        Rom rom = new Rom(multicartRom());
+        Path save = Files.createTempFile("unlicensed-256m-disabled", ".sav");
+        try {
+            byte[] initial = new byte[0x80000];
+            Arrays.fill(initial, (byte) 0xff);
+            initial[slotRamOffset(5, 2, 0x123)] = 0x5a;
+            Files.write(save, initial);
+
+            Cartridge cartridge = persistentCartridge(rom, save);
+            configure(cartridge, 0x60, 0xe0, 0xd1);
+            cartridge.setByte(0x0000, 0x0a);
+            cartridge.setByte(0x4000, 0x02);
+            assertEquals(0xff, cartridge.getByte(0xa123));
+            cartridge.setByte(0xa123, 0x6b);
+            assertEquals(0xff, cartridge.getByte(0xa123));
+            cartridge.flushBattery();
+
+            assertArrayEquals(initial, Files.readAllBytes(save));
+        } finally {
+            Files.deleteIfExists(save);
+        }
+    }
+
+    private static Cartridge persistentCartridge(Rom rom, Path save) {
+        return new Cartridge(
+                rom,
+                true,
+                BatteryStorage.direct(save),
+                new SystemTimeSource(),
+                ClockSpec.LEGACY);
+    }
+
+    private static int slotRamOffset(int slot, int ramBank, int address) {
+        return slot * 0x8000 + ramBank * 0x2000 + address;
+    }
+
+    private static void configure(AddressSpace mapper, int page, int invertedMask, int flags) {
         mapper.setByte(0x7000, page);
         mapper.setByte(0x7001, invertedMask);
         mapper.setByte(0x7002, flags);
@@ -87,7 +168,7 @@ public class Unlicensed256MTest {
         data[0x0101] = (byte) 0xc3;
         data[0x0102] = 0x00;
         data[0x0103] = 0x40;
-        putHeader(data, 0xc0, "SELECTED", 0x19, 0x05, 0x00);
+        putHeader(data, 0xc0, "SELECTED", 0x1b, 0x05, 0x03);
         return data;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
@@ -1,0 +1,108 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Unlicensed256MTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void detectsTheGbHiColBoardWithItsExactEntryPoint() throws IOException {
+        byte[] data = multicartRom();
+        Rom rom = new Rom(data);
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.UNLICENSED_256M,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof Unlicensed256M);
+
+        data[0x0103] ^= 1;
+        assertFalse(new Rom(data).getCartridgeProperties().getMapper()
+                == CartridgeProperties.Mapper.UNLICENSED_256M);
+    }
+
+    @Test
+    public void commitsTheBasePageAndInvertedSizeMaskAt7002() throws IOException {
+        MemoryController mapper = new Unlicensed256M(
+                new Rom(multicartRom()), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2000, 2);
+        assertEquals(2, mapper.getByte(0x4000));
+
+        configure(mapper, 0x60, 0xe0, 0x91);
+
+        assertEquals(0xc0, mapper.getByte(0x0000));
+        assertEquals(0xc1, mapper.getByte(0x4000));
+        mapper.setByte(0x2000, 0x21);
+        assertEquals(0xe1, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void restoresTheSelectedGameAndItsMapperState() throws IOException {
+        Unlicensed256M mapper = new Unlicensed256M(
+                new Rom(multicartRom()), Battery.NULL_BATTERY);
+        configure(mapper, 0x60, 0xe0, 0x91);
+        mapper.setByte(0x2000, 3);
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2000, 7);
+        mapper.restoreState(state);
+
+        assertEquals(0xc0, mapper.getByte(0x0000));
+        assertEquals(0xc3, mapper.getByte(0x4000));
+    }
+
+    private static void configure(MemoryController mapper, int page, int invertedMask, int flags) {
+        mapper.setByte(0x7000, page);
+        mapper.setByte(0x7001, invertedMask);
+        mapper.setByte(0x7002, flags);
+    }
+
+    private static byte[] multicartRom() {
+        byte[] data = new byte[0x400000];
+        for (int bank = 0; bank < data.length / 0x4000; bank++) {
+            data[bank * 0x4000] = (byte) bank;
+        }
+        putHeader(data, 0, "GB HiCol", 0x03, 0x01, 0x00);
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x00;
+        data[0x0103] = 0x40;
+        putHeader(data, 0xc0, "SELECTED", 0x19, 0x05, 0x00);
+        return data;
+    }
+
+    private static void putHeader(
+            byte[] data, int bank, String title, int type, int romSize, int ramSize) {
+        int base = bank * 0x4000;
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[base + 0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        for (int i = 0; i < title.length(); i++) {
+            data[base + 0x0134 + i] = (byte) title.charAt(i);
+        }
+        data[base + 0x0143] = (byte) 0x80;
+        data[base + 0x0147] = (byte) type;
+        data[base + 0x0148] = (byte) romSize;
+        data[base + 0x0149] = (byte) ramSize;
+    }
+}


### PR DESCRIPTION
## Summary

`Shuma Baolong Zhuanji 10 in 1 (Taiwan) (Unl)` reaches its CGB menu, but selecting a game on `master` leaves a blank screen. The menu programs an Unlicensed 256M multicart controller; Coffee GB instead trusted the nominal MBC1 header and never installed the selected game's cartridge view.

This change:

- detects the narrow 4 MiB `GB HiCol` board signature, including its entry point and header metadata;
- adds the Unlicensed 256M controller's `0x7000` base-page, `0x7001` inverted-size-mask, and `0x7002` commit behavior;
- exposes the selected region as a virtual cartridge and uses its embedded header to select the inner mapper;
- models the board's shared 512 KiB SRAM, including an exact 32 KiB selected-game page, the configuration bit-6 disconnect, and one file-backed top-level battery;
- preserves menu, selected-game, mapper, shared-RAM, and clock-related state across ordinary rewind and portable snapshots; and
- adds focused detection, register-protocol, SRAM-persistence, and state-restore coverage.

The observed launch transaction was `0x7000=0x60`, `0x7001=0xe0`, `0x7002=0x91`, followed by the selected game's inner bank write. Modeling that transaction fixes multiple entries without a per-game offset special case.

## Verification

- Baseline: `origin/master` at `3f0804a2`, normal CGB boot, press START for 2 frames at frame 150. The menu appeared, then remained blank through the captured post-selection frame.
- Fixed reproduction: the first entry advances through its boot sequence and renders its animated intro through frame 700.
- Additional coverage: menu entries 5 and 10 also launch and render through frames 700 and 800 respectively.
- `/opt/maven/bin/mvn -pl core -Dtest=eu.rekawek.coffeegb.core.memory.cart.type.Unlicensed256MTest test` — 5 tests, 0 failures/errors.
- Focused controller state coverage (`Unlicensed256MStateTest` and `StateCoverageMatrixTest`) — 8 tests, 0 failures/errors.
- `/opt/maven/bin/mvn -pl core,controller test` — core: 1,602 tests, 0 failures/errors (8 skipped); controller: 906 tests, 0 failures/errors (2 skipped).

## Visual evidence

Same normal-CGB configuration, with START pressed at frame 150 and both captures taken at frame 500:

| Before | After |
| --- | --- |
| ![Before: selected game remains on a white screen](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Shuma_Baolong_Zhuanji_10_in_1_Taiwan_Unl_gbc_f500-f5c33a6d.png) | ![After: selected game renders its boot sequence](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/issue552_gbc_f500-14f1db83.png) |
| Selecting the first menu entry leaves a persistent white screen. | The selected game reaches its rendered boot sequence. |

Fixes #552

