### PR TITLE
Unlock Android PERFORMANCE packet spans

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -783,11 +783,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             long remaining = ticks;
             while (remaining > 0) {
                 int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
-                // At a machine-cycle boundary the CPU limit is zero. Do not walk the GPU's
-                // direct/steady eligibility predicates on those scalar-authority iterations.
-                int span = cpuSpanLimit > 0
-                        ? Math.min(cpuSpanLimit, timer.performanceQuietSpanLimit(cpuSpanLimit)) : 0;
+                // Build one primitive packet plan.  Every component horizon is evaluated once
+                // against the already-shortened tail; the trusted commits below must not repeat
+                // those walks on each normal-speed three-tick phase.
+                int span = cpuSpanLimit;
+                boolean directRasterSpan = false;
+                boolean steadyRasterSpan = false;
                 if (span > 0) {
+                    span = Math.min(span, timer.performanceQuietSpanLimit(span));
                     span = Math.min(span, serialPort.performanceQuietSpanLimit(span));
                     span = Math.min(span, joypad.performanceQuietSpanLimit(span));
                     span = Math.min(span, sound.performanceQuietSpanLimit(span));
@@ -800,7 +803,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     if (gbc) {
                         span = Math.min(span, infraredPort.performanceQuietSpanLimit(span));
                     }
-                    span = Math.min(span, gpu.performanceQuietSpanLimit());
+                    int gpuSpanLimit = gpu.performanceQuietSpanLimit();
+                    span = Math.min(span, gpuSpanLimit);
+                    directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+                    steadyRasterSpan = span > 0 && !directRasterSpan
+                            && gpu.isPerformanceSteadyCursorActive();
                     span = Math.min(span, statRegister.performanceQuietSpanLimit(span));
                 }
                 // The two subsystem limits are int-sized, while runTicks accepts a long. A small
@@ -810,25 +817,19 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     span = (int) remaining;
                 }
                 boolean reachesCpuBoundary = span > 0 && span == cpuSpanLimit;
-                boolean directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
-                boolean steadyRasterSpan = span > 0 && !directRasterSpan
-                        && gpu.isPerformanceSteadyCursorActive();
                 if (span > 0
                         && !warmResetRequested
                         && speedSwitchTailTicks == 0
                         && cpu.performancePhaseOnlySpanEligible()
                         && cpu.performanceNoPendingPpuReadPhase()
                         && !dma.isTransferInProgress()
+                        && !dma.requiresClockTick(false)
                         && (!gbc || !hdma.hasActiveOrPendingTransfer())
-                        && timer.canTickPerformanceQuietSpan(span)
-                        && serialPort.canTickPerformanceQuietSpan(span)
-                        && joypad.canTickPerformanceQuietSpan(span)
-                        && (!cartridgeClocked
-                        || cartridge.performanceQuietSpanLimit(span) >= span)
-                        && (!slotCartridgeClocked
-                        || slotCartridge.performanceQuietSpanLimit(span) >= span)
-                        && (!gbc || infraredPort.performanceQuietSpanLimit(span) >= span)
-                        && statRegister.canTickPerformanceQuietSpan(span)) {
+                        // This is intentionally the one post-preflight volatile Joypad check.
+                        // A legacy/debug/input mutation published after the horizon walk must
+                        // fall back to one scalar tick; a PlayerInputHub snapshot update does not
+                        // clear its eligibility and remains invisible until the next poll.
+                        && joypad.isPerformanceQuietSpanStillEligible()) {
                     tickPerformanceQuietSpan(span, directRasterSpan, steadyRasterSpan);
                     remaining -= span;
                     performanceBulkSpanCount++;
@@ -894,6 +895,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         cpu.advancePerformancePhaseOnlyTrusted(ticks);
         gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
+        if (gbc) {
+            // Scalar tick() publishes these post-GPU timing latches on every dot.  A packet
+            // reaches the same final observable state by overwriting them once at its end.
+            hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                    gpu.isStatModeLatchRephasedBySpeedSwitch());
+            cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
+        }
     }
 
     /** Number of all-subsystem PERFORMANCE bulk spans taken by the current session. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -124,9 +124,8 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         if (ticks <= 0) {
             return;
         }
-        if (!tickPerformanceQuietSpan(ticks)) {
-            throw new IllegalStateException("Infrared quiet span is not eligible: " + ticks);
-        }
+        // The packet preflight proves a disabled/null-endpoint IR state.  There is no arithmetic
+        // state to advance in that state, so the trusted commit is intentionally just a no-op.
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -286,8 +286,6 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0
-                || !releasedInputFastPathEligible
-                || playerInputSource != PlayerInputSource.RELEASED
                 || inputChangedSinceLastTick
                 || !buttons.isEmpty()
                 || players != 0
@@ -296,7 +294,22 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 || isSgb) {
             return 0;
         }
-        return Math.min(requested, PERFORMANCE_MAX_QUIET_SPAN);
+        if (releasedInputFastPathEligible && playerInputSource == PlayerInputSource.RELEASED) {
+            return Math.min(requested, PERFORMANCE_MAX_QUIET_SPAN);
+        }
+        if (playerInputHubFastPathEligible && playerInputSource instanceof PlayerInputHub) {
+            // The hub is sampled only on the post-increment residue 1.  The snapshot may change
+            // between polls, but that change is intentionally invisible until the next poll, so
+            // a span may advance only to the tick immediately before that residue.
+            long residue = tick & (PLAYER_INPUT_HUB_POLL_TICKS - 1L);
+            long distance = (1L - residue) & (PLAYER_INPUT_HUB_POLL_TICKS - 1L);
+            if (distance == 0) {
+                distance = PLAYER_INPUT_HUB_POLL_TICKS;
+            }
+            return Math.min(Math.min(requested, PERFORMANCE_MAX_QUIET_SPAN),
+                    (int) Math.max(0, distance - 1));
+        }
+        return 0;
     }
 
     /** Returns the largest safe span using the scheduler's normal three-clock bound. */
