### PR TITLE
Speed up PERFORMANCE mode for idle links and settled HALT

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
@@ -339,7 +339,9 @@ final class AndroidBenchmarkDiagnostics {
         speedFinalSample = speedModeFinal == 1 || speedModeFinal == 2;
         record("event=speed_sample frame=600 effective_gbc=" + event.getEffectiveGbc()
                 + " effective_dmg_compat=" + event.getEffectiveDmgCompat()
-                + " speed_mode_final=" + speedModeFinal + " speed_mode_sample=frame_600");
+                + " speed_mode_final=" + speedModeFinal + " speed_mode_sample=frame_600"
+                + " performance_bulk_spans=" + event.getPerformanceBulkSpans()
+                + " performance_bulk_ticks=" + event.getPerformanceBulkTicks());
         if (phase == Phase.ARMED) {
             phase = Phase.CORE_FROZEN;
         }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
@@ -179,7 +179,7 @@ public class AndroidBenchmarkDiagnosticsTest {
             diagnostics.frameReady();
         }
         diagnostics.benchmarkFrameBoundary(
-                new Controller.BenchmarkFrameBoundaryEvent(600L, true, true, 1));
+                new Controller.BenchmarkFrameBoundaryEvent(600L, true, true, 1, 12L, 345L));
         for (int submission = 1; submission <= 600; submission++) {
             diagnostics.frameSubmitted(submission);
         }
