### PR TITLE
Add local netplay client launcher

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -189,7 +189,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         // Release/non-diagnostic callers retain the ordinary settings path unchanged.
         BootstrapMode bootstrapMode = checked.enabled ? BootstrapMode.SKIP : null;
         return new ApplicationSettingsOverrides(profile, bootstrapMode,
-                checked.enabled ? false : null, false,
+                checked.enabled ? false : null, false, false, false,
                 checked.enabled && checked.runtimeWarmup, checked.enabled,
                 checked.enabled ? checked.executionMode : null);
     }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4782,7 +4782,8 @@ class BasicController private constructor(
   }
 
   private fun shouldPersistCloseAutosave(): Boolean =
-      session?.config?.rom?.file != null &&
+      !properties.overrides.suppressCloseAutosave &&
+          session?.config?.rom?.file != null &&
           closeAutosaveCompletedSessionId != stateSessionId &&
           closeAutosaveSkippedSessionId != stateSessionId
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -697,6 +697,11 @@ interface Controller : AutoCloseable {
       config.setBootstrapMode(bootstrapMode)
       config.setExecutionMode(properties.system.executionMode)
       config.setSupportBatterySave(properties.saves.batterySavesEnabled)
+      if (properties.overrides.forceInMemoryBattery && rom.type.isBattery) {
+        // A local netplay child must never touch the host's sidecar, but its detached checkpoint
+        // still needs the same battery-state presence as the service-free network peer target.
+        config.setBatteryData(byteArrayOf())
+      }
       config.setPlayerInputSource(properties.playerInputSource)
       if (!config.hardwareProfile.capabilities().superGameboyBorder() ||
           !rom.isSuperGameboyFlag) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -2969,6 +2969,9 @@ class LinkedController(
   }
 
   private fun broadcastCurrentState() {
+    // Freeze the boundary before capture so every ROM header and the final SYNCHRONIZE record
+    // describe the exact same frame.
+    val checkpointFrame = frame
     val states =
         sessions.mapIndexedNotNull { player, session ->
           val config = configs[player] ?: return@mapIndexedNotNull null
@@ -2981,7 +2984,7 @@ class LinkedController(
               portableState = null,
               gameboyType = config.gameboyType,
               bootstrapMode = config.bootstrapMode,
-              frame = frame,
+              frame = checkpointFrame,
               cgb0Revision = config.isCgb0Revision,
               hardwareProfileId = config.hardwareProfile.id(),
               mealybugDmgBlob = config.isMealybugDmgBlob,
@@ -2993,7 +2996,7 @@ class LinkedController(
           )
         }
     // Encoding and per-connection validation/compression are package work, not frame work.
-    eventBus.postAsync(SessionStateReadyEvent(frame, states))
+    eventBus.postAsync(SessionStateReadyEvent(checkpointFrame, states))
   }
 
   private fun isFourPlayerHost(): Boolean =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -2463,7 +2463,11 @@ class LinkedController(
         event.player in configs.indices &&
         configs[event.player] == null) {
       return if (validatePeer(event.source) {
-            PeerFrameWindow.validateRuntimeFrame(event.frame, 0)
+            // A newly-launched local client can run hundreds of frames while it loads and boots
+            // before its first ROM record reaches the host. That private pre-link frame is never
+            // replayed: hot-plugging below rebases it to the host's current adapter phase. It
+            // therefore needs only the absolute protocol bound, not the runtime rollback window.
+            PeerFrameWindow.validateAbsolute(event.frame)
           }) {
         event.copy(frame = frame)
       } else {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedController.kt
@@ -2412,7 +2412,7 @@ class LinkedController(
               event.mealybugDmgBlob,
               event.codeBreakerRumble,
               event.displaySgbBorder,
-              event.portableState != null,
+              event.portableState?.let(Connection::portableStateHasBattery) == true,
           )
           .setPlayerInputSource(PlayerInputSource.RELEASED)
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -184,6 +184,11 @@ class Connection(
     }
     eventBus.register<LinkedController.SessionStateReadyEvent> {
       if (server && mode == LinkMode.FOUR_PLAYER_ADAPTER) {
+        // A client can finish its TCP handshake before the host accepts its initial MACHINE
+        // state. Do not replace that client's just-started local controller with a partial
+        // checkpoint that has no state for its assigned physical port; its first checkpoint must
+        // instead be the authoritative one produced after the host has installed that port.
+        if (it.states.none { state -> state.player == player }) return@register
         sendSafely {
           // A checkpoint is one output transaction. Runtime traffic cannot split its state
           // records from the synchronization marker that commits them.

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -589,7 +589,12 @@ class Connection(
     val slotRomDeclaration =
         validateDeclaration(slotRomSize, slotRomCompressed, StateLimits.ROM)
     val batteryDeclaration =
-        validateDeclaration(batterySize, batteryCompressed, StateLimits.BATTERY)
+        validateDeclaration(
+            batterySize,
+            batteryCompressed,
+            StateLimits.BATTERY,
+            allowEmptyPayload = true,
+        )
     val stateDeclaration = validateStateFileDeclaration(stateSize)
     val checkpointRecord = !server && mode == LinkMode.FOUR_PLAYER_ADAPTER
     val expectedStateRoot =
@@ -648,7 +653,7 @@ class Connection(
             gameboyType,
             bootstrapMode,
             profileFlags,
-            decodedState != null,
+            decodedState?.file?.let(::portableStateHasBattery) == true,
         )
     decodedState?.let {
       validatePeerState(configuration, it.file, expectedStateRoot, eventPlayer)
@@ -828,7 +833,7 @@ class Connection(
       gameboyType: GameboyType,
       bootstrapMode: BootstrapMode,
       profileFlags: Int,
-      portableStatePresent: Boolean,
+      portableStateHasBattery: Boolean,
   ): Gameboy.GameboyConfiguration =
       try {
         peerConfiguration(
@@ -841,7 +846,7 @@ class Connection(
             profileFlags and PROFILE_MEALYBUG_DMG_BLOB != 0,
             profileFlags and PROFILE_CODEBREAKER_RUMBLE != 0,
             profileFlags and PROFILE_SGB_BORDER != 0,
-            portableStatePresent,
+            portableStateHasBattery,
         )
       } catch (e: Exception) {
         failProtocol(
@@ -1520,6 +1525,10 @@ class Connection(
             PROFILE_MEALYBUG_DMG_BLOB or
             PROFILE_CODEBREAKER_RUMBLE or
             PROFILE_SGB_BORDER
+    private const val MEMORY_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"
+    private const val FILE_BATTERY_STATE =
+        "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"
 
     internal fun reject(outputStream: OutputStream, reason: RejectionReason) {
       val output = DataOutputStream(BufferedOutputStream(outputStream))
@@ -1567,7 +1576,7 @@ class Connection(
         mealybugDmgBlob: Boolean,
         codeBreakerRumble: Boolean,
         displaySgbBorder: Boolean,
-        portableStatePresent: Boolean = false,
+        portableStateHasBattery: Boolean = false,
     ): Gameboy.GameboyConfiguration {
       val primary = Rom(rom)
       if (slotRom != null &&
@@ -1587,15 +1596,25 @@ class Connection(
           .setExecutionMode(ExecutionMode.ACCURACY)
           .setSlotRom(slotRom?.let(::Rom))
           .setSupportBatterySave(false)
-      // A portable checkpoint already owns the mapper RAM and RTC data, but its detached graph
-      // also retains the sender's file-backed battery bookkeeping. Give a battery cartridge a
-      // service-free in-memory target even when no save file was transferred so the audited
-      // FileBattery -> MemoryBattery adapter can preflight that graph. A state-less ROM load keeps
-      // the old absent-save behavior (default cartridge RAM, no synthetic save contents).
-      if (battery != null || portableStatePresent && primary.type.isBattery) {
+      // A portable checkpoint can retain the sender's battery owner even when no sidecar payload
+      // was transferred. Mirror that owner with a service-free MemoryBattery only when the
+      // detached graph actually contains one; a battery-less checkpoint must retain its absence.
+      if (battery != null || portableStateHasBattery) {
         configuration.setBatteryData(battery?.clone() ?: byteArrayOf())
       }
       return configuration
+    }
+
+    /** Whether restoring this network state requires a battery-backed cartridge target. */
+    internal fun portableStateHasBattery(file: StateFile): Boolean {
+      val machine =
+          when (val root = file.root) {
+            is MachineStateRoot -> root.machine
+            is SessionStateRoot -> root.session.machine
+            else -> return false
+          }
+      return machine.recordCount(FILE_BATTERY_STATE) > 0 ||
+          machine.recordCount(MEMORY_BATTERY_STATE) > 0
     }
 
     internal fun validateStateFileDeclaration(size: Int): StateFileDeclaration? {
@@ -1694,6 +1713,16 @@ class Connection(
         throw IOException(
             "Compressed ${limit.description} length changed while it was being read")
       }
+      if (declaration.decodedBytes == 0 && declaration.encodedBytes > 0) {
+        // Inflater cannot make observable progress for a zero-byte result on every supported JDK.
+        // Accept only the exact zlib representation our Deflater emits, so an explicitly present
+        // empty battery remains distinguishable from an omitted battery without broadening the
+        // compressed-input trust boundary.
+        if (!data.contentEquals(deflate(byteArrayOf(), limit))) {
+          throw IOException("Corrupted compressed empty ${limit.description}")
+        }
+        return byteArrayOf()
+      }
       val inflater = Inflater()
       try {
         inflater.setInput(data)
@@ -1745,9 +1774,17 @@ class Connection(
         encodedBytes: Int,
         limit: StateLimits.Payload,
         required: Boolean = false,
+        allowEmptyPayload: Boolean = false,
     ): PayloadDeclaration {
       if (decodedBytes == 0 && encodedBytes == 0 && !required) {
         return PayloadDeclaration(0, 0)
+      }
+      if (decodedBytes == 0 && encodedBytes > 0 && !required && allowEmptyPayload) {
+        if (encodedBytes > limit.encodedBytes) {
+          throw IOException(
+              "Compressed ${limit.description} exceeds ${limit.encodedBytes} bytes: $encodedBytes")
+        }
+        return PayloadDeclaration(0, encodedBytes)
       }
       if (decodedBytes <= 0 || encodedBytes <= 0) {
         throw IOException(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/network/Connection.kt
@@ -899,15 +899,28 @@ class Connection(
         else -> throw IOException("Unexpected network StateFile root ${file.root.kind}")
       }
     } catch (e: Exception) {
+      val detail = portableStateMismatchDetail(e)
       failProtocol(
           ProtocolErrorReason.INVALID_PORTABLE_STATE,
           IOException(
-              "Peer ${expectedRoot.name} StateFile does not match its ROM/profile or endpoint",
+              "Peer ${expectedRoot.name} StateFile does not match its ROM/profile or endpoint" +
+                  if (detail == null) "." else ": $detail",
               e,
           ),
       )
     }
   }
+
+  /**
+   * Protocol diagnostics reach a remote peer, so retain only the bounded and redacted public
+   * validation message. The top-level exception identifies the failed portable-state boundary;
+   * its cause chain can contain implementation and filesystem details that do not help a player.
+   */
+  private fun portableStateMismatchDetail(failure: Exception): String? =
+      failure.message
+          ?.takeIf(String::isNotBlank)
+          ?.let(NetplayDiagnosticSanitizer::redact)
+          ?.takeIf(String::isNotBlank)
 
   private fun readNetworkState(
       declaration: StateFileDeclaration,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -622,6 +622,8 @@ data class ApplicationSettingsOverrides(
      * Netplay children use this to retain the same portable-state graph as a transferred peer.
      */
     val forceInMemoryBattery: Boolean = false,
+    /** A netplay child receives its initial state from the host and must not create a local autosave. */
+    val suppressCloseAutosave: Boolean = false,
     val rewindEnabled: Boolean? = null,
     val runtimeWarmupEnabled: Boolean? = null,
     /** Transient benchmark policy; never persisted into user settings or save state. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -617,6 +617,11 @@ data class ApplicationSettingsOverrides(
     val hardwareProfile: HardwareProfile? = null,
     val bootstrapMode: BootstrapMode? = null,
     val batterySavesEnabled: Boolean? = null,
+    /**
+     * Supplies a blank in-memory cartridge battery without reading or writing a local sidecar.
+     * Netplay children use this to retain the same portable-state graph as a transferred peer.
+     */
+    val forceInMemoryBattery: Boolean = false,
     val rewindEnabled: Boolean? = null,
     val runtimeWarmupEnabled: Boolean? = null,
     /** Transient benchmark policy; never persisted into user settings or save state. */

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -2961,6 +2961,7 @@ class LinkedControllerTest {
     val checkpoint = assertNotNull(checkpoints.poll(5, TimeUnit.SECONDS))
     assertTrue(checkpoint.frame > StateLimits.NETPLAY_FUTURE_FRAMES)
     assertEquals(listOf(0, 1), checkpoint.states.map { it.player })
+    assertTrue(checkpoint.states.all { it.frame == checkpoint.frame })
     assertTrue(
         checkpoint.states.all {
           it.portableStateFile?.root is SessionStateRoot

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -3940,7 +3940,7 @@ class LinkedControllerTest {
   }
 
   @Test
-  fun existingFourPlayerPeerReloadUsesCurrentFrameWhileNewSlotUsesZeroFrame() {
+  fun existingFourPlayerPeerReloadUsesCurrentFrameWhileNewSlotRebasesItsLateBootFrame() {
     val eventBus = EventBusImpl()
     val sut =
         LinkedController(
@@ -3987,7 +3987,7 @@ class LinkedControllerTest {
             null,
             GAMEBOY_TYPE,
             BOOTSTRAP_MODE,
-            0,
+            StateLimits.NETPLAY_FUTURE_FRAMES + 11,
             player = 2,
             source = joining,
         ))

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
@@ -753,6 +753,23 @@ class ConnectionTest {
   }
 
   @Test
+  fun explicitlyPresentEmptyBatteryRoundTrips() {
+    val encoded = Connection.deflate(byteArrayOf(), StateLimits.BATTERY)
+    val declaration =
+        Connection.validateDeclaration(
+            0,
+            encoded.size,
+            StateLimits.BATTERY,
+            allowEmptyPayload = true,
+        )
+
+    assertContentEquals(
+        byteArrayOf(),
+        assertNotNull(Connection.inflate(encoded, declaration, StateLimits.BATTERY)),
+    )
+  }
+
+  @Test
   fun inflateRejectsCorruptionTrailingDataAndOutputPastDeclaration() {
     val limit = StateLimits.Payload("test payload", 4096, 4096)
     val original = ByteArray(1024) { (it % 31).toByte() }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/ConnectionTest.kt
@@ -279,7 +279,7 @@ class ConnectionTest {
             gameboyType = GameboyType.DMG,
             bootstrapMode = Gameboy.BootstrapMode.SKIP,
             frame = 73,
-            player = 0,
+            player = 1,
             heldButtons = setOf(Button.START),
         )
     assertContentEquals(
@@ -299,6 +299,30 @@ class ConnectionTest {
     assertEquals(StateCodec.decode(checkNotNull(state.portableState)), game.portableState)
     assertEquals(setOf(Button.START), game.heldButtons)
     assertEquals(73, checkpoint.frame)
+  }
+
+  @Test
+  fun fourPlayerHostWaitsForCheckpointThatIncludesConnectedPlayer() {
+    val synchronized = LinkedBlockingQueue<Connection.SessionCheckpointEvent>()
+    receiverBus.register<Connection.SessionCheckpointEvent> { synchronized.add(it) }
+    connect(mode = LinkMode.FOUR_PLAYER_ADAPTER)
+
+    val state =
+        LinkedController.LocalRomLoadedEvent(
+            romFile = ROM.readBytes(),
+            batteryFile = null,
+            portableState = portableStates().second,
+            gameboyType = GameboyType.DMG,
+            bootstrapMode = Gameboy.BootstrapMode.SKIP,
+            frame = 73,
+            player = 0,
+        )
+    senderBus.post(LinkedController.SessionStateReadyEvent(73, listOf(state)))
+    assertEquals(null, synchronized.poll(200, TimeUnit.MILLISECONDS))
+
+    senderBus.post(LinkedController.SessionStateReadyEvent(73, listOf(state, state.copy(player = 1))))
+    val checkpoint = assertNotNull(synchronized.poll(5, TimeUnit.SECONDS))
+    assertEquals(listOf(0, 1), checkpoint.states.map { it.player })
   }
 
   @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -899,6 +899,60 @@ class TcpConnectionTest {
   }
 
   @Test
+  fun peerTargetPreservesABatterylessCheckpointGraph() {
+    val rom =
+        StateCodecTestSupport.rom().also {
+          it[0x147] = 0x1b // MBC5 + RAM + battery
+          it[0x149] = 0x03 // 32 KiB RAM
+        }
+    val configuration =
+        Gameboy.GameboyConfiguration(Rom(rom))
+            .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+            .setGameboyType(GameboyType.DMG)
+            .setSupportBatterySave(false)
+    val sourceBus = EventBusImpl()
+    val source = configuration.build()
+    source.init(sourceBus, SerialEndpoint.NULL_ENDPOINT, InfraredEndpoint.NULL_ENDPOINT, null)
+    val file =
+        try {
+          StateCodec.capture(configuration, source)
+        } finally {
+          source.stop()
+          source.close()
+          sourceBus.close()
+        }
+
+    assertFalse(Connection.portableStateHasBattery(file))
+    val target =
+        Connection.peerConfiguration(
+            rom,
+            null,
+            null,
+            GameboyType.DMG,
+            Gameboy.BootstrapMode.SKIP,
+            false,
+            false,
+            false,
+            false,
+            Connection.portableStateHasBattery(file),
+        )
+    val bus = EventBusImpl()
+    val probe = target.build()
+    probe.init(bus, SerialEndpoint.NULL_ENDPOINT, InfraredEndpoint.NULL_ENDPOINT, null)
+    try {
+      assertEquals(
+          0,
+          DetachedStateAdapter.capture(probe).recordCount(MEMORY_BATTERY_STATE),
+      )
+      DetachedStateAdapter.validateTarget(probe, (file.root as MachineStateRoot).machine)
+    } finally {
+      probe.stop()
+      probe.close()
+      bus.close()
+    }
+  }
+
+  @Test
   fun linkedFourPlayerClientStartsFromPortableCheckpointOverTcp() {
     val port = ServerSocket(0).use { it.localPort }
     val serverStarted = LinkedBlockingQueue<ConnectionController.ServerStartedEvent>()
@@ -1203,7 +1257,7 @@ class TcpConnectionTest {
             false,
             false,
             false,
-            true,
+            Connection.portableStateHasBattery(file),
         )
     assertEquals(sourceIdentity, StateIdentity.from(target))
     StateCodec.validateForTarget(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -608,8 +608,10 @@ class TcpConnectionTest {
           serverBus.post(LinkedController.SessionStateReadyEvent(attempt.toLong(), listOf(state)))
         }
       }
+      // The queue needs enough compressed random ROM records to exceed its byte budget. On a
+      // contended CI worker, compression of that deliberate 320 MiB burst can exceed ten seconds.
       val dropped =
-          assertNotNull(disconnected.poll(10, TimeUnit.SECONDS), "slow peer was not isolated")
+          assertNotNull(disconnected.poll(30, TimeUnit.SECONDS), "slow peer was not isolated")
       assertEquals(1, dropped.player)
 
       val heartbeatStart = System.nanoTime()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/network/TcpConnectionTest.kt
@@ -601,11 +601,14 @@ class TcpConnectionTest {
             73,
             player = 0,
         )
+    // Four-player clients wait for an atomic checkpoint that includes their own physical port.
+    val slowPeerState = state.copy(player = 1)
     val slow = handshakenRawClient(port)
     try {
       repeat(20) { attempt ->
         if (disconnected.isEmpty()) {
-          serverBus.post(LinkedController.SessionStateReadyEvent(attempt.toLong(), listOf(state)))
+          serverBus.post(
+              LinkedController.SessionStateReadyEvent(attempt.toLong(), listOf(slowPeerState)))
         }
       }
       // The queue needs enough compressed random ROM records to exceed its byte budget. On a
@@ -631,7 +634,7 @@ class TcpConnectionTest {
 
     // The old physical slot is reusable, proving that only the offending connection was removed.
     val replacement = handshakenRawClient(port)
-    serverBus.post(LinkedController.SessionStateReadyEvent(200, listOf(state)))
+    serverBus.post(LinkedController.SessionStateReadyEvent(200, listOf(slowPeerState)))
     Thread.sleep(100)
     val stopper = Thread(server::stop, "slow-reader-stop").also { it.start() }
     stopper.join(2_000)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
@@ -1,12 +1,15 @@
 package eu.rekawek.coffeegb.controller.properties
 
 import eu.rekawek.coffeegb.controller.Controller
+import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
 import eu.rekawek.coffeegb.controller.state.StateIdentity
 import eu.rekawek.coffeegb.core.Gameboy
+import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memory.cart.Rom
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint
 import java.util.Properties
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -111,6 +114,37 @@ class ControllerPropertiesTest {
 
     assertSame(properties.playerInputSource, config.playerInputSource)
     assertSame(config.playerInputSource, config.forRestore().playerInputSource)
+  }
+
+  @Test
+  fun netplayLaunchUsesAnInMemoryBatteryWithoutEnablingSidecarPersistence() {
+    val bytes = StateCodecTestSupport.rom(cgb = true).also {
+      it[0x147] = 0x1b // MBC5 + RAM + battery
+      it[0x149] = 0x03 // 32 KiB RAM
+    }
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                hardwareProfile = HardwareProfileRegistry.CGB,
+                batterySavesEnabled = false,
+                forceInMemoryBattery = true,
+            ))
+    val configuration = Controller.createGameboyConfig(properties, Rom(bytes))
+
+    try {
+      assertFalse(configuration.isSupportBatterySave)
+      Session(configuration, EventBusImpl(), null, SerialEndpoint.NULL_ENDPOINT).use { session ->
+        assertEquals(
+            1,
+            session
+                .captureDetachedState()
+                .machine
+                .recordCount("eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"),
+        )
+      }
+    } finally {
+      properties.close()
+    }
   }
 
   @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
@@ -134,12 +134,15 @@ class ControllerPropertiesTest {
     try {
       assertFalse(configuration.isSupportBatterySave)
       Session(configuration, EventBusImpl(), null, SerialEndpoint.NULL_ENDPOINT).use { session ->
+        val machine = session.captureDetachedState().machine
+        assertTrue(
+            machine.recordCount(
+                "eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState") > 0,
+        )
         assertEquals(
-            1,
-            session
-                .captureDetachedState()
-                .machine
-                .recordCount("eu.rekawek.coffeegb.core.memory.cart.battery.MemoryBattery\$MemoryBatteryState"),
+            0,
+            machine.recordCount(
+                "eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery\$FileBatteryState"),
         )
       }
     } finally {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopRomOpen.kt
@@ -104,8 +104,8 @@ internal class DesktopRomOpen(
     archiveSelectionHost = host
   }
 
-  fun open(path: Path, source: RomOpenSource) {
-    open(listOf(RomOpenInput.LocalPath(path)), source)
+  fun open(path: Path, source: RomOpenSource, allowAutosaveResume: Boolean = true) {
+    open(listOf(RomOpenInput.LocalPath(path)), source, allowAutosaveResume)
   }
 
   /** Reopens a recent archive candidate by exact entry identity when the sidecar still matches. */
@@ -121,12 +121,16 @@ internal class DesktopRomOpen(
     )
   }
 
-  fun open(inputs: List<RomOpenInput>, source: RomOpenSource) {
+  fun open(
+      inputs: List<RomOpenInput>,
+      source: RomOpenSource,
+      allowAutosaveResume: Boolean = true,
+  ) {
     if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater { open(inputs, source) }
+      SwingUtilities.invokeLater { open(inputs, source, allowAutosaveResume) }
       return
     }
-    beginOpen(inputs, source)
+    beginOpen(inputs, source, allowAutosaveResume = allowAutosaveResume)
   }
 
   fun ownsVisibleRequest(requestId: Long): Boolean =
@@ -346,10 +350,18 @@ internal class DesktopRomOpen(
       source: RomOpenSource,
       recentPathToReplace: Path? = null,
       preferredOrigin: RomOrigin? = null,
+      allowAutosaveResume: Boolean = true,
   ): Long? {
     val singlePath = (inputs.singleOrNull() as? RomOpenInput.LocalPath)?.path
     if (singlePath != null && !confirm(singlePath)) return null
-    return service.open(RomOpenRequest(inputs, source, recentPathToReplace, preferredOrigin))
+    return service.open(
+        RomOpenRequest(
+            inputs,
+            source,
+            recentPathToReplace,
+            preferredOrigin,
+            allowAutosaveResume,
+        ))
   }
 
   private fun progressMessage(update: RomOpenUpdate.Progress): String {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
@@ -1,0 +1,107 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile
+import java.nio.file.Path
+
+/** Launches sibling desktop processes that use the current executable or Java launcher. */
+internal fun interface LocalNetplayInstanceLauncher {
+  fun launch(
+      rom: Path,
+      profile: HardwareProfile,
+      endpoint: NetplayV8Endpoint,
+      count: Int,
+  ): LocalNetplayInstanceLaunchResult
+}
+
+internal data class LocalNetplayInstanceLaunchResult(
+    val started: Int,
+    val requested: Int,
+    val launcherAvailable: Boolean,
+) {
+  init {
+    require(requested in 1..3) { "Local netplay client count must be in 1..3" }
+    require(started in 0..requested) { "Started client count must not exceed requested count" }
+  }
+
+  fun userMessage(): String =
+      when {
+        !launcherAvailable ->
+            "Hosting is ready, but Coffee GB could not determine how to relaunch this installation."
+        started == requested ->
+            "Started $started local Coffee GB ${instanceWord(started)}; ${pluralPronoun(started)} will join localhost."
+        started == 0 -> "Hosting is ready, but Coffee GB could not start the local client instances."
+        else ->
+            "Hosting is ready, but Coffee GB started only $started of $requested local client instances."
+      }
+
+  private fun instanceWord(count: Int): String = if (count == 1) "instance" else "instances"
+
+  private fun pluralPronoun(count: Int): String = if (count == 1) "it" else "them"
+}
+
+/**
+ * Reuses the current package launcher (or `java -jar`/module invocation) rather than depending on
+ * a platform-specific installation path. Child clients deliberately disable battery saves so they
+ * cannot race the host process over the same sidecar files.
+ */
+internal class CurrentProcessLocalNetplayInstanceLauncher(
+    private val currentCommand: List<String> = currentProcessCommand(),
+    private val startProcess: (List<String>) -> Unit = { command -> ProcessBuilder(command).start() },
+) : LocalNetplayInstanceLauncher {
+
+  override fun launch(
+      rom: Path,
+      profile: HardwareProfile,
+      endpoint: NetplayV8Endpoint,
+      count: Int,
+  ): LocalNetplayInstanceLaunchResult {
+    require(count in 1..3) { "Local netplay client count must be in 1..3" }
+    val launcher = localNetplayLauncherPrefix(currentCommand)
+        ?: return LocalNetplayInstanceLaunchResult(0, count, launcherAvailable = false)
+    val command =
+        launcher +
+            listOf(
+                "--profile=${profile.id()}",
+                "--disable-battery-saves",
+                "--join-netplay",
+                endpoint.startClientValue,
+                rom.toAbsolutePath().normalize().toString(),
+            )
+    var started = 0
+    repeat(count) {
+      try {
+        startProcess(command)
+        started++
+      } catch (_: Exception) {
+        return LocalNetplayInstanceLaunchResult(started, count, launcherAvailable = true)
+      }
+    }
+    return LocalNetplayInstanceLaunchResult(started, count, launcherAvailable = true)
+  }
+}
+
+/** Builds a fresh Coffee GB command without replaying this process's app arguments. */
+internal fun localNetplayLauncherPrefix(command: List<String>): List<String>? {
+  if (command.isEmpty()) return null
+  val jar = command.indexOf("-jar")
+  if (jar >= 0 && jar + 1 < command.size) return command.take(jar + 2)
+
+  val module = command.indexOfFirst { it == "-m" || it == "--module" }
+  if (module >= 0 && module + 1 < command.size) return command.take(module + 2)
+
+  val mainClass = command.indexOf("eu.rekawek.coffeegb.swing.MainKt")
+  if (mainClass >= 0) return command.take(mainClass + 1)
+
+  val executable = command.first()
+  val executableName = executable.substringAfterLast('/').substringAfterLast('\\').substringBeforeLast('.')
+  if (executableName.equals("java", ignoreCase = true)) {
+    return null
+  }
+  return listOf(executable)
+}
+
+private fun currentProcessCommand(): List<String> {
+  val info = ProcessHandle.current().info()
+  val executable = info.command().orElse(null) ?: return emptyList()
+  return listOf(executable) + info.arguments().orElse(emptyArray()).toList()
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
@@ -46,7 +46,7 @@ internal data class LocalNetplayInstanceLaunchResult(
  */
 internal class CurrentProcessLocalNetplayInstanceLauncher(
     private val currentCommand: List<String> = currentProcessCommand(),
-    private val startProcess: (List<String>) -> Unit = { command -> ProcessBuilder(command).start() },
+    private val startProcess: (List<String>) -> Unit = ::startProcessWithInheritedError,
 ) : LocalNetplayInstanceLauncher {
 
   override fun launch(
@@ -79,6 +79,18 @@ internal class CurrentProcessLocalNetplayInstanceLauncher(
     return LocalNetplayInstanceLaunchResult(started, count, launcherAvailable = true)
   }
 }
+
+/**
+ * A child desktop process has no terminal of its own when launched from the netplay window.
+ * Keep its diagnostic stream attached to the host process so a rejected checkpoint can be
+ * diagnosed without a separate client console.
+ */
+private fun startProcessWithInheritedError(command: List<String>) {
+  localNetplayProcessBuilder(command).start()
+}
+
+internal fun localNetplayProcessBuilder(command: List<String>): ProcessBuilder =
+    ProcessBuilder(command).redirectError(ProcessBuilder.Redirect.INHERIT)
 
 /** Builds a fresh Coffee GB command without replaying this process's app arguments. */
 internal fun localNetplayLauncherPrefix(command: List<String>): List<String>? {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -21,6 +21,8 @@ internal data class CliLaunchRequest(
     val initialRom: File?,
     /** Validated direct-host endpoint text to join after [initialRom] has opened. */
     val joinNetplayHost: String?,
+    /** A netplay child receives its authoritative state from the host, never from a local resume. */
+    val suppressInitialAutosaveResume: Boolean,
     val settingsOverrides: ApplicationSettingsOverrides,
 )
 
@@ -60,6 +62,7 @@ fun main(args: Array<String>) {
             request.initialRom,
             request.settingsOverrides,
             request.joinNetplayHost,
+            request.suppressInitialAutosaveResume,
         )
       }
   if (exitCode != SUCCESS) {
@@ -266,6 +269,7 @@ private fun parseCli(args: Array<String>): CliCommand {
           debug = debug,
           initialRom = positional.singleOrNull()?.let(::File),
           joinNetplayHost = joinNetplayEndpoint?.startClientValue,
+          suppressInitialAutosaveResume = joinNetplayEndpoint != null,
           settingsOverrides =
               ApplicationSettingsOverrides(
                   hardwareProfile = profileOverride,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -276,6 +276,7 @@ private fun parseCli(args: Array<String>): CliCommand {
                   bootstrapMode = if (useBootstrap) BootstrapMode.NORMAL else null,
                   batterySavesEnabled = if (disableBatterySaves) false else null,
                   forceInMemoryBattery = joinNetplayEndpoint != null,
+                  suppressCloseAutosave = joinNetplayEndpoint != null,
               ),
       ))
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -16,9 +16,11 @@ private const val USAGE_ERROR = 2
 private const val DEVELOPMENT_VERSION = "development"
 
 /** Everything the CLI contributes to one desktop launch. CLI values remain process-local. */
-data class CliLaunchRequest(
+internal data class CliLaunchRequest(
     val debug: Boolean,
     val initialRom: File?,
+    /** Validated direct-host endpoint text to join after [initialRom] has opened. */
+    val joinNetplayHost: String?,
     val settingsOverrides: ApplicationSettingsOverrides,
 )
 
@@ -53,7 +55,12 @@ fun main(args: Array<String>) {
       ) { request ->
         // SwingGui installs the macOS open-file handler before resolving package natives so an
         // early Finder event cannot be lost during bootstrap.
-        run(request.debug, request.initialRom, request.settingsOverrides)
+        run(
+            request.debug,
+            request.initialRom,
+            request.settingsOverrides,
+            request.joinNetplayHost,
+        )
       }
   if (exitCode != SUCCESS) {
     exitProcess(exitCode)
@@ -119,19 +126,25 @@ private fun parseCli(args: Array<String>): CliCommand {
   var disableBatterySaves = false
   var profileId: String? = null
   var profileOccurrences = 0
+  var joinNetplayEndpoint: NetplayV8Endpoint? = null
   val positional = mutableListOf<String>()
 
-  for (argument in args) {
+  var index = 0
+  while (index < args.size) {
+    val argument = args[index]
     if (!parseOptions) {
       positional += argument
+      index++
       continue
     }
     if (argument == "--") {
       parseOptions = false
+      index++
       continue
     }
     if (argument == "-" || !argument.startsWith("-")) {
       positional += argument
+      index++
       continue
     }
     if (argument.startsWith("--profile=")) {
@@ -144,6 +157,13 @@ private fun parseCli(args: Array<String>): CliCommand {
         cliError("--profile requires one non-empty stable ID")
       }
       profileId = value
+      index++
+      continue
+    }
+    if (argument.startsWith("--join-netplay=")) {
+      if (joinNetplayEndpoint != null) repeatedOption("--join-netplay")
+      joinNetplayEndpoint = parseJoinNetplayEndpoint(argument.substringAfter("--join-netplay="))
+      index++
       continue
     }
 
@@ -181,8 +201,18 @@ private fun parseCli(args: Array<String>): CliCommand {
         disableBatterySaves = true
       }
       "--profile" -> cliError("--profile requires =<id>")
+      "--join-netplay" -> {
+        if (joinNetplayEndpoint != null) repeatedOption("--join-netplay")
+        val value = args.getOrNull(++index)
+            ?: cliError("--join-netplay requires a hostname or IPv4 address")
+        if (value.startsWith("-")) {
+          cliError("--join-netplay requires a hostname or IPv4 address")
+        }
+        joinNetplayEndpoint = parseJoinNetplayEndpoint(value)
+      }
       else -> cliError("Unknown option '$argument'")
     }
+    index++
   }
 
   if (positional.size > 1) {
@@ -197,6 +227,9 @@ private fun parseCli(args: Array<String>): CliCommand {
   if (profileId != null && (forceDmg || forceCgb)) {
     cliError("--profile conflicts with --force-dmg/--force-cgb")
   }
+  if (joinNetplayEndpoint != null && positional.isEmpty()) {
+    cliError("--join-netplay requires a ROM file")
+  }
   if (packageSmoke &&
       (debug ||
           forceDmg ||
@@ -204,6 +237,7 @@ private fun parseCli(args: Array<String>): CliCommand {
           useBootstrap ||
           disableBatterySaves ||
           profileId != null ||
+          joinNetplayEndpoint != null ||
           positional.isNotEmpty())) {
     cliError("--package-smoke cannot be combined with launch options or a ROM file")
   }
@@ -231,6 +265,7 @@ private fun parseCli(args: Array<String>): CliCommand {
       CliLaunchRequest(
           debug = debug,
           initialRom = positional.singleOrNull()?.let(::File),
+          joinNetplayHost = joinNetplayEndpoint?.startClientValue,
           settingsOverrides =
               ApplicationSettingsOverrides(
                   hardwareProfile = profileOverride,
@@ -239,6 +274,12 @@ private fun parseCli(args: Array<String>): CliCommand {
               ),
       ))
 }
+
+private fun parseJoinNetplayEndpoint(value: String): NetplayV8Endpoint =
+    when (val validation = validateNetplayV8Address(value)) {
+      is NetplayAddressValidation.Valid -> validation.endpoint
+      is NetplayAddressValidation.Invalid -> cliError("--join-netplay ${validation.message}")
+    }
 
 private fun validateBootstrapProfile(useBootstrap: Boolean, profile: HardwareProfile?) {
   if (useBootstrap && profile != null && !Bios.hasBundledBootRom(profile)) {
@@ -265,6 +306,7 @@ internal fun printUsage(stream: PrintStream) {
           HardwareProfileRegistry.supportedIds().joinToString(", "))
   stream.println("  -b  --use-bootstrap            Run the bundled boot ROM normally")
   stream.println("  -db --disable-battery-saves    Disable battery save reads and writes")
+  stream.println("      --join-netplay HOST        Join a netplay host after opening ROM_FILE")
   stream.println("      --debug                    Enable debug console")
   stream.println("  -h  --help                     Display this help and exit")
   stream.println("      --version                  Display version and exit")

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -275,6 +275,7 @@ private fun parseCli(args: Array<String>): CliCommand {
                   hardwareProfile = profileOverride,
                   bootstrapMode = if (useBootstrap) BootstrapMode.NORMAL else null,
                   batterySavesEnabled = if (disableBatterySaves) false else null,
+                  forceInMemoryBattery = joinNetplayEndpoint != null,
               ),
       ))
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/NetplayWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/NetplayWindow.kt
@@ -44,10 +44,14 @@ import java.awt.event.ComponentEvent
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.nio.file.Path
 import javax.swing.AbstractAction
 import javax.swing.BorderFactory
 import javax.swing.ButtonGroup
+import javax.swing.DefaultComboBoxModel
 import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
 import javax.swing.JDialog
 import javax.swing.JFrame
 import javax.swing.JComponent
@@ -229,6 +233,7 @@ internal data class NetplayUiState(
     val connectedPeers: Int = 0,
     val requiredPeers: Int = 0,
     val localPlayer: Int? = null,
+    val localInstanceCount: Int = 0,
     val failure: NetplayFailure? = null,
     val notice: String? = null,
 ) {
@@ -239,6 +244,7 @@ internal data class NetplayUiState(
       "Connected peer count cannot exceed the required count"
     }
     require(localPlayer == null || localPlayer in 0..3) { "Netplay player must be in 0..3" }
+    require(localInstanceCount in 0..3) { "Local instance count must be in 0..3" }
   }
 }
 
@@ -324,7 +330,7 @@ internal fun presentNetplay(state: NetplayUiState): NetplayUiPresentation {
 
 internal data class NetplayWindowActions(
     val selectSetup: (NetplaySetupView) -> Unit,
-    val startHosting: (LinkMode) -> Unit,
+    val startHosting: (LinkMode, Int) -> Unit,
     val join: (String) -> Unit,
     val stopSession: () -> Unit,
     val retry: () -> Unit,
@@ -352,6 +358,10 @@ internal fun interface NetplayWindowViewFactory {
 internal class NetplayWindowHost(
     rootEventBus: EventBus,
     private val viewFactory: NetplayWindowViewFactory,
+    private val initialJoinEndpoint: NetplayV8Endpoint? = null,
+    private val localRomPath: () -> Path? = { null },
+    private val localInstanceLauncher: LocalNetplayInstanceLauncher =
+        CurrentProcessLocalNetplayInstanceLauncher(),
     private val onPresentation: (NetplayUiPresentation) -> Unit = {},
     private val confirmPeripheralHandoff:
         (Controller.SerialPeripheralSelection) -> Boolean = { true },
@@ -367,6 +377,8 @@ internal class NetplayWindowHost(
   private var activeAttemptId: Long? = null
   private var cancellationAttemptId: Long? = null
   private var nextAttemptId = 1L
+  private var automaticJoinEndpoint = initialJoinEndpoint
+  private var pendingLocalInstanceLaunch: PendingLocalInstanceLaunch? = null
   private var closed = false
 
   private sealed interface PendingNetworkStart {
@@ -375,6 +387,7 @@ internal class NetplayWindowHost(
     data class Host(
         override val attemptId: Long,
         val mode: LinkMode,
+        val localInstanceCount: Int,
     ) : PendingNetworkStart
 
     data class Client(
@@ -383,9 +396,18 @@ internal class NetplayWindowHost(
     ) : PendingNetworkStart
   }
 
+  private data class PendingLocalInstanceLaunch(
+      val attemptId: Long,
+      val count: Int,
+  )
+
   constructor(
       owner: JFrame,
       rootEventBus: EventBus,
+      initialJoinEndpoint: NetplayV8Endpoint? = null,
+      localRomPath: () -> Path? = { null },
+      localInstanceLauncher: LocalNetplayInstanceLauncher =
+          CurrentProcessLocalNetplayInstanceLauncher(),
       onPresentation: (NetplayUiPresentation) -> Unit = {},
       confirmPeripheralHandoff: (Controller.SerialPeripheralSelection) -> Boolean = { true },
       initialBounds: Rectangle? = null,
@@ -395,6 +417,9 @@ internal class NetplayWindowHost(
       NetplayWindowViewFactory { actions ->
         SwingNetplayWindow(owner, actions, initialBounds, onBoundsChanged)
       },
+      initialJoinEndpoint,
+      localRomPath,
+      localInstanceLauncher,
       onPresentation,
       confirmPeripheralHandoff,
   )
@@ -441,12 +466,13 @@ internal class NetplayWindowHost(
     update(state.copy(setupView = setup, failure = null, notice = null))
   }
 
-  private fun startHosting(mode: LinkMode) {
+  private fun startHosting(mode: LinkMode, localInstanceCount: Int = 0) {
     requireNetplayEdt("Netplay host start")
     if (closed || state.phase != NetplayPhase.DISCONNECTED || !state.availability.available) return
+    if (localInstanceCount !in 0..mode.playerCount - 1) return
     val previous = serialSelectionForRestore()
     if (!mayTakePeerToPeerPort(previous)) return
-    val pending = PendingNetworkStart.Host(allocateAttemptId(), mode)
+    val pending = PendingNetworkStart.Host(allocateAttemptId(), mode, localInstanceCount)
     cancellationAttemptId = null
     update(
         state.copy(
@@ -458,6 +484,7 @@ internal class NetplayWindowHost(
             connectedPeers = 0,
             requiredPeers = mode.playerCount - 1,
             localPlayer = 0,
+            localInstanceCount = localInstanceCount,
             failure = null,
             notice = null,
         ))
@@ -487,6 +514,40 @@ internal class NetplayWindowHost(
             notice = null,
         ))
     preparePeerToPeerPort(pending, previous)
+  }
+
+  private fun startAutomaticJoinIfReady() {
+    val endpoint = automaticJoinEndpoint ?: return
+    if (state.phase != NetplayPhase.DISCONNECTED || !state.availability.available) return
+    automaticJoinEndpoint = null
+    join(endpoint.startClientValue)
+  }
+
+  private fun launchPendingLocalInstances(attemptId: Long) {
+    dispatchSwingMutation {
+      if (closed || state.role != NetplayRole.HOST || !matchesAttempt(attemptId)) {
+        return@dispatchSwingMutation
+      }
+      val pending = pendingLocalInstanceLaunch?.takeIf { it.attemptId == attemptId }
+          ?: return@dispatchSwingMutation
+      pendingLocalInstanceLaunch = null
+      val rom = localRomPath()
+      val profile = latestProfile
+      if (rom == null || profile == null) {
+        update(
+            state.copy(
+                notice =
+                    "Hosting is ready, but local client instances require a game opened directly from a file.",
+            ))
+        return@dispatchSwingMutation
+      }
+      val localhost =
+          (validateNetplayV8Address("localhost") as NetplayAddressValidation.Valid).endpoint
+      update(
+          state.copy(
+              notice = localInstanceLauncher.launch(rom, profile, localhost, pending.count).userMessage(),
+          ))
+    }
   }
 
   private fun serialSelectionForRestore(): Controller.SerialPeripheralSelection =
@@ -520,7 +581,13 @@ internal class NetplayWindowHost(
     if (closed || activeAttemptId != pending.attemptId || pendingNetworkStart != pending) return
     pendingNetworkStart = null
     when (pending) {
-      is PendingNetworkStart.Host -> eventBus.post(StartServerEvent(pending.mode, pending.attemptId))
+      is PendingNetworkStart.Host -> {
+        if (pending.localInstanceCount > 0) {
+          pendingLocalInstanceLaunch =
+              PendingLocalInstanceLaunch(pending.attemptId, pending.localInstanceCount)
+        }
+        eventBus.post(StartServerEvent(pending.mode, pending.attemptId))
+      }
       is PendingNetworkStart.Client ->
           eventBus.post(StartClientEvent(pending.endpoint.startClientValue, pending.attemptId))
     }
@@ -618,7 +685,7 @@ internal class NetplayWindowHost(
     val old = state
     update(disconnectedState(old.setupView))
     when (old.role) {
-      NetplayRole.HOST -> old.mode?.let(::startHosting)
+      NetplayRole.HOST -> old.mode?.let { startHosting(it, old.localInstanceCount) }
       NetplayRole.CLIENT -> old.endpoint?.startClientValue?.let(::join)
       null -> Unit
     }
@@ -648,6 +715,7 @@ internal class NetplayWindowHost(
           setupView = setup,
           mode = state.mode,
           endpoint = state.endpoint,
+          localInstanceCount = state.localInstanceCount,
           notice = notice,
       )
 
@@ -733,7 +801,10 @@ internal class NetplayWindowHost(
         if (closed) return@dispatchSwingMutation
         latestProfile = event.profile
         val game = state.availability.gameName
-        if (game != null) update(state.copy(availability = availability(game, event.profile)))
+        if (game != null) {
+          update(state.copy(availability = availability(game, event.profile)))
+          startAutomaticJoinIfReady()
+        }
       }
     }
     eventBus.register<Controller.EmulationStartedEvent> { event ->
@@ -744,6 +815,7 @@ internal class NetplayWindowHost(
             if (profile == null) NetplayAvailability.CheckingProfile(event.romName)
             else availability(event.romName, profile)
         update(state.copy(availability = availability))
+        startAutomaticJoinIfReady()
       }
     }
     eventBus.register<Controller.EmulationStoppedEvent> {
@@ -771,6 +843,7 @@ internal class NetplayWindowHost(
                 connectedPeers = 0,
                 requiredPeers = event.mode.playerCount - 1,
                 localPlayer = 0,
+                localInstanceCount = 0,
                 failure = null,
                 notice = null,
             ))
@@ -813,9 +886,11 @@ internal class NetplayWindowHost(
             failure = null,
         )
       }
+      launchPendingLocalInstances(event.attemptId)
     }
     eventBus.register<ServerStartFailedEvent> { event ->
       mutateHost(event.attemptId, terminal = true) {
+        clearPendingLocalInstanceLaunch(event.attemptId)
         val canceled = consumeCancellation(event.attemptId)
         restoreSerialPeripheralAfterNetplay()
         if (canceled) {
@@ -899,6 +974,7 @@ internal class NetplayWindowHost(
     }
     eventBus.register<ServerStoppedEvent> { event ->
       mutateHost(event.attemptId, terminal = true) {
+        clearPendingLocalInstanceLaunch(event.attemptId)
         val canceled = consumeCancellation(event.attemptId)
         restoreSerialPeripheralAfterNetplay()
         disconnectedState(
@@ -977,6 +1053,12 @@ internal class NetplayWindowHost(
           phase = NetplayPhase.FAILED,
           failure = NetplayFailure(kind, literalNetworkMessage(message)),
       )
+    }
+  }
+
+  private fun clearPendingLocalInstanceLaunch(attemptId: Long) {
+    if (pendingLocalInstanceLaunch?.attemptId == attemptId) {
+      pendingLocalInstanceLaunch = null
     }
   }
 
@@ -1152,6 +1234,9 @@ internal class NetplayPanel(private val actions: NetplayWindowActions) :
   private val availabilityMessages = mutableListOf<JTextArea>()
   private val normalMode = JRadioButton("2-player link", true)
   private val fourPlayerMode = JRadioButton("4-player adapter")
+  private val startLocalInstances = JCheckBox("Start")
+  private val localInstanceCount = JComboBox(DefaultComboBoxModel(arrayOf(1)))
+  private val localInstanceSuffix = JLabel("local Coffee GB instance and connect it to this host")
   private val startHosting = JButton("Start hosting")
   private val address = JTextField("127.0.0.1", 28)
   private val addressValidation = literalTextArea(" ", 2)
@@ -1241,6 +1326,7 @@ internal class NetplayPanel(private val actions: NetplayWindowActions) :
       setupLayout.show(setupCards, next.state.setupView.name)
       normalMode.isSelected = next.state.mode != LinkMode.FOUR_PLAYER_ADAPTER
       fourPlayerMode.isSelected = next.state.mode == LinkMode.FOUR_PLAYER_ADAPTER
+      updateLocalInstanceControls()
       if (next.state.setupView == NetplaySetupView.JOIN &&
           next.state.phase == NetplayPhase.DISCONNECTED &&
           next.state.endpoint != null &&
@@ -1277,11 +1363,32 @@ internal class NetplayPanel(private val actions: NetplayWindowActions) :
     modes.add(normalMode)
     modes.add(fourPlayerMode)
     addFormRow(form, 1, "Mode", modes)
-    addFormRow(form, 2, "Port", JLabel("6688 (fixed by protocol v8)"))
+    normalMode.addActionListener {
+      if (!rendering) updateLocalInstanceControls()
+    }
+    fourPlayerMode.addActionListener {
+      if (!rendering) updateLocalInstanceControls()
+    }
+
+    startLocalInstances.accessibleContext.accessibleName = "Start local Coffee GB instances"
+    startLocalInstances.accessibleContext.accessibleDescription =
+        "Launch local Coffee GB instances with this game and connect them to this host."
+    startLocalInstances.addActionListener { updateLocalInstanceControls() }
+    localInstanceCount.accessibleContext.accessibleName = "Number of local Coffee GB instances"
+    localInstanceCount.accessibleContext.accessibleDescription =
+        "Two-player link can launch one local client; the four-player adapter can launch one to three."
+    localInstanceCount.addActionListener { updateLocalInstanceSuffix() }
+    val localInstances = JPanel(FlowLayout(FlowLayout.LEADING, 4, 0))
+    localInstances.add(startLocalInstances)
+    localInstances.add(localInstanceCount)
+    localInstances.add(localInstanceSuffix)
+    addFormRow(form, 2, "Local clients", localInstances)
+
+    addFormRow(form, 3, "Port", JLabel("6688 (fixed by protocol v8)"))
     val availability = literalTextArea(" ", 3)
     availability.accessibleContext.accessibleName = "Hosting availability"
     availabilityMessages += availability
-    val availabilityConstraints = formValueConstraints(3)
+    val availabilityConstraints = formValueConstraints(4)
     availabilityConstraints.gridwidth = 2
     availabilityConstraints.gridx = 0
     form.add(availability, availabilityConstraints)
@@ -1304,12 +1411,34 @@ internal class NetplayPanel(private val actions: NetplayWindowActions) :
         "Start a direct TCP protocol-v8 server on port 6688."
     startHosting.addActionListener {
       actions.startHosting(
-          if (fourPlayerMode.isSelected) LinkMode.FOUR_PLAYER_ADAPTER else LinkMode.NORMAL)
+          if (fourPlayerMode.isSelected) LinkMode.FOUR_PLAYER_ADAPTER else LinkMode.NORMAL,
+          if (startLocalInstances.isSelected) localInstanceCount.selectedItem as Int else 0,
+      )
     }
     val buttons = JPanel(FlowLayout(FlowLayout.TRAILING, 0, 0))
     buttons.add(startHosting)
     card.add(buttons, BorderLayout.SOUTH)
     return card
+  }
+
+  private fun updateLocalInstanceControls() {
+    val options = if (fourPlayerMode.isSelected) arrayOf(1, 2, 3) else arrayOf(1)
+    val selected = localInstanceCount.selectedItem as? Int ?: 1
+    if ((0 until localInstanceCount.itemCount).map(localInstanceCount::getItemAt) != options.toList()) {
+      localInstanceCount.model = DefaultComboBoxModel(options)
+    }
+    localInstanceCount.selectedItem = selected.takeIf { it in options } ?: 1
+    localInstanceCount.isEnabled = startLocalInstances.isSelected
+    updateLocalInstanceSuffix()
+  }
+
+  private fun updateLocalInstanceSuffix() {
+    localInstanceSuffix.text =
+        if (localInstanceCount.selectedItem == 1) {
+          "local Coffee GB instance and connect it to this host"
+        } else {
+          "local Coffee GB instances and connect them to this host"
+        }
   }
 
   private fun createJoinCard(): JPanel {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/RomOpenService.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/RomOpenService.kt
@@ -48,13 +48,22 @@ data class RomOpenRequest(
     val recentPathToReplace: Path? = null,
     /** Exact path-backed ROM previously selected from this file or archive, when known. */
     val preferredOrigin: RomOrigin? = null,
+    /** Netplay children start from their host-synchronized state rather than a local resume. */
+    val allowAutosaveResume: Boolean = true,
 ) {
   constructor(
       path: Path,
       source: RomOpenSource,
       recentPathToReplace: Path? = null,
       preferredOrigin: RomOrigin? = null,
-  ) : this(listOf(RomOpenInput.LocalPath(path)), source, recentPathToReplace, preferredOrigin)
+      allowAutosaveResume: Boolean = true,
+  ) : this(
+      listOf(RomOpenInput.LocalPath(path)),
+      source,
+      recentPathToReplace,
+      preferredOrigin,
+      allowAutosaveResume,
+  )
 }
 
 /** Resolves a persisted archive identity against the newly snapshotted, bounded inventory. */
@@ -341,6 +350,7 @@ internal constructor(
             request.source,
             request.recentPathToReplace,
             request.preferredOrigin,
+            request.allowAutosaveResume,
         )
     val operation = Operation(nextRequestId.getAndIncrement(), boundedRequest)
     var unavailable = false
@@ -850,6 +860,7 @@ internal constructor(
               image,
               state = null,
               openRequestId = operation.id,
+              allowAutosaveResume = operation.request.allowAutosaveResume,
           ))
     } finally {
       operation.controllerDispatchComplete.countDown()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -80,6 +80,7 @@ private enum class ClosePersistenceDecision {
 class SwingGui private constructor(
     debug: Boolean,
     private val initialRom: File?,
+    private val initialJoinNetplayHost: String?,
     private val properties: EmulatorProperties,
     private val mobileAdapterConfiguration: MobileAdapterConfigurationCoordinator,
     private val mobileAdapterConfigurationUiState: MobileAdapterConfigurationUiState,
@@ -341,6 +342,13 @@ class SwingGui private constructor(
         NetplayWindowHost(
             owner = mainWindow,
             rootEventBus = eventBus,
+            initialJoinEndpoint = initialJoinNetplayHost?.let(::requireNetplayV8Endpoint),
+            localRomPath = {
+              activeRecentOrigin
+                  ?.takeIf { it.kind() == RomOrigin.Kind.DIRECT_FILE }
+                  ?.containerPath()
+                  ?.orElse(null)
+            },
             onPresentation = { presentation ->
               if (::desktopUiCoordinator.isInitialized) {
                 desktopUiCoordinator.netplaySummary(netplaySummary(presentation))
@@ -1241,6 +1249,7 @@ class SwingGui private constructor(
         debug: Boolean,
         initialRom: File?,
         settingsOverrides: ApplicationSettingsOverrides = ApplicationSettingsOverrides(),
+        initialJoinNetplayHost: String? = null,
     ) {
       val desktopOpenFiles = DesktopOpenFilesBridge()
       prepareDesktopLaunch(
@@ -1284,6 +1293,7 @@ class SwingGui private constructor(
         SwingGui(
                 debug,
                 initialRom,
+                initialJoinNetplayHost,
                 properties,
                 mobileAdapterConfiguration,
                 mobileAdapterConfigurationUiState,
@@ -1299,6 +1309,10 @@ class SwingGui private constructor(
     }
   }
 }
+
+private fun requireNetplayV8Endpoint(value: String): NetplayV8Endpoint =
+    (validateNetplayV8Address(value) as? NetplayAddressValidation.Valid)?.endpoint
+        ?: throw IllegalArgumentException("Initial netplay host must be a valid protocol-v8 address")
 
 /** Keeps Proposal 3 construction and its input capture out of the default desktop startup path. */
 internal fun <T> installDesktopProposal3Menu(enabled: Boolean, install: () -> T): T? =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -81,6 +81,7 @@ class SwingGui private constructor(
     debug: Boolean,
     private val initialRom: File?,
     private val initialJoinNetplayHost: String?,
+    private val suppressInitialAutosaveResume: Boolean,
     private val properties: EmulatorProperties,
     private val mobileAdapterConfiguration: MobileAdapterConfigurationCoordinator,
     private val mobileAdapterConfigurationUiState: MobileAdapterConfigurationUiState,
@@ -696,7 +697,11 @@ class SwingGui private constructor(
       Thread(console).start()
     }
     if (initialRom != null) {
-      romOpen.open(initialRom.toPath(), RomOpenSource.INITIAL_ARGUMENT)
+      romOpen.open(
+          initialRom.toPath(),
+          RomOpenSource.INITIAL_ARGUMENT,
+          allowAutosaveResume = !suppressInitialAutosaveResume,
+      )
     } else {
       // With Proposal 3 enabled, idle desktop startup is the same controller-friendly Library
       // entry point as Android. The default desktop home remains untouched when the flag is off.
@@ -1250,6 +1255,7 @@ class SwingGui private constructor(
         initialRom: File?,
         settingsOverrides: ApplicationSettingsOverrides = ApplicationSettingsOverrides(),
         initialJoinNetplayHost: String? = null,
+        suppressInitialAutosaveResume: Boolean = false,
     ) {
       val desktopOpenFiles = DesktopOpenFilesBridge()
       prepareDesktopLaunch(
@@ -1294,6 +1300,7 @@ class SwingGui private constructor(
                 debug,
                 initialRom,
                 initialJoinNetplayHost,
+                suppressInitialAutosaveResume,
                 properties,
                 mobileAdapterConfiguration,
                 mobileAdapterConfigurationUiState,

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
@@ -10,6 +10,14 @@ import org.junit.Test
 class LocalNetplayInstanceLauncherTest {
 
   @Test
+  fun `child processes inherit the host error stream`() {
+    assertEquals(
+        ProcessBuilder.Redirect.INHERIT,
+        localNetplayProcessBuilder(listOf("coffee-gb")).redirectError(),
+    )
+  }
+
+  @Test
   fun `jar launcher starts each client with the ROM profile and localhost join command`() {
     val started = mutableListOf<List<String>>()
     val rom = Path.of("test data", "Tetris.gb").toAbsolutePath().normalize()

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
@@ -1,0 +1,76 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class LocalNetplayInstanceLauncherTest {
+
+  @Test
+  fun `jar launcher starts each client with the ROM profile and localhost join command`() {
+    val started = mutableListOf<List<String>>()
+    val rom = Path.of("test data", "Tetris.gb").toAbsolutePath().normalize()
+    val launcher =
+        CurrentProcessLocalNetplayInstanceLauncher(
+            listOf("/usr/bin/java", "-Dcoffee-gb.theme=dark", "-jar", "/apps/coffee-gb.jar", "old.gb"),
+        started::add,
+    )
+
+    val result = launcher.launch(rom, HardwareProfileRegistry.CGB, endpoint("localhost"), 3)
+
+    assertEquals(3, result.started)
+    assertEquals(3, started.size)
+    val command = started.first()
+    assertEquals(
+        listOf(
+            "/usr/bin/java",
+            "-Dcoffee-gb.theme=dark",
+            "-jar",
+            "/apps/coffee-gb.jar",
+            "--profile=cgb",
+            "--disable-battery-saves",
+            "--join-netplay",
+            "localhost",
+            rom.toString(),
+        ),
+        command,
+    )
+    assertTrue(started.all { it == command })
+  }
+
+  @Test
+  fun `native launcher omits the current process app arguments`() {
+    assertEquals(
+        listOf("/Applications/Coffee GB.app/Contents/MacOS/Coffee GB"),
+        localNetplayLauncherPrefix(
+            listOf("/Applications/Coffee GB.app/Contents/MacOS/Coffee GB", "--debug", "old.gb"),
+        ),
+    )
+    assertNull(localNetplayLauncherPrefix(listOf("/usr/bin/java", "old.gb")))
+  }
+
+  @Test
+  fun `a failed child launch retains the successful launches in the result`() {
+    var attempts = 0
+    val launcher =
+        CurrentProcessLocalNetplayInstanceLauncher(
+            listOf("coffee-gb"),
+        ) {
+          attempts++
+          if (attempts == 2) throw IllegalStateException("synthetic failure")
+        }
+
+    val result =
+        launcher.launch(Path.of("Tetris.gb"), HardwareProfileRegistry.DMG, endpoint("localhost"), 3)
+
+    assertEquals(1, result.started)
+    assertEquals(3, result.requested)
+    assertTrue(result.userMessage().contains("only 1 of 3"))
+  }
+
+  private fun endpoint(value: String): NetplayV8Endpoint =
+      (validateNetplayV8Address(value) as NetplayAddressValidation.Valid).endpoint
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -66,11 +66,13 @@ class MainTest {
     assertEquals("play.local:7000", spaced.joinNetplayHost)
     assertTrue(spaced.suppressInitialAutosaveResume)
     assertTrue(spaced.settingsOverrides.forceInMemoryBattery)
+    assertTrue(spaced.settingsOverrides.suppressCloseAutosave)
 
     val equals = execute("--join-netplay=localhost", "game.gb").singleLaunch()
     assertEquals("localhost", equals.joinNetplayHost)
     assertTrue(equals.suppressInitialAutosaveResume)
     assertTrue(equals.settingsOverrides.forceInMemoryBattery)
+    assertTrue(equals.settingsOverrides.suppressCloseAutosave)
 
     assertUsageFailure(
         execute("--join-netplay"),

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -39,6 +39,7 @@ class MainTest {
     assertEquals("", execution.stderr)
     assertFalse(request.debug)
     assertNull(request.initialRom)
+    assertNull(request.joinNetplayHost)
     assertNull(request.settingsOverrides.hardwareProfile)
     assertNull(request.settingsOverrides.bootstrapMode)
     assertNull(request.settingsOverrides.batterySavesEnabled)
@@ -55,6 +56,26 @@ class MainTest {
     assertEquals(HardwareProfileRegistry.DMG, request.settingsOverrides.hardwareProfile)
     assertEquals(BootstrapMode.NORMAL, request.settingsOverrides.bootstrapMode)
     assertEquals(false, request.settingsOverrides.batterySavesEnabled)
+  }
+
+  @Test
+  fun `join netplay accepts a direct host value and requires a ROM`() {
+    val spaced = execute("--join-netplay", "play.local:7000", "game.gb").singleLaunch()
+    assertEquals(File("game.gb"), spaced.initialRom)
+    assertEquals("play.local:7000", spaced.joinNetplayHost)
+
+    val equals = execute("--join-netplay=localhost", "game.gb").singleLaunch()
+    assertEquals("localhost", equals.joinNetplayHost)
+
+    assertUsageFailure(
+        execute("--join-netplay"),
+        "--join-netplay requires a hostname or IPv4 address",
+    )
+    assertUsageFailure(execute("--join-netplay", "localhost"), "--join-netplay requires a ROM file")
+    assertUsageFailure(
+        execute("--join-netplay", "play.local:0", "game.gb"),
+        "--join-netplay The port must be between 1 and 65535",
+    )
   }
 
   @Test
@@ -121,6 +142,7 @@ class MainTest {
               "--profile=<id>",
               "-b  --use-bootstrap",
               "-db --disable-battery-saves",
+              "--join-netplay HOST",
               "--debug",
               "-h  --help",
               "--version",
@@ -188,6 +210,10 @@ class MainTest {
             Failure(arrayOf("--profile="), "--profile requires one non-empty stable ID"),
             Failure(arrayOf("--profile=cgb=extra"), "--profile requires one non-empty stable ID"),
             Failure(arrayOf("--profile=CGB"), "Unknown hardware profile 'CGB'"),
+            Failure(
+                arrayOf("--join-netplay=host", "--join-netplay=other", "game.gb"),
+                "Option '--join-netplay' may be specified only once",
+            ),
             Failure(
                 arrayOf("--package-smoke", "game.gb"),
                 "--package-smoke cannot be combined with launch options or a ROM file",

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -40,6 +40,7 @@ class MainTest {
     assertFalse(request.debug)
     assertNull(request.initialRom)
     assertNull(request.joinNetplayHost)
+    assertFalse(request.suppressInitialAutosaveResume)
     assertNull(request.settingsOverrides.hardwareProfile)
     assertNull(request.settingsOverrides.bootstrapMode)
     assertNull(request.settingsOverrides.batterySavesEnabled)
@@ -63,9 +64,11 @@ class MainTest {
     val spaced = execute("--join-netplay", "play.local:7000", "game.gb").singleLaunch()
     assertEquals(File("game.gb"), spaced.initialRom)
     assertEquals("play.local:7000", spaced.joinNetplayHost)
+    assertTrue(spaced.suppressInitialAutosaveResume)
 
     val equals = execute("--join-netplay=localhost", "game.gb").singleLaunch()
     assertEquals("localhost", equals.joinNetplayHost)
+    assertTrue(equals.suppressInitialAutosaveResume)
 
     assertUsageFailure(
         execute("--join-netplay"),

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -65,10 +65,12 @@ class MainTest {
     assertEquals(File("game.gb"), spaced.initialRom)
     assertEquals("play.local:7000", spaced.joinNetplayHost)
     assertTrue(spaced.suppressInitialAutosaveResume)
+    assertTrue(spaced.settingsOverrides.forceInMemoryBattery)
 
     val equals = execute("--join-netplay=localhost", "game.gb").singleLaunch()
     assertEquals("localhost", equals.joinNetplayHost)
     assertTrue(equals.suppressInitialAutosaveResume)
+    assertTrue(equals.settingsOverrides.forceInMemoryBattery)
 
     assertUsageFailure(
         execute("--join-netplay"),

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayWindowTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayWindowTest.kt
@@ -23,12 +23,16 @@ import java.awt.Component
 import java.awt.Container
 import java.net.ServerSocket
 import java.net.Socket
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.swing.AbstractButton
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
 import javax.swing.JLabel
+import javax.swing.JRadioButton
 import javax.swing.JTextArea
 import javax.swing.JTextField
 import javax.swing.SwingUtilities
@@ -138,7 +142,7 @@ class NetplayWindowTest {
       assertEquals(1, fixture.factoryCalls)
       assertEquals(2, fixture.view.showCalls)
 
-      onEdt { fixture.view.actions.startHosting(LinkMode.FOUR_PLAYER_ADAPTER) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.FOUR_PLAYER_ADAPTER, 0) }
       assertEquals(listOf(LinkMode.FOUR_PLAYER_ADAPTER), serverStarts.map { it.mode })
       val attemptId = serverStarts.single().attemptId
       assertTrue(attemptId > 0)
@@ -263,6 +267,70 @@ class NetplayWindowTest {
   }
 
   @Test
+  fun `initial CLI join waits for the loaded ROM and starts the client once`() {
+    val bus = EventBusImpl()
+    val starts = mutableListOf<StartClientEvent>()
+    bus.register<StartClientEvent>(starts::add)
+    val fixture = onEdt { HostFixture(bus, initialJoinEndpoint = validEndpoint("localhost")) }
+
+    try {
+      publishAvailableGame(bus)
+      flushEdt()
+
+      assertEquals(listOf("localhost"), starts.map { it.host })
+      assertEquals(NetplayPhase.CONNECTING, onEdt { fixture.host.currentPresentation().state.phase })
+
+      bus.post(Controller.EmulationStartedEvent("Tetris"))
+      flushEdt()
+      assertEquals(1, starts.size)
+    } finally {
+      onEdt { fixture.host.close() }
+      bus.close()
+    }
+  }
+
+  @Test
+  fun `host launches requested local clients after the server is listening`() {
+    val bus = EventBusImpl()
+    val starts = mutableListOf<StartServerEvent>()
+    val launches = mutableListOf<LocalLaunch>()
+    bus.register<StartServerEvent>(starts::add)
+    val fixture =
+        onEdt {
+          HostFixture(
+              bus,
+              localRomPath = { Path.of("Tetris.gb") },
+              localInstanceLauncher =
+                  LocalNetplayInstanceLauncher { rom, profile, endpoint, count ->
+                    launches += LocalLaunch(rom, profile.id(), endpoint.startClientValue, count)
+                    LocalNetplayInstanceLaunchResult(count, count, launcherAvailable = true)
+                  },
+          )
+        }
+
+    try {
+      publishAvailableGame(bus)
+      flushEdt()
+      onEdt { fixture.host.show() }
+      onEdt { fixture.view.actions.startHosting(LinkMode.FOUR_PLAYER_ADAPTER, 3) }
+      val attemptId = starts.single().attemptId
+
+      assertTrue(launches.isEmpty())
+      bus.post(ServerStartedEvent(LinkMode.FOUR_PLAYER_ADAPTER, attemptId))
+      flushEdt()
+
+      assertEquals(
+          listOf(LocalLaunch(Path.of("Tetris.gb"), "dmg", "localhost", 3)),
+          launches,
+      )
+      assertTrue(onEdt { fixture.host.currentPresentation().status.contains("Started 3 local") })
+    } finally {
+      onEdt { fixture.host.close() }
+      bus.close()
+    }
+  }
+
+  @Test
   fun `profile preflight rejects MGB and closing the retained host never disconnects`() {
     val bus = EventBusImpl()
     val stopRequests = AtomicInteger()
@@ -299,7 +367,10 @@ class NetplayWindowTest {
     bus.register<Controller.SetSerialPeripheralEvent> { selections += it.selection }
     bus.register<StartServerEvent>(starts::add)
     val confirmed = mutableListOf<Controller.SerialPeripheralSelection>()
-    val fixture = onEdt { HostFixture(bus) { selection -> confirmed += selection; true } }
+    val fixture =
+        onEdt {
+          HostFixture(bus, confirmPeripheralHandoff = { selection -> confirmed += selection; true })
+        }
 
     try {
       publishAvailableGame(bus)
@@ -309,7 +380,7 @@ class NetplayWindowTest {
       flushEdt()
 
       onEdt { fixture.host.show() }
-      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL, 0) }
       assertEquals(listOf(Controller.SerialPeripheralSelection.PRINTER), confirmed)
       assertEquals(Controller.SerialPeripheralSelection.PEER_TO_PEER, selections.last())
       assertTrue(starts.isEmpty(), "network startup waits for the serial ownership commit")
@@ -411,7 +482,7 @@ class NetplayWindowTest {
       flushEdt()
 
       onEdt { fixture.host.show() }
-      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL, 0) }
       val firstAttemptId = starts.single().attemptId
       bus.post(
           ServerStartFailedEvent(
@@ -466,7 +537,7 @@ class NetplayWindowTest {
       flushEdt()
       onEdt { fixture.host.show() }
 
-      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL, 0) }
       assertTrue(starts.isEmpty())
       assertEquals(NetplaySessionAction.CANCEL, onEdt { fixture.host.currentPresentation().sessionAction })
 
@@ -521,7 +592,7 @@ class NetplayWindowTest {
       flushEdt()
       onEdt { fixture.host.show() }
 
-      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL, 0) }
       bus.post(
           Controller.SerialPeripheralSelectionChangedEvent(
               Controller.SerialPeripheralSelection.PEER_TO_PEER))
@@ -642,7 +713,7 @@ class NetplayWindowTest {
     val bus = EventBusImpl()
     val starts = mutableListOf<StartServerEvent>()
     bus.register<StartServerEvent>(starts::add)
-    val fixture = onEdt { HostFixture(bus) { false } }
+    val fixture = onEdt { HostFixture(bus, confirmPeripheralHandoff = { false }) }
     try {
       publishAvailableGame(bus)
       bus.post(
@@ -651,7 +722,7 @@ class NetplayWindowTest {
       flushEdt()
 
       onEdt { fixture.host.show() }
-      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL) }
+      onEdt { fixture.view.actions.startHosting(LinkMode.NORMAL, 0) }
 
       assertTrue(starts.isEmpty())
       assertEquals(NetplayPhase.DISCONNECTED, onEdt { fixture.host.currentPresentation().state.phase })
@@ -724,9 +795,61 @@ class NetplayWindowTest {
       }
   }
 
+  @Test
+  fun `host card limits local clients for normal link and exposes one through three for adapter`() {
+    onEdt {
+      val starts = mutableListOf<Pair<LinkMode, Int>>()
+      val panel =
+          NetplayPanel(
+              NetplayWindowActions(
+                  { _ -> },
+                  { mode, count -> starts += mode to count },
+                  { _ -> },
+                  {},
+                  {},
+                  {},
+              ))
+      panel.render(
+          presentNetplay(
+              NetplayUiState(
+                  availability = NetplayAvailability.Available("Tetris", "dmg", "Game Boy"))))
+      val components = descendants(panel)
+      val checkbox =
+          components.filterIsInstance<JCheckBox>().single {
+            it.accessibleContext.accessibleName == "Start local Coffee GB instances"
+          }
+      val count =
+          components.filterIsInstance<JComboBox<*>>().single {
+            it.accessibleContext.accessibleName == "Number of local Coffee GB instances"
+          }
+      val normal = components.filterIsInstance<JRadioButton>().single { it.text == "2-player link" }
+      val adapter = components.filterIsInstance<JRadioButton>().single { it.text == "4-player adapter" }
+      val start = components.filterIsInstance<AbstractButton>().single { it.text == "Start hosting" }
+
+      assertEquals(listOf(1), (0 until count.itemCount).map(count::getItemAt))
+      assertFalse(count.isEnabled)
+      checkbox.doClick()
+      assertTrue(count.isEnabled)
+      adapter.doClick()
+      assertEquals(listOf(1, 2, 3), (0 until count.itemCount).map(count::getItemAt))
+      count.selectedItem = 3
+      start.doClick()
+      assertEquals(listOf(LinkMode.FOUR_PLAYER_ADAPTER to 3), starts)
+
+      normal.doClick()
+      assertEquals(listOf(1), (0 until count.itemCount).map(count::getItemAt))
+    }
+  }
+
   private class HostFixture(
       bus: EventBusImpl,
       confirmPeripheralHandoff: (Controller.SerialPeripheralSelection) -> Boolean = { true },
+      initialJoinEndpoint: NetplayV8Endpoint? = null,
+      localRomPath: () -> Path? = { null },
+      localInstanceLauncher: LocalNetplayInstanceLauncher =
+          LocalNetplayInstanceLauncher { _, _, _, count ->
+            LocalNetplayInstanceLaunchResult(count, count, launcherAvailable = true)
+          },
   ) {
     lateinit var view: RecordingNetplayView
     var factoryCalls = 0
@@ -737,9 +860,19 @@ class NetplayWindowTest {
               factoryCalls++
               RecordingNetplayView(actions).also { view = it }
             },
+            initialJoinEndpoint = initialJoinEndpoint,
+            localRomPath = localRomPath,
+            localInstanceLauncher = localInstanceLauncher,
             confirmPeripheralHandoff = confirmPeripheralHandoff,
         )
   }
+
+  private data class LocalLaunch(
+      val rom: Path,
+      val profile: String,
+      val endpoint: String,
+      val count: Int,
+  )
 
   private class RecordingNetplayView(val actions: NetplayWindowActions) : NetplayWindowView {
     val presentations = mutableListOf<NetplayUiPresentation>()
@@ -777,7 +910,7 @@ class NetplayWindowTest {
       assertIs<NetplayAddressValidation.Valid>(validateNetplayV8Address(value)).endpoint
 
   private fun noOpActions(): NetplayWindowActions =
-      NetplayWindowActions({ _ -> }, { _ -> }, { _ -> }, {}, {}, {})
+      NetplayWindowActions({ _ -> }, { _, _ -> }, { _ -> }, {}, {}, {})
 
   private fun descendants(component: Component): List<Component> =
       buildList {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/RomOpenServiceTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/RomOpenServiceTest.kt
@@ -81,6 +81,24 @@ class RomOpenServiceTest {
   }
 
   @Test
+  fun `a netplay child open does not request a local autosave resume`() {
+    val fixture = fixture()
+    try {
+      fixture.service.open(
+          RomOpenRequest(
+              romFile("netplay-child.gb", "NETPLAY_CHILD"),
+              RomOpenSource.INITIAL_ARGUMENT,
+              allowAutosaveResume = false,
+          ))
+      fixture.worker.runAll()
+
+      assertEquals(false, fixture.loads.single().allowAutosaveResume)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
   fun `a desktop open reaches the Swing emulator controller after inspecting the ROM`() {
     val eventBus = EventBusImpl()
     val properties = EmulatorProperties()


### PR DESCRIPTION
Closes #549\n\nAdds an optional local-client launcher to netplay hosting. The Host UI offers a checkbox and a mode-aware 1–3 instance selector. After the server starts listening, Coffee GB launches the selected local clients with the active direct ROM, matching profile, and --join-netplay localhost.\n\nAlso adds the --join-netplay HOST CLI option, which waits until the supplied ROM has loaded before connecting.\n\nTests: /opt/maven/bin/mvn -q -pl swing -Dkotlin.compiler.execution.strategy=in-process -Dtest=MainTest,NetplayWindowTest,LocalNetplayInstanceLauncherTest test