### PR TITLE
Fix Uno four-player connection setup

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -218,7 +218,7 @@ public final class FourPlayerAdapter {
                 // Player 1 is the protocol master. Once it starts the AA command, complete the
                 // current ping packet before switching phases. Only three AA replies fit after
                 // the FE header; games may send the fourth alongside the first CC response.
-                if (player == 0 && reply == 0xaa) {
+                if (player == 0 && connected[player] && reply == 0xaa) {
                     transmissionRequested = true;
                 }
             } else if (phase == Phase.TRANSMISSION) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -28,6 +28,21 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
+    public void ignoresMasterTransmissionCommandBeforeThePingAcknowledgement() {
+        Rig rig = new Rig();
+
+        // Boot-time serial traffic can contain AA before a port has completed the ping ACK.
+        // It must not permanently switch the adapter away from the connection phase.
+        rig.transfer(0xaa, 0, 0, 0);
+        rig.transfer(0, 0, 0, 0);
+        rig.transfer(0, 0, 0, 0);
+        rig.transfer(0, 0, 0, 0);
+
+        assertArrayEquals(new int[]{0xfe, 0xfe, 0xfe, 0xfe},
+                rig.transfer(0, 0, 0, 0));
+    }
+
+    @Test
     public void transmissionBroadcastsPreviousPacketWithoutCrossPacketSplicing() {
         Rig rig = new Rig();
 


### PR DESCRIPTION
## Compatibility fix

`Uno - Small World (Japan)` and `Uno 2 - Small World (Japan)` can send an `AA` byte while their boot-time serial activity has not completed the DMG-07 ping acknowledgement. The adapter treated that byte as a transmission request, left the ping phase with no connected ports, and never reached the games' four-player connection screen.

The adapter now accepts player 1's `AA` transmission command only after that player has completed the ping acknowledgement. This preserves the real transmission transition while ignoring the premature boot-time command.

## Visual verification

Before — current `master`, player 1 at frame 850 of the same four-console input sequence: the selected multiplayer mode remains on the menu.

![Before: multiplayer menu remains selected](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/frame-0850-player-1-5268ff78.png)

After — this branch, same four-console input sequence and frame: the four-player connection screen appears.

![After: four-player connection screen](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/frame-0850-player-1-8df222d5.png)

The same guarded adapter path was also verified with `Uno 2 - Small World (Japan)`.

## Verification

- `mvn -pl core -Dtest=FourPlayerAdapterTest test` — 7 passed.
- `mvn -pl core test` — 1,732 passed, 0 failed, 0 errors, 8 skipped.
- Reproduced the supplied four-console connection sequence before and after the change on both reported Uno releases.

Fixes #568