@@ -191,6 +191,12 @@ public class AndroidBenchmarkDiagnosticsTest {
         assertTrue(finalRecord.contains("effective_gbc=true"));
         assertTrue(finalRecord.contains("effective_dmg_compat=true"));
         assertTrue(finalRecord.contains("effective_mode=cgb-dmg-compat"));
+        String speedRecord = records.stream()
+                .filter(line -> line.startsWith("event=speed_sample"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(speedRecord.contains("performance_bulk_spans=12"));
+        assertTrue(speedRecord.contains("performance_bulk_ticks=345"));
     }
 
     private static AndroidBenchmarkDiagnostics armedDiagnostics(long generation) {

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
@@ -798,6 +798,7 @@ public final class BenchmarkMatrix {
                 || key.endsWith("_ns")
                 || key.endsWith("_ms") || key.endsWith("_bytes") || key.endsWith("_frames")
                 || key.endsWith("_count") || key.endsWith("_events")
+                || key.endsWith("_spans") || key.endsWith("_ticks")
                 || key.endsWith("_millihz")
                 || key.endsWith("_milli") || key.endsWith("_rate") || key.endsWith("_status")
                 || key.endsWith("_hz")
@@ -850,7 +851,8 @@ public final class BenchmarkMatrix {
             case "benchmark_arm_rejected" -> Set.of("event", "phase", "reason");
             case "benchmark_anchor" -> Set.of("event", "success", "phase", "reason");
             case "speed_sample" -> Set.of("event", "frame", "effective_gbc",
-                    "effective_dmg_compat", "speed_mode_final", "speed_mode_sample");
+                    "effective_dmg_compat", "speed_mode_final", "speed_mode_sample",
+                    "performance_bulk_spans", "performance_bulk_ticks");
             case "first_frame" -> Set.of("event", "frame", "wall_ns", "since_launch_ms",
                     "prep_to_frame_ms");
             case "frames" -> Set.of("event", "frame", "ready_count", "submitted_count",

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
@@ -88,6 +88,26 @@ public class BenchmarkMatrixTest {
     }
 
     @Test
+    public void validatesPerformanceBulkSpanAndTickTelemetryAsIntegers() {
+        List<String> valid = new ArrayList<>(syntheticSummaryLog(61.0, 62.0));
+        valid.add(
+                "event=speed_sample frame=600 effective_gbc=false"
+                        + " effective_dmg_compat=false speed_mode_final=1"
+                        + " speed_mode_sample=frame_600 performance_bulk_spans=12"
+                        + " performance_bulk_ticks=345");
+        BenchmarkMatrix.Report accepted = parse(valid);
+        assertTrue(accepted.errors().toString(), accepted.valid());
+
+        List<String> malformed = new ArrayList<>(valid);
+        int speedIndex = malformed.size() - 1;
+        malformed.set(speedIndex, malformed.get(speedIndex).replace("performance_bulk_ticks=345",
+                        "performance_bulk_ticks=not-a-number"));
+        BenchmarkMatrix.Report rejected = parse(malformed);
+        assertFalse(rejected.valid());
+        assertContains(rejected.errors(), "invalid integer performance_bulk_ticks");
+    }
+
+    @Test
     public void acceptsReadyOnlyFrameSinkContractButDoesNotUseItForVisibleGate() {
         List<String> sink = toSinkSummaryLog(syntheticSummaryLog(61.0, 62.0));
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -557,6 +557,7 @@ class BasicController private constructor(
         benchmarkGeneration = it.generation
         benchmarkArmed = true
         benchmarkCoreFrozen = false
+        currentSession.gameboy.resetPerformanceBulkCounters()
         debugFrame = 0L
         debugMasterTick = 0L
         debugFramePosition = 0
@@ -581,6 +582,8 @@ class BasicController private constructor(
                 gpu.isGbc(),
                 gpu.isDmgCompatMode(),
                 speedMode.getSpeedMode(),
+                currentSession.gameboy.getPerformanceBulkSpanCount(),
+                currentSession.gameboy.getPerformanceBulkTicks(),
             ),
         )
         benchmarkCoreFrozen = true

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -256,10 +256,22 @@ interface Controller : AutoCloseable {
       val effectiveGbc: Boolean,
       val effectiveDmgCompat: Boolean,
       val speedMode: Int,
+      val performanceBulkSpans: Long = 0L,
+      val performanceBulkTicks: Long = 0L,
   ) : Event {
+    /** Java/source compatibility for callers that predate bulk telemetry. */
+    constructor(
+        frame: Long,
+        effectiveGbc: Boolean,
+        effectiveDmgCompat: Boolean,
+        speedMode: Int,
+    ) : this(frame, effectiveGbc, effectiveDmgCompat, speedMode, 0L, 0L)
+
     init {
       require(frame > 0) { "Benchmark frame must be positive" }
       require(speedMode == 1 || speedMode == 2) { "Benchmark speed mode must be 1 or 2" }
+      require(performanceBulkSpans >= 0L) { "Benchmark bulk span count must be non-negative" }
+      require(performanceBulkTicks >= 0L) { "Benchmark bulk tick count must be non-negative" }
     }
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -823,7 +823,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                         && cpu.performancePhaseOnlySpanEligible()
                         && cpu.performanceNoPendingPpuReadPhase()
                         && !dma.isTransferInProgress()
-                        && !dma.requiresClockTick(false)
+                        && !dma.requiresClockTick(cpu.getState() == Cpu.State.HALTED)
                         && (!gbc || !hdma.hasActiveOrPendingTransfer())
                         // This is intentionally the one post-preflight volatile Joypad check.
                         // A legacy/debug/input mutation published after the horizon walk must
@@ -891,7 +891,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.tickPerformanceQuietSpanTrusted(ticks);
 
         // No CPU bus boundary exists inside this span. Advance the free-running phase once;
-        // running-state preflight proves Cpu.onPeripheralsTicked() is a no-op here.
+        // running state, or settled HALT, proves Cpu.onPeripheralsTicked() is a no-op here.
         cpu.advancePerformancePhaseOnlyTrusted(ticks);
         gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
@@ -904,13 +904,19 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
     }
 
+    /** Resets the session-only PERFORMANCE bulk counters at benchmark arm. */
+    public void resetPerformanceBulkCounters() {
+        performanceBulkSpanCount = 0L;
+        performanceBulkTicks = 0L;
+    }
+
     /** Number of all-subsystem PERFORMANCE bulk spans taken by the current session. */
-    long getPerformanceBulkSpanCount() {
+    public long getPerformanceBulkSpanCount() {
         return performanceBulkSpanCount;
     }
 
     /** Number of master ticks covered by all-subsystem PERFORMANCE bulk spans. */
-    long getPerformanceBulkTicks() {
+    public long getPerformanceBulkTicks() {
         return performanceBulkTicks;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -216,18 +216,20 @@ public class Cpu implements StatefulComponent<Cpu> {
     /**
      * Whether a PERFORMANCE phase-only span may safely call the peripheral wake callback.
      *
-     * <p>HALT entry and wake are deliberately kept on the scalar scheduler.  The callback can
-     * rephase {@link #clockCycle} for the HALT bug, or change the CPU state as an interrupt edge
-     * becomes visible.  The interrupt sequencer and locked/paused states are likewise cheap to
-     * leave scalar; a phase-only span is only useful while the ordinary instruction sequencer is
-     * active.</p>
+     * <p>HALT entry and wake are deliberately kept on the scalar scheduler. Once HALT's entry
+     * sample has settled, however, the peripheral callback is a no-op until an existing quiet
+     * horizon reaches the next wake edge, so its non-boundary dots are eligible. The callback can
+     * otherwise rephase {@link #clockCycle} for the HALT bug or change the CPU state as an
+     * interrupt edge becomes visible. The interrupt sequencer and locked/paused states remain
+     * scalar.</p>
      */
     public boolean performancePhaseOnlySpanEligible() {
         return haltEntrySampleTicks == 0
                 && (state == State.OPCODE
                 || state == State.EXT_OPCODE
                 || state == State.OPERAND
-                || state == State.RUNNING);
+                || state == State.RUNNING
+                || state == State.HALTED);
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -98,14 +98,15 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
     }
 
     /**
-     * Returns the exact idle CGB IR span.  External endpoints and the FullChanger are deliberately
-     * fail-closed: their callbacks or pulse edges must remain visible in the scalar ordering.
+     * Returns the exact idle CGB IR span. External infrared endpoints, non-quiet serial inputs,
+     * and the FullChanger are deliberately fail-closed: their callbacks or pulse edges must
+     * remain visible in the scalar ordering.
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0 || !gbc || speedMode.getSpeedMode() != 1
                 || fullChangerActive
                 || endpoint != InfraredEndpoint.NULL_ENDPOINT
-                || serialEndpoint != SerialEndpoint.NULL_ENDPOINT
+                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
                 || debugHooks != null) {
             return 0;
         }
@@ -124,8 +125,8 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         if (ticks <= 0) {
             return;
         }
-        // The packet preflight proves a disabled/null-endpoint IR state.  There is no arithmetic
-        // state to advance in that state, so the trusted commit is intentionally just a no-op.
+        // The packet preflight proves an inactive FullChanger, null IR endpoint, and quiet serial
+        // input. There is no arithmetic state to advance, so the trusted commit is a no-op.
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
@@ -18,6 +18,7 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
 
     private int bitIndex = 7;
 
+    /** Pairs two endpoints before session installation; this is not a concurrent hot-plug API. */
     public void init(Peer2PeerSerialEndpoint peer) {
         this.peer = peer;
         peer.peer = this;
@@ -26,6 +27,12 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
     /** True only while this endpoint has a live peer whose traffic must be replayed jointly. */
     public boolean isConnected() {
         return peer != null;
+    }
+
+    /** An unconnected cable is stably high and has no peer work; a connected cable stays scalar. */
+    @Override
+    public int performanceQuietSpanLimit(int requested) {
+        return requested > 0 && peer == null ? requested : 0;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -5,6 +5,24 @@ import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
 public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
     /**
+     * Returns the largest span for which omitting this endpoint's master-clock callback is exact.
+     * During the admitted span {@link #tick()} and {@link #setExternalTransfer(boolean)} with a
+     * false argument must be inert, {@link #recvBit()} must return {@code -1}, and
+     * {@link #isSerialInputHigh()} must remain true. PERFORMANCE uses this capability instead of
+     * assuming that an endpoint's default methods are inert; external endpoints must opt in
+     * explicitly. Endpoint topology is configured before installation, or by the Gameboy owner
+     * thread between ticks, and must not change concurrently with this query or the admitted span.
+     */
+    default int performanceQuietSpanLimit(int requested) {
+        return 0;
+    }
+
+    /** Returns whether the endpoint is quiet for the requested PERFORMANCE span. */
+    default boolean canTickPerformanceQuietSpan(int ticks) {
+        return ticks > 0 && performanceQuietSpanLimit(ticks) >= ticks;
+    }
+
+    /**
      * Releases deterministic ownership held by this endpoint before it is detached or discarded.
      *
      * <p>Most synchronous peripherals own no external lifecycle and therefore need no action. An
@@ -97,6 +115,11 @@ public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
                 @Override
                 public int sendBit() {
                     return 1;
+                }
+
+                @Override
+                public int performanceQuietSpanLimit(int requested) {
+                    return requested > 0 ? requested : 0;
                 }
             };
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -84,16 +84,15 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     /**
      * Returns the largest exact PERFORMANCE span for an idle link port.
      *
-     * <p>The NULL endpoint has no wall-clock work and a stopped transfer has no serial edge to
-     * deliver.  In that state the only serial state which advances is the free-running 8-bit
-     * phase.  External endpoints, active transfers, HALT wake delay, debug hooks, and the
-     * interrupt acknowledge path remain scalar so endpoint callbacks and trace ordering cannot
-     * be observed late.</p>
+     * <p>A quiet endpoint has no wall-clock work and a stopped transfer has no serial edge to
+     * deliver. In that state the only serial state which advances is the free-running 8-bit
+     * phase. Other endpoints, active transfers, HALT wake delay, and debug hooks remain scalar so
+     * endpoint callbacks and trace ordering cannot be observed late.</p>
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0
                 || speedMode.getSpeedMode() != 1
-                || serialEndpoint != SerialEndpoint.NULL_ENDPOINT
+                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
                 || (sc & 0x80) != 0
                 || haltWakeDelay != 0
                 || debugHooks != null) {
@@ -113,7 +112,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     }
 
     /**
-     * Advances an idle NULL-endpoint serial port without entering its per-clock callback path.
+     * Advances an idle quiet-endpoint serial port without entering its per-clock callback path.
      * A pending acknowledge is consumed at the same beginning-of-tick boundary as scalar
      * execution; no active transfer exists in an eligible span, so this cannot create a hidden
      * shift or completion event.
@@ -134,7 +133,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         if (ticks <= 0) {
             return;
         }
-        // The packet preflight has already established an idle NULL endpoint and no pending
+        // The packet preflight has already established an idle quiet endpoint and no pending
         // acknowledge/transfer edge.  Do not repeat that walk on the hot commit path.
         acknowledgeInterruptIfNeeded();
         serialClocks = (serialClocks + ticks) & 0xff;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -5,6 +5,9 @@ import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.cpu.Cpu;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
 
@@ -125,6 +128,93 @@ public final class GameboyPlayerInputHubPerformanceTest {
         }
     }
 
+    @Test
+    public void settledHaltMatchesScalarDmgAndCgbWithBulkCoverage() throws Exception {
+        for (boolean cgb : new boolean[]{false, true}) {
+            PlayerInputHub hub = new PlayerInputHub();
+            hub.openSource(0);
+            try (Gameboy performance = haltSession(cgb, hub);
+                    // A non-hub source deliberately makes Joypad's horizon zero, retaining the
+                    // PERFORMANCE components while forcing the scalar scheduler as the oracle.
+                    Gameboy scalar = haltSession(cgb,
+                            () -> PlayerInputSnapshot.released())) {
+                for (int chunk = 0; chunk < 120; chunk++) {
+                    performance.runTicks(100);
+                    scalar.runTicks(100);
+                }
+
+                assertEquals("HALT state cgb=" + cgb, Cpu.State.HALTED,
+                        performance.getCpu().getState());
+                assertEquals("scalar HALT state cgb=" + cgb, Cpu.State.HALTED,
+                        scalar.getCpu().getState());
+                assertEquals("HALT differential cgb=" + cgb + " "
+                                + componentHashes(scalar.captureState(), performance.captureState()),
+                        stateHash(scalar.captureState()), stateHash(performance.captureState()));
+                assertRasterEquivalent(scalar, performance, "HALT cgb=" + cgb);
+                assertTrue("stable HALT had no substantial bulk coverage cgb=" + cgb
+                                + " ticks=" + performance.getPerformanceBulkTicks(),
+                        performance.getPerformanceBulkTicks() > 1_000);
+            }
+        }
+    }
+
+    @Test
+    public void settledHaltWakeEdgesMatchScalarForOneToThreeDotTails() throws Exception {
+        for (boolean cgb : new boolean[]{false, true}) {
+            for (WakeSource wakeSource : WakeSource.values()) {
+                for (int tail = 1; tail <= 3; tail++) {
+                    PlayerInputHub hub = new PlayerInputHub();
+                    hub.openSource(0);
+                    try (Gameboy performance = haltSession(cgb, hub);
+                            Gameboy scalar = haltSession(cgb,
+                                    () -> PlayerInputSnapshot.released())) {
+                        settleHalt(performance, scalar, cgb, wakeSource, tail);
+                        armWakeSource(performance, wakeSource);
+                        armWakeSource(scalar, wakeSource);
+                        performance.resetPerformanceBulkCounters();
+                        scalar.resetPerformanceBulkCounters();
+
+                        boolean sawWholeTail = false;
+                        int elapsed = 0;
+                        while (performance.getCpu().getState() == Cpu.State.HALTED
+                                && elapsed < 2_000) {
+                            long bulkBefore = performance.getPerformanceBulkTicks();
+                            long performanceFrames = performance.runTicks(tail);
+                            long scalarFrames = runScalarTicks(scalar, tail);
+                            sawWholeTail |= performance.getPerformanceBulkTicks() - bulkBefore
+                                    == tail;
+                            assertEquals(context(cgb, wakeSource, tail) + " frame events",
+                                    scalarFrames, performanceFrames);
+                            assertEquals(context(cgb, wakeSource, tail) + " CPU wake tick",
+                                    scalar.getCpu().getState(), performance.getCpu().getState());
+                            elapsed += tail;
+                        }
+
+                        assertTrue(context(cgb, wakeSource, tail) + " did not wake",
+                                performance.getCpu().getState() != Cpu.State.HALTED);
+                        assertTrue(context(cgb, wakeSource, tail)
+                                        + " never committed a whole caller tail",
+                                sawWholeTail);
+
+                        // Continue past the wake boundary. Inactive OAM DMA must leave its
+                        // HALT-pause latch on the same running-CPU value as the scalar machine.
+                        assertEquals(context(cgb, wakeSource, tail) + " post-wake frame events",
+                                runScalarTicks(scalar, 8), performance.runTicks(8));
+                        ComponentState<Gameboy> scalarState = scalar.captureState();
+                        ComponentState<Gameboy> performanceState = performance.captureState();
+                        assertEquals(context(cgb, wakeSource, tail) + " DMA pause latch",
+                                recordComponentHash(scalarState, "dmaMemento"),
+                                recordComponentHash(performanceState, "dmaMemento"));
+                        assertStateEquivalent(scalarState, performanceState,
+                                context(cgb, wakeSource, tail));
+                        assertRasterEquivalent(scalar, performance,
+                                context(cgb, wakeSource, tail));
+                    }
+                }
+            }
+        }
+    }
+
     private static Gameboy session(boolean cgb, ExecutionMode mode, PlayerInputHub hub)
             throws Exception {
         return session(cgb, mode, (PlayerInputSource) hub);
@@ -143,12 +233,119 @@ public final class GameboyPlayerInputHubPerformanceTest {
         image[0x105] = (byte) 0xfe;
         image[0x143] = (byte) (cgb ? 0x80 : 0);
         image[0x147] = 0;
-        return new Gameboy.GameboyConfiguration(new Rom(image))
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(image))
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(mode)
                 .setSupportBatterySave(false)
                 .setPlayerInputSource(inputSource)
                 .build();
+        // Use the real disconnected cable endpoint used by the controller link path.  Its
+        // PERFORMANCE capability is intentionally distinct from the NULL endpoint and must
+        // remain quiet only while it has no peer.
+        gameboy.init(new EventBusImpl(null, null, false), new Peer2PeerSerialEndpoint(), null);
+        return gameboy;
+    }
+
+    private static Gameboy haltSession(boolean cgb, PlayerInputSource inputSource) throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x76; // HALT with no interrupt sources enabled
+        image[0x101] = 0x00;
+        image[0x143] = (byte) (cgb ? 0x80 : 0);
+        image[0x147] = 0;
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(image))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+        gameboy.init(new EventBusImpl(null, null, false), new Peer2PeerSerialEndpoint(), null);
+        return gameboy;
+    }
+
+    private static void settleHalt(Gameboy performance, Gameboy scalar, boolean cgb,
+                                   WakeSource wakeSource, int tail) {
+        performance.runTicks(128);
+        runScalarTicks(scalar, 128);
+        assertEquals(context(cgb, wakeSource, tail) + " candidate did not settle in HALT",
+                Cpu.State.HALTED, performance.getCpu().getState());
+        assertEquals(context(cgb, wakeSource, tail) + " oracle did not settle in HALT",
+                Cpu.State.HALTED, scalar.getCpu().getState());
+
+        // Arm mode-2 STAT only from a deasserted source so the tested interrupt is the next
+        // PPU edge, rather than the register write itself.
+        if (wakeSource == WakeSource.STAT) {
+            int guard = 0;
+            while (performance.getGpu().getVisibleStatMode() == 2 && guard++ < 100) {
+                performance.runTicks(1);
+                scalar.runTicks(1);
+            }
+            assertTrue(context(cgb, wakeSource, tail) + " STAT source did not deassert",
+                    performance.getGpu().getVisibleStatMode() != 2);
+        }
+        assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                context(cgb, wakeSource, tail) + " pre-arm");
+    }
+
+    private static void armWakeSource(Gameboy gameboy, WakeSource wakeSource) {
+        var bus = gameboy.getAddressSpace();
+        bus.setByte(0xffff, 0);
+        bus.setByte(0xff0f, 0);
+        if (wakeSource == WakeSource.TIMER) {
+            bus.setByte(0xff07, 0);
+            bus.setByte(0xff04, 0);
+            bus.setByte(0xff06, 0);
+            bus.setByte(0xff05, 0xff);
+            bus.setByte(0xff07, 0x05);
+            bus.setByte(0xffff, 0x04);
+        } else {
+            bus.setByte(0xff41, 0x20);
+            bus.setByte(0xff0f, 0);
+            bus.setByte(0xffff, 0x02);
+        }
+    }
+
+    private static long runScalarTicks(Gameboy scalar, int ticks) {
+        long frameEvents = 0;
+        for (int tick = 0; tick < ticks; tick++) {
+            frameEvents += scalar.runTicks(1);
+        }
+        return frameEvents;
+    }
+
+    private static String context(boolean cgb, WakeSource wakeSource, int tail) {
+        return "cgb=" + cgb + ", wake=" + wakeSource + ", tail=" + tail;
+    }
+
+    private static void assertStateEquivalent(ComponentState<Gameboy> scalar,
+                                              ComponentState<Gameboy> performance,
+                                              String context) {
+        int scalarHash = stateHash(scalar);
+        int performanceHash = stateHash(performance);
+        if (scalarHash != performanceHash) {
+            assertEquals(context + " " + componentHashes(scalar, performance),
+                    scalarHash, performanceHash);
+        }
+    }
+
+    private static int recordComponentHash(Object value, String componentName) {
+        for (RecordComponent component : value.getClass().getRecordComponents()) {
+            if (!component.getName().equals(componentName)) {
+                continue;
+            }
+            try {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                return stateHash(accessor.invoke(value));
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError("Cannot hash state component " + component, e);
+            }
+        }
+        throw new AssertionError("Missing record component " + componentName);
+    }
+
+    private enum WakeSource {
+        TIMER,
+        STAT
     }
 
     private static PlayerInputSnapshot snapshot(Set<Button> buttons) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.ir;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -29,6 +30,21 @@ public class InfraredPortTest {
         port.setSerialEndpoint(new LowSerialInput());
 
         assertEquals(0x2e, port.getByte(0xff56));
+    }
+
+    @Test
+    public void performanceQuietSpanAdmitsOnlyDisconnectedPeerCable() {
+        InfraredPort port = new InfraredPort(true, new SpeedMode(true));
+        port.setSerialEndpoint(new Peer2PeerSerialEndpoint());
+        assertEquals(3, port.performanceQuietSpanLimit(3));
+
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        first.init(new Peer2PeerSerialEndpoint());
+        port.setSerialEndpoint(first);
+        assertEquals(0, port.performanceQuietSpanLimit(3));
+
+        port.setSerialEndpoint(new LowSerialInput());
+        assertEquals(0, port.performanceQuietSpanLimit(3));
     }
 
     private static class LowSerialInput implements SerialEndpoint {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
@@ -78,6 +78,24 @@ public class SerialPortPerformanceSpanTest {
         assertEquals(0, debug.performanceQuietSpanLimit(1));
     }
 
+    @Test
+    public void disconnectedPeerCableIsQuietButConnectedCableIsNot() {
+        Peer2PeerSerialEndpoint disconnected = new Peer2PeerSerialEndpoint();
+        SerialPort idle = new SerialPort(
+                new InterruptManager(false), false, new SpeedMode(false));
+        idle.init(disconnected);
+        assertEquals(3, idle.performanceQuietSpanLimit(3));
+
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+        SerialPort connected = new SerialPort(
+                new InterruptManager(false), false, new SpeedMode(false));
+        connected.init(first);
+        assertEquals(0, connected.performanceQuietSpanLimit(3));
+        assertEquals(0, first.performanceQuietSpanLimit(3));
+    }
+
     private static final class NoopEndpoint implements SerialEndpoint {
         @Override
         public void setSb(int sb) {


### PR DESCRIPTION
## Summary

- enable exact PERFORMANCE bulk spans for the disconnected peer-link endpoint used by Android while keeping connected and custom endpoints fail-closed
- admit settled HALT between CPU boundaries, preserving interrupt-wake timing and the OAM-DMA HALT pause state
- reset and expose session-only bulk-span telemetry at benchmark arm, with strict Android log parsing

ACCURACY mode is unchanged, and this adds no portable/save-state fields.

## Validation

- full core unit suite: 1,734 tests, 0 failures/errors (8 expected skips)
- full timing, rendering, audio, microtest, and hardware compatibility profiles: all green
- controller validation: 77 tests, 0 failures/errors
- Android diagnostics/parser/runtime validation: 44 tests, 0 failures/errors
- Android benchmark matrix harness: 168 launch/gate checks passed
- focused DMG/CGB differentials cover settled HALT, timer and STAT wake edges, 1–3-dot tails, post-wake DMA pause state, disconnected/connected links, and IR gating

## Android device A/B

| Profile | Parent | Candidate | Change | Bulk coverage |
| --- | ---: | ---: | ---: | ---: |
| Native CGB | 20.79 FPS | 37.09 FPS | +78.4% | 58.1% |
| DMG | 26.11 FPS | 43.73 FPS | +67.5% | 57.3% |

Average committed span was 2.80–2.81 ticks. Both profiles retained zero dropped, duplicate, late, or corrupt frames; zero candidate allocations/GC; no thermal event; and no audio-write failures.

This is a substantial step toward real-time PERFORMANCE mode, though these device rows do not yet reach 60 FPS.
