### PR TITLE
Add GGB81 mapper support for Shuma Baolong

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -126,6 +126,7 @@ internal object StateTypeRegistry {
           // controller snapshots to carry the new occupancy/delay state.
           "eu.rekawek.coffeegb.core.gpu.ScalarTimingDmgPixelFifo\$State",
           "eu.rekawek.coffeegb.core.gpu.ScalarTimingColorPixelFifo\$State",
+          "eu.rekawek.coffeegb.core.memory.cart.type.Ggb81\$Ggb81State",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -1730,6 +1730,11 @@ internal object StateSemantics {
           it.intValues("ram", 0, 0xff)
           it.range("lowRomBank", 0, 0xff); it.range("highRomBank", 0, 0xff)
         }
+    target[GGB81_STATE] =
+        constrained("GGB81 retains an MBC5 child and one of eight data-bit permutations.") {
+          it.requiredRecordType("delegateState", MBC5_STATE)
+          it.range("dataSwapMode", 0, 7)
+        }
     target[MBC5_MULTICART_LOADER_STATE] =
         constrained("The MBC5 menu loader preserves a bounded two-bank transition window.") {
           it.requiredRecordType("mbc5State", MBC5_STATE)
@@ -1951,6 +1956,7 @@ internal object StateSemantics {
   private const val MBC5_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5\$Mbc5State"
   private const val BASIC_ROM_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.BasicRom\$BasicRomState"
   private const val NTNEW_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.NtNew\$NtNewState"
+  private const val GGB81_STATE = "eu.rekawek.coffeegb.core.memory.cart.type.Ggb81\$Ggb81State"
   private const val MBC5_MULTICART_STATE =
       "eu.rekawek.coffeegb.core.memory.cart.type.Mbc5Multicart\$Mbc5MulticartState"
   private const val UNLICENSED_256M_STATE =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Ggb81StateTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/Ggb81StateTest.kt
@@ -1,0 +1,59 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.core.GameboyType
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class Ggb81StateTest {
+
+  @Test
+  fun ordinaryRewindAndPortableSnapshotsRestoreTheProtectedMapper() {
+    val configuration = StateCodecTestSupport.configuration(ggb81Rom(), GameboyType.CGB)
+    StateCodecTestSupport.session(configuration).use { session ->
+      val gameboy = session.gameboy
+      gameboy.addressSpace.setByte(0x2001, 0x03)
+      assertEquals(0x06, gameboy.addressSpace.getByte(0x4000))
+
+      val rewind = MachineSnapshot.capture(gameboy)
+      val portable = StateCodec.encode(StateCodec.capture(configuration, gameboy))
+
+      gameboy.addressSpace.setByte(0x2001, 0x00)
+      assertEquals(0x00, gameboy.addressSpace.getByte(0x4000))
+      rewind.restore(gameboy)
+      assertEquals(0x06, gameboy.addressSpace.getByte(0x4000))
+
+      gameboy.addressSpace.setByte(0x2001, 0x00)
+      StateCodec.decodeAndApply(portable, configuration, gameboy)
+      assertEquals(0x06, gameboy.addressSpace.getByte(0x4000))
+    }
+  }
+
+  private fun ggb81Rom(): ByteArray = ByteArray(0x80000).also { data ->
+    data[0x100] = 0x18
+    data[0x101] = 0xfe.toByte()
+    NINTENDO_LOGO.copyInto(data, 0x104)
+    "DIGIMON".forEachIndexed { index, character ->
+      data[0x134 + index] = character.code.toByte()
+    }
+    data[0x143] = 0x80.toByte()
+    data[0x144] = 'A'.code.toByte()
+    data[0x145] = '7'.code.toByte()
+    data[0x147] = 0x19
+    data[0x148] = 0x06
+    data[0x149] = 0x01
+    data[3 * 0x4000] = 0x22
+  }
+
+  private companion object {
+    val NINTENDO_LOGO =
+        byteArrayOf(
+            0xce.toByte(), 0xed.toByte(), 0x66, 0x66, 0xcc.toByte(), 0x0d, 0, 0x0b,
+            0x03, 0x73, 0, 0x83.toByte(), 0, 0x0c, 0, 0x0d,
+            0, 0x08, 0x11, 0x1f, 0x88.toByte(), 0x89.toByte(), 0, 0x0e,
+            0xdc.toByte(), 0xcc.toByte(), 0x6e, 0xe6.toByte(), 0xdd.toByte(), 0xdd.toByte(),
+            0xd9.toByte(), 0x99.toByte(), 0xbb.toByte(), 0xbb.toByte(), 0x67, 0x63, 0x6e,
+            0x0e, 0xec.toByte(), 0xcc.toByte(), 0xdd.toByte(), 0xdc.toByte(), 0x99.toByte(),
+            0x9f.toByte(), 0xbb.toByte(), 0xb9.toByte(), 0x33, 0x3e,
+        )
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -60,6 +60,9 @@ class StateCoverageMatrixTest {
             mapper("Mbc5", listOf(0x0000 to 0x0a, 0x2000 to 0x25, 0x4000 to 0x0a, 0xa000 to 0x34)) {
               Mbc5(mutableRom(0x1e), Battery.NULL_BATTERY)
             },
+            mapper("Ggb81", listOf(0x2001 to 0x03), listOf(0x4000)) {
+              Ggb81(mutableRom(0x19), Battery.NULL_BATTERY)
+            },
             mapper(
                 "Unlicensed256M",
                 listOf(
@@ -242,7 +245,7 @@ class StateCoverageMatrixTest {
         StateTypeRegistry.recordClassNames.filter {
           it.startsWith("eu.rekawek.coffeegb.core.memory.cart.type.")
         }
-    assertEquals(33, registeredMapperRecords.size)
+    assertEquals(34, registeredMapperRecords.size)
   }
 
   private fun directState(controller: MemoryController): DirectState =
@@ -860,6 +863,7 @@ class StateCoverageMatrixTest {
             "Mbc2",
             "Mbc3",
             "Mbc5",
+            "Ggb81",
             "Unlicensed256M",
             "Mbc5Multicart",
             "LiCheng",

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -100,6 +100,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
             case LI_CHENG -> new LiCheng(rom, battery);
             case GOWIN -> new Gowin(rom, battery);
+            case GGB81 -> new Ggb81(rom, battery);
             case VF001_ZOOK -> new Vf001Zook(rom, battery);
             case VF001_GENERAL -> new Vf001General(rom, battery);
             case HITEK -> new Hitek(rom, battery);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -28,6 +28,7 @@ public final class CartridgeProperties {
         MAKON_NT_OLD_2,
         LI_CHENG,
         GOWIN,
+        GGB81,
         VF001_ZOOK,
         VF001_GENERAL,
         HITEK,
@@ -128,6 +129,8 @@ public final class CartridgeProperties {
                     Mapper.LI_CHENG),
             mapper("Gowin protection mapper", CartridgeProperties::isGowin,
                     Mapper.GOWIN),
+            mapper("Vast Fame GGB81 protection", CartridgeProperties::isGgb81,
+                    Mapper.GGB81),
             mapper("Vast Fame VF001 Zook protection", CartridgeProperties::isVf001Zook,
                     Mapper.VF001_ZOOK),
             mapper("Vast Fame VF001 protection", CartridgeProperties::isVf001General,
@@ -448,6 +451,18 @@ public final class CartridgeProperties {
                 && info.rawType() == 0x01
                 && info.byteAt(0x0148) == 0x04
                 && info.byteAt(0x0149) == 0x00;
+    }
+
+    private static boolean isGgb81(RomInfo info) {
+        return info.data.length == 0x80000
+                && "DIGIMON".equals(info.title())
+                && info.hasValidLogo()
+                && info.byteAt(0x0143) == 0x80
+                && info.byteAt(0x0144) == 'A'
+                && info.byteAt(0x0145) == '7'
+                && info.rawType() == 0x19
+                && info.byteAt(0x0148) == 0x06
+                && info.byteAt(0x0149) == 0x01;
     }
 
     private static boolean isVf001Zook(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Ggb81.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Ggb81.java
@@ -1,0 +1,116 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+
+/**
+ * The Vast Fame GGB81 mapper used by secondary releases of the company's games. It is
+ * MBC5-compatible, with a register that selects a data-bit permutation for the switchable ROM
+ * window. The permutation observations come from hhugboy's CC0 GGB81 mapper implementation.
+ */
+public class Ggb81 implements MemoryController {
+
+    private static final int[] IDENTITY = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    private static final int[][] DATA_REORDERING = {
+            IDENTITY,
+            {0, 2, 1, 3, 4, 6, 5, 7},
+            {0, 6, 5, 3, 4, 2, 1, 7},
+            {0, 5, 1, 3, 4, 2, 6, 7},
+            {0, 5, 2, 3, 4, 1, 6, 7},
+            {0, 2, 6, 3, 4, 5, 1, 7},
+            {0, 1, 6, 3, 4, 2, 5, 7},
+            {0, 2, 5, 3, 4, 6, 1, 7}
+    };
+
+    private final Mbc5 delegate;
+
+    private int dataSwapMode;
+
+    public Ggb81(Rom rom, Battery battery) {
+        delegate = new Mbc5(rom, battery);
+    }
+
+    @Override
+    public void init(EventBus eventBus) {
+        delegate.init(eventBus);
+    }
+
+    @Override
+    public boolean accepts(int address) {
+        return delegate.accepts(address);
+    }
+
+    @Override
+    public void setByte(int address, int value) {
+        if ((address & 0xf0ff) == 0x2001) {
+            dataSwapMode = value & 0x07;
+        }
+        delegate.setByte(address, value);
+    }
+
+    @Override
+    public int getByte(int address) {
+        int value = delegate.getByte(address);
+        if (address >= 0x4000 && address < 0x8000) {
+            return reorderBits(value, DATA_REORDERING[dataSwapMode]);
+        }
+        return value;
+    }
+
+    private static int reorderBits(int value, int[] reorder) {
+        int result = 0;
+        for (int newBit = 0; newBit < 8; newBit++) {
+            result |= ((value >> reorder[newBit]) & 1) << newBit;
+        }
+        return result;
+    }
+
+    @Override
+    public void flushRam() {
+        delegate.flushRam();
+    }
+
+    @Override
+    public boolean isRumbleActive() {
+        return delegate.isRumbleActive();
+    }
+
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        delegate.setDebugHooks(hooks);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState() {
+        return new Ggb81State(delegate.captureState(), dataSwapMode);
+    }
+
+    @Override
+    public ComponentState<MemoryController> captureState(MachineStateCapture capture) {
+        return new Ggb81State(delegate.captureState(capture), dataSwapMode);
+    }
+
+    @Override
+    public void declareMachineStatePayloads(MachineStateCapture capture) {
+        delegate.declareMachineStatePayloads(capture);
+    }
+
+    @Override
+    public void restoreState(ComponentState<MemoryController> state) {
+        if (!(state instanceof Ggb81State mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        delegate.restoreState(mem.delegateState);
+        dataSwapMode = mem.dataSwapMode;
+    }
+
+    private record Ggb81State(ComponentState<MemoryController> delegateState, int dataSwapMode)
+            implements ComponentState<MemoryController> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Ggb81Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Ggb81Test.java
@@ -1,0 +1,69 @@
+package eu.rekawek.coffeegb.core.memory.cart.type;
+
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
+import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Ggb81Test {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void detectsTheVastFameDigimonRelease() throws IOException {
+        Rom rom = new Rom(gbb81Rom());
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.GGB81,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof Ggb81);
+    }
+
+    @Test
+    public void reordersSwitchableRomDataAndRestoresTheMode() throws IOException {
+        byte[] data = gbb81Rom();
+        data[3 * 0x4000] = 0x22;
+        Ggb81 mapper = new Ggb81(new Rom(data), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2001, 0x03);
+        assertEquals(0x06, mapper.getByte(0x4000));
+        ComponentState<MemoryController> state = mapper.captureState();
+
+        mapper.setByte(0x2001, 0x00);
+        mapper.restoreState(state);
+
+        assertEquals(0x06, mapper.getByte(0x4000));
+    }
+
+    private static byte[] gbb81Rom() {
+        byte[] data = new byte[0x80000];
+        byte[] title = "DIGIMON".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        data[0x0143] = (byte) 0x80;
+        data[0x0144] = 'A';
+        data[0x0145] = '7';
+        data[0x0147] = 0x19;
+        data[0x0148] = 0x06;
+        data[0x0149] = 0x01;
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary

`Shuma Baolong - Koudai Ban (Taiwan) (Unl)` remains white after normal CGB boot on `master`. Its nominal MBC5 header does not describe the Vast Fame GGB81 board's switchable-ROM data-line permutation, so Coffee GB reads scrambled code/data after the game selects its protection mode.

This change:

- detects the release using its physical size, valid logo, title, licensee, CGB flag, and mapper/size metadata;
- adds a GGB81 controller that keeps ordinary MBC5 banking while applying the selected data-bit permutation in `0x4000-0x7fff`;
- registers and constrains the GGB81 state record for ordinary rewind and portable snapshots;
- includes the protection mode in captured/restored state; and
- adds focused detection, permutation, state-matrix, and capture/restore coverage.

The permutation table and register decode follow the public CC0 hhugboy GGB81 implementation. The supplied image has a valid standard logo and now completes normal boot without GGB81's separate custom-logo switching behavior; that behavior was not implicated in this report.

## Verification

- Baseline: `origin/master` at `3f0804a2`, normal CGB boot with no input; the display remains white through frame 600.
- Fixed reproduction: the game renders its city scene at frame 120, continues its animated sequence at frame 300, and reaches the room scene at frame 600.
- `/opt/maven/bin/mvn -pl core -Dtest=eu.rekawek.coffeegb.core.memory.cart.type.Ggb81Test test` — 2 tests, 0 failures/errors.
- Focused controller state coverage (`Ggb81StateTest` and `StateCoverageMatrixTest`) — 8 tests, 0 failures/errors.
- `/opt/maven/bin/mvn -pl core,controller test` — core: 1,599 tests, 0 failures/errors (8 skipped); controller: 906 tests, 0 failures/errors (2 skipped).

## Visual evidence

Same normal-CGB configuration with no input at frame 600:

| Before | After |
| --- | --- |
| ![Before: white screen at frame 600](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Shuma_Baolong_Koudai_Ban_Taiwan_Unl_gbc_f600-a655d3ed.png) | ![After: rendered room scene at frame 600](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Shuma_Baolong_Koudai_Ban_Taiwan_Unl_gbc_f600-439cca5d.png) |
| The display remains white through frame 600. | The game reaches its rendered room scene. |

Fixes #553

