### PR TITLE
Fix Jantaku Boy four-player transition

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
@@ -382,7 +382,13 @@ internal object StateValueCodec {
             listOf("NONE", "REVERSE_PENDING", "PREEMPT_CPU", "YIELD_CPU"),
             listOf("IDLE", "COMMAND", "READING", "WRITING"),
             listOf("HANDSHAKE", "READY", "SENDING"),
-            listOf("PING", "TRANSMISSION_INDICATOR", "TRANSMISSION", "PING_INDICATOR"),
+            listOf(
+                "PING",
+                "TRANSMISSION_INDICATOR",
+                "TRANSMISSION",
+                "PING_INDICATOR",
+                "JANTAKU_BOY_CONTROL",
+            ),
             listOf("CANCEL", "FREEZE", "BLANK_BLACK", "BLANK_COLOR0"),
         )
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -60,6 +60,7 @@ import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
 import eu.rekawek.coffeegb.core.rumble.CodeBreakerRumble;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.serial.SerialCompatibilityProfile;
 import eu.rekawek.coffeegb.core.serial.SerialPort;
 import eu.rekawek.coffeegb.core.sgb.Background;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
@@ -164,6 +165,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final CodeBreakerRumble codeBreakerRumble;
 
+    private final boolean jantakuBoyFourPlayerPatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -266,6 +269,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.CLEAR_BOOT_TILEMAP);
         clearCgbBootOamShadowPending = cartridgeProperties.has(
                 CartridgeProperties.Feature.CLEAR_CGB_BOOT_OAM_SHADOW);
+        jantakuBoyFourPlayerPatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -587,6 +592,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.init(eventBus);
         display.init(eventBus);
         sound.init(eventBus);