@@ -328,9 +341,14 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (ticks <= 0) {
             return;
         }
-        if (!tickPerformanceQuietSpan(ticks)) {
-            throw new IllegalStateException("Joypad quiet span is not eligible: " + ticks);
-        }
+        // Gameboy has already preflighted the full packet and performs one final volatile
+        // eligibility read immediately before beginning the trusted packet commit.
+        tick += ticks;
+    }
+
+    /** One cheap owner-thread commit guard for the packet scheduler. */
+    public boolean isPerformanceQuietSpanStillEligible() {
+        return releasedInputFastPathEligible || playerInputHubFastPathEligible;
     }
 
     /** Naming alias for schedulers which use the GPU's advance-oriented bulk vocabulary. */
@@ -718,6 +736,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (inputTimelineObserver != null) {
             return false;
         }
+        invalidateInputFastPaths();
         alignInputTimeline();
         this.inputTimelineObserver = observer;
         return true;
@@ -729,6 +748,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         if (inputTimelineObserver != observer) {
             return false;
         }
+        invalidateInputFastPaths();
         alignInputTimeline();
         inputTimelineObserver = null;
         return true;
@@ -736,6 +756,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     /** Installs an optional owner-thread observer without emitting an alignment event. */
     public void setDebugHooks(DebugHooks debugHooks) {
+        invalidateInputFastPaths();
         alignDebugInput();
         this.debugHooks = debugHooks;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc3.java
@@ -159,6 +159,15 @@ public class Mbc3 implements MemoryController {
     }
 
     @Override
+    public void tickPerformanceQuietSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        // Cartridge/Gameboy has already established the mapper horizon and debug-free state.
+        clock.tickPerformanceQuietSpan(ticks);
+    }
+
+    @Override
     public boolean isClocked() {
         return true;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5Multicart.java
@@ -139,6 +139,16 @@ public class Mbc5Multicart implements MemoryController {
     }
 
     @Override
+    public void tickPerformanceQuietSpanTrusted(int ticks) {
+        if (ticks <= 0 || selectedGame == null) {
+            return;
+        }
+        // The enclosing packet preflight already checked the selected mapper's horizon and
+        // debug state; avoid re-entering the limit walk on commit.
+        selectedGame.tickPerformanceQuietSpanTrusted(ticks);
+    }
+
+    @Override
     public void setClockPaused(boolean paused) {
         clockPaused = paused;
         if (selectedGame != null) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -134,9 +134,10 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         if (ticks <= 0) {
             return;
         }
-        if (!tickPerformanceQuietSpan(ticks)) {
-            throw new IllegalStateException("Serial quiet span is not eligible: " + ticks);
-        }
+        // The packet preflight has already established an idle NULL endpoint and no pending
+        // acknowledge/transfer edge.  Do not repeat that walk on the hot commit path.
+        acknowledgeInterruptIfNeeded();
+        serialClocks = (serialClocks + ticks) & 0xff;
     }
 
     /** Naming alias for schedulers which use the GPU's advance-oriented bulk vocabulary. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -188,9 +188,17 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         if (ticks <= 0) {
             return;
         }
-        if (!tickPerformanceQuietSpan(ticks)) {
-            throw new IllegalStateException("Timer quiet span is not eligible: " + ticks);
+        // Gameboy has already preflighted this span and commits it as one packet.  Keep this
+        // path free of a second horizon walk; the scalar-safe state transitions are the same as
+        // tickPerformanceQuietSpan once the caller has established the quiet contract.
+        acknowledgeInterruptIfNeeded();
+        divReset = false;
+        div = (div + ticks) & 0xffff;
+        previousBit = timerInput(div, tac);
+        if (ticksSinceDivReset != Integer.MAX_VALUE) {
+            ticksSinceDivReset += ticks;
         }
+        haltBugDivRippleVisible = false;
     }
 
     /** Naming alias for schedulers which use the GPU's advance-oriented bulk vocabulary. */

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -1,0 +1,261 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** End-to-end coverage for the live PlayerInputHub path used by Android adapters. */
+public final class GameboyPlayerInputHubPerformanceTest {
+
+    @Test
+    public void performanceHubMatchesScalarAtRandomChunkBoundariesAndRestores() throws Exception {
+        for (boolean cgb : new boolean[]{false, true}) {
+            for (boolean held : new boolean[]{false, true}) {
+                PlayerInputHub performanceHub = new PlayerInputHub();
+                PlayerInputHub.SourceHandle performanceSource = performanceHub.openSource(0);
+                AtomicReference<PlayerInputSnapshot> scalarInput = new AtomicReference<>(
+                        PlayerInputSnapshot.released());
+                if (held) {
+                    Set<Button> initial = Set.of(Button.A, Button.RIGHT);
+                    performanceSource.update(initial);
+                    scalarInput.set(snapshot(initial));
+                }
+                try (Gameboy performance = session(cgb, ExecutionMode.PERFORMANCE, performanceHub);
+                        Gameboy scalar = session(cgb, ExecutionMode.PERFORMANCE, scalarInput::get)) {
+                    Random random = new Random(0x4f3d_21a7L + (cgb ? 1 : 0)
+                            + (held ? 7 : 0));
+                    for (int chunkIndex = 0; chunkIndex < 90; chunkIndex++) {
+                        int chunk = 1 + random.nextInt(97);
+                        long scalarFrames = 0;
+                        for (int tick = 0; tick < chunk; tick++) {
+                            if (scalar.runTicks(1) != 0) {
+                                scalarFrames++;
+                            }
+                        }
+                        assertEquals("frame events cgb=" + cgb + ", held=" + held
+                                        + ", chunk=" + chunkIndex,
+                                scalarFrames, performance.runTicks(chunk));
+                        ComponentState<Gameboy> scalarState = scalar.captureState();
+                        ComponentState<Gameboy> performanceState = performance.captureState();
+                        assertEquals("state cgb=" + cgb + ", held=" + held
+                                        + ", chunk=" + chunkIndex + " "
+                                        + componentHashes(scalarState, performanceState),
+                                stateHash(scalarState), stateHash(performanceState));
+                        assertRasterEquivalent(scalar, performance,
+                                "cgb=" + cgb + ", held=" + held + ", chunk=" + chunkIndex);
+                    }
+                    assertTrue("hub performance path had no bulk coverage cgb=" + cgb
+                                    + ", held=" + held,
+                            performance.getPerformanceBulkTicks() > 0);
+
+                    ComponentState<Gameboy> saved = performance.captureState();
+                    int savedHash = stateHash(saved);
+                    performance.runTicks(73);
+                    performance.restoreState(saved);
+                    assertEquals("capture/restore cgb=" + cgb + ", held=" + held,
+                            savedHash, stateHash(performance.captureState()));
+
+                    for (int tick = 0; tick < 32; tick++) {
+                        long scalarFrame = scalar.runTicks(1);
+                        assertEquals("restore frame cgb=" + cgb + ", held=" + held,
+                                scalarFrame != 0, performance.runTicks(1) != 0);
+                        assertEquals("restore state cgb=" + cgb + ", held=" + held,
+                                stateHash(scalar.captureState()), stateHash(performance.captureState()));
+                        assertRasterEquivalent(scalar, performance,
+                                "restore cgb=" + cgb + ", held=" + held);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void cgbBulkTailPublishesGpuTimingBeforeImmediateFf55Start() throws Exception {
+        for (int tail = 1; tail <= 3; tail++) {
+            PlayerInputHub hub = new PlayerInputHub();
+            hub.openSource(0);
+            AtomicReference<PlayerInputSnapshot> scalarInput = new AtomicReference<>(
+                    PlayerInputSnapshot.released());
+            try (Gameboy performance = session(true, ExecutionMode.PERFORMANCE, hub);
+                    Gameboy scalar = session(true, ExecutionMode.PERFORMANCE, scalarInput::get)) {
+                // Find a synchronized endpoint where the immediately preceding call is exactly
+                // one all-subsystem packet of the requested 1–3 dots. The scalar oracle follows
+                // the same PERFORMANCE renderer lifecycle but has a custom source, so its
+                // all-subsystem packet horizon is zero.
+                boolean allBulk = false;
+                for (int attempt = 0; attempt < 4_000 && !allBulk; attempt++) {
+                    long before = performance.getPerformanceBulkTicks();
+                    performance.runTicks(tail);
+                    for (int i = 0; i < tail; i++) {
+                        scalar.runTicks(1);
+                    }
+                    allBulk = performance.getPerformanceBulkTicks() - before == tail;
+                }
+                assertTrue("CGB setup did not exercise an all-bulk " + tail + "-dot tail",
+                        allBulk);
+
+                // Start GDMA immediately after the proven packet tail. The final GPU timing
+                // publication must make FF55 observe the same request state as scalar execution.
+                startOneBlockGdma(performance);
+                startOneBlockGdma(scalar);
+                performance.runTicks(1);
+                scalar.runTicks(1);
+
+                assertEquals("FF55 start after " + tail + "-dot packet tail",
+                        scalar.getAddressSpace().getByte(0xff55),
+                        performance.getAddressSpace().getByte(0xff55));
+                assertEquals("HDMA timing latch after " + tail + "-dot packet tail",
+                        stateHash(scalar.getHdma().captureState()),
+                        stateHash(performance.getHdma().captureState()));
+            }
+        }
+    }
+
+    private static Gameboy session(boolean cgb, ExecutionMode mode, PlayerInputHub hub)
+            throws Exception {
+        return session(cgb, mode, (PlayerInputSource) hub);
+    }
+
+    private static Gameboy session(boolean cgb, ExecutionMode mode, PlayerInputSource inputSource)
+            throws Exception {
+        byte[] image = new byte[0x8000];
+        // Select both JOYP rows once, then hold a stable CPU loop. Android's physical hub is
+        // therefore observable through the same filtered P10-P13 path as a real game.
+        image[0x100] = 0x3e; // LD A,0
+        image[0x101] = 0;
+        image[0x102] = (byte) 0xe0; // LDH (FF00),A
+        image[0x103] = 0;
+        image[0x104] = 0x18; // JR $0104
+        image[0x105] = (byte) 0xfe;
+        image[0x143] = (byte) (cgb ? 0x80 : 0);
+        image[0x147] = 0;
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(mode)
+                .setSupportBatterySave(false)
+                .setPlayerInputSource(inputSource)
+                .build();
+    }
+
+    private static PlayerInputSnapshot snapshot(Set<Button> buttons) {
+        ArrayList<Set<Button>> players = new ArrayList<>();
+        players.add(buttons);
+        players.add(Set.of());
+        players.add(Set.of());
+        players.add(Set.of());
+        return PlayerInputSnapshot.of(players);
+    }
+
+    private static void startOneBlockGdma(Gameboy gameboy) {
+        var bus = gameboy.getAddressSpace();
+        bus.setByte(0xff51, 0);
+        bus.setByte(0xff52, 0);
+        bus.setByte(0xff53, 0);
+        bus.setByte(0xff54, 0);
+        bus.setByte(0xff55, 0);
+    }
+
+    /** Canonical recursive hash for record mementos, including primitive/object arrays. */
+    private static int stateHash(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        Class<?> type = value.getClass();
+        if (type.isArray()) {
+            int hash = 1;
+            int length = Array.getLength(value);
+            for (int i = 0; i < length; i++) {
+                hash = 31 * hash + stateHash(Array.get(value, i));
+            }
+            return hash;
+        }
+        if (type.isRecord()) {
+            int hash = type.getName().hashCode();
+            for (RecordComponent component : type.getRecordComponents()) {
+                try {
+                    if (isHostOnlyState(type, component.getName())) {
+                        continue;
+                    }
+                    hash = 31 * hash + component.getName().hashCode();
+                    var accessor = component.getAccessor();
+                    accessor.setAccessible(true);
+                    hash = 31 * hash + stateHash(accessor.invoke(value));
+                } catch (ReflectiveOperationException e) {
+                    throw new AssertionError("Cannot hash state component " + component, e);
+                }
+            }
+            return hash;
+        }
+        return value.hashCode();
+    }
+
+    private static boolean isHostOnlyState(Class<?> type, String componentName) {
+        String name = type.getName();
+        if (name.equals("eu.rekawek.coffeegb.core.sound.Sound$SoundState")
+                || name.equals("eu.rekawek.coffeegb.core.sound.Sound$SoundMemento")) {
+            return switch (componentName) {
+                case "buffer", "i", "performanceSamplePhase", "audioDecimation" -> true;
+                default -> false;
+            };
+        }
+        if (name.equals("eu.rekawek.coffeegb.core.gpu.Gpu$GpuState")
+                || name.equals("eu.rekawek.coffeegb.core.gpu.Gpu$GpuMemento")) {
+            return switch (componentName) {
+                case "performanceWindowLineCounter", "performanceScanlineCursor",
+                        "performanceScanlineLine", "performanceScanlineEndTick",
+                        "pixelTransferPhaseMemento", "pixelMachineMemento" -> true;
+                default -> false;
+            };
+        }
+        return name.equals("eu.rekawek.coffeegb.core.gpu.VRamTransfer$VRamTransferState")
+                || name.equals("eu.rekawek.coffeegb.core.gpu.VRamTransfer$VRamTransferMemento");
+    }
+
+    private static void assertRasterEquivalent(Gameboy scalar, Gameboy performance,
+                                               String context) {
+        assertEquals(context + " LY", scalar.getGpu().getLine(), performance.getGpu().getLine());
+        assertEquals(context + " line ticks", scalar.getGpu().getTicksInLine(),
+                performance.getGpu().getTicksInLine());
+        assertEquals(context + " mode", scalar.getGpu().getMode(), performance.getGpu().getMode());
+        assertEquals(context + " LCDC", scalar.getGpu().getByte(0xff40),
+                performance.getGpu().getByte(0xff40));
+        assertEquals(context + " STAT", scalar.getGpu().getByte(0xff41),
+                performance.getGpu().getByte(0xff41));
+    }
+
+    private static String componentHashes(Object left, Object right) {
+        if (!left.getClass().isRecord() || !right.getClass().isRecord()) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder("components[");
+        for (RecordComponent component : left.getClass().getRecordComponents()) {
+            try {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                int leftHash = stateHash(accessor.invoke(left));
+                int rightHash = stateHash(accessor.invoke(right));
+                if (leftHash != rightHash) {
+                    result.append(component.getName()).append('=').append(leftHash)
+                            .append('/').append(rightHash).append(',');
+                }
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            }
+        }
+        return result.append(']').toString();
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadHotPathTest.java
@@ -147,6 +147,97 @@ public class JoypadHotPathTest {
     }
 
     @Test
+    public void playerInputHubQuietSpanStopsBeforeEveryPostIncrementPollResidue() {
+        int[] residues = {0, 1, 61, 62, 63};
+        int[] expected = {0, 3, 3, 2, 1};
+        for (boolean held : new boolean[]{false, true}) {
+            for (int i = 0; i < residues.length; i++) {
+                PlayerInputHub hub = new PlayerInputHub();
+                PlayerInputHub.SourceHandle source = hub.openSource(0);
+                if (held) {
+                    source.update(Set.of(Button.A));
+                }
+                Joypad joypad = new Joypad(
+                        new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, hub);
+                joypad.setByte(JOYP, 0x00);
+                settlePlayerInputHub(joypad);
+                advanceToHubResidue(joypad, residues[i]);
+
+                assertTrue(playerInputHubFastPathEligible(joypad));
+                assertEquals("held=" + held + ", residue=" + residues[i], expected[i],
+                        joypad.performanceQuietSpanLimit(99));
+            }
+        }
+    }
+
+    @Test
+    public void playerInputHubBulkLeavesSnapshotAndFilterUntouchedUntilExactPoll() {
+        InterruptManager interrupts = new InterruptManager(false);
+        PlayerInputHub hub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle source = hub.openSource(0);
+        Joypad joypad = new Joypad(interrupts, EventBus.NULL_EVENT_BUS, false, hub);
+        joypad.setByte(JOYP, 0x00);
+        settlePlayerInputHub(joypad);
+        advanceToHubResidue(joypad, 62);
+        assertEquals(2, joypad.performanceQuietSpanLimit(99));
+
+        ComponentState<Joypad> before = joypad.captureState();
+        ComponentState<InterruptManager> interruptBefore = interrupts.captureState();
+        source.update(Set.of(Button.A));
+        assertTrue(joypad.tickPerformanceQuietSpan(2));
+        assertEquals("hub changes are observed only by a poll", PlayerInputSnapshot.RELEASED,
+                joypad.getSampledInput());
+        assertEquals(inputHistory(before), inputHistory(joypad.captureState()));
+        assertEquals(filteredInputLines(before), filteredInputLines(joypad.captureState()));
+        assertEquals(interruptBefore, interrupts.captureState());
+
+        // The next scalar tick is the post-increment poll (residue 1), and only then adopts the
+        // changed immutable hub snapshot. The electrical filter still advances on its own clock.
+        joypad.tick();
+        assertSame(hub.sample(), joypad.getSampledInput());
+    }
+
+    @Test
+    public void playerInputHubTrustedBulkKeepsScalarContractAcrossCaptureRestore() {
+        PlayerInputHub hub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle source = hub.openSource(0);
+        source.update(Set.of(Button.RIGHT));
+        InterruptManager interrupts = new InterruptManager(false);
+        Joypad joypad = new Joypad(interrupts, EventBus.NULL_EVENT_BUS, false, hub);
+        joypad.setByte(JOYP, 0x00);
+        settlePlayerInputHub(joypad);
+        advanceToHubResidue(joypad, 1);
+        ComponentState<Joypad> checkpoint = joypad.captureState();
+        ComponentState<InterruptManager> interruptCheckpoint = interrupts.captureState();
+
+        InterruptManager bulkInterrupts = new InterruptManager(false);
+        bulkInterrupts.restoreState(interruptCheckpoint);
+        Joypad bulk = new Joypad(bulkInterrupts, EventBus.NULL_EVENT_BUS, false, hub);
+        bulk.restoreState(checkpoint);
+        bulk.seedDeterministicReplayInput(Set.of(), hub.sample());
+        bulk.tick(); // restore intentionally clears derived eligibility; rebuild it off-poll
+        assertTrue(bulk.canTickPerformanceQuietSpan(3));
+        bulk.tickPerformanceQuietSpanTrusted(3);
+
+        InterruptManager scalarInterrupts = new InterruptManager(false);
+        scalarInterrupts.restoreState(interruptCheckpoint);
+        Joypad scalar = new Joypad(scalarInterrupts, EventBus.NULL_EVENT_BUS, false, hub);
+        scalar.restoreState(checkpoint);
+        scalar.seedDeterministicReplayInput(Set.of(), hub.sample());
+        scalar.tick();
+        for (int i = 0; i < 3; i++) {
+            scalar.tick();
+        }
+        assertEquals(tick(scalar.captureState()), tick(bulk.captureState()));
+        assertEquals(inputHistory(scalar.captureState()), inputHistory(bulk.captureState()));
+        assertEquals(filteredInputLines(scalar.captureState()),
+                filteredInputLines(bulk.captureState()));
+        assertEquals(inputChangedSinceLastTick(scalar.captureState()),
+                inputChangedSinceLastTick(bulk.captureState()));
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
     public void playerInputHubChangesAreBoundedAndRetainOneMegahertzFilterTiming() {
         InterruptManager interrupts = new InterruptManager(false);
         interrupts.setByte(0xff0f, 0);
@@ -577,6 +668,13 @@ public class JoypadHotPathTest {
 
     private static void tickNonPollHubInterval(Joypad joypad) {
         for (int tick = 0; tick < Joypad.PLAYER_INPUT_HUB_POLL_TICKS - 1; tick++) {
+            joypad.tick();
+        }
+    }
+
+    private static void advanceToHubResidue(Joypad joypad, int residue) {
+        while ((tick(joypad.captureState()) & (Joypad.PLAYER_INPUT_HUB_POLL_TICKS - 1L))
+                != residue) {
             joypad.tick();
         }
     }


### PR DESCRIPTION
## Summary

- admit the Android `PlayerInputHub` between its exact 64-tick poll boundaries so the existing PERFORMANCE packet path can run on device
- evaluate packet horizons once and use preflighted Timer, Serial, IR, Joypad, and cartridge commits while keeping the fourth CPU/bus dot scalar
- reject pending OAM DMA clock work and republish final CGB GPU timing to HDMA after every bulk tail
- add DMG/CGB state differentials, capture/restore coverage, hub poll-boundary tests, and 1–3-dot FF55 seam tests

## Validation

- `/opt/maven/bin/mvn -pl core test` — 1,721 tests, 0 failures/errors, 8 expected skips
- `git diff --check`
- two independent timing/correctness reviews found no production blocker

## Android A/B

Sustained 600-frame PERFORMANCE runs with presentation and app audio enabled, 60 Hz, stable thermals, zero GC, and 600/600 integrity:

- native CGB: 23.274 FPS vs 23.015 baseline (+1.12%); controller CPU 25,539 ms vs 25,866 ms
- DMG: 26.237 FPS vs 26.517 baseline (-1.05%); controller CPU 22,608 ms vs 22,403 ms

This is performance-flat within device run noise and is not a 55/60 FPS claim. Android benchmark logs do not currently expose the core bulk-span counters.

## Performance scope

This enables the existing all-subsystem short-span scheduler for Android input; it deliberately leaves the CPU-authoritative fourth dot scalar and keeps unsupported/device-sensitive paths fail-closed.