### PR TITLE
Avoid wrapped frames after linked rollback

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -2005,14 +2005,24 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // asking to change the following physical frame.
         if (!requestedFrameRenderSuppression) {
             if (frameRenderSuppressed) {
-                frameRenderSuppressed = false;
-                gpu.setRenderOutput(true);
+                resumeHostFrameRenderingAtVBlank();
             }
             return;
         }
         // Sustained catch-up pressure still presents every other physical LCD frame.
-        frameRenderSuppressed = !frameRenderSuppressed;
-        gpu.setRenderOutput(!frameRenderSuppressed);
+        if (frameRenderSuppressed) {
+            resumeHostFrameRenderingAtVBlank();
+        } else {
+            frameRenderSuppressed = true;
+            gpu.setRenderOutput(false);
+        }
+    }
+
+    /** Starts a complete host scanout after any hidden partial frame. Called only at VBlank. */
+    private void resumeHostFrameRenderingAtVBlank() {
+        display.discardPartialFrame();
+        frameRenderSuppressed = false;
+        gpu.setRenderOutput(true);
     }
 
     /** Current aggregate emulated motor output, without invoking host services. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Display.java
@@ -92,6 +92,18 @@ public class Display implements StatefulComponent<Display> {
         }
     }
 
+    /**
+     * Discards an incomplete host scanout without changing the panel image being held.
+     *
+     * <p>A state restore can land in the middle of a visible frame. Rendering stays suppressed
+     * through the next VBlank, but the first frame after that boundary must start at pixel zero;
+     * retaining the restored write cursor would append the new top rows below the old partial
+     * scanout and briefly publish a vertically wrapped composite.</p>
+     */
+    public void discardPartialFrame() {
+        i = 0;
+    }
+
     public void enableLcd() {
         i = 0;
         enabled = true;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
@@ -10,8 +10,11 @@ import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -71,6 +74,46 @@ public class GameboyAdaptiveFrameRenderingTest {
     }
 
     @Test
+    public void silentRollbackRestoreResetsTheWriteCursorWhenPacingResumes() throws Exception {
+        try (EventBus sourceBus = new EventBusImpl();
+             EventBus targetBus = new EventBusImpl();
+             Gameboy source = newGameboy();
+             Gameboy target = newGameboy()) {
+            configureStaticPattern(source);
+            configureStaticPattern(target);
+            source.init(sourceBus, SerialEndpoint.NULL_ENDPOINT, null);
+            List<int[]> targetFrames = new ArrayList<>();
+            targetBus.register(
+                    e -> targetFrames.add(e.pixels().clone()), Display.DmgFrameReadyEvent.class);
+            target.init(targetBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            runToNextFrame(source, target);
+            runToNextFrame(source, target);
+            target.requestFrameRenderSuppression(true);
+            runToNextFrame(source, target);
+            assertFalse(target.isCurrentVisibleFrameFullyRendering());
+
+            runUntilLineDot(source, target, 72, 200);
+            var replayHead = source.captureState();
+            target.restoreStateSilently(replayHead);
+            assertFalse("silent rollback preserves the live pacing gate",
+                    target.isCurrentVisibleFrameFullyRendering());
+            targetFrames.clear();
+
+            // Linked rollback installs replay state silently while presentation may already be
+            // suppressed by pacing debt. The restored nonzero cursor must be discarded at the
+            // VBlank where output resumes. Sustained debt then yields two comparable publications.
+            runToNextFrame(target);
+            runToNextFrame(target);
+            runToNextFrame(target);
+            runToNextFrame(target);
+
+            assertEquals(2, targetFrames.size());
+            assertArrayEquals(targetFrames.get(1), targetFrames.get(0));
+        }
+    }
+
+    @Test
     public void silentRestorePreservesTheExistingHostRenderGate() throws Exception {
         try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newGameboy()) {
             gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
@@ -125,6 +168,47 @@ public class GameboyAdaptiveFrameRenderingTest {
         rom[0x101] = (byte) 0xfe;
         rom[0x147] = 0;
         return rom;
+    }
+
+    private static void configureStaticPattern(Gameboy gameboy) {
+        for (int tile = 0; tile < 4; tile++) {
+            int low = (tile & 1) == 0 ? 0x00 : 0xff;
+            int high = (tile & 2) == 0 ? 0x00 : 0xff;
+            for (int row = 0; row < 8; row++) {
+                gameboy.getGpu().getVideoRam().setByte(0x8000 + tile * 16 + row * 2, low);
+                gameboy.getGpu().getVideoRam().setByte(0x8000 + tile * 16 + row * 2 + 1, high);
+            }
+        }
+        for (int row = 0; row < 32; row++) {
+            for (int column = 0; column < 32; column++) {
+                int tile = (row * row + row * 3 + column * 2 + column / 3) & 3;
+                gameboy.getGpu().getVideoRam().setByte(0x9800 + row * 32 + column, tile);
+            }
+        }
+        gameboy.getGpu().setByte(0xff47, 0xe4);
+    }
+
+    private static void runUntilLineDot(Gameboy first, Gameboy second, int line, int dot) {
+        for (int tick = 0; tick < 100_000; tick++) {
+            if (first.getGpu().getLine() == line && first.getGpu().getTicksInLine() == dot) {
+                return;
+            }
+            first.tick();
+            second.tick();
+        }
+        assertTrue("PPUs did not reach the requested line and dot", false);
+    }
+
+    private static void runToNextFrame(Gameboy first, Gameboy second) {
+        for (int tick = 0; tick < 100_000; tick++) {
+            boolean firstFrame = first.tick();
+            boolean secondFrame = second.tick();
+            if (firstFrame || secondFrame) {
+                assertEquals(firstFrame, secondFrame);
+                return;
+            }
+        }
+        assertTrue("PPUs did not reach VBlank", false);
     }
 
     private static void runToNextFrame(Gameboy gameboy) {


### PR DESCRIPTION
## Symptom

In a two-player linked *Uno - Small World* session, either window could briefly show a vertically wrapped/ghosted frame while link play caught up. I reviewed the supplied 49.92-second recording frame by frame and found the same short flash recurring in both windows.

## Root cause

Linked history reconciliation commits a detached replay state with `Gameboy.restoreStateSilently(...)` so the live host presentation gate is preserved. When pacing had already suppressed rendering, that restore could install a mid-scanout `Display` write cursor. The next VBlank resumed output without resetting the cursor, so the following visible frame was appended at a nonzero offset and published as a vertically wrapped composite. Swing's adjacent-frame blending made that corrupt publication look like the translucent ghost in the recording.

## Fix

Reset only the incomplete host scanout cursor whenever rendering transitions from suppressed to visible at VBlank. The held panel image and emulated PPU state remain unchanged, and sustained catch-up still presents every other physical frame.

The regression test recreates the production condition with two aligned patterned DMG machines: it suppresses the target's live presentation gate, installs a mid-visible replay state through the silent restore path, resumes under sustained pacing pressure, and requires the next two publications to be pixel-identical. It fails on the old behavior with a wrapped frame.

## Verification

- Replayed the identified first *Uno - Small World (Japan)* release with two linked DMG peers and deterministic controller input.
- Forced pacing suppression, committed a replay-head state through the production-equivalent silent/detached rollback path, and resumed at VBlank.
- Verified the first two post-rollback raw publications and Swing-style blended frames were identical and visually clean for both peers; the wrapped/ghost flash from the supplied recording no longer appeared.
- `mvn -pl core test` — 1,598 tests, 0 failures (8 skipped)
- `mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` — 132 tests, 0 failures
- `mvn -pl core test -Ptest-blargg-individual,test-blargg` — 54 tests, 0 failures
- `mvn -pl controller -am -Dtest=LinkedControllerTest,DetachedStateTest -Dsurefire.failIfNoSpecifiedTests=false test` — 100 tests, 0 failures

## Visual evidence

**Before — supplied two-player link recording, frames 238–247.** The left peer is clean through frame 240, publishes a vertically wrapped/ghosted composite at frames 241–243, and recovers at frame 244.

![Before: linked-session wrapped-frame sequence](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/issue558-flash-238-247-9a966211.png)

**After — fixed build under forced linked rollback and pacing suppression.** Both linked outputs remain clean on the first post-rollback publication; the second publication is pixel-identical.

![After: both linked outputs remain clean](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/uno-issue558-fixed-publish1-481874b7.png)

Fixes #558