+        if (jantakuBoyFourPlayerPatch) {
+            serialEndpoint.enableCompatibilityProfile(
+                    SerialCompatibilityProfile.JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET);
+        }
         serialPort.init(serialEndpoint);
         infraredPort.setSerialEndpoint(serialEndpoint);
         infraredPort.init(eventBus, infraredEndpoint);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -69,10 +69,11 @@ public final class CartridgeProperties {
         CGB0_REVISION,
         MEALYBUG_DMG_BLOB,
         CODEBREAKER_RUMBLE,
-        JANTAKU_BOY_FOUR_PLAYER_PATCH,
         EARLY_CGB_LY_READ_EDGE,
         PRESERVE_INVALID_HEADER_CHECKSUM,
-        SUPER_FIGHTERS_S_LIVE_PATCH
+        SUPER_FIGHTERS_S_LIVE_PATCH,
+        // Append new features: Feature ordinals are part of the StateFile v1 identity.
+        JANTAKU_BOY_FOUR_PLAYER_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -69,6 +69,7 @@ public final class CartridgeProperties {
         CGB0_REVISION,
         MEALYBUG_DMG_BLOB,
         CODEBREAKER_RUMBLE,
+        JANTAKU_BOY_FOUR_PLAYER_PATCH,
         EARLY_CGB_LY_READ_EDGE,
         PRESERVE_INVALID_HEADER_CHECKSUM,
         SUPER_FIGHTERS_S_LIVE_PATCH
@@ -201,6 +202,9 @@ public final class CartridgeProperties {
             features("CodeBreaker in-game rumble demo",
                     CartridgeProperties::isCodeBreakerRumbleDemo,
                     Feature.CODEBREAKER_RUMBLE),
+            features("Jantaku Boy four-player transition workaround",
+                    CartridgeProperties::isJantakuBoyFourPlayer,
+                    Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -804,6 +808,27 @@ public final class CartridgeProperties {
 
     private static boolean isCodeBreakerRumbleDemo(RomInfo info) {
         return info.crc32() == 0xfd096905;
+    }
+
+    private static boolean isJantakuBoyFourPlayer(RomInfo info) {
+        int[] fourPlayerWait = {
+                0xf0, 0x9b, 0x47, 0x0e, 0x00, 0x21, 0x9d, 0xff,
+                0x3e, 0xfd, 0xbe, 0xc0, 0x71, 0x3e, 0xff, 0x23,
+                0x05, 0x20, 0xf7, 0x3e, 0x02, 0xe0, 0x99, 0x3e,
+                0x01, 0xe0, 0xa8
+        };
+        return info.data.length == 0x20000
+                && "JANTAKUBOY".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x02
+                && info.byteAt(0x0149) == 0x00
+                && matches(info.data, 0x0395, fourPlayerWait);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapter.java
@@ -27,6 +27,8 @@ public final class FourPlayerAdapter {
 
     private static final int PING_PACKET_GAP_TICKS = 51_548;
 
+    private static final int[] JANTAKU_BOY_CONTROL_PACKET = {0xfd, 0xff, 0xff, 0xff};
+
     private final int clockTicksPerBit;
 
     private final int pingByteGapTicks;
@@ -50,6 +52,8 @@ public final class FourPlayerAdapter {
     private final int[] pendingBits = new int[PLAYER_COUNT];
 
     private final boolean[] connected = new boolean[PLAYER_COUNT];
+
+    private final boolean[] jantakuBoyControlPacket = new boolean[PLAYER_COUNT];
 
     private final int[] consecutiveFf = new int[PLAYER_COUNT];
 
@@ -104,6 +108,7 @@ public final class FourPlayerAdapter {
             case PING -> packetByte == 0 ? 0xfe : statusMask();
             case TRANSMISSION_INDICATOR -> 0xcc;
             case PING_INDICATOR -> 0xff;
+            case JANTAKU_BOY_CONTROL -> JANTAKU_BOY_CONTROL_PACKET[packetByte];
             case TRANSMISSION -> transmissionBuffer[packetByte];
         };
     }
@@ -128,13 +133,14 @@ public final class FourPlayerAdapter {
 
     private int packetLength() {
         return switch (phase) {
-            case PING, TRANSMISSION_INDICATOR -> 4;
+            case PING, TRANSMISSION_INDICATOR, JANTAKU_BOY_CONTROL -> 4;
             case TRANSMISSION, PING_INDICATOR -> size * PLAYER_COUNT;
         };
     }
 
     private int byteGapTicks() {
-        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR) {
+        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR
+                || phase == Phase.JANTAKU_BOY_CONTROL) {
             return pingByteGapTicks;
         }
         return Math.addExact(
@@ -143,7 +149,8 @@ public final class FourPlayerAdapter {
     }
 
     private int packetGapTicks(int packetLength) {
-        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR) {
+        if (phase == Phase.PING || phase == Phase.TRANSMISSION_INDICATOR
+                || phase == Phase.JANTAKU_BOY_CONTROL) {
             return Math.addExact(
                     pingPacketGapTicks,
                     Math.multiplyExact(rate & 0x0f, ticksPerMillisecond));
@@ -159,12 +166,18 @@ public final class FourPlayerAdapter {
     private void finishPacket() {
         switch (phase) {
             case PING -> finishPingPacket();
-            case TRANSMISSION_INDICATOR -> phase = Phase.TRANSMISSION;
+            case TRANSMISSION_INDICATOR -> {
+                phase = Phase.TRANSMISSION;
+                if (allPlayersUseJantakuBoyControlPacket() && size == 1) {
+                    transmissionBuffer = Arrays.copyOf(JANTAKU_BOY_CONTROL_PACKET, 16);
+                }
+            }
             case TRANSMISSION -> finishTransmissionPacket();
             case PING_INDICATOR -> {
                 phase = Phase.PING;
                 Arrays.fill(connected, false);
             }
+            case JANTAKU_BOY_CONTROL -> finishJantakuBoyControlPacket();
         }
         for (int[] playerReplies : replies) {
             Arrays.fill(playerReplies, 0);
@@ -198,6 +211,14 @@ public final class FourPlayerAdapter {
     }
 
     private void finishTransmissionPacket() {
+        if (restartPingRequested && allPlayersUseJantakuBoyControlPacket() && size == 1) {
+            // This title requires a non-standard control response at this restart boundary.
+            // Preserve the restart packet's framing/timing but return only the detected title's
+            // FD/FF/FF/FF response instead of disconnecting the four linked consoles.
+            phase = Phase.JANTAKU_BOY_CONTROL;
+            restartPingRequested = false;
+            return;
+        }
         int[] nextBuffer = new int[16];
         for (int player = 0; player < PLAYER_COUNT; player++) {
             // Games load byte 1 after receiving byte 0, so the first SIZE replies are physically
@@ -209,6 +230,21 @@ public final class FourPlayerAdapter {
             phase = Phase.PING_INDICATOR;
             restartPingRequested = false;
         }
+    }
+
+    private void finishJantakuBoyControlPacket() {
+        // Retain the control phase: this exact title expects this bridge response in place of
+        // the adapter's normal disconnect/re-ping sequence.
+        finishTransmissionPacket();
+    }
+
+    private boolean allPlayersUseJantakuBoyControlPacket() {
+        for (boolean enabled : jantakuBoyControlPacket) {
+            if (!enabled) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void observeReplyByte() {
@@ -223,7 +259,8 @@ public final class FourPlayerAdapter {
                 }
             } else if (phase == Phase.TRANSMISSION) {
                 consecutiveFf[player] = reply == 0xff ? consecutiveFf[player] + 1 : 0;
-                if (consecutiveFf[player] >= 3) {
+                int restartThreshold = allPlayersUseJantakuBoyControlPacket() ? 2 : 3;
+                if (consecutiveFf[player] >= restartThreshold) {
                     restartPingRequested = true;
                 }
             }
@@ -265,7 +302,8 @@ public final class FourPlayerAdapter {
         PING,
         TRANSMISSION_INDICATOR,
         TRANSMISSION,
-        PING_INDICATOR
+        PING_INDICATOR,
+        JANTAKU_BOY_CONTROL
     }
 
     private record AdapterState(int[] sb, boolean[] transferArmed, int[] pendingBits,
@@ -291,6 +329,13 @@ public final class FourPlayerAdapter {
 
         private Endpoint(int player) {
             this.player = player;
+        }
+
+        @Override
+        public void enableCompatibilityProfile(SerialCompatibilityProfile profile) {
+            if (profile == SerialCompatibilityProfile.JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET) {
+                jantakuBoyControlPacket[player] = true;
+            }
         }
 
         @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialCompatibilityProfile.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialCompatibilityProfile.java
@@ -1,0 +1,8 @@
+package eu.rekawek.coffeegb.core.serial;
+
+/**
+ * Narrowly scoped serial-device workarounds requested by a detected cartridge.
+ */
+public enum SerialCompatibilityProfile {
+    JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -4,6 +4,11 @@ import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
 public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
+
+    /** Enables a narrowly detected cartridge compatibility profile for this endpoint. */
+    default void enableCompatibilityProfile(SerialCompatibilityProfile profile) {
+    }
+
     /**
      * Returns the largest span for which omitting this endpoint's master-clock callback is exact.
      * During the admitted span {@link #tick()} and {@link #setExternalTransfer(boolean)} with a

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/JantakuBoyFourPlayerPatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/JantakuBoyFourPlayerPatchTest.java
@@ -1,0 +1,115 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.SerialCompatibilityProfile;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JantakuBoyFourPlayerPatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownFourPlayerTransition() throws IOException {
+        Rom rom = new Rom(jantakuBoyRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH));
+        assertEquals(0xf0, rom.getRom()[0x0395]);
+    }
+
+    @Test
+    public void rejectsARevisionWithoutTheKnownHandler() throws IOException {
+        byte[] data = jantakuBoyRom();
+        data[0x0395] = 0;
+
+        Rom rom = new Rom(data);
+
+        assertFalse(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH));
+        assertEquals(0x00, rom.getRom()[0x0395]);
+    }
+
+    @Test
+    public void enablesTheSerialWorkaroundOnlyForTheDetectedRom() throws IOException {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(jantakuBoyRom()))
+                .setSupportBatterySave(false)
+                .build()) {
+            RecordingEndpoint endpoint = new RecordingEndpoint();
+
+            gameboy.init(EventBus.NULL_EVENT_BUS, endpoint, null);
+
+            assertEquals(SerialCompatibilityProfile.JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET,
+                    endpoint.profile);
+        }
+    }
+
+    private static final class RecordingEndpoint implements SerialEndpoint {
+
+        private SerialCompatibilityProfile profile;
+
+        @Override
+        public void enableCompatibilityProfile(SerialCompatibilityProfile profile) {
+            this.profile = profile;
+        }
+
+        @Override
+        public ComponentState<SerialEndpoint> captureState() {
+            return null;
+        }
+
+        @Override
+        public void restoreState(ComponentState<SerialEndpoint> state) {
+        }
+
+        @Override
+        public void setSb(int sb) {
+        }
+
+        @Override
+        public int recvBit() {
+            return -1;
+        }
+
+        @Override
+        public void startSending() {
+        }
+
+        @Override
+        public int sendBit() {
+            return 1;
+        }
+    }
+
+    private static byte[] jantakuBoyRom() {
+        byte[] data = new byte[0x20000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "JANTAKUBOY".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x00;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x02;
+        data[0x0149] = 0x00;
+        int[] fourPlayerWait = {
+                0xf0, 0x9b, 0x47, 0x0e, 0x00, 0x21, 0x9d, 0xff,
+                0x3e, 0xfd, 0xbe, 0xc0, 0x71, 0x3e, 0xff, 0x23,
+                0x05, 0x20, 0xf7, 0x3e, 0x02, 0xe0, 0x99, 0x3e,
+                0x01, 0xe0, 0xa8
+        };
+        for (int i = 0; i < fourPlayerWait.length; i++) {
+            data[0x0395 + i] = (byte) fourPlayerWait[i];
+        }
+        return data;
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/FourPlayerAdapterTest.java
@@ -92,6 +92,27 @@ public class FourPlayerAdapterTest {
     }
 
     @Test
+    public void jantakuBoyProfileSeedsAndBridgesItsTwoFfControlPacket() {
+        Rig rig = new Rig(true);
+
+        enterTransmission(rig, 1);
+
+        assertArrayEquals(new int[]{0xfd, 0xfd, 0xfd, 0xfd},
+                rig.transfer(0, 0, 0, 0));
+        for (int i = 0; i < 3; i++) {
+            assertArrayEquals(new int[]{0xff, 0xff, 0xff, 0xff},
+                    rig.transfer(i < 2 ? 0xff : 0, 0, 0, 0));
+        }
+
+        assertArrayEquals(new int[]{0xfd, 0xfd, 0xfd, 0xfd},
+                rig.transfer(0, 0, 0, 0));
+        for (int i = 0; i < 3; i++) {
+            assertArrayEquals(new int[]{0xff, 0xff, 0xff, 0xff},
+                    rig.transfer(0, 0, 0, 0));
+        }
+    }
+
+    @Test
     public void restartSequenceReturnsToPingAfterFullFfIndicatorPacket() {
         Rig rig = new Rig();
         enterTransmission(rig, 1);
@@ -166,14 +187,27 @@ public class FourPlayerAdapterTest {
         private int lastTransferTicks;
 
         private Rig() {
-            this(ClockSpec.LEGACY);
+            this(ClockSpec.LEGACY, false);
         }
 
         private Rig(ClockSpec clockSpec) {
+            this(clockSpec, false);
+        }
+
+        private Rig(boolean jantakuBoy) {
+            this(ClockSpec.LEGACY, jantakuBoy);
+        }
+
+        private Rig(ClockSpec clockSpec, boolean jantakuBoy) {
             FourPlayerAdapter adapter = new FourPlayerAdapter(clockSpec);
             for (int i = 0; i < ports.length; i++) {
                 ports[i] = new SerialPort(new InterruptManager(false), false, new SpeedMode(false));
-                ports[i].init(adapter.endpoint(i));
+                SerialEndpoint endpoint = adapter.endpoint(i);
+                if (jantakuBoy) {
+                    endpoint.enableCompatibilityProfile(
+                            SerialCompatibilityProfile.JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET);
+                }
+                ports[i].init(endpoint);
             }
         }
 


### PR DESCRIPTION
Fixes #559

## Summary

- Detect the exact Jantaku Boy four-player transition routine and enable a runtime-only serial compatibility profile for all four linked instances.
- Bridge the title's non-standard four-player control packet while retaining ordinary DMG-07 behavior for every other game.
- Keep the ROM image and source file untouched.

## Verification

- `mvn -pl core test` — 1,735 tests passed; 0 failures, 0 errors, 8 skipped.
- Focused cartridge detector, Game Boy profile wiring, and FourPlayerAdapter packet tests passed.
- Authorized local four-instance replay: stable four-player views through frame 600; a Player 1 A press at frame 650 advances the game animation.

## Visual evidence

Before — unpatched four-player replay remains blank after the parent starts the game (frame 360):

![Before: blank Player 1 display](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/frame-0360-player-1-cbd33979.png)

After — the compatibility profile reaches active views on all four linked consoles (frame 400):

![After: four active player views](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/jantaku-four-player-f400-eec0ef5a.png)
