### PR TITLE
Batch settled DMG HALT spans in PERFORMANCE mode

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -10,3 +10,9 @@
 # created by a release build has the same schema as a debug or desktop build.
 -keepattributes MethodParameters,Signature
 -keep class * implements eu.rekawek.coffeegb.core.state.ComponentState { <fields>; <init>(...); }
+
+# Keep the DMG settled-HALT side entrance visible to R8's call graph without pinning its class
+# or method name; the ordinary PERFORMANCE scheduler remains free to optimize normally.
+-keepclassmembers,allowobfuscation class eu.rekawek.coffeegb.core.Gameboy {
+    private int tryPerformanceSettledDmgHaltSpan(long);
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -119,6 +119,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     static final int OAM_DMA_HBLANK_SPEED_SWITCH_DELAY_TICKS = 2;
 
+    /** Maximum packet horizon for the settled normal-speed HALT path. */
+    private static final int SETTLED_HALT_PERFORMANCE_MAX_SPAN = 54;
+
     // A granted HBlank burst can finish while the CPU speed-switch countdown is still
     // running. Its completed bus hand-off removes five ticks from the retained tail.
     static final int COMPLETED_HBLANK_SPEED_SWITCH_ADVANCE_TICKS = 5;
@@ -221,6 +224,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private transient long performanceBulkSpanCount;
 
     private transient long performanceBulkTicks;
+
+    /** Largest long DMG settled-HALT PERFORMANCE packet in this session (diagnostic only). */
+    private transient int performanceBulkMaxTicks;
 
     public Gameboy(Rom rom) {
         this(new GameboyConfiguration(rom));
@@ -772,9 +778,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /**
      * PERFORMANCE-only frame loop. At a normal-speed CPU boundary the scalar tick remains the
      * authority; between boundaries, a short span can advance the independent peripherals while
-     * the CPU/PPU/STAT hot paths use their bulk phase methods. The span is intentionally capped
-     * at the next CPU boundary, so a guest write, interrupt, DMA request, or speed switch always
-     * returns to the scalar path before it can be observed late.
+     * the CPU/PPU/STAT hot paths use their bulk phase methods. ACCURACY retains the exact scalar
+     * behavior.
      */
     private long runPerformanceTicks(long ticks) {
         gpu.setPerformanceScanlineEnabled(true);
@@ -782,6 +787,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             long frameEvents = 0;
             long remaining = ticks;
             while (remaining > 0) {
+                if (!gbc && cpu.getState() == Cpu.State.HALTED) {
+                    int committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
+                }
                 int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
                 // Build one primitive packet plan.  Every component horizon is evaluated once
                 // against the already-shortened tail; the trusted commits below must not repeat
@@ -864,6 +876,76 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
     }
 
+    /**
+     * Attempts the long settled-HALT packet used only by the DMG PERFORMANCE side entrance.
+     * Every horizon and volatile guard is read before the commit, so a zero result leaves the
+     * machine untouched and lets the ordinary Stage4 scheduler handle the next scalar phase.
+     */
+    private int tryPerformanceSettledDmgHaltSpan(long remaining) {
+        if (remaining <= 0 || !cpu.performanceSettledHaltSpanEligible()) {
+            return 0;
+        }
+        int span = (int) Math.min((long) SETTLED_HALT_PERFORMANCE_MAX_SPAN, remaining);
+        span = Math.min(span, timer.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, serialPort.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, sound.performanceQuietSpanLimit(span));
+        if (cartridgeClocked) {
+            span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
+        if (slotCartridgeClocked) {
+            span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+        }
+        int gpuSpanLimit = gpu.performanceQuietSpanLimit();
+        span = Math.min(span, gpuSpanLimit);
+        boolean directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+        boolean steadyRasterSpan = span > 0 && !directRasterSpan
+                && gpu.isPerformanceSteadyCursorActive();
+        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
+        if (span <= 3
+                || warmResetRequested
+                || speedSwitchTailTicks != 0
+                || !cpu.performanceNoPendingPpuReadPhase()
+                || dma.isTransferInProgress()
+                || dma.requiresClockTick(true)
+                // This is intentionally the one post-preflight volatile Joypad check.
+                // A legacy/debug/input mutation published after the horizon walk must
+                // fall back to one scalar tick; a PlayerInputHub snapshot update does not
+                // clear its eligibility and remains invisible until the next poll.
+                || !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
+        tickPerformanceSettledDmgHaltSpan(span, directRasterSpan, steadyRasterSpan);
+        performanceBulkSpanCount++;
+        performanceBulkTicks += span;
+        if (span > performanceBulkMaxTicks) {
+            performanceBulkMaxTicks = span;
+        }
+        return span;
+    }
+
+    /** Commits a preflighted long DMG settled-HALT packet without CGB-only peripherals. */
+    private void tickPerformanceSettledDmgHaltSpan(int ticks, boolean directRasterSpan,
+                                                    boolean steadyRasterSpan) {
+        if (cartridgeClocked) {
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        timer.tickPerformanceQuietSpanTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed a PERFORMANCE quiet span";
+        sound.commitFrameSequencerClock();
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformanceQuietSpanTrusted(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+        cpu.advancePerformanceSettledHaltSpanTrusted(ticks);
+        gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        statRegister.tickPerformanceQuietSpanTrusted(ticks);
+    }
+
     /** Advances the non-CPU-bus peripherals for one preflighted quiet span. */
     private void tickPerformanceQuietSpan(int ticks, boolean directRasterSpan,
                                           boolean steadyRasterSpan) {
@@ -908,6 +990,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     public void resetPerformanceBulkCounters() {
         performanceBulkSpanCount = 0L;
         performanceBulkTicks = 0L;
+        performanceBulkMaxTicks = 0;
     }
 
     /** Number of all-subsystem PERFORMANCE bulk spans taken by the current session. */
@@ -918,6 +1001,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Number of master ticks covered by all-subsystem PERFORMANCE bulk spans. */
     public long getPerformanceBulkTicks() {
         return performanceBulkTicks;
+    }
+
+    /** Largest long DMG settled-HALT PERFORMANCE packet in the current session. */
+    public int getPerformanceBulkMaxTicks() {
+        return performanceBulkMaxTicks;
     }
 
     private Mode tickSubsystems() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -214,6 +214,22 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     /**
+     * Returns whether a settled normal-speed HALT can own a multi-machine-cycle PERFORMANCE
+     * span.  HALT entry and the first wake sample remain scalar; once both have settled, a
+     * halted CPU is only an idle NOP sequencer until the next wake edge.
+     */
+    public boolean performanceSettledHaltSpanEligible() {
+        return speedMode.getSpeedMode() == 1
+                && state == State.HALTED
+                && haltEntrySampleTicks == 0
+                && !synchronousHaltEntryStatPhase
+                && !asynchronousHaltEntryStatPhase
+                && !ordinaryHaltWakeStatPhase
+                && !interruptManager.isInterruptRequestedForHalt()
+                && !interruptManager.isInterruptRequestedWhileHaltWakeBlocked();
+    }
+
+    /**
      * Whether a PERFORMANCE phase-only span may safely call the peripheral wake callback.
      *
      * <p>HALT entry and wake are deliberately kept on the scalar scheduler. Once HALT's entry
@@ -269,6 +285,26 @@ public class Cpu implements StatefulComponent<Cpu> {
         hdmaOpcodePrefetched = false;
         updatePhasedPpuInput();
         clockCycle += ticks;
+    }
+
+    /**
+     * Advances a preflighted settled-HALT span, including complete idle machine cycles.  The
+     * next peripheral/wake edge is excluded by the caller's horizon, so no instruction
+     * sequencer callback is needed inside the span. The arithmetic consumes complete idle
+     * machine-cycle boundaries inside the span; only the excluded next event tick is left to
+     * the scalar scheduler.
+     */
+    public void advancePerformanceSettledHaltSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        hdmaOpcodePrefetched = false;
+        updatePhasedPpuInput();
+        int distanceToBoundary = 4 - clockCycle;
+        int completedBoundaries = ticks >= distanceToBoundary
+                ? 1 + (ticks - distanceToBoundary) / 4 : 0;
+        clockCycle = (clockCycle + ticks) & 0x03;
+        haltedCpuCycles = Math.min(2, haltedCpuCycles + completedBoundaries);
     }
 
     private void updatePhasedPpuInput() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1754,6 +1754,43 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
+     * Distance in dots to the next future STAT checkpoint. The STAT caller rejects a checkpoint
+     * on the current dot before consulting this method. This is the scalar counterpart used by
+     * the settled-HALT horizon and intentionally avoids walking every candidate offset.
+     */
+    int performanceStatCheckpointDistance() {
+        if (!lcdEnabled) {
+            return Integer.MAX_VALUE;
+        }
+        int lineLength = firstLine ? 455 : 456;
+        int distance = Integer.MAX_VALUE;
+        if (ticksInLine < 13) {
+            distance = Math.min(distance, 13 - ticksInLine);
+        }
+        if (ticksInLine < 448) {
+            distance = Math.min(distance, 448 - ticksInLine);
+        } else {
+            distance = 1;
+        }
+        if (ticksInLine < lineLength) {
+            distance = Math.min(distance, lineLength - ticksInLine);
+        } else {
+            distance = 1;
+        }
+        int mode0InterruptTick = getMode0InterruptTickForTick();
+        if (mode0InterruptTick != Integer.MAX_VALUE) {
+            if (ticksInLine < mode0InterruptTick) {
+                distance = Math.min(distance, mode0InterruptTick - ticksInLine);
+            }
+            int mode0WakeTick = mode0InterruptTick + 2;
+            if (ticksInLine < mode0WakeTick) {
+                distance = Math.min(distance, mode0WakeTick - ticksInLine);
+            }
+        }
+        return distance;
+    }
+
+    /**
      * Applies the DMG OAM corruption bug if the PPU is currently scanning the OAM.
      */
     public void corruptOam(SpriteBug.CorruptionType type) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -637,6 +637,51 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         return 0;
     }
 
+    /** Same checkpoint walk for settled HALT packets, without the ordinary three-dot cap. */
+    public int performanceSettledHaltSpanLimit(int requested) {
+        if (requested <= 0 || statEvaluationDirty || gpu.isStatEventCheckpointForTick()
+                || pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingModeIrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingCgbMode2PublicationClock != NO_LYC_IRQ_EVENT
+                || pendingCgbMode0Interrupt
+                || interruptManager.hasPpuTickSignals()) {
+            return 0;
+        }
+        int limit = requested;
+        int gpuDistance = gpu.performanceStatCheckpointDistance();
+        if (gpuDistance != Integer.MAX_VALUE) {
+            limit = Math.min(limit, gpuDistance - 1);
+        }
+        long clock = lycIrqClock;
+        long event = nextLycIrqEvent;
+        if (event != NO_LYC_IRQ_EVENT) {
+            long distance = event - clock;
+            if (distance <= 0) {
+                return 0;
+            }
+            limit = Math.min(limit, (int) Math.min(Integer.MAX_VALUE, distance - 1));
+        }
+        event = pendingLycWriteIrq;
+        if (event != NO_LYC_IRQ_EVENT) {
+            long distance = event - clock;
+            if (distance <= 0) {
+                return 0;
+            }
+            limit = Math.min(limit, (int) Math.min(Integer.MAX_VALUE, distance - 1));
+        }
+        event = pendingLycComparatorIrq;
+        if (event != NO_LYC_IRQ_EVENT) {
+            long distance = event - clock;
+            if (distance <= 0) {
+                return 0;
+            }
+            limit = Math.min(limit, (int) Math.min(Integer.MAX_VALUE, distance - 1));
+        }
+        return Math.max(0, limit);
+    }
+
     /** Advances the invariant STAT clock for a span whose CPU bus is known to be idle. */
     public boolean tickPerformanceQuietSpan(int ticks) {
         // The caller preflights the GPU checkpoint before advancing the raster counters. At

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -312,6 +312,35 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
         return 0;
     }
 
+    /**
+     * Same settled released-input/PlayerInputHub horizon for a HALT packet, without the normal
+     * three-tick scheduler cap.  A hub poll remains the hard endpoint; a host update is sampled
+     * only by that poll, preserving the scalar visibility contract.
+     */
+    public int performanceSettledHaltSpanLimit(int requested) {
+        if (requested <= 0
+                || inputChangedSinceLastTick
+                || !buttons.isEmpty()
+                || players != 0
+                || inputTimelineObserver != null
+                || debugHooks != null
+                || isSgb) {
+            return 0;
+        }
+        if (releasedInputFastPathEligible && playerInputSource == PlayerInputSource.RELEASED) {
+            return requested;
+        }
+        if (playerInputHubFastPathEligible && playerInputSource instanceof PlayerInputHub) {
+            long residue = tick & (PLAYER_INPUT_HUB_POLL_TICKS - 1L);
+            long distance = (1L - residue) & (PLAYER_INPUT_HUB_POLL_TICKS - 1L);
+            if (distance == 0) {
+                distance = PLAYER_INPUT_HUB_POLL_TICKS;
+            }
+            return (int) Math.min((long) requested, Math.max(0, distance - 1));
+        }
+        return 0;
+    }
+
     /** Returns the largest safe span using the scheduler's normal three-clock bound. */
     public int performanceQuietSpanLimit() {
         return performanceQuietSpanLimit(PERFORMANCE_MAX_QUIET_SPAN);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -101,6 +101,19 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         return Math.min(requested, PERFORMANCE_MAX_QUIET_SPAN);
     }
 
+    /** Same idle-link horizon for a settled HALT packet, without the normal three-dot cap. */
+    public int performanceSettledHaltSpanLimit(int requested) {
+        if (requested <= 0
+                || speedMode.getSpeedMode() != 1
+                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
+                || (sc & 0x80) != 0
+                || haltWakeDelay != 0
+                || debugHooks != null) {
+            return 0;
+        }
+        return requested;
+    }
+
     /** Returns the largest safe span using the scheduler's normal three-clock bound. */
     public int performanceQuietSpanLimit() {
         return performanceQuietSpanLimit(PERFORMANCE_MAX_QUIET_SPAN);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -142,6 +142,27 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         return Math.max(0, span);
     }
 
+    /**
+     * Returns the same exact horizon for a settled normal-speed HALT span, without the ordinary
+     * three-dot scheduler cap. The DMG HALT side entrance bounds the request before calling this
+     * method; every divider, TIMA, overflow, wake, and frame-sequencer edge remains excluded.
+     */
+    public int performanceSettledHaltSpanLimit(int requested) {
+        if (requested <= 0 || speedMode.getSpeedMode() != 1 || debugHooks != null
+                || divReset || overflow || haltWakeDelay != 0
+                || haltBugDivRippleVisible || suppressNextInterruptRequest) {
+            return 0;
+        }
+        int span = requested;
+        span = capBefore(span, clocksToTimerFallingEdge());
+        span = capBefore(span, clocksToPendingDividerRipple());
+        span = capBefore(span, clocksToFrameSequencerEdge(0));
+        if (speedMode.isGbc()) {
+            span = capBefore(span, clocksToFrameSequencerEdge(2));
+        }
+        return Math.max(0, span);
+    }
+
     /** Returns the largest safe span using the scheduler's normal three-clock bound. */
     public int performanceQuietSpanLimit() {
         return performanceQuietSpanLimit(PERFORMANCE_MAX_QUIET_SPAN);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -154,15 +154,24 @@ public final class GameboyPlayerInputHubPerformanceTest {
                 assertTrue("stable HALT had no substantial bulk coverage cgb=" + cgb
                                 + " ticks=" + performance.getPerformanceBulkTicks(),
                         performance.getPerformanceBulkTicks() > 1_000);
+                if (cgb) {
+                    assertEquals("CGB settled HALT must retain the ordinary three-dot cap",
+                            0, performance.getPerformanceBulkMaxTicks());
+                } else {
+                    assertTrue("DMG settled HALT never crossed a machine-cycle boundary"
+                                    + " maxSpan=" + performance.getPerformanceBulkMaxTicks(),
+                            performance.getPerformanceBulkMaxTicks() > 3);
+                }
             }
         }
     }
 
     @Test
-    public void settledHaltWakeEdgesMatchScalarForOneToThreeDotTails() throws Exception {
+    public void settledHaltWakeEdgesMatchScalarForShortAndLongTails() throws Exception {
+        int[] tails = {1, 3, 7, 17, 53};
         for (boolean cgb : new boolean[]{false, true}) {
             for (WakeSource wakeSource : WakeSource.values()) {
-                for (int tail = 1; tail <= 3; tail++) {
+                for (int tail : tails) {
                     PlayerInputHub hub = new PlayerInputHub();
                     hub.openSource(0);
                     try (Gameboy performance = haltSession(cgb, hub);
@@ -192,9 +201,11 @@ public final class GameboyPlayerInputHubPerformanceTest {
 
                         assertTrue(context(cgb, wakeSource, tail) + " did not wake",
                                 performance.getCpu().getState() != Cpu.State.HALTED);
-                        assertTrue(context(cgb, wakeSource, tail)
-                                        + " never committed a whole caller tail",
-                                sawWholeTail);
+                        if (tail <= 3) {
+                            assertTrue(context(cgb, wakeSource, tail)
+                                            + " never committed a whole caller tail",
+                                    sawWholeTail);
+                        }
 
                         // Continue past the wake boundary. Inactive OAM DMA must leave its
                         // HALT-pause latch on the same running-CPU value as the scalar machine.
@@ -210,6 +221,85 @@ public final class GameboyPlayerInputHubPerformanceTest {
                         assertRasterEquivalent(scalar, performance,
                                 context(cgb, wakeSource, tail));
                     }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void settledHaltRandomLongChunkTailsMatchFullState() throws Exception {
+        for (boolean cgb : new boolean[]{false, true}) {
+            PlayerInputHub performanceHub = new PlayerInputHub();
+            performanceHub.openSource(0);
+            try (Gameboy performance = haltSession(cgb, performanceHub);
+                    Gameboy scalar = haltSession(cgb,
+                            () -> PlayerInputSnapshot.released())) {
+                performance.runTicks(128);
+                runScalarTicks(scalar, 128);
+                Random random = new Random(0x6a17_2b9dL + (cgb ? 1 : 0));
+                for (int chunkIndex = 0; chunkIndex < 80; chunkIndex++) {
+                    int chunk = 4 + random.nextInt(50);
+                    long scalarFrames = runScalarTicks(scalar, chunk);
+                    long performanceFrames = performance.runTicks(chunk);
+                    assertEquals("random HALT tail frame cgb=" + cgb
+                                    + ", chunk=" + chunkIndex,
+                            scalarFrames, performanceFrames);
+                    assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                            "random HALT tail cgb=" + cgb + ", chunk=" + chunkIndex);
+                    assertRasterEquivalent(scalar, performance,
+                            "random HALT tail cgb=" + cgb + ", chunk=" + chunkIndex);
+                }
+                if (cgb) {
+                    assertEquals("CGB random HALT tails must retain the ordinary three-dot cap",
+                            0, performance.getPerformanceBulkMaxTicks());
+                } else {
+                    assertTrue("DMG random HALT tails never crossed a machine cycle",
+                            performance.getPerformanceBulkMaxTicks() > 3);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void settledHaltPlayerInputHubMutationWaitsForTheSixtyFourTickPoll() throws Exception {
+        for (boolean cgb : new boolean[]{false, true}) {
+            PlayerInputHub performanceHub = new PlayerInputHub();
+            PlayerInputHub.SourceHandle performanceSource = performanceHub.openSource(0);
+            AtomicReference<PlayerInputSnapshot> scalarInput = new AtomicReference<>(
+                    PlayerInputSnapshot.released());
+            try (Gameboy performance = haltSession(cgb, performanceHub);
+                    Gameboy scalar = haltSession(cgb, scalarInput::get)) {
+                performance.runTicks(128);
+                scalar.runTicks(128);
+                // Move away from the initial poll residue, then mutate both hosts before the
+                // next 64-T master-tick poll. The candidate must retain the hub's settled horizon
+                // until that poll, and both full canonical states must remain identical.
+                performance.runTicks(11);
+                scalar.runTicks(11);
+                Set<Button> held = Set.of(Button.A, Button.LEFT);
+                performanceSource.update(held);
+                // At tick 139 the next hub poll is tick 193. Keep the scalar oracle released
+                // through the 53 pre-poll dots, then publish the same snapshot immediately
+                // before the poll tick so the canonical states meet exactly at that boundary.
+                assertEquals("hub mutation pre-poll frame cgb=" + cgb,
+                        runScalarTicks(scalar, 53), performance.runTicks(53));
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "hub mutation before poll cgb=" + cgb);
+                scalarInput.set(snapshot(held));
+                assertEquals("hub mutation poll frame cgb=" + cgb,
+                        runScalarTicks(scalar, 1), performance.runTicks(1));
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "hub mutation at poll cgb=" + cgb);
+                int[] chunks = {7, 17, 31, 53, 7};
+                for (int chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+                    int chunk = chunks[chunkIndex];
+                    long scalarFrames = runScalarTicks(scalar, chunk);
+                    long performanceFrames = performance.runTicks(chunk);
+                    assertEquals("hub mutation frame cgb=" + cgb
+                                    + ", chunk=" + chunkIndex,
+                            scalarFrames, performanceFrames);
+                    assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                            "hub mutation cgb=" + cgb + ", chunk=" + chunkIndex);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- batch settled normal-speed DMG `HALT` intervals across multiple machine cycles in PERFORMANCE mode
- stop before every Timer, APU sample, input poll, PPU/STAT, mapper, DMA, or host-visible event so the event tick remains scalar
- keep the ordinary Stage 4 scheduler unchanged and isolate the long planner behind a DMG-only, R8 non-inline side entrance
- add randomized full-state, wake-edge, input-poll, and DMA-latch differentials against scalar execution

## Physical-device result

Audio on, 600 rendered frames, in-place parent/candidate installs with identical app data:

| Profile | Parent | Candidate | Controller CPU | Result |
| --- | ---: | ---: | ---: | --- |
| DMG | 43.75 FPS | 59.78 FPS | 13,453 → 8,925 ms | +36.6% FPS, −33.7% CPU |
| Native CGB | 37.40 FPS | 38.20 FPS | 15,791 → 15,458 ms | +2.2% FPS, −2.1% CPU |

DMG bulk coverage increased from 24.02M ticks in 8.58M spans (2.80 ticks/span) to 32.17M ticks in 1.33M spans (24.24 ticks/span). Audio underruns fell from 307 to zero. Both rows had zero allocation/GC deltas, dropped/duplicate/late/corrupt frames, input mutations, thermal events, focus losses, and audio write/route failures.

The CGB row deliberately does not enter the new planner. Post-R8 inspection confirmed the common scheduler remains a separate 22-register method with no settled-HALT horizon code; the 25-register DMG helper is retained as a private non-inline method and contains no CGB infrared path.

## Validation

- `mvn -pl core test` — 1,737 tests, 0 failures/errors
- `mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` — 132 tests, 0 failures/errors
- `mvn -pl core test -Ptest-blargg-individual,test-blargg` — 46 tests, 0 failures/errors
- Android benchmark APK assembled, signature verified, R8 mapping/DEX structure inspected
- independent correctness review: GO, no functional blocker
