### PR TITLE
Detect Makon NT-new mapper for Digimon 4

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -408,11 +408,13 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
                 == CartridgeProperties.Mapper.XPLODER_GB;
         // MBC6 persists both its SRAM and flash although its header type has no BATTERY segment.
         // Pocket Camera likewise has 128 KiB of cartridge RAM, including compatibility-profiled
-        // dumps whose nominal header is not 0xFC. These are mapper capabilities, not a claim that
-        // a save file already exists.
+        // dumps whose nominal header is not 0xFC. Makon's newer N&T board supplies 8 KiB of
+        // battery-backed RAM even though its raw header type is the non-battery MBC5 value 0x19.
+        // These are mapper capabilities, not a claim that a save file already exists.
         boolean mapperPersists = rom.getType().isMbc6()
                 || rom.getType().isPocketCamera()
-                || mapper == CartridgeProperties.Mapper.POCKET_CAMERA;
+                || mapper == CartridgeProperties.Mapper.POCKET_CAMERA
+                || mapper == CartridgeProperties.Mapper.MAKON_NT_NEW;
         if (rom.getType().isBattery() || xploderGb || mapperPersists) {
             // Existing MBC implementations expose RAM in 8 KiB banks. Plain ROM+RAM
             // is the exception: its 2 KiB header size is mirrored across A000-BFFF.
@@ -426,6 +428,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             }
             if (mapper == CartridgeProperties.Mapper.UNLICENSED_256M) {
                 ramSize = 0x80000;
+            }
+            if (mapper == CartridgeProperties.Mapper.MAKON_NT_NEW) {
+                ramSize = 0x2000;
             }
             if (xploderGb) {
                 ramSize = 0x20000;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -98,6 +98,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
             case DUZ_MULTICART -> new DuzMulticart(rom, battery);
             case BHGOS_MULTICART -> new BhgosMulticart(rom, battery);
             case MAKON_NT_OLD_2 -> new MakonNtOld2(rom, battery);
+            case MAKON_NT_NEW -> new NtNew(rom, battery);
             case LI_CHENG -> new LiCheng(rom, battery);
             case GOWIN -> new Gowin(rom, battery);
             case GGB81 -> new Ggb81(rom, battery);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -26,6 +26,7 @@ public final class CartridgeProperties {
         DUZ_MULTICART,
         BHGOS_MULTICART,
         MAKON_NT_OLD_2,
+        MAKON_NT_NEW,
         LI_CHENG,
         GOWIN,
         GGB81,
@@ -125,6 +126,8 @@ public final class CartridgeProperties {
                     Mapper.BHGOS_MULTICART),
             mapper("Makon/NT old type 2 multicart", CartridgeProperties::isMakonNtOld2,
                     Mapper.MAKON_NT_OLD_2),
+            mapper("Makon/NT new single cart", CartridgeProperties::isMakonNtNew,
+                    Mapper.MAKON_NT_NEW),
             mapper("Li Cheng unlicensed mapper", CartridgeProperties::isLiCheng,
                     Mapper.LI_CHENG),
             mapper("Gowin protection mapper", CartridgeProperties::isGowin,
@@ -429,6 +432,18 @@ public final class CartridgeProperties {
                 || info.data.length > 0x80000
                 && "POKEBOM USA".equals(info.title())
                 && info.byteAt(0x0102) == 0xe0;
+    }
+
+    private static boolean isMakonNtNew(RomInfo info) {
+        return info.data.length == 0x100000
+                && info.title().startsWith("DIGIMON 4")
+                && info.hasValidLogo()
+                && info.byteAt(0x0143) == 0x80
+                && info.byteAt(0x0144) == 'M'
+                && info.byteAt(0x0145) == 'K'
+                && info.rawType() == 0x19
+                && info.byteAt(0x0148) == 0x05
+                && info.byteAt(0x0149) == 0x02;
     }
 
     private static boolean isLiCheng(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
@@ -5,10 +5,15 @@ import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage;
+import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -18,6 +23,51 @@ public class NtNewTest {
 
     @Test
     public void detectsTheMakonDigimonFourRelease() throws IOException {
+        Rom rom = new Rom(makonDigimonFourRom());
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_NEW,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof NtNew);
+    }
+
+    @Test
+    public void persistsTheBoards8KiBRamDespiteItsNonBatteryHeader() throws IOException {
+        Rom rom = new Rom(makonDigimonFourRom());
+        Path save = Files.createTempFile("makon-nt-new", ".sav");
+        try {
+            byte[] initial = new byte[0x2000];
+            Arrays.fill(initial, (byte) 0xff);
+            initial[0x123] = 0x5a;
+            Files.write(save, initial);
+
+            assertTrue(Cartridge.supportsBatterySave(rom));
+            Cartridge cartridge = persistentCartridge(rom, save);
+            assertTrue(cartridge.getMemoryController() instanceof NtNew);
+            cartridge.setByte(0x0000, 0x0a);
+            assertEquals(0x5a, cartridge.getByte(0xa123));
+            cartridge.setByte(0xa123, 0x6b);
+            cartridge.flushBattery();
+
+            assertEquals(0x2000, Files.size(save));
+            Cartridge reloaded = persistentCartridge(rom, save);
+            reloaded.setByte(0x0000, 0x0a);
+            assertEquals(0x6b, reloaded.getByte(0xa123));
+        } finally {
+            Files.deleteIfExists(save);
+        }
+    }
+
+    private static Cartridge persistentCartridge(Rom rom, Path save) {
+        return new Cartridge(
+                rom,
+                true,
+                BatteryStorage.direct(save),
+                new SystemTimeSource(),
+                ClockSpec.LEGACY);
+    }
+
+    private static byte[] makonDigimonFourRom() {
         byte[] data = new byte[0x100000];
         byte[] title = "DIGIMON 4".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
         System.arraycopy(title, 0, data, 0x0134, title.length);
@@ -38,13 +88,7 @@ public class NtNewTest {
         data[0x0147] = 0x19;
         data[0x0148] = 0x05;
         data[0x0149] = 0x02;
-
-        Rom rom = new Rom(data);
-        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
-
-        assertEquals(CartridgeProperties.Mapper.MAKON_NT_NEW,
-                rom.getCartridgeProperties().getMapper());
-        assertTrue(cartridge.getMemoryController() instanceof NtNew);
+        return data;
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/NtNewTest.java
@@ -1,5 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
@@ -10,8 +12,40 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NtNewTest {
+
+    @Test
+    public void detectsTheMakonDigimonFourRelease() throws IOException {
+        byte[] data = new byte[0x100000];
+        byte[] title = "DIGIMON 4".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        int[] logo = {
+                0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+                0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+                0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+                0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+                0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+                0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+        };
+        for (int i = 0; i < logo.length; i++) {
+            data[0x0104 + i] = (byte) logo[i];
+        }
+        data[0x0143] = (byte) 0x80;
+        data[0x0144] = 'M';
+        data[0x0145] = 'K';
+        data[0x0147] = 0x19;
+        data[0x0148] = 0x05;
+        data[0x0149] = 0x02;
+
+        Rom rom = new Rom(data);
+        Cartridge cartridge = new Cartridge(rom, Battery.NULL_BATTERY);
+
+        assertEquals(CartridgeProperties.Mapper.MAKON_NT_NEW,
+                rom.getCartridgeProperties().getMapper());
+        assertTrue(cartridge.getMemoryController() instanceof NtNew);
+    }
 
     @Test
     public void changesFromA16KiBWindowToIndependent8KiBWindows() throws IOException {


### PR DESCRIPTION
## Summary

`Shuma Baolong 02 4 (Taiwan) (Unl)` remains white after normal CGB boot on `master`. The dump advertises MBC5, but its software uses the Makon/N&T new controller's independently selected 8 KiB ROM windows. Treating those writes as ordinary MBC5 banking sends execution to the wrong data.

Coffee GB already models this controller as `NtNew`. This change adds a narrow compatibility profile for the affected 1 MiB `DIGIMON 4` release and routes it to that existing implementation. It also treats this exact mapper as having 8 KiB of persistent RAM despite its raw non-battery type `0x19`, matching the board rather than the nominal header. Regression coverage proves detection, controller protocol/state restore, battery-save capability, and load/write/flush/reload persistence.

## Verification

- Baseline: `origin/master` at `3f0804a2`, normal CGB boot with no input; the display remains white through frame 600.
- Fixed reproduction: the game renders its Digimon splash at frame 120 and continues through character scenes at frames 300 and 600.
- `/opt/maven/bin/mvn -pl core -Dtest=eu.rekawek.coffeegb.core.memory.cart.type.NtNewTest test` — 4 tests, 0 failures/errors.
- `/opt/maven/bin/mvn -pl core,controller test` — core: 1,599 tests, 0 failures/errors (8 skipped); controller: 905 tests, 0 failures/errors (2 skipped).

## Visual evidence

Same normal-CGB configuration with no input at frame 600:

| Before | After |
| --- | --- |
| ![Before: white screen at frame 600](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Shuma_Baolong_02_4_Taiwan_Unl_gbc_f600-27405eeb.png) | ![After: rendered character scene at frame 600](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Shuma_Baolong_02_4_Taiwan_Unl_gbc_f600-989a7147.png) |
| The display remains white through frame 600. | The game progresses to a fully rendered character scene. |

Fixes #554

