### PR TITLE
Optimize native CGB performance path

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -15,6 +15,7 @@
 # or method name; the ordinary PERFORMANCE scheduler remains free to optimize normally.
 -keepclassmembers,allowobfuscation class eu.rekawek.coffeegb.core.Gameboy {
     private int tryPerformanceSettledDmgHaltSpan(long);
+    private int tryPerformanceSettledNativeCgbHaltSpan(long);
 }
 
 # This native-CGB commit is deliberately kept as the coarse epoch's small call boundary. R8 may
@@ -28,4 +29,10 @@
 # its own optimization boundary.
 -keepclassmembers,allowobfuscation,allowshrinking class eu.rekawek.coffeegb.core.Gameboy {
     private void tickNativeCgbPerformanceStatPrologue(int);
+}
+
+# Keep the native-CGB scanline dispatch as a narrow renderer optimization boundary. Do not allow
+# R8 to inline it into Gpu's scheduler; its body still selects the exact or generic renderer path.
+-keepclassmembers,allowobfuscation,allowshrinking class eu.rekawek.coffeegb.core.gpu.PerformanceScanlineRenderer {
+    void renderLinePerformanceBoundary(eu.rekawek.coffeegb.core.gpu.Display,int,int);
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -16,3 +16,16 @@
 -keepclassmembers,allowobfuscation class eu.rekawek.coffeegb.core.Gameboy {
     private int tryPerformanceSettledDmgHaltSpan(long);
 }
+
+# This native-CGB commit is deliberately kept as the coarse epoch's small call boundary. R8 may
+# shrink and rename it, but must not inline its body back into Gameboy's already-large commit.
+-keepclassmembers,allowobfuscation,allowshrinking class eu.rekawek.coffeegb.core.gpu.Gpu {
+    public void advancePerformanceEpochQuietSpanTrusted(int,boolean,boolean);
+}
+
+# Keep the native-CGB scalar STAT prologue out of the shared subsystem scheduler. The one-shot
+# owner branch must stay tiny for DMG/ACCURACY ticks while the packed native implementation keeps
+# its own optimization boundary.
+-keepclassmembers,allowobfuscation,allowshrinking class eu.rekawek.coffeegb.core.Gameboy {
+    private void tickNativeCgbPerformanceStatPrologue(int);
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
@@ -80,10 +80,32 @@ final class AndroidAudioSink implements AutoCloseable {
                          long playbackPositionFrames, long overruns, long underruns,
                          long outputUnderruns, long restarts,
                          long routeFailures, boolean outputOpen, boolean outputPlaying,
-                         int sampleRate, int queueCapacityFrames, int maximumFrameBytes) {
+                         int sampleRate, int queueCapacityFrames, int maximumFrameBytes,
+                         boolean active, boolean paused, boolean muted, int volume,
+                         int systemVolume, int systemVolumeMax, boolean systemMusicMuted,
+                         int queuedFrames, boolean reopenPending, long outputIdentity,
+                         long queueIdentity) {
+        /** Source-compatible constructor retained for existing benchmark fixtures. */
+        AudioBaseline(long inputEvents, long inputFrames, long enqueuedBytes, long enqueuedFrames,
+                long writtenBytes, long writtenFrames, long writeFailures,
+                long discardedBytes, long pendingBytes, long queuedBytes,
+                long playbackPositionFrames, long overruns, long underruns,
+                long outputUnderruns, long restarts, long routeFailures,
+                boolean outputOpen, boolean outputPlaying, int sampleRate,
+                int queueCapacityFrames, int maximumFrameBytes) {
+            this(inputEvents, inputFrames, enqueuedBytes, enqueuedFrames, writtenBytes,
+                    writtenFrames, writeFailures, discardedBytes, pendingBytes, queuedBytes,
+                    playbackPositionFrames, overruns, underruns, outputUnderruns, restarts,
+                    routeFailures, outputOpen, outputPlaying, sampleRate, queueCapacityFrames,
+                    maximumFrameBytes, outputOpen, false, false, 100, 1, 1, false,
+                    queuedBytes > 0L ? 1 : 0, false, outputOpen ? 1L : 0L,
+                    queueCapacityFrames > 0 ? 1L : 0L);
+        }
+
         static AudioBaseline unavailable() {
             return new AudioBaseline(-1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L, -1L,
-                    -1L, -1L, -1L, -1L, -1L, -1L, -1L, false, false, -1, -1, -1);
+                    -1L, -1L, -1L, -1L, -1L, -1L, -1L, false, false, -1, -1, -1,
+                    false, true, true, 0, -1, -1, true, -1, true, 0L, 0L);
         }
     }
 
@@ -98,6 +120,8 @@ final class AndroidAudioSink implements AutoCloseable {
     private final AtomicBoolean reopenRequested = new AtomicBoolean();
     private final AtomicLong underruns = new AtomicLong();
     private final AtomicLong restarts = new AtomicLong();
+    /** Monotonic identity fence for observational benchmark snapshots. */
+    private final AtomicLong routeGeneration = new AtomicLong();
     /** Benchmark-only ledger.  Release R8 removes its implementation and all guarded call sites. */
     private final PcmAccounting pcmAccounting = BuildConfig.DIAGNOSTICS_ENABLED
             ? new DiagnosticPcmAccounting() : NoOpPcmAccounting.INSTANCE;
@@ -201,18 +225,46 @@ final class AndroidAudioSink implements AutoCloseable {
         if (!BuildConfig.DIAGNOSTICS_ENABLED) {
             return AudioBaseline.unavailable();
         }
-        synchronized (pcmAccounting) {
-            updatePlaybackEvidence(activeOutput);
-            BoundedPcmQueue active = queue;
-            PcmSnapshot snapshot = pcmAccounting.snapshot();
-            return new AudioBaseline(snapshot.inputEvents(), snapshot.inputFrames(),
-                    snapshot.enqueuedBytes(), snapshot.enqueuedFrames(), snapshot.writtenBytes(),
-                    snapshot.writtenFrames(), snapshot.writeFailures(), snapshot.discardedBytes(),
-                    snapshot.pendingBytes(), active == null ? 0L : active.queuedBytes(),
-                    playbackPositionFrames, active == null ? 0L : active.overruns(),
-                    underruns.get(), outputUnderruns, restarts.get(), snapshot.routeFailures(), outputOpen,
-                    outputPlaying, sampleRate, active == null ? 0 : active.capacityFrames(),
-                    active == null ? 0 : active.maximumFrameBytes());
+        try {
+            synchronized (pcmAccounting) {
+                long generation = routeGeneration.get();
+                Output output = activeOutput;
+                BoundedPcmQueue active = queue;
+                updatePlaybackEvidence(output);
+                PcmSnapshot snapshot = pcmAccounting.snapshot();
+                boolean baselineOutputOpen = outputOpen;
+                boolean baselineOutputPlaying = outputPlaying;
+                boolean baselineReopenPending = reopenRequested.get();
+                long outputIdentity = output == null ? 0L
+                        : Integer.toUnsignedLong(System.identityHashCode(output));
+                long queueIdentity = active == null ? 0L
+                        : Integer.toUnsignedLong(System.identityHashCode(active));
+                AudioBaseline baseline = new AudioBaseline(
+                        snapshot.inputEvents(), snapshot.inputFrames(),
+                        snapshot.enqueuedBytes(), snapshot.enqueuedFrames(), snapshot.writtenBytes(),
+                        snapshot.writtenFrames(), snapshot.writeFailures(), snapshot.discardedBytes(),
+                        snapshot.pendingBytes(), active == null ? 0L : active.queuedBytes(),
+                        playbackPositionFrames, active == null ? 0L : active.overruns(),
+                        underruns.get(), outputUnderruns, restarts.get(), snapshot.routeFailures(),
+                        baselineOutputOpen, baselineOutputPlaying, sampleRate,
+                        active == null ? 0 : active.capacityFrames(),
+                        active == null ? 0 : active.maximumFrameBytes(), running.get(), paused, muted,
+                        volume, systemVolume, systemVolumeMax, systemMusicMuted,
+                        active == null ? 0 : active.queuedFrames(), baselineReopenPending,
+                        outputIdentity, queueIdentity);
+                if (routeGeneration.get() != generation
+                        || activeOutput != output || queue != active
+                        || outputOpen != baselineOutputOpen
+                        || outputPlaying != baselineOutputPlaying
+                        || reopenRequested.get() != baselineReopenPending) {
+                    return AudioBaseline.unavailable();
+                }
+                return baseline;
+            }
+        } catch (RuntimeException unavailable) {
+            // The consumer may release/rebuild an AudioTrack or queue concurrently with the
+            // observational ARM read. Fail closed instead of publishing a mixed-session proof.
+            return AudioBaseline.unavailable();
         }
     }
 
@@ -355,6 +407,7 @@ final class AndroidAudioSink implements AutoCloseable {
                     release(output);
                     output = openOutput();
                     activeOutput = output;
+                    routeGeneration.incrementAndGet();
                     outputPaused = false;
                     if (output == null) {
                         if (BuildConfig.DIAGNOSTICS_ENABLED) {
@@ -385,6 +438,7 @@ final class AndroidAudioSink implements AutoCloseable {
                         }
                         activeQueue = new BoundedPcmQueue(output.sampleRate(), queueClock);
                         queue = activeQueue;
+                        routeGeneration.incrementAndGet();
                     } else {
                         if (BuildConfig.DIAGNOSTICS_ENABLED) {
                             clearAndAccount(activeQueue);
@@ -481,6 +535,7 @@ final class AndroidAudioSink implements AutoCloseable {
             }
             queue = null;
             activeOutput = null;
+            routeGeneration.incrementAndGet();
             sampleRate = 0;
             minimumBufferBytes = 0;
             configuredBufferBytes = 0;

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -50,9 +51,12 @@ final class AndroidBenchmarkDiagnostics {
     private static final int INTERVAL_FRAMES = 60;
     private static final int FINAL_FRAME = 600;
     private static final int UNKNOWN = -1;
+    /** Leaves explicit headroom below Android's approximately 4 KiB per-record payload cliff. */
+    static final int MAX_LOG_RECORD_BYTES = 3_750;
 
     private enum Phase {
         IDLE,
+        SCENARIO_RUNNING,
         WARMING,
         ANCHOR_READY,
         ARMED,
@@ -103,6 +107,17 @@ final class AndroidBenchmarkDiagnostics {
     private boolean measurementArmed;
     private Phase phase = Phase.IDLE;
     private long benchmarkGeneration;
+    private long activeSessionGeneration;
+    private long scenarioSessionGeneration;
+    private int scenarioExpectedFrames;
+    private int scenarioCompletedFrames;
+    private boolean scenarioCompleted;
+    private boolean scenarioSourceClosed;
+    private boolean scenarioAudioDrained;
+    /** Terminal for one active session: visibility cannot be reconstructed before ARM. */
+    private boolean preArmVisibilityLost;
+    /** Sticky visibility poison inherited by every session generation in this runtime. */
+    private boolean nextSessionVisibilityLost;
     private boolean speedFinalSample;
     private int speedModeFinal = UNKNOWN;
     /** Audio counters sampled at the physical ready-600 boundary, before compositor drain delay. */
@@ -154,15 +169,32 @@ final class AndroidBenchmarkDiagnostics {
 
     AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options, RecordSink recordSink,
             LongSupplier monotonicNanos) {
+        this(context, options, recordSink, monotonicNanos, null, null);
+    }
+
+    /** Test seam for production-length redacted identities without depending on an Android APK. */
+    AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options, RecordSink recordSink,
+            LongSupplier monotonicNanos, String artifactIdOverride, String deviceIdOverride) {
         this.context = context == null ? null : context.getApplicationContext();
         this.options = options == null ? DiagnosticsOptions.disabled() : options;
         this.recordSink = recordSink == null ? AndroidBenchmarkDiagnostics::logRecord : recordSink;
         this.monotonicNanos = monotonicNanos == null
                 ? AndroidBenchmarkDiagnostics::systemNow : monotonicNanos;
         enabled = BuildConfig.DIAGNOSTICS_ENABLED && this.options.enabled;
-        artifactId = enabled ? sha256File(this.context == null ? null
-                : this.context.getPackageCodePath()) : "unavailable";
-        deviceId = enabled ? deviceIdentity(this.context) : "unavailable";
+        artifactId = enabled && artifactIdOverride != null
+                ? boundedDigestOverride(artifactIdOverride)
+                : enabled ? sha256File(this.context == null ? null
+                        : this.context.getPackageCodePath()) : "unavailable";
+        deviceId = enabled && deviceIdOverride != null
+                ? boundedDigestOverride(deviceIdOverride)
+                : enabled ? deviceIdentity(this.context) : "unavailable";
+    }
+
+    private static String boundedDigestOverride(String value) {
+        if (!value.matches("[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("Benchmark identity override must be SHA-256 hex");
+        }
+        return value;
     }
 
     boolean enabled() {
@@ -182,12 +214,28 @@ final class AndroidBenchmarkDiagnostics {
     }
 
     /** Returns whether the host may issue the one-shot compositor-baseline arm action. */
-    synchronized boolean benchmarkAnchorReady() {
-        return enabled && phase == Phase.ANCHOR_READY && !measurementArmed;
+    synchronized boolean benchmarkAnchorReady(long sessionGeneration) {
+        return enabled && sessionGeneration > 0L
+                && sessionGeneration == activeSessionGeneration
+                && !preArmVisibilityLost
+                && phase == Phase.ANCHOR_READY && !measurementArmed
+                && scenarioCompleted && scenarioSourceClosed && scenarioAudioDrained;
     }
 
     /** Completes the host anchor only after the renderer has returned from unlockCanvasAndPost. */
-    synchronized void benchmarkAnchorPosted(boolean success) {
+    synchronized void benchmarkAnchorPosted(long sessionGeneration, boolean success) {
+        if (sessionGeneration <= 0L || sessionGeneration != activeSessionGeneration) {
+            if (enabled) {
+                record("event=benchmark_anchor success=false phase="
+                        + phase.name().toLowerCase() + " reason=stale_session");
+            }
+            return;
+        }
+        if (preArmVisibilityLost) {
+            record("event=benchmark_anchor success=false phase="
+                    + phase.name().toLowerCase() + " reason=visibility_lost");
+            return;
+        }
         if (!enabled || phase != Phase.WARMING || !warmupComplete) {
             if (enabled) {
                 record("event=benchmark_anchor success=false phase="
@@ -216,16 +264,27 @@ final class AndroidBenchmarkDiagnostics {
      * The controller receives the matching [Controller.BenchmarkArmEvent] before its Resume event,
      * so timing debt and frame counters reset while the core is still paused.
      */
-    synchronized boolean armBenchmark(long generation, String token,
+    synchronized boolean armBenchmark(long sessionGeneration, long generation, String token,
             AndroidAudioSink.AudioBaseline baseline) {
+        boolean audioPending = options.audioOutput && baseline != null
+                && (baseline.pendingBytes() != 0L || baseline.queuedBytes() != 0L);
+        boolean audioNotPlaying = options.audioOutput && baseline != null
+                && !baseline.outputPlaying();
         if (!enabled || phase != Phase.ANCHOR_READY || !warmupComplete
+                || sessionGeneration <= 0L || sessionGeneration != activeSessionGeneration
+                || preArmVisibilityLost
+                || !scenarioCompleted || !scenarioSourceClosed || !scenarioAudioDrained
                 || generation <= 0L || token == null
                 || !token.matches("[a-z0-9][a-z0-9._-]{15,63}") || baseline == null
+                || audioPending || audioNotPlaying
                 || (options.audioOutput && !audioFocusGranted)) {
             if (enabled) {
                 record("event=benchmark_arm_rejected phase=" + phase.name().toLowerCase()
-                        + " reason=" + (options.audioOutput && !audioFocusGranted
-                        ? "audio_focus" : "not_anchor_ready"));
+                        + " reason=" + (preArmVisibilityLost ? "visibility_lost"
+                        : audioPending ? "audio_pending"
+                        : audioNotPlaying ? "audio_not_playing"
+                        : options.audioOutput && !audioFocusGranted
+                                ? "audio_focus" : "not_anchor_ready"));
             }
             return false;
         }
@@ -341,7 +400,16 @@ final class AndroidBenchmarkDiagnostics {
                 + " effective_dmg_compat=" + event.getEffectiveDmgCompat()
                 + " speed_mode_final=" + speedModeFinal + " speed_mode_sample=frame_600"
                 + " performance_bulk_spans=" + event.getPerformanceBulkSpans()
-                + " performance_bulk_ticks=" + event.getPerformanceBulkTicks());
+                + " performance_bulk_ticks=" + event.getPerformanceBulkTicks()
+                + " performance_epoch_count=" + event.getPerformanceEpochCount()
+                + " performance_epoch_ticks=" + event.getPerformanceEpochTicks()
+                + " performance_epoch_max_ticks=" + event.getPerformanceEpochMaxTicks()
+                + " performance_epoch_raster_fast_ticks="
+                + event.getPerformanceEpochRasterFastTicks()
+                + " performance_epoch_mode2_replay_ticks="
+                + event.getPerformanceEpochMode2ReplayTicks()
+                + " performance_epoch_mode2_bulk_ticks="
+                + event.getPerformanceEpochMode2BulkTicks());
         if (phase == Phase.ARMED) {
             phase = Phase.CORE_FROZEN;
         }
@@ -414,6 +482,7 @@ final class AndroidBenchmarkDiagnostics {
         audioFocusGranted = false;
         audioFocusLossCount = 0L;
         audioFocusStartLossCount = 0L;
+        nextSessionVisibilityLost = false;
         record("event=session_launch launch_ns=" + launchNanos
                 + " hardware=" + options.hardware.name().toLowerCase()
                 + " requested_hardware=" + options.hardware.externalValue()
@@ -466,8 +535,109 @@ final class AndroidBenchmarkDiagnostics {
      * controller benchmark policy has already paused the core; this method only establishes the
      * host-visible anchor-ready state.  Counters and environment baselines wait for ARM.
      */
-    synchronized void emulationStarted() {
+    synchronized void beginSession(long sessionGeneration) {
+        if (!enabled || sessionGeneration <= 0L) {
+            return;
+        }
+        activeSessionGeneration = sessionGeneration;
+        benchmarkGeneration = 0L;
+        measurementArmed = false;
+        scenarioExpectedFrames = options.benchmarkScenario == DiagnosticsOptions.BenchmarkScenario.NONE
+                ? 0 : -1;
+        scenarioSessionGeneration = 0L;
+        scenarioCompletedFrames = 0;
+        scenarioCompleted = options.benchmarkScenario == DiagnosticsOptions.BenchmarkScenario.NONE;
+        scenarioSourceClosed = scenarioCompleted;
+        scenarioAudioDrained = scenarioCompleted;
+        // A benchmark runtime is one visibility-continuous attempt. Once the host disappears,
+        // every replacement generation in that runtime remains poisoned; only sessionLaunch on
+        // a fresh runtime clears nextSessionVisibilityLost.
+        preArmVisibilityLost = nextSessionVisibilityLost;
+        phase = scenarioCompleted ? Phase.IDLE : Phase.SCENARIO_RUNNING;
+        if (preArmVisibilityLost) {
+            recordBenchmarkInvalidated(sessionGeneration);
+        }
+    }
+
+    synchronized void invalidateSession() {
+        activeSessionGeneration = 0L;
+        benchmarkGeneration = 0L;
+        measurementArmed = false;
+        scenarioCompleted = false;
+        scenarioSessionGeneration = 0L;
+        scenarioSourceClosed = false;
+        scenarioAudioDrained = false;
+        preArmVisibilityLost = false;
+        phase = Phase.IDLE;
+    }
+
+    /** Latches a visibility discontinuity against the current and every replacement session. */
+    synchronized void benchmarkVisibilityLost() {
         if (!enabled) {
+            return;
+        }
+        nextSessionVisibilityLost = true;
+        if (measurementArmed) {
+            liveInputMutations++;
+        }
+        if (activeSessionGeneration <= 0L || preArmVisibilityLost) {
+            return;
+        }
+        preArmVisibilityLost = true;
+        recordBenchmarkInvalidated(activeSessionGeneration);
+    }
+
+    /** Run-bound evidence retained even when visibility is lost after final_result was emitted. */
+    private void recordBenchmarkInvalidated(long sessionGeneration) {
+        record("event=benchmark_invalidated artifact_id=" + artifactId
+                + " pair_id=" + options.pairId
+                + " matrix_block=" + options.matrixBlock
+                + " row_order=" + options.rowOrder
+                + " run_side=" + options.runSide.externalValue()
+                + " session_generation=" + sessionGeneration
+                + " phase=" + phase.name().toLowerCase()
+                + " reason=visibility_lost");
+    }
+
+    synchronized boolean benchmarkPreArmValid(long sessionGeneration) {
+        return enabled && sessionGeneration > 0L
+                && sessionGeneration == activeSessionGeneration && !preArmVisibilityLost;
+    }
+
+    synchronized void benchmarkScenarioCompleted(long sessionGeneration, int completedFrames,
+            int expectedFrames, boolean completed, boolean sourceClosed, boolean audioDrained) {
+        if (!enabled || sessionGeneration <= 0L || sessionGeneration != activeSessionGeneration
+                || options.benchmarkScenario == DiagnosticsOptions.BenchmarkScenario.NONE) {
+            return;
+        }
+        scenarioExpectedFrames = expectedFrames;
+        scenarioCompletedFrames = completedFrames;
+        scenarioSessionGeneration = sessionGeneration;
+        scenarioCompleted = completed && completedFrames == expectedFrames
+                && !preArmVisibilityLost;
+        scenarioSourceClosed = sourceClosed;
+        scenarioAudioDrained = audioDrained;
+        record("event=scenario_complete artifact_id=" + artifactId
+                + " pair_id=" + options.pairId
+                + " matrix_block=" + options.matrixBlock
+                + " row_order=" + options.rowOrder
+                + " run_side=" + options.runSide.externalValue()
+                + " session_generation=" + sessionGeneration
+                + " input_contract=" + options.benchmarkScenario.externalValue()
+                + " completed=" + scenarioCompleted
+                + " completed_frames=" + completedFrames
+                + " expected_frames=" + expectedFrames
+                + " source_closed=" + sourceClosed
+                + " audio_drained=" + audioDrained);
+    }
+
+    synchronized void emulationStarted(long sessionGeneration) {
+        if (!enabled) {
+            return;
+        }
+        if (sessionGeneration <= 0L || sessionGeneration != activeSessionGeneration
+                || preArmVisibilityLost
+                || !scenarioCompleted || !scenarioSourceClosed || !scenarioAudioDrained) {
             return;
         }
         long preparationOrigin = openNanos == 0L ? launchNanos : openNanos;
@@ -504,6 +674,7 @@ final class AndroidBenchmarkDiagnostics {
         // post one real out-of-epoch buffer on this SurfaceView before taking SF's baseline.
         phase = Phase.WARMING;
         record("event=emulation_started wall_ns=" + preparationNanos
+                + " session_generation=" + activeSessionGeneration
                 + " prep_ms=" + elapsedMillis(preparationNanos, preparationOrigin)
                 + " requested_hardware=" + options.hardware.externalValue()
                 + " profile=" + (profile == null ? "unknown" : profile.id())
@@ -558,10 +729,17 @@ final class AndroidBenchmarkDiagnostics {
                 + " row_order=" + options.rowOrder
                 + " run_side=" + options.runSide.externalValue()
                 + " first_side=" + options.firstSide.externalValue()
+                + " session_generation=" + activeSessionGeneration
                 + " benchmark_generation=" + benchmarkGeneration
                 + " workload_nonce=" + workloadNonce
                 + " warmup=" + warmupComplete
-                + " input_contract=none"
+                + " input_contract=" + options.benchmarkScenario.externalValue()
+                + " scenario_session_generation=" + scenarioSessionGeneration
+                + " scenario_completed=" + scenarioCompleted
+                + " scenario_completed_frames=" + scenarioCompletedFrames
+                + " scenario_expected_frames=" + scenarioExpectedFrames
+                + " scenario_source_closed=" + scenarioSourceClosed
+                + " scenario_audio_drained=" + scenarioAudioDrained
                 + " execution_mode=" + DiagnosticsOptions.executionModeValue(options.executionMode)
                 + " thermal_window=" + options.thermalWindow
                 + " audio=" + (options.audioOutput ? "on" : "off")
@@ -790,7 +968,6 @@ final class AndroidBenchmarkDiagnostics {
                 + " wall_ms=" + elapsedMillis(current, firstFrameNanos)
                 + " fps=" + format(submissionFps)
                 + " " + finalHardwareEvidenceFields()
-                + " " + environmentStartFields()
                 + " " + environmentEndFields(environmentEnd)
                 + " environment_sample_count=" + environmentSampleCount
                 + " thermal_worst=" + thermalWorst
@@ -831,10 +1008,17 @@ final class AndroidBenchmarkDiagnostics {
                 + " artifact_id=" + artifactId + " pair_id=" + options.pairId
                 + " matrix_block=" + options.matrixBlock + " row_order=" + options.rowOrder
                 + " run_side=" + options.runSide.externalValue()
+                + " session_generation=" + activeSessionGeneration
                 + " benchmark_generation=" + benchmarkGeneration
                 + " workload_nonce=" + workloadNonce
                 + " warmup=" + warmupComplete
-                + " input_contract=none"
+                + " input_contract=" + options.benchmarkScenario.externalValue()
+                + " scenario_session_generation=" + scenarioSessionGeneration
+                + " scenario_completed=" + scenarioCompleted
+                + " scenario_completed_frames=" + scenarioCompletedFrames
+                + " scenario_expected_frames=" + scenarioExpectedFrames
+                + " scenario_source_closed=" + scenarioSourceClosed
+                + " scenario_audio_drained=" + scenarioAudioDrained
                 + " execution_mode=" + DiagnosticsOptions.executionModeValue(options.executionMode);
     }
 
@@ -915,7 +1099,7 @@ final class AndroidBenchmarkDiagnostics {
                     + " audio_volume=0 audio_route_failures=-1 audio_playback_position_frames=-1"
                     + " audio_system_volume=-1 audio_system_volume_max=-1"
                     + " audio_system_music_muted=true audio_queue_capacity_frames=0"
-                    + " audio_max_frame_bytes=0 " + audioBaselineFields();
+                    + " audio_max_frame_bytes=0";
         }
         return "audio_active=" + stats.active()
                 + " audio_sample_rate=" + stats.sampleRate()
@@ -948,8 +1132,7 @@ final class AndroidBenchmarkDiagnostics {
                 + " audio_system_volume_max=" + stats.systemVolumeMax()
                 + " audio_system_music_muted=" + stats.systemMusicMuted()
                 + " audio_queue_capacity_frames=" + stats.queueCapacityFrames()
-                + " audio_max_frame_bytes=" + stats.maximumFrameBytes()
-                + " " + audioBaselineFields();
+                + " audio_max_frame_bytes=" + stats.maximumFrameBytes();
     }
 
     private String audioBaselineFields() {
@@ -1273,6 +1456,12 @@ final class AndroidBenchmarkDiagnostics {
     }
 
     private void record(String message) {
+        int encodedBytes = message.getBytes(StandardCharsets.UTF_8).length;
+        if (encodedBytes > MAX_LOG_RECORD_BYTES) {
+            throw new IllegalStateException(
+                    "Benchmark telemetry record exceeds bounded Android payload: "
+                            + encodedBytes + " bytes");
+        }
         recordSink.write(message);
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnostics.java
@@ -40,6 +40,11 @@ import java.util.function.LongSupplier;
  */
 final class AndroidBenchmarkDiagnostics {
 
+    /** Callback used by the runtime to revoke one measured generation on a bad host-audio read. */
+    interface SystemAudioViolationSink {
+        void onViolation(long generation, long sessionGeneration);
+    }
+
     /** Bounded log seam; production uses Android Log, benchmark JVM tests inject a no-op sink. */
     interface RecordSink {
         void write(String message);
@@ -107,6 +112,8 @@ final class AndroidBenchmarkDiagnostics {
     private boolean measurementArmed;
     private Phase phase = Phase.IDLE;
     private long benchmarkGeneration;
+    /** Opaque host arm token copied into every run-bound record. */
+    private String benchmarkToken = "unknown";
     private long activeSessionGeneration;
     private long scenarioSessionGeneration;
     private int scenarioExpectedFrames;
@@ -122,6 +129,9 @@ final class AndroidBenchmarkDiagnostics {
     private int speedModeFinal = UNKNOWN;
     /** Audio counters sampled at the physical ready-600 boundary, before compositor drain delay. */
     private AndroidAudioSink.Stats audioTerminalStats;
+    /** Output/queue identities sampled with the terminal PCM counters. */
+    private long audioTerminalOutputIdentity;
+    private long audioTerminalQueueIdentity;
     private String workloadNonce = "unknown";
     private long liveInputMutations;
     private HardwareProfile profile;
@@ -147,11 +157,35 @@ final class AndroidBenchmarkDiagnostics {
     private int batteryTempMin;
     private int batteryTempMax;
     private AndroidAudioSink audioSink;
+    /** JVM-only seam used by production-length diagnostics tests; real runs always read audioSink. */
+    private AndroidAudioSink.AudioBaseline systemAudioBaselineForTesting;
+    /** Absolute sink ledger captured when the current emulation session materializes. */
+    private AndroidAudioSink.AudioBaseline audioSessionBaseline =
+            AndroidAudioSink.AudioBaseline.unavailable();
     private AndroidAudioSink.AudioBaseline audioBaseline =
             AndroidAudioSink.AudioBaseline.unavailable();
     private boolean audioFocusGranted;
     private long audioFocusLossCount;
     private long audioFocusStartLossCount;
+    private DiagnosticsOptions.AudioPolicy benchmarkAudioPolicy =
+            DiagnosticsOptions.AudioPolicy.CANONICAL;
+    private boolean benchmarkAudioRequested;
+    private boolean benchmarkAudioActiveAtBoundary;
+    private boolean benchmarkAudioDisabledAfterBoundary;
+    private long benchmarkAudioSkippedTicks;
+    private long benchmarkAudioZeroSampleSlots;
+    private long benchmarkAudioZeroSampleEvents;
+    private long benchmarkAudioMaxDebt;
+    private long benchmarkAudioApuReads;
+    private long benchmarkAudioApuWrites;
+    private long benchmarkAudioFrameSequencerCommits;
+    private long benchmarkAudioDroppedChannelTicks;
+    /** Silent-PCM host proof: ARM, ten interval boundaries, and one terminal read. */
+    private int systemAudioSampleCount;
+    private int systemAudioBadCount;
+    private boolean systemAudioBadLatched;
+    private int systemAudioLastFrame;
+    private final SystemAudioViolationSink systemAudioViolationSink;
 
     AndroidBenchmarkDiagnostics(DiagnosticsOptions options) {
         this(null, options, AndroidBenchmarkDiagnostics::logRecord,
@@ -161,6 +195,12 @@ final class AndroidBenchmarkDiagnostics {
     AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options) {
         this(context, options, AndroidBenchmarkDiagnostics::logRecord,
                 AndroidBenchmarkDiagnostics::systemNow);
+    }
+
+    AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options,
+            SystemAudioViolationSink systemAudioViolationSink) {
+        this(context, options, AndroidBenchmarkDiagnostics::logRecord,
+                AndroidBenchmarkDiagnostics::systemNow, null, null, systemAudioViolationSink);
     }
 
     AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options, RecordSink recordSink) {
@@ -175,11 +215,20 @@ final class AndroidBenchmarkDiagnostics {
     /** Test seam for production-length redacted identities without depending on an Android APK. */
     AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options, RecordSink recordSink,
             LongSupplier monotonicNanos, String artifactIdOverride, String deviceIdOverride) {
+        this(context, options, recordSink, monotonicNanos, artifactIdOverride, deviceIdOverride,
+                (generation, sessionGeneration) -> { });
+    }
+
+    AndroidBenchmarkDiagnostics(Context context, DiagnosticsOptions options, RecordSink recordSink,
+            LongSupplier monotonicNanos, String artifactIdOverride, String deviceIdOverride,
+            SystemAudioViolationSink systemAudioViolationSink) {
         this.context = context == null ? null : context.getApplicationContext();
         this.options = options == null ? DiagnosticsOptions.disabled() : options;
         this.recordSink = recordSink == null ? AndroidBenchmarkDiagnostics::logRecord : recordSink;
         this.monotonicNanos = monotonicNanos == null
                 ? AndroidBenchmarkDiagnostics::systemNow : monotonicNanos;
+        this.systemAudioViolationSink = systemAudioViolationSink == null
+                ? (generation, sessionGeneration) -> { } : systemAudioViolationSink;
         enabled = BuildConfig.DIAGNOSTICS_ENABLED && this.options.enabled;
         artifactId = enabled && artifactIdOverride != null
                 ? boundedDigestOverride(artifactIdOverride)
@@ -270,6 +319,25 @@ final class AndroidBenchmarkDiagnostics {
                 && (baseline.pendingBytes() != 0L || baseline.queuedBytes() != 0L);
         boolean audioNotPlaying = options.audioOutput && baseline != null
                 && !baseline.outputPlaying();
+        boolean silentPolicyValid = !options.audioPolicy.isSilent()
+                || (validSilentPcmBaseline(baseline)
+                && validSilentPcmSessionEvidence(audioSessionBaseline, baseline));
+        boolean silentFocusHistoryValid = !options.audioPolicy.isSilent()
+                || audioFocusLossCount == 0L;
+        // A bad ARM read is itself a generation-bound policy violation. Capture it before the
+        // ordinary admission checks so unavailable output cannot be mistaken for a benign reject.
+        if (enabled && options.audioPolicy.isSilent() && generation > 0L
+                && sessionGeneration > 0L && sessionGeneration == activeSessionGeneration
+                && !validSystemAudioSample(baseline)) {
+            benchmarkGeneration = generation;
+            benchmarkToken = token == null ? "unknown" : token;
+            systemAudioSampleCount = 0;
+            systemAudioBadCount = 0;
+            systemAudioBadLatched = false;
+            systemAudioLastFrame = 0;
+            sampleSystemAudioLocked(0, baseline);
+            return false;
+        }
         if (!enabled || phase != Phase.ANCHOR_READY || !warmupComplete
                 || sessionGeneration <= 0L || sessionGeneration != activeSessionGeneration
                 || preArmVisibilityLost
@@ -277,11 +345,14 @@ final class AndroidBenchmarkDiagnostics {
                 || generation <= 0L || token == null
                 || !token.matches("[a-z0-9][a-z0-9._-]{15,63}") || baseline == null
                 || audioPending || audioNotPlaying
-                || (options.audioOutput && !audioFocusGranted)) {
+                || (options.audioOutput && !audioFocusGranted) || !silentPolicyValid
+                || !silentFocusHistoryValid) {
             if (enabled) {
                 record("event=benchmark_arm_rejected phase=" + phase.name().toLowerCase()
                         + " reason=" + (preArmVisibilityLost ? "visibility_lost"
                         : audioPending ? "audio_pending"
+                        : !silentPolicyValid ? "silent_pcm_baseline"
+                        : !silentFocusHistoryValid ? "audio_focus_history"
                         : audioNotPlaying ? "audio_not_playing"
                         : options.audioOutput && !audioFocusGranted
                                 ? "audio_focus" : "not_anchor_ready"));
@@ -289,6 +360,25 @@ final class AndroidBenchmarkDiagnostics {
             return false;
         }
         benchmarkGeneration = generation;
+        benchmarkToken = token;
+        benchmarkAudioPolicy = options.audioPolicy;
+        benchmarkAudioRequested = options.audioPolicy.isSilent();
+        benchmarkAudioActiveAtBoundary = false;
+        benchmarkAudioDisabledAfterBoundary = false;
+        benchmarkAudioSkippedTicks = 0L;
+        benchmarkAudioZeroSampleSlots = 0L;
+        benchmarkAudioZeroSampleEvents = 0L;
+        benchmarkAudioMaxDebt = 0L;
+        benchmarkAudioApuReads = 0L;
+        benchmarkAudioApuWrites = 0L;
+        benchmarkAudioFrameSequencerCommits = 0L;
+        benchmarkAudioDroppedChannelTicks = 0L;
+        systemAudioSampleCount = 0;
+        systemAudioBadCount = 0;
+        systemAudioBadLatched = false;
+        systemAudioLastFrame = 0;
+        audioTerminalOutputIdentity = 0L;
+        audioTerminalQueueIdentity = 0L;
         audioBaseline = baseline;
         audioFocusStartLossCount = audioFocusLossCount;
         resetMeasurementWindow();
@@ -304,6 +394,10 @@ final class AndroidBenchmarkDiagnostics {
         measurementArmed = true;
         emulationStarted = true;
         phase = Phase.ARMED;
+        sampleSystemAudioLocked(0, baseline);
+        if (systemAudioBadLatched) {
+            return false;
+        }
         record("event=benchmark_arm generation=" + generation + " token=" + token
                 + " phase=armed");
         recordMatrixRun();
@@ -316,6 +410,124 @@ final class AndroidBenchmarkDiagnostics {
         }
         audioBaseline = baseline;
         return true;
+    }
+
+    /** True after the current silent-PCM generation has been irreversibly revoked. */
+    synchronized boolean systemAudioBadLatched() {
+        return systemAudioBadLatched;
+    }
+
+    /** Bounded test seam for exercising the read-only system-audio fail-closed latch. */
+    synchronized void sampleSystemAudioForTesting(int frame,
+            AndroidAudioSink.AudioBaseline baseline) {
+        sampleSystemAudioLocked(frame, baseline);
+    }
+
+    private static boolean validSilentPcmBaseline(AndroidAudioSink.AudioBaseline baseline) {
+        return baseline != null
+                && baseline.active()
+                && !baseline.paused()
+                && baseline.outputOpen()
+                && baseline.outputPlaying()
+                && !baseline.muted()
+                && baseline.volume() == 100
+                && baseline.pendingBytes() == 0L
+                && baseline.queuedBytes() == 0L
+                && baseline.queuedFrames() == 0
+                && baseline.systemVolume() == 0
+                && baseline.systemVolumeMax() > 0
+                && baseline.systemMusicMuted()
+                && baseline.sampleRate() > 0
+                && baseline.queueCapacityFrames() > 0
+                && baseline.maximumFrameBytes() > 0
+                && baseline.playbackPositionFrames() >= 0L
+                && baseline.inputEvents() > 0L
+                && baseline.inputFrames() > 0L
+                && baseline.writtenBytes() > 0L
+                && baseline.writtenFrames() > 0L
+                && baseline.writeFailures() == 0L
+                && baseline.routeFailures() == 0L
+                && !baseline.reopenPending()
+                && baseline.outputIdentity() != 0L
+                && baseline.queueIdentity() != 0L;
+    }
+
+    /**
+     * Proves that the PCM evidence belongs to this emulation session rather than an older ROM
+     * played through the runtime's lifetime-owned sink. The ARM snapshot stays absolute for the
+     * final conservation ledger; only this admission check consumes the session-start delta.
+     */
+    private static boolean validSilentPcmSessionEvidence(
+            AndroidAudioSink.AudioBaseline sessionStart,
+            AndroidAudioSink.AudioBaseline arm) {
+        if (sessionStart == null || arm == null) {
+            return false;
+        }
+        long[] startCounters = {
+                sessionStart.inputEvents(), sessionStart.inputFrames(),
+                sessionStart.writtenBytes(), sessionStart.writtenFrames(),
+                sessionStart.writeFailures(), sessionStart.routeFailures()
+        };
+        for (long counter : startCounters) {
+            if (counter < 0L) {
+                return false;
+            }
+        }
+        return arm.inputEvents() > sessionStart.inputEvents()
+                && arm.inputFrames() > sessionStart.inputFrames()
+                && arm.writtenBytes() > sessionStart.writtenBytes()
+                && arm.writtenFrames() > sessionStart.writtenFrames()
+                && arm.writeFailures() == sessionStart.writeFailures()
+                && arm.routeFailures() == sessionStart.routeFailures();
+    }
+
+    /** Returns true only for an affirmative, readable muted system-music state. */
+    private static boolean validSystemAudioSample(AndroidAudioSink.AudioBaseline baseline) {
+        return baseline != null && baseline.systemVolume() == 0
+                && baseline.systemVolumeMax() > 0 && baseline.systemMusicMuted();
+    }
+
+    /** Samples only the selected silent policy. Canonical runs intentionally retain normal audio. */
+    private void sampleSystemAudioLocked(int frame, AndroidAudioSink.AudioBaseline baseline) {
+        if (!options.audioPolicy.isSilent() || systemAudioBadLatched || phase == Phase.DONE) {
+            return;
+        }
+        systemAudioSampleCount++;
+        systemAudioLastFrame = frame;
+        if (!validSystemAudioSample(baseline)) {
+            systemAudioBadCount++;
+            if (!systemAudioBadLatched) {
+                systemAudioBadLatched = true;
+                measurementArmed = false;
+                phase = Phase.CORE_FROZEN;
+                // The owner-thread freeze and app-owned PCM pause are the safety boundary. Run
+                // that callback before telemetry; logging must not delay the transition. Keep a
+                // callback failure visible, but always emit the invalidation record in finally.
+                try {
+                    systemAudioViolationSink.onViolation(benchmarkGeneration,
+                            activeSessionGeneration);
+                } finally {
+                    recordBenchmarkInvalidated(activeSessionGeneration, "system_audio_unmuted");
+                }
+            }
+        }
+    }
+
+    /** Called by the physical frame boundary after the core has materialized frame-600 counters. */
+    private void sampleSystemAudioTerminalLocked() {
+        if (!options.audioPolicy.isSilent() || systemAudioBadLatched) {
+            return;
+        }
+        AndroidAudioSink.AudioBaseline baseline = systemAudioCheckpointBaselineLocked();
+        sampleSystemAudioLocked(FINAL_FRAME, baseline);
+    }
+
+    private AndroidAudioSink.AudioBaseline systemAudioCheckpointBaselineLocked() {
+        if (audioSink != null) {
+            return audioSink.benchmarkBaseline();
+        }
+        return systemAudioBaselineForTesting == null
+                ? AndroidAudioSink.AudioBaseline.unavailable() : systemAudioBaselineForTesting;
     }
 
     synchronized void audioFocusResult(boolean granted) {
@@ -384,8 +596,33 @@ final class AndroidBenchmarkDiagnostics {
         return finalResultEmitted;
     }
 
+    synchronized int systemAudioSampleCountForTesting() {
+        return systemAudioSampleCount;
+    }
+
+    synchronized int systemAudioBadCountForTesting() {
+        return systemAudioBadCount;
+    }
+
+    synchronized int systemAudioLastFrameForTesting() {
+        return systemAudioLastFrame;
+    }
+
     synchronized void benchmarkFrameBoundary(Controller.BenchmarkFrameBoundaryEvent event) {
-        if (!enabled || event == null || !measurementArmed || event.getFrame() != FINAL_FRAME) {
+        if (!enabled || event == null || event.getFrame() != FINAL_FRAME) {
+            return;
+        }
+        sampleSystemAudioTerminalLocked();
+        if (!measurementArmed || systemAudioBadLatched) {
+            return;
+        }
+        if (!options.audioPolicy.externalValue().equals(event.getBenchmarkAudioPolicy())
+                || event.getBenchmarkAudioRequested() != options.audioPolicy.isSilent()) {
+            // The controller's terminal evidence is generation-bound.  A policy/token drift
+            // cannot be reinterpreted as canonical output, so leave the run frozen without a
+            // final_result record.
+            measurementArmed = false;
+            phase = Phase.CORE_FROZEN;
             return;
         }
         // Rebind the final evidence to the actual core state sampled at physical Display frame
@@ -396,6 +633,19 @@ final class AndroidBenchmarkDiagnostics {
                 profile, effectiveGbc, effectiveDmgCompat);
         speedModeFinal = event.getSpeedMode();
         speedFinalSample = speedModeFinal == 1 || speedModeFinal == 2;
+        benchmarkAudioPolicy = DiagnosticsOptions.AudioPolicy.fromExternalValue(
+                event.getBenchmarkAudioPolicy());
+        benchmarkAudioRequested = event.getBenchmarkAudioRequested();
+        benchmarkAudioActiveAtBoundary = event.getBenchmarkAudioActiveAtBoundary();
+        benchmarkAudioDisabledAfterBoundary = event.getBenchmarkAudioDisabledAfterBoundary();
+        benchmarkAudioSkippedTicks = event.getBenchmarkAudioSkippedTicks();
+        benchmarkAudioZeroSampleSlots = event.getBenchmarkAudioZeroSampleSlots();
+        benchmarkAudioZeroSampleEvents = event.getBenchmarkAudioZeroSampleEvents();
+        benchmarkAudioMaxDebt = event.getBenchmarkAudioMaxDebt();
+        benchmarkAudioApuReads = event.getBenchmarkAudioApuReads();
+        benchmarkAudioApuWrites = event.getBenchmarkAudioApuWrites();
+        benchmarkAudioFrameSequencerCommits = event.getBenchmarkAudioFrameSequencerCommits();
+        benchmarkAudioDroppedChannelTicks = event.getBenchmarkAudioDroppedChannelTicks();
         record("event=speed_sample frame=600 effective_gbc=" + event.getEffectiveGbc()
                 + " effective_dmg_compat=" + event.getEffectiveDmgCompat()
                 + " speed_mode_final=" + speedModeFinal + " speed_mode_sample=frame_600"
@@ -409,7 +659,25 @@ final class AndroidBenchmarkDiagnostics {
                 + " performance_epoch_mode2_replay_ticks="
                 + event.getPerformanceEpochMode2ReplayTicks()
                 + " performance_epoch_mode2_bulk_ticks="
-                + event.getPerformanceEpochMode2BulkTicks());
+                + event.getPerformanceEpochMode2BulkTicks()
+                + " benchmark_audio_policy=" + event.getBenchmarkAudioPolicy()
+                + " benchmark_audio_requested=" + event.getBenchmarkAudioRequested()
+                + " benchmark_audio_active_at_boundary="
+                + event.getBenchmarkAudioActiveAtBoundary()
+                + " benchmark_audio_disabled_after="
+                + event.getBenchmarkAudioDisabledAfterBoundary()
+                + " benchmark_audio_skipped_ticks=" + event.getBenchmarkAudioSkippedTicks()
+                + " benchmark_audio_zero_sample_slots="
+                + event.getBenchmarkAudioZeroSampleSlots()
+                + " benchmark_audio_zero_sample_events="
+                + event.getBenchmarkAudioZeroSampleEvents()
+                + " benchmark_audio_max_debt=" + event.getBenchmarkAudioMaxDebt()
+                + " benchmark_audio_apu_reads=" + event.getBenchmarkAudioApuReads()
+                + " benchmark_audio_apu_writes=" + event.getBenchmarkAudioApuWrites()
+                + " benchmark_audio_frame_sequencer_commits="
+                + event.getBenchmarkAudioFrameSequencerCommits()
+                + " benchmark_audio_dropped_channel_ticks="
+                + event.getBenchmarkAudioDroppedChannelTicks());
         if (phase == Phase.ARMED) {
             phase = Phase.CORE_FROZEN;
         }
@@ -453,6 +721,8 @@ final class AndroidBenchmarkDiagnostics {
         speedFinalSample = false;
         speedModeFinal = UNKNOWN;
         audioTerminalStats = null;
+        audioTerminalOutputIdentity = 0L;
+        audioTerminalQueueIdentity = 0L;
         workloadNonce = "unknown";
         liveInputMutations = 0L;
         profile = null;
@@ -478,10 +748,29 @@ final class AndroidBenchmarkDiagnostics {
         batteryTempMin = UNKNOWN;
         batteryTempMax = UNKNOWN;
         audioSink = null;
+        systemAudioBaselineForTesting = null;
+        audioSessionBaseline = AndroidAudioSink.AudioBaseline.unavailable();
         audioBaseline = AndroidAudioSink.AudioBaseline.unavailable();
         audioFocusGranted = false;
         audioFocusLossCount = 0L;
         audioFocusStartLossCount = 0L;
+        benchmarkAudioPolicy = DiagnosticsOptions.AudioPolicy.CANONICAL;
+        benchmarkAudioRequested = false;
+        benchmarkAudioActiveAtBoundary = false;
+        benchmarkAudioDisabledAfterBoundary = false;
+        benchmarkAudioSkippedTicks = 0L;
+        benchmarkAudioZeroSampleSlots = 0L;
+        benchmarkAudioZeroSampleEvents = 0L;
+        benchmarkAudioMaxDebt = 0L;
+        benchmarkAudioApuReads = 0L;
+        benchmarkAudioApuWrites = 0L;
+        benchmarkAudioFrameSequencerCommits = 0L;
+        benchmarkAudioDroppedChannelTicks = 0L;
+        benchmarkToken = "unknown";
+        systemAudioSampleCount = 0;
+        systemAudioBadCount = 0;
+        systemAudioBadLatched = false;
+        systemAudioLastFrame = 0;
         nextSessionVisibilityLost = false;
         record("event=session_launch launch_ns=" + launchNanos
                 + " hardware=" + options.hardware.name().toLowerCase()
@@ -536,10 +825,20 @@ final class AndroidBenchmarkDiagnostics {
      * host-visible anchor-ready state.  Counters and environment baselines wait for ARM.
      */
     synchronized void beginSession(long sessionGeneration) {
+        AndroidAudioSink.AudioBaseline sessionBaseline = audioSink == null
+                ? AndroidAudioSink.AudioBaseline.unavailable() : audioSink.benchmarkBaseline();
+        beginSession(sessionGeneration, sessionBaseline);
+    }
+
+    /** Deterministic package-private seam for diagnostics fixtures. */
+    synchronized void beginSession(long sessionGeneration,
+            AndroidAudioSink.AudioBaseline sessionBaseline) {
         if (!enabled || sessionGeneration <= 0L) {
             return;
         }
         activeSessionGeneration = sessionGeneration;
+        audioSessionBaseline = sessionBaseline == null
+                ? AndroidAudioSink.AudioBaseline.unavailable() : sessionBaseline;
         benchmarkGeneration = 0L;
         measurementArmed = false;
         scenarioExpectedFrames = options.benchmarkScenario == DiagnosticsOptions.BenchmarkScenario.NONE
@@ -568,6 +867,7 @@ final class AndroidBenchmarkDiagnostics {
         scenarioSourceClosed = false;
         scenarioAudioDrained = false;
         preArmVisibilityLost = false;
+        audioSessionBaseline = AndroidAudioSink.AudioBaseline.unavailable();
         phase = Phase.IDLE;
     }
 
@@ -589,6 +889,10 @@ final class AndroidBenchmarkDiagnostics {
 
     /** Run-bound evidence retained even when visibility is lost after final_result was emitted. */
     private void recordBenchmarkInvalidated(long sessionGeneration) {
+        recordBenchmarkInvalidated(sessionGeneration, "visibility_lost");
+    }
+
+    private void recordBenchmarkInvalidated(long sessionGeneration, String reason) {
         record("event=benchmark_invalidated artifact_id=" + artifactId
                 + " pair_id=" + options.pairId
                 + " matrix_block=" + options.matrixBlock
@@ -596,7 +900,7 @@ final class AndroidBenchmarkDiagnostics {
                 + " run_side=" + options.runSide.externalValue()
                 + " session_generation=" + sessionGeneration
                 + " phase=" + phase.name().toLowerCase()
-                + " reason=visibility_lost");
+                + " reason=" + reason);
     }
 
     synchronized boolean benchmarkPreArmValid(long sessionGeneration) {
@@ -718,6 +1022,8 @@ final class AndroidBenchmarkDiagnostics {
         speedFinalSample = false;
         speedModeFinal = UNKNOWN;
         audioTerminalStats = null;
+        audioTerminalOutputIdentity = 0L;
+        audioTerminalQueueIdentity = 0L;
         environmentStart = EnvironmentSample.unavailable();
         resetEnvironmentAggregate();
     }
@@ -731,6 +1037,7 @@ final class AndroidBenchmarkDiagnostics {
                 + " first_side=" + options.firstSide.externalValue()
                 + " session_generation=" + activeSessionGeneration
                 + " benchmark_generation=" + benchmarkGeneration
+                + " benchmark_token=" + benchmarkToken
                 + " workload_nonce=" + workloadNonce
                 + " warmup=" + warmupComplete
                 + " input_contract=" + options.benchmarkScenario.externalValue()
@@ -747,6 +1054,7 @@ final class AndroidBenchmarkDiagnostics {
                         ? "sink" : "presentation")
                 + " availability=available"
                 + " requested_hardware=" + options.hardware.externalValue()
+                + " benchmark_audio_policy=" + options.audioPolicy.externalValue()
                 + " surface_vote_hz=" + options.displayTargetHz
                 + " display_target_hz=" + options.displayTargetHz
                 + " surface_content_rate_millihz=" + options.surfaceContentRateMillihz
@@ -757,6 +1065,11 @@ final class AndroidBenchmarkDiagnostics {
 
     synchronized void setAudioSink(AndroidAudioSink audioSink) {
         this.audioSink = audioSink;
+    }
+
+    /** Test-only source for a stable read-only system-audio snapshot. */
+    synchronized void setSystemAudioBaselineForTesting(AndroidAudioSink.AudioBaseline baseline) {
+        this.systemAudioBaselineForTesting = baseline;
     }
 
     /** Counts one core frame-ready event after SGB transfer filtering. */
@@ -787,12 +1100,22 @@ final class AndroidBenchmarkDiagnostics {
                     + " prep_to_frame_ms=" + elapsedMillis(current, preparationNanos));
         }
         if (count % INTERVAL_FRAMES == 0L && count <= FINAL_FRAME) {
+            if (options.audioPolicy.isSilent()) {
+                AndroidAudioSink.AudioBaseline checkpoint = systemAudioCheckpointBaselineLocked();
+                sampleSystemAudioLocked((int) count, checkpoint);
+                if (systemAudioBadLatched) {
+                    return false;
+                }
+            }
             interval(current, count);
         }
         if (count == FINAL_FRAME) {
             // The renderer intentionally waits before posting the SF drain.  Freeze the audio
             // evidence now so that that delay (and any AudioTrack empty-poll underrun) cannot
             // contaminate the emulated 600-frame measurement window.
+            AndroidAudioSink.AudioBaseline terminalBaseline = systemAudioCheckpointBaselineLocked();
+            audioTerminalOutputIdentity = terminalBaseline.outputIdentity();
+            audioTerminalQueueIdentity = terminalBaseline.queueIdentity();
             audioTerminalStats = audioSink == null ? null : audioSink.stats();
             // Freeze diagnostics immediately. The controller boundary event freezes the core
             // before its next chunk; submissions already in flight remain countable.
@@ -917,13 +1240,8 @@ final class AndroidBenchmarkDiagnostics {
                 + " alloc_bytes_delta=" + delta(globalAllocBytes(), allocBytesStart));
         previousIntervalNanos = current;
         previousIntervalFrame = frame;
-        if (frame == FINAL_FRAME && options.render == DiagnosticsOptions.Render.FRAME_SINK) {
-            // A sink has no SurfaceFlinger drain.  Its ready-only terminal is complete at the
-            // 600th physical publication, so satisfy the same latch explicitly before the final
-            // speed-boundary callback attempts emission.
-            benchmarkDrainSuccess = true;
-            emitFinalResult();
-        }
+        // Frame-sink finalization is deferred to the physical frame-600 boundary; that callback
+        // performs the terminal system-audio sample and speed-token binding.
     }
 
     private void emitFinalResult() {
@@ -932,7 +1250,7 @@ final class AndroidBenchmarkDiagnostics {
         // Visible runs must not finalize merely because the 600th measured submission raced
         // ahead of the frame-600 speed callback.  The renderer's one delayed out-of-epoch drain
         // is the explicit latch that lets the host take a complete TimeStats after-dump.
-        if (finalResultEmitted || !terminal || !speedFinalSample
+        if (finalResultEmitted || systemAudioBadLatched || !terminal || !speedFinalSample
                 || (options.render == DiagnosticsOptions.Render.PRESENTATION
                 && !benchmarkDrainSuccess)) {
             return;
@@ -974,6 +1292,8 @@ final class AndroidBenchmarkDiagnostics {
                 + " system_load_worst_milli=" + systemLoadWorstMilli
                 + " cpu_freq_min_khz=" + cpuFreqMinKHz
                 + " " + audioEvidenceFields()
+                + " system_audio_sample_count=" + systemAudioSampleCount
+                + " system_audio_bad_count=" + systemAudioBadCount
                 + " display_refresh_min_millihz=" + displayRefreshMinMillihz
                 + " display_bad_count=" + displayBadCount
                 + " interactive_bad_count=" + interactiveBadCount
@@ -1010,6 +1330,7 @@ final class AndroidBenchmarkDiagnostics {
                 + " run_side=" + options.runSide.externalValue()
                 + " session_generation=" + activeSessionGeneration
                 + " benchmark_generation=" + benchmarkGeneration
+                + " benchmark_token=" + benchmarkToken
                 + " workload_nonce=" + workloadNonce
                 + " warmup=" + warmupComplete
                 + " input_contract=" + options.benchmarkScenario.externalValue()
@@ -1099,7 +1420,12 @@ final class AndroidBenchmarkDiagnostics {
                     + " audio_volume=0 audio_route_failures=-1 audio_playback_position_frames=-1"
                     + " audio_system_volume=-1 audio_system_volume_max=-1"
                     + " audio_system_music_muted=true audio_queue_capacity_frames=0"
-                    + " audio_max_frame_bytes=0";
+                    + " audio_max_frame_bytes=0"
+                    + " audio_output_identity=" + audioTerminalOutputIdentity
+                    + " audio_queue_identity=" + audioTerminalQueueIdentity
+                    + " benchmark_audio_policy=" + benchmarkAudioPolicy.externalValue()
+                    + " benchmark_audio_flags=" + compactAudioFlags()
+                    + " benchmark_audio_calendar=" + compactAudioCalendar();
         }
         return "audio_active=" + stats.active()
                 + " audio_sample_rate=" + stats.sampleRate()
@@ -1132,7 +1458,32 @@ final class AndroidBenchmarkDiagnostics {
                 + " audio_system_volume_max=" + stats.systemVolumeMax()
                 + " audio_system_music_muted=" + stats.systemMusicMuted()
                 + " audio_queue_capacity_frames=" + stats.queueCapacityFrames()
-                + " audio_max_frame_bytes=" + stats.maximumFrameBytes();
+                + " audio_max_frame_bytes=" + stats.maximumFrameBytes()
+                + " audio_output_identity=" + audioTerminalOutputIdentity
+                + " audio_queue_identity=" + audioTerminalQueueIdentity
+                + " benchmark_audio_policy=" + benchmarkAudioPolicy.externalValue()
+                + " benchmark_audio_flags=" + compactAudioFlags()
+                + " benchmark_audio_calendar=" + compactAudioCalendar();
+    }
+
+    /**
+     * Compact final-result policy flags in requested, active-at-boundary, disabled-after order.
+     * The speed_sample event intentionally keeps the expanded policy schema for host diagnostics.
+     */
+    private String compactAudioFlags() {
+        return (benchmarkAudioRequested ? "1" : "0")
+                + (benchmarkAudioActiveAtBoundary ? "1" : "0")
+                + (benchmarkAudioDisabledAfterBoundary ? "1" : "0");
+    }
+
+    /** Compact final-result calendar in skipped, zero-slots, zero-events, debt, APU reads,
+     * APU writes, frame-sequencer commits, dropped-channel-ticks order. */
+    private String compactAudioCalendar() {
+        return benchmarkAudioSkippedTicks + "," + benchmarkAudioZeroSampleSlots + ","
+                + benchmarkAudioZeroSampleEvents + "," + benchmarkAudioMaxDebt + ","
+                + benchmarkAudioApuReads + "," + benchmarkAudioApuWrites + ","
+                + benchmarkAudioFrameSequencerCommits + ","
+                + benchmarkAudioDroppedChannelTicks;
     }
 
     private String audioBaselineFields() {
@@ -1157,7 +1508,18 @@ final class AndroidBenchmarkDiagnostics {
                 + " audio_start_output_playing=" + baseline.outputPlaying()
                 + " audio_start_sample_rate=" + baseline.sampleRate()
                 + " audio_start_queue_capacity_frames=" + baseline.queueCapacityFrames()
-                + " audio_start_max_frame_bytes=" + baseline.maximumFrameBytes();
+                + " audio_start_max_frame_bytes=" + baseline.maximumFrameBytes()
+                + " audio_start_active=" + baseline.active()
+                + " audio_start_paused=" + baseline.paused()
+                + " audio_start_muted=" + baseline.muted()
+                + " audio_start_volume=" + baseline.volume()
+                + " audio_start_system_volume=" + baseline.systemVolume()
+                + " audio_start_system_volume_max=" + baseline.systemVolumeMax()
+                + " audio_start_system_music_muted=" + baseline.systemMusicMuted()
+                + " audio_start_queued_frames=" + baseline.queuedFrames()
+                + " audio_start_reopen_pending=" + baseline.reopenPending()
+                + " audio_start_output_identity=" + baseline.outputIdentity()
+                + " audio_start_queue_identity=" + baseline.queueIdentity();
     }
 
     private EnvironmentSample sampleEnvironment(int observedThreadPriority) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -14,6 +14,7 @@ import eu.rekawek.coffeegb.controller.BasicController;
 import eu.rekawek.coffeegb.controller.Controller;
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides;
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.controller.properties.RuntimeWarmupFlavor;
 import eu.rekawek.coffeegb.controller.state.StateIdentity;
 import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
@@ -175,7 +176,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         benchmarkScenario = new BenchmarkGameplayScenario(
                 diagnosticsOptions.benchmarkScenario,
                 diagnosticsOptions.benchmarkNativeFrameKind());
-        diagnostics = new AndroidBenchmarkDiagnostics(this.context, diagnosticsOptions);
+        diagnostics = new AndroidBenchmarkDiagnostics(this.context, diagnosticsOptions,
+                this::onSystemAudioViolation);
         // Release/non-diagnostic sessions use a null sink so the native frame hot path does not
         // enter synchronized benchmark methods on every frame.
         frames = new NativeFrameStore(diagnostics.enabled() ? diagnostics : null,
@@ -201,8 +203,20 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         BootstrapMode bootstrapMode = checked.enabled ? BootstrapMode.SKIP : null;
         return new ApplicationSettingsOverrides(profile, bootstrapMode,
                 checked.enabled ? false : null, false, false, false,
-                checked.enabled && checked.runtimeWarmup, checked.enabled,
+                checked.enabled && checked.runtimeWarmup, runtimeWarmupFlavor(checked), checked.enabled,
                 checked.enabled ? checked.executionMode : null);
+    }
+
+    private static RuntimeWarmupFlavor runtimeWarmupFlavor(DiagnosticsOptions options) {
+        if (options.enabled
+                && options.runtimeWarmup
+                && options.hardware == DiagnosticsOptions.Hardware.CGB
+                && options.executionMode == ExecutionMode.PERFORMANCE
+                && options.benchmarkScenario == DiagnosticsOptions.BenchmarkScenario.CGB_ACTION_V1
+                && options.audioPolicy == DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1) {
+            return RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1;
+        }
+        return RuntimeWarmupFlavor.SCALAR;
     }
 
     public RuntimeState state() {
@@ -215,6 +229,59 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             return;
         }
         eventBus.post(new Controller.BenchmarkPhysicalFrameBoundaryEvent(600L, generation));
+    }
+
+    /** Revokes one silent-PCM generation on the first bad read-only system-audio sample. */
+    private void onSystemAudioViolation(long generation, long sessionGeneration) {
+        if (!diagnostics.enabled() || eventBus == null || generation <= 0L
+                || sessionGeneration <= 0L || generation != diagnostics.benchmarkGeneration()
+                || sessionGeneration != activeSessionGeneration
+                || !diagnostics.systemAudioBadLatched()) {
+            return;
+        }
+        // This callback can originate while diagnostics holds its monitor. Do not acquire the
+        // lifecycle gate here: visibility/focus paths take that gate before sampling diagnostics,
+        // so taking it in the reverse order would deadlock. BasicController's owner-thread
+        // listener freezes synchronously before app PCM is paused. Keep all three safety actions
+        // independent so a sink or event subscriber failure cannot skip the owner freeze or the
+        // generation-bound terminal policy record.
+        RuntimeException failure = null;
+        try {
+            eventBus.post(new Controller.BenchmarkSystemAudioViolationEvent(
+                    generation, sessionGeneration, diagnosticsOptions.audioPolicy.externalValue()));
+        } catch (RuntimeException exception) {
+            failure = exception;
+        }
+        try {
+            AndroidAudioSink activeAudio = audio;
+            if (activeAudio != null) {
+                // Stop and clear app-owned PCM immediately; this does not touch system volume/mute.
+                activeAudio.pause();
+            }
+        } catch (RuntimeException exception) {
+            if (failure == null) {
+                failure = exception;
+            }
+        }
+        try {
+            eventBus.post(new Controller.BenchmarkSilentPcmPolicyEvent(
+                    false, generation, sessionGeneration, false,
+                    diagnosticsOptions.audioPolicy.externalValue()));
+        } catch (RuntimeException exception) {
+            if (failure == null) {
+                failure = exception;
+            }
+        }
+        try {
+            eventBus.post(new Controller.PauseEmulationEvent());
+        } catch (RuntimeException exception) {
+            if (failure == null) {
+                failure = exception;
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
     }
 
     /** Advances the configured timeline on the controller's physical native-frame callback. */
@@ -855,6 +922,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 // Diagnostics owns the atomic current-or-next generation decision. This closes
                 // both the pre-OPENING queue race and the LOADING-to-STARTED handoff.
                 diagnostics.benchmarkVisibilityLost();
+                postBenchmarkAudioDisableAndPauseLocked();
                 AndroidAudioSink activeAudio = audio;
                 if (activeAudio != null) {
                     // The same gate surrounds the only pre-ARM resume path. If a poll wins first,
@@ -901,13 +969,42 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     /** Audio loss follows the same conservative policy: pause, flush, and require user resume. */
     public void onAudioFocusLost() {
-        diagnostics.audioFocusLost();
+        if (diagnostics.enabled()) {
+            benchmarkAudioLifecycle.run(() -> {
+                diagnostics.audioFocusLost();
+                postBenchmarkAudioDisableAndPauseLocked();
+                AndroidAudioSink activeAudio = audio;
+                if (activeAudio != null) {
+                    activeAudio.pause();
+                }
+            });
+            return;
+        }
         onHostNotVisible();
     }
 
     /** Records the service's intrinsic focus request result before a benchmark ARM. */
     public void onAudioFocusResult(boolean granted) {
-        diagnostics.audioFocusResult(granted);
+        if (diagnostics.enabled()) {
+            benchmarkAudioLifecycle.run(() -> diagnostics.audioFocusResult(granted));
+        } else {
+            diagnostics.audioFocusResult(granted);
+        }
+    }
+
+    /** Runs under benchmarkAudioLifecycle; policy disable is FIFO before the pause command. */
+    private void postBenchmarkAudioDisableAndPauseLocked() {
+        if (!diagnostics.enabled() || eventBus == null) {
+            return;
+        }
+        long generation = diagnostics.benchmarkGeneration();
+        long sessionGeneration = activeSessionGeneration;
+        if (generation > 0L && sessionGeneration > 0L) {
+            eventBus.post(new Controller.BenchmarkSilentPcmPolicyEvent(
+                    false, generation, sessionGeneration, false,
+                    diagnosticsOptions.audioPolicy.externalValue()));
+        }
+        eventBus.post(new Controller.PauseEmulationEvent());
     }
 
     /** Audio focus gain intentionally does not resume emulation without an explicit user command. */
@@ -969,7 +1066,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             // acknowledgement on its owner thread. CPU/priority/environment baselines and the
             // matrix_run record are taken only from that acknowledgement callback.
             eventBus.post(new Controller.BenchmarkArmEvent(
-                    generation, token, sessionGeneration));
+                    generation, token, sessionGeneration,
+                    diagnosticsOptions.audioPolicy.externalValue()));
         });
     }
 
@@ -1339,31 +1437,72 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(
                 event -> diagnostics.benchmarkFrameBoundary(event),
                 Controller.BenchmarkFrameBoundaryEvent.class);
+        // A rejected ARM is reported by BasicController as a generation-bound false policy. Clear
+        // only the matching pending host request; a stale false event must never cancel a newer
+        // generation or touch the controller's already-authoritative policy state.
+        eventBus.register(
+                (Controller.BenchmarkSilentPcmPolicyEvent event) -> {
+                    if (!diagnostics.enabled() || event.getRequested()) {
+                        return;
+                    }
+                    PendingBenchmarkArm pending = pendingBenchmarkArm;
+                    if (pending != null
+                            && pending.sessionGeneration() == event.getSessionGeneration()
+                            && pending.generation() == event.getGeneration()) {
+                        // This listener may run while diagnostics owns its sample monitor.
+                        // The field is volatile and clearing it needs no lifecycle lock.
+                        pendingBenchmarkArm = null;
+                    }
+                },
+                Controller.BenchmarkSilentPcmPolicyEvent.class);
         eventBus.register(
                 event -> {
                     if (!diagnostics.enabled()) {
                         return;
                     }
-                    PendingBenchmarkArm pending = pendingBenchmarkArm;
-                    if (pending == null || !pending.matches(event)
-                            || !benchmarkSessionMatches(
-                                    event.getSessionGeneration(), activeSessionGeneration,
-                                    benchmarkScenario.enabled()
-                                            ? benchmarkScenario.sessionGeneration()
-                                            : event.getSessionGeneration(),
-                                    state.sessionGeneration())
-                            || state.phase() != RuntimeState.Phase.PAUSED) {
-                        return;
-                    }
-                    pendingBenchmarkArm = null;
-                    if (!diagnostics.armBenchmark(
-                            event.getSessionGeneration(), event.getGeneration(), event.getToken(),
-                            pending.baseline())) {
-                        return;
-                    }
-                    frames.beginBenchmarkEpoch(event.getGeneration());
-                    input.lockBenchmarkWindow();
-                    eventBus.post(new Controller.ResumeEmulationEvent());
+                    benchmarkAudioLifecycle.run(() -> {
+                        PendingBenchmarkArm pending = pendingBenchmarkArm;
+                        if (pending == null || !pending.matches(event)
+                                || !benchmarkSessionMatches(
+                                        event.getSessionGeneration(), activeSessionGeneration,
+                                        benchmarkScenario.enabled()
+                                                ? benchmarkScenario.sessionGeneration()
+                                                : event.getSessionGeneration(),
+                                        state.sessionGeneration())
+                                || state.phase() != RuntimeState.Phase.PAUSED) {
+                            return;
+                        }
+                        pendingBenchmarkArm = null;
+                        // The pre-ACK sample only gates the host's arm request. The controller
+                        // acknowledgement is the authority boundary, so capture a fresh sink
+                        // baseline here while the lifecycle gate excludes drain/focus races.
+                        AndroidAudioSink activeAudio = audio;
+                        AndroidAudioSink.AudioBaseline freshBaseline = activeAudio == null
+                                ? AndroidAudioSink.AudioBaseline.unavailable()
+                                : activeAudio.benchmarkBaseline();
+                        if (!diagnostics.armBenchmark(
+                                event.getSessionGeneration(), event.getGeneration(), event.getToken(),
+                                freshBaseline)) {
+                            // Never resume an arm whose fresh host proof failed. A matching false
+                            // policy event also clears any controller-side stale calendar. A
+                            // system-audio violation already emitted its one revocation callback
+                            // synchronously while armBenchmark sampled the baseline.
+                            if (!diagnostics.systemAudioBadLatched()) {
+                                eventBus.post(new Controller.BenchmarkSilentPcmPolicyEvent(
+                                        false, event.getGeneration(),
+                                        event.getSessionGeneration(), false,
+                                        diagnosticsOptions.audioPolicy.externalValue()));
+                            }
+                            return;
+                        }
+                        frames.beginBenchmarkEpoch(event.getGeneration());
+                        input.lockBenchmarkWindow();
+                        eventBus.post(new Controller.BenchmarkSilentPcmPolicyEvent(
+                                diagnosticsOptions.audioPolicy.isSilent(),
+                                event.getGeneration(), event.getSessionGeneration(), true,
+                                diagnosticsOptions.audioPolicy.externalValue()));
+                        eventBus.post(new Controller.ResumeEmulationEvent());
+                    });
                 },
                 Controller.BenchmarkArmAcknowledgedEvent.class);
         // Display events run synchronously on the controller thread. The bounded store must copy

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -70,6 +70,8 @@ import java.util.stream.Collectors;
 public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private static final long BACKGROUND_FLUSH_TIMEOUT_MILLIS = 5_000L;
+    private static final int BENCHMARK_AUDIO_DRAIN_MAX_POLLS = 50;
+    private static final long BENCHMARK_AUDIO_DRAIN_POLL_MILLIS = 20L;
 
     private final Context context;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
@@ -95,6 +97,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final RuntimeLifecycleGate lifecycle = new RuntimeLifecycleGate();
     private final DiagnosticsOptions diagnosticsOptions;
     private final AndroidBenchmarkDiagnostics diagnostics;
+    private final BenchmarkGameplayScenario benchmarkScenario;
     private final NativeFrameStore frames;
     /** Session timing belongs to the service, not to a short-lived Activity attachment. */
     private final PlayTimeTracker playTime = new PlayTimeTracker();
@@ -110,7 +113,12 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private BasicController controller;
     private volatile AndroidAudioSink audio;
     /** Published before the controller-thread arm acknowledgement; never retained after ACK. */
-    private volatile AndroidAudioSink.AudioBaseline pendingBenchmarkAudioBaseline;
+    private volatile PendingBenchmarkArm pendingBenchmarkArm;
+    /** Serializes hidden-session pause against scenario-drain inspection and audio resume. */
+    private final BenchmarkAudioLifecycleGate benchmarkAudioLifecycle =
+            new BenchmarkAudioLifecycleGate();
+    /** Owner-thread fence invalidating every scheduled scenario/audio poll on replacement. */
+    private long benchmarkScenarioCompletionEpoch;
     private volatile AndroidRumbleSink rumble;
     private volatile AndroidTiltSink tilt;
     private volatile AndroidCameraSource camera;
@@ -148,7 +156,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Mapper-derived metadata for the active controller session; never inferred from files. */
     private String activeRomTitle = "";
     private boolean activeBatterySave;
-    private long activeSessionGeneration;
+    private volatile long activeSessionGeneration;
     private boolean playbackTimerSessionActive;
     private long playbackTimerSessionGeneration;
     private boolean restartPlaybackTimerOnNextPublish;
@@ -164,6 +172,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     AndroidEmulationRuntime(Context context, DiagnosticsOptions options) {
         this.context = Objects.requireNonNull(context, "context").getApplicationContext();
         diagnosticsOptions = options == null ? DiagnosticsOptions.disabled() : options;
+        benchmarkScenario = new BenchmarkGameplayScenario(
+                diagnosticsOptions.benchmarkScenario,
+                diagnosticsOptions.benchmarkNativeFrameKind());
         diagnostics = new AndroidBenchmarkDiagnostics(this.context, diagnosticsOptions);
         // Release/non-diagnostic sessions use a null sink so the native frame hot path does not
         // enter synchronized benchmark methods on every frame.
@@ -204,6 +215,29 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             return;
         }
         eventBus.post(new Controller.BenchmarkPhysicalFrameBoundaryEvent(600L, generation));
+    }
+
+    /** Advances the configured timeline on the controller's physical native-frame callback. */
+    private void benchmarkScenarioFrameReady(BenchmarkGameplayScenario.NativeFrameKind frameKind) {
+        if (!diagnostics.enabled() || !benchmarkScenario.enabled()) {
+            return;
+        }
+        long sessionGeneration = benchmarkScenario.sessionGeneration();
+        if (!benchmarkScenario.acceptsNativeFrame(frameKind, sessionGeneration)) {
+            return;
+        }
+        int nextMask = benchmarkScenario.onFrameReady(frameKind, sessionGeneration);
+        if (nextMask != BenchmarkGameplayScenario.UNCHANGED) {
+            input.setBenchmarkScenarioMask(nextMask);
+        }
+        if (!benchmarkScenario.consumePauseRequest()) {
+            return;
+        }
+        // The endpoint is a released frame. Explicitly clear the private source before asking the
+        // controller for its safe pause; no scenario input survives into the measured epoch.
+        input.clearBenchmarkScenario();
+        eventBus.post(new Controller.BenchmarkGameplayScenarioEndpointEvent(
+                sessionGeneration, benchmarkScenario.frameForTesting()));
     }
 
     private ExecutionMode executionModeForSession() {
@@ -769,11 +803,14 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             diagnostics.openStart();
             diagnostics.setWorkloadNonce(new RecentSafDocuments(context)
                     .ensureBenchmarkNonce(recent));
-            // Freeze gameplay input before materialization. The benchmark session is paused until
-            // the host arms it, but a touch/key/controller event could otherwise mutate the
-            // initial Joypad state during ROM preparation and before the controller ACKs ARM.
-            // The ACK handler repeats this idempotently as an epoch guard.
-            input.lockBenchmarkWindow();
+            // Freeze gameplay input before materialization. A configured scenario keeps only its
+            // private frame-driven source admitted until the preconditioning pause; the ordinary
+            // benchmark path locks all sources immediately. The ACK handler repeats this
+            // idempotently as the measured-epoch guard.
+            if (!invalidateBenchmarkSession(true)) {
+                publishBenchmarkScenarioInputFailure();
+                return;
+            }
             openRecentGame(recent);
         });
     }
@@ -814,13 +851,17 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (diagnostics.enabled()) {
             // Benchmark visibility is a scheduler precondition.  Do not flush/reopen audio or
             // enter the ordinary battery/autosave lifecycle barrier; a hidden run is discarded.
-            diagnostics.inputMutation();
-            AndroidAudioSink activeAudio = audio;
-            if (activeAudio != null) {
-                // Stop output immediately, but keep the measured counters/baseline intact so the
-                // eventual record is rejected rather than presenting a false continuous stream.
-                activeAudio.pause();
-            }
+            benchmarkAudioLifecycle.run(() -> {
+                // Diagnostics owns the atomic current-or-next generation decision. This closes
+                // both the pre-OPENING queue race and the LOADING-to-STARTED handoff.
+                diagnostics.benchmarkVisibilityLost();
+                AndroidAudioSink activeAudio = audio;
+                if (activeAudio != null) {
+                    // The same gate surrounds the only pre-ARM resume path. If a poll wins first,
+                    // this pause wins last; if visibility loss wins first, the poll fails closed.
+                    activeAudio.pause();
+                }
+            });
             return;
         }
         input.releaseAll();
@@ -904,44 +945,142 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
      * Arms one benchmark generation after the host has captured the warm-up compositor baseline.
      * This path is benchmark-only; ordinary resume remains a separate user operation.
      */
-    void armBenchmark(String token) {
+    void armBenchmark(String token, long requestedSessionGeneration) {
         if (!diagnostics.enabled()) {
             return;
         }
         submit(() -> {
             long generation = System.nanoTime();
+            long sessionGeneration = activeSessionGeneration;
             if (generation <= 0L || token == null
                     || !token.matches("[a-z0-9][a-z0-9._-]{15,63}")
-                    || !diagnostics.benchmarkAnchorReady()) {
+                    || requestedSessionGeneration != sessionGeneration
+                    || sessionGeneration <= 0L || state.phase() != RuntimeState.Phase.PAUSED
+                    || state.sessionGeneration() != sessionGeneration
+                    || !diagnostics.benchmarkAnchorReady(sessionGeneration)) {
                 return;
             }
             AndroidAudioSink activeAudio = audio;
             AndroidAudioSink.AudioBaseline audioBaseline = activeAudio == null
                     ? AndroidAudioSink.AudioBaseline.unavailable() : activeAudio.benchmarkBaseline();
-            pendingBenchmarkAudioBaseline = audioBaseline;
+            pendingBenchmarkArm = new PendingBenchmarkArm(
+                    sessionGeneration, generation, token, audioBaseline);
             // BasicController performs the ticker/deadline reset and synchronously emits the
             // acknowledgement on its owner thread. CPU/priority/environment baselines and the
             // matrix_run record are taken only from that acknowledgement callback.
-            eventBus.post(new Controller.BenchmarkArmEvent(generation, token));
+            eventBus.post(new Controller.BenchmarkArmEvent(
+                    generation, token, sessionGeneration));
         });
     }
 
-    boolean benchmarkAnchorReady() {
-        return diagnostics.enabled() && diagnostics.benchmarkAnchorReady();
+    boolean benchmarkAnchorReady(long sessionGeneration) {
+        return diagnostics.enabled() && sessionGeneration > 0L
+                && sessionGeneration == activeSessionGeneration
+                && state.phase() == RuntimeState.Phase.PAUSED
+                && state.sessionGeneration() == sessionGeneration
+                && diagnostics.benchmarkAnchorReady(sessionGeneration);
+    }
+
+    /** The host may request its compositor anchor only after optional input preconditioning. */
+    boolean benchmarkPreconditionReady() {
+        return !diagnostics.enabled()
+                || diagnostics.benchmarkPreArmValid(activeSessionGeneration)
+                && (!benchmarkScenario.enabled() || benchmarkScenario.preconditionReady());
     }
 
     /** Receives the renderer-thread result of the one-time pre-measurement Surface anchor post. */
-    void benchmarkAnchorPosted(boolean success) {
+    void benchmarkAnchorPosted(long sessionGeneration, boolean success, Runnable completed) {
         if (!diagnostics.enabled()) {
             return;
         }
-        submit(() -> diagnostics.benchmarkAnchorPosted(success));
+        submit(() -> {
+            diagnostics.benchmarkAnchorPosted(sessionGeneration, success);
+            if (completed != null) {
+                completed.run();
+            }
+        });
+    }
+
+    /**
+     * Waits outside the controller thread for a two-phase audio barrier. First the paused sink
+     * must report an empty queue and a stopped output, proving the scenario PCM was flushed. Then
+     * the output is resumed while the guest remains paused, and readiness requires the clean,
+     * playing baseline that the benchmark matrix records at ARM.
+     */
+    private void finishBenchmarkScenarioCompletion(
+            Controller.BenchmarkGameplayScenarioCompletedEvent event, long completionEpoch,
+            int attempt,
+            boolean audioResumeRequested) {
+        benchmarkAudioLifecycle.run(() -> finishBenchmarkScenarioCompletionLocked(
+                event, completionEpoch, attempt, audioResumeRequested));
+    }
+
+    /** Runs under {@link #benchmarkAudioLifecycle}; never call this method directly. */
+    private void finishBenchmarkScenarioCompletionLocked(
+            Controller.BenchmarkGameplayScenarioCompletedEvent event, long completionEpoch,
+            int attempt,
+            boolean audioResumeRequested) {
+        if (closed.get() || !benchmarkCompletionPollMayTouchAudio(
+                diagnostics.benchmarkPreArmValid(event.getSessionGeneration()),
+                completionEpoch, benchmarkScenarioCompletionEpoch,
+                event.getSessionGeneration(), activeSessionGeneration,
+                benchmarkScenario.sessionGeneration(), state.sessionGeneration())) {
+            return;
+        }
+        AndroidAudioSink activeAudio = audio;
+        AndroidAudioSink.AudioBaseline baseline = activeAudio == null
+                ? AndroidAudioSink.AudioBaseline.unavailable() : activeAudio.benchmarkBaseline();
+        boolean sourceClosed = input.benchmarkScenarioSourceClosed();
+        boolean emptyAudio = !diagnosticsOptions.audioOutput
+                || baseline.pendingBytes() == 0L && baseline.queuedBytes() == 0L;
+        boolean audioReady;
+        if (!diagnosticsOptions.audioOutput) {
+            audioReady = true;
+        } else if (!audioResumeRequested) {
+            audioReady = false;
+            boolean flushObserved = activeAudio != null && emptyAudio && !baseline.outputPlaying();
+            if (flushObserved) {
+                activeAudio.resume();
+                deadlines.schedule(
+                        () -> submit(() -> finishBenchmarkScenarioCompletion(
+                                event, completionEpoch, 0, true)),
+                        BENCHMARK_AUDIO_DRAIN_POLL_MILLIS,
+                        TimeUnit.MILLISECONDS);
+                return;
+            }
+        } else {
+            audioReady = activeAudio != null && emptyAudio && baseline.outputPlaying();
+        }
+        if ((!audioReady || !sourceClosed) && attempt < BENCHMARK_AUDIO_DRAIN_MAX_POLLS) {
+            deadlines.schedule(
+                    () -> submit(() -> finishBenchmarkScenarioCompletion(
+                            event, completionEpoch, attempt + 1, audioResumeRequested)),
+                    BENCHMARK_AUDIO_DRAIN_POLL_MILLIS,
+                    TimeUnit.MILLISECONDS);
+            return;
+        }
+        boolean completed = event.getCompleted() && audioReady && sourceClosed
+                && event.getCompletedFrames() == event.getExpectedFrames();
+        diagnostics.benchmarkScenarioCompleted(
+                event.getSessionGeneration(), event.getCompletedFrames(), event.getExpectedFrames(),
+                completed, sourceClosed, audioReady);
+        if (!completed) {
+            return;
+        }
+        benchmarkScenario.markPreconditionReady();
+        diagnostics.emulationStarted(event.getSessionGeneration());
+        RuntimeState current = state;
+        if (current.sessionGeneration() == event.getSessionGeneration()) {
+            publish(RuntimeState.Phase.PAUSED, "Benchmark preconditioning complete.", List.of(),
+                    true, true, current.flushPending());
+        }
     }
 
     /** Stops one session and recreates its controller shell for a later load without leaks. */
     public void stop() {
         input.releaseAll();
         submit(() -> {
+            invalidateBenchmarkSession(false);
             persistCurrentRecentGame();
             clearPendingSource();
             if (!closeController()) {
@@ -1205,9 +1344,21 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     if (!diagnostics.enabled()) {
                         return;
                     }
-                    AndroidAudioSink.AudioBaseline baseline = pendingBenchmarkAudioBaseline;
-                    pendingBenchmarkAudioBaseline = null;
-                    if (!diagnostics.armBenchmark(event.getGeneration(), event.getToken(), baseline)) {
+                    PendingBenchmarkArm pending = pendingBenchmarkArm;
+                    if (pending == null || !pending.matches(event)
+                            || !benchmarkSessionMatches(
+                                    event.getSessionGeneration(), activeSessionGeneration,
+                                    benchmarkScenario.enabled()
+                                            ? benchmarkScenario.sessionGeneration()
+                                            : event.getSessionGeneration(),
+                                    state.sessionGeneration())
+                            || state.phase() != RuntimeState.Phase.PAUSED) {
+                        return;
+                    }
+                    pendingBenchmarkArm = null;
+                    if (!diagnostics.armBenchmark(
+                            event.getSessionGeneration(), event.getGeneration(), event.getToken(),
+                            pending.baseline())) {
                         return;
                     }
                     frames.beginBenchmarkEpoch(event.getGeneration());
@@ -1217,10 +1368,43 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 Controller.BenchmarkArmAcknowledgedEvent.class);
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
-        eventBus.register(frames::publish, Display.DmgFrameReadyEvent.class);
-        eventBus.register(frames::publish, Display.GbcFrameReadyEvent.class);
+        // A configured scenario observes only its matching native event, so an SGB transfer DMG
+        // event cannot advance the timeline twice for one displayed frame.
+        eventBus.register(
+                (Display.DmgFrameReadyEvent event) -> {
+                    frames.publish(event);
+                    benchmarkScenarioFrameReady(BenchmarkGameplayScenario.NativeFrameKind.DMG);
+                },
+                Display.DmgFrameReadyEvent.class);
+        eventBus.register(
+                (Display.GbcFrameReadyEvent event) -> {
+                    frames.publish(event);
+                    benchmarkScenarioFrameReady(BenchmarkGameplayScenario.NativeFrameKind.GBC);
+                },
+                Display.GbcFrameReadyEvent.class);
         eventBus.register(frames::publish, SgbDisplay.SgbFrameReadyEvent.class);
         eventBus.register(printer::append, Controller.PrinterPrintEvent.class);
+        eventBus.register(
+                (Controller.BenchmarkGameplayScenarioCompletedEvent event) -> {
+                    if (!diagnostics.enabled() || !benchmarkScenario.enabled()
+                            || !benchmarkSessionMatches(
+                                    event.getSessionGeneration(), activeSessionGeneration,
+                                    benchmarkScenario.sessionGeneration(), state.sessionGeneration())) {
+                        return;
+                    }
+                    // Stop accepting PCM and clear the bounded queue before any host anchor can
+                    // be requested. The owner waits for an in-flight write to leave accounting.
+                    AndroidAudioSink activeAudio = audio;
+                    if (activeAudio != null) {
+                        activeAudio.pause();
+                    }
+                    input.endBenchmarkScenario();
+                    submit(() -> {
+                        long completionEpoch = ++benchmarkScenarioCompletionEpoch;
+                        finishBenchmarkScenarioCompletion(event, completionEpoch, 0, false);
+                    });
+                },
+                Controller.BenchmarkGameplayScenarioCompletedEvent.class);
         eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
@@ -1235,13 +1419,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     // This callback runs synchronously on the controller thread. Keep the CPU
                     // sample on that thread instead of the runtime owner executor.
                     AndroidPerformanceBoost.apply(executionModeForSession());
-                    if (diagnostics.enabled()) {
-                        // BasicController materializes benchmark sessions paused.  Diagnostics
-                        // now reports ANCHOR_READY; the host must arm a generation explicitly.
-                        diagnostics.emulationStarted();
-                    } else {
-                        diagnostics.emulationStarted();
-                    }
                     submit(() -> {
                     boolean requestedOpen = event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId;
@@ -1255,6 +1432,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         activeBatterySave = false;
                         activeSessionGeneration = event.getSessionGeneration() == null ? 0L
                                 : event.getSessionGeneration();
+                        diagnostics.beginSession(activeSessionGeneration);
                         restartPlaybackTimerOnNextPublish = true;
                         clearPauseMenuSnapshotInternal();
                         AndroidTiltSink activeTilt = tilt;
@@ -1281,10 +1459,28 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         if (gpsEnabled) {
                             eventBus.post(new Controller.SetGpsReceiverEvent(true));
                         }
-                        publish(diagnostics.enabled() ? RuntimeState.Phase.PAUSED
+                        boolean configuredScenario = diagnostics.enabled()
+                                && benchmarkScenario.enabled();
+                        if (configuredScenario) {
+                            benchmarkScenario.beginSession(activeSessionGeneration);
+                            if (!input.beginBenchmarkScenario()) {
+                                benchmarkScenario.resetSession();
+                                diagnostics.invalidateSession();
+                                publishBenchmarkScenarioInputFailure();
+                                return;
+                            }
+                            eventBus.post(new Controller.BenchmarkGameplayScenarioStartEvent(
+                                    activeSessionGeneration,
+                                    benchmarkScenario.endpointFrameForTesting()));
+                            eventBus.post(new Controller.ResumeEmulationEvent());
+                        } else {
+                            diagnostics.emulationStarted(activeSessionGeneration);
+                        }
+                        boolean benchmarkPaused = diagnostics.enabled() && !configuredScenario;
+                        publish(benchmarkPaused ? RuntimeState.Phase.PAUSED
                                         : RuntimeState.Phase.RUNNING,
                                 "Loaded " + event.getRomName() + ". App-private saves are ready.",
-                                List.of(), true, diagnostics.enabled(), false);
+                                List.of(), true, benchmarkPaused, false);
                     }
                     });
                 },
@@ -1315,6 +1511,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     AndroidPerformanceBoost.apply(ExecutionMode.ACCURACY);
                     submit(() -> {
                         if (!closed.get()) {
+                            invalidateBenchmarkSession(false);
                             if (!diagnostics.enabled()) {
                                 persistActiveRecentGame(frames.snapshot());
                             }
@@ -1329,6 +1526,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 (Controller.LoadRomFailedEvent event) -> submit(() -> {
                     if (event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId) {
+                        invalidateBenchmarkSession(false);
                         if (!diagnostics.enabled()) {
                             new RecentSafDocuments(context).removeGame(currentSource,
                                     activeCandidateToken, activeArchiveEntryName,
@@ -1343,6 +1541,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(
                 (Controller.SessionPlaybackStateEvent event) -> submit(() -> {
                     if (activeLayout == null || state.phase() == RuntimeState.Phase.LOADING) {
+                        return;
+                    }
+                    if (event.getSessionGeneration() != activeSessionGeneration) {
                         return;
                     }
                     if (event.getPaused()) {
@@ -1527,6 +1728,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             frames.clear();
             activeRomTitle = "";
             activeBatterySave = false;
+            if (!invalidateBenchmarkSession(true)) {
+                publishBenchmarkScenarioInputFailure();
+                return;
+            }
             activeSessionGeneration = 0L;
             clearPauseMenuSnapshotInternal();
             activeLayout = layout;
@@ -1756,6 +1961,60 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             throw new IllegalStateException("Android emulator runtime is not available");
         }
         return eventBus;
+    }
+
+    /** Drops every generation-bound benchmark latch before a session is replaced or removed. */
+    private boolean invalidateBenchmarkSession(boolean prepareScenarioSource) {
+        if (!diagnostics.enabled()) {
+            return true;
+        }
+        pendingBenchmarkArm = null;
+        benchmarkScenarioCompletionEpoch++;
+        benchmarkScenario.resetSession();
+        diagnostics.invalidateSession();
+        input.resetBenchmarkSession();
+        if (!prepareScenarioSource) {
+            return true;
+        }
+        if (benchmarkScenario.enabled()) {
+            return input.beginBenchmarkScenario();
+        }
+        input.lockBenchmarkWindow();
+        return true;
+    }
+
+    /** Package-visible replacement seam used by the deterministic router/runtime unit test. */
+    static boolean resetBenchmarkScenarioInput(
+            AndroidInputRouter input, boolean prepareScenarioSource) {
+        input.resetBenchmarkSession();
+        return !prepareScenarioSource || input.beginBenchmarkScenario();
+    }
+
+    static boolean benchmarkCompletionPollMatches(
+            long completionEpoch, long activeCompletionEpoch,
+            long eventSessionGeneration, long activeSessionGeneration,
+            long scenarioSessionGeneration, long presentedSessionGeneration) {
+        return completionEpoch > 0L && completionEpoch == activeCompletionEpoch
+                && benchmarkSessionMatches(eventSessionGeneration, activeSessionGeneration,
+                        scenarioSessionGeneration, presentedSessionGeneration);
+    }
+
+    /** A stale or hidden pre-ARM session must not let a scheduled poll resume audio. */
+    static boolean benchmarkCompletionPollMayTouchAudio(
+            boolean preArmValid,
+            long completionEpoch, long activeCompletionEpoch,
+            long eventSessionGeneration, long activeSessionGeneration,
+            long scenarioSessionGeneration, long presentedSessionGeneration) {
+        return preArmValid && benchmarkCompletionPollMatches(
+                completionEpoch, activeCompletionEpoch,
+                eventSessionGeneration, activeSessionGeneration,
+                scenarioSessionGeneration, presentedSessionGeneration);
+    }
+
+    private void publishBenchmarkScenarioInputFailure() {
+        publish(RuntimeState.Phase.FAILED,
+                "Benchmark scenario input could not be isolated for this session.",
+                List.of(), activeLayout != null, true, false);
     }
 
     private boolean closeController() {
@@ -2098,6 +2357,15 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 && eventSessionGeneration > activeSessionGeneration;
     }
 
+    /** Shared fail-closed generation gate for synchronous and owner-queued benchmark events. */
+    static boolean benchmarkSessionMatches(long eventGeneration, long activeGeneration,
+            long scenarioGeneration, long presentedGeneration) {
+        return eventGeneration > 0L
+                && eventGeneration == activeGeneration
+                && eventGeneration == scenarioGeneration
+                && eventGeneration == presentedGeneration;
+    }
+
     private static boolean hasActiveSession(RuntimeState state) {
         return state.phase() == RuntimeState.Phase.RUNNING
                 || state.phase() == RuntimeState.Phase.PAUSED;
@@ -2168,6 +2436,27 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     }
 
     private record ObserverRegistration(RuntimeObserver observer, Long registrationId) {
+    }
+
+    private record PendingBenchmarkArm(
+            long sessionGeneration,
+            long generation,
+            String token,
+            AndroidAudioSink.AudioBaseline baseline) {
+
+        private boolean matches(Controller.BenchmarkArmAcknowledgedEvent event) {
+            return event != null
+                    && sessionGeneration == event.getSessionGeneration()
+                    && generation == event.getGeneration()
+                    && token.equals(event.getToken());
+        }
+    }
+
+    /** Tiny testable monitor shared by the main-thread hide path and owner-thread audio polls. */
+    static final class BenchmarkAudioLifecycleGate {
+        synchronized void run(Runnable action) {
+            Objects.requireNonNull(action, "action").run();
+        }
     }
 
     @FunctionalInterface

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidInputRouter.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidInputRouter.java
@@ -28,6 +28,10 @@ import java.security.NoSuchAlgorithmException;
 final class AndroidInputRouter implements AutoCloseable {
 
     private static final float DEAD_ZONE = 0.45f;
+    private static final EnumSet<Button> NO_BUTTONS = EnumSet.noneOf(Button.class);
+    private static final EnumSet<Button> RIGHT_BUTTON = EnumSet.of(Button.RIGHT);
+    private static final EnumSet<Button> B_BUTTON = EnumSet.of(Button.B);
+    private static final EnumSet<Button> START_BUTTON = EnumSet.of(Button.START);
 
     private static final Map<Integer, Button> DEFAULT_KEYS = Map.ofEntries(
             Map.entry(KeyEvent.KEYCODE_DPAD_LEFT, Button.LEFT),
@@ -50,6 +54,8 @@ final class AndroidInputRouter implements AutoCloseable {
     private final Map<Integer, String> deviceIds = new HashMap<>();
     private final Map<String, InputDevice> connectedDevices = new HashMap<>();
     private final PlayerInputHub.SourceHandle keyboard;
+    /** Dedicated benchmark preconditioning source; it is never exposed to ordinary input APIs. */
+    private PlayerInputHub.SourceHandle benchmarkScenarioSource;
     private final EnumSet<Button> keyboardButtons = EnumSet.noneOf(Button.class);
     private final ControllerKeyCapture capture;
     private final Runnable benchmarkMutationRecorder;
@@ -59,6 +65,11 @@ final class AndroidInputRouter implements AutoCloseable {
     private String gamepadSelection = "auto";
     private boolean closed;
     private boolean benchmarkLocked;
+    private boolean benchmarkScenarioActive;
+    /** True only after this benchmark session admitted and then closed its private source. */
+    private boolean benchmarkScenarioSourceClosureProven;
+    /** Last mask accepted from the frame-driven scenario while its private source is admitted. */
+    private int benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
 
     AndroidInputRouter(PlayerInputHub hub) {
         this(hub, null);
@@ -86,7 +97,7 @@ final class AndroidInputRouter implements AutoCloseable {
         if (closed) {
             return;
         }
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return;
         }
@@ -111,7 +122,7 @@ final class AndroidInputRouter implements AutoCloseable {
         if (closed || event.getAction() == KeyEvent.ACTION_MULTIPLE) {
             return false;
         }
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return true;
         }
@@ -169,7 +180,7 @@ final class AndroidInputRouter implements AutoCloseable {
         if (closed || !isGameController(event.getSource()) || event.getAction() != MotionEvent.ACTION_MOVE) {
             return false;
         }
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return true;
         }
@@ -207,7 +218,7 @@ final class AndroidInputRouter implements AutoCloseable {
     }
 
     synchronized void disconnect(int deviceId) {
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return;
         }
@@ -231,7 +242,7 @@ final class AndroidInputRouter implements AutoCloseable {
         if (closed || configurationDevice() == null) {
             return false;
         }
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return false;
         }
@@ -241,7 +252,7 @@ final class AndroidInputRouter implements AutoCloseable {
 
     /** Selects which physical gamepad is allowed to feed player one. */
     synchronized void setGamepadSelection(String selection) {
-        if (benchmarkLocked) {
+        if (benchmarkInputBlocked()) {
             recordBenchmarkMutation();
             return;
         }
@@ -272,12 +283,13 @@ final class AndroidInputRouter implements AutoCloseable {
     }
 
     synchronized boolean acceptsController(InputDevice device) {
-        return isAllowed(device);
+        return !benchmarkInputBlocked() && isAllowed(device);
     }
 
     /** Menu navigation remains available from a physical controller even when gameplay is OFF. */
     synchronized boolean acceptsMenuController(InputDevice device) {
-        return device != null && acceptsMenuControllerSources(device.getSources(), device.isVirtual());
+        return !benchmarkInputBlocked() && device != null
+                && acceptsMenuControllerSources(device.getSources(), device.isVirtual());
     }
 
     static boolean acceptsMenuControllerSources(int sources, boolean virtual) {
@@ -301,7 +313,7 @@ final class AndroidInputRouter implements AutoCloseable {
     }
 
     synchronized CaptureResult captureKeyEvent(KeyEvent event) {
-        if (closed || benchmarkLocked || !capture.active() || event == null
+        if (closed || benchmarkInputBlocked() || !capture.active() || event == null
                 || !isConfigurableController(event.getDevice())
                 || !isAllowed(event.getDevice())) {
             return CaptureResult.NONE;
@@ -401,7 +413,104 @@ final class AndroidInputRouter implements AutoCloseable {
         keyboardButtons.clear();
         keyboard.update(keyboardButtons);
         devices.values().forEach(DeviceSource::clear);
+        if (benchmarkScenarioSource != null) {
+            // Activity focus/lifecycle cleanup must not silently release a scripted hold. The
+            // scenario advances only on native frame boundaries and will not republish an
+            // unchanged mask, so preserve its private source while clearing every physical one.
+            benchmarkScenarioSource.update(benchmarkScenarioActive
+                    ? scenarioButtons(benchmarkScenarioMask) : NO_BUTTONS);
+        }
         cancelCapture();
+    }
+
+    /**
+     * Admits the private benchmark scenario source while rejecting all physical input sources.
+     * The source remains admitted-but-empty after the preconditioning pause until benchmark arm,
+     * so physical input cannot race the anchor.
+     */
+    synchronized boolean beginBenchmarkScenario() {
+        if (closed || benchmarkLocked) {
+            return false;
+        }
+        if (benchmarkScenarioSource == null) {
+            benchmarkScenarioSource = hub.openSource(0);
+        }
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
+        benchmarkScenarioSourceClosureProven = false;
+        releaseAll();
+        benchmarkScenarioActive = true;
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.update(NO_BUTTONS);
+        }
+        return true;
+    }
+
+    /** Applies a prebuilt scenario mask; calls between transitions do not touch the hub. */
+    synchronized void setBenchmarkScenarioMask(int mask) {
+        if (closed || benchmarkLocked || !benchmarkScenarioActive) {
+            return;
+        }
+        benchmarkScenarioMask = mask;
+        benchmarkScenarioSource.update(scenarioButtons(benchmarkScenarioMask));
+    }
+
+    synchronized void clearBenchmarkScenario() {
+        if (closed) {
+            return;
+        }
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.update(NO_BUTTONS);
+        }
+    }
+
+    /** Closes the private source and returns input ownership to the normal router. */
+    synchronized void endBenchmarkScenario() {
+        if (closed) {
+            return;
+        }
+        boolean admittedSource = benchmarkScenarioSource != null;
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.close();
+            benchmarkScenarioSource = null;
+        }
+        benchmarkScenarioActive = false;
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
+        if (admittedSource) {
+            benchmarkScenarioSourceClosureProven = true;
+            // Source closure is also the pre-ARM physical-input boundary. Keep it atomic with
+            // closing the scripted source so audio drain/anchor can never expose an input gap.
+            benchmarkLocked = true;
+        }
+    }
+
+    /**
+     * Opens a fresh benchmark-session input epoch. The measured-window lock belongs only to the
+     * session that set it; a replacement/reset must explicitly rotate this epoch before it can
+     * admit another scripted source.
+     */
+    synchronized void resetBenchmarkSession() {
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.close();
+            benchmarkScenarioSource = null;
+        }
+        benchmarkScenarioActive = false;
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
+        benchmarkScenarioSourceClosureProven = false;
+        benchmarkLocked = false;
+    }
+
+    synchronized boolean benchmarkScenarioActiveForTesting() {
+        return benchmarkScenarioActive;
+    }
+
+    synchronized boolean benchmarkScenarioSourceClosed() {
+        return benchmarkScenarioSourceClosureProven
+                && !benchmarkScenarioActive && benchmarkScenarioSource == null;
+    }
+
+    synchronized boolean benchmarkLockedForTesting() {
+        return benchmarkLocked;
     }
 
     /** Freezes all live controller/touch sources for the measured benchmark window. */
@@ -409,7 +518,14 @@ final class AndroidInputRouter implements AutoCloseable {
         if (closed || benchmarkLocked) {
             return;
         }
+        benchmarkScenarioActive = false;
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
         releaseAll();
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.close();
+            benchmarkScenarioSource = null;
+            benchmarkScenarioSourceClosureProven = true;
+        }
         benchmarkLocked = true;
     }
 
@@ -426,13 +542,33 @@ final class AndroidInputRouter implements AutoCloseable {
         }
         releaseAllTouch();
         keyboard.close();
+        if (benchmarkScenarioSource != null) {
+            benchmarkScenarioSource.close();
+            benchmarkScenarioSource = null;
+        }
         devices.values().forEach(DeviceSource::close);
         devices.clear();
         deviceIds.clear();
         connectedDevices.clear();
         activeController = null;
+        benchmarkScenarioActive = false;
+        benchmarkScenarioMask = BenchmarkGameplayScenario.NONE_MASK;
+        benchmarkScenarioSourceClosureProven = false;
         cancelCapture();
         closed = true;
+    }
+
+    private boolean benchmarkInputBlocked() {
+        return benchmarkLocked || benchmarkScenarioActive;
+    }
+
+    private static EnumSet<Button> scenarioButtons(int mask) {
+        return switch (mask) {
+            case BenchmarkGameplayScenario.RIGHT_MASK -> RIGHT_BUTTON;
+            case BenchmarkGameplayScenario.B_MASK -> B_BUTTON;
+            case BenchmarkGameplayScenario.START_MASK -> START_BUTTON;
+            default -> NO_BUTTONS;
+        };
     }
 
     private DeviceSource device(InputDevice device) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/BenchmarkGameplayScenario.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/BenchmarkGameplayScenario.java
@@ -1,0 +1,205 @@
+package eu.rekawek.coffeegb.android;
+
+/**
+ * Deterministic, benchmark-only input preconditioning timeline.
+ *
+ * <p>The timeline is advanced only by a native display frame-ready callback.  It deliberately
+ * does not use wall-clock time, UI callbacks, or an input scheduler.  A caller applies the value
+ * returned by {@link #onFrameReady()} only when it is not {@link #UNCHANGED}; this keeps the
+ * PlayerInputHub source quiet between the handful of physical button transitions.</p>
+ */
+final class BenchmarkGameplayScenario {
+
+    enum NativeFrameKind {
+        DMG,
+        GBC
+    }
+
+    static final int UNCHANGED = -1;
+    static final int NONE_MASK = 0;
+    static final int RIGHT_MASK = 1 << 0;
+    static final int B_MASK = 1 << 5;
+    static final int START_MASK = 1 << 7;
+
+    private enum Phase {
+        DISABLED,
+        RUNNING,
+        PAUSE_REQUESTED,
+        ENDPOINT_SENT,
+        READY
+    }
+
+    private final DiagnosticsOptions.BenchmarkScenario scenario;
+    private final NativeFrameKind nativeFrameKind;
+    private final int releaseBeforeActionFrames;
+    private final int firstActionMask;
+    private final int firstActionFrames;
+    private final int releaseBetweenActionsFrames;
+    private final int secondActionMask;
+    private final int secondActionFrames;
+    private final int releaseAfterActionFrames;
+    private final int endpointFrame;
+    private Phase phase;
+    private int frame;
+    private int mask;
+    private long sessionGeneration;
+
+    BenchmarkGameplayScenario(DiagnosticsOptions.BenchmarkScenario scenario) {
+        this(scenario, scenario == DiagnosticsOptions.BenchmarkScenario.CGB_ACTION_V1
+                ? NativeFrameKind.GBC : NativeFrameKind.DMG);
+    }
+
+    BenchmarkGameplayScenario(DiagnosticsOptions.BenchmarkScenario scenario,
+            NativeFrameKind nativeFrameKind) {
+        this.scenario = scenario == null ? DiagnosticsOptions.BenchmarkScenario.NONE : scenario;
+        this.nativeFrameKind = nativeFrameKind == null ? NativeFrameKind.DMG : nativeFrameKind;
+        if (this.scenario == DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1) {
+            releaseBeforeActionFrames = 120;
+            firstActionMask = START_MASK;
+            firstActionFrames = 3;
+            releaseBetweenActionsFrames = 60;
+            secondActionMask = RIGHT_MASK;
+            secondActionFrames = 120;
+            releaseAfterActionFrames = 10;
+        } else if (this.scenario == DiagnosticsOptions.BenchmarkScenario.CGB_ACTION_V1) {
+            releaseBeforeActionFrames = 670;
+            firstActionMask = B_MASK;
+            firstActionFrames = 3;
+            releaseBetweenActionsFrames = 120;
+            secondActionMask = RIGHT_MASK;
+            secondActionFrames = 120;
+            releaseAfterActionFrames = 10;
+        } else {
+            releaseBeforeActionFrames = 0;
+            firstActionMask = NONE_MASK;
+            firstActionFrames = 0;
+            releaseBetweenActionsFrames = 0;
+            secondActionMask = NONE_MASK;
+            secondActionFrames = 0;
+            releaseAfterActionFrames = 0;
+        }
+        endpointFrame = releaseBeforeActionFrames + firstActionFrames
+                + releaseBetweenActionsFrames + secondActionFrames + releaseAfterActionFrames;
+        phase = enabled() ? Phase.DISABLED : Phase.READY;
+    }
+
+    boolean enabled() {
+        return scenario != DiagnosticsOptions.BenchmarkScenario.NONE;
+    }
+
+    /** Begins one generation-bound timeline after the controller materializes a paused session. */
+    synchronized void beginSession(long generation) {
+        if (!enabled()) {
+            phase = Phase.READY;
+            return;
+        }
+        if (generation <= 0L) {
+            throw new IllegalArgumentException("Session generation must be positive");
+        }
+        sessionGeneration = generation;
+        frame = 0;
+        mask = NONE_MASK;
+        phase = Phase.RUNNING;
+    }
+
+    /**
+     * Advances one physical frame and returns a new mask only when a transition is due.
+     * {@link #pauseRequested()} becomes true on the final released frame.
+     */
+    synchronized int onFrameReady() {
+        return onFrameReady(nativeFrameKind, sessionGeneration);
+    }
+
+    synchronized int onFrameReady(NativeFrameKind kind, long generation) {
+        if (kind != nativeFrameKind || generation <= 0L || generation != sessionGeneration) {
+            return UNCHANGED;
+        }
+        if (phase != Phase.RUNNING) {
+            return UNCHANGED;
+        }
+        frame++;
+        int next = maskForFrame(frame);
+        boolean changed = next != mask;
+        mask = next;
+        if (frame >= endpointFrame) {
+            phase = Phase.PAUSE_REQUESTED;
+        }
+        return changed ? next : UNCHANGED;
+    }
+
+    synchronized boolean pauseRequested() {
+        return phase == Phase.PAUSE_REQUESTED;
+    }
+
+    /** Consumes the endpoint edge exactly once; readiness still waits for controller evidence. */
+    synchronized boolean consumePauseRequest() {
+        if (phase != Phase.PAUSE_REQUESTED) {
+            return false;
+        }
+        phase = Phase.ENDPOINT_SENT;
+        return true;
+    }
+
+    /** Completes the controller pause handshake before the host may request its anchor. */
+    synchronized void markPreconditionReady() {
+        if (phase == Phase.ENDPOINT_SENT) {
+            phase = Phase.READY;
+        }
+    }
+
+    synchronized boolean preconditionReady() {
+        return phase == Phase.READY;
+    }
+
+    synchronized boolean acceptsNativeFrame(NativeFrameKind kind, long generation) {
+        return phase == Phase.RUNNING && kind == nativeFrameKind
+                && generation > 0L && generation == sessionGeneration;
+    }
+
+    synchronized long sessionGeneration() {
+        return sessionGeneration;
+    }
+
+    NativeFrameKind nativeFrameKind() {
+        return nativeFrameKind;
+    }
+
+    synchronized void resetSession() {
+        frame = 0;
+        mask = NONE_MASK;
+        sessionGeneration = 0L;
+        phase = enabled() ? Phase.DISABLED : Phase.READY;
+    }
+
+    synchronized int frameForTesting() {
+        return frame;
+    }
+
+    synchronized int maskForTesting() {
+        return mask;
+    }
+
+    synchronized int endpointFrameForTesting() {
+        return endpointFrame;
+    }
+
+    private int maskForFrame(int frameNumber) {
+        int cursor = releaseBeforeActionFrames;
+        if (frameNumber < cursor) {
+            return NONE_MASK;
+        }
+        cursor += firstActionFrames;
+        if (frameNumber < cursor) {
+            return firstActionMask;
+        }
+        cursor += releaseBetweenActionsFrames;
+        if (frameNumber < cursor) {
+            return NONE_MASK;
+        }
+        cursor += secondActionFrames;
+        if (frameNumber < cursor) {
+            return secondActionMask;
+        }
+        return NONE_MASK;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import eu.rekawek.coffeegb.core.ExecutionMode;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.sound.Sound;
 
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -49,6 +50,8 @@ final class DiagnosticsOptions {
     static final String EXTRA_EXECUTION_MODE = "coffee_gb_execution_mode";
     /** Benchmark-only deterministic gameplay preconditioning contract. */
     static final String EXTRA_BENCHMARK_SCENARIO = "coffee_gb_benchmark_scenario";
+    /** Host-audio evidence policy; canonical is the compatibility-safe default. */
+    static final String EXTRA_AUDIO_POLICY = "coffee_gb_audio_policy";
 
     private static final Pattern SAFE_TOKEN = Pattern.compile("[a-z0-9][a-z0-9._-]{0,63}");
     private static final String UNKNOWN_TOKEN = "unknown";
@@ -176,6 +179,55 @@ final class DiagnosticsOptions {
         }
     }
 
+    enum AudioPolicy {
+        CANONICAL("canonical"),
+        SILENT_PCM_V1("silent-pcm-v1"),
+        SILENT_PCM_RELAXED_APU_V1("silent-pcm-relaxed-apu-v1");
+
+        private final String externalValue;
+
+        AudioPolicy(String externalValue) {
+            this.externalValue = externalValue;
+        }
+
+        String externalValue() {
+            return externalValue;
+        }
+
+        boolean isSilent() {
+            return this != CANONICAL;
+        }
+
+        boolean isRelaxedApu() {
+            return this == SILENT_PCM_RELAXED_APU_V1;
+        }
+
+        /** Maps the diagnostics-only wire token to the transient core calendar mode. */
+        Sound.PerformanceSystemMutedAudioMode performanceSystemMutedAudioMode() {
+            switch (this) {
+                case SILENT_PCM_V1:
+                    return Sound.PerformanceSystemMutedAudioMode.EXACT;
+                case SILENT_PCM_RELAXED_APU_V1:
+                    return Sound.PerformanceSystemMutedAudioMode.RELAXED_APU;
+                default:
+                    return Sound.PerformanceSystemMutedAudioMode.OFF;
+            }
+        }
+
+        static AudioPolicy fromExternalValue(String value) {
+            if (value == null || value.isBlank()) {
+                return CANONICAL;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            for (AudioPolicy policy : values()) {
+                if (policy.externalValue.equals(normalized)) {
+                    return policy;
+                }
+            }
+            return CANONICAL;
+        }
+    }
+
     BenchmarkGameplayScenario.NativeFrameKind benchmarkNativeFrameKind() {
         return hardware == Hardware.CGB || hardware == Hardware.CGB0
                 ? BenchmarkGameplayScenario.NativeFrameKind.GBC
@@ -215,7 +267,7 @@ final class DiagnosticsOptions {
             false, Hardware.AUTO, true, Render.PRESENTATION, false, false,
             "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN, RunSide.UNKNOWN,
             UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-            ExecutionMode.ACCURACY, BenchmarkScenario.NONE);
+            ExecutionMode.ACCURACY, BenchmarkScenario.NONE, AudioPolicy.CANONICAL);
 
     final boolean enabled;
     final Hardware hardware;
@@ -243,13 +295,15 @@ final class DiagnosticsOptions {
     final ExecutionMode executionMode;
     /** Deterministic benchmark-only input contract; never persisted or exposed to release UI. */
     final BenchmarkScenario benchmarkScenario;
+    /** Explicit host-audio evidence policy; never persisted or exposed to release UI. */
+    final AudioPolicy audioPolicy;
 
     private DiagnosticsOptions(boolean enabled, Hardware hardware, boolean audioOutput,
             Render render, boolean runtimeWarmup, boolean launchRecent, String buildId,
             String pairId, String matrixBlock, int rowOrder, RunSide runSide,
             RunSide firstSide, String deviceBuild, String thermalWindow, boolean thermalValid,
             String workloadNonce, int displayTargetHz, int recentSlot, ExecutionMode executionMode,
-            BenchmarkScenario benchmarkScenario) {
+            BenchmarkScenario benchmarkScenario, AudioPolicy audioPolicy) {
         this.enabled = enabled;
         this.hardware = hardware;
         this.audioOutput = audioOutput;
@@ -272,6 +326,20 @@ final class DiagnosticsOptions {
         this.executionMode = executionMode == null ? ExecutionMode.ACCURACY : executionMode;
         this.benchmarkScenario = enabled && benchmarkScenario != null
                 ? benchmarkScenario : BenchmarkScenario.NONE;
+        AudioPolicy requestedPolicy = audioPolicy == null ? AudioPolicy.CANONICAL : audioPolicy;
+        // The silent calendar is intentionally unavailable outside the measured PERFORMANCE
+        // topology, when host audio is disabled, or when the explicit profile could resolve to
+        // an SGB clock. The official silent runner is deliberately bounded to DMG/CGB rows;
+        // unknown/AUTO and SGB profiles fail closed to canonical evidence.
+        this.audioPolicy = enabled && this.executionMode == ExecutionMode.PERFORMANCE
+                && audioOutput && requestedPolicy.isSilent()
+                && supportsSilentPcmProfile(hardware)
+                ? requestedPolicy : AudioPolicy.CANONICAL;
+    }
+
+    private static boolean supportsSilentPcmProfile(Hardware hardware) {
+        return hardware == Hardware.DMG || hardware == Hardware.MGB
+                || hardware == Hardware.CGB || hardware == Hardware.CGB0;
     }
 
     static DiagnosticsOptions disabled() {
@@ -286,7 +354,7 @@ final class DiagnosticsOptions {
         return new DiagnosticsOptions(false, Hardware.AUTO, true, Render.PRESENTATION, false,
                 false, "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN,
                 RunSide.UNKNOWN, UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-                selected, BenchmarkScenario.NONE);
+                selected, BenchmarkScenario.NONE, AudioPolicy.CANONICAL);
     }
 
     static ExecutionMode parseExecutionMode(String value) {
@@ -351,7 +419,8 @@ final class DiagnosticsOptions {
                 intExtra(intent, EXTRA_SURFACE_RATE_HZ, -1),
                 intExtra(intent, EXTRA_RECENT_SLOT, -1),
                 stringExtra(intent, EXTRA_EXECUTION_MODE),
-                stringExtra(intent, EXTRA_BENCHMARK_SCENARIO));
+                stringExtra(intent, EXTRA_BENCHMARK_SCENARIO),
+                stringExtra(intent, EXTRA_AUDIO_POLICY));
     }
 
     static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
@@ -421,6 +490,18 @@ final class DiagnosticsOptions {
             String runSide, String firstSide, String deviceBuild, String thermalWindow,
             boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
             String executionModeValue, String benchmarkScenarioValue) {
+        return parseValues(diagnosticsEnabled, hardwareValue, audioValue, renderValue, warmup,
+                recent, frameSink, buildId, pairId, matrixBlock, rowOrder, runSide, firstSide,
+                deviceBuild, thermalWindow, thermalValid, workloadNonce, displayTargetHz,
+                recentSlot, executionModeValue, benchmarkScenarioValue, null);
+    }
+
+    static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
+            Object audioValue, String renderValue, boolean warmup, boolean recent,
+            boolean frameSink, String buildId, String pairId, String matrixBlock, int rowOrder,
+            String runSide, String firstSide, String deviceBuild, String thermalWindow,
+            boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
+            String executionModeValue, String benchmarkScenarioValue, String audioPolicyValue) {
         if (!diagnosticsEnabled) {
             return disabled(parseExecutionMode(executionModeValue));
         }
@@ -439,7 +520,8 @@ final class DiagnosticsOptions {
                 safeToken(deviceBuild, UNKNOWN_TOKEN), safeToken(thermalWindow, UNKNOWN_TOKEN),
                 thermalValid, safeToken(workloadNonce, UNKNOWN_TOKEN), rate, recentSlot,
                 parseExecutionMode(executionModeValue),
-                BenchmarkScenario.fromExternalValue(benchmarkScenarioValue));
+                BenchmarkScenario.fromExternalValue(benchmarkScenarioValue),
+                AudioPolicy.fromExternalValue(audioPolicyValue));
     }
 
     private static Hardware parseHardware(String value) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
@@ -47,6 +47,8 @@ final class DiagnosticsOptions {
     static final String EXTRA_BENCHMARK_ARM_TOKEN = "coffee_gb_benchmark_arm_token";
     /** Session execution strategy; Accuracy is the compatibility-safe default. */
     static final String EXTRA_EXECUTION_MODE = "coffee_gb_execution_mode";
+    /** Benchmark-only deterministic gameplay preconditioning contract. */
+    static final String EXTRA_BENCHMARK_SCENARIO = "coffee_gb_benchmark_scenario";
 
     private static final Pattern SAFE_TOKEN = Pattern.compile("[a-z0-9][a-z0-9._-]{0,63}");
     private static final String UNKNOWN_TOKEN = "unknown";
@@ -145,6 +147,41 @@ final class DiagnosticsOptions {
         FRAME_SINK
     }
 
+    enum BenchmarkScenario {
+        NONE("none"),
+        DMG_ACTION_V1("dmg-action-v1"),
+        CGB_ACTION_V1("cgb-action-v1");
+
+        private final String externalValue;
+
+        BenchmarkScenario(String externalValue) {
+            this.externalValue = externalValue;
+        }
+
+        String externalValue() {
+            return externalValue;
+        }
+
+        static BenchmarkScenario fromExternalValue(String value) {
+            if (value == null || value.isBlank()) {
+                return NONE;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            for (BenchmarkScenario scenario : values()) {
+                if (scenario.externalValue.equals(normalized)) {
+                    return scenario;
+                }
+            }
+            return NONE;
+        }
+    }
+
+    BenchmarkGameplayScenario.NativeFrameKind benchmarkNativeFrameKind() {
+        return hardware == Hardware.CGB || hardware == Hardware.CGB0
+                ? BenchmarkGameplayScenario.NativeFrameKind.GBC
+                : BenchmarkGameplayScenario.NativeFrameKind.DMG;
+    }
+
     enum RunSide {
         UNKNOWN("unknown"),
         PARENT("parent"),
@@ -178,7 +215,7 @@ final class DiagnosticsOptions {
             false, Hardware.AUTO, true, Render.PRESENTATION, false, false,
             "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN, RunSide.UNKNOWN,
             UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-            ExecutionMode.ACCURACY);
+            ExecutionMode.ACCURACY, BenchmarkScenario.NONE);
 
     final boolean enabled;
     final Hardware hardware;
@@ -204,12 +241,15 @@ final class DiagnosticsOptions {
     final int recentSlot;
     /** Core-owned session strategy. This is not persisted in a save state. */
     final ExecutionMode executionMode;
+    /** Deterministic benchmark-only input contract; never persisted or exposed to release UI. */
+    final BenchmarkScenario benchmarkScenario;
 
     private DiagnosticsOptions(boolean enabled, Hardware hardware, boolean audioOutput,
             Render render, boolean runtimeWarmup, boolean launchRecent, String buildId,
             String pairId, String matrixBlock, int rowOrder, RunSide runSide,
             RunSide firstSide, String deviceBuild, String thermalWindow, boolean thermalValid,
-            String workloadNonce, int displayTargetHz, int recentSlot, ExecutionMode executionMode) {
+            String workloadNonce, int displayTargetHz, int recentSlot, ExecutionMode executionMode,
+            BenchmarkScenario benchmarkScenario) {
         this.enabled = enabled;
         this.hardware = hardware;
         this.audioOutput = audioOutput;
@@ -230,6 +270,8 @@ final class DiagnosticsOptions {
         this.surfaceContentRateMillihz = contentRateMillihz(hardware);
         this.recentSlot = recentSlot >= 0 && recentSlot < 10 ? recentSlot : -1;
         this.executionMode = executionMode == null ? ExecutionMode.ACCURACY : executionMode;
+        this.benchmarkScenario = enabled && benchmarkScenario != null
+                ? benchmarkScenario : BenchmarkScenario.NONE;
     }
 
     static DiagnosticsOptions disabled() {
@@ -244,7 +286,7 @@ final class DiagnosticsOptions {
         return new DiagnosticsOptions(false, Hardware.AUTO, true, Render.PRESENTATION, false,
                 false, "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN,
                 RunSide.UNKNOWN, UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-                selected);
+                selected, BenchmarkScenario.NONE);
     }
 
     static ExecutionMode parseExecutionMode(String value) {
@@ -308,7 +350,8 @@ final class DiagnosticsOptions {
                 stringExtra(intent, EXTRA_WORKLOAD_NONCE),
                 intExtra(intent, EXTRA_SURFACE_RATE_HZ, -1),
                 intExtra(intent, EXTRA_RECENT_SLOT, -1),
-                stringExtra(intent, EXTRA_EXECUTION_MODE));
+                stringExtra(intent, EXTRA_EXECUTION_MODE),
+                stringExtra(intent, EXTRA_BENCHMARK_SCENARIO));
     }
 
     static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
@@ -366,6 +409,18 @@ final class DiagnosticsOptions {
             String runSide, String firstSide, String deviceBuild, String thermalWindow,
             boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
             String executionModeValue) {
+        return parseValues(diagnosticsEnabled, hardwareValue, audioValue, renderValue, warmup,
+                recent, frameSink, buildId, pairId, matrixBlock, rowOrder, runSide, firstSide,
+                deviceBuild, thermalWindow, thermalValid, workloadNonce, displayTargetHz,
+                recentSlot, executionModeValue, null);
+    }
+
+    static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
+            Object audioValue, String renderValue, boolean warmup, boolean recent,
+            boolean frameSink, String buildId, String pairId, String matrixBlock, int rowOrder,
+            String runSide, String firstSide, String deviceBuild, String thermalWindow,
+            boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
+            String executionModeValue, String benchmarkScenarioValue) {
         if (!diagnosticsEnabled) {
             return disabled(parseExecutionMode(executionModeValue));
         }
@@ -383,7 +438,8 @@ final class DiagnosticsOptions {
                 RunSide.fromExternalValue(runSide), RunSide.fromExternalValue(firstSide),
                 safeToken(deviceBuild, UNKNOWN_TOKEN), safeToken(thermalWindow, UNKNOWN_TOKEN),
                 thermalValid, safeToken(workloadNonce, UNKNOWN_TOKEN), rate, recentSlot,
-                parseExecutionMode(executionModeValue));
+                parseExecutionMode(executionModeValue),
+                BenchmarkScenario.fromExternalValue(benchmarkScenarioValue));
     }
 
     private static Hardware parseHardware(String value) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -61,6 +61,11 @@ public final class EmulationService extends Service implements AudioManager.OnAu
         return checked.benchmarkScenario.externalValue();
     }
 
+    static String audioPolicyExtraValue(DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return checked.audioPolicy.externalValue();
+    }
+
     private static Intent populateStartIntent(Intent intent, DiagnosticsOptions checked) {
         nextStartOptions = checked;
         return intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK, checked.enabled)
@@ -86,7 +91,9 @@ public final class EmulationService extends Service implements AudioManager.OnAu
                 .putExtra(DiagnosticsOptions.EXTRA_EXECUTION_MODE,
                         DiagnosticsOptions.executionModeValue(checked.executionMode))
                 .putExtra(DiagnosticsOptions.EXTRA_BENCHMARK_SCENARIO,
-                        benchmarkScenarioExtraValue(checked));
+                        benchmarkScenarioExtraValue(checked))
+                .putExtra(DiagnosticsOptions.EXTRA_AUDIO_POLICY,
+                        audioPolicyExtraValue(checked));
     }
 
     @Override

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -41,10 +41,29 @@ public final class EmulationService extends Service implements AudioManager.OnAu
     }
 
     static void start(Context context, DiagnosticsOptions options) {
-        Intent intent = new Intent(context, EmulationService.class);
         DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        context.startService(startIntent(context, checked));
+    }
+
+    /** Builds the service wire separately so its typed diagnostics extras can be unit-tested. */
+    static Intent startIntent(Context context, DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return populateStartIntent(new Intent(context, EmulationService.class), checked);
+    }
+
+    static Intent startIntent(DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return populateStartIntent(new Intent(), checked);
+    }
+
+    static String benchmarkScenarioExtraValue(DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return checked.benchmarkScenario.externalValue();
+    }
+
+    private static Intent populateStartIntent(Intent intent, DiagnosticsOptions checked) {
         nextStartOptions = checked;
-        intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK, checked.enabled)
+        return intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK, checked.enabled)
                 .putExtra(DiagnosticsOptions.EXTRA_HARDWARE,
                         checked.hardware.externalValue())
                 .putExtra(DiagnosticsOptions.EXTRA_AUDIO, checked.audioOutput)
@@ -65,8 +84,9 @@ public final class EmulationService extends Service implements AudioManager.OnAu
                 .putExtra(DiagnosticsOptions.EXTRA_SURFACE_RATE_HZ, checked.displayTargetHz)
                 .putExtra(DiagnosticsOptions.EXTRA_RECENT_SLOT, checked.recentSlot)
                 .putExtra(DiagnosticsOptions.EXTRA_EXECUTION_MODE,
-                        DiagnosticsOptions.executionModeValue(checked.executionMode));
-        context.startService(intent);
+                        DiagnosticsOptions.executionModeValue(checked.executionMode))
+                .putExtra(DiagnosticsOptions.EXTRA_BENCHMARK_SCENARIO,
+                        benchmarkScenarioExtraValue(checked));
     }
 
     @Override

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -166,7 +166,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private DiagnosticsOptions diagnosticsOptions = DiagnosticsOptions.disabled();
     private boolean benchmarkRecentLaunchRequested;
     private boolean benchmarkAnchorRequested;
-    private String pendingBenchmarkArmToken;
+    private long benchmarkAnchorSessionGeneration;
+    private final BenchmarkArmTokenLatch pendingBenchmarkArm = new BenchmarkArmTokenLatch();
     // Android 6-8 can return from a cancelled permission Activity without delivering its result.
     private MenuExternalSurfaceState legacyCameraPermissionFallbackSurface;
     private boolean legacyCameraPermissionFallbackPosted;
@@ -214,6 +215,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 observedRuntime = connected;
                 observedGeneration = -1L;
                 benchmarkAnchorRequested = false;
+                benchmarkAnchorSessionGeneration = 0L;
+                pendingBenchmarkArm.clear();
             }
             runtime = connected;
             bound = true;
@@ -282,6 +285,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             observedRuntime = null;
             observedGeneration = -1L;
             benchmarkAnchorRequested = false;
+            benchmarkAnchorSessionGeneration = 0L;
+            pendingBenchmarkArm.clear();
             bound = false;
             observedState = RuntimeState.stopped();
             stateCatalogGeneration++;
@@ -308,10 +313,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             return;
         }
         AndroidEmulationRuntime active = runtime;
-        if (active == null || !bound) {
-            pendingBenchmarkArmToken = token;
-        } else {
-            pendingBenchmarkArmToken = token;
+        pendingBenchmarkArm.put(token, observedState.sessionGeneration());
+        if (active != null && bound) {
             armPendingBenchmarkIfReady(active);
         }
     }
@@ -2549,6 +2552,12 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         if (state.generation() < observedGeneration) {
             return;
         }
+        long previousSessionGeneration = observedState.sessionGeneration();
+        if (diagnosticsOptions.enabled
+                && pendingBenchmarkArm.onStateTransition(previousSessionGeneration, state)) {
+            benchmarkAnchorRequested = false;
+            benchmarkAnchorSessionGeneration = 0L;
+        }
         observedGeneration = state.generation();
         if (state.flushPending() && !observedState.flushPending()
                 && menuController != null && menuController.visible()
@@ -2557,14 +2566,24 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
         observedState = state;
         if (diagnosticsOptions.enabled && state.phase() == RuntimeState.Phase.PAUSED
-                && !benchmarkAnchorRequested && runtime != null && video != null) {
+                && !benchmarkAnchorRequested && runtime != null && video != null
+                && state.sessionGeneration() > 0L
+                && runtime.benchmarkPreconditionReady()) {
             benchmarkAnchorRequested = true;
+            benchmarkAnchorSessionGeneration = state.sessionGeneration();
             AndroidEmulationRuntime active = runtime;
+            long anchorSessionGeneration = benchmarkAnchorSessionGeneration;
             video.requestBenchmarkAnchor(success -> {
-                active.benchmarkAnchorPosted(success);
-                if (success) {
-                    armPendingBenchmarkIfReady(active);
-                }
+                active.benchmarkAnchorPosted(anchorSessionGeneration, success,
+                        () -> runOnUiThread(() -> {
+                            if (success && runtime == active
+                                    && observedState.phase() == RuntimeState.Phase.PAUSED
+                                    && observedState.sessionGeneration() == anchorSessionGeneration
+                                    && benchmarkAnchorSessionGeneration
+                                            == anchorSessionGeneration) {
+                                armPendingBenchmarkIfReady(active, anchorSessionGeneration);
+                            }
+                        }));
             });
         }
         refreshMenuPages();
@@ -2584,13 +2603,63 @@ public final class MainActivity extends Activity implements RuntimeObserver {
 
     /** Defers a singleTop arm token until the real anchor has completed on the renderer. */
     private void armPendingBenchmarkIfReady(AndroidEmulationRuntime active) {
-        if (!diagnosticsOptions.enabled || active == null || pendingBenchmarkArmToken == null
-                || !active.benchmarkAnchorReady()) {
+        armPendingBenchmarkIfReady(active, observedState.sessionGeneration());
+    }
+
+    private void armPendingBenchmarkIfReady(
+            AndroidEmulationRuntime active, long sessionGeneration) {
+        if (!diagnosticsOptions.enabled || active == null
+                || !pendingBenchmarkArm.pendingFor(sessionGeneration)
+                || sessionGeneration <= 0L
+                || observedState.phase() != RuntimeState.Phase.PAUSED
+                || observedState.sessionGeneration() != sessionGeneration
+                || !active.benchmarkAnchorReady(sessionGeneration)) {
             return;
         }
-        String token = pendingBenchmarkArmToken;
-        pendingBenchmarkArmToken = null;
-        active.armBenchmark(token);
+        String token = pendingBenchmarkArm.take(sessionGeneration);
+        if (token != null) {
+            active.armBenchmark(token, sessionGeneration);
+        }
+    }
+
+    /** Generation-bound singleTop token latch; renderer completion may race a later intent. */
+    static final class BenchmarkArmTokenLatch {
+        private String token;
+        private long sessionGeneration;
+
+        synchronized void put(String token, long sessionGeneration) {
+            this.token = token;
+            this.sessionGeneration = sessionGeneration;
+        }
+
+        synchronized boolean pendingFor(long sessionGeneration) {
+            return token != null && sessionGeneration > 0L
+                    && this.sessionGeneration == sessionGeneration;
+        }
+
+        synchronized String take(long sessionGeneration) {
+            if (!pendingFor(sessionGeneration)) {
+                return null;
+            }
+            String result = token;
+            clear();
+            return result;
+        }
+
+        synchronized boolean onStateTransition(
+                long previousSessionGeneration, RuntimeState state) {
+            boolean invalidate = state.phase() == RuntimeState.Phase.LOADING
+                    || state.sessionGeneration() != previousSessionGeneration;
+            if (invalidate) {
+                clear();
+            }
+            return invalidate;
+        }
+
+        synchronized void clear() {
+            token = null;
+            sessionGeneration = 0L;
+        }
     }
 
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
@@ -114,6 +114,8 @@ public class AndroidAudioSinkTest {
             AndroidAudioSink.AudioBaseline baseline = sink.benchmarkBaseline();
             assertTrue(baseline.outputOpen());
             assertTrue(baseline.outputPlaying());
+            assertTrue(baseline.outputIdentity() > 0L);
+            assertTrue(baseline.queueIdentity() > 0L);
             int flushesBefore = factory.current().flushes;
 
             AtomicInteger snapshots = new AtomicInteger();

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -214,6 +215,7 @@ public class AndroidBenchmarkDiagnosticsTest {
         assertTrue(speedRecord.contains("performance_epoch_raster_fast_ticks=7654"));
         assertTrue(speedRecord.contains("performance_epoch_mode2_replay_ticks=4321"));
         assertTrue(speedRecord.contains("performance_epoch_mode2_bulk_ticks=4000"));
+        assertTrue(speedRecord.contains("benchmark_audio_dropped_channel_ticks=0"));
     }
 
     private static AndroidBenchmarkDiagnostics armedDiagnostics(long generation) {
@@ -267,6 +269,106 @@ public class AndroidBenchmarkDiagnosticsTest {
                 SESSION, 62L, TOKEN, audioBaseline(0L, 0L, false)));
         assertTrue(diagnostics.armBenchmark(
                 SESSION, 63L, TOKEN, readyAudioBaseline()));
+    }
+
+    @Test
+    public void silentPcmArmRequiresFreshStrictMutedHostProof() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = newSilentDiagnostics();
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(SESSION, silentSessionStartAudioBaseline());
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.armBenchmark(SESSION, 64L, TOKEN, readyAudioBaseline()));
+        assertTrue(diagnostics.systemAudioBadLatched());
+
+        // A system-audio ARM failure is terminal for its diagnostics/session generation. A
+        // later valid admission must start from a fresh diagnostics/session instance.
+        AndroidBenchmarkDiagnostics valid = newSilentDiagnostics();
+        valid.sessionLaunch();
+        valid.beginSession(SESSION + 1L, silentSessionStartAudioBaseline());
+        valid.emulationStarted(SESSION + 1L);
+        valid.benchmarkAnchorPosted(SESSION + 1L, true);
+        valid.audioFocusResult(true);
+        assertTrue(valid.armBenchmark(SESSION + 1L, 65L, TOKEN, silentAudioBaseline()));
+    }
+
+    @Test
+    public void silentPcmArmRejectsAnyPriorFocusLossEvenAfterRegain() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = newSilentDiagnostics();
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(SESSION, silentSessionStartAudioBaseline());
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        diagnostics.audioFocusResult(true);
+        diagnostics.audioFocusLost();
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.armBenchmark(SESSION, 66L, TOKEN, silentAudioBaseline()));
+    }
+
+    @Test
+    public void silentPcmArmRejectsPcmEvidenceInheritedFromAnOlderSession() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = newSilentDiagnostics();
+        diagnostics.sessionLaunch();
+        AndroidAudioSink.AudioBaseline inherited = silentAudioBaseline();
+        diagnostics.beginSession(SESSION, inherited);
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.armBenchmark(SESSION, 67L, TOKEN, inherited));
+    }
+
+    @Test
+    public void silentPcmSystemAudioAllGoodHasArmIntervalsAndTerminalProof() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = armedSilentDiagnostics(null);
+        for (int frame = 60; frame <= 600; frame += 60) {
+            diagnostics.sampleSystemAudioForTesting(frame, silentAudioBaseline());
+        }
+        diagnostics.sampleSystemAudioForTesting(600, silentAudioBaseline());
+        assertEquals(12, diagnostics.systemAudioSampleCountForTesting());
+        assertEquals(0, diagnostics.systemAudioBadCountForTesting());
+        assertEquals(600, diagnostics.systemAudioLastFrameForTesting());
+    }
+
+    @Test
+    public void silentPcmSystemAudioFailureAtFrame60RevokesOnceAndStaysFrozen() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AtomicInteger revocations = new AtomicInteger();
+        AndroidBenchmarkDiagnostics diagnostics = armedSilentDiagnostics(revocations);
+        diagnostics.sampleSystemAudioForTesting(60, systemAudioBaseline(1, 15, false));
+        diagnostics.sampleSystemAudioForTesting(540, systemAudioBaseline(1, 15, false));
+        assertEquals(1, revocations.get());
+        assertEquals(1, diagnostics.systemAudioBadCountForTesting());
+    }
+
+    @Test
+    public void silentPcmSystemAudioFailureAtFrame540RevokesAndUnavailableFailsClosed() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AtomicInteger revocations = new AtomicInteger();
+        AndroidBenchmarkDiagnostics diagnostics = armedSilentDiagnostics(revocations);
+        diagnostics.sampleSystemAudioForTesting(540, systemAudioBaseline(1, 15, false));
+        diagnostics.sampleSystemAudioForTesting(600, null);
+        assertEquals(1, revocations.get());
+        assertEquals(1, diagnostics.systemAudioBadCountForTesting());
     }
 
     @Test
@@ -399,12 +501,15 @@ public class AndroidBenchmarkDiagnosticsTest {
         }
         List<String> records = new ArrayList<>();
         String longToken = "a".repeat(64);
-        String workloadNonce = "b".repeat(48);
+        String workloadNonce = "b".repeat(64);
+        long sessionGeneration = 9_223_372_036_854_775_000L;
+        long benchmarkGeneration = 9_223_372_036_854_774_000L;
         DiagnosticsOptions options = DiagnosticsOptions.parseValues(
                 true, "cgb", true, "presentation", true, true, false,
                 longToken, "c".repeat(64), "d".repeat(64), 6,
                 "variant", "variant", "e".repeat(64), "f".repeat(64), true,
-                workloadNonce, 120, 9, "performance", "cgb-action-v1");
+                workloadNonce, 120, 9, "performance", "cgb-action-v1",
+                "silent-pcm-relaxed-apu-v1");
         AtomicLong now = new AtomicLong(9_000_000_000_000_000L);
         AndroidBenchmarkDiagnostics diagnostics = new AndroidBenchmarkDiagnostics(
                 null, options, records::add, () -> now.addAndGet(1_000_000L),
@@ -414,22 +519,26 @@ public class AndroidBenchmarkDiagnosticsTest {
         diagnostics.hardwareProfile(new Controller.HardwareProfileEvent(
                 HardwareProfileRegistry.CGB,
                 HardwareProfileRegistry.CGB.identity(), true, false, 2));
-        diagnostics.beginSession(9_999_999_999L);
+        diagnostics.beginSession(sessionGeneration, silentSessionStartAudioBaseline());
         diagnostics.benchmarkScenarioCompleted(
-                9_999_999_999L, 923, 923, true, true, true);
-        diagnostics.emulationStarted(9_999_999_999L);
-        diagnostics.benchmarkAnchorPosted(9_999_999_999L, true);
+                sessionGeneration, 923, 923, true, true, true);
+        diagnostics.emulationStarted(sessionGeneration);
+        diagnostics.benchmarkAnchorPosted(sessionGeneration, true);
         diagnostics.audioFocusResult(true);
         assertTrue(diagnostics.armBenchmark(
-                9_999_999_999L, 8_888_888_888L, "z".repeat(64),
+                sessionGeneration, benchmarkGeneration, "z".repeat(64),
                 productionLikeAudioBaseline()));
+        diagnostics.setSystemAudioBaselineForTesting(productionLikeAudioBaseline());
         for (int frame = 1; frame <= 600; frame++) {
             diagnostics.frameReady();
         }
         diagnostics.benchmarkFrameBoundary(new Controller.BenchmarkFrameBoundaryEvent(
                 600L, true, false, 2, 9_999_999L, 999_999_999L,
                 999_999_999L, Long.MAX_VALUE, Integer.MAX_VALUE,
-                Long.MAX_VALUE, Long.MAX_VALUE));
+                Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                "silent-pcm-relaxed-apu-v1", true, true, true,
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L));
         for (int submission = 1; submission <= 600; submission++) {
             diagnostics.frameSubmitted(submission);
         }
@@ -450,6 +559,11 @@ public class AndroidBenchmarkDiagnosticsTest {
         assertTrue(matrixRecord.contains("audio_start_input_events=999999999"));
         assertFalse(finalRecord.contains("audio_start_input_events="));
         assertTrue(finalRecord.contains("audio_pcm_input_events=999999999"));
+        assertTrue(finalRecord.contains("benchmark_audio_policy=silent-pcm-relaxed-apu-v1"));
+        assertTrue(finalRecord.contains("benchmark_audio_flags=111"));
+        assertTrue(finalRecord.contains("benchmark_audio_calendar=999999999,999999999,999999999,999999999,999999999,999999999,999999999,999999999"));
+        assertTrue(finalRecord.contains("system_audio_sample_count=12"));
+        assertTrue(finalRecord.contains("system_audio_bad_count=0"));
         assertTrue(finalRecord.getBytes(StandardCharsets.UTF_8).length
                 <= AndroidBenchmarkDiagnostics.MAX_LOG_RECORD_BYTES);
         for (String record : records) {
@@ -465,10 +579,11 @@ public class AndroidBenchmarkDiagnosticsTest {
     private static AndroidAudioSink.AudioBaseline productionLikeAudioBaseline() {
         return new AndroidAudioSink.AudioBaseline(
                 999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
-                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 0L, 999_999_999L,
                 0L, 0L, 999_999_999L, 999_999_999L, 999_999_999L,
-                999_999_999L, 999_999_999L, 999_999_999L,
-                true, true, 48_000, 6, 140_448);
+                999_999_999L, 999_999_999L, 0L,
+                true, true, 48_000, 6, 140_448, true, false, false, 100,
+                0, 15, true, 0, false, 999_999_999L, 999_999_999L);
     }
 
     private static AndroidAudioSink.Stats productionLikeAudioStats() {
@@ -480,7 +595,7 @@ public class AndroidBenchmarkDiagnosticsTest {
                 999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
                 999_999_999L, 999_999_999L, 6,
                 true, true, false, 100,
-                999_999_999L, 999_999_999L, 100, 100, false, 6, 999_999_999);
+                999_999_999L, 999_999_999L, 0, 15, true, 6, 999_999_999);
     }
 
     private static AndroidAudioSink.AudioBaseline audioBaseline(
@@ -513,5 +628,64 @@ public class AndroidBenchmarkDiagnosticsTest {
         AtomicLong now = new AtomicLong();
         return new AndroidBenchmarkDiagnostics(
                 null, options, records::add, () -> now.addAndGet(1_000_000L));
+    }
+
+    private static AndroidBenchmarkDiagnostics newSilentDiagnostics() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                "ignored-build", "pair-0001", "block-0001", 0,
+                "parent", "parent", "ignored-device", "thermal", true,
+                "workload-0001", 60, -1, "performance", null, "silent-pcm-v1");
+        AtomicLong now = new AtomicLong();
+        return new AndroidBenchmarkDiagnostics(null, options, message -> {
+        }, () -> now.addAndGet(1_000_000L));
+    }
+
+    private static AndroidBenchmarkDiagnostics armedSilentDiagnostics(AtomicInteger revocations) {
+        AndroidBenchmarkDiagnostics diagnostics = newSilentDiagnosticsWithRevocations(revocations);
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(SESSION, silentSessionStartAudioBaseline());
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        diagnostics.audioFocusResult(true);
+        assertTrue(diagnostics.armBenchmark(SESSION, 65L, TOKEN, silentAudioBaseline()));
+        return diagnostics;
+    }
+
+    private static AndroidBenchmarkDiagnostics newSilentDiagnosticsWithRevocations(
+            AtomicInteger revocations) {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                "ignored-build", "pair-0001", "block-0001", 0,
+                "parent", "parent", "ignored-device", "thermal", true,
+                "workload-0001", 60, -1, "performance", null, "silent-pcm-v1");
+        AtomicLong now = new AtomicLong();
+        return new AndroidBenchmarkDiagnostics(null, options, message -> {
+        }, () -> now.addAndGet(1_000_000L), null, null,
+                revocations == null ? (generation, session) -> {
+                } : (generation, session) -> revocations.incrementAndGet());
+    }
+
+    private static AndroidAudioSink.AudioBaseline systemAudioBaseline(
+            int systemVolume, int systemVolumeMax, boolean systemMuted) {
+        return new AndroidAudioSink.AudioBaseline(
+                1L, 1L, 4L, 1L, 4L, 1L, 0L, 0L, 0L, 0L,
+                0L, 0L, 0L, 0L, 0L, 0L, true, true, 48_000, 6, 140_448,
+                true, false, false, 100, systemVolume, systemVolumeMax, systemMuted,
+                0, false, 1L, 2L);
+    }
+
+    private static AndroidAudioSink.AudioBaseline silentAudioBaseline() {
+        return new AndroidAudioSink.AudioBaseline(
+                1L, 1L, 4L, 1L, 4L, 1L, 0L, 0L, 0L, 0L,
+                0L, 0L, 0L, 0L, 0L, 0L, true, true, 48_000, 6, 140_448,
+                true, false, false, 100, 0, 15, true, 0, false, 1L, 2L);
+    }
+
+    private static AndroidAudioSink.AudioBaseline silentSessionStartAudioBaseline() {
+        return new AndroidAudioSink.AudioBaseline(
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+                0L, 0L, 0L, 0L, 0L, 0L, true, true, 48_000, 6, 140_448,
+                true, false, false, 100, 0, 15, true, 0, false, 1L, 2L);
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidBenchmarkDiagnosticsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
@@ -21,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 public class AndroidBenchmarkDiagnosticsTest {
 
     private static final String TOKEN = "benchmark-token-0001";
+    private static final long SESSION = 7L;
 
     @Test
     public void benchmarkAnchorMustCompleteBeforeArmAcknowledgement() {
@@ -29,25 +31,25 @@ public class AndroidBenchmarkDiagnosticsTest {
         }
         AndroidBenchmarkDiagnostics diagnostics = newDiagnostics();
         diagnostics.sessionLaunch();
-        diagnostics.emulationStarted();
+        diagnostics.beginSession(SESSION);
+        diagnostics.emulationStarted(SESSION);
 
         assertEquals("WARMING", diagnostics.phaseForTesting());
-        assertFalse(diagnostics.benchmarkAnchorReady());
-        diagnostics.benchmarkAnchorPosted(false);
-        assertFalse(diagnostics.benchmarkAnchorReady());
-        assertFalse(diagnostics.armBenchmark(17L, TOKEN,
-                AndroidAudioSink.AudioBaseline.unavailable()));
+        assertFalse(diagnostics.benchmarkAnchorReady(SESSION));
+        diagnostics.benchmarkAnchorPosted(SESSION, false);
+        assertFalse(diagnostics.benchmarkAnchorReady(SESSION));
+        assertFalse(diagnostics.armBenchmark(SESSION, 17L, TOKEN, readyAudioBaseline()));
 
-        diagnostics.benchmarkAnchorPosted(true);
-        assertTrue(diagnostics.benchmarkAnchorReady());
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        assertTrue(diagnostics.benchmarkAnchorReady(SESSION));
         assertEquals("ANCHOR_READY", diagnostics.phaseForTesting());
         diagnostics.audioFocusResult(true);
-        assertTrue(diagnostics.armBenchmark(17L, TOKEN,
-                AndroidAudioSink.AudioBaseline.unavailable()));
+        assertTrue(diagnostics.armBenchmark(SESSION, 17L, TOKEN, readyAudioBaseline()));
         Controller.BenchmarkArmAcknowledgedEvent ack =
-                new Controller.BenchmarkArmAcknowledgedEvent(17L, TOKEN);
+                new Controller.BenchmarkArmAcknowledgedEvent(17L, TOKEN, SESSION);
         assertEquals(17L, ack.getGeneration());
         assertEquals(TOKEN, ack.getToken());
+        assertEquals(SESSION, ack.getSessionGeneration());
         assertEquals("ARMED", diagnostics.phaseForTesting());
     }
 
@@ -58,8 +60,7 @@ public class AndroidBenchmarkDiagnosticsTest {
         }
         AndroidBenchmarkDiagnostics diagnostics = armedDiagnostics(23L);
 
-        assertFalse(diagnostics.armBenchmark(24L, TOKEN,
-                AndroidAudioSink.AudioBaseline.unavailable()));
+        assertFalse(diagnostics.armBenchmark(SESSION, 24L, TOKEN, readyAudioBaseline()));
         assertTrue(diagnostics.acceptsFrameEpoch(23L));
         assertFalse(diagnostics.acceptsFrameEpoch(24L));
 
@@ -133,7 +134,7 @@ public class AndroidBenchmarkDiagnosticsTest {
             return;
         }
         try {
-            new Controller.BenchmarkArmEvent(0L, TOKEN);
+            new Controller.BenchmarkArmEvent(0L, TOKEN, SESSION);
             throw new AssertionError("zero generation accepted");
         } catch (IllegalArgumentException expected) {
             // expected
@@ -141,6 +142,14 @@ public class AndroidBenchmarkDiagnosticsTest {
         try {
             new Controller.BenchmarkFrameBoundaryEvent(600L, false, false, 0);
             throw new AssertionError("invalid speed accepted");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+        try {
+            new Controller.BenchmarkFrameBoundaryEvent(
+                    600L, false, false, 1, 0L, 0L,
+                    0L, 0L, -1, 0L, 0L);
+            throw new AssertionError("negative epoch maximum accepted");
         } catch (IllegalArgumentException expected) {
             // expected
         }
@@ -170,16 +179,18 @@ public class AndroidBenchmarkDiagnosticsTest {
         diagnostics.hardwareProfile(new Controller.HardwareProfileEvent(
                 HardwareProfileRegistry.CGB,
                 HardwareProfileRegistry.CGB.identity(), true, false, 1));
-        diagnostics.emulationStarted();
-        diagnostics.benchmarkAnchorPosted(true);
+        diagnostics.beginSession(SESSION);
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
         diagnostics.audioFocusResult(true);
-        assertTrue(diagnostics.armBenchmark(41L, TOKEN,
-                AndroidAudioSink.AudioBaseline.unavailable()));
+        assertTrue(diagnostics.armBenchmark(SESSION, 41L, TOKEN, readyAudioBaseline()));
         for (int frame = 1; frame <= 600; frame++) {
             diagnostics.frameReady();
         }
         diagnostics.benchmarkFrameBoundary(
-                new Controller.BenchmarkFrameBoundaryEvent(600L, true, true, 1, 12L, 345L));
+                new Controller.BenchmarkFrameBoundaryEvent(
+                        600L, true, true, 1, 12L, 345L,
+                        67L, 8_901L, 64, 7_654L, 4_321L, 4_000L));
         for (int submission = 1; submission <= 600; submission++) {
             diagnostics.frameSubmitted(submission);
         }
@@ -197,18 +208,287 @@ public class AndroidBenchmarkDiagnosticsTest {
                 .orElseThrow();
         assertTrue(speedRecord.contains("performance_bulk_spans=12"));
         assertTrue(speedRecord.contains("performance_bulk_ticks=345"));
+        assertTrue(speedRecord.contains("performance_epoch_count=67"));
+        assertTrue(speedRecord.contains("performance_epoch_ticks=8901"));
+        assertTrue(speedRecord.contains("performance_epoch_max_ticks=64"));
+        assertTrue(speedRecord.contains("performance_epoch_raster_fast_ticks=7654"));
+        assertTrue(speedRecord.contains("performance_epoch_mode2_replay_ticks=4321"));
+        assertTrue(speedRecord.contains("performance_epoch_mode2_bulk_ticks=4000"));
     }
 
     private static AndroidBenchmarkDiagnostics armedDiagnostics(long generation) {
         AndroidBenchmarkDiagnostics diagnostics = newDiagnostics();
         diagnostics.sessionLaunch();
-        diagnostics.emulationStarted();
-        diagnostics.benchmarkAnchorPosted(true);
+        diagnostics.beginSession(SESSION);
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
         diagnostics.audioFocusResult(true);
-        assertTrue(diagnostics.armBenchmark(generation, TOKEN,
-                AndroidAudioSink.AudioBaseline.unavailable()));
+        assertTrue(diagnostics.armBenchmark(
+                SESSION, generation, TOKEN, readyAudioBaseline()));
         assertEquals(generation, diagnostics.benchmarkGeneration());
         return diagnostics;
+    }
+
+    @Test
+    public void staleSessionCannotPublishAnchorOrArmReplacement() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = newDiagnostics();
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(11L);
+        diagnostics.emulationStarted(11L);
+        diagnostics.beginSession(12L);
+
+        diagnostics.benchmarkAnchorPosted(11L, true);
+        assertFalse(diagnostics.benchmarkAnchorReady(12L));
+        diagnostics.emulationStarted(12L);
+        diagnostics.benchmarkAnchorPosted(12L, true);
+        diagnostics.audioFocusResult(true);
+        assertFalse(diagnostics.armBenchmark(11L, 51L, TOKEN, readyAudioBaseline()));
+        assertTrue(diagnostics.armBenchmark(12L, 52L, TOKEN, readyAudioBaseline()));
+    }
+
+    @Test
+    public void armRequiresEmptyPlayingAudioBaseline() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        AndroidBenchmarkDiagnostics diagnostics = newDiagnostics();
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(SESSION);
+        diagnostics.emulationStarted(SESSION);
+        diagnostics.benchmarkAnchorPosted(SESSION, true);
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.armBenchmark(
+                SESSION, 61L, TOKEN, audioBaseline(4L, 0L, true)));
+        assertFalse(diagnostics.armBenchmark(
+                SESSION, 62L, TOKEN, audioBaseline(0L, 0L, false)));
+        assertTrue(diagnostics.armBenchmark(
+                SESSION, 63L, TOKEN, readyAudioBaseline()));
+    }
+
+    @Test
+    public void scriptedSessionNeedsCurrentExactCompletionEvidence() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        List<String> records = new ArrayList<>();
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                "ignored-build", "pair-0001", "block-0001", 0,
+                "parent", "parent", "ignored-device", "thermal", true,
+                "workload-0001", 60, -1, "performance", "dmg-action-v1");
+        AndroidBenchmarkDiagnostics diagnostics = new AndroidBenchmarkDiagnostics(
+                null, options, records::add, () -> 1_000_000L);
+        diagnostics.beginSession(71L);
+
+        diagnostics.benchmarkScenarioCompleted(70L, 313, 313, true, true, true);
+        diagnostics.emulationStarted(71L);
+        assertEquals("SCENARIO_RUNNING", diagnostics.phaseForTesting());
+        diagnostics.benchmarkScenarioCompleted(71L, 312, 313, true, true, true);
+        diagnostics.emulationStarted(71L);
+        assertEquals("SCENARIO_RUNNING", diagnostics.phaseForTesting());
+        diagnostics.benchmarkScenarioCompleted(71L, 313, 313, true, true, true);
+        diagnostics.emulationStarted(71L);
+        assertEquals("WARMING", diagnostics.phaseForTesting());
+        String completion = records.stream()
+                .filter(line -> line.startsWith("event=scenario_complete")
+                        && line.contains("completed=true"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(completion.contains("session_generation=71"));
+        assertTrue(completion.contains("completed_frames=313"));
+        assertTrue(completion.contains("source_closed=true"));
+        assertTrue(completion.contains("audio_drained=true"));
+        assertTrue(completion.contains("artifact_id="));
+        assertTrue(completion.contains("pair_id=pair-0001"));
+        assertTrue(completion.contains("matrix_block=block-0001"));
+        assertTrue(completion.contains("row_order=0"));
+        assertTrue(completion.contains("run_side=parent"));
+    }
+
+    @Test
+    public void visibilityLossIsTerminalBeforeScenarioOrAnchorArm() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        List<String> records = new ArrayList<>();
+        AndroidBenchmarkDiagnostics diagnostics = scriptedDiagnostics(records);
+        diagnostics.sessionLaunch();
+        diagnostics.beginSession(81L);
+
+        diagnostics.benchmarkVisibilityLost();
+        diagnostics.benchmarkScenarioCompleted(81L, 313, 313, true, true, true);
+        diagnostics.emulationStarted(81L);
+        diagnostics.benchmarkAnchorPosted(81L, true);
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.benchmarkPreArmValid(81L));
+        assertFalse(diagnostics.benchmarkAnchorReady(81L));
+        assertFalse(diagnostics.armBenchmark(81L, 71L, TOKEN, readyAudioBaseline()));
+        assertTrue(records.stream().anyMatch(line ->
+                line.startsWith("event=benchmark_invalidated artifact_id=")
+                        && line.contains(" pair_id=pair-0001 ")
+                        && line.contains(" matrix_block=block-0001 ")
+                        && line.contains(" row_order=0 run_side=parent ")
+                        && line.endsWith("session_generation=81"
+                                + " phase=scenario_running reason=visibility_lost")));
+
+        // A replacement in the same runtime remains poisoned even after the old generation is
+        // invalidated. Only a fresh runtime/sessionLaunch may establish continuous visibility.
+        diagnostics.invalidateSession();
+        diagnostics.beginSession(82L);
+        diagnostics.benchmarkScenarioCompleted(82L, 313, 313, true, true, true);
+        diagnostics.emulationStarted(82L);
+        assertEquals("SCENARIO_RUNNING", diagnostics.phaseForTesting());
+        diagnostics.benchmarkAnchorPosted(82L, true);
+        assertFalse(diagnostics.benchmarkAnchorReady(82L));
+        assertFalse(diagnostics.armBenchmark(82L, 72L, TOKEN, readyAudioBaseline()));
+
+        AndroidBenchmarkDiagnostics fresh = scriptedDiagnostics(new ArrayList<>());
+        fresh.sessionLaunch();
+        fresh.beginSession(83L);
+        fresh.benchmarkScenarioCompleted(83L, 313, 313, true, true, true);
+        fresh.emulationStarted(83L);
+        fresh.benchmarkAnchorPosted(83L, true);
+        fresh.audioFocusResult(true);
+        assertTrue(fresh.benchmarkAnchorReady(83L));
+        assertTrue(fresh.armBenchmark(83L, 73L, TOKEN, readyAudioBaseline()));
+    }
+
+    @Test
+    public void loadingVisibilityLossPoisonsTheNextPublishedSessionGeneration() {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        List<String> records = new ArrayList<>();
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "dmg", true, "presentation", true, true, false,
+                "ignored-build", "pair-0001", "block-0001", 0,
+                "parent", "parent", "ignored-device", "thermal", true,
+                "workload-0001", 60);
+        AndroidBenchmarkDiagnostics diagnostics = new AndroidBenchmarkDiagnostics(
+                null, options, records::add, () -> 1_000_000L);
+        diagnostics.sessionLaunch();
+        diagnostics.invalidateSession();
+
+        diagnostics.benchmarkVisibilityLost();
+        diagnostics.beginSession(91L);
+        diagnostics.emulationStarted(91L);
+        diagnostics.benchmarkAnchorPosted(91L, true);
+        diagnostics.audioFocusResult(true);
+
+        assertFalse(diagnostics.benchmarkPreArmValid(91L));
+        assertFalse(diagnostics.benchmarkAnchorReady(91L));
+        assertFalse(diagnostics.armBenchmark(91L, 81L, TOKEN, readyAudioBaseline()));
+        assertTrue(records.stream().anyMatch(line ->
+                line.startsWith("event=benchmark_invalidated artifact_id=")
+                        && line.contains(" pair_id=pair-0001 ")
+                        && line.contains(" matrix_block=block-0001 ")
+                        && line.contains(" row_order=0 run_side=parent ")
+                        && line.endsWith("session_generation=91"
+                                + " phase=idle reason=visibility_lost")));
+    }
+
+    @Test
+    public void productionLengthFinalRecordStaysBelowBoundedUtf8Payload() throws Exception {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        List<String> records = new ArrayList<>();
+        String longToken = "a".repeat(64);
+        String workloadNonce = "b".repeat(48);
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                longToken, "c".repeat(64), "d".repeat(64), 6,
+                "variant", "variant", "e".repeat(64), "f".repeat(64), true,
+                workloadNonce, 120, 9, "performance", "cgb-action-v1");
+        AtomicLong now = new AtomicLong(9_000_000_000_000_000L);
+        AndroidBenchmarkDiagnostics diagnostics = new AndroidBenchmarkDiagnostics(
+                null, options, records::add, () -> now.addAndGet(1_000_000L),
+                "1".repeat(64), "2".repeat(64));
+        diagnostics.sessionLaunch();
+        diagnostics.setWorkloadNonce(workloadNonce);
+        diagnostics.hardwareProfile(new Controller.HardwareProfileEvent(
+                HardwareProfileRegistry.CGB,
+                HardwareProfileRegistry.CGB.identity(), true, false, 2));
+        diagnostics.beginSession(9_999_999_999L);
+        diagnostics.benchmarkScenarioCompleted(
+                9_999_999_999L, 923, 923, true, true, true);
+        diagnostics.emulationStarted(9_999_999_999L);
+        diagnostics.benchmarkAnchorPosted(9_999_999_999L, true);
+        diagnostics.audioFocusResult(true);
+        assertTrue(diagnostics.armBenchmark(
+                9_999_999_999L, 8_888_888_888L, "z".repeat(64),
+                productionLikeAudioBaseline()));
+        for (int frame = 1; frame <= 600; frame++) {
+            diagnostics.frameReady();
+        }
+        diagnostics.benchmarkFrameBoundary(new Controller.BenchmarkFrameBoundaryEvent(
+                600L, true, false, 2, 9_999_999L, 999_999_999L,
+                999_999_999L, Long.MAX_VALUE, Integer.MAX_VALUE,
+                Long.MAX_VALUE, Long.MAX_VALUE));
+        for (int submission = 1; submission <= 600; submission++) {
+            diagnostics.frameSubmitted(submission);
+        }
+        java.lang.reflect.Field terminalStats = AndroidBenchmarkDiagnostics.class
+                .getDeclaredField("audioTerminalStats");
+        terminalStats.setAccessible(true);
+        terminalStats.set(diagnostics, productionLikeAudioStats());
+        diagnostics.benchmarkDrainPosted(true);
+
+        String finalRecord = records.stream()
+                .filter(line -> line.startsWith("event=final_result"))
+                .findFirst()
+                .orElseThrow();
+        String matrixRecord = records.stream()
+                .filter(line -> line.startsWith("event=matrix_run"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(matrixRecord.contains("audio_start_input_events=999999999"));
+        assertFalse(finalRecord.contains("audio_start_input_events="));
+        assertTrue(finalRecord.contains("audio_pcm_input_events=999999999"));
+        assertTrue(finalRecord.getBytes(StandardCharsets.UTF_8).length
+                <= AndroidBenchmarkDiagnostics.MAX_LOG_RECORD_BYTES);
+        for (String record : records) {
+            assertTrue(record.getBytes(StandardCharsets.UTF_8).length
+                    <= AndroidBenchmarkDiagnostics.MAX_LOG_RECORD_BYTES);
+        }
+    }
+
+    private static AndroidAudioSink.AudioBaseline readyAudioBaseline() {
+        return audioBaseline(0L, 0L, true);
+    }
+
+    private static AndroidAudioSink.AudioBaseline productionLikeAudioBaseline() {
+        return new AndroidAudioSink.AudioBaseline(
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                0L, 0L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 999_999_999L,
+                true, true, 48_000, 6, 140_448);
+    }
+
+    private static AndroidAudioSink.Stats productionLikeAudioStats() {
+        return new AndroidAudioSink.Stats(
+                48_000, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, false, true,
+                999_999_999, 999_999_999, 999_999_999,
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 999_999_999L, 999_999_999L,
+                999_999_999L, 999_999_999L, 6,
+                true, true, false, 100,
+                999_999_999L, 999_999_999L, 100, 100, false, 6, 999_999_999);
+    }
+
+    private static AndroidAudioSink.AudioBaseline audioBaseline(
+            long pendingBytes, long queuedBytes, boolean outputPlaying) {
+        return new AndroidAudioSink.AudioBaseline(
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+                pendingBytes, queuedBytes, 0L, 0L, 0L, 0L, 0L, 0L,
+                true, outputPlaying, 48_000, 4_800, 140_448);
     }
 
     private static AndroidBenchmarkDiagnostics newDiagnostics() {
@@ -222,5 +502,16 @@ public class AndroidBenchmarkDiagnosticsTest {
             // Android's JVM stub Log throws without a device/Robolectric.  The benchmark variant
             // still exercises the real compile-time diagnostics branch with this bounded sink.
         }, () -> now.addAndGet(1_000_000L));
+    }
+
+    private static AndroidBenchmarkDiagnostics scriptedDiagnostics(List<String> records) {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                "ignored-build", "pair-0001", "block-0001", 0,
+                "parent", "parent", "ignored-device", "thermal", true,
+                "workload-0001", 60, -1, "performance", "dmg-action-v1");
+        AtomicLong now = new AtomicLong();
+        return new AndroidBenchmarkDiagnostics(
+                null, options, records::add, () -> now.addAndGet(1_000_000L));
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
@@ -8,6 +8,12 @@ import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,6 +47,111 @@ public class AndroidEmulationRuntimeTest {
         assertFalse(AndroidEmulationRuntime.isResetReload(null, true, 11L, 11L));
         assertFalse(AndroidEmulationRuntime.isResetReload(7L, true, 12L, 11L));
         assertFalse(AndroidEmulationRuntime.isResetReload(null, false, 12L, 11L));
+    }
+
+    @Test
+    public void benchmarkEndpointAndAckMustBelongToOneCurrentPresentedSession() {
+        assertTrue(AndroidEmulationRuntime.benchmarkSessionMatches(12L, 12L, 12L, 12L));
+        assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(11L, 12L, 12L, 12L));
+        assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(12L, 11L, 12L, 12L));
+        assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(12L, 12L, 11L, 12L));
+        assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(12L, 12L, 12L, 13L));
+        assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(0L, 0L, 0L, 0L));
+    }
+
+    @Test
+    public void replacementRotatesTheLockedScenarioInputEpoch() {
+        eu.rekawek.coffeegb.core.joypad.PlayerInputHub hub =
+                new eu.rekawek.coffeegb.core.joypad.PlayerInputHub();
+        AndroidInputRouter input = new AndroidInputRouter(hub);
+        try {
+            assertTrue(AndroidEmulationRuntime.resetBenchmarkScenarioInput(input, true));
+            input.setBenchmarkScenarioMask(BenchmarkGameplayScenario.RIGHT_MASK);
+            input.endBenchmarkScenario();
+            assertTrue(input.benchmarkScenarioSourceClosed());
+
+            assertTrue(AndroidEmulationRuntime.resetBenchmarkScenarioInput(input, true));
+            assertFalse(input.benchmarkScenarioSourceClosed());
+            input.setBenchmarkScenarioMask(BenchmarkGameplayScenario.B_MASK);
+            assertEquals(java.util.Set.of(eu.rekawek.coffeegb.core.joypad.Button.B),
+                    hub.sample().buttons(0));
+        } finally {
+            input.close();
+        }
+    }
+
+    @Test
+    public void replacementRejectsAClosedRouterAndCannotClaimSourceClosure() {
+        AndroidInputRouter input = new AndroidInputRouter(
+                new eu.rekawek.coffeegb.core.joypad.PlayerInputHub());
+        input.close();
+
+        assertFalse(AndroidEmulationRuntime.resetBenchmarkScenarioInput(input, true));
+        assertFalse(input.benchmarkScenarioSourceClosed());
+    }
+
+    @Test
+    public void replacementInvalidatesEveryScheduledScenarioCompletionPoll() {
+        assertTrue(AndroidEmulationRuntime.benchmarkCompletionPollMatches(
+                4L, 4L, 21L, 21L, 21L, 21L));
+        assertFalse(AndroidEmulationRuntime.benchmarkCompletionPollMatches(
+                4L, 5L, 21L, 21L, 21L, 21L));
+        assertFalse(AndroidEmulationRuntime.benchmarkCompletionPollMatches(
+                5L, 5L, 21L, 22L, 22L, 22L));
+    }
+
+    @Test
+    public void visibilityLossStopsAScheduledCompletionPollBeforeItCanResumeAudio() {
+        assertTrue(AndroidEmulationRuntime.benchmarkCompletionPollMayTouchAudio(
+                true, 4L, 4L, 21L, 21L, 21L, 21L));
+        // All epoch and generation identities still match, but visibility loss has made the
+        // diagnostic session terminal. The real poll returns at this guard before reading or
+        // resuming AndroidAudioSink.
+        assertFalse(AndroidEmulationRuntime.benchmarkCompletionPollMayTouchAudio(
+                false, 4L, 4L, 21L, 21L, 21L, 21L));
+    }
+
+    @Test
+    public void visibilityPauseWinsWhenItRacesAnInFlightAudioResumePoll() throws Exception {
+        AndroidEmulationRuntime.BenchmarkAudioLifecycleGate gate =
+                new AndroidEmulationRuntime.BenchmarkAudioLifecycleGate();
+        AtomicBoolean outputPlaying = new AtomicBoolean(false);
+        CountDownLatch pollEntered = new CountDownLatch(1);
+        CountDownLatch releasePoll = new CountDownLatch(1);
+        CountDownLatch lossAttempted = new CountDownLatch(1);
+        ExecutorService threads = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> poll = threads.submit(() -> gate.run(() -> {
+                pollEntered.countDown();
+                await(releasePoll);
+                outputPlaying.set(true);
+            }));
+            assertTrue(pollEntered.await(1, TimeUnit.SECONDS));
+            Future<?> visibilityLoss = threads.submit(() -> {
+                lossAttempted.countDown();
+                gate.run(() -> outputPlaying.set(false));
+            });
+            assertTrue(lossAttempted.await(1, TimeUnit.SECONDS));
+            releasePoll.countDown();
+            poll.get(1, TimeUnit.SECONDS);
+            visibilityLoss.get(1, TimeUnit.SECONDS);
+            assertFalse(outputPlaying.get());
+        } finally {
+            releasePoll.countDown();
+            threads.shutdownNow();
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(1, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting for benchmark audio gate test");
+            }
+        } catch (InterruptedException failure) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for benchmark audio gate test",
+                    failure);
+        }
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.android;
 
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.controller.properties.RuntimeWarmupFlavor;
 import eu.rekawek.coffeegb.core.ExecutionMode;
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
@@ -232,6 +233,42 @@ public class AndroidEmulationRuntimeTest {
                 AndroidEmulationRuntime.androidSettingsOverrides(options))) {
             assertEquals(ExecutionMode.PERFORMANCE,
                     properties.getOverrides().getExecutionMode());
+        }
+    }
+
+    @Test
+    public void shadowMeasuredWarmupSelectorIsOnlyNativeCgbPerformanceSilentScenario() {
+        DiagnosticsOptions eligible = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "cgb-action-v1", "silent-pcm-v1");
+        try (EmulatorProperties properties = new EmulatorProperties(
+                AndroidEmulationRuntime.androidSettingsOverrides(eligible))) {
+            assertEquals(RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+                    properties.getOverrides().getRuntimeWarmupFlavor());
+        }
+
+        String[] rejectedHardware = {"dmg", "cgb0"};
+        for (String hardware : rejectedHardware) {
+            DiagnosticsOptions rejected = DiagnosticsOptions.parseValues(
+                    true, hardware, true, "presentation", true, true, false,
+                    null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                    "performance", "cgb-action-v1", "silent-pcm-v1");
+            try (EmulatorProperties properties = new EmulatorProperties(
+                    AndroidEmulationRuntime.androidSettingsOverrides(rejected))) {
+                assertEquals(RuntimeWarmupFlavor.SCALAR,
+                        properties.getOverrides().getRuntimeWarmupFlavor());
+            }
+        }
+
+        DiagnosticsOptions accuracy = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "accuracy", "cgb-action-v1", "silent-pcm-v1");
+        try (EmulatorProperties properties = new EmulatorProperties(
+                AndroidEmulationRuntime.androidSettingsOverrides(accuracy))) {
+            assertEquals(RuntimeWarmupFlavor.SCALAR,
+                    properties.getOverrides().getRuntimeWarmupFlavor());
         }
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidInputRouterTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidInputRouterTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AndroidInputRouterTest {
@@ -65,6 +66,126 @@ public class AndroidInputRouterTest {
         } finally {
             router.close();
         }
+    }
+
+    @Test
+    public void scenarioSourceIsIsolatedAndClearedByMeasurementLock() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            assertTrue(router.beginBenchmarkScenario());
+            router.updateTouchPointer(1, List.of(Button.A));
+            assertTrue(hub.sample().buttons(0).isEmpty());
+
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.RIGHT_MASK);
+            assertEquals(java.util.Set.of(Button.RIGHT), hub.sample().buttons(0));
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.RIGHT_MASK);
+            assertTrue(router.benchmarkScenarioActiveForTesting());
+
+            router.lockBenchmarkWindow();
+            assertTrue(hub.sample().buttons(0).isEmpty());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.START_MASK);
+            assertTrue(hub.sample().buttons(0).isEmpty());
+            router.endBenchmarkScenario();
+            assertTrue(hub.sample().buttons(0).isEmpty());
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void focusLossReleasePreservesActiveScenarioHold() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            assertTrue(router.beginBenchmarkScenario());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.RIGHT_MASK);
+
+            // MainActivity.onWindowFocusChanged(false) delegates to this cleanup.
+            router.releaseAll();
+
+            assertEquals(java.util.Set.of(Button.RIGHT), hub.sample().buttons(0));
+            assertTrue(router.benchmarkScenarioActiveForTesting());
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void lifecycleReleasePreservesHoldUntilScenarioTransition() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            assertTrue(router.beginBenchmarkScenario());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.B_MASK);
+
+            // MainActivity.onStop() may repeat focus cleanup before the next native-frame edge.
+            router.releaseAll();
+            router.releaseAll();
+            assertEquals(java.util.Set.of(Button.B), hub.sample().buttons(0));
+
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.NONE_MASK);
+            assertTrue(hub.sample().buttons(0).isEmpty());
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void replacementResetsMeasuredLockAndAdmitsANewScenarioSource() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            assertTrue(router.beginBenchmarkScenario());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.B_MASK);
+            router.endBenchmarkScenario();
+            assertTrue(router.benchmarkScenarioSourceClosed());
+            assertTrue(router.benchmarkLockedForTesting());
+            assertFalse(router.beginBenchmarkScenario());
+
+            router.resetBenchmarkSession();
+            assertFalse(router.benchmarkScenarioSourceClosed());
+            assertFalse(router.benchmarkLockedForTesting());
+            assertTrue(router.beginBenchmarkScenario());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.START_MASK);
+
+            assertEquals(java.util.Set.of(Button.START), hub.sample().buttons(0));
+            assertFalse(router.benchmarkScenarioSourceClosed());
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void sourceClosureAtomicallyLocksPhysicalInputBeforeArm() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        try {
+            assertFalse(router.benchmarkScenarioSourceClosed());
+            assertTrue(router.beginBenchmarkScenario());
+            router.setBenchmarkScenarioMask(BenchmarkGameplayScenario.RIGHT_MASK);
+
+            router.endBenchmarkScenario();
+            assertTrue(router.benchmarkScenarioSourceClosed());
+            assertTrue(router.benchmarkLockedForTesting());
+            assertTrue(hub.sample().buttons(0).isEmpty());
+
+            // Audio drain and compositor anchoring happen after source closure but before ARM.
+            router.updateTouchPointer(9, List.of(Button.A));
+            assertTrue(hub.sample().buttons(0).isEmpty());
+        } finally {
+            router.close();
+        }
+    }
+
+    @Test
+    public void failedScenarioAdmissionCannotManufactureSourceClosedProof() {
+        PlayerInputHub hub = new PlayerInputHub();
+        AndroidInputRouter router = new AndroidInputRouter(hub);
+        router.close();
+
+        assertFalse(router.beginBenchmarkScenario());
+        assertFalse(router.benchmarkScenarioSourceClosed());
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkGameplayScenarioTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkGameplayScenarioTest.java
@@ -1,0 +1,121 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BenchmarkGameplayScenarioTest {
+
+    @Test
+    public void dmgTimelineUsesPhysicalFrameBoundariesAndEndsReleased() {
+        BenchmarkGameplayScenario scenario = new BenchmarkGameplayScenario(
+                DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1);
+        scenario.beginSession(1L);
+
+        for (int frame = 1; frame < 120; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.START_MASK, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.NONE_MASK, scenario.onFrameReady());
+        for (int frame = 124; frame < 183; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.RIGHT_MASK, scenario.onFrameReady());
+        for (int frame = 184; frame < 303; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.NONE_MASK, scenario.onFrameReady());
+        for (int frame = 304; frame < 313; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertTrue(scenario.pauseRequested());
+        assertFalse(scenario.preconditionReady());
+        assertTrue(scenario.consumePauseRequest());
+        assertFalse(scenario.consumePauseRequest());
+        scenario.markPreconditionReady();
+        assertTrue(scenario.preconditionReady());
+        assertEquals(313, scenario.frameForTesting());
+        assertEquals(BenchmarkGameplayScenario.NONE_MASK, scenario.maskForTesting());
+    }
+
+    @Test
+    public void cgbTimelineHasLongReleasedPrefixAndNoPostEndpointInput() {
+        BenchmarkGameplayScenario scenario = new BenchmarkGameplayScenario(
+                DiagnosticsOptions.BenchmarkScenario.CGB_ACTION_V1);
+        scenario.beginSession(1L);
+        for (int frame = 1; frame < 670; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.B_MASK, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertEquals(BenchmarkGameplayScenario.NONE_MASK, scenario.onFrameReady());
+        for (int frame = 674; frame < 793; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.RIGHT_MASK, scenario.onFrameReady());
+        for (int frame = 794; frame < 913; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.NONE_MASK, scenario.onFrameReady());
+        for (int frame = 914; frame < 923; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        }
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertTrue(scenario.pauseRequested());
+        assertEquals(923, scenario.endpointFrameForTesting());
+        assertTrue(scenario.consumePauseRequest());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+        assertFalse(scenario.consumePauseRequest());
+    }
+
+    @Test
+    public void dmgCompatUsesDmgActionsButOnlyGbcNativeFrameEvents() {
+        BenchmarkGameplayScenario scenario = new BenchmarkGameplayScenario(
+                DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1,
+                BenchmarkGameplayScenario.NativeFrameKind.GBC);
+        scenario.beginSession(41L);
+
+        for (int frame = 1; frame < 120; frame++) {
+            assertEquals(BenchmarkGameplayScenario.UNCHANGED,
+                    scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.GBC, 41L));
+        }
+        assertEquals(119, scenario.frameForTesting());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED,
+                scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.DMG, 41L));
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED,
+                scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.GBC, 40L));
+        assertEquals(119, scenario.frameForTesting());
+        assertEquals(BenchmarkGameplayScenario.START_MASK,
+                scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.GBC, 41L));
+        assertEquals(120, scenario.frameForTesting());
+        assertEquals(313, scenario.endpointFrameForTesting());
+    }
+
+    @Test
+    public void replacementSessionRejectsStaleNativeFrames() {
+        BenchmarkGameplayScenario scenario = new BenchmarkGameplayScenario(
+                DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1);
+        scenario.beginSession(7L);
+        scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.DMG, 7L);
+        scenario.beginSession(8L);
+
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED,
+                scenario.onFrameReady(BenchmarkGameplayScenario.NativeFrameKind.DMG, 7L));
+        assertEquals(0, scenario.frameForTesting());
+        assertFalse(scenario.preconditionReady());
+    }
+
+    @Test
+    public void noneIsReadyWithoutAControllerTimeline() {
+        BenchmarkGameplayScenario scenario = new BenchmarkGameplayScenario(
+                DiagnosticsOptions.BenchmarkScenario.NONE);
+        assertTrue(scenario.preconditionReady());
+        assertEquals(BenchmarkGameplayScenario.UNCHANGED, scenario.onFrameReady());
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
@@ -91,6 +91,7 @@ public final class BenchmarkMatrix {
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
             "first_side", "thermal_window", "audio", "render", "availability",
             "session_generation", "benchmark_generation",
+            "benchmark_token",
             "requested_hardware", "requested_profile", "profile", "effective_gbc",
             "effective_dmg_compat", "effective_mode", "device_id", "speed_mode_initial",
             "build_profile",
@@ -116,7 +117,12 @@ public final class BenchmarkMatrix {
             "audio_start_restarts",
             "audio_start_route_failures",
             "audio_start_output_open", "audio_start_output_playing", "audio_start_sample_rate",
-            "audio_start_queue_capacity_frames", "audio_start_max_frame_bytes");
+            "audio_start_queue_capacity_frames", "audio_start_max_frame_bytes",
+            "audio_start_active", "audio_start_paused", "audio_start_muted",
+            "audio_start_volume", "audio_start_system_volume", "audio_start_system_volume_max",
+            "audio_start_system_music_muted", "audio_start_queued_frames",
+            "audio_start_reopen_pending", "audio_start_output_identity", "audio_start_queue_identity",
+            "benchmark_audio_policy");
     private static final Set<String> SCENARIO_FIELDS = Set.of(
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
             "session_generation", "input_contract", "completed",
@@ -131,6 +137,7 @@ public final class BenchmarkMatrix {
     private static final Set<String> FINAL_FIELDS = Set.of(
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
             "session_generation", "benchmark_generation",
+            "benchmark_token",
             "build_profile",
             "frame", "ready_count", "submitted_count", "dropped_count", "duplicate_count",
             "late_count", "corrupt_count", "ready_first_id", "ready_last_id",
@@ -160,7 +167,14 @@ public final class BenchmarkMatrix {
             "audio_output_open", "audio_output_playing", "audio_muted", "audio_volume",
             "audio_route_failures", "audio_playback_position_frames", "audio_system_volume",
             "audio_system_volume_max", "audio_system_music_muted", "audio_queue_capacity_frames",
-            "audio_max_frame_bytes",
+            "audio_max_frame_bytes", "audio_output_identity", "audio_queue_identity",
+            "benchmark_audio_policy", "benchmark_audio_requested",
+            "benchmark_audio_active_at_boundary", "benchmark_audio_disabled_after",
+            "benchmark_audio_flags", "benchmark_audio_calendar",
+            "benchmark_audio_skipped_ticks", "benchmark_audio_zero_sample_slots",
+            "benchmark_audio_zero_sample_events", "benchmark_audio_max_debt",
+            "benchmark_audio_apu_reads", "benchmark_audio_apu_writes",
+            "benchmark_audio_frame_sequencer_commits", "benchmark_audio_dropped_channel_ticks",
             "audio_start_input_frames",
             "audio_start_input_events", "audio_start_enqueued_bytes",
             "audio_start_enqueued_frames", "audio_start_written_bytes",
@@ -183,6 +197,7 @@ public final class BenchmarkMatrix {
             "interactive_bad_count", "plugged_bad_count", "power_save_bad_count",
             "stay_awake_bad_count", "priority_bad_count", "importance_bad_count",
             "battery_temp_min", "battery_temp_max", "live_input_mutations",
+            "system_audio_sample_count", "system_audio_bad_count",
             "surface_vote_hz", "display_target_hz", "surface_content_rate_millihz",
             "controller_cpu_ms", "controller_util_pct", "gc_count_delta",
             "gc_time_ms_delta", "alloc_bytes_delta");
@@ -197,9 +212,25 @@ public final class BenchmarkMatrix {
             "compositor_histogram_fps",
             "dropped_frames", "late_acquire_frames", "bad_desired_present_frames",
             "display_refresh_hz", "measurement");
+    private static final List<String> EXPANDED_AUDIO_PROOF_FIELDS = List.of(
+            "benchmark_audio_requested", "benchmark_audio_active_at_boundary",
+            "benchmark_audio_disabled_after", "benchmark_audio_skipped_ticks",
+            "benchmark_audio_zero_sample_slots", "benchmark_audio_zero_sample_events",
+            "benchmark_audio_max_debt", "benchmark_audio_apu_reads",
+            "benchmark_audio_apu_writes", "benchmark_audio_frame_sequencer_commits",
+            "benchmark_audio_dropped_channel_ticks");
+    private static final List<String> AUDIO_CALENDAR_COUNTER_FIELDS = List.of(
+            "benchmark_audio_skipped_ticks", "benchmark_audio_zero_sample_slots",
+            "benchmark_audio_zero_sample_events", "benchmark_audio_max_debt",
+            "benchmark_audio_apu_reads", "benchmark_audio_apu_writes",
+            "benchmark_audio_frame_sequencer_commits",
+            "benchmark_audio_dropped_channel_ticks");
     private static final List<Row> REQUIRED_ROWS = List.of(
             Row.DMG, Row.MGB, Row.CGB_NATIVE, Row.CGB0_NATIVE,
             Row.CGB_DMG_COMPAT, Row.SGB, Row.SGB2);
+    /** Silent PCM calendars have only the five DMG/CGB performance rows. */
+    private static final List<Row> SILENT_REQUIRED_ROWS = List.of(
+            Row.DMG, Row.MGB, Row.CGB_NATIVE, Row.CGB0_NATIVE, Row.CGB_DMG_COMPAT);
 
     private BenchmarkMatrix() {
     }
@@ -319,6 +350,8 @@ public final class BenchmarkMatrix {
                     addFinal(fields, lineNumber + 1, runs, errors);
                 } else if ("compositor_result".equals(event)) {
                     addCompositor(fields, lineNumber + 1, runs, errors);
+                } else if ("speed_sample".equals(event)) {
+                    validateSpeedSampleSchema(fields, lineNumber + 1, errors);
                 }
             }
         }
@@ -394,7 +427,7 @@ public final class BenchmarkMatrix {
         System.out.println("accepted=" + report.accepted);
         System.out.println("parent_artifact_id=" + expectedParent
                 + " candidate_artifact_id=" + expectedCandidate);
-        for (Row row : REQUIRED_ROWS) {
+        for (Row row : report.rows.keySet()) {
             RowSummary summary = report.rows.get(row);
             if (summary == null) {
                 continue;
@@ -766,7 +799,8 @@ public final class BenchmarkMatrix {
         // records because acceptance still requires a later valid matrix_run/final_result pair.
         if ("reason".equals(key) && !Set.of("not_anchor_ready", "not_warming",
                 "post_failed", "stale_session", "audio_pending", "audio_not_playing",
-                "audio_focus", "visibility_lost").contains(value)) {
+                "audio_focus", "audio_focus_history", "visibility_lost",
+                "silent_pcm_baseline", "system_audio_unmuted").contains(value)) {
             errors.add("line " + lineNumber + ": invalid benchmark rejection reason");
             return;
         }
@@ -779,6 +813,24 @@ public final class BenchmarkMatrix {
         if ("speed_mode_sample".equals(key)) {
             if (!("boot_resolved".equals(value) || "frame_600".equals(value))) {
                 errors.add("line " + lineNumber + ": invalid speed_mode_sample");
+            }
+            return;
+        }
+        if ("benchmark_audio_policy".equals(key)
+                && !Set.of("canonical", "silent-pcm-v1", "silent-pcm-relaxed-apu-v1")
+                        .contains(value)) {
+            errors.add("line " + lineNumber + ": invalid benchmark audio policy");
+            return;
+        }
+        if ("benchmark_audio_flags".equals(key)) {
+            if (!value.matches("[01]{3}")) {
+                errors.add("line " + lineNumber + ": invalid compact benchmark audio flags");
+            }
+            return;
+        }
+        if ("benchmark_audio_calendar".equals(key)) {
+            if (!value.matches("[0-9]+(,[0-9]+){7}")) {
+                errors.add("line " + lineNumber + ": invalid compact benchmark audio calendar");
             }
             return;
         }
@@ -830,8 +882,14 @@ public final class BenchmarkMatrix {
                 || key.equals("audio_output_open") || key.equals("audio_output_playing")
                 || key.equals("audio_start_output_open")
                 || key.equals("audio_start_output_playing")
+                || key.equals("audio_start_active") || key.equals("audio_start_paused")
+                || key.equals("audio_start_muted") || key.equals("audio_start_system_music_muted")
+                || key.equals("audio_start_reopen_pending")
                 || key.equals("audio_muted") || key.equals("audio_system_music_muted")
-                || key.equals("audio_focus_granted");
+                || key.equals("audio_focus_granted")
+                || key.equals("benchmark_audio_requested")
+                || key.equals("benchmark_audio_active_at_boundary")
+                || key.equals("benchmark_audio_disabled_after");
     }
 
     private static boolean isFloatingField(String key) {
@@ -860,8 +918,20 @@ public final class BenchmarkMatrix {
                 || key.equals("display_state_end") || key.equals("thread_priority_start")
                 || key.equals("thread_priority_end") || key.equals("app_importance_start")
                 || key.equals("app_importance_end") || key.equals("audio_volume")
+                || key.equals("audio_start_volume")
                 || key.equals("audio_system_volume") || key.equals("audio_system_volume_max")
-                || key.equals("audio_route_failures") || key.equals("layer_uid");
+                || key.equals("audio_output_identity") || key.equals("audio_queue_identity")
+                || key.equals("audio_route_failures") || key.equals("layer_uid")
+                || key.equals("benchmark_audio_zero_sample_slots")
+                || key.equals("benchmark_audio_max_debt")
+                || key.equals("benchmark_audio_apu_reads")
+                || key.equals("benchmark_audio_apu_writes")
+                || key.equals("benchmark_audio_frame_sequencer_commits")
+                || key.equals("benchmark_audio_dropped_channel_ticks")
+                || key.equals("audio_start_system_volume")
+                || key.equals("audio_start_system_volume_max")
+                || key.equals("audio_start_output_identity")
+                || key.equals("audio_start_queue_identity");
     }
 
     private static void integerValue(String value, int lineNumber, List<String> errors,
@@ -909,7 +979,13 @@ public final class BenchmarkMatrix {
                     "performance_epoch_count", "performance_epoch_ticks",
                     "performance_epoch_max_ticks", "performance_epoch_raster_fast_ticks",
                     "performance_epoch_mode2_replay_ticks",
-                    "performance_epoch_mode2_bulk_ticks");
+                    "performance_epoch_mode2_bulk_ticks", "benchmark_audio_policy",
+                    "benchmark_audio_requested", "benchmark_audio_active_at_boundary",
+                    "benchmark_audio_disabled_after", "benchmark_audio_skipped_ticks",
+                    "benchmark_audio_zero_sample_slots", "benchmark_audio_zero_sample_events",
+                    "benchmark_audio_max_debt", "benchmark_audio_apu_reads",
+                    "benchmark_audio_apu_writes", "benchmark_audio_frame_sequencer_commits",
+                    "benchmark_audio_dropped_channel_ticks");
             case "first_frame" -> Set.of("event", "frame", "wall_ns", "since_launch_ms",
                     "prep_to_frame_ms");
             case "frames" -> Set.of("event", "frame", "ready_count", "submitted_count",
@@ -920,6 +996,63 @@ public final class BenchmarkMatrix {
                     "configured_buffer_bytes", "actual_buffer_bytes");
             default -> Set.of("event");
         };
+    }
+
+    /** Current speed samples carry the complete audio-policy proof as one atomic schema. */
+    private static void validateSpeedSampleSchema(Map<String, String> fields, int lineNumber,
+            List<String> errors) {
+        if (!fields.containsKey("benchmark_audio_policy")) {
+            return; // pre-policy diagnostic fixtures
+        }
+        String[] required = {
+            "benchmark_audio_policy", "benchmark_audio_requested",
+            "benchmark_audio_active_at_boundary", "benchmark_audio_disabled_after",
+            "benchmark_audio_skipped_ticks", "benchmark_audio_zero_sample_slots",
+            "benchmark_audio_zero_sample_events", "benchmark_audio_max_debt",
+            "benchmark_audio_apu_reads", "benchmark_audio_apu_writes",
+            "benchmark_audio_frame_sequencer_commits",
+            "benchmark_audio_dropped_channel_ticks"
+        };
+        for (String key : required) {
+            if (!fields.containsKey(key)) {
+                errors.add("line " + lineNumber + ": speed_sample is missing " + key);
+            } else if ("benchmark_audio_requested".equals(key)
+                    || "benchmark_audio_active_at_boundary".equals(key)
+                    || "benchmark_audio_disabled_after".equals(key)) {
+                if (!"true".equals(fields.get(key)) && !"false".equals(fields.get(key))) {
+                    errors.add("line " + lineNumber + ": invalid boolean " + key);
+                }
+            } else if (!"benchmark_audio_policy".equals(key)) {
+                integerValue(fields.get(key), lineNumber, errors, key);
+            }
+        }
+        String policy = fields.get("benchmark_audio_policy");
+        if ("canonical".equals(policy)
+                && (!"false".equals(fields.get("benchmark_audio_requested"))
+                || !"false".equals(fields.get("benchmark_audio_active_at_boundary"))
+                || !"true".equals(fields.get("benchmark_audio_disabled_after")))) {
+            errors.add("line " + lineNumber
+                    + ": canonical speed_sample policy flags are not terminal-off");
+        } else if ("canonical".equals(policy)) {
+            for (String key : required) {
+                if (!key.endsWith("policy") && !key.endsWith("requested")
+                        && !key.endsWith("boundary") && !key.endsWith("after")
+                        && !"0".equals(fields.get(key))) {
+                    errors.add("line " + lineNumber
+                            + ": canonical speed_sample calendar counters are not zero");
+                    break;
+                }
+            }
+        } else if ("silent-pcm-v1".equals(policy)
+                && !"0".equals(fields.get("benchmark_audio_dropped_channel_ticks"))) {
+            errors.add("line " + lineNumber + ": exact speed_sample dropped ticks are non-zero");
+        } else if ("silent-pcm-relaxed-apu-v1".equals(policy)
+                && ("0".equals(fields.get("benchmark_audio_skipped_ticks"))
+                || !fields.get("benchmark_audio_dropped_channel_ticks")
+                        .equals(fields.get("benchmark_audio_skipped_ticks")))) {
+            errors.add("line " + lineNumber
+                    + ": relaxed speed_sample dropped ticks must equal positive skipped ticks");
+        }
     }
 
     private static boolean containsForbiddenKey(String key) {
@@ -970,7 +1103,8 @@ public final class BenchmarkMatrix {
         Side runSide = side(fields.get("run_side"), "run_side", lineNumber, errors);
         long sessionGeneration = longValue(
                 fields, "session_generation", lineNumber, errors);
-        if (!"visibility_lost".equals(fields.get("reason"))) {
+        if (!"visibility_lost".equals(fields.get("reason"))
+                && !"system_audio_unmuted".equals(fields.get("reason"))) {
             errors.add("line " + lineNumber
                     + ": benchmark_invalidated has an unsupported reason");
         }
@@ -1046,9 +1180,22 @@ public final class BenchmarkMatrix {
         Side side = side(fields.get("run_side"), "run_side", lineNumber, errors);
         Side firstSide = side(fields.get("first_side"), "first_side", lineNumber, errors);
         int rowOrder = integer(fields, "row_order", lineNumber, errors);
+        String benchmarkToken = fields.getOrDefault("benchmark_token", "unknown");
+        if (!"unknown".equals(benchmarkToken)
+                && !benchmarkToken.matches("[a-z0-9][a-z0-9._-]{15,63}")) {
+            errors.add("line " + lineNumber + ": invalid benchmark token");
+        }
         String requestedProfile = requiredToken(fields, "requested_profile", lineNumber, errors);
         String profile = requiredToken(fields, "profile", lineNumber, errors);
         String executionMode = fields.getOrDefault("execution_mode", "accuracy");
+        String benchmarkAudioPolicy = fields.getOrDefault("benchmark_audio_policy", "canonical");
+        if (!Set.of("canonical", "silent-pcm-v1", "silent-pcm-relaxed-apu-v1")
+                .contains(benchmarkAudioPolicy)) {
+            errors.add("line " + lineNumber + ": invalid benchmark audio policy");
+        }
+        if (!"canonical".equals(benchmarkAudioPolicy) && "unknown".equals(benchmarkToken)) {
+            errors.add("line " + lineNumber + ": silent benchmark token is missing");
+        }
         String workloadNonce = requiredToken(fields, "workload_nonce", lineNumber, errors);
         boolean warmup = booleanValue(fields, "warmup", lineNumber, errors);
         String inputContract = requiredToken(fields, "input_contract", lineNumber, errors);
@@ -1114,8 +1261,10 @@ public final class BenchmarkMatrix {
             errors.add("line " + lineNumber + ": missing render");
             render = "unknown";
         }
-        if (rowOrder < 0 || rowOrder >= REQUIRED_ROWS.size()) {
-            errors.add("line " + lineNumber + ": row_order must be 0..6");
+        int requiredRowCount = "canonical".equals(benchmarkAudioPolicy)
+                ? REQUIRED_ROWS.size() : SILENT_REQUIRED_ROWS.size();
+        if (rowOrder < 0 || rowOrder >= requiredRowCount) {
+            errors.add("line " + lineNumber + ": row_order is outside selected matrix");
         }
         EnvironmentFields environment = parseStartEnvironment(fields, lineNumber, errors);
         AudioStartFields audioStart = parseMatrixAudioStart(fields, lineNumber, errors);
@@ -1160,7 +1309,7 @@ public final class BenchmarkMatrix {
                 render, !unavailable, environment, workloadNonce, warmup, inputContract,
                 surfaceVoteHz, displayTargetHz, surfaceContentRateMillihz, sessionGeneration,
                 benchmarkGeneration, scenarioSessionGeneration, scenarioCompletedFrames,
-                scenarioExpectedFrames, audioStart));
+                scenarioExpectedFrames, audioStart, benchmarkAudioPolicy, benchmarkToken));
     }
 
     private static void addFrame(Map<String, String> fields, int lineNumber,
@@ -1210,6 +1359,11 @@ public final class BenchmarkMatrix {
             }
             long sessionGeneration = longValue(fields, "session_generation", lineNumber, errors);
             long benchmarkGeneration = longValue(fields, "benchmark_generation", lineNumber, errors);
+            String benchmarkToken = fields.getOrDefault("benchmark_token", "unknown");
+            if (!"unknown".equals(benchmarkToken)
+                    && !benchmarkToken.matches("[a-z0-9][a-z0-9._-]{15,63}")) {
+                errors.add("line " + lineNumber + ": invalid benchmark token");
+            }
             String requestedProfile = requiredToken(fields, "requested_profile", lineNumber, errors);
             String profile = requiredToken(fields, "profile", lineNumber, errors);
             Boolean effectiveGbc = strictBoolean(fields, "effective_gbc", lineNumber, errors);
@@ -1252,6 +1406,10 @@ public final class BenchmarkMatrix {
             // counters but may omit that duplicated 21-field block to stay below Android's log
             // payload cliff. Older fixtures which repeat it remain accepted and are cross-bound.
             AudioFields audio = parseAudio(fields, lineNumber, errors, run.audioStart);
+            if (audio != null && !"canonical".equals(audio.benchmarkAudioPolicy)
+                    && "unknown".equals(benchmarkToken)) {
+                errors.add("line " + lineNumber + ": silent benchmark token is missing");
+            }
             if (!requestedProfileMatches(requestedProfile, profile)) {
                 errors.add("line " + lineNumber
                         + ": final requested profile does not match actual profile");
@@ -1262,6 +1420,7 @@ public final class BenchmarkMatrix {
                     scenarioCompletedFrames, scenarioExpectedFrames,
                     Boolean.TRUE.equals(scenarioSourceClosed),
                     Boolean.TRUE.equals(scenarioAudioDrained),
+                    benchmarkToken,
                     requestedProfile, profile, effectiveGbc, effectiveDmgCompat,
                     effectiveMode, executionMode, speedModeInitial, speedModeFinal, clock, deviceId, start, end,
                     audio,
@@ -1303,7 +1462,9 @@ public final class BenchmarkMatrix {
                     integer(fields, "battery_temp_min", lineNumber, errors),
                     integer(fields, "battery_temp_max", lineNumber, errors),
                     integer(fields, "live_input_mutations", lineNumber, errors), surfaceVoteHz,
-                    displayTargetHz, surfaceContentRateMillihz);
+                    displayTargetHz, surfaceContentRateMillihz,
+                    optionalLong(fields, "system_audio_sample_count"),
+                    optionalLong(fields, "system_audio_bad_count"));
         }
     }
 
@@ -1387,12 +1548,25 @@ public final class BenchmarkMatrix {
     private static Report finish(Map<String, RunBuilder> runs, List<String> errors,
             long seed, int resamples, String expectedParentArtifact,
             String expectedCandidateArtifact) {
+        Set<String> benchmarkAudioPolicies = new LinkedHashSet<>();
+        for (RunBuilder run : runs.values()) {
+            benchmarkAudioPolicies.add(run.benchmarkAudioPolicy);
+        }
+        if (benchmarkAudioPolicies.size() > 1) {
+            errors.add("mixed benchmark audio policies");
+        }
+        String selectedAudioPolicy = benchmarkAudioPolicies.isEmpty()
+                ? "canonical" : benchmarkAudioPolicies.iterator().next();
+        List<Row> requiredRows = "canonical".equals(selectedAudioPolicy)
+                ? REQUIRED_ROWS : SILENT_REQUIRED_ROWS;
         LinkedHashMap<Row, List<RunBuilder>> byRow = new LinkedHashMap<>();
-        for (Row row : REQUIRED_ROWS) {
+        for (Row row : requiredRows) {
             byRow.put(row, new ArrayList<>());
         }
         validateEventIntervals(runs.values(), errors);
-        List<BlockSummary> completeBlocks = validateBlocks(runs.values(), errors);
+        List<BlockSummary> completeBlocks = validateBlocks(runs.values(), errors, requiredRows);
+        validateRowOrderPermutations(runs.values(), errors, requiredRows);
+        validateObservedRowOrder(runs.values(), errors, requiredRows);
         Set<String> completeBlockNames = new LinkedHashSet<>();
         for (BlockSummary block : completeBlocks) {
             completeBlockNames.add(block.name);
@@ -1416,7 +1590,7 @@ public final class BenchmarkMatrix {
             if (run.row == Row.CGB0_DMG_COMPAT && run.available) {
                 errors.add(run.key + " is diagnostic-only cgb0-dmg-compat and cannot be measured");
             }
-            if (run.row != null && REQUIRED_ROWS.contains(run.row) && run.available
+            if (run.row != null && requiredRows.contains(run.row) && run.available
                     && completeBlockNames.contains(run.matrixBlock)) {
                 byRow.get(run.row).add(run);
             }
@@ -1467,11 +1641,11 @@ public final class BenchmarkMatrix {
             errors.add("mixed audio requests");
         }
 
-        validateRandomizedOrder(completeBlocks, errors);
+        validateRandomizedOrder(completeBlocks, errors, requiredRows);
         validateWorkloadNonces(runs.values(), completeBlocks, errors);
 
         LinkedHashMap<Row, RowSummary> summaries = new LinkedHashMap<>();
-        for (Row row : REQUIRED_ROWS) {
+        for (Row row : requiredRows) {
             List<RunBuilder> rowRuns = byRow.get(row);
             List<Pair> pairs = pairRuns(row, rowRuns, errors);
             if (pairs.size() < MIN_PAIRS) {
@@ -1482,7 +1656,7 @@ public final class BenchmarkMatrix {
             }
         }
 
-        for (Row row : REQUIRED_ROWS) {
+        for (Row row : requiredRows) {
             if (byRow.get(row).isEmpty()) {
                 boolean explicitUnavailable = hasExplicitUnavailable(runs.values(), row);
                 errors.add(explicitUnavailable
@@ -1497,13 +1671,13 @@ public final class BenchmarkMatrix {
                 && expectedCandidateArtifact != null;
         boolean targetAudioEligible = true;
         for (RunBuilder run : runs.values()) {
-            if (run.available && run.row != null && REQUIRED_ROWS.contains(run.row)) {
+            if (run.available && run.row != null && requiredRows.contains(run.row)) {
                 targetAudioEligible &= run.audioTargetEligible;
             }
         }
         boolean accepted = errors.isEmpty() && pinnedArtifacts && visiblePresentation
-                && summaries.size() == REQUIRED_ROWS.size() && targetAudioEligible;
-        boolean valid = errors.isEmpty() && summaries.size() == REQUIRED_ROWS.size();
+                && summaries.size() == requiredRows.size() && targetAudioEligible;
+        boolean valid = errors.isEmpty() && summaries.size() == requiredRows.size();
         for (RowSummary summary : summaries.values()) {
             accepted &= summary.lowerBoundPass && !summary.alarm && !summary.regression;
         }
@@ -1513,7 +1687,7 @@ public final class BenchmarkMatrix {
     }
 
     private static void validateRandomizedOrder(List<BlockSummary> blocks,
-            List<String> errors) {
+            List<String> errors, List<Row> requiredRows) {
         if (blocks.size() < MIN_PAIRS) {
             errors.add("fewer than " + MIN_PAIRS + " complete matrix blocks");
         }
@@ -1527,7 +1701,7 @@ public final class BenchmarkMatrix {
             signatures.add(block.rowSignature);
         }
         if (blocks.size() > 1 && signatures.size() < 2) {
-            errors.add("seven-row order was not randomized between blocks");
+            errors.add(requiredRows.size() + "-row order was not randomized between blocks");
         }
     }
 
@@ -1574,7 +1748,7 @@ public final class BenchmarkMatrix {
     }
 
     private static List<BlockSummary> validateBlocks(Iterable<RunBuilder> runs,
-            List<String> errors) {
+            List<String> errors, List<Row> requiredRows) {
         Map<String, BlockState> states = new LinkedHashMap<>();
         ArrayList<RunBuilder> orderedRuns = new ArrayList<>();
         for (RunBuilder run : runs) {
@@ -1601,18 +1775,19 @@ public final class BenchmarkMatrix {
         for (BlockState state : states.values()) {
             state.runs.sort(Comparator.comparingInt(run -> run.ingestionOrdinal));
             boolean ok = true;
-            if (state.byRow.size() != REQUIRED_ROWS.size()
-                    || !state.byRow.keySet().containsAll(REQUIRED_ROWS)
-                    || state.runs.size() != REQUIRED_ROWS.size() * 2) {
+            if (state.byRow.size() != requiredRows.size()
+                    || !state.byRow.keySet().containsAll(requiredRows)
+                    || state.runs.size() != requiredRows.size() * 2) {
                 errors.add("matrix block " + state.name
-                        + " does not contain exactly one parent/candidate pair for seven rows");
+                        + " does not contain exactly one parent/candidate pair for "
+                        + requiredRows.size() + " rows");
                 ok = false;
             }
-            ok &= validateObservedSequence(state, errors);
+            ok &= validateObservedSequence(state, errors, requiredRows);
             Side firstSide = null;
             int firstOrdinal = Integer.MAX_VALUE;
             ArrayList<RunBuilder> firstRows = new ArrayList<>();
-            for (Row row : REQUIRED_ROWS) {
+            for (Row row : requiredRows) {
                 List<RunBuilder> rowRuns = state.byRow.get(row);
                 if (rowRuns == null || rowRuns.size() != 2) {
                     ok = false;
@@ -1679,12 +1854,13 @@ public final class BenchmarkMatrix {
         return complete;
     }
 
-    private static boolean validateObservedSequence(BlockState state, List<String> errors) {
-        if (state.runs.size() != REQUIRED_ROWS.size() * 2) {
+    private static boolean validateObservedSequence(BlockState state, List<String> errors,
+            List<Row> requiredRows) {
+        if (state.runs.size() != requiredRows.size() * 2) {
             return false;
         }
         boolean ok = true;
-        for (int rowOrder = 0; rowOrder < REQUIRED_ROWS.size(); rowOrder++) {
+        for (int rowOrder = 0; rowOrder < requiredRows.size(); rowOrder++) {
             RunBuilder first = state.runs.get(rowOrder * 2);
             RunBuilder second = state.runs.get(rowOrder * 2 + 1);
             if (first.rowOrder != rowOrder || second.rowOrder != rowOrder
@@ -1753,7 +1929,7 @@ public final class BenchmarkMatrix {
     }
 
     private static void validateRowOrderPermutations(Iterable<RunBuilder> runs,
-            List<String> errors) {
+            List<String> errors, List<Row> requiredRows) {
         Map<String, Map<Integer, Row>> rowsByBlock = new LinkedHashMap<>();
         for (RunBuilder run : runs) {
             if (!run.available || run.row == null) {
@@ -1768,27 +1944,32 @@ public final class BenchmarkMatrix {
             }
         }
         for (Map.Entry<String, Map<Integer, Row>> entry : rowsByBlock.entrySet()) {
-            if (entry.getValue().size() != REQUIRED_ROWS.size()
-                    || !entry.getValue().keySet().containsAll(Set.of(0, 1, 2, 3, 4, 5, 6))) {
+            Set<Integer> expectedOrders = new LinkedHashSet<>();
+            for (int order = 0; order < requiredRows.size(); order++) {
+                expectedOrders.add(order);
+            }
+            if (entry.getValue().size() != requiredRows.size()
+                    || !entry.getValue().keySet().containsAll(expectedOrders)) {
                 errors.add("matrix block " + entry.getKey()
-                        + " does not contain a seven-row order permutation");
+                        + " does not contain a " + requiredRows.size()
+                        + "-row order permutation");
             }
         }
         Set<String> signatures = new LinkedHashSet<>();
         for (Map<Integer, Row> rowSlots : rowsByBlock.values()) {
             StringBuilder signature = new StringBuilder();
-            for (int rowOrder = 0; rowOrder < REQUIRED_ROWS.size(); rowOrder++) {
+            for (int rowOrder = 0; rowOrder < requiredRows.size(); rowOrder++) {
                 signature.append(rowSlots.get(rowOrder)).append('/');
             }
             signatures.add(signature.toString());
         }
         if (rowsByBlock.size() > 1 && signatures.size() < 2) {
-            errors.add("seven-row order was not randomized between blocks");
+            errors.add(requiredRows.size() + "-row order was not randomized between blocks");
         }
     }
 
     private static void validateObservedRowOrder(Iterable<RunBuilder> runs,
-            List<String> errors) {
+            List<String> errors, List<Row> requiredRows) {
         Map<String, Map<Row, RunBuilder>> firstByRowByBlock = new LinkedHashMap<>();
         for (RunBuilder run : runs) {
             if (!run.available || run.row == null) {
@@ -1804,10 +1985,10 @@ public final class BenchmarkMatrix {
         for (Map.Entry<String, Map<Row, RunBuilder>> entry : firstByRowByBlock.entrySet()) {
             List<RunBuilder> firstRows = new ArrayList<>(entry.getValue().values());
             firstRows.sort(Comparator.comparingInt(run -> run.ingestionOrdinal));
-            if (firstRows.size() != REQUIRED_ROWS.size()) {
+            if (firstRows.size() != requiredRows.size()) {
                 continue;
             }
-            for (int expectedOrder = 0; expectedOrder < REQUIRED_ROWS.size(); expectedOrder++) {
+            for (int expectedOrder = 0; expectedOrder < requiredRows.size(); expectedOrder++) {
                 RunBuilder observed = firstRows.get(expectedOrder);
                 if (observed.rowOrder != expectedOrder) {
                     errors.add("matrix block " + entry.getKey()
@@ -1880,6 +2061,7 @@ public final class BenchmarkMatrix {
                     || !parent.thermalWindow.equals(candidate.thermalWindow)
                     || !parent.requestedProfile.equals(candidate.requestedProfile)
                     || !parent.profile.equals(candidate.profile)
+                    || !parent.benchmarkToken.equals(candidate.benchmarkToken)
                     || parent.effectiveGbc != candidate.effectiveGbc
                     || parent.effectiveDmgCompat != candidate.effectiveDmgCompat
                     || !parent.effectiveMode.equals(candidate.effectiveMode)
@@ -1966,7 +2148,8 @@ public final class BenchmarkMatrix {
                 && parent.maximumFrameBytes == candidate.maximumFrameBytes
                 && parent.systemVolume == candidate.systemVolume
                 && parent.systemVolumeMax == candidate.systemVolumeMax
-                && parent.systemMusicMuted.equals(candidate.systemMusicMuted);
+                && parent.systemMusicMuted.equals(candidate.systemMusicMuted)
+                && parent.benchmarkAudioPolicy.equals(candidate.benchmarkAudioPolicy);
     }
 
     private static boolean memoryWithinTolerance(long first, long second) {
@@ -1995,6 +2178,7 @@ public final class BenchmarkMatrix {
         if (!run.artifactId.equals(result.artifactId)
                 || run.sessionGeneration != result.sessionGeneration
                 || run.benchmarkGeneration != result.benchmarkGeneration
+                || !run.benchmarkToken.equals(result.benchmarkToken)
                 || run.scenarioSessionGeneration != result.scenarioSessionGeneration
                 || run.scenarioCompletedFrames != result.scenarioCompletedFrames
                 || run.scenarioExpectedFrames != result.scenarioExpectedFrames
@@ -2016,9 +2200,12 @@ public final class BenchmarkMatrix {
                 || run.displayTargetHz != result.displayTargetHz
                 || run.surfaceContentRateMillihz != result.surfaceContentRateMillihz
                 || !run.environment.equals(result.environmentStart)
+                || result.audio == null
+                || !run.benchmarkAudioPolicy.equals(result.audio.benchmarkAudioPolicy)
                 || (run.audioStart != null && !run.audioStart.equals(audioStart(result.audio)))) {
             errors.add(run.key + " final evidence does not match matrix_run");
         }
+        validateSystemAudioProof(run, result, errors);
         if (!validScenarioCompletion(run.row, result.inputContract, result.sessionGeneration,
                 result.scenarioSessionGeneration, result.scenarioCompleted,
                 result.scenarioCompletedFrames, result.scenarioExpectedFrames,
@@ -2133,6 +2320,30 @@ public final class BenchmarkMatrix {
                     || !close(result.presentationIntervalFps, submissionFps)) {
                 errors.add(run.key + " reports an inexact interval FPS");
             }
+        }
+    }
+
+    private static void validateSystemAudioProof(RunBuilder run, FinalFields result,
+            List<String> errors) {
+        long samples = result.systemAudioSampleCount;
+        long bad = result.systemAudioBadCount;
+        if (samples < 0L && bad < 0L) {
+            if ("canonical".equals(run.benchmarkAudioPolicy)) {
+                return; // legacy canonical fixture without the compact proof
+            }
+            errors.add(run.key + " silent run is missing system-audio proof");
+            return;
+        }
+        if (samples < 0L || bad < 0L) {
+            errors.add(run.key + " has an incomplete system-audio proof");
+            return;
+        }
+        if ("canonical".equals(run.benchmarkAudioPolicy)) {
+            if (samples != 0L || bad != 0L) {
+                errors.add(run.key + " canonical system-audio counters are not zero");
+            }
+        } else if (samples != 12L || bad != 0L) {
+            errors.add(run.key + " silent system-audio proof must be 12/0");
         }
     }
 
@@ -2552,6 +2763,36 @@ public final class BenchmarkMatrix {
             List<String> errors, AudioStartFields inheritedStart) {
         AudioStartFields inlineStart = parseMatrixAudioStart(fields, lineNumber, errors);
         AudioStartFields start = inlineStart == null ? inheritedStart : inlineStart;
+        boolean expandedProofPresent = EXPANDED_AUDIO_PROOF_FIELDS.stream()
+                .anyMatch(fields::containsKey);
+        if (expandedProofPresent && !fields.keySet().containsAll(EXPANDED_AUDIO_PROOF_FIELDS)) {
+            errors.add("line " + lineNumber
+                    + ": expanded benchmark audio proof must be all-or-none");
+        }
+        if (expandedProofPresent) {
+            for (String key : AUDIO_CALENDAR_COUNTER_FIELDS) {
+                if (optionalLong(fields, key) < 0L) {
+                    errors.add("line " + lineNumber
+                            + ": expanded benchmark audio calendar must be nonnegative");
+                    break;
+                }
+            }
+        }
+        CompactAudioProof compact = parseCompactAudioProof(fields, lineNumber, errors);
+        Boolean requested = compact == null ? (fields.containsKey("benchmark_audio_requested")
+                ? strictBoolean(fields, "benchmark_audio_requested", lineNumber, errors) : false)
+                : compact.requested;
+        Boolean activeAtBoundary = compact == null
+                ? (fields.containsKey("benchmark_audio_active_at_boundary")
+                        ? strictBoolean(fields, "benchmark_audio_active_at_boundary", lineNumber,
+                                errors) : false)
+                : compact.activeAtBoundary;
+        Boolean disabledAfter = compact == null
+                ? (fields.containsKey("benchmark_audio_disabled_after")
+                        ? strictBoolean(fields, "benchmark_audio_disabled_after", lineNumber, errors)
+                        : false)
+                : compact.disabledAfter;
+        long[] calendar = compact == null ? null : compact.calendar;
         return new AudioFields(
                 strictBoolean(fields, "audio_active", lineNumber, errors),
                 integer(fields, "audio_sample_rate", lineNumber, errors),
@@ -2585,6 +2826,8 @@ public final class BenchmarkMatrix {
                 strictBoolean(fields, "audio_system_music_muted", lineNumber, errors),
                 integer(fields, "audio_queue_capacity_frames", lineNumber, errors),
                 integer(fields, "audio_max_frame_bytes", lineNumber, errors),
+                optionalLong(fields, "audio_output_identity"),
+                optionalLong(fields, "audio_queue_identity"),
                 start == null ? -1L : start.inputEvents,
                 start == null ? -1L : start.inputFrames,
                 start == null ? -1L : start.enqueuedBytes,
@@ -2606,9 +2849,84 @@ public final class BenchmarkMatrix {
                 start == null ? -1 : start.sampleRate,
                 start == null ? -1 : start.queueCapacityFrames,
                 start == null ? -1 : start.maximumFrameBytes,
+                start == null ? null : start.active,
+                start == null ? null : start.paused,
+                start == null ? null : start.muted,
+                start == null ? -1 : start.volume,
+                start == null ? -1 : start.systemVolume,
+                start == null ? -1 : start.systemVolumeMax,
+                start == null ? null : start.systemMusicMuted,
+                start == null ? -1 : start.queuedFrames,
+                start == null ? null : start.reopenPending,
+                start == null ? -1L : start.outputIdentity,
+                start == null ? -1L : start.queueIdentity,
                 strictBoolean(fields, "audio_focus_granted", lineNumber, errors),
                 longValue(fields, "audio_focus_start_loss_count", lineNumber, errors),
-                longValue(fields, "audio_focus_loss_count", lineNumber, errors));
+                longValue(fields, "audio_focus_loss_count", lineNumber, errors),
+                fields.getOrDefault("benchmark_audio_policy", "canonical"),
+                requested,
+                activeAtBoundary,
+                disabledAfter,
+                calendar == null ? optionalLong(fields, "benchmark_audio_skipped_ticks") : calendar[0],
+                calendar == null ? optionalLong(fields, "benchmark_audio_zero_sample_slots") : calendar[1],
+                calendar == null ? optionalLong(fields, "benchmark_audio_zero_sample_events") : calendar[2],
+                calendar == null ? optionalLong(fields, "benchmark_audio_max_debt") : calendar[3],
+                calendar == null ? optionalLong(fields, "benchmark_audio_apu_reads") : calendar[4],
+                calendar == null ? optionalLong(fields, "benchmark_audio_apu_writes") : calendar[5],
+                calendar == null ? optionalLong(fields, "benchmark_audio_frame_sequencer_commits") : calendar[6],
+                calendar == null ? optionalLong(fields, "benchmark_audio_dropped_channel_ticks") : calendar[7]);
+    }
+
+    /** Decodes compact final-result policy proof while retaining legacy expanded fields. */
+    private static CompactAudioProof parseCompactAudioProof(Map<String, String> fields,
+            int lineNumber, List<String> errors) {
+        String flagsValue = fields.get("benchmark_audio_flags");
+        String calendarValue = fields.get("benchmark_audio_calendar");
+        if (flagsValue == null && calendarValue == null) {
+            return null;
+        }
+        boolean expandedProofPresent = EXPANDED_AUDIO_PROOF_FIELDS.stream()
+                .anyMatch(fields::containsKey);
+        if (expandedProofPresent) {
+            errors.add("line " + lineNumber
+                    + ": compact and expanded benchmark audio proofs cannot be mixed");
+            return null;
+        }
+        if (flagsValue == null || calendarValue == null) {
+            errors.add("line " + lineNumber + ": compact benchmark audio proof is incomplete");
+            return null;
+        }
+        if (!flagsValue.matches("[01]{3}")) {
+            errors.add("line " + lineNumber + ": invalid compact benchmark audio flags");
+            return null;
+        }
+        boolean requested = flagsValue.charAt(0) == '1';
+        boolean activeAtBoundary = flagsValue.charAt(1) == '1';
+        boolean disabledAfter = flagsValue.charAt(2) == '1';
+        String[] parts = calendarValue.split(",", -1);
+        long[] calendar = new long[8];
+        if (parts.length != calendar.length) {
+            errors.add("line " + lineNumber + ": compact benchmark audio calendar has wrong width");
+            return null;
+        }
+        for (int index = 0; index < calendar.length; index++) {
+            if (!parts[index].matches("[0-9]+")) {
+                errors.add("line " + lineNumber
+                        + ": invalid compact benchmark audio calendar");
+                return null;
+            }
+            try {
+                calendar[index] = Long.parseLong(parts[index]);
+            } catch (NumberFormatException malformed) {
+                errors.add("line " + lineNumber + ": invalid compact benchmark audio calendar");
+                return null;
+            }
+        }
+        return new CompactAudioProof(requested, activeAtBoundary, disabledAfter, calendar);
+    }
+
+    private record CompactAudioProof(boolean requested, boolean activeAtBoundary,
+            boolean disabledAfter, long[] calendar) {
     }
 
     /**
@@ -2642,7 +2960,27 @@ public final class BenchmarkMatrix {
                 strictBoolean(fields, "audio_start_output_playing", lineNumber, errors),
                 integer(fields, "audio_start_sample_rate", lineNumber, errors),
                 integer(fields, "audio_start_queue_capacity_frames", lineNumber, errors),
-                integer(fields, "audio_start_max_frame_bytes", lineNumber, errors));
+                integer(fields, "audio_start_max_frame_bytes", lineNumber, errors),
+                fields.containsKey("audio_start_active")
+                        ? strictBoolean(fields, "audio_start_active", lineNumber, errors) : null,
+                fields.containsKey("audio_start_paused")
+                        ? strictBoolean(fields, "audio_start_paused", lineNumber, errors) : null,
+                fields.containsKey("audio_start_muted")
+                        ? strictBoolean(fields, "audio_start_muted", lineNumber, errors) : null,
+                fields.containsKey("audio_start_volume")
+                        ? integer(fields, "audio_start_volume", lineNumber, errors) : -1,
+                fields.containsKey("audio_start_system_volume")
+                        ? integer(fields, "audio_start_system_volume", lineNumber, errors) : -1,
+                fields.containsKey("audio_start_system_volume_max")
+                        ? integer(fields, "audio_start_system_volume_max", lineNumber, errors) : -1,
+                fields.containsKey("audio_start_system_music_muted")
+                        ? strictBoolean(fields, "audio_start_system_music_muted", lineNumber, errors) : null,
+                fields.containsKey("audio_start_queued_frames")
+                        ? integer(fields, "audio_start_queued_frames", lineNumber, errors) : -1,
+                fields.containsKey("audio_start_reopen_pending")
+                        ? strictBoolean(fields, "audio_start_reopen_pending", lineNumber, errors) : null,
+                optionalLong(fields, "audio_start_output_identity"),
+                optionalLong(fields, "audio_start_queue_identity"));
     }
 
     private static AudioStartFields audioStart(AudioFields audio) {
@@ -2654,7 +2992,10 @@ public final class BenchmarkMatrix {
                 audio.startUnderruns, audio.startOutputUnderruns, audio.startRestarts,
                 audio.startRouteFailures, audio.startOutputOpen, audio.startOutputPlaying,
                 audio.startSampleRate, audio.startQueueCapacityFrames,
-                audio.startMaximumFrameBytes);
+                audio.startMaximumFrameBytes, audio.startActive, audio.startPaused,
+                audio.startMuted, audio.startVolume, audio.startSystemVolume,
+                audio.startSystemVolumeMax, audio.startSystemMusicMuted, audio.startQueuedFrames,
+                audio.startReopenPending, audio.startOutputIdentity, audio.startQueueIdentity);
     }
 
     private static Row recomputeRow(String profile, Boolean effectiveGbc,
@@ -2925,7 +3266,64 @@ public final class BenchmarkMatrix {
         } catch (ArithmeticException overflow) {
             return false;
         }
-        return audio.sampleRate > 0 && audio.startSampleRate == audio.sampleRate
+        boolean exactSilentPolicy = "silent-pcm-v1".equals(audio.benchmarkAudioPolicy);
+        boolean relaxedSilentPolicy = "silent-pcm-relaxed-apu-v1".equals(
+                audio.benchmarkAudioPolicy);
+        boolean silentPolicy = exactSilentPolicy || relaxedSilentPolicy;
+        boolean canonicalCalendarAbsent = audio.benchmarkAudioSkippedTicks < 0L
+                && audio.benchmarkAudioZeroSampleSlots < 0L
+                && audio.benchmarkAudioZeroSampleEvents < 0L
+                && audio.benchmarkAudioMaxDebt < 0L
+                && audio.benchmarkAudioApuReads < 0L
+                && audio.benchmarkAudioApuWrites < 0L
+                && audio.benchmarkAudioFrameSequencerCommits < 0L
+                && audio.benchmarkAudioDroppedChannelTicks < 0L;
+        boolean canonicalCalendarZero = canonicalCalendarAbsent
+                || Boolean.FALSE.equals(audio.benchmarkAudioRequested)
+                && Boolean.FALSE.equals(audio.benchmarkAudioActiveAtBoundary)
+                && Boolean.TRUE.equals(audio.benchmarkAudioDisabledAfterBoundary)
+                && audio.benchmarkAudioSkippedTicks == 0L
+                && audio.benchmarkAudioZeroSampleSlots == 0L
+                && audio.benchmarkAudioZeroSampleEvents == 0L
+                && audio.benchmarkAudioMaxDebt == 0L
+                && audio.benchmarkAudioApuReads == 0L
+                && audio.benchmarkAudioApuWrites == 0L
+                && audio.benchmarkAudioFrameSequencerCommits == 0L
+                && audio.benchmarkAudioDroppedChannelTicks == 0L;
+        boolean policyProof = !silentPolicy
+                ? "canonical".equals(audio.benchmarkAudioPolicy) && canonicalCalendarZero
+                : Boolean.TRUE.equals(audio.benchmarkAudioRequested)
+                && Boolean.TRUE.equals(audio.benchmarkAudioActiveAtBoundary)
+                && Boolean.TRUE.equals(audio.benchmarkAudioDisabledAfterBoundary)
+                && audio.benchmarkAudioSkippedTicks > 0L
+                && audio.benchmarkAudioZeroSampleSlots > 0L
+                && audio.benchmarkAudioZeroSampleEvents > 0L
+                && audio.benchmarkAudioMaxDebt > 0L
+                && audio.benchmarkAudioApuReads >= 0L
+                && audio.benchmarkAudioApuWrites >= 0L
+                && audio.benchmarkAudioFrameSequencerCommits > 0L
+                && (exactSilentPolicy
+                        ? audio.benchmarkAudioDroppedChannelTicks == 0L
+                        : audio.benchmarkAudioDroppedChannelTicks
+                                == audio.benchmarkAudioSkippedTicks
+                                && audio.benchmarkAudioDroppedChannelTicks > 0L);
+        boolean silentBaseline = !silentPolicy || audio.startActive != null
+                && Boolean.TRUE.equals(audio.startActive)
+                && Boolean.FALSE.equals(audio.startPaused)
+                && Boolean.FALSE.equals(audio.startMuted)
+                && audio.startVolume == 100
+                && audio.startSystemVolume == 0
+                && audio.startSystemVolumeMax > 0
+                && Boolean.TRUE.equals(audio.startSystemMusicMuted)
+                && audio.startQueuedFrames == 0
+                && Boolean.FALSE.equals(audio.startReopenPending)
+                && audio.startOutputIdentity > 0L
+                && audio.startQueueIdentity > 0L
+                && audio.startInputEvents > 0L
+                && audio.startWrittenBytes > 0L
+                && audio.startWrittenFrames > 0L;
+        return policyProof && silentBaseline
+                && audio.sampleRate > 0 && audio.startSampleRate == audio.sampleRate
                 && (!requireRealtime || (overruns == 0L && underruns == 0L
                 && outputUnderruns == 0L && restarts == 0L))
                 && writeFailures == 0L && discardedBytes == 0L && routeFailures == 0L
@@ -2934,9 +3332,17 @@ public final class BenchmarkMatrix {
                 && Boolean.TRUE.equals(audio.startOutputPlaying)
                 && Boolean.TRUE.equals(audio.outputOpen)
                 && Boolean.TRUE.equals(audio.outputPlaying)
-                && Boolean.FALSE.equals(audio.muted) && audio.volume > 0 && audio.volume <= 100
-                && audio.systemVolume > 0 && audio.systemVolumeMax >= audio.systemVolume
-                && Boolean.FALSE.equals(audio.systemMusicMuted)
+                && Boolean.FALSE.equals(audio.muted)
+                && (silentPolicy ? audio.volume == 100 : audio.volume > 0 && audio.volume <= 100)
+                && (silentPolicy
+                        ? audio.systemVolume == 0 && audio.systemVolumeMax > 0
+                                && Boolean.TRUE.equals(audio.systemMusicMuted)
+                                && audio.audioOutputIdentity > 0L
+                                && audio.audioQueueIdentity > 0L
+                                && audio.audioOutputIdentity == audio.startOutputIdentity
+                                && audio.audioQueueIdentity == audio.startQueueIdentity
+                        : audio.systemVolume > 0 && audio.systemVolumeMax >= audio.systemVolume
+                                && Boolean.FALSE.equals(audio.systemMusicMuted))
                 && Boolean.TRUE.equals(audio.focusGranted) && focusLosses == 0L
                 && audio.playbackPositionFrames > audio.startPlaybackPositionFrames
                 && audio.minimumBufferBytes > 0 && audio.configuredBufferBytes > 0
@@ -3204,6 +3610,8 @@ public final class BenchmarkMatrix {
         final long scenarioSessionGeneration;
         final int scenarioCompletedFrames;
         final int scenarioExpectedFrames;
+        final String benchmarkAudioPolicy;
+        final String benchmarkToken;
         final List<Long> readyIds = new ArrayList<>();
         final List<Long> readyNanos = new ArrayList<>();
         final List<Long> submissionIds = new ArrayList<>();
@@ -3224,7 +3632,7 @@ public final class BenchmarkMatrix {
                 int displayTargetHz, int surfaceContentRateMillihz, long sessionGeneration,
                 long benchmarkGeneration, long scenarioSessionGeneration,
                 int scenarioCompletedFrames, int scenarioExpectedFrames,
-                AudioStartFields audioStart) {
+                AudioStartFields audioStart, String benchmarkAudioPolicy, String benchmarkToken) {
             this.key = key;
             this.ingestionOrdinal = ingestionOrdinal;
             this.artifactId = artifactId;
@@ -3260,6 +3668,8 @@ public final class BenchmarkMatrix {
             this.scenarioSessionGeneration = scenarioSessionGeneration;
             this.scenarioCompletedFrames = scenarioCompletedFrames;
             this.scenarioExpectedFrames = scenarioExpectedFrames;
+            this.benchmarkAudioPolicy = benchmarkAudioPolicy;
+            this.benchmarkToken = benchmarkToken;
         }
     }
 
@@ -3267,6 +3677,7 @@ public final class BenchmarkMatrix {
             long scenarioSessionGeneration, boolean scenarioCompleted,
             int scenarioCompletedFrames, int scenarioExpectedFrames,
             boolean scenarioSourceClosed, boolean scenarioAudioDrained,
+            String benchmarkToken,
             String requestedProfile, String profile,
             Boolean effectiveGbc, Boolean effectiveDmgCompat, String effectiveMode,
             String executionMode,
@@ -3286,7 +3697,8 @@ public final class BenchmarkMatrix {
             int interactiveBadCount, int pluggedBadCount, int powerSaveBadCount,
             int stayAwakeBadCount, int priorityBadCount, int importanceBadCount,
             int batteryTempMin, int batteryTempMax, int liveInputMutations, int surfaceVoteHz,
-            int displayTargetHz, int surfaceContentRateMillihz) {
+            int displayTargetHz, int surfaceContentRateMillihz,
+            long systemAudioSampleCount, long systemAudioBadCount) {
     }
 
     private record EnvironmentFields(int thermalStatus, int batteryTemperatureDeciC,
@@ -3316,9 +3728,10 @@ public final class BenchmarkMatrix {
             long enqueuedFrames, long writtenBytes, long writtenFrames, long writeFailures,
             long discardedBytes, long pendingBytes, long queuedBytes, int queueFrames,
             Boolean outputOpen, Boolean outputPlaying, Boolean muted, int volume,
-                long routeFailures, long playbackPositionFrames, int systemVolume,
-                int systemVolumeMax, Boolean systemMusicMuted, int queueCapacityFrames,
-                int maximumFrameBytes, long startInputEvents, long startInputFrames,
+            long routeFailures, long playbackPositionFrames, int systemVolume,
+            int systemVolumeMax, Boolean systemMusicMuted, int queueCapacityFrames,
+            int maximumFrameBytes, long audioOutputIdentity, long audioQueueIdentity,
+            long startInputEvents, long startInputFrames,
                 long startEnqueuedBytes,
                 long startEnqueuedFrames, long startWrittenBytes, long startWrittenFrames,
                 long startWriteFailures, long startDiscardedBytes, long startPendingBytes,
@@ -3326,8 +3739,18 @@ public final class BenchmarkMatrix {
                 long startUnderruns, long startOutputUnderruns,
                 long startRestarts, long startRouteFailures, Boolean startOutputOpen,
                 Boolean startOutputPlaying, int startSampleRate, int startQueueCapacityFrames,
-                int startMaximumFrameBytes, Boolean focusGranted, long focusStartLossCount,
-                long focusLossCount) {
+                int startMaximumFrameBytes, Boolean startActive, Boolean startPaused,
+                Boolean startMuted, int startVolume, int startSystemVolume,
+                int startSystemVolumeMax, Boolean startSystemMusicMuted, int startQueuedFrames,
+                Boolean startReopenPending, long startOutputIdentity, long startQueueIdentity,
+                Boolean focusGranted, long focusStartLossCount,
+                long focusLossCount, String benchmarkAudioPolicy,
+                Boolean benchmarkAudioRequested, Boolean benchmarkAudioActiveAtBoundary,
+                Boolean benchmarkAudioDisabledAfterBoundary, long benchmarkAudioSkippedTicks,
+                long benchmarkAudioZeroSampleSlots, long benchmarkAudioZeroSampleEvents,
+                long benchmarkAudioMaxDebt, long benchmarkAudioApuReads,
+                long benchmarkAudioApuWrites, long benchmarkAudioFrameSequencerCommits,
+                long benchmarkAudioDroppedChannelTicks) {
     }
 
     private record AudioStartFields(long inputEvents, long inputFrames, long enqueuedBytes,
@@ -3335,7 +3758,10 @@ public final class BenchmarkMatrix {
             long discardedBytes, long pendingBytes, long queuedBytes, long playbackPositionFrames,
             long overruns, long underruns, long outputUnderruns, long restarts,
             long routeFailures, Boolean outputOpen, Boolean outputPlaying, int sampleRate,
-            int queueCapacityFrames, int maximumFrameBytes) {
+            int queueCapacityFrames, int maximumFrameBytes, Boolean active, Boolean paused,
+            Boolean muted, int volume, int systemVolume, int systemVolumeMax,
+            Boolean systemMusicMuted, int queuedFrames, Boolean reopenPending,
+            long outputIdentity, long queueIdentity) {
     }
 
     private record CompositorFields(String artifactId, String deviceId, long benchmarkGeneration,

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -70,17 +71,26 @@ public final class BenchmarkMatrix {
 
     private static final Pattern SAFE_TOKEN = Pattern.compile("[a-z0-9][a-z0-9._-]{0,63}");
     private static final Set<String> INTERESTING_EVENTS = Set.of(
-            "matrix_run", "frame_ready", "frame_submitted", "final_result",
+            "scenario_complete", "matrix_run", "frame_ready", "frame_submitted", "final_result",
             "compositor_result");
     private static final Set<String> BENIGN_EVENTS = Set.of(
             "session_launch", "rom_open_start", "recent_missing", "hardware_profile",
             "emulation_started", "warmup_complete", "benchmark_arm",
-            "benchmark_arm_rejected", "benchmark_anchor", "speed_sample", "first_frame", "frames",
+            "benchmark_arm_rejected", "benchmark_anchor", "benchmark_invalidated",
+            "speed_sample", "first_frame", "frames",
             "audio_output");
+    private static final Set<String> INPUT_CONTRACTS = Set.of(
+            "none", "dmg-action-v1", "cgb-action-v1");
+    private static final Set<String> ENVIRONMENT_START_FIELDS = Set.of(
+            "thermal_start", "battery_temp_start", "display_refresh_start_millihz",
+            "display_state_start", "interactive_start", "plugged_start", "power_save_start",
+            "stay_awake_start", "stay_on_plugged_mask_start", "thread_priority_start",
+            "app_importance_start", "system_load_start_milli", "cpu_count_start",
+            "memory_available_start_bytes");
     private static final Set<String> MATRIX_FIELDS = Set.of(
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
             "first_side", "thermal_window", "audio", "render", "availability",
-            "benchmark_generation",
+            "session_generation", "benchmark_generation",
             "requested_hardware", "requested_profile", "profile", "effective_gbc",
             "effective_dmg_compat", "effective_mode", "device_id", "speed_mode_initial",
             "build_profile",
@@ -92,6 +102,9 @@ public final class BenchmarkMatrix {
             "stay_on_plugged_mask_start", "thread_priority_start", "app_importance_start",
             "system_load_start_milli", "cpu_count_start", "memory_available_start_bytes",
             "workload_nonce", "warmup", "input_contract", "surface_vote_hz",
+            "scenario_session_generation", "scenario_completed",
+            "scenario_completed_frames", "scenario_expected_frames",
+            "scenario_source_closed", "scenario_audio_drained",
             "display_target_hz", "surface_content_rate_millihz",
             "audio_start_input_events", "audio_start_enqueued_bytes",
             "audio_start_input_frames",
@@ -99,10 +112,15 @@ public final class BenchmarkMatrix {
             "audio_start_written_frames", "audio_start_write_failures",
             "audio_start_discarded_bytes", "audio_start_pending_bytes",
             "audio_start_queued_bytes", "audio_start_playback_position_frames",
-            "audio_start_overruns", "audio_start_underruns", "audio_start_restarts",
+            "audio_start_overruns", "audio_start_underruns", "audio_start_track_underruns",
+            "audio_start_restarts",
             "audio_start_route_failures",
             "audio_start_output_open", "audio_start_output_playing", "audio_start_sample_rate",
             "audio_start_queue_capacity_frames", "audio_start_max_frame_bytes");
+    private static final Set<String> SCENARIO_FIELDS = Set.of(
+            "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
+            "session_generation", "input_contract", "completed",
+            "completed_frames", "expected_frames", "source_closed", "audio_drained");
     private static final Set<String> FRAME_READY_FIELDS = Set.of(
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
             "benchmark_generation",
@@ -112,7 +130,7 @@ public final class BenchmarkMatrix {
             "submission_id", "submission_ns");
     private static final Set<String> FINAL_FIELDS = Set.of(
             "event", "artifact_id", "pair_id", "matrix_block", "row_order", "run_side",
-            "benchmark_generation",
+            "session_generation", "benchmark_generation",
             "build_profile",
             "frame", "ready_count", "submitted_count", "dropped_count", "duplicate_count",
             "late_count", "corrupt_count", "ready_first_id", "ready_last_id",
@@ -123,7 +141,9 @@ public final class BenchmarkMatrix {
             "speed_mode_initial", "speed_mode_final", "clock_ticks_num", "clock_ticks_den",
             "execution_mode",
             "clock_frames_num", "clock_frames_den", "clock_ticks_frame",
-            "workload_nonce", "warmup", "input_contract",
+            "workload_nonce", "warmup", "input_contract", "scenario_session_generation",
+            "scenario_completed", "scenario_completed_frames", "scenario_expected_frames",
+            "scenario_source_closed", "scenario_audio_drained",
             "drain_success",
             "speed_mode_sample",
             "thermal_start", "thermal_end", "battery_temp_start", "battery_temp_end",
@@ -253,6 +273,8 @@ public final class BenchmarkMatrix {
             String expectedParentArtifact, String expectedCandidateArtifact) {
         List<String> errors = new BoundedErrors();
         LinkedHashMap<String, RunBuilder> runs = new LinkedHashMap<>();
+        List<BenchmarkInvalidation> invalidations = new ArrayList<>();
+        ScenarioCompletion pendingScenario = null;
         if (resamples < BOOTSTRAP_RESAMPLES) {
             errors.add("bootstrap resamples must be at least " + BOOTSTRAP_RESAMPLES);
         }
@@ -274,7 +296,20 @@ public final class BenchmarkMatrix {
                     continue;
                 }
                 String event = fields.get("event");
-                if ("matrix_run".equals(event)) {
+                if ("benchmark_invalidated".equals(event)) {
+                    invalidations.add(parseBenchmarkInvalidation(
+                            fields, lineNumber + 1, errors));
+                } else if ("scenario_complete".equals(event)) {
+                    ScenarioCompletion scenario = parseScenarioCompletion(
+                            fields, lineNumber + 1, errors);
+                    if (pendingScenario != null) {
+                        errors.add("line " + (lineNumber + 1)
+                                + ": scenario_complete was not consumed by a matrix_run");
+                    }
+                    pendingScenario = scenario;
+                } else if ("matrix_run".equals(event)) {
+                    pendingScenario = consumeScenarioCompletion(
+                            fields, lineNumber + 1, pendingScenario, errors);
                     addMatrixRun(fields, lineNumber + 1, runs, errors);
                 } else if ("frame_ready".equals(event)) {
                     addFrame(fields, lineNumber + 1, runs, true, errors);
@@ -287,6 +322,11 @@ public final class BenchmarkMatrix {
                 }
             }
         }
+        if (pendingScenario != null) {
+            errors.add("line " + pendingScenario.ordinal
+                    + ": scenario_complete has no following matrix_run");
+        }
+        rejectInvalidatedRuns(runs.values(), invalidations, errors);
         if (errors instanceof BoundedErrors bounded) {
             bounded.beginStructuralPhase();
         }
@@ -716,14 +756,17 @@ public final class BenchmarkMatrix {
             return;
         }
         if ("phase".equals(key)) {
-            if (!Set.of("warming", "anchor_ready", "armed", "core_frozen",
+            if (!Set.of("scenario_running", "warming", "anchor_ready", "armed", "core_frozen",
                     "submissions_complete", "done", "idle").contains(value)) {
                 errors.add("line " + lineNumber + ": invalid benchmark phase");
             }
             return;
         }
+        // Rejections are terminal for that individual attempt. They remain benign aggregate
+        // records because acceptance still requires a later valid matrix_run/final_result pair.
         if ("reason".equals(key) && !Set.of("not_anchor_ready", "not_warming",
-                "post_failed").contains(value)) {
+                "post_failed", "stale_session", "audio_pending", "audio_not_playing",
+                "audio_focus", "visibility_lost").contains(value)) {
             errors.add("line " + lineNumber + ": invalid benchmark rejection reason");
             return;
         }
@@ -775,6 +818,10 @@ public final class BenchmarkMatrix {
 
     private static boolean isBooleanField(String key) {
         return key.equals("audio") || key.equals("warmup") || key.equals("effective_gbc")
+                || key.equals("completed") || key.equals("source_closed")
+                || key.equals("audio_drained") || key.equals("scenario_completed")
+                || key.equals("scenario_source_closed")
+                || key.equals("scenario_audio_drained")
                 || key.equals("effective_dmg_compat") || key.equals("interactive_start")
                 || key.equals("interactive_end") || key.equals("power_save_start")
                 || key.equals("power_save_end") || key.equals("stay_awake_start")
@@ -795,6 +842,7 @@ public final class BenchmarkMatrix {
 
     private static boolean isNumericField(String key) {
         return key.equals("frame") || key.equals("row_order") || key.equals("benchmark_generation")
+                || key.equals("session_generation")
                 || key.endsWith("_ns")
                 || key.endsWith("_ms") || key.endsWith("_bytes") || key.endsWith("_frames")
                 || key.endsWith("_count") || key.endsWith("_events")
@@ -827,6 +875,7 @@ public final class BenchmarkMatrix {
 
     private static Set<String> allowedFields(String event) {
         return switch (event) {
+            case "scenario_complete" -> SCENARIO_FIELDS;
             case "matrix_run" -> MATRIX_FIELDS;
             case "frame_ready" -> FRAME_READY_FIELDS;
             case "frame_submitted" -> FRAME_SUBMITTED_FIELDS;
@@ -842,6 +891,7 @@ public final class BenchmarkMatrix {
                     "clock_ticks_num", "clock_ticks_den", "clock_frames_num",
                     "clock_frames_den", "clock_ticks_frame", "device_id");
             case "emulation_started" -> Set.of("event", "wall_ns", "prep_ms",
+                    "session_generation",
                     "requested_hardware", "profile", "effective_gbc", "effective_dmg_compat",
                     "effective_mode", "speed_mode_initial", "speed_mode_sample",
                     "clock_ticks_num", "clock_ticks_den", "clock_frames_num",
@@ -850,9 +900,16 @@ public final class BenchmarkMatrix {
             case "benchmark_arm" -> Set.of("event", "generation", "token", "phase");
             case "benchmark_arm_rejected" -> Set.of("event", "phase", "reason");
             case "benchmark_anchor" -> Set.of("event", "success", "phase", "reason");
+            case "benchmark_invalidated" -> Set.of(
+                    "event", "artifact_id", "pair_id", "matrix_block", "row_order",
+                    "run_side", "session_generation", "phase", "reason");
             case "speed_sample" -> Set.of("event", "frame", "effective_gbc",
                     "effective_dmg_compat", "speed_mode_final", "speed_mode_sample",
-                    "performance_bulk_spans", "performance_bulk_ticks");
+                    "performance_bulk_spans", "performance_bulk_ticks",
+                    "performance_epoch_count", "performance_epoch_ticks",
+                    "performance_epoch_max_ticks", "performance_epoch_raster_fast_ticks",
+                    "performance_epoch_mode2_replay_ticks",
+                    "performance_epoch_mode2_bulk_ticks");
             case "first_frame" -> Set.of("event", "frame", "wall_ns", "since_launch_ms",
                     "prep_to_frame_ms");
             case "frames" -> Set.of("event", "frame", "ready_count", "submitted_count",
@@ -874,6 +931,106 @@ public final class BenchmarkMatrix {
                 || key.endsWith("_payload");
     }
 
+    private static ScenarioCompletion parseScenarioCompletion(Map<String, String> fields,
+            int lineNumber, List<String> errors) {
+        String artifactId = artifactToken(fields, "artifact_id", lineNumber, errors);
+        String pairId = requiredToken(fields, "pair_id", lineNumber, errors);
+        String matrixBlock = requiredToken(fields, "matrix_block", lineNumber, errors);
+        int rowOrder = integer(fields, "row_order", lineNumber, errors);
+        Side runSide = side(fields.get("run_side"), "run_side", lineNumber, errors);
+        long sessionGeneration = longValue(fields, "session_generation", lineNumber, errors);
+        String inputContract = requiredToken(fields, "input_contract", lineNumber, errors);
+        Boolean completed = strictBoolean(fields, "completed", lineNumber, errors);
+        int completedFrames = integer(fields, "completed_frames", lineNumber, errors);
+        int expectedFrames = integer(fields, "expected_frames", lineNumber, errors);
+        Boolean sourceClosed = strictBoolean(fields, "source_closed", lineNumber, errors);
+        Boolean audioDrained = strictBoolean(fields, "audio_drained", lineNumber, errors);
+        int contractFrames = expectedScenarioFrames(inputContract);
+        if (artifactId == null || pairId == null || matrixBlock == null || rowOrder < 0
+                || runSide == null || sessionGeneration <= 0L || inputContract == null
+                || !Boolean.TRUE.equals(completed)
+                || contractFrames <= 0 || completedFrames != contractFrames
+                || expectedFrames != contractFrames
+                || !Boolean.TRUE.equals(sourceClosed) || !Boolean.TRUE.equals(audioDrained)) {
+            errors.add("line " + lineNumber
+                    + ": scenario_complete is not exact, closed, and audio-drained");
+        }
+        return new ScenarioCompletion(artifactId, pairId, matrixBlock, rowOrder, runSide,
+                sessionGeneration, inputContract, completedFrames, expectedFrames,
+                Boolean.TRUE.equals(completed), Boolean.TRUE.equals(sourceClosed),
+                Boolean.TRUE.equals(audioDrained), lineNumber);
+    }
+
+    private static BenchmarkInvalidation parseBenchmarkInvalidation(
+            Map<String, String> fields, int lineNumber, List<String> errors) {
+        String artifactId = artifactToken(fields, "artifact_id", lineNumber, errors);
+        String pairId = requiredToken(fields, "pair_id", lineNumber, errors);
+        String matrixBlock = requiredToken(fields, "matrix_block", lineNumber, errors);
+        int rowOrder = integer(fields, "row_order", lineNumber, errors);
+        Side runSide = side(fields.get("run_side"), "run_side", lineNumber, errors);
+        long sessionGeneration = longValue(
+                fields, "session_generation", lineNumber, errors);
+        if (!"visibility_lost".equals(fields.get("reason"))) {
+            errors.add("line " + lineNumber
+                    + ": benchmark_invalidated has an unsupported reason");
+        }
+        return new BenchmarkInvalidation(artifactId, pairId, matrixBlock, rowOrder,
+                runSide, sessionGeneration, lineNumber);
+    }
+
+    private static void rejectInvalidatedRuns(Iterable<RunBuilder> runs,
+            List<BenchmarkInvalidation> invalidations, List<String> errors) {
+        for (BenchmarkInvalidation invalidation : invalidations) {
+            for (RunBuilder run : runs) {
+                if (invalidation.sessionGeneration == run.sessionGeneration
+                        && invalidation.rowOrder == run.rowOrder
+                        && invalidation.runSide == run.side
+                        && Objects.equals(invalidation.artifactId, run.artifactId)
+                        && Objects.equals(invalidation.pairId, run.pairId)
+                        && Objects.equals(invalidation.matrixBlock, run.matrixBlock)) {
+                    errors.add(run.key + " was invalidated by host visibility loss at line "
+                            + invalidation.ordinal);
+                }
+            }
+        }
+    }
+
+    private static ScenarioCompletion consumeScenarioCompletion(Map<String, String> fields,
+            int lineNumber, ScenarioCompletion pending, List<String> errors) {
+        String inputContract = fields.get("input_contract");
+        String artifactId = fields.get("artifact_id");
+        String pairId = fields.get("pair_id");
+        String matrixBlock = fields.get("matrix_block");
+        int rowOrder = integer(fields, "row_order", lineNumber, errors);
+        Side runSide = Side.fromExternalValue(fields.get("run_side"));
+        long sessionGeneration = optionalLong(fields, "scenario_session_generation");
+        if ("none".equals(inputContract)) {
+            if (pending != null) {
+                errors.add("line " + lineNumber
+                        + ": no-input row has unexpected scenario_complete evidence");
+            }
+            return null;
+        }
+        if (pending == null) {
+            errors.add("line " + lineNumber
+                    + ": scripted row is missing scenario_complete evidence");
+        } else if (pending.inputContract == null
+                || !pending.inputContract.equals(inputContract)) {
+            errors.add("line " + lineNumber
+                    + ": scenario_complete input contract does not match matrix_run");
+        } else if (sessionGeneration <= 0L || pending.sessionGeneration != sessionGeneration) {
+            errors.add("line " + lineNumber
+                    + ": scenario_complete session generation does not match matrix_run");
+        } else if (!Objects.equals(pending.artifactId, artifactId)
+                || !Objects.equals(pending.pairId, pairId)
+                || !Objects.equals(pending.matrixBlock, matrixBlock)
+                || pending.rowOrder != rowOrder || pending.runSide != runSide) {
+            errors.add("line " + lineNumber
+                    + ": scenario_complete run identity does not match matrix_run");
+        }
+        return null;
+    }
+
     private static void addMatrixRun(Map<String, String> fields, int lineNumber,
             Map<String, RunBuilder> runs, List<String> errors) {
         String artifactId = artifactToken(fields, "artifact_id", lineNumber, errors);
@@ -882,6 +1039,7 @@ public final class BenchmarkMatrix {
         }
         String pairId = requiredToken(fields, "pair_id", lineNumber, errors);
         String block = requiredToken(fields, "matrix_block", lineNumber, errors);
+        long sessionGeneration = longValue(fields, "session_generation", lineNumber, errors);
         long benchmarkGeneration = longValue(fields, "benchmark_generation", lineNumber, errors);
         String device = deviceToken(fields, "device_id", lineNumber, errors);
         String thermalWindow = requiredToken(fields, "thermal_window", lineNumber, errors);
@@ -894,6 +1052,17 @@ public final class BenchmarkMatrix {
         String workloadNonce = requiredToken(fields, "workload_nonce", lineNumber, errors);
         boolean warmup = booleanValue(fields, "warmup", lineNumber, errors);
         String inputContract = requiredToken(fields, "input_contract", lineNumber, errors);
+        long scenarioSessionGeneration = longValue(
+                fields, "scenario_session_generation", lineNumber, errors);
+        Boolean scenarioCompleted = strictBoolean(fields, "scenario_completed", lineNumber, errors);
+        int scenarioCompletedFrames = integer(
+                fields, "scenario_completed_frames", lineNumber, errors);
+        int scenarioExpectedFrames = integer(
+                fields, "scenario_expected_frames", lineNumber, errors);
+        Boolean scenarioSourceClosed = strictBoolean(
+                fields, "scenario_source_closed", lineNumber, errors);
+        Boolean scenarioAudioDrained = strictBoolean(
+                fields, "scenario_audio_drained", lineNumber, errors);
         Boolean effectiveGbc = strictBoolean(fields, "effective_gbc", lineNumber, errors);
         Boolean effectiveDmgCompat = strictBoolean(fields, "effective_dmg_compat", lineNumber, errors);
         String effectiveMode = requiredToken(fields, "effective_mode", lineNumber, errors);
@@ -955,13 +1124,25 @@ public final class BenchmarkMatrix {
                 || requestedProfile == null || profile == null || effectiveMode == null
                 || effectiveGbc == null || effectiveDmgCompat == null || environment == null
                 || speedModeInitial < 1 || clock == null || workloadNonce == null
-                || benchmarkGeneration <= 0L
+                || sessionGeneration <= 0L || benchmarkGeneration <= 0L
                 || inputContract == null || surfaceVoteHz < 60 || displayTargetHz < 60
                 || surfaceContentRateMillihz <= 0) {
             return;
         }
-        if (!warmup || !"none".equals(inputContract)) {
-            errors.add("line " + lineNumber + ": run lacks required warmup/no-input contract");
+        if (!warmup || !INPUT_CONTRACTS.contains(inputContract)) {
+            errors.add("line " + lineNumber + ": run lacks a supported warmup/input contract");
+        }
+        if (!validScenarioCompletion(row, inputContract, sessionGeneration,
+                scenarioSessionGeneration,
+                scenarioCompleted,
+                scenarioCompletedFrames, scenarioExpectedFrames, scenarioSourceClosed,
+                scenarioAudioDrained)) {
+            errors.add("line " + lineNumber
+                    + ": matrix_run scenario completion does not match its hardware row");
+        }
+        if (audio && "presentation".equals(render) && !validArmAudioBaseline(audioStart)) {
+            errors.add("line " + lineNumber
+                    + ": audio arm baseline is not drained and playing");
         }
         String key = runKey(pairId, side, block, rowOrder);
         if (runs.containsKey(key)) {
@@ -977,8 +1158,9 @@ public final class BenchmarkMatrix {
                 effectiveGbc, effectiveDmgCompat, effectiveMode, executionMode,
                 speedModeInitial, clock, audio,
                 render, !unavailable, environment, workloadNonce, warmup, inputContract,
-                surfaceVoteHz, displayTargetHz, surfaceContentRateMillihz, benchmarkGeneration,
-                audioStart));
+                surfaceVoteHz, displayTargetHz, surfaceContentRateMillihz, sessionGeneration,
+                benchmarkGeneration, scenarioSessionGeneration, scenarioCompletedFrames,
+                scenarioExpectedFrames, audioStart));
     }
 
     private static void addFrame(Map<String, String> fields, int lineNumber,
@@ -1026,6 +1208,7 @@ public final class BenchmarkMatrix {
             if (!"benchmark".equals(fields.get("build_profile"))) {
                 errors.add("line " + lineNumber + ": benchmark build profile is missing or invalid");
             }
+            long sessionGeneration = longValue(fields, "session_generation", lineNumber, errors);
             long benchmarkGeneration = longValue(fields, "benchmark_generation", lineNumber, errors);
             String requestedProfile = requiredToken(fields, "requested_profile", lineNumber, errors);
             String profile = requiredToken(fields, "profile", lineNumber, errors);
@@ -1045,16 +1228,41 @@ public final class BenchmarkMatrix {
             String workloadNonce = requiredToken(fields, "workload_nonce", lineNumber, errors);
             boolean warmup = booleanValue(fields, "warmup", lineNumber, errors);
             String inputContract = requiredToken(fields, "input_contract", lineNumber, errors);
+            long scenarioSessionGeneration = longValue(
+                    fields, "scenario_session_generation", lineNumber, errors);
+            Boolean scenarioCompleted = strictBoolean(
+                    fields, "scenario_completed", lineNumber, errors);
+            int scenarioCompletedFrames = integer(
+                    fields, "scenario_completed_frames", lineNumber, errors);
+            int scenarioExpectedFrames = integer(
+                    fields, "scenario_expected_frames", lineNumber, errors);
+            Boolean scenarioSourceClosed = strictBoolean(
+                    fields, "scenario_source_closed", lineNumber, errors);
+            Boolean scenarioAudioDrained = strictBoolean(
+                    fields, "scenario_audio_drained", lineNumber, errors);
             Boolean drainSuccess = strictBoolean(fields, "drain_success", lineNumber, errors);
-            EnvironmentFields start = parseStartEnvironment(fields, lineNumber, errors);
+            // Current records inherit matrix_run's immutable sample to retain Android payload
+            // headroom. Legacy records may repeat it, but the block is all-or-none and must bind
+            // exactly instead of allowing contradictory evidence to be silently ignored.
+            EnvironmentFields legacyStart = parseOptionalStartEnvironment(
+                    fields, lineNumber, errors);
+            EnvironmentFields start = legacyStart == null ? run.environment : legacyStart;
             EnvironmentFields end = parseEndEnvironment(fields, lineNumber, errors);
-            AudioFields audio = parseAudio(fields, lineNumber, errors);
+            // matrix_run owns the ARM-time audio baseline. final_result retains terminal audio
+            // counters but may omit that duplicated 21-field block to stay below Android's log
+            // payload cliff. Older fixtures which repeat it remain accepted and are cross-bound.
+            AudioFields audio = parseAudio(fields, lineNumber, errors, run.audioStart);
             if (!requestedProfileMatches(requestedProfile, profile)) {
                 errors.add("line " + lineNumber
                         + ": final requested profile does not match actual profile");
             }
             run.finalFields = new FinalFields(
-                    artifactId, benchmarkGeneration, requestedProfile, profile, effectiveGbc, effectiveDmgCompat,
+                    artifactId, sessionGeneration, benchmarkGeneration,
+                    scenarioSessionGeneration, Boolean.TRUE.equals(scenarioCompleted),
+                    scenarioCompletedFrames, scenarioExpectedFrames,
+                    Boolean.TRUE.equals(scenarioSourceClosed),
+                    Boolean.TRUE.equals(scenarioAudioDrained),
+                    requestedProfile, profile, effectiveGbc, effectiveDmgCompat,
                     effectiveMode, executionMode, speedModeInitial, speedModeFinal, clock, deviceId, start, end,
                     audio,
                     integer(fields, "frame", lineNumber, errors),
@@ -1785,7 +1993,13 @@ public final class BenchmarkMatrix {
         }
         FinalFields result = run.finalFields;
         if (!run.artifactId.equals(result.artifactId)
+                || run.sessionGeneration != result.sessionGeneration
                 || run.benchmarkGeneration != result.benchmarkGeneration
+                || run.scenarioSessionGeneration != result.scenarioSessionGeneration
+                || run.scenarioCompletedFrames != result.scenarioCompletedFrames
+                || run.scenarioExpectedFrames != result.scenarioExpectedFrames
+                || !result.scenarioCompleted || !result.scenarioSourceClosed
+                || !result.scenarioAudioDrained
                 || !run.requestedProfile.equals(result.requestedProfile)
                 || !run.profile.equals(result.profile)
                 || run.effectiveGbc != result.effectiveGbc
@@ -1804,6 +2018,12 @@ public final class BenchmarkMatrix {
                 || !run.environment.equals(result.environmentStart)
                 || (run.audioStart != null && !run.audioStart.equals(audioStart(result.audio)))) {
             errors.add(run.key + " final evidence does not match matrix_run");
+        }
+        if (!validScenarioCompletion(run.row, result.inputContract, result.sessionGeneration,
+                result.scenarioSessionGeneration, result.scenarioCompleted,
+                result.scenarioCompletedFrames, result.scenarioExpectedFrames,
+                result.scenarioSourceClosed, result.scenarioAudioDrained)) {
+            errors.add(run.key + " final scenario completion does not match its hardware row");
         }
         Row finalRow = recomputeRow(result.profile, result.effectiveGbc,
                 result.effectiveDmgCompat);
@@ -2275,6 +2495,19 @@ public final class BenchmarkMatrix {
         return parseEnvironment(fields, "start", lineNumber, errors);
     }
 
+    private static EnvironmentFields parseOptionalStartEnvironment(Map<String, String> fields,
+            int lineNumber, List<String> errors) {
+        boolean any = ENVIRONMENT_START_FIELDS.stream().anyMatch(fields::containsKey);
+        if (!any) {
+            return null;
+        }
+        if (!fields.keySet().containsAll(ENVIRONMENT_START_FIELDS)) {
+            errors.add("line " + lineNumber
+                    + ": legacy final environment-start block must be all-or-none");
+        }
+        return parseStartEnvironment(fields, lineNumber, errors);
+    }
+
     private static ClockFields parseClock(Map<String, String> fields, int lineNumber,
             List<String> errors) {
         long ticksNumerator = longValue(fields, "clock_ticks_num", lineNumber, errors);
@@ -2316,7 +2549,9 @@ public final class BenchmarkMatrix {
     }
 
     private static AudioFields parseAudio(Map<String, String> fields, int lineNumber,
-            List<String> errors) {
+            List<String> errors, AudioStartFields inheritedStart) {
+        AudioStartFields inlineStart = parseMatrixAudioStart(fields, lineNumber, errors);
+        AudioStartFields start = inlineStart == null ? inheritedStart : inlineStart;
         return new AudioFields(
                 strictBoolean(fields, "audio_active", lineNumber, errors),
                 integer(fields, "audio_sample_rate", lineNumber, errors),
@@ -2350,27 +2585,27 @@ public final class BenchmarkMatrix {
                 strictBoolean(fields, "audio_system_music_muted", lineNumber, errors),
                 integer(fields, "audio_queue_capacity_frames", lineNumber, errors),
                 integer(fields, "audio_max_frame_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_input_events", lineNumber, errors),
-                longValue(fields, "audio_start_input_frames", lineNumber, errors),
-                longValue(fields, "audio_start_enqueued_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_enqueued_frames", lineNumber, errors),
-                longValue(fields, "audio_start_written_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_written_frames", lineNumber, errors),
-                longValue(fields, "audio_start_write_failures", lineNumber, errors),
-                longValue(fields, "audio_start_discarded_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_pending_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_queued_bytes", lineNumber, errors),
-                longValue(fields, "audio_start_playback_position_frames", lineNumber, errors),
-                longValue(fields, "audio_start_overruns", lineNumber, errors),
-                longValue(fields, "audio_start_underruns", lineNumber, errors),
-                longValue(fields, "audio_start_track_underruns", lineNumber, errors),
-                longValue(fields, "audio_start_restarts", lineNumber, errors),
-                longValue(fields, "audio_start_route_failures", lineNumber, errors),
-                strictBoolean(fields, "audio_start_output_open", lineNumber, errors),
-                strictBoolean(fields, "audio_start_output_playing", lineNumber, errors),
-                integer(fields, "audio_start_sample_rate", lineNumber, errors),
-                integer(fields, "audio_start_queue_capacity_frames", lineNumber, errors),
-                integer(fields, "audio_start_max_frame_bytes", lineNumber, errors),
+                start == null ? -1L : start.inputEvents,
+                start == null ? -1L : start.inputFrames,
+                start == null ? -1L : start.enqueuedBytes,
+                start == null ? -1L : start.enqueuedFrames,
+                start == null ? -1L : start.writtenBytes,
+                start == null ? -1L : start.writtenFrames,
+                start == null ? -1L : start.writeFailures,
+                start == null ? -1L : start.discardedBytes,
+                start == null ? -1L : start.pendingBytes,
+                start == null ? -1L : start.queuedBytes,
+                start == null ? -1L : start.playbackPositionFrames,
+                start == null ? -1L : start.overruns,
+                start == null ? -1L : start.underruns,
+                start == null ? -1L : start.outputUnderruns,
+                start == null ? -1L : start.restarts,
+                start == null ? -1L : start.routeFailures,
+                start == null ? null : start.outputOpen,
+                start == null ? null : start.outputPlaying,
+                start == null ? -1 : start.sampleRate,
+                start == null ? -1 : start.queueCapacityFrames,
+                start == null ? -1 : start.maximumFrameBytes,
                 strictBoolean(fields, "audio_focus_granted", lineNumber, errors),
                 longValue(fields, "audio_focus_start_loss_count", lineNumber, errors),
                 longValue(fields, "audio_focus_loss_count", lineNumber, errors));
@@ -2548,6 +2783,47 @@ public final class BenchmarkMatrix {
         return rateMillihz == (int) Math.round(row.nominalFps() * 1_000.0);
     }
 
+    private static String expectedInputContract(Row row) {
+        if (row == null) {
+            return null;
+        }
+        return switch (row) {
+            case DMG, MGB, CGB_DMG_COMPAT, CGB0_DMG_COMPAT -> "dmg-action-v1";
+            case CGB_NATIVE, CGB0_NATIVE -> "cgb-action-v1";
+            case SGB, SGB2 -> "none";
+        };
+    }
+
+    private static int expectedScenarioFrames(String inputContract) {
+        if (inputContract == null) {
+            return -1;
+        }
+        return switch (inputContract) {
+            case "none" -> 0;
+            case "dmg-action-v1" -> 313;
+            case "cgb-action-v1" -> 923;
+            default -> -1;
+        };
+    }
+
+    private static boolean validScenarioCompletion(Row row, String inputContract,
+            long sessionGeneration, long scenarioSessionGeneration, Boolean completed,
+            int completedFrames, int expectedFrames, Boolean sourceClosed, Boolean audioDrained) {
+        int contractFrames = expectedScenarioFrames(inputContract);
+        return row != null && expectedInputContract(row).equals(inputContract)
+                && sessionGeneration > 0L
+                && (contractFrames == 0 ? scenarioSessionGeneration == 0L
+                        : scenarioSessionGeneration == sessionGeneration)
+                && contractFrames >= 0 && completedFrames == contractFrames
+                && expectedFrames == contractFrames && Boolean.TRUE.equals(completed)
+                && Boolean.TRUE.equals(sourceClosed) && Boolean.TRUE.equals(audioDrained);
+    }
+
+    private static boolean validArmAudioBaseline(AudioStartFields audio) {
+        return audio != null && audio.pendingBytes == 0L && audio.queuedBytes == 0L
+                && Boolean.TRUE.equals(audio.outputPlaying);
+    }
+
     private static boolean validAudio(AudioFields audio, Row row, ClockFields clock, int readyCount,
             long readyFirstNanos, long readyLastNanos, double readyIntervalFps,
             boolean requireRealtime) {
@@ -2676,7 +2952,7 @@ public final class BenchmarkMatrix {
                 && audio.queueCapacityFrames == 6 && audio.startQueueCapacityFrames == 6
                 && audio.maximumFrameBytes > 0
                 && audio.startMaximumFrameBytes == audio.maximumFrameBytes
-                && startQueuedBytes >= 0L && startQueuedBytes <= startPendingBytes
+                && startPendingBytes == 0L && startQueuedBytes == 0L
                 && queuedBytes <= pendingBytes
                 && queuedBytes <= (long) audio.queueCapacityFrames * audio.maximumFrameBytes
                 && pendingBytes - queuedBytes <= audio.maximumFrameBytes
@@ -2923,7 +3199,11 @@ public final class BenchmarkMatrix {
         final int surfaceVoteHz;
         final int displayTargetHz;
         final int surfaceContentRateMillihz;
+        final long sessionGeneration;
         final long benchmarkGeneration;
+        final long scenarioSessionGeneration;
+        final int scenarioCompletedFrames;
+        final int scenarioExpectedFrames;
         final List<Long> readyIds = new ArrayList<>();
         final List<Long> readyNanos = new ArrayList<>();
         final List<Long> submissionIds = new ArrayList<>();
@@ -2941,7 +3221,9 @@ public final class BenchmarkMatrix {
                 String executionMode, int speedModeInitial, ClockFields clock, boolean audio,
                 String render, boolean available, EnvironmentFields environment,
                 String workloadNonce, boolean warmup, String inputContract, int surfaceVoteHz,
-                int displayTargetHz, int surfaceContentRateMillihz, long benchmarkGeneration,
+                int displayTargetHz, int surfaceContentRateMillihz, long sessionGeneration,
+                long benchmarkGeneration, long scenarioSessionGeneration,
+                int scenarioCompletedFrames, int scenarioExpectedFrames,
                 AudioStartFields audioStart) {
             this.key = key;
             this.ingestionOrdinal = ingestionOrdinal;
@@ -2973,11 +3255,18 @@ public final class BenchmarkMatrix {
             this.surfaceVoteHz = surfaceVoteHz;
             this.displayTargetHz = displayTargetHz;
             this.surfaceContentRateMillihz = surfaceContentRateMillihz;
+            this.sessionGeneration = sessionGeneration;
             this.benchmarkGeneration = benchmarkGeneration;
+            this.scenarioSessionGeneration = scenarioSessionGeneration;
+            this.scenarioCompletedFrames = scenarioCompletedFrames;
+            this.scenarioExpectedFrames = scenarioExpectedFrames;
         }
     }
 
-    private record FinalFields(String artifactId, long benchmarkGeneration,
+    private record FinalFields(String artifactId, long sessionGeneration, long benchmarkGeneration,
+            long scenarioSessionGeneration, boolean scenarioCompleted,
+            int scenarioCompletedFrames, int scenarioExpectedFrames,
+            boolean scenarioSourceClosed, boolean scenarioAudioDrained,
             String requestedProfile, String profile,
             Boolean effectiveGbc, Boolean effectiveDmgCompat, String effectiveMode,
             String executionMode,
@@ -3008,6 +3297,16 @@ public final class BenchmarkMatrix {
 
     private record ClockFields(long ticksNumerator, long ticksDenominator,
             long framesNumerator, long framesDenominator, long ticksPerControllerFrame) {
+    }
+
+    private record ScenarioCompletion(String artifactId, String pairId, String matrixBlock,
+            int rowOrder, Side runSide, long sessionGeneration, String inputContract,
+            int completedFrames, int expectedFrames, boolean completed, boolean sourceClosed,
+            boolean audioDrained, int ordinal) {
+    }
+
+    private record BenchmarkInvalidation(String artifactId, String pairId, String matrixBlock,
+            int rowOrder, Side runSide, long sessionGeneration, int ordinal) {
     }
 
     private record AudioFields(Boolean active, int sampleRate, long overruns, long underruns,

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -222,6 +223,136 @@ public class BenchmarkMatrixTest {
         BenchmarkMatrix.Report stoppedReport = parse(stopped);
         assertFalse(stoppedReport.accepted());
         assertContains(stoppedReport.errors(), "audio arm baseline is not drained and playing");
+    }
+
+    @Test
+    public void silentPcmPolicyRequiresPositiveCalendarAndFrameSequencerEvidence() {
+        List<String> valid = withSilentPolicyForSilentRows(
+                omitFinalAudioStartFields(syntheticSilentSummaryLog(61.0, 62.0)));
+        assertTrue(parse(valid).errors().toString(), parse(valid).accepted());
+
+        List<String> compact = valid.stream().map(line -> line.startsWith("event=final_result")
+                ? compactFinalAudioProof(line, "111", "1000,10,2,100,0,0,1,0") : line)
+                .collect(java.util.stream.Collectors.toList());
+        assertTrue(parse(compact).errors().toString(), parse(compact).accepted());
+
+        List<String> negativeCompact = syntheticSummaryLog(61.0, 62.0).stream()
+                .map(line -> line.startsWith("event=final_result")
+                        ? compactFinalAudioProof(line, "111", "-1,-1,-1,-1,-1,-1,-1,-1")
+                        : line)
+                .collect(java.util.stream.Collectors.toList());
+        BenchmarkMatrix.Report negativeReport = parse(negativeCompact);
+        assertFalse(negativeReport.accepted());
+        assertContains(negativeReport.errors(), "invalid compact benchmark audio calendar");
+
+        ArrayList<String> negativeExpanded = new ArrayList<>(valid);
+        for (int index = 0; index < negativeExpanded.size(); index++) {
+            String line = negativeExpanded.get(index);
+            if (line.startsWith("event=final_result")) {
+                for (String key : List.of(
+                        "benchmark_audio_skipped_ticks",
+                        "benchmark_audio_zero_sample_slots",
+                        "benchmark_audio_zero_sample_events",
+                        "benchmark_audio_max_debt", "benchmark_audio_apu_reads",
+                        "benchmark_audio_apu_writes",
+                        "benchmark_audio_frame_sequencer_commits",
+                        "benchmark_audio_dropped_channel_ticks")) {
+                    line = line.replaceAll(" " + key + "=[^ ]*", " " + key + "=-1");
+                }
+                negativeExpanded.set(index, line);
+                break;
+            }
+        }
+        BenchmarkMatrix.Report negativeExpandedReport = parse(negativeExpanded);
+        assertFalse(negativeExpandedReport.accepted());
+        assertContains(negativeExpandedReport.errors(),
+                "expanded benchmark audio calendar must be nonnegative");
+
+        ArrayList<String> mixedSchemas = new ArrayList<>(valid);
+        for (int index = 0; index < mixedSchemas.size(); index++) {
+            String line = mixedSchemas.get(index);
+            if (line.startsWith("event=final_result")) {
+                mixedSchemas.set(index, line + " benchmark_audio_flags=111"
+                        + " benchmark_audio_calendar=1000,10,2,100,0,0,1,0");
+                break;
+            }
+        }
+        BenchmarkMatrix.Report mixedSchemaReport = parse(mixedSchemas);
+        assertFalse(mixedSchemaReport.accepted());
+        assertContains(mixedSchemaReport.errors(),
+                "compact and expanded benchmark audio proofs cannot be mixed");
+
+        for (String field : List.of(
+                "benchmark_audio_zero_sample_slots",
+                "benchmark_audio_zero_sample_events",
+                "benchmark_audio_max_debt",
+                "benchmark_audio_frame_sequencer_commits")) {
+            List<String> missing = replaceFirstLineKey(
+                    valid, "event=final_result", "pair_id=p00-dmg ", field, "0");
+            BenchmarkMatrix.Report report = parse(missing);
+            assertFalse(field, report.accepted());
+            assertContains(report.errors(), "intrinsic audio output evidence");
+        }
+    }
+
+    @Test
+    public void relaxedSilentPcmPolicyRequiresDroppedTicksEqualToSkippedTicks() {
+        List<String> exact = withSilentPolicyForSilentRows(
+                omitFinalAudioStartFields(syntheticSilentSummaryLog(61.0, 62.0)));
+        List<String> relaxed = exact.stream().map(line -> {
+            if (silentRow(line, List.of("dmg", "mgb", "cgb-native", "cgb0-native",
+                    "cgb-dmg-compat")) == null) {
+                return line;
+            }
+            return line.replace("silent-pcm-v1", "silent-pcm-relaxed-apu-v1")
+                    .replace("benchmark_audio_dropped_channel_ticks=0",
+                            "benchmark_audio_dropped_channel_ticks=1000");
+        }).collect(java.util.stream.Collectors.toList());
+        assertTrue(parse(relaxed).errors().toString(), parse(relaxed).accepted());
+
+        List<String> mismatch = relaxed.stream()
+                .map(line -> line.replace("benchmark_audio_dropped_channel_ticks=1000",
+                        "benchmark_audio_dropped_channel_ticks=999"))
+                .collect(java.util.stream.Collectors.toList());
+        BenchmarkMatrix.Report report = parse(mismatch);
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "intrinsic audio output evidence");
+    }
+
+    @Test
+    public void rejectsMixedCanonicalAndSilentPolicies() {
+        List<String> mixed = withSilentPolicyForSilentRows(syntheticSummaryLog(61.0, 62.0));
+        BenchmarkMatrix.Report report = parse(mixed);
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "mixed benchmark audio policies");
+    }
+
+    @Test
+    public void silentPolicyRejectsSgbRows() {
+        List<String> allRows = withSilentPolicyForRows(syntheticSummaryLog(61.0, 62.0),
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat",
+                        "sgb", "sgb2"));
+        BenchmarkMatrix.Report report = parse(allRows);
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "row_order is outside selected matrix");
+    }
+
+    @Test
+    public void silentPolicyRequiresAndBindsBenchmarkToken() {
+        List<String> valid = withSilentPolicyForSilentRows(
+                omitFinalAudioStartFields(syntheticSilentSummaryLog(61.0, 62.0)));
+        List<String> missing = replaceFirstLine(valid, "event=matrix_run", "",
+                "benchmark_token=silent-token-001 ", "");
+        BenchmarkMatrix.Report missingReport = parse(missing);
+        assertFalse(missingReport.accepted());
+        assertContains(missingReport.errors(), "silent benchmark token is missing");
+
+        List<String> drift = replaceFirstLine(valid, "event=final_result", "",
+                "benchmark_token=silent-token-001",
+                "benchmark_token=drift-token-0001");
+        BenchmarkMatrix.Report driftReport = parse(drift);
+        assertFalse(driftReport.accepted());
+        assertContains(driftReport.errors(), "final evidence does not match matrix_run");
     }
 
     @Test
@@ -909,6 +1040,55 @@ public class BenchmarkMatrixTest {
         return lines;
     }
 
+    private static List<String> syntheticSilentSummaryLog(double parentFps, double candidateFps) {
+        List<String> source = syntheticSummaryLog(parentFps, candidateFps);
+        List<String> silentRows = List.of("dmg", "mgb", "cgb-native", "cgb0-native",
+                "cgb-dmg-compat");
+        Map<String, Map<String, Integer>> orders = new java.util.LinkedHashMap<>();
+        List<String> selected = new ArrayList<>();
+        for (String line : source) {
+            String row = silentRow(line, silentRows);
+            if (row == null) {
+                continue;
+            }
+            String block = field(line, "matrix_block");
+            if (line.startsWith("event=matrix_run")) {
+                Map<String, Integer> blockOrders = orders.computeIfAbsent(block,
+                        ignored -> new java.util.LinkedHashMap<>());
+                blockOrders.computeIfAbsent(row, ignored -> blockOrders.size());
+            }
+            selected.add(line);
+        }
+        List<String> remapped = new ArrayList<>(selected.size());
+        for (String line : selected) {
+            String row = silentRow(line, silentRows);
+            String block = field(line, "matrix_block");
+            Integer order = orders.get(block).get(row);
+            remapped.add(line.replaceFirst("row_order=[0-9]+", "row_order=" + order));
+        }
+        return remapped;
+    }
+
+    private static String silentRow(String line, List<String> rows) {
+        for (String row : rows) {
+            if (line.contains("-" + row + " ")) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    private static String field(String line, String key) {
+        String prefix = key + "=";
+        int start = line.indexOf(prefix);
+        if (start < 0) {
+            throw new IllegalArgumentException("missing field " + key);
+        }
+        int valueStart = start + prefix.length();
+        int end = line.indexOf(' ', valueStart);
+        return line.substring(valueStart, end < 0 ? line.length() : end);
+    }
+
     private static List<String> declarationsBeforeCompletions() {
         ArrayList<String> result = new ArrayList<>();
         for (String block : BLOCK_NAMES) {
@@ -1291,6 +1471,90 @@ public class BenchmarkMatrixTest {
                 + " " + audioStartEvidence()
                 + " audio_focus_granted=true audio_focus_start_loss_count=0"
                 + " audio_focus_loss_count=0";
+    }
+
+    private static List<String> withSilentPolicyForSilentRows(List<String> source) {
+        return withSilentPolicyForRows(source,
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat"));
+    }
+
+    private static List<String> withSilentPolicyForRows(List<String> source,
+            List<String> selectedRows) {
+        String token = "silent-token-001";
+        ArrayList<String> result = new ArrayList<>(source.size());
+        for (String original : source) {
+            if (silentRow(original, selectedRows) == null) {
+                result.add(original);
+                continue;
+            }
+            String line = original;
+            if (line.startsWith("event=matrix_run")) {
+                line += " benchmark_token=" + token + " benchmark_audio_policy=silent-pcm-v1"
+                        + " audio_start_active=true audio_start_paused=false"
+                        + " audio_start_muted=false audio_start_volume=100"
+                        + " audio_start_system_volume=0 audio_start_system_volume_max=15"
+                        + " audio_start_system_music_muted=true audio_start_queued_frames=0"
+                        + " audio_start_reopen_pending=false"
+                        + " audio_start_output_identity=11 audio_start_queue_identity=12";
+                line = line.replace("audio_start_input_events=0", "audio_start_input_events=1")
+                        .replace("audio_start_input_frames=0", "audio_start_input_frames=1")
+                        .replace("audio_start_written_bytes=0", "audio_start_written_bytes=4")
+                        .replace("audio_start_written_frames=0", "audio_start_written_frames=1");
+            } else if (line.startsWith("event=final_result")) {
+                line = line.replace("audio_system_volume=10", "audio_system_volume=0")
+                        .replace("audio_system_music_muted=false",
+                                "audio_system_music_muted=true");
+                line = incrementLongField(line, "audio_pcm_input_events", 1L);
+                line = incrementLongField(line, "audio_pcm_input_frames", 1L);
+                line = incrementLongField(line, "audio_pcm_written_bytes", 4L);
+                line = incrementLongField(line, "audio_pcm_written_frames", 1L);
+                line += " benchmark_token=" + token + " benchmark_audio_policy=silent-pcm-v1"
+                        + " benchmark_audio_requested=true"
+                        + " benchmark_audio_active_at_boundary=true"
+                        + " benchmark_audio_disabled_after=true"
+                        + " benchmark_audio_skipped_ticks=1000"
+                        + " benchmark_audio_zero_sample_slots=10"
+                        + " benchmark_audio_zero_sample_events=2"
+                        + " benchmark_audio_max_debt=100"
+                        + " benchmark_audio_apu_reads=0 benchmark_audio_apu_writes=0"
+                        + " benchmark_audio_frame_sequencer_commits=1"
+                        + " benchmark_audio_dropped_channel_ticks=0"
+                        + " system_audio_sample_count=12 system_audio_bad_count=0"
+                        + " audio_output_identity=11 audio_queue_identity=12";
+            }
+            result.add(line);
+        }
+        return result;
+    }
+
+    private static String incrementLongField(String line, String key, long delta) {
+        String prefix = key + "=";
+        int start = line.indexOf(prefix);
+        if (start < 0) {
+            throw new IllegalArgumentException("missing field " + key);
+        }
+        int valueStart = start + prefix.length();
+        int end = line.indexOf(' ', valueStart);
+        if (end < 0) {
+            end = line.length();
+        }
+        long value = Long.parseLong(line.substring(valueStart, end));
+        return line.substring(0, valueStart) + (value + delta) + line.substring(end);
+    }
+
+    private static String compactFinalAudioProof(String line, String flags, String calendar) {
+        String compact = line;
+        for (String key : List.of(
+                "benchmark_audio_requested", "benchmark_audio_active_at_boundary",
+                "benchmark_audio_disabled_after", "benchmark_audio_skipped_ticks",
+                "benchmark_audio_zero_sample_slots", "benchmark_audio_zero_sample_events",
+                "benchmark_audio_max_debt", "benchmark_audio_apu_reads",
+                "benchmark_audio_apu_writes", "benchmark_audio_frame_sequencer_commits",
+                "benchmark_audio_dropped_channel_ticks")) {
+            compact = compact.replaceAll(" " + key + "=[^ ]*", "");
+        }
+        return compact + " benchmark_audio_flags=" + flags
+                + " benchmark_audio_calendar=" + calendar;
     }
 
     private record Evidence(String requestedProfile, String profile, boolean gbc,

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
@@ -84,17 +84,158 @@ public class BenchmarkMatrixTest {
         BenchmarkMatrix.Report report = parse(log);
 
         assertTrue(report.errors().toString(), report.accepted());
-        assertEquals(7 * BenchmarkMatrix.MIN_PAIRS * 2 * 3, log.size());
+        assertEquals(7 * BenchmarkMatrix.MIN_PAIRS * 2 * 3
+                + 5 * BenchmarkMatrix.MIN_PAIRS * 2, log.size());
     }
 
     @Test
-    public void validatesPerformanceBulkSpanAndTickTelemetryAsIntegers() {
+    public void finalResultMayInheritStartBaselinesFromMatrixRun() {
+        List<String> log = omitFinalEnvironmentStartFields(
+                omitFinalAudioStartFields(syntheticSummaryLog(61.0, 62.0)));
+
+        BenchmarkMatrix.Report report = parse(log);
+
+        assertTrue(report.errors().toString(), report.accepted());
+    }
+
+    @Test
+    public void contradictoryLegacyFinalEnvironmentStartIsRejected() {
+        List<String> log = replaceFirstLine(
+                syntheticSummaryLog(61.0, 62.0), "event=final_result", "",
+                "thermal_start=0", "thermal_start=1");
+
+        BenchmarkMatrix.Report report = parse(log);
+
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "final evidence does not match matrix_run");
+    }
+
+    @Test
+    public void requiresExactGenerationBoundScenarioCompletionEvidence() {
+        List<String> base = syntheticSummaryLog(61.0, 62.0);
+        ArrayList<String> missing = new ArrayList<>(base);
+        missing.removeIf(line -> line.startsWith("event=scenario_complete"));
+        BenchmarkMatrix.Report missingReport = parse(missing);
+        assertFalse(missingReport.accepted());
+        assertContains(missingReport.errors(), "missing scenario_complete evidence");
+
+        List<String> wrongFrames = replaceFirstLine(base, "event=scenario_complete", "",
+                "completed_frames=313", "completed_frames=312");
+        BenchmarkMatrix.Report framesReport = parse(wrongFrames);
+        assertFalse(framesReport.accepted());
+        assertContains(framesReport.errors(), "scenario_complete is not exact");
+
+        List<String> wrongGeneration = replaceFirstLineKey(base, "event=scenario_complete", "",
+                "session_generation", "999999999");
+        BenchmarkMatrix.Report generationReport = parse(wrongGeneration);
+        assertFalse(generationReport.accepted());
+        assertContains(generationReport.errors(), "session generation does not match");
+
+        List<String> wrongIdentity = replaceFirstLineKey(base, "event=scenario_complete", "",
+                "pair_id", "stale-pair");
+        BenchmarkMatrix.Report identityReport = parse(wrongIdentity);
+        assertFalse(identityReport.accepted());
+        assertContains(identityReport.errors(), "run identity does not match");
+
+        List<String> missingIdentity = replaceFirstLine(base, "event=scenario_complete", "",
+                "artifact_id=" + PARENT_ARTIFACT + " ", "");
+        BenchmarkMatrix.Report malformedIdentityReport = parse(missingIdentity);
+        assertFalse(malformedIdentityReport.accepted());
+        assertContains(malformedIdentityReport.errors(), "scenario_complete is not exact");
+    }
+
+    @Test
+    public void acceptsEmittedRejectionSchemaButStillRequiresCompletedRuns() {
+        List<String> rejections = List.of(
+                "event=benchmark_anchor success=false phase=scenario_running reason=stale_session",
+                "event=benchmark_arm_rejected phase=anchor_ready reason=audio_pending",
+                "event=benchmark_arm_rejected phase=anchor_ready reason=audio_not_playing",
+                "event=benchmark_arm_rejected phase=anchor_ready reason=audio_focus",
+                "event=benchmark_invalidated artifact_id=" + "f".repeat(64)
+                        + " pair_id=unrelated-pair matrix_block=unrelated-block row_order=0"
+                        + " run_side=parent session_generation=42 phase=scenario_running"
+                        + " reason=visibility_lost");
+        ArrayList<String> complete = new ArrayList<>(rejections);
+        complete.addAll(syntheticSummaryLog(61.0, 62.0));
+
+        BenchmarkMatrix.Report completeReport = parse(complete);
+        assertTrue(completeReport.errors().toString(), completeReport.accepted());
+
+        BenchmarkMatrix.Report rejectionOnlyReport = parse(rejections);
+        assertFalse(rejectionOnlyReport.accepted());
+        assertFalse(rejectionOnlyReport.errors().isEmpty());
+    }
+
+    @Test
+    public void rejectsSameRunVisibilityInvalidationEvenAfterFinalResult() {
+        List<String> invalidated = new ArrayList<>(syntheticSummaryLog(61.0, 62.0));
+        invalidated.add("event=benchmark_invalidated artifact_id=" + PARENT_ARTIFACT
+                + " pair_id=p00-sgb2 matrix_block=zeta row_order=0 run_side=parent"
+                + " session_generation=1 phase=done reason=visibility_lost");
+
+        BenchmarkMatrix.Report report = parse(invalidated);
+
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "was invalidated by host visibility loss");
+    }
+
+    @Test
+    public void requiresRowMappedCompletionAndClosedDrainedScenario() {
+        List<String> base = syntheticSummaryLog(61.0, 62.0);
+        List<String> wrongContract = replaceFirstLine(base, "event=matrix_run",
+                "effective_mode=cgb-dmg-compat", "input_contract=dmg-action-v1",
+                "input_contract=cgb-action-v1");
+        BenchmarkMatrix.Report contractReport = parse(wrongContract);
+        assertFalse(contractReport.accepted());
+        assertContains(contractReport.errors(), "does not match its hardware row");
+
+        List<String> openSource = replaceFirstLine(base, "event=matrix_run", "",
+                "scenario_source_closed=true", "scenario_source_closed=false");
+        BenchmarkMatrix.Report sourceReport = parse(openSource);
+        assertFalse(sourceReport.accepted());
+        assertContains(sourceReport.errors(), "scenario completion does not match");
+
+        List<String> undrained = replaceFirstLine(base, "event=matrix_run", "",
+                "scenario_audio_drained=true", "scenario_audio_drained=false");
+        BenchmarkMatrix.Report audioReport = parse(undrained);
+        assertFalse(audioReport.accepted());
+        assertContains(audioReport.errors(), "scenario completion does not match");
+    }
+
+    @Test
+    public void requiresEmptyPlayingAudioArmBaselineForVisibleRuns() {
+        List<String> base = syntheticSummaryLog(61.0, 62.0);
+        List<String> pending = replaceFirstLine(base, "event=matrix_run", "",
+                "audio_start_pending_bytes=0", "audio_start_pending_bytes=4");
+        BenchmarkMatrix.Report pendingReport = parse(pending);
+        assertFalse(pendingReport.accepted());
+        assertContains(pendingReport.errors(), "audio arm baseline is not drained and playing");
+
+        List<String> queued = replaceFirstLine(base, "event=matrix_run", "",
+                "audio_start_queued_bytes=0", "audio_start_queued_bytes=4");
+        BenchmarkMatrix.Report queuedReport = parse(queued);
+        assertFalse(queuedReport.accepted());
+        assertContains(queuedReport.errors(), "audio arm baseline is not drained and playing");
+
+        List<String> stopped = replaceFirstLine(base, "event=matrix_run", "",
+                "audio_start_output_playing=true", "audio_start_output_playing=false");
+        BenchmarkMatrix.Report stoppedReport = parse(stopped);
+        assertFalse(stoppedReport.accepted());
+        assertContains(stoppedReport.errors(), "audio arm baseline is not drained and playing");
+    }
+
+    @Test
+    public void validatesPerformanceSchedulerTelemetryAsIntegers() {
         List<String> valid = new ArrayList<>(syntheticSummaryLog(61.0, 62.0));
         valid.add(
                 "event=speed_sample frame=600 effective_gbc=false"
                         + " effective_dmg_compat=false speed_mode_final=1"
                         + " speed_mode_sample=frame_600 performance_bulk_spans=12"
-                        + " performance_bulk_ticks=345");
+                        + " performance_bulk_ticks=345 performance_epoch_count=67"
+                        + " performance_epoch_ticks=8901 performance_epoch_max_ticks=64"
+                        + " performance_epoch_raster_fast_ticks=7654"
+                        + " performance_epoch_mode2_replay_ticks=4321"
+                        + " performance_epoch_mode2_bulk_ticks=4000");
         BenchmarkMatrix.Report accepted = parse(valid);
         assertTrue(accepted.errors().toString(), accepted.valid());
 
@@ -105,6 +246,20 @@ public class BenchmarkMatrixTest {
         BenchmarkMatrix.Report rejected = parse(malformed);
         assertFalse(rejected.valid());
         assertContains(rejected.errors(), "invalid integer performance_bulk_ticks");
+
+        for (String key : List.of(
+                "performance_epoch_count",
+                "performance_epoch_ticks",
+                "performance_epoch_max_ticks",
+                "performance_epoch_raster_fast_ticks",
+                "performance_epoch_mode2_replay_ticks",
+                "performance_epoch_mode2_bulk_ticks")) {
+            List<String> malformedEpoch = replaceFirstLineKey(
+                    valid, "event=speed_sample", "", key, "not-a-number");
+            BenchmarkMatrix.Report rejectedEpoch = parse(malformedEpoch);
+            assertFalse(rejectedEpoch.valid());
+            assertContains(rejectedEpoch.errors(), "invalid integer " + key);
+        }
     }
 
     @Test
@@ -831,11 +986,18 @@ public class BenchmarkMatrixTest {
                 * 1_000_000_000.0 / (lastNanos - firstNanos);
         Evidence evidence = evidence(row);
         String artifact = "parent".equals(side) ? PARENT_ARTIFACT : CANDIDATE_ARTIFACT;
+        String inputContract = inputContractFor(row);
+        if (!"none".equals(inputContract)) {
+            lines.add(scenarioCompleteEvidence(artifact, pairId, block, rowOrder, side, row,
+                    generationFor(baseNanos, side)));
+        }
         lines.add("event=matrix_run build_profile=benchmark artifact_id=" + artifact + " pair_id=" + pairId
                 + " matrix_block=" + block + " row_order=" + rowOrder
                 + " run_side=" + side + " first_side=" + firstSide
+                + " session_generation=" + generationFor(baseNanos, side)
                 + " benchmark_generation=" + generationFor(baseNanos, side)
-                + " workload_nonce=" + nonceFor(row) + " warmup=on input_contract=none"
+                + " workload_nonce=" + nonceFor(row) + " warmup=on input_contract=" + inputContract
+                + " " + scenarioCompletionFields(row, generationFor(baseNanos, side))
                 + " device_id=" + DEVICE_ID + " thermal_window=window-a"
                         + " audio=on render=presentation availability=available"
                         + " requested_profile=" + evidence.requestedProfile + " profile=" + evidence.profile
@@ -844,10 +1006,10 @@ public class BenchmarkMatrixTest {
                         + ("sgb".equals(row) ? 120 : 60) + " display_target_hz="
                         + ("sgb".equals(row) ? 120 : 60) + " surface_content_rate_millihz="
                         + contentRateMillihz(row) + " " + clockEvidence(row) + " "
-                + environmentStart());
+                + environmentStart() + " " + audioStartEvidence());
         lines.add(String.format(Locale.ROOT,
                 "event=final_result build_profile=benchmark artifact_id=%s pair_id=%s matrix_block=%s row_order=%d "
-                        + "run_side=%s benchmark_generation=%d workload_nonce=%s warmup=on input_contract=none drain_success=true "
+                        + "run_side=%s session_generation=%d benchmark_generation=%d workload_nonce=%s warmup=on input_contract=%s %s drain_success=true "
                         + "frame=600 ready_count=600 submitted_count=600 "
                         + "dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 "
                         + "ready_first_id=1 ready_last_id=600 ready_first_ns=%d ready_last_ns=%d "
@@ -868,7 +1030,9 @@ public class BenchmarkMatrixTest {
                         + "effective_dmg_compat=%s effective_mode=%s device_id=%s %s "
                         + "%s %s %s",
                 artifact, pairId, block, rowOrder, side, generationFor(baseNanos, side),
-                nonceFor(row), firstNanos, lastNanos,
+                generationFor(baseNanos, side), nonceFor(row), inputContract,
+                scenarioCompletionFields(row, generationFor(baseNanos, side)),
+                firstNanos, lastNanos,
                 firstNanos, lastNanos, intervalFps, intervalFps,
                 Math.max(1L, Math.round(1_000.0 * 599.0 / fps)), fps,
                 "sgb".equals(row) ? 120 : 60, "sgb".equals(row) ? 120 : 60,
@@ -889,11 +1053,18 @@ public class BenchmarkMatrixTest {
         ArrayList<Long> presented = new ArrayList<>(BenchmarkMatrix.REQUIRED_FRAME_COUNT);
         Evidence evidence = evidence(row);
         String artifact = "parent".equals(side) ? PARENT_ARTIFACT : CANDIDATE_ARTIFACT;
+        String inputContract = inputContractFor(row);
+        if (!"none".equals(inputContract)) {
+            lines.add(scenarioCompleteEvidence(artifact, pairId, block, rowOrder, side, row,
+                    generationFor(baseNanos, side)));
+        }
         lines.add("event=matrix_run build_profile=benchmark artifact_id=" + artifact + " pair_id=" + pairId
                 + " matrix_block=" + block + " row_order=" + rowOrder
                 + " run_side=" + side + " first_side=" + firstSide
+                + " session_generation=" + generationFor(baseNanos, side)
                 + " benchmark_generation=" + generationFor(baseNanos, side)
-                + " workload_nonce=" + nonceFor(row) + " warmup=on input_contract=none"
+                + " workload_nonce=" + nonceFor(row) + " warmup=on input_contract=" + inputContract
+                + " " + scenarioCompletionFields(row, generationFor(baseNanos, side))
                 + " device_id=" + DEVICE_ID + " thermal_window=window-a"
                         + " audio=on render=presentation availability=available"
                         + " requested_profile=" + evidence.requestedProfile + " profile=" + evidence.profile
@@ -902,7 +1073,7 @@ public class BenchmarkMatrixTest {
                         + ("sgb".equals(row) ? 120 : 60) + " display_target_hz="
                         + ("sgb".equals(row) ? 120 : 60) + " surface_content_rate_millihz="
                         + contentRateMillihz(row) + " " + clockEvidence(row) + " "
-                + environmentStart());
+                + environmentStart() + " " + audioStartEvidence());
         for (int frame = 1; frame <= BenchmarkMatrix.REQUIRED_FRAME_COUNT; frame++) {
             long timestamp = baseNanos + frame * interval;
             ready.add(timestamp);
@@ -918,7 +1089,7 @@ public class BenchmarkMatrixTest {
         double intervalFps = BenchmarkMatrix.intervalFps(ready);
         lines.add(String.format(Locale.ROOT,
                 "event=final_result build_profile=benchmark artifact_id=%s pair_id=%s matrix_block=%s row_order=%d "
-                        + "run_side=%s benchmark_generation=%d workload_nonce=%s warmup=on input_contract=none drain_success=true "
+                        + "run_side=%s session_generation=%d benchmark_generation=%d workload_nonce=%s warmup=on input_contract=%s %s drain_success=true "
                         + "frame=600 ready_count=600 submitted_count=600 "
                         + "dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 "
                         + "ready_first_id=1 ready_last_id=600 ready_first_ns=%d ready_last_ns=%d "
@@ -939,7 +1110,8 @@ public class BenchmarkMatrixTest {
                         + "effective_dmg_compat=%s effective_mode=%s device_id=%s %s "
                         + "%s %s %s",
                 artifact, pairId, block, rowOrder, side, generationFor(baseNanos, side),
-                nonceFor(row),
+                generationFor(baseNanos, side), nonceFor(row), inputContract,
+                scenarioCompletionFields(row, generationFor(baseNanos, side)),
                 ready.get(0), ready.get(ready.size() - 1),
                 presented.get(0), presented.get(presented.size() - 1), intervalFps, intervalFps,
                 Math.max(1L, Math.round(1_000.0 * 599.0 / fps)), fps,
@@ -983,6 +1155,44 @@ public class BenchmarkMatrixTest {
             case "sgb2" -> new Evidence("sgb2", "sgb2", false, false);
             default -> throw new IllegalArgumentException("unknown row " + row);
         };
+    }
+
+    private static String inputContractFor(String row) {
+        return switch (row) {
+            case "dmg", "mgb", "cgb-dmg-compat", "cgb0-dmg-compat" -> "dmg-action-v1";
+            case "cgb-native", "cgb0-native" -> "cgb-action-v1";
+            case "sgb", "sgb2" -> "none";
+            default -> throw new IllegalArgumentException("unknown row " + row);
+        };
+    }
+
+    private static int scenarioFramesFor(String row) {
+        return switch (inputContractFor(row)) {
+            case "dmg-action-v1" -> 313;
+            case "cgb-action-v1" -> 923;
+            default -> 0;
+        };
+    }
+
+    private static String scenarioCompleteEvidence(String artifact, String pairId, String block,
+            int rowOrder, String side, String row, long sessionGeneration) {
+        int frames = scenarioFramesFor(row);
+        return "event=scenario_complete artifact_id=" + artifact + " pair_id=" + pairId
+                + " matrix_block=" + block + " row_order=" + rowOrder + " run_side=" + side
+                + " session_generation=" + sessionGeneration
+                + " input_contract=" + inputContractFor(row)
+                + " completed=true completed_frames=" + frames
+                + " expected_frames=" + frames
+                + " source_closed=true audio_drained=true";
+    }
+
+    private static String scenarioCompletionFields(String row, long sessionGeneration) {
+        int frames = scenarioFramesFor(row);
+        return "scenario_session_generation="
+                + (frames == 0 ? 0L : sessionGeneration)
+                + " scenario_completed=true scenario_completed_frames=" + frames
+                + " scenario_expected_frames=" + frames
+                + " scenario_source_closed=true scenario_audio_drained=true";
     }
 
     private static String nonceFor(String row) {
@@ -1033,6 +1243,20 @@ public class BenchmarkMatrixTest {
                 + " cpu_count_end=8 memory_available_end_bytes=1000000000";
     }
 
+    private static String audioStartEvidence() {
+        return "audio_start_input_events=0 audio_start_input_frames=0"
+                + " audio_start_enqueued_bytes=0 audio_start_enqueued_frames=0"
+                + " audio_start_written_bytes=0 audio_start_written_frames=0"
+                + " audio_start_write_failures=0 audio_start_discarded_bytes=0"
+                + " audio_start_pending_bytes=0 audio_start_queued_bytes=0"
+                + " audio_start_playback_position_frames=1 audio_start_overruns=0"
+                + " audio_start_underruns=0 audio_start_track_underruns=0"
+                + " audio_start_restarts=0 audio_start_route_failures=0"
+                + " audio_start_output_open=true audio_start_output_playing=true"
+                + " audio_start_sample_rate=48000 audio_start_queue_capacity_frames=6"
+                + " audio_start_max_frame_bytes=1000000";
+    }
+
     private static String audioEvidence(String row, double fps) {
         double controllerFps = "sgb".equals(row)
                 ? (47_250_000.0 / 11.0) / 70_224.0
@@ -1064,17 +1288,7 @@ public class BenchmarkMatrixTest {
                 + " audio_playback_position_frames=100 audio_system_volume=10"
                 + " audio_system_volume_max=15 audio_system_music_muted=false"
                 + " audio_queue_capacity_frames=6 audio_max_frame_bytes=1000000"
-                + " audio_start_input_events=0 audio_start_input_frames=0"
-                + " audio_start_enqueued_bytes=0 audio_start_enqueued_frames=0"
-                + " audio_start_written_bytes=0 audio_start_written_frames=0"
-                + " audio_start_write_failures=0 audio_start_discarded_bytes=0"
-                + " audio_start_pending_bytes=0 audio_start_queued_bytes=0"
-                + " audio_start_playback_position_frames=1 audio_start_overruns=0"
-                + " audio_start_underruns=0 audio_start_track_underruns=0"
-                + " audio_start_restarts=0 audio_start_route_failures=0"
-                + " audio_start_output_open=true audio_start_output_playing=true"
-                + " audio_start_sample_rate=48000 audio_start_queue_capacity_frames=6"
-                + " audio_start_max_frame_bytes=1000000"
+                + " " + audioStartEvidence()
                 + " audio_focus_granted=true audio_focus_start_loss_count=0"
                 + " audio_focus_loss_count=0";
     }
@@ -1090,6 +1304,70 @@ public class BenchmarkMatrixTest {
                 result.set(index, result.get(index).replace(from, to));
                 break;
             }
+        }
+        return result;
+    }
+
+    private static List<String> omitFinalAudioStartFields(List<String> source) {
+        ArrayList<String> result = new ArrayList<>(source.size());
+        for (String line : source) {
+            if (!line.startsWith("event=final_result")) {
+                result.add(line);
+                continue;
+            }
+            StringBuilder bounded = new StringBuilder(line.length());
+            for (String field : line.split(" ")) {
+                if (!field.startsWith("audio_start_")) {
+                    if (!bounded.isEmpty()) {
+                        bounded.append(' ');
+                    }
+                    bounded.append(field);
+                }
+            }
+            result.add(bounded.toString());
+        }
+        return result;
+    }
+
+    private static List<String> omitFinalEnvironmentStartFields(List<String> source) {
+        ArrayList<String> result = new ArrayList<>(source.size());
+        String block = " " + environmentStart();
+        for (String line : source) {
+            result.add(line.startsWith("event=final_result") ? line.replace(block, "") : line);
+        }
+        return result;
+    }
+
+    private static List<String> replaceFirstLine(List<String> source, String prefix,
+            String contains, String from, String to) {
+        ArrayList<String> result = new ArrayList<>(source);
+        for (int index = 0; index < result.size(); index++) {
+            String line = result.get(index);
+            if (line.startsWith(prefix) && line.contains(contains) && line.contains(from)) {
+                result.set(index, line.replace(from, to));
+                break;
+            }
+        }
+        return result;
+    }
+
+    private static List<String> replaceFirstLineKey(List<String> source, String prefix,
+            String contains, String key, String replacement) {
+        ArrayList<String> result = new ArrayList<>(source);
+        String field = key + "=";
+        for (int index = 0; index < result.size(); index++) {
+            String line = result.get(index);
+            int start = line.indexOf(field);
+            if (!line.startsWith(prefix) || !line.contains(contains) || start < 0) {
+                continue;
+            }
+            int end = line.indexOf(' ', start);
+            if (end < 0) {
+                end = line.length();
+            }
+            result.set(index, line.substring(0, start) + field + replacement
+                    + line.substring(end));
+            break;
         }
         return result;
     }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
@@ -23,6 +23,20 @@ public class DiagnosticsOptionsTest {
     }
 
     @Test
+    public void releaseGateCannotEnableRelaxedAudioPolicy() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                false, "cgb", true, "presentation", true, true, false,
+                "build-0001", "pair-0001", "block-0001", 0,
+                "parent", "parent", "device-0001", "thermal-0001", true,
+                "workload-0001", 60, -1, "performance", null,
+                "silent-pcm-relaxed-apu-v1");
+
+        assertFalse(options.enabled);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, options.audioPolicy);
+        assertEquals(ExecutionMode.PERFORMANCE, options.executionMode);
+    }
+
+    @Test
     public void benchmarkOptionsAreTypedAndTransient() {
         DiagnosticsOptions options = DiagnosticsOptions.parseValues(
                 true, "dmg", false, "sink", true, false, false);
@@ -102,6 +116,51 @@ public class DiagnosticsOptionsTest {
         assertEquals("performance", DiagnosticsOptions.executionModeValue(performance.executionMode));
         assertEquals(ExecutionMode.ACCURACY, malformed.executionMode);
         assertEquals("accuracy", DiagnosticsOptions.executionModeValue(malformed.executionMode));
+    }
+
+    @Test
+    public void silentPcmPolicyIsPerformanceOnlyAndDefaultsToCanonical() {
+        DiagnosticsOptions silent = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-v1");
+        DiagnosticsOptions accuracy = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "accuracy", null, "silent-pcm-v1");
+        DiagnosticsOptions noAudio = DiagnosticsOptions.parseValues(
+                true, "cgb", false, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-v1");
+        DiagnosticsOptions sgb = DiagnosticsOptions.parseValues(
+                true, "sgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-v1");
+        DiagnosticsOptions auto = DiagnosticsOptions.parseValues(
+                true, "auto", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-v1");
+
+        assertEquals(DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1, silent.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, accuracy.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, noAudio.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, sgb.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, auto.audioPolicy);
+    }
+
+    @Test
+    public void relaxedSilentPcmPolicyUsesItsOwnCoreCalendarMode() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "dmg", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-relaxed-apu-v1");
+
+        assertEquals(DiagnosticsOptions.AudioPolicy.SILENT_PCM_RELAXED_APU_V1,
+                options.audioPolicy);
+        assertTrue(options.audioPolicy.isSilent());
+        assertTrue(options.audioPolicy.isRelaxedApu());
+        assertEquals(eu.rekawek.coffeegb.core.sound.Sound.PerformanceSystemMutedAudioMode.RELAXED_APU,
+                options.audioPolicy.performanceSystemMutedAudioMode());
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
@@ -34,6 +34,57 @@ public class DiagnosticsOptionsTest {
         assertTrue(options.runtimeWarmup);
         assertFalse(options.launchRecent);
         assertEquals(ExecutionMode.ACCURACY, options.executionMode);
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.NONE, options.benchmarkScenario);
+    }
+
+    @Test
+    public void benchmarkScenarioUsesOnlySafeExternalContracts() {
+        DiagnosticsOptions dmg = DiagnosticsOptions.parseValues(
+                true, "dmg", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "DMG-ACTION-V1");
+        DiagnosticsOptions cgb = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "cgb-action-v1");
+        DiagnosticsOptions malformed = DiagnosticsOptions.parseValues(
+                true, "dmg", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "../private");
+
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1, dmg.benchmarkScenario);
+        assertEquals("dmg-action-v1", dmg.benchmarkScenario.externalValue());
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.CGB_ACTION_V1, cgb.benchmarkScenario);
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.NONE, malformed.benchmarkScenario);
+        assertEquals(BenchmarkGameplayScenario.NativeFrameKind.DMG,
+                dmg.benchmarkNativeFrameKind());
+        assertEquals(BenchmarkGameplayScenario.NativeFrameKind.GBC,
+                cgb.benchmarkNativeFrameKind());
+    }
+
+    @Test
+    public void cgbDmgCompatKeepsDmgTimelineOnGbcNativeFrames() {
+        DiagnosticsOptions compat = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "dmg-action-v1");
+        DiagnosticsOptions cgb0 = DiagnosticsOptions.parseValues(
+                true, "cgb0", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "cgb-action-v1");
+        DiagnosticsOptions mgb = DiagnosticsOptions.parseValues(
+                true, "mgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "dmg-action-v1");
+
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.DMG_ACTION_V1,
+                compat.benchmarkScenario);
+        assertEquals(BenchmarkGameplayScenario.NativeFrameKind.GBC,
+                compat.benchmarkNativeFrameKind());
+        assertEquals(BenchmarkGameplayScenario.NativeFrameKind.GBC,
+                cgb0.benchmarkNativeFrameKind());
+        assertEquals(BenchmarkGameplayScenario.NativeFrameKind.DMG,
+                mgb.benchmarkNativeFrameKind());
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
@@ -15,4 +15,14 @@ public class EmulationServiceTest {
 
         assertEquals("cgb-action-v1", EmulationService.benchmarkScenarioExtraValue(options));
     }
+
+    @Test
+    public void startWireForwardsSilentPcmPolicyToken() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "cgb-action-v1", "silent-pcm-v1");
+
+        assertEquals("silent-pcm-v1", EmulationService.audioPolicyExtraValue(options));
+    }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
@@ -1,0 +1,18 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EmulationServiceTest {
+
+    @Test
+    public void startWireForwardsBenchmarkScenarioToken() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", "cgb-action-v1");
+
+        assertEquals("cgb-action-v1", EmulationService.benchmarkScenarioExtraValue(options));
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/MainActivityBenchmarkArmTokenTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/MainActivityBenchmarkArmTokenTest.java
@@ -1,0 +1,52 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MainActivityBenchmarkArmTokenTest {
+
+    @Test
+    public void earlyTokenRemainsBoundToItsPausedSessionUntilAnchorCompletion() {
+        MainActivity.BenchmarkArmTokenLatch latch =
+                new MainActivity.BenchmarkArmTokenLatch();
+        latch.put("benchmark-token-0001", 31L);
+
+        assertTrue(latch.pendingFor(31L));
+        assertFalse(latch.pendingFor(32L));
+        assertNull(latch.take(32L));
+        assertTrue(latch.pendingFor(31L));
+        assertEquals("benchmark-token-0001", latch.take(31L));
+        assertFalse(latch.pendingFor(31L));
+    }
+
+    @Test
+    public void loadingOrSessionReplacementCanDiscardAnOldToken() {
+        MainActivity.BenchmarkArmTokenLatch latch =
+                new MainActivity.BenchmarkArmTokenLatch();
+        latch.put("benchmark-token-0001", 31L);
+
+        assertFalse(latch.onStateTransition(31L, state(RuntimeState.Phase.PAUSED, 31L)));
+        assertTrue(latch.pendingFor(31L));
+        assertTrue(latch.onStateTransition(31L, state(RuntimeState.Phase.LOADING, 31L)));
+
+        assertFalse(latch.pendingFor(31L));
+
+        latch.put("benchmark-token-0002", 31L);
+        assertTrue(latch.onStateTransition(31L, state(RuntimeState.Phase.PAUSED, 32L)));
+
+        assertFalse(latch.pendingFor(31L));
+        assertNull(latch.take(32L));
+    }
+
+    private static RuntimeState state(RuntimeState.Phase phase, long sessionGeneration) {
+        return new RuntimeState(phase, phase.name(), List.of(), true,
+                phase == RuntimeState.Phase.PAUSED, false, "", false,
+                sessionGeneration, 0L, 1L);
+    }
+}

--- a/android/benchmark-device-matrix-test.sh
+++ b/android/benchmark-device-matrix-test.sh
@@ -132,6 +132,9 @@ fi
 if [ "$sub" = cmd ]; then
   case "${2:-}:${3:-}" in
     package:list) echo 'package:eu.rekawek.coffeegb.android uid:10327' ;;
+    display:get-user-preferred-display-mode) echo 'User preferred display mode: -1 -1 0.0' ;;
+    display:set-user-preferred-display-mode) printf '%s\n' "${6:-60}" >"$rate_file" ;;
+    display:clear-user-preferred-display-mode) : ;;
     display:get-displays) echo "Display id 0: DisplayInfo{mode 3, renderFrameRate $(cat "$rate_file").0, supportedModes [{id=3, fps=$(cat "$rate_file").0}], state ON, committedState ON}" ;;
     *) : ;;
   esac
@@ -140,8 +143,8 @@ fi
 
 if [ "$sub" = dumpsys ]; then
   case "${2:-}" in
-    power) echo 'mWakefulness=Awake mInteractive=true' ;;
-    battery) echo 'AC powered: true'; echo 'USB powered: false'; echo 'Wireless powered: false'; echo 'plugged: 1' ;;
+    power) echo 'mWakefulness=Awake mHalInteractiveModeEnabled=true' ;;
+    battery) echo 'AC powered: true'; echo 'USB powered: false'; echo 'Wireless powered: false'; echo 'Dock powered: false' ;;
     thermalservice) echo 'ThermalStatusListeners:'; echo 'Thermal Status: 0' ;;
     activity) echo 'mResumedActivity: ActivityRecord{eu.rekawek.coffeegb.android/.MainActivity}' ;;
     package) echo 'ApplicationInfo{eu.rekawek.coffeegb.android flags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ] privateFlags=[ DIRECT_BOOT_AWARE ]}' ;;
@@ -176,7 +179,7 @@ if [ "$sub" = am ]; then
     exit 0
   fi
   [ "$action" = start ] || exit 1
-  profile=; pair=; block=; order=; side=; first=; slot=; launch_rate=; artifact=; execution=accuracy; scenario=none; session_generation=; arm=
+  profile=; pair=; block=; order=; side=; first=; slot=; launch_rate=; artifact=; execution=accuracy; audio_policy=canonical; scenario=none; session_generation=; arm=
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -193,6 +196,7 @@ if [ "$sub" = am ]; then
           coffee_gb_recent_slot) slot=$value ;;
           coffee_gb_surface_rate_hz) launch_rate=$value ;;
           coffee_gb_execution_mode) execution=$value ;;
+          coffee_gb_audio_policy) audio_policy=$value ;;
           coffee_gb_benchmark_scenario) scenario=$value ;;
           coffee_gb_benchmark_arm_token) arm=$value ;;
         esac
@@ -214,6 +218,7 @@ if [ "$sub" = am ]; then
       launch_rate=$(awk -F= '$1 == "rate" { print $2 }' "$context")
       artifact=$(awk -F= '$1 == "artifact" { print $2 }' "$context")
       execution=$(awk -F= '$1 == "execution" { print $2 }' "$context")
+      audio_policy=$(awk -F= '$1 == "audio_policy" { print $2 }' "$context")
       scenario=$(awk -F= '$1 == "scenario" { print $2 }' "$context")
       session_generation=$(awk -F= '$1 == "session_generation" { print $2 }' "$context")
     fi
@@ -255,9 +260,61 @@ if [ "$sub" = am ]; then
       [ "$mode" = baseline_pending ] && audio_start_pending=4
       [ "$mode" = baseline_queued ] && audio_start_queued=4
       [ "$mode" = baseline_stopped ] && audio_start_playing=false
-      matrix_record="I/CoffeeGbBench: event=matrix_run build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side first_side=$first session_generation=$session_generation benchmark_generation=$generation workload_nonce=app-owned-test-nonce-0001 warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained execution_mode=$execution thermal_window=m2 audio=on render=presentation availability=available requested_hardware=$profile surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective device_id=3333333333333333333333333333333333333333333333333333333333333333 audio_start_pending_bytes=$audio_start_pending audio_start_queued_bytes=$audio_start_queued audio_start_output_playing=$audio_start_playing"
+      audio_start_system_volume=10
+      audio_start_system_music_muted=false
+      { [ "$audio_policy" = silent-pcm-v1 ] || [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ]; } && {
+        audio_start_system_volume=0
+        audio_start_system_music_muted=true
+      }
+      matrix_record="I/CoffeeGbBench: event=matrix_run build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side first_side=$first session_generation=$session_generation benchmark_generation=$generation benchmark_token=$arm workload_nonce=app-owned-test-nonce-0001 warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained execution_mode=$execution thermal_window=m2 audio=on render=presentation availability=available requested_hardware=$profile benchmark_audio_policy=$audio_policy surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective device_id=3333333333333333333333333333333333333333333333333333333333333333 audio_start_pending_bytes=$audio_start_pending audio_start_queued_bytes=$audio_start_queued audio_start_output_playing=$audio_start_playing audio_start_active=true audio_start_paused=false audio_start_muted=false audio_start_volume=100 audio_start_system_volume=$audio_start_system_volume audio_start_system_volume_max=15 audio_start_system_music_muted=$audio_start_system_music_muted audio_start_queued_frames=0 audio_start_reopen_pending=false audio_start_output_identity=1 audio_start_queue_identity=1"
       printf '%s\n' "$matrix_record" >>"$log"
-      final_record="I/CoffeeGbBench: event=final_result build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side session_generation=$session_generation benchmark_generation=$generation frame=600 ready_count=600 ready_interval_fps=$ready_fps submission_interval_fps=$ready_fps submitted_count=600 dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 requested_profile=$profile profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective execution_mode=$execution surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained drain_success=true audio_active=true audio_output_playing=true audio_muted=false audio_system_music_muted=false audio_track_underruns=0 audio_focus_granted=true audio_focus_start_loss_count=0 audio_focus_loss_count=0 live_input_mutations=0 thermal_worst=0 display_bad_count=0 interactive_bad_count=0 plugged_bad_count=0 power_save_bad_count=0 stay_awake_bad_count=0 workload_nonce=app-owned-test-nonce-0001 device_id=3333333333333333333333333333333333333333333333333333333333333333"
+      audio_system_volume=10
+      audio_system_music_muted=false
+      benchmark_audio_requested=false
+      benchmark_audio_active_at_boundary=false
+      benchmark_audio_disabled_after=true
+      benchmark_audio_skipped_ticks=0
+      benchmark_audio_zero_sample_slots=0
+      benchmark_audio_zero_sample_events=0
+      benchmark_audio_max_debt=0
+      benchmark_audio_apu_reads=0
+      benchmark_audio_apu_writes=0
+      benchmark_audio_frame_sequencer_commits=0
+      benchmark_audio_dropped_channel_ticks=0
+      benchmark_audio_flags=001
+      benchmark_audio_calendar=0,0,0,0,0,0,0,0
+      { [ "$audio_policy" = silent-pcm-v1 ] || [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ]; } && {
+        audio_system_volume=0
+        audio_system_music_muted=true
+        benchmark_audio_requested=true
+        benchmark_audio_active_at_boundary=true
+        benchmark_audio_disabled_after=true
+        benchmark_audio_skipped_ticks=1
+        benchmark_audio_zero_sample_slots=1
+        benchmark_audio_zero_sample_events=1
+        benchmark_audio_max_debt=1
+        benchmark_audio_apu_reads=1
+        benchmark_audio_apu_writes=1
+        benchmark_audio_frame_sequencer_commits=1
+        [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ] && \
+          benchmark_audio_dropped_channel_ticks=1
+        benchmark_audio_flags=111
+        benchmark_audio_calendar="$benchmark_audio_skipped_ticks,$benchmark_audio_zero_sample_slots,$benchmark_audio_zero_sample_events,$benchmark_audio_max_debt,$benchmark_audio_apu_reads,$benchmark_audio_apu_writes,$benchmark_audio_frame_sequencer_commits,$benchmark_audio_dropped_channel_ticks"
+      }
+      compact_audio_extra=
+      [ "$mode" = compact_flags_tail ] && benchmark_audio_flags="${benchmark_audio_flags}0"
+      [ "$mode" = compact_calendar_extra ] && \
+        benchmark_audio_calendar="${benchmark_audio_calendar},0"
+      [ "$mode" = compact_apu_overflow ] && \
+        benchmark_audio_calendar='1,1,1,1,9223372036854775808,0,1,0'
+      [ "$mode" = compact_mixed ] && \
+        compact_audio_extra=' benchmark_audio_requested=false'
+      system_audio_sample_count=0
+      system_audio_bad_count=0
+      { [ "$audio_policy" = silent-pcm-v1 ] || [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ]; } && {
+        system_audio_sample_count=12
+      }
+      final_record="I/CoffeeGbBench: event=final_result build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side session_generation=$session_generation benchmark_generation=$generation benchmark_token=$arm frame=600 ready_count=600 ready_interval_fps=$ready_fps submission_interval_fps=$ready_fps submitted_count=600 dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 requested_profile=$profile profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective execution_mode=$execution surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained drain_success=true benchmark_audio_policy=$audio_policy benchmark_audio_flags=$benchmark_audio_flags benchmark_audio_calendar=$benchmark_audio_calendar$compact_audio_extra audio_active=true audio_output_playing=true audio_muted=false audio_volume=100 audio_system_volume=$audio_system_volume audio_system_music_muted=$audio_system_music_muted audio_output_identity=1 audio_queue_identity=1 audio_track_underruns=0 audio_focus_granted=true audio_focus_start_loss_count=0 audio_focus_loss_count=0 live_input_mutations=0 thermal_worst=0 display_bad_count=0 interactive_bad_count=0 plugged_bad_count=0 power_save_bad_count=0 stay_awake_bad_count=0 workload_nonce=app-owned-test-nonce-0001 device_id=3333333333333333333333333333333333333333333333333333333333333333 system_audio_sample_count=$system_audio_sample_count system_audio_bad_count=$system_audio_bad_count"
       printf '%s\n' "$final_record" >>"$log"
     fi
   elif [ "$mode" != timeout ]; then
@@ -289,8 +346,8 @@ if [ "$sub" = am ]; then
     printf 'I/CoffeeGbBench: event=benchmark_anchor success=true phase=anchor_ready\n' >>"$log"
   fi
   if [ -z "$arm" ]; then
-    printf 'profile=%s\npair=%s\nblock=%s\norder=%s\nside=%s\nfirst=%s\nslot=%s\nrate=%s\nartifact=%s\nexecution=%s\nscenario=%s\nsession_generation=%s\n' \
-      "$profile" "$pair" "$block" "$order" "$side" "$first" "$slot" "$launch_rate" "$artifact" "$execution" "$scenario" "$session_generation" >"$context"
+    printf 'profile=%s\npair=%s\nblock=%s\norder=%s\nside=%s\nfirst=%s\nslot=%s\nrate=%s\nartifact=%s\nexecution=%s\naudio_policy=%s\nscenario=%s\nsession_generation=%s\n' \
+      "$profile" "$pair" "$block" "$order" "$side" "$first" "$slot" "$launch_rate" "$artifact" "$execution" "$audio_policy" "$scenario" "$session_generation" >"$context"
     printf 'launch profile=%s slot=%s rate=%s mode=%s scenario=%s pair=%s order=%s side=%s first=%s\n' \
       "$profile" "$slot" "$launch_rate" "$execution" "$scenario" "$pair" "$order" "$side" "$first" >>"$records"
   fi
@@ -369,6 +426,7 @@ chmod 700 "$tmp/matrix"
 
 run_case() {
   mode=$1
+  policy=${2:-canonical}
   FAKE_APKSIGNER_MODE=${FAKE_APKSIGNER_MODE:-ok} FAKE_MODE=$mode \
     FAKE_CALLS="$calls" FAKE_RECORDS="$records" FAKE_LOG="$fake_log" \
     FAKE_RATE="$rate_file" FAKE_GEN="$gen_file" \
@@ -378,12 +436,14 @@ run_case() {
     COFFEE_GB_M2_ANCHOR_POLLS=2 COFFEE_GB_M2_FINAL_POLLS=2 \
     "$root/benchmark-device-matrix.sh" --parent-apk "$parent" --candidate-apk "$candidate" \
       --color-slot 2 --non-color-slot 3 --execution-mode performance \
+      --audio-policy "$policy" \
       --output-dir "$tmp/out-$mode" \
       >"$tmp/$mode.stdout" 2>"$tmp/$mode.stderr"
 }
 
 expect_failure() {
   mode=$1
+  policy=${2:-canonical}
   : >"$records"
   : >"$fake_log"
   printf '0\n' >"$gen_file"
@@ -392,7 +452,7 @@ expect_failure() {
     FAKE_APKSIGNER_MODE=unsigned run_case ok
     rc=$?
   else
-    run_case "$mode"
+    run_case "$mode" "$policy"
     rc=$?
   fi
   set -e
@@ -468,6 +528,15 @@ if grep -E 'pm clear|clear-data|\.gb(c|cstate)?|\.sav|uri=|title=' "$calls" >/de
   echo 'privacy/data-clear command was observed' >&2
   exit 1
 fi
+if grep -Ei 'adjust[-_[:alnum:]]*volume|set[-_[:alnum:]]*volume|set[-_[:alnum:]]*mute|set[-_[:alnum:]]*ringer|cmd[[:space:]]+audio|cmd[[:space:]]+media_session[[:space:]]+.*volume|media_session[[:space:]]+volume|keyevent[[:space:]]+(24|25|164|volume_up|volume_down|volume_mute)|settings[[:space:]]+put[[:space:]]+.*(volume|mute|ringer)' "$calls" >/dev/null 2>&1; then
+  echo 'audio volume mutation command was observed' >&2
+  exit 1
+fi
+if rg -n -i 'audioManager\.(adjustVolume|adjustStreamVolume|adjustSuggestedStreamVolume|setStreamVolume|setStreamMute|setRingerMode)\(|KEYCODE_VOLUME_(UP|DOWN|MUTE)' \
+    "$root/app/src/main" >/dev/null 2>&1; then
+  echo 'Android production source contains a system-audio mutation API' >&2
+  exit 1
+fi
 [ -f "$tmp/out-ok/matrix.log" ] && [ -f "$tmp/out-ok/matrix-report.txt" ] || {
   echo 'redacted output artifacts are missing' >&2
   exit 1
@@ -518,6 +587,45 @@ awk '
   END { if (gate_no != 168) exit 3 }
 ' "$records" || { echo 'compositor gate identity/generation linkage assertion failed' >&2; exit 1; }
 
+# The explicit silent policy is bounded to the five DMG/CGB rows; SGB/SGB2 remain canonical.
+: >"$records"
+: >"$fake_log"
+printf '0\n' >"$gen_file"
+if ! run_case silent_ok silent-pcm-v1; then
+  cat "$tmp/silent_ok.stderr" >&2
+  exit 1
+fi
+silent_launch_count=$(awk '/^launch / { count++ } END { print count + 0 }' "$records")
+[ "$silent_launch_count" -eq 120 ] || {
+  echo "expected 120 silent-policy launches, got $silent_launch_count" >&2
+  exit 1
+}
+if awk '/^launch / { pair=$0; sub(/^.*pair=/, "", pair); sub(/[[:space:]].*$/, "", pair); row=pair; sub(/^p[0-9]+-/, "", row); if (row == "sgb" || row == "sgb2") bad=1 } END { exit bad ? 0 : 1 }' "$records"; then
+  echo 'silent policy scheduled an unsupported SGB row' >&2
+  exit 1
+fi
+grep -q -- '--es coffee_gb_audio_policy silent-pcm-v1' "$calls" || {
+  echo 'silent audio policy was not passed' >&2
+  exit 1
+}
+
+: >"$records"
+: >"$fake_log"
+printf '0\n' >"$gen_file"
+if ! run_case relaxed_ok silent-pcm-relaxed-apu-v1; then
+  cat "$tmp/relaxed_ok.stderr" >&2
+  exit 1
+fi
+relaxed_launch_count=$(awk '/^launch / { count++ } END { print count + 0 }' "$records")
+[ "$relaxed_launch_count" -eq 120 ] || {
+  echo "expected 120 relaxed silent-policy launches, got $relaxed_launch_count" >&2
+  exit 1
+}
+grep -q -- '--es coffee_gb_audio_policy silent-pcm-relaxed-apu-v1' "$calls" || {
+  echo 'relaxed silent audio policy was not passed' >&2
+  exit 1
+}
+
 expect_failure wrong_device
 expect_failure unsigned
 expect_failure layer
@@ -533,5 +641,9 @@ expect_failure baseline_pending
 expect_failure baseline_queued
 expect_failure baseline_stopped
 expect_failure post_final_invalidation
+expect_failure compact_flags_tail
+expect_failure compact_calendar_extra
+expect_failure compact_mixed
+expect_failure compact_apu_overflow silent-pcm-v1
 
 echo 'benchmark device matrix hermetic fixture: PASS'

--- a/android/benchmark-device-matrix-test.sh
+++ b/android/benchmark-device-matrix-test.sh
@@ -81,7 +81,24 @@ if [ "$command" = install ]; then echo Success; exit 0; fi
 if [ "$command" = logcat ]; then
   if [ "${2:-}" = -c ]; then
     : >"$log"
+    rm -f "$records.postfinal-seen" "$records.postfinal-emitted"
   else
+    if [ "$mode" = post_final_invalidation ] \
+        && grep -q 'event=final_result ' "$log"; then
+      if [ -f "$records.postfinal-seen" ] && [ ! -f "$records.postfinal-emitted" ]; then
+        artifact=$(awk -F= '$1 == "artifact" { print $2 }' "$context")
+        pair=$(awk -F= '$1 == "pair" { print $2 }' "$context")
+        block=$(awk -F= '$1 == "block" { print $2 }' "$context")
+        order=$(awk -F= '$1 == "order" { print $2 }' "$context")
+        side=$(awk -F= '$1 == "side" { print $2 }' "$context")
+        session_generation=$(awk -F= '$1 == "session_generation" { print $2 }' "$context")
+        printf 'I/CoffeeGbBench: event=benchmark_invalidated artifact_id=%s pair_id=%s matrix_block=%s row_order=%s run_side=%s session_generation=%s phase=done reason=visibility_lost\n' \
+          "$artifact" "$pair" "$block" "$order" "$side" "$session_generation" >>"$log"
+        : >"$records.postfinal-emitted"
+      else
+        : >"$records.postfinal-seen"
+      fi
+    fi
     cat "$log"
   fi
   exit 0
@@ -159,7 +176,7 @@ if [ "$sub" = am ]; then
     exit 0
   fi
   [ "$action" = start ] || exit 1
-  profile=; pair=; block=; order=; side=; first=; slot=; launch_rate=; artifact=; execution=accuracy; arm=
+  profile=; pair=; block=; order=; side=; first=; slot=; launch_rate=; artifact=; execution=accuracy; scenario=none; session_generation=; arm=
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -176,6 +193,7 @@ if [ "$sub" = am ]; then
           coffee_gb_recent_slot) slot=$value ;;
           coffee_gb_surface_rate_hz) launch_rate=$value ;;
           coffee_gb_execution_mode) execution=$value ;;
+          coffee_gb_benchmark_scenario) scenario=$value ;;
           coffee_gb_benchmark_arm_token) arm=$value ;;
         esac
         shift 3
@@ -196,6 +214,8 @@ if [ "$sub" = am ]; then
       launch_rate=$(awk -F= '$1 == "rate" { print $2 }' "$context")
       artifact=$(awk -F= '$1 == "artifact" { print $2 }' "$context")
       execution=$(awk -F= '$1 == "execution" { print $2 }' "$context")
+      scenario=$(awk -F= '$1 == "scenario" { print $2 }' "$context")
+      session_generation=$(awk -F= '$1 == "session_generation" { print $2 }' "$context")
     fi
     generation=$(($(cat "$gen_file") + 1))
     printf '%s\n' "$generation" >"$gen_file"
@@ -215,20 +235,64 @@ if [ "$sub" = am ]; then
       content_rate=59728
       ready_fps=59.7275
       [ "$effective" = sgb ] && { content_rate=61168; ready_fps=61.1679; }
-      matrix_record="I/CoffeeGbBench: event=matrix_run build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side first_side=$first benchmark_generation=$generation workload_nonce=app-owned-test-nonce-0001 warmup=true input_contract=none execution_mode=$execution thermal_window=m2 audio=on render=presentation availability=available requested_hardware=$profile surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective device_id=3333333333333333333333333333333333333333333333333333333333333333"
+      case "$scenario" in
+        dmg-action-v1) scenario_frames=313; scenario_generation=$session_generation ;;
+        cgb-action-v1) scenario_frames=923; scenario_generation=$session_generation ;;
+        *) scenario_frames=0; scenario_generation=0 ;;
+      esac
+      if [ "$mode" = scenario_generation ] && [ "$scenario_generation" -gt 0 ]; then
+        scenario_generation=$((scenario_generation + 1))
+      fi
+      [ "$mode" = scenario_frames ] && scenario_frames=$((scenario_frames + 1))
+      scenario_completed=true
+      scenario_source_closed=true
+      scenario_audio_drained=true
+      [ "$mode" = scenario_incomplete ] && scenario_completed=false
+      [ "$mode" = scenario_cleanup ] && { scenario_source_closed=false; scenario_audio_drained=false; }
+      audio_start_pending=0
+      audio_start_queued=0
+      audio_start_playing=true
+      [ "$mode" = baseline_pending ] && audio_start_pending=4
+      [ "$mode" = baseline_queued ] && audio_start_queued=4
+      [ "$mode" = baseline_stopped ] && audio_start_playing=false
+      matrix_record="I/CoffeeGbBench: event=matrix_run build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side first_side=$first session_generation=$session_generation benchmark_generation=$generation workload_nonce=app-owned-test-nonce-0001 warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained execution_mode=$execution thermal_window=m2 audio=on render=presentation availability=available requested_hardware=$profile surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective device_id=3333333333333333333333333333333333333333333333333333333333333333 audio_start_pending_bytes=$audio_start_pending audio_start_queued_bytes=$audio_start_queued audio_start_output_playing=$audio_start_playing"
       printf '%s\n' "$matrix_record" >>"$log"
-      final_record="I/CoffeeGbBench: event=final_result build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side benchmark_generation=$generation frame=600 ready_count=600 ready_interval_fps=$ready_fps submission_interval_fps=$ready_fps submitted_count=600 dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 requested_profile=$profile profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective execution_mode=$execution surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate warmup=true input_contract=none drain_success=true audio_active=true audio_muted=false audio_system_music_muted=false audio_track_underruns=0 audio_start_track_underruns=0 audio_focus_granted=true audio_focus_start_loss_count=0 audio_focus_loss_count=0 live_input_mutations=0 thermal_worst=0 display_bad_count=0 interactive_bad_count=0 plugged_bad_count=0 power_save_bad_count=0 stay_awake_bad_count=0 workload_nonce=app-owned-test-nonce-0001 device_id=3333333333333333333333333333333333333333333333333333333333333333"
+      final_record="I/CoffeeGbBench: event=final_result build_profile=benchmark artifact_id=$artifact pair_id=$pair matrix_block=$block row_order=$order run_side=$side session_generation=$session_generation benchmark_generation=$generation frame=600 ready_count=600 ready_interval_fps=$ready_fps submission_interval_fps=$ready_fps submitted_count=600 dropped_count=0 duplicate_count=0 late_count=0 corrupt_count=0 requested_profile=$profile profile=$profile effective_gbc=$gbc effective_dmg_compat=$compat effective_mode=$effective execution_mode=$execution surface_vote_hz=$launch_rate display_target_hz=$launch_rate surface_content_rate_millihz=$content_rate warmup=true input_contract=$scenario scenario_session_generation=$scenario_generation scenario_completed=$scenario_completed scenario_completed_frames=$scenario_frames scenario_expected_frames=$scenario_frames scenario_source_closed=$scenario_source_closed scenario_audio_drained=$scenario_audio_drained drain_success=true audio_active=true audio_output_playing=true audio_muted=false audio_system_music_muted=false audio_track_underruns=0 audio_focus_granted=true audio_focus_start_loss_count=0 audio_focus_loss_count=0 live_input_mutations=0 thermal_worst=0 display_bad_count=0 interactive_bad_count=0 plugged_bad_count=0 power_save_bad_count=0 stay_awake_bad_count=0 workload_nonce=app-owned-test-nonce-0001 device_id=3333333333333333333333333333333333333333333333333333333333333333"
       printf '%s\n' "$final_record" >>"$log"
     fi
   elif [ "$mode" != timeout ]; then
+    session_generation=$(($(cat "$gen_file") + 1))
+    case "$scenario" in
+      dmg-action-v1) scenario_frames=313 ;;
+      cgb-action-v1) scenario_frames=923 ;;
+      *) scenario_frames=0 ;;
+    esac
+    if [ "$scenario" != none ] && [ "$mode" != scenario_missing ]; then
+      emitted_frames=$scenario_frames
+      [ "$mode" = scenario_frames ] && emitted_frames=$((emitted_frames + 1))
+      scenario_pair=$pair
+      [ "$mode" = scenario_identity ] && scenario_pair=stale-pair
+      completed=true
+      source_closed=true
+      audio_drained=true
+      [ "$mode" = scenario_incomplete ] && completed=false
+      [ "$mode" = scenario_cleanup ] && { source_closed=false; audio_drained=false; }
+      printf 'I/CoffeeGbBench: event=scenario_complete artifact_id=%s pair_id=%s matrix_block=%s row_order=%s run_side=%s session_generation=%s input_contract=%s completed=%s completed_frames=%s expected_frames=%s source_closed=%s audio_drained=%s\n' \
+        "$artifact" "$scenario_pair" "$block" "$order" "$side" "$session_generation" \
+        "$scenario" "$completed" "$emitted_frames" "$scenario_frames" "$source_closed" \
+        "$audio_drained" >>"$log"
+    elif [ "$scenario" = none ] && [ "$mode" = scenario_missing ]; then
+      printf 'I/CoffeeGbBench: event=scenario_complete artifact_id=%s pair_id=%s matrix_block=%s row_order=%s run_side=%s session_generation=%s input_contract=dmg-action-v1 completed=true completed_frames=313 expected_frames=313 source_closed=true audio_drained=true\n' \
+        "$artifact" "$pair" "$block" "$order" "$side" "$session_generation" >>"$log"
+    fi
     printf 'I/CoffeeGbBench: event=warmup_complete completed=true phase=warming\n' >>"$log"
     printf 'I/CoffeeGbBench: event=benchmark_anchor success=true phase=anchor_ready\n' >>"$log"
   fi
   if [ -z "$arm" ]; then
-    printf 'profile=%s\npair=%s\nblock=%s\norder=%s\nside=%s\nfirst=%s\nslot=%s\nrate=%s\nartifact=%s\nexecution=%s\n' \
-      "$profile" "$pair" "$block" "$order" "$side" "$first" "$slot" "$launch_rate" "$artifact" "$execution" >"$context"
-    printf 'launch profile=%s slot=%s rate=%s mode=%s pair=%s order=%s side=%s first=%s\n' \
-      "$profile" "$slot" "$launch_rate" "$execution" "$pair" "$order" "$side" "$first" >>"$records"
+    printf 'profile=%s\npair=%s\nblock=%s\norder=%s\nside=%s\nfirst=%s\nslot=%s\nrate=%s\nartifact=%s\nexecution=%s\nscenario=%s\nsession_generation=%s\n' \
+      "$profile" "$pair" "$block" "$order" "$side" "$first" "$slot" "$launch_rate" "$artifact" "$execution" "$scenario" "$session_generation" >"$context"
+    printf 'launch profile=%s slot=%s rate=%s mode=%s scenario=%s pair=%s order=%s side=%s first=%s\n' \
+      "$profile" "$slot" "$launch_rate" "$execution" "$scenario" "$pair" "$order" "$side" "$first" >>"$records"
   fi
   printf 'Status: ok\n'
   exit 0
@@ -363,6 +427,7 @@ awk '
     rate=$0; sub(/^.*rate=/, "", rate); sub(/[[:space:]].*$/, "", rate)
     mode=$0; sub(/^.*mode=/, "", mode); sub(/[[:space:]].*$/, "", mode)
     profile=$0; sub(/^.*profile=/, "", profile); sub(/[[:space:]].*$/, "", profile)
+    scenario=$0; sub(/^.*scenario=/, "", scenario); sub(/[[:space:]].*$/, "", scenario)
     slot=$0; sub(/^.*slot=/, "", slot); sub(/[[:space:]].*$/, "", slot)
     if ((launch_no - 1) % 14 == 0) { block_no++; expected_first=(block_no % 2 == 1 ? "parent" : "candidate") }
     if (first != expected_first) exit 2
@@ -375,6 +440,9 @@ awk '
     if ((row == "cgb-native" || row == "cgb-dmg-compat") && profile != "cgb") exit 6
     if (row == "cgb0-native" && profile != "cgb0") exit 7
     if ((row == "dmg" || row == "mgb" || row == "sgb" || row == "sgb2") && profile != row) exit 8
+    if (((row == "dmg" || row == "mgb" || row == "cgb-dmg-compat") && scenario != "dmg-action-v1") || \
+        ((row == "cgb-native" || row == "cgb0-native") && scenario != "cgb-action-v1") || \
+        ((row == "sgb" || row == "sgb2") && scenario != "none")) exit 13
     if ((launch_no % 2) == 1) {
       if (seen[block_no SUBSEP row]++) exit 9
       rows_in_block[block_no]++
@@ -389,6 +457,9 @@ awk '
 grep -q -- '--es coffee_gb_hardware cgb' "$calls" || { echo 'profile was not passed' >&2; exit 1; }
 grep -q -- '--ei coffee_gb_recent_slot 2' "$calls" || { echo 'color slot was not passed' >&2; exit 1; }
 grep -q -- '--ei coffee_gb_recent_slot 3' "$calls" || { echo 'non-color slot was not passed' >&2; exit 1; }
+grep -q -- '--es coffee_gb_benchmark_scenario dmg-action-v1' "$calls" || { echo 'DMG input contract was not passed' >&2; exit 1; }
+grep -q -- '--es coffee_gb_benchmark_scenario cgb-action-v1' "$calls" || { echo 'CGB input contract was not passed' >&2; exit 1; }
+grep -q -- '--es coffee_gb_benchmark_scenario none' "$calls" || { echo 'SGB input contract was not passed' >&2; exit 1; }
 if grep -q -- 'coffee_gb_workload_nonce' "$calls"; then
   echo 'host workload nonce was passed' >&2
   exit 1
@@ -452,5 +523,15 @@ expect_failure unsigned
 expect_failure layer
 expect_failure timeout
 expect_failure privacy
+expect_failure scenario_missing
+expect_failure scenario_frames
+expect_failure scenario_generation
+expect_failure scenario_identity
+expect_failure scenario_incomplete
+expect_failure scenario_cleanup
+expect_failure baseline_pending
+expect_failure baseline_queued
+expect_failure baseline_stopped
+expect_failure post_final_invalidation
 
 echo 'benchmark device matrix hermetic fixture: PASS'

--- a/android/benchmark-device-matrix.sh
+++ b/android/benchmark-device-matrix.sh
@@ -52,7 +52,8 @@ GATE_SCRIPT=${COFFEE_GB_M2_GATE_SCRIPT:-$SCRIPT_DIR/surface-timestats-gate.sh}
 usage() {
   echo "usage: benchmark-device-matrix.sh --parent-apk <signed.apk> --candidate-apk <signed.apk>" >&2
   echo "       --color-slot <0..9> --non-color-slot <0..9>" >&2
-  echo "       [--execution-mode accuracy|performance] [--output-dir <dir>]" >&2
+  echo "       [--execution-mode accuracy|performance] [--audio-policy canonical|silent-pcm-v1|silent-pcm-relaxed-apu-v1]" >&2
+  echo "       [--output-dir <dir>]" >&2
 }
 
 fatal() {
@@ -85,12 +86,14 @@ color_slot=
 non_color_slot=
 output_dir=
 execution_mode=accuracy
+audio_policy=canonical
 parent_seen=false
 candidate_seen=false
 color_seen=false
 non_color_seen=false
 output_seen=false
 execution_mode_seen=false
+audio_policy_seen=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -136,6 +139,13 @@ while [ "$#" -gt 0 ]; do
       execution_mode_seen=true
       shift 2
       ;;
+    --audio-policy)
+      require_arg "$@"
+      [ "$audio_policy_seen" = false ] || { usage; exit 2; }
+      audio_policy=$(printf '%s' "$2" | tr 'A-Z' 'a-z')
+      audio_policy_seen=true
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -153,6 +163,20 @@ done
 case "$execution_mode" in
   accuracy|performance) : ;;
   *) fatal "execution mode must be accuracy or performance" ;;
+esac
+
+case "$audio_policy" in
+  canonical) : ;;
+  silent-pcm-v1|silent-pcm-relaxed-apu-v1)
+    [ "$execution_mode" = performance ] \
+      || fatal "silent-pcm-v1 requires PERFORMANCE execution mode"
+    # The silent calendar is a DMG/CGB proof only. SGB/SGB2 have a distinct source clock and
+    # are intentionally retained in the canonical seven-row matrix.
+    RUN_ROWS=5
+    RUNS_PER_BLOCK=$((RUN_ROWS * 2))
+    TOTAL_RUNS=$((RUN_BLOCKS * RUNS_PER_BLOCK))
+    ;;
+  *) fatal "audio policy must be canonical, silent-pcm-v1, or silent-pcm-relaxed-apu-v1" ;;
 esac
 
 case "$color_slot" in 0|1|2|3|4|5|6|7|8|9) : ;; *) fatal "color catalog slot must be 0..9" ;; esac
@@ -190,6 +214,25 @@ cleanup() {
         fi
       fi
     done
+    if [ -f "$tmp_dir/original.user-preferred-display-mode" ]; then
+      original_preferred=$(awk '
+        tolower($0) ~ /user preferred display mode:/ {
+          line=$0
+          sub(/^.*:[[:space:]]*/, "", line)
+          if (split(line, fields, /[[:space:]]+/) == 3) print fields[1], fields[2], fields[3]
+          exit
+        }
+      ' "$tmp_dir/original.user-preferred-display-mode")
+      set -- $original_preferred
+      if [ "$#" -eq 3 ] && awk -v width="$1" -v height="$2" -v rate="$3" \
+          'BEGIN { exit(width > 0 && height > 0 && rate > 0 ? 0 : 1) }'; then
+        "$ADB_BIN" -s "$DEVICE_SERIAL" shell cmd display set-user-preferred-display-mode \
+          "$1" "$2" "$3" 0 >/dev/null 2>&1 || :
+      else
+        "$ADB_BIN" -s "$DEVICE_SERIAL" shell cmd display clear-user-preferred-display-mode 0 \
+          >/dev/null 2>&1 || :
+      fi
+    fi
   fi
   rm -rf "$tmp_dir"
 }
@@ -353,6 +396,7 @@ check_host_environment() {
     || fatal "power state query failed"
   if ! awk '
     tolower($0) ~ /minteractive[[:space:]]*=[[:space:]]*true/ { interactive=1 }
+    tolower($0) ~ /mhalinteractivemodeenabled[[:space:]]*=[[:space:]]*true/ { interactive=1 }
     tolower($0) ~ /mwakefulness[[:space:]]*=[[:space:]]*awake/ { awake=1 }
     END { exit(interactive && awake ? 0 : 1) }
   ' "$tmp_dir/power"; then
@@ -361,12 +405,28 @@ check_host_environment() {
 
   adb_shell_capture "$tmp_dir/battery" dumpsys battery \
     || fatal "battery state query failed"
-  if ! awk 'tolower($0) ~ /(ac|usb|wireless) powered[[:space:]]*:[[:space:]]*true/ \
+  if ! awk 'tolower($0) ~ /(ac|usb|wireless|dock) powered[[:space:]]*:[[:space:]]*true/ \
       || tolower($0) ~ /^[[:space:]]*powered[[:space:]]*:[[:space:]]*true/ { ok=1 }
       END { exit(ok ? 0 : 1) }' "$tmp_dir/battery"; then
     fatal "device is not physically plugged in"
   fi
   plugged_mask=$(awk -F: 'tolower($1) ~ /^[[:space:]]*plugged[[:space:]]*$/ { gsub(/[[:space:]]/, "", $2); print $2; exit }' "$tmp_dir/battery")
+  if [ -z "$plugged_mask" ]; then
+    plugged_mask=$(awk -F: '
+      {
+        key=tolower($1)
+        value=tolower($2)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        if (value != "true") next
+        if (key == "ac powered") mask += 1
+        else if (key == "usb powered") mask += 2
+        else if (key == "wireless powered") mask += 4
+        else if (key == "dock powered") mask += 8
+      }
+      END { if (mask > 0) print mask }
+    ' "$tmp_dir/battery")
+  fi
   case "$plugged_mask" in ''|*[!0-9]*) fatal "battery plugged mask is unavailable" ;; esac
   [ "$plugged_mask" -gt 0 ] || fatal "device is not plugged into a power source"
 
@@ -418,6 +478,8 @@ pin_display_rate() {
   adb_shell_checked settings put system peak_refresh_rate "$rate"
   adb_shell_checked settings put system min_refresh_rate "$rate"
   adb_shell_checked settings put system user_refresh_rate "$rate"
+  adb_shell_checked cmd display set-user-preferred-display-mode 720 1600 "$rate" 0
+  bounded_sleep "$REFRESH_WAIT_SECONDS"
   verify_display_rate "$rate"
 }
 
@@ -474,6 +536,9 @@ save_display_settings() {
     adb_shell_capture "$tmp_dir/original.$setting" settings get system "$setting" \
       || fatal "display setting query failed"
   done
+  adb_shell_capture "$tmp_dir/original.user-preferred-display-mode" \
+    cmd display get-user-preferred-display-mode 0 \
+    || fatal "user-preferred display mode query failed"
   display_settings_saved=true
 }
 
@@ -576,6 +641,8 @@ line_field() {
   line=$2
   printf '%s\n' "$line" | awk -v wanted="$key" '
     {
+      compact_flags=""
+      compact_calendar=""
       for (i = 1; i <= NF; i++) {
         if (index($i, wanted "=") == 1) {
           value=$i
@@ -583,9 +650,67 @@ line_field() {
           print value
           exit
         }
+        if (index($i, "benchmark_audio_flags=") == 1) {
+          compact_flags=$i
+          sub("^benchmark_audio_flags=", "", compact_flags)
+        }
+        if (index($i, "benchmark_audio_calendar=") == 1) {
+          compact_calendar=$i
+          sub("^benchmark_audio_calendar=", "", compact_calendar)
+        }
+      }
+      if (wanted == "benchmark_audio_requested" && compact_flags != "") {
+        print (substr(compact_flags, 1, 1) == "1" ? "true" : "false")
+        exit
+      }
+      if (wanted == "benchmark_audio_active_at_boundary" && compact_flags != "") {
+        print (substr(compact_flags, 2, 1) == "1" ? "true" : "false")
+        exit
+      }
+      if (wanted == "benchmark_audio_disabled_after" && compact_flags != "") {
+        print (substr(compact_flags, 3, 1) == "1" ? "true" : "false")
+        exit
+      }
+      if (compact_calendar != "") {
+        split(compact_calendar, calendar, ",")
+        if (wanted == "benchmark_audio_skipped_ticks") { print calendar[1]; exit }
+        if (wanted == "benchmark_audio_zero_sample_slots") { print calendar[2]; exit }
+        if (wanted == "benchmark_audio_zero_sample_events") { print calendar[3]; exit }
+        if (wanted == "benchmark_audio_max_debt") { print calendar[4]; exit }
+        if (wanted == "benchmark_audio_apu_reads") { print calendar[5]; exit }
+        if (wanted == "benchmark_audio_apu_writes") { print calendar[6]; exit }
+        if (wanted == "benchmark_audio_frame_sequencer_commits") { print calendar[7]; exit }
+        if (wanted == "benchmark_audio_dropped_channel_ticks") { print calendar[8]; exit }
       }
     }
   '
+}
+
+require_compact_audio_proof() {
+  line=$1
+  printf '%s\n' "$line" | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^benchmark_audio_flags=/) {
+          flags_count++
+          flags=$i
+          sub(/^benchmark_audio_flags=/, "", flags)
+        } else if ($i ~ /^benchmark_audio_calendar=/) {
+          calendar_count++
+          calendar=$i
+          sub(/^benchmark_audio_calendar=/, "", calendar)
+        } else if ($i ~ /^benchmark_audio_(requested|active_at_boundary|disabled_after|skipped_ticks|zero_sample_slots|zero_sample_events|max_debt|apu_reads|apu_writes|frame_sequencer_commits|dropped_channel_ticks)=/) {
+          expanded_count++
+        }
+      }
+    }
+    END {
+      if (flags_count != 1 || calendar_count != 1 || expanded_count != 0) exit 1
+      if (flags !~ /^[01][01][01]$/) exit 2
+      if (split(calendar, part, ",") != 8) exit 3
+      for (i = 1; i <= 8; i++) if (part[i] !~ /^[0-9]+$/) exit 4
+    }
+  ' || fatal "final benchmark evidence has malformed compact audio proof"
 }
 
 require_line_field() {
@@ -594,6 +719,23 @@ require_line_field() {
   expected=$3
   actual=$(line_field "$key" "$line")
   [ "$actual" = "$expected" ] || fatal "final benchmark evidence has an unexpected $key"
+}
+
+require_positive_line_field() {
+  line=$1
+  key=$2
+  actual=$(line_field "$key" "$line")
+  case "$actual" in ''|*[!0-9]*) fatal "benchmark evidence has malformed $key" ;; esac
+  [ "$actual" -gt 0 ] || fatal "benchmark evidence has non-positive $key"
+}
+
+require_nonnegative_line_field() {
+  line=$1
+  key=$2
+  actual=$(line_field "$key" "$line")
+  case "$actual" in ''|*[!0-9]*) fatal "benchmark evidence has malformed $key" ;; esac
+  [ "$actual" -ge 0 ] 2>/dev/null \
+    || fatal "benchmark evidence has out-of-range $key"
 }
 
 valid_opaque_token() {
@@ -690,6 +832,17 @@ wait_for_final() {
       final_result_line=$final_line
       return 0
     fi
+    invalidated_count=$(event_count "$tmp_dir/logcat" "$EVENT_INVALIDATED")
+    if [ "$invalidated_count" -gt 0 ]; then
+      [ "$invalidated_count" -eq 1 ] || fatal "multiple benchmark invalidation events were observed"
+      invalidated_line=$(event_line "$tmp_dir/logcat" "$EVENT_INVALIDATED")
+      invalidated_reason=$(line_field reason "$invalidated_line")
+      case "$invalidated_reason" in
+        system_audio_unmuted) fatal "benchmark generation was invalidated by system audio" ;;
+        visibility_lost) fatal "benchmark generation was invalidated by visibility loss" ;;
+        *) fatal "benchmark generation was invalidated for an unsupported reason" ;;
+      esac
+    fi
     if ! lifecycle_ok; then
       fatal "benchmark Activity lost visibility while waiting for final_result"
     fi
@@ -723,19 +876,19 @@ fi
 case "$random_seed" in *[!0-9]*) random_seed=$$ ;; esac
 
 schedule_file=$tmp_dir/schedule
-awk -v seed="$random_seed" '
+awk -v seed="$random_seed" -v row_count="$RUN_ROWS" '
   BEGIN {
     srand(seed + 0)
     row[0]="dmg"; row[1]="mgb"; row[2]="cgb-native"; row[3]="cgb0-native"
     row[4]="cgb-dmg-compat"; row[5]="sgb"; row[6]="sgb2"
     for (block = 0; block < 12; block++) {
-      for (i = 0; i < 7; i++) order[i] = i
-      for (i = 6; i > 0; i--) {
+      for (i = 0; i < row_count; i++) order[i] = i
+      for (i = row_count - 1; i > 0; i--) {
         j = int(rand() * (i + 1))
         temp = order[i]; order[i] = order[j]; order[j] = temp
       }
       first = (block % 2 == 0) ? "parent" : "candidate"
-      for (i = 0; i < 7; i++) printf "%02d %d %s %s\n", block, i, row[order[i]], first
+      for (i = 0; i < row_count; i++) printf "%02d %d %s %s\n", block, i, row[order[i]], first
     }
   }
 ' >"$schedule_file" || fatal "could not create randomized schedule"
@@ -850,7 +1003,7 @@ run_one() {
   scenario_frames=$(row_scenario_frames "$row") || fatal "unknown scheduled scenario length"
   pair_id=p${block}-${row}
   matrix_block=mb${block}
-  arm_token=$(make_token a)
+  arm_token=$8
 
   run_number=$((run_number + 1))
   printf 'run=%s/%s block=%s row_order=%s row=%s side=%s first_side=%s mode=%s rate=%s\n' \
@@ -896,6 +1049,7 @@ run_one() {
     --ez coffee_gb_thermal_valid true \
     --ei coffee_gb_surface_rate_hz "$rate" \
     --es coffee_gb_execution_mode "$execution_mode" \
+    --es coffee_gb_audio_policy "$audio_policy" \
     --es coffee_gb_benchmark_scenario "$input_contract" \
     --ei coffee_gb_recent_slot "$slot" \
     || fatal "visible benchmark Activity launch failed"
@@ -982,6 +1136,7 @@ run_one() {
       || fatal "scenario_complete and matrix_run session generations differ"
   fi
   require_line_field "$matrix_run_line" benchmark_generation "$benchmark_generation"
+  require_line_field "$matrix_run_line" benchmark_token "$arm_token"
   require_line_field "$matrix_run_line" execution_mode "$execution_mode"
   require_line_field "$matrix_run_line" requested_hardware "$profile"
   require_line_field "$matrix_run_line" warmup true
@@ -992,9 +1147,16 @@ run_one() {
   require_line_field "$matrix_run_line" scenario_expected_frames "$scenario_frames"
   require_line_field "$matrix_run_line" scenario_source_closed true
   require_line_field "$matrix_run_line" scenario_audio_drained true
+  require_line_field "$matrix_run_line" benchmark_audio_policy "$audio_policy"
   require_line_field "$matrix_run_line" audio_start_pending_bytes 0
   require_line_field "$matrix_run_line" audio_start_queued_bytes 0
   require_line_field "$matrix_run_line" audio_start_output_playing true
+  require_line_field "$matrix_run_line" audio_start_active true
+  require_line_field "$matrix_run_line" audio_start_paused false
+  require_line_field "$matrix_run_line" audio_start_muted false
+  require_line_field "$matrix_run_line" audio_start_volume 100
+  require_line_field "$matrix_run_line" audio_start_queued_frames 0
+  require_line_field "$matrix_run_line" audio_start_reopen_pending false
   require_line_field "$matrix_run_line" thermal_window m2
   require_line_field "$matrix_run_line" audio on
   require_line_field "$matrix_run_line" render presentation
@@ -1019,6 +1181,7 @@ run_one() {
   require_line_field "$final_line" row_order "$row_order"
   require_line_field "$final_line" run_side "$run_side"
   require_line_field "$final_line" session_generation "$matrix_session_generation"
+  require_line_field "$final_line" benchmark_token "$arm_token"
   require_line_field "$final_line" execution_mode "$execution_mode"
   require_line_field "$final_line" frame 600
   require_line_field "$final_line" ready_count 600
@@ -1044,12 +1207,66 @@ run_one() {
   require_line_field "$final_line" scenario_expected_frames "$scenario_frames"
   require_line_field "$final_line" scenario_source_closed true
   require_line_field "$final_line" scenario_audio_drained true
+  require_compact_audio_proof "$final_line"
+  require_line_field "$final_line" benchmark_audio_policy "$audio_policy"
   # The ARM baseline is bound once in matrix_run. final_result intentionally omits its duplicated
   # 21-field copy to retain Android log-payload headroom.
   require_line_field "$final_line" audio_active true
   require_line_field "$final_line" audio_output_playing true
   require_line_field "$final_line" audio_muted false
-  require_line_field "$final_line" audio_system_music_muted false
+  if [ "$audio_policy" = silent-pcm-v1 ] || [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ]; then
+    require_line_field "$final_line" audio_volume 100
+    require_line_field "$final_line" audio_system_volume 0
+    require_line_field "$final_line" audio_system_music_muted true
+    require_line_field "$final_line" benchmark_audio_requested true
+    require_line_field "$final_line" benchmark_audio_active_at_boundary true
+    require_line_field "$final_line" benchmark_audio_disabled_after true
+    require_positive_line_field "$final_line" benchmark_audio_skipped_ticks
+    require_positive_line_field "$final_line" benchmark_audio_zero_sample_slots
+    require_positive_line_field "$final_line" benchmark_audio_zero_sample_events
+    require_positive_line_field "$final_line" benchmark_audio_max_debt
+    require_nonnegative_line_field "$final_line" benchmark_audio_apu_reads
+    require_nonnegative_line_field "$final_line" benchmark_audio_apu_writes
+    require_positive_line_field "$final_line" benchmark_audio_frame_sequencer_commits
+    if [ "$audio_policy" = silent-pcm-relaxed-apu-v1 ]; then
+      require_positive_line_field "$final_line" benchmark_audio_dropped_channel_ticks
+      [ "$(line_field benchmark_audio_dropped_channel_ticks "$final_line")" = \
+        "$(line_field benchmark_audio_skipped_ticks "$final_line")" ] \
+        || fatal "relaxed silent benchmark dropped ticks must equal skipped ticks"
+    else
+      require_line_field "$final_line" benchmark_audio_dropped_channel_ticks 0
+    fi
+    require_positive_line_field "$final_line" audio_output_identity
+    require_positive_line_field "$final_line" audio_queue_identity
+    start_output_identity=$(line_field audio_start_output_identity "$matrix_run_line")
+    start_queue_identity=$(line_field audio_start_queue_identity "$matrix_run_line")
+    [ "$start_output_identity" = "$(line_field audio_output_identity "$final_line")" ] \
+      || fatal "silent benchmark output identity changed during measurement"
+    [ "$start_queue_identity" = "$(line_field audio_queue_identity "$final_line")" ] \
+      || fatal "silent benchmark queue identity changed during measurement"
+    require_line_field "$matrix_run_line" audio_start_system_volume 0
+    require_line_field "$matrix_run_line" audio_start_system_music_muted true
+  else
+    require_line_field "$final_line" audio_system_music_muted false
+    require_line_field "$final_line" benchmark_audio_requested false
+    require_line_field "$final_line" benchmark_audio_active_at_boundary false
+    require_line_field "$final_line" benchmark_audio_disabled_after true
+    require_line_field "$final_line" benchmark_audio_skipped_ticks 0
+    require_line_field "$final_line" benchmark_audio_zero_sample_slots 0
+    require_line_field "$final_line" benchmark_audio_zero_sample_events 0
+    require_line_field "$final_line" benchmark_audio_max_debt 0
+    require_line_field "$final_line" benchmark_audio_apu_reads 0
+    require_line_field "$final_line" benchmark_audio_apu_writes 0
+    require_line_field "$final_line" benchmark_audio_frame_sequencer_commits 0
+    require_line_field "$final_line" benchmark_audio_dropped_channel_ticks 0
+  fi
+  if [ "$audio_policy" = canonical ]; then
+    require_line_field "$final_line" system_audio_sample_count 0
+    require_line_field "$final_line" system_audio_bad_count 0
+  else
+    require_line_field "$final_line" system_audio_sample_count 12
+    require_line_field "$final_line" system_audio_bad_count 0
+  fi
   require_line_field "$final_line" live_input_mutations 0
   require_line_field "$final_line" thermal_worst 0
   require_line_field "$final_line" display_bad_count 0
@@ -1190,8 +1407,9 @@ while IFS=' ' read -r block row_order row first_side; do
     second_apk=$parent_apk
     second_hash=$parent_hash
   fi
-  run_one "$block" "$row_order" "$row" "$first_side" "$first_side" "$first_apk" "$first_hash"
-  run_one "$block" "$row_order" "$row" "$first_side" "$second_side" "$second_apk" "$second_hash"
+  pair_token=$(make_token a)
+  run_one "$block" "$row_order" "$row" "$first_side" "$first_side" "$first_apk" "$first_hash" "$pair_token"
+  run_one "$block" "$row_order" "$row" "$first_side" "$second_side" "$second_apk" "$second_hash" "$pair_token"
 done <"$schedule_file"
 
 matrix_report=$tmp_dir/matrix-report.txt

--- a/android/benchmark-device-matrix.sh
+++ b/android/benchmark-device-matrix.sh
@@ -5,6 +5,7 @@ set -eu
 #
 # The benchmark wire is intentionally kept here as one small list of constants.  The Android
 # diagnostics side owns the event names; this host runner assumes the current contract is:
+#   event=scenario_complete ... completed_frames=<exact> source_closed=true audio_drained=true
 #   event=warmup_complete completed=true phase=warming
 #   event=benchmark_anchor success=true phase=anchor_ready
 #   event=final_result ... frame=600 ...
@@ -29,7 +30,9 @@ EXPECTED_API=35
 
 EVENT_WARMUP=warmup_complete
 EVENT_ANCHOR=benchmark_anchor
+EVENT_SCENARIO=scenario_complete
 EVENT_FINAL=final_result
+EVENT_INVALIDATED=benchmark_invalidated
 
 RUN_BLOCKS=12
 RUN_ROWS=7
@@ -809,6 +812,25 @@ row_effective_dmg_compat() {
   esac
 }
 
+row_input_contract() {
+  case "$1" in
+    dmg|mgb) printf '%s\n' dmg-action-v1 ;;
+    cgb-native|cgb0-native) printf '%s\n' cgb-action-v1 ;;
+    cgb-dmg-compat) printf '%s\n' dmg-action-v1 ;;
+    sgb|sgb2) printf '%s\n' none ;;
+    *) return 1 ;;
+  esac
+}
+
+row_scenario_frames() {
+  case "$1" in
+    dmg|mgb|cgb-dmg-compat) printf '%s\n' 313 ;;
+    cgb-native|cgb0-native) printf '%s\n' 923 ;;
+    sgb|sgb2) printf '%s\n' 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 run_one() {
   block=$1
   row_order=$2
@@ -824,6 +846,8 @@ run_one() {
   nominal_fps=$(row_nominal_fps "$row") || fatal "unknown scheduled nominal FPS"
   expected_gbc=$(row_effective_gbc "$row") || fatal "unknown scheduled CGB mode"
   expected_compat=$(row_effective_dmg_compat "$row") || fatal "unknown scheduled compatibility mode"
+  input_contract=$(row_input_contract "$row") || fatal "unknown scheduled input contract"
+  scenario_frames=$(row_scenario_frames "$row") || fatal "unknown scheduled scenario length"
   pair_id=p${block}-${row}
   matrix_block=mb${block}
   arm_token=$(make_token a)
@@ -872,6 +896,7 @@ run_one() {
     --ez coffee_gb_thermal_valid true \
     --ei coffee_gb_surface_rate_hz "$rate" \
     --es coffee_gb_execution_mode "$execution_mode" \
+    --es coffee_gb_benchmark_scenario "$input_contract" \
     --ei coffee_gb_recent_slot "$slot" \
     || fatal "visible benchmark Activity launch failed"
   if ! awk 'tolower($0) ~ /status:[[:space:]]*ok/ { ok=1 } END { exit(ok ? 0 : 1) }' "$tmp_dir/launch"; then
@@ -903,6 +928,32 @@ run_one() {
 
   # Matrix identity is app evidence, not a host relabel.  Pin every field which can otherwise
   # turn a stale lifecycle/log record into an accepted row.
+  scenario_count=$(event_count "$tmp_dir/logcat" "$EVENT_SCENARIO")
+  scenario_generation=0
+  if [ "$input_contract" = none ]; then
+    [ "$scenario_count" -eq 0 ] \
+      || fatal "no-input row emitted unexpected scenario_complete evidence"
+  else
+    [ "$scenario_count" -eq 1 ] \
+      || fatal "scripted row scenario_complete evidence was absent or ambiguous"
+    scenario_line=$(event_line "$tmp_dir/logcat" "$EVENT_SCENARIO")
+    require_line_field "$scenario_line" artifact_id "$artifact_id"
+    require_line_field "$scenario_line" pair_id "$pair_id"
+    require_line_field "$scenario_line" matrix_block "$matrix_block"
+    require_line_field "$scenario_line" row_order "$row_order"
+    require_line_field "$scenario_line" run_side "$run_side"
+    require_line_field "$scenario_line" input_contract "$input_contract"
+    require_line_field "$scenario_line" completed true
+    require_line_field "$scenario_line" completed_frames "$scenario_frames"
+    require_line_field "$scenario_line" expected_frames "$scenario_frames"
+    require_line_field "$scenario_line" source_closed true
+    require_line_field "$scenario_line" audio_drained true
+    scenario_generation=$(line_field session_generation "$scenario_line")
+    case "$scenario_generation" in
+      ''|*[!0-9]*) fatal "scenario session generation is malformed" ;;
+    esac
+    [ "$scenario_generation" -gt 0 ] || fatal "scenario session generation is invalid"
+  fi
   matrix_run_count=$(event_count "$tmp_dir/logcat" matrix_run)
   [ "$matrix_run_count" -eq 1 ] || fatal "matrix_run evidence was absent or ambiguous"
   matrix_run_line=$(event_line "$tmp_dir/logcat" matrix_run)
@@ -921,11 +972,29 @@ run_one() {
   require_line_field "$matrix_run_line" row_order "$row_order"
   require_line_field "$matrix_run_line" run_side "$run_side"
   require_line_field "$matrix_run_line" first_side "$first_side"
+  matrix_session_generation=$(line_field session_generation "$matrix_run_line")
+  case "$matrix_session_generation" in
+    ''|*[!0-9]*) fatal "matrix_run session generation is malformed" ;;
+  esac
+  [ "$matrix_session_generation" -gt 0 ] || fatal "matrix_run session generation is invalid"
+  if [ "$input_contract" != none ]; then
+    [ "$matrix_session_generation" = "$scenario_generation" ] \
+      || fatal "scenario_complete and matrix_run session generations differ"
+  fi
   require_line_field "$matrix_run_line" benchmark_generation "$benchmark_generation"
   require_line_field "$matrix_run_line" execution_mode "$execution_mode"
   require_line_field "$matrix_run_line" requested_hardware "$profile"
   require_line_field "$matrix_run_line" warmup true
-  require_line_field "$matrix_run_line" input_contract none
+  require_line_field "$matrix_run_line" input_contract "$input_contract"
+  require_line_field "$matrix_run_line" scenario_session_generation "$scenario_generation"
+  require_line_field "$matrix_run_line" scenario_completed true
+  require_line_field "$matrix_run_line" scenario_completed_frames "$scenario_frames"
+  require_line_field "$matrix_run_line" scenario_expected_frames "$scenario_frames"
+  require_line_field "$matrix_run_line" scenario_source_closed true
+  require_line_field "$matrix_run_line" scenario_audio_drained true
+  require_line_field "$matrix_run_line" audio_start_pending_bytes 0
+  require_line_field "$matrix_run_line" audio_start_queued_bytes 0
+  require_line_field "$matrix_run_line" audio_start_output_playing true
   require_line_field "$matrix_run_line" thermal_window m2
   require_line_field "$matrix_run_line" audio on
   require_line_field "$matrix_run_line" render presentation
@@ -949,6 +1018,7 @@ run_one() {
   require_line_field "$final_line" matrix_block "$matrix_block"
   require_line_field "$final_line" row_order "$row_order"
   require_line_field "$final_line" run_side "$run_side"
+  require_line_field "$final_line" session_generation "$matrix_session_generation"
   require_line_field "$final_line" execution_mode "$execution_mode"
   require_line_field "$final_line" frame 600
   require_line_field "$final_line" ready_count 600
@@ -967,8 +1037,17 @@ run_one() {
   require_line_field "$final_line" display_target_hz "$rate"
   require_line_field "$final_line" surface_content_rate_millihz "$content_rate"
   require_line_field "$final_line" warmup true
-  require_line_field "$final_line" input_contract none
+  require_line_field "$final_line" input_contract "$input_contract"
+  require_line_field "$final_line" scenario_session_generation "$scenario_generation"
+  require_line_field "$final_line" scenario_completed true
+  require_line_field "$final_line" scenario_completed_frames "$scenario_frames"
+  require_line_field "$final_line" scenario_expected_frames "$scenario_frames"
+  require_line_field "$final_line" scenario_source_closed true
+  require_line_field "$final_line" scenario_audio_drained true
+  # The ARM baseline is bound once in matrix_run. final_result intentionally omits its duplicated
+  # 21-field copy to retain Android log-payload headroom.
   require_line_field "$final_line" audio_active true
+  require_line_field "$final_line" audio_output_playing true
   require_line_field "$final_line" audio_muted false
   require_line_field "$final_line" audio_system_music_muted false
   require_line_field "$final_line" live_input_mutations 0
@@ -1053,7 +1132,33 @@ run_one() {
   require_line_field "$gate_line" late_acquire_frames 0
   require_line_field "$gate_line" bad_desired_present_frames 0
   require_line_field "$gate_line" measurement surfaceflinger_timestats
+
+  # The first final_result capture precedes SurfaceFlinger collection. Re-read the app evidence
+  # after that gate so a visibility/focus loss during the compositor tail cannot be hidden behind
+  # the stale capture. An invalidation is terminal even if final_result was already emitted.
+  capture_benchmark_log "$tmp_dir/logcat"
   check_redacted_lines "$tmp_dir/logcat"
+  [ "$(event_count "$tmp_dir/logcat" "$EVENT_INVALIDATED")" -eq 0 ] \
+    || fatal "benchmark session was invalidated before evidence collection completed"
+  [ "$(event_count "$tmp_dir/logcat" "$EVENT_FINAL")" -eq 1 ] \
+    || fatal "fresh final_result evidence was absent or ambiguous"
+  fresh_final_line=$(event_line "$tmp_dir/logcat" "$EVENT_FINAL")
+  require_line_field "$fresh_final_line" artifact_id "$artifact_id"
+  require_line_field "$fresh_final_line" pair_id "$pair_id"
+  require_line_field "$fresh_final_line" matrix_block "$matrix_block"
+  require_line_field "$fresh_final_line" row_order "$row_order"
+  require_line_field "$fresh_final_line" run_side "$run_side"
+  require_line_field "$fresh_final_line" session_generation "$matrix_session_generation"
+  require_line_field "$fresh_final_line" benchmark_generation "$benchmark_generation"
+  [ "$(event_count "$tmp_dir/logcat" matrix_run)" -eq 1 ] \
+    || fatal "fresh matrix_run evidence was absent or ambiguous"
+  if [ "$input_contract" = none ]; then
+    [ "$(event_count "$tmp_dir/logcat" "$EVENT_SCENARIO")" -eq 0 ] \
+      || fatal "fresh no-input row emitted unexpected scenario evidence"
+  else
+    [ "$(event_count "$tmp_dir/logcat" "$EVENT_SCENARIO")" -eq 1 ] \
+      || fatal "fresh scenario_complete evidence was absent or ambiguous"
+  fi
   # Only event records and the numeric compositor record become durable evidence.
   awk 'index($0, "CoffeeGbBench") > 0 && index($0, "event=") > 0 { print }' \
     "$tmp_dir/logcat" >>"$aggregate"

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -72,6 +72,7 @@ import eu.rekawek.coffeegb.controller.state.StateWorkspace
 import eu.rekawek.coffeegb.controller.state.StateCodec
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.ExecutionMode
+import eu.rekawek.coffeegb.core.sound.Sound
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.debug.DebugButton
@@ -381,8 +382,16 @@ class BasicController private constructor(
 
   /** Benchmark-only epoch state; ordinary sessions never consult these fields in the hot loop. */
   private var benchmarkArmed = false
-  private var benchmarkCoreFrozen = false
+  private val benchmarkCoreFrozenGate = BenchmarkCoreFrozenGate()
   private var benchmarkGeneration = 0L
+  /** FIFO policy decision required before a benchmark Resume can release the core. */
+  private var benchmarkAudioPolicyProcessed = false
+  private var benchmarkAudioPolicyAccepted = false
+  private var benchmarkAudioPolicyRequested = false
+  /** Selected host token; retained separately from the boolean for EXACT vs RELAXED_APU. */
+  private var benchmarkAudioPolicyToken = "canonical"
+  private var benchmarkAudioPolicyGeneration = 0L
+  private var benchmarkAudioPolicySessionGeneration = 0L
 
   /** Exact native-frame endpoint gate used only by Android benchmark preconditioning. */
   private var benchmarkGameplayScenarioActive = false
@@ -585,14 +594,36 @@ class BasicController private constructor(
     }
     eventQueue.register<Controller.BenchmarkArmEvent> {
       val currentSession = session
-      if (properties.overrides.benchmarkPolicyEnabled && !benchmarkArmed
+      val accepted = properties.overrides.benchmarkPolicyEnabled && !benchmarkArmed
           && currentSession != null && isEffectivelyPaused()
           && benchmarkGameplayScenarioReady
-          && playbackSessionGeneration == it.sessionGeneration) {
+          && playbackSessionGeneration == it.sessionGeneration
+      if (!accepted) {
+        // A rejected arm must terminate the host's pending policy decision. It is deliberately
+        // posted as a false decision and never followed by Resume.
+        if (properties.overrides.benchmarkPolicyEnabled) {
+          eventBus.post(
+              Controller.BenchmarkSilentPcmPolicyEvent(
+                  false, it.generation, it.sessionGeneration, accepted = false, policy = it.policy))
+        }
+        return@register
+      }
+      if (accepted) {
+        val checkedSession = checkNotNull(currentSession)
+        // A replacement/reset may leave a transient calendar armed on the old machine. Clear and
+        // materialize it before any new generation counters or acknowledgement become visible.
+        checkedSession.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
         benchmarkGeneration = it.generation
         benchmarkArmed = true
-        benchmarkCoreFrozen = false
-        currentSession.gameboy.resetPerformanceBulkCounters()
+        benchmarkCoreFrozenGate.setFrozen(false)
+        benchmarkAudioPolicyProcessed = false
+        benchmarkAudioPolicyAccepted = false
+        benchmarkAudioPolicyRequested = false
+        benchmarkAudioPolicyToken = it.policy
+        benchmarkAudioPolicyGeneration = it.generation
+        benchmarkAudioPolicySessionGeneration = it.sessionGeneration
+        checkedSession.gameboy.resetPerformanceBulkCounters()
+        checkedSession.gameboy.sound.resetPerformanceSystemMutedAudioCalendarCounters()
         debugFrame = 0L
         debugMasterTick = 0L
         debugFramePosition = 0
@@ -607,38 +638,128 @@ class BasicController private constructor(
         )
       }
     }
-    eventQueue.register<Controller.BenchmarkPhysicalFrameBoundaryEvent> {
-      if (properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
-          && !benchmarkCoreFrozen && it.frame == 600L
-          && it.generation == benchmarkGeneration) {
-        val currentSession = session ?: return@register
-        val speedMode = currentSession.gameboy.getSpeedMode()
-        val gpu = currentSession.gameboy.getGpu()
-        postSessionEventSafely(
-            currentSession,
-            Controller.BenchmarkFrameBoundaryEvent(
-                it.frame,
-                gpu.isGbc(),
-                gpu.isDmgCompatMode(),
-                speedMode.getSpeedMode(),
-                currentSession.gameboy.getPerformanceBulkSpanCount(),
-                currentSession.gameboy.getPerformanceBulkTicks(),
-                currentSession.gameboy.getPerformanceEpochCount(),
-                currentSession.gameboy.getPerformanceEpochTicks(),
-                currentSession.gameboy.getPerformanceEpochMaxTicks(),
-                currentSession.gameboy.getPerformanceEpochRasterFastTicks(),
-                currentSession.gameboy.getPerformanceEpochMode2ReplayTicks(),
-                currentSession.gameboy.getPerformanceEpochMode2BulkTicks(),
-            ),
-        )
-        benchmarkCoreFrozen = true
-        setPaused(true)
+    // Physical frame publication is synchronous on the controller owner. Handle that path
+    // directly so no late queued work can execute another measured tick before the freeze.
+    eventBus.register<Controller.BenchmarkPhysicalFrameBoundaryEvent> {
+      if (Thread.currentThread() !== thread) {
+        return@register
       }
+      handleBenchmarkPhysicalFrameBoundary(it)
+    }
+    // Test/headless producers may publish the same event from another thread. Queue that case
+    // onto the owner; the owner-thread listener above remains the synchronous Android path.
+    eventQueue.register<Controller.BenchmarkPhysicalFrameBoundaryEvent> {
+      handleBenchmarkPhysicalFrameBoundary(it)
+    }
+    // A system-audio checkpoint runs on the same owner callback as Display.frameIsReady().
+    // Freeze synchronously before the current measured tick batch can continue; the companion
+    // accepted=false policy event remains the generation-bound telemetry record.
+    eventBus.register<Controller.BenchmarkSystemAudioViolationEvent> {
+      val currentSession = session
+      if (Thread.currentThread() !== thread
+          || !properties.overrides.benchmarkPolicyEnabled
+          || !benchmarkArmed
+          || currentSession == null
+          || it.generation != benchmarkAudioPolicyGeneration
+          || it.sessionGeneration != benchmarkAudioPolicySessionGeneration
+          || it.policy != benchmarkAudioPolicyToken
+          || playbackSessionGeneration != it.sessionGeneration) {
+        return@register
+      }
+      val sound = currentSession.gameboy.sound
+      sound.setPerformanceSystemMutedAudioCalendar(false)
+      benchmarkAudioPolicyToken = it.policy
+      benchmarkAudioPolicyRequested = false
+      benchmarkAudioPolicyAccepted = false
+      benchmarkAudioPolicyProcessed = true
+      benchmarkCoreFrozenGate.setFrozen(true)
+      setPaused(true)
+    }
+    eventQueue.register<Controller.BenchmarkSilentPcmPolicyEvent> {
+      val currentSession = session
+      val matching = properties.overrides.benchmarkPolicyEnabled
+          && benchmarkArmed && currentSession != null
+          && it.generation == benchmarkAudioPolicyGeneration
+          && it.sessionGeneration == benchmarkAudioPolicySessionGeneration
+          && it.policy == benchmarkAudioPolicyToken
+          && playbackSessionGeneration == it.sessionGeneration
+      if (!matching) {
+        return@register
+      }
+      val sound = checkNotNull(currentSession).gameboy.sound
+      if (!it.accepted) {
+        sound.setPerformanceSystemMutedAudioCalendar(false)
+        benchmarkAudioPolicyToken = it.policy
+        benchmarkAudioPolicyRequested = false
+        benchmarkAudioPolicyAccepted = false
+        benchmarkAudioPolicyProcessed = true
+        benchmarkCoreFrozenGate.setFrozen(true)
+        // Revocation is an owner-thread terminal decision for this generation.  Pause here as
+        // well as rejecting future Resume events; Android's separately queued Pause must not
+        // leave a one-frame window in which ordinary emulation can run.
+        setPaused(true)
+        return@register
+      }
+      // The arm selected one immutable token.  Accepted policy decisions are one-shot; allowing
+      // a later exact/relaxed event to replace it would make the final counters ambiguous.
+      if (it.policy != benchmarkAudioPolicyToken || benchmarkAudioPolicyProcessed) {
+        return@register
+      }
+      if (!it.requested) {
+        sound.setPerformanceSystemMutedAudioCalendar(false)
+        benchmarkAudioPolicyToken = it.policy
+        benchmarkAudioPolicyRequested = false
+        benchmarkAudioPolicyAccepted = true
+        benchmarkAudioPolicyProcessed = true
+        return@register
+      }
+      if (benchmarkCoreFrozenGate.getAsBoolean() || !isEffectivelyPaused()
+          || checkNotNull(currentSession).gameboy.executionMode != ExecutionMode.PERFORMANCE) {
+        return@register
+      }
+      val selectedMode = when (it.policy) {
+        Controller.BenchmarkSilentPcmPolicyEvent.POLICY ->
+          Sound.PerformanceSystemMutedAudioMode.EXACT
+        Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY ->
+          Sound.PerformanceSystemMutedAudioMode.RELAXED_APU
+        else -> return@register
+      }
+      sound.setPerformanceSystemMutedAudioMode(selectedMode)
+      if (!sound.isPerformanceSystemMutedAudioCalendarEnabled()) {
+        return@register
+      }
+      benchmarkAudioPolicyToken = it.policy
+      benchmarkAudioPolicyRequested = true
+      benchmarkAudioPolicyAccepted = true
+      benchmarkAudioPolicyProcessed = true
     }
     eventQueue.register<Controller.ResumeEmulationEvent> {
-      if (properties.overrides.benchmarkPolicyEnabled && benchmarkCoreFrozen) {
+      if (properties.overrides.benchmarkPolicyEnabled && benchmarkCoreFrozenGate.getAsBoolean()) {
         // The 600th measured core boundary owns the terminal freeze.  A lifecycle/audio resume
         // cannot accidentally create an unmeasured 601st frame before the host collects SF data.
+        return@register
+      }
+      if (!Controller.benchmarkResumePolicyAllows(
+              properties.overrides.benchmarkPolicyEnabled,
+              benchmarkArmed,
+              benchmarkCoreFrozenGate.getAsBoolean(),
+              benchmarkAudioPolicyProcessed,
+              benchmarkAudioPolicyAccepted,
+              benchmarkAudioPolicyGeneration == benchmarkGeneration
+                  && benchmarkAudioPolicySessionGeneration == playbackSessionGeneration,
+              benchmarkAudioPolicyRequested,
+              session?.gameboy?.sound?.let { sound ->
+                when (benchmarkAudioPolicyToken) {
+                  Controller.BenchmarkSilentPcmPolicyEvent.POLICY ->
+                    sound.getPerformanceSystemMutedAudioMode() ==
+                        Sound.PerformanceSystemMutedAudioMode.EXACT
+                  Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY ->
+                    sound.getPerformanceSystemMutedAudioMode() ==
+                        Sound.PerformanceSystemMutedAudioMode.RELAXED_APU
+                  else -> !benchmarkAudioPolicyRequested
+                }
+              } ?: !benchmarkAudioPolicyRequested,
+          )) {
         return@register
       }
       if (pauseStateBeforeLoading != null) {
@@ -751,7 +872,9 @@ class BasicController private constructor(
     // An instruction-safe pause may stop between controller frame boundaries. Keep ordinary
     // application/state events at their established frame safe point while the private debug lane
     // remains responsive and can resume or advance the machine to the next lattice boundary.
-    if (debugFramePosition != 0 || pendingDebugAction != null) {
+    if (!(properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
+        && benchmarkCoreFrozenGate.getAsBoolean())
+        && (debugFramePosition != 0 || pendingDebugAction != null)) {
       runDebugContinuation()
       return
     }
@@ -772,10 +895,15 @@ class BasicController private constructor(
     finishStop()
     finishBatteryFlush()
 
+    val benchmarkExecutionFrozen =
+        properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
+            && benchmarkCoreFrozenGate.getAsBoolean()
+
     // rewinding restores one recorded state and then emulates a single frame from it,
     // so the display and audio play backwards at RewindManager.RECORD_INTERVAL speed
     val rewound =
-        loadJob == null &&
+        !benchmarkExecutionFrozen &&
+            loadJob == null &&
             replacementJob == null &&
             stopJob == null &&
             isRewinding &&
@@ -790,13 +918,14 @@ class BasicController private constructor(
     var emulated = false
     val clockSpec = session?.gameboy?.clockSpec ?: ClockSpec.LEGACY
     val frameTicks = clockSpec.controllerTicksPerFrame()
-    if (!rewound && (debugPaused || pendingDebugAction != null)) {
+    if (!benchmarkExecutionFrozen && !rewound && (debugPaused || pendingDebugAction != null)) {
       session?.gameboy?.requestFrameRenderSuppression(false)
       runDebugTickWindow(clockSpec, stopAtNextBoundary = false)
       return
     }
 
-    if (!rewound &&
+    if (!benchmarkExecutionFrozen &&
+        !rewound &&
         !isEffectivelyPaused() &&
         !isRewinding &&
         debugInstrumentation?.hasEnabledBreakpoints() == true) {
@@ -824,7 +953,8 @@ class BasicController private constructor(
     )
     val gameboy = session?.gameboy
     var emulatedTicks = 0
-    if (gameboy != null && (rewound || (!isEffectivelyPaused() && !isRewinding))) {
+    if (gameboy != null && !benchmarkExecutionFrozen
+        && (rewound || (!isEffectivelyPaused() && !isRewinding))) {
       relinquishDebugBreakpointPauseOwnership()
       val exactBenchmarkScenarioFrame = benchmarkGameplayScenarioActive
       if (exactBenchmarkScenarioFrame) {
@@ -833,6 +963,12 @@ class BasicController private constructor(
         // tail even when the ordinary PERFORMANCE path would own a frame-sized runTicks batch.
         emulatedTicks =
             gameboy.runTicksUntilStop(frameTicks) { benchmarkGameplayScenarioStopRequested }
+      } else if (properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
+          && !benchmarkCoreFrozenGate.getAsBoolean() && !trackDebugHistory && !rewound) {
+        // The physical frame-600 callback is synchronous on this owner thread. Keep the normal
+        // PERFORMANCE epoch/scanline scheduler for the measured window, but stop at the callback
+        // before another scalar hand-off or bulk packet can advance the frozen core.
+        emulatedTicks = gameboy.runMeasuredTicksUntilStop(frameTicks, benchmarkCoreFrozenGate)
       } else if (!trackDebugHistory && !rewound
           && gameboy.executionMode == ExecutionMode.PERFORMANCE) {
         // The core owns the frame-sized loop in ordinary PERFORMANCE mode. Debug/history
@@ -869,6 +1005,91 @@ class BasicController private constructor(
     if (emulated && !rewound) {
       recordCompletedFrame()
     }
+  }
+
+  /** Applies one accepted physical frame boundary on the emulation owner. */
+  private fun handleBenchmarkPhysicalFrameBoundary(
+      event: Controller.BenchmarkPhysicalFrameBoundaryEvent,
+  ) {
+    if (!properties.overrides.benchmarkPolicyEnabled || !benchmarkArmed
+        || benchmarkCoreFrozenGate.getAsBoolean()
+        || event.frame != 600L || event.generation != benchmarkGeneration) {
+      return
+    }
+    val currentSession = session ?: return
+    val speedMode = currentSession.gameboy.getSpeedMode()
+    val gpu = currentSession.gameboy.getGpu()
+    val sound = currentSession.gameboy.sound
+    val audioRequestedAtBoundary = benchmarkAudioPolicyRequested
+    val policy = if (audioRequestedAtBoundary) benchmarkAudioPolicyToken else "canonical"
+    val selectedModeMatches = when (policy) {
+      Controller.BenchmarkSilentPcmPolicyEvent.POLICY ->
+        sound.getPerformanceSystemMutedAudioMode() == Sound.PerformanceSystemMutedAudioMode.EXACT
+      Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY ->
+        sound.getPerformanceSystemMutedAudioMode() == Sound.PerformanceSystemMutedAudioMode.RELAXED_APU
+      else -> !audioRequestedAtBoundary
+    }
+    val activeAtBoundary = sound.isPerformanceSystemMutedAudioCalendarEnabled()
+        && selectedModeMatches
+    if (audioRequestedAtBoundary && !selectedModeMatches) {
+      sound.setPerformanceSystemMutedAudioCalendar(false)
+      benchmarkAudioPolicyProcessed = true
+      benchmarkAudioPolicyAccepted = false
+      benchmarkAudioPolicyRequested = false
+      benchmarkCoreFrozenGate.setFrozen(true)
+      setPaused(true)
+      return
+    }
+    // Turning the calendar OFF materializes the final pending span. Read all counters only after
+    // that transition so RELAXED_APU's dropped-channel debt is included in the terminal record.
+    sound.setPerformanceSystemMutedAudioCalendar(false)
+    val disabledAfterBoundary = !sound.isPerformanceSystemMutedAudioCalendarEnabled()
+    val skippedTicks = sound.getPerformanceSystemMutedAudioCalendarSkippedTicks()
+    val zeroSlots = sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots()
+    val zeroEvents = sound.getPerformanceSystemMutedAudioCalendarZeroSampleEvents()
+    val maxDebt = sound.getPerformanceSystemMutedAudioCalendarMaxPendingTicks()
+    val apuReads = sound.getPerformanceSystemMutedAudioCalendarApuReads()
+    val apuWrites = sound.getPerformanceSystemMutedAudioCalendarApuWrites()
+    val frameSequencerCommits =
+        sound.getPerformanceSystemMutedAudioCalendarFrameSequencerCommits()
+    val droppedChannelTicks = sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks()
+    // Publish the terminal ownership decision before notifying host consumers. A synchronous
+    // subscriber must observe the frozen core, and cannot re-enter a measured tick while the
+    // boundary event is being delivered.
+    benchmarkAudioPolicyProcessed = true
+    benchmarkAudioPolicyAccepted = false
+    benchmarkAudioPolicyRequested = false
+    benchmarkCoreFrozenGate.setFrozen(true)
+    postSessionEventSafely(
+        currentSession,
+        Controller.BenchmarkFrameBoundaryEvent(
+            event.frame,
+            gpu.isGbc(),
+            gpu.isDmgCompatMode(),
+            speedMode.getSpeedMode(),
+            currentSession.gameboy.getPerformanceBulkSpanCount(),
+            currentSession.gameboy.getPerformanceBulkTicks(),
+            currentSession.gameboy.getPerformanceEpochCount(),
+            currentSession.gameboy.getPerformanceEpochTicks(),
+            currentSession.gameboy.getPerformanceEpochMaxTicks(),
+            currentSession.gameboy.getPerformanceEpochRasterFastTicks(),
+            currentSession.gameboy.getPerformanceEpochMode2ReplayTicks(),
+            currentSession.gameboy.getPerformanceEpochMode2BulkTicks(),
+            policy,
+            audioRequestedAtBoundary,
+            activeAtBoundary,
+            disabledAfterBoundary,
+            skippedTicks,
+            zeroSlots,
+            zeroEvents,
+            maxDebt,
+            apuReads,
+            apuWrites,
+            frameSequencerCommits,
+            droppedChannelTicks,
+        ),
+    )
+    setPaused(true)
   }
 
   private fun runDebugContinuation() {
@@ -1414,6 +1635,9 @@ class BasicController private constructor(
     detachAndClearDebugTimelineObservation(gameboy)
     val status =
         try {
+          // The host calendar is transient and must not survive a restore boundary, even though
+          // Sound's memento also fail-closes it. Materialize the live prefix before replacement.
+          gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
           result.snapshot.restore(currentSession, effectiveCartridgePause = true)
           gameboy.seedDeterministicReplayInput(
               JoypadButtonMask.toButtons(result.input.legacyMask),
@@ -2551,6 +2775,9 @@ class BasicController private constructor(
     val mobileExternalIo = hasMobileAdapterExternalIo()
     val mobileBackendOwnership = mobileAdapterBackendOwnershipVersion()
     try {
+      // State application is a lifecycle boundary for the host-only calendar. Do not let a
+      // restored machine inherit deferred silent PCM debt from the pre-load timeline.
+      currentSession.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
       when (read.state.root) {
         is SessionStateRoot ->
             StateCodec.applyDecoded(read.state, currentSession, context.identity)
@@ -2653,6 +2880,9 @@ class BasicController private constructor(
     val mobileExternalIo = hasMobileAdapterExternalIo()
     val mobileBackendOwnership = mobileAdapterBackendOwnershipVersion()
     try {
+      // The compatibility loader mutates the live machine in place; clear the transient calendar
+      // before applying it so deferred APU debt is committed on the old timeline first.
+      currentSession.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
       manager.applySnapshotReadOnly(snapshot, currentSession)
       relinquishDebugBreakpointPauseOwnership()
       // Match managed-load ownership: a saved cartridge clock pause bit must not override the
@@ -3496,6 +3726,9 @@ class BasicController private constructor(
   }
 
   private fun setPaused(paused: Boolean) {
+    if (paused) {
+      disableBenchmarkAudioCalendar()
+    }
     if (isPaused == paused) {
       return
     }
@@ -3506,6 +3739,9 @@ class BasicController private constructor(
   }
 
   private fun setDebugPaused(paused: Boolean) {
+    if (paused) {
+      disableBenchmarkAudioCalendar()
+    }
     if (!paused) {
       relinquishDebugBreakpointPauseOwnership()
     }
@@ -3552,6 +3788,10 @@ class BasicController private constructor(
   private fun relinquishDebugBreakpointPauseOwnership() {
     debugBreakpointPauseActive = false
     lastDebugBreakpointHit = lastDebugBreakpointHit?.withActivePause(false)
+  }
+
+  private fun disableBenchmarkAudioCalendar() {
+    session?.gameboy?.sound?.setPerformanceSystemMutedAudioCalendar(false)
   }
 
   private fun updateCartridgePause(wasEffectivelyPaused: Boolean) {
@@ -4182,12 +4422,21 @@ class BasicController private constructor(
   ) {
     val session = session ?: return
 
+    // A newly committed session never inherits the transient host calendar from a replaced
+    // machine, even when the controller was already paused and no pause transition is emitted.
+    session.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
     // Benchmark sessions materialize into an explicit anchor-ready pause.  The host arms one
     // generation after capturing its compositor baseline; normal sessions retain auto-resume.
     isPaused = properties.overrides.benchmarkPolicyEnabled
     benchmarkArmed = false
-    benchmarkCoreFrozen = false
+    benchmarkCoreFrozenGate.setFrozen(false)
     benchmarkGeneration = 0L
+    benchmarkAudioPolicyProcessed = false
+    benchmarkAudioPolicyAccepted = false
+    benchmarkAudioPolicyRequested = false
+    benchmarkAudioPolicyToken = "canonical"
+    benchmarkAudioPolicyGeneration = 0L
+    benchmarkAudioPolicySessionGeneration = 0L
     benchmarkGameplayScenarioActive = false
     benchmarkGameplayScenarioExpectedFrames = 0
     benchmarkGameplayScenarioReady = true
@@ -4485,6 +4734,9 @@ class BasicController private constructor(
       closeDeadlineNanos: Long? = null,
   ) {
     val session = session ?: return
+    // Stop is also used by terminal close paths that may bypass a visible pause transition.
+    // Clear the transient calendar before releasing the machine or its event bus.
+    session.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
     revokeDebugPort(session, replaced = false)
     postSerialPeripheralStatus(
         serialPeripheralSelection,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -384,6 +384,13 @@ class BasicController private constructor(
   private var benchmarkCoreFrozen = false
   private var benchmarkGeneration = 0L
 
+  /** Exact native-frame endpoint gate used only by Android benchmark preconditioning. */
+  private var benchmarkGameplayScenarioActive = false
+  private var benchmarkGameplayScenarioExpectedFrames = 0
+  private var benchmarkGameplayScenarioReady = true
+  private var benchmarkGameplayScenarioStopRequested = false
+  private var benchmarkGameplayScenarioCompletedFrames = 0
+
   private var debugTrackingEnabled = false
 
   private var pendingDebugAction: PendingDebugAction? = null
@@ -551,9 +558,37 @@ class BasicController private constructor(
       }
       setPaused(true)
     }
+    eventQueue.register<Controller.BenchmarkGameplayScenarioStartEvent> {
+      val currentGeneration = playbackSessionGeneration
+      if (properties.overrides.benchmarkPolicyEnabled && session != null
+          && isEffectivelyPaused() && currentGeneration == it.sessionGeneration) {
+        benchmarkGameplayScenarioActive = true
+        benchmarkGameplayScenarioExpectedFrames = it.expectedFrames
+        benchmarkGameplayScenarioReady = false
+        benchmarkGameplayScenarioStopRequested = false
+        benchmarkGameplayScenarioCompletedFrames = 0
+      }
+    }
+    // This event is deliberately synchronous rather than routed through EventQueue. It is posted
+    // by Android from inside Display.frameIsReady() on this owner thread; setting the pause here
+    // lets the stop-aware benchmark scenario loop stop before one more guest tick is executed.
+    eventBus.register<Controller.BenchmarkGameplayScenarioEndpointEvent> {
+      val currentGeneration = playbackSessionGeneration
+      if (!properties.overrides.benchmarkPolicyEnabled
+          || Thread.currentThread() !== thread
+          || !benchmarkGameplayScenarioActive
+          || currentGeneration != it.sessionGeneration) {
+        return@register
+      }
+      benchmarkGameplayScenarioCompletedFrames = it.completedFrames
+      benchmarkGameplayScenarioStopRequested = true
+    }
     eventQueue.register<Controller.BenchmarkArmEvent> {
       val currentSession = session
-      if (properties.overrides.benchmarkPolicyEnabled && !benchmarkArmed && currentSession != null) {
+      if (properties.overrides.benchmarkPolicyEnabled && !benchmarkArmed
+          && currentSession != null && isEffectivelyPaused()
+          && benchmarkGameplayScenarioReady
+          && playbackSessionGeneration == it.sessionGeneration) {
         benchmarkGeneration = it.generation
         benchmarkArmed = true
         benchmarkCoreFrozen = false
@@ -564,7 +599,11 @@ class BasicController private constructor(
         timingTicker.resetForBenchmark()
         postSessionEventSafely(
             currentSession,
-            Controller.BenchmarkArmAcknowledgedEvent(it.generation, it.token),
+            Controller.BenchmarkArmAcknowledgedEvent(
+                it.generation,
+                it.token,
+                it.sessionGeneration,
+            ),
         )
       }
     }
@@ -584,6 +623,12 @@ class BasicController private constructor(
                 speedMode.getSpeedMode(),
                 currentSession.gameboy.getPerformanceBulkSpanCount(),
                 currentSession.gameboy.getPerformanceBulkTicks(),
+                currentSession.gameboy.getPerformanceEpochCount(),
+                currentSession.gameboy.getPerformanceEpochTicks(),
+                currentSession.gameboy.getPerformanceEpochMaxTicks(),
+                currentSession.gameboy.getPerformanceEpochRasterFastTicks(),
+                currentSession.gameboy.getPerformanceEpochMode2ReplayTicks(),
+                currentSession.gameboy.getPerformanceEpochMode2BulkTicks(),
             ),
         )
         benchmarkCoreFrozen = true
@@ -778,13 +823,23 @@ class BasicController private constructor(
             timingTicker.hasPacingDebt,
     )
     val gameboy = session?.gameboy
+    var emulatedTicks = 0
     if (gameboy != null && (rewound || (!isEffectivelyPaused() && !isRewinding))) {
       relinquishDebugBreakpointPauseOwnership()
-      if (!trackDebugHistory && !rewound && gameboy.executionMode == ExecutionMode.PERFORMANCE) {
+      val exactBenchmarkScenarioFrame = benchmarkGameplayScenarioActive
+      if (exactBenchmarkScenarioFrame) {
+        // Native Display events are emitted synchronously from Gameboy.tick(). The endpoint event
+        // above sets the pause before that call returns, so this loop executes no post-endpoint
+        // tail even when the ordinary PERFORMANCE path would own a frame-sized runTicks batch.
+        emulatedTicks =
+            gameboy.runTicksUntilStop(frameTicks) { benchmarkGameplayScenarioStopRequested }
+      } else if (!trackDebugHistory && !rewound
+          && gameboy.executionMode == ExecutionMode.PERFORMANCE) {
         // The core owns the frame-sized loop in ordinary PERFORMANCE mode. Debug/history
         // paths remain on their per-tick hooks so every observation and checkpoint boundary is
         // still materialized before the next callback.
         gameboy.runTicks(frameTicks)
+        emulatedTicks = frameTicks
       } else {
         repeat(frameTicks) {
           if (trackDebugHistory) {
@@ -792,13 +847,19 @@ class BasicController private constructor(
           } else {
             gameboy.tick()
           }
+          emulatedTicks++
         }
       }
-      emulated = true
+      emulated = emulatedTicks == frameTicks
+    }
+    if (benchmarkGameplayScenarioStopRequested) {
+      finishBenchmarkGameplayScenarioEndpoint()
     }
     timingTicker.runFrame(clockSpec)
+    if (emulatedTicks > 0) {
+      debugMasterTick = Math.addExact(debugMasterTick, emulatedTicks.toLong())
+    }
     if (emulated) {
-      debugMasterTick = Math.addExact(debugMasterTick, frameTicks.toLong())
       debugFrame = Math.addExact(debugFrame, 1L)
       debugFramePosition = 0
     }
@@ -980,6 +1041,25 @@ class BasicController private constructor(
         debugCheckpointHistory.disable(DebugHistoryTruncationReason.SESSION_BOUNDARY)
       }
     }
+  }
+
+  /** Completes the exact native-frame pause only after the stop-aware core call has unwound. */
+  private fun finishBenchmarkGameplayScenarioEndpoint() {
+    val generation = playbackSessionGeneration ?: return
+    val expectedFrames = benchmarkGameplayScenarioExpectedFrames
+    val completedFrames = benchmarkGameplayScenarioCompletedFrames
+    val completed = completedFrames == expectedFrames
+    benchmarkGameplayScenarioStopRequested = false
+    benchmarkGameplayScenarioActive = false
+    benchmarkGameplayScenarioReady = completed
+    setPaused(true)
+    eventBus.post(
+        Controller.BenchmarkGameplayScenarioCompletedEvent(
+            generation,
+            completedFrames,
+            expectedFrames,
+            completed,
+        ))
   }
 
   private fun releaseClosedDebugPortIfNeeded(notifyLifecycle: Boolean = true) {
@@ -3293,7 +3373,11 @@ class BasicController private constructor(
 
     val previousSession = session
     val committedSession = checkNotNull(nextSession)
-    val pauseNewSession = pauseStateBeforeLoading == true
+    // Benchmark activation owns an explicit preconditioning pause independently of the user's
+    // pre-load playback state. Do not let the loading workflow's `false` restore overwrite the
+    // pause established by start(), or the generation-bound scenario start will be rejected.
+    val pauseNewSession =
+        properties.overrides.benchmarkPolicyEnabled || pauseStateBeforeLoading == true
 
     // This assignment is the ownership commit. From here on the old session is never resumed:
     // its bus may need deferred cleanup, but it cannot invalidate the fully staged candidate.
@@ -4104,6 +4188,11 @@ class BasicController private constructor(
     benchmarkArmed = false
     benchmarkCoreFrozen = false
     benchmarkGeneration = 0L
+    benchmarkGameplayScenarioActive = false
+    benchmarkGameplayScenarioExpectedFrames = 0
+    benchmarkGameplayScenarioReady = true
+    benchmarkGameplayScenarioStopRequested = false
+    benchmarkGameplayScenarioCompletedFrames = 0
     debugPaused = false
     playbackSessionGeneration = SessionPresentationGeneration.next()
     pauseStateBeforeResume = null

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BenchmarkCoreFrozenGate.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BenchmarkCoreFrozenGate.kt
@@ -1,0 +1,20 @@
+package eu.rekawek.coffeegb.controller
+
+import java.util.function.BooleanSupplier
+
+/**
+ * Owner-thread stop gate shared by measured controller execution and disposable warmup.
+ *
+ * The value is deliberately non-volatile: both callers read and write it on their owning
+ * emulation thread, and the Java BooleanSupplier shape keeps the stop predicate identical at
+ * both call sites.
+ */
+internal class BenchmarkCoreFrozenGate : BooleanSupplier {
+  private var frozen = false
+
+  override fun getAsBoolean(): Boolean = frozen
+
+  fun setFrozen(nextFrozen: Boolean) {
+    frozen = nextFrozen
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -170,7 +170,9 @@ interface Controller : AutoCloseable {
    * pause. PERFORMANCE keeps its scheduler semantics; the session generation prevents a delayed
    * Android owner callback from controlling a replacement session.
    */
-  data class BenchmarkGameplayScenarioStartEvent(
+  data class BenchmarkGameplayScenarioStartEvent
+  @JvmOverloads
+  constructor(
       val sessionGeneration: Long,
       val expectedFrames: Int,
   ) : Event {
@@ -310,6 +312,19 @@ interface Controller : AutoCloseable {
       val performanceEpochRasterFastTicks: Long = 0L,
       val performanceEpochMode2ReplayTicks: Long = 0L,
       val performanceEpochMode2BulkTicks: Long = 0L,
+      /** Host-only benchmark audio policy requested for this measured generation. */
+      val benchmarkAudioPolicy: String = "canonical",
+      val benchmarkAudioRequested: Boolean = false,
+      val benchmarkAudioActiveAtBoundary: Boolean = false,
+      val benchmarkAudioDisabledAfterBoundary: Boolean = false,
+      val benchmarkAudioSkippedTicks: Long = 0L,
+      val benchmarkAudioZeroSampleSlots: Long = 0L,
+      val benchmarkAudioZeroSampleEvents: Long = 0L,
+      val benchmarkAudioMaxDebt: Long = 0L,
+      val benchmarkAudioApuReads: Long = 0L,
+      val benchmarkAudioApuWrites: Long = 0L,
+      val benchmarkAudioFrameSequencerCommits: Long = 0L,
+      val benchmarkAudioDroppedChannelTicks: Long = 0L,
   ) : Event {
     /** Java/source compatibility for callers that predate bulk telemetry. */
     constructor(
@@ -317,7 +332,11 @@ interface Controller : AutoCloseable {
         effectiveGbc: Boolean,
         effectiveDmgCompat: Boolean,
         speedMode: Int,
-    ) : this(frame, effectiveGbc, effectiveDmgCompat, speedMode, 0L, 0L)
+    ) : this(
+        frame, effectiveGbc, effectiveDmgCompat, speedMode,
+        0L, 0L, 0L, 0L, 0, 0L, 0L, 0L,
+        "canonical", false, false, false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+    )
 
     /** Java/source compatibility for callers that supply the original bulk telemetry pair. */
     constructor(
@@ -328,18 +347,9 @@ interface Controller : AutoCloseable {
         performanceBulkSpans: Long,
         performanceBulkTicks: Long,
     ) : this(
-        frame,
-        effectiveGbc,
-        effectiveDmgCompat,
-        speedMode,
-        performanceBulkSpans,
-        performanceBulkTicks,
-        0L,
-        0L,
-        0,
-        0L,
-        0L,
-        0L,
+        frame, effectiveGbc, effectiveDmgCompat, speedMode,
+        performanceBulkSpans, performanceBulkTicks, 0L, 0L, 0, 0L, 0L, 0L,
+        "canonical", false, false, false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
     )
 
     /** Java/source compatibility for callers that predate the mode-2 bulk subset metric. */
@@ -356,18 +366,33 @@ interface Controller : AutoCloseable {
         performanceEpochRasterFastTicks: Long,
         performanceEpochMode2ReplayTicks: Long,
     ) : this(
-        frame,
-        effectiveGbc,
-        effectiveDmgCompat,
-        speedMode,
-        performanceBulkSpans,
-        performanceBulkTicks,
-        performanceEpochCount,
-        performanceEpochTicks,
-        performanceEpochMaxTicks,
-        performanceEpochRasterFastTicks,
-        performanceEpochMode2ReplayTicks,
-        0L,
+        frame, effectiveGbc, effectiveDmgCompat, speedMode,
+        performanceBulkSpans, performanceBulkTicks, performanceEpochCount,
+        performanceEpochTicks, performanceEpochMaxTicks, performanceEpochRasterFastTicks,
+        performanceEpochMode2ReplayTicks, 0L,
+        "canonical", false, false, false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+    )
+
+    /** Java/source compatibility for callers that supplied the complete pre-policy telemetry. */
+    constructor(
+        frame: Long,
+        effectiveGbc: Boolean,
+        effectiveDmgCompat: Boolean,
+        speedMode: Int,
+        performanceBulkSpans: Long,
+        performanceBulkTicks: Long,
+        performanceEpochCount: Long,
+        performanceEpochTicks: Long,
+        performanceEpochMaxTicks: Int,
+        performanceEpochRasterFastTicks: Long,
+        performanceEpochMode2ReplayTicks: Long,
+        performanceEpochMode2BulkTicks: Long,
+    ) : this(
+        frame, effectiveGbc, effectiveDmgCompat, speedMode,
+        performanceBulkSpans, performanceBulkTicks, performanceEpochCount,
+        performanceEpochTicks, performanceEpochMaxTicks, performanceEpochRasterFastTicks,
+        performanceEpochMode2ReplayTicks, performanceEpochMode2BulkTicks,
+        "canonical", false, false, false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
     )
 
     init {
@@ -387,6 +412,34 @@ interface Controller : AutoCloseable {
       require(performanceEpochMode2BulkTicks >= 0L) {
         "Benchmark epoch mode-2 bulk tick count must be non-negative"
       }
+      require(benchmarkAudioPolicy == "canonical" || benchmarkAudioPolicy == "silent-pcm-v1"
+          || benchmarkAudioPolicy == "silent-pcm-relaxed-apu-v1") {
+        "Benchmark audio policy must be canonical, silent-pcm-v1, or silent-pcm-relaxed-apu-v1"
+      }
+      require(benchmarkAudioSkippedTicks >= 0L) {
+        "Benchmark audio skipped tick count must be non-negative"
+      }
+      require(benchmarkAudioZeroSampleSlots >= 0L) {
+        "Benchmark audio zero sample slot count must be non-negative"
+      }
+      require(benchmarkAudioZeroSampleEvents >= 0L) {
+        "Benchmark audio zero sample event count must be non-negative"
+      }
+      require(benchmarkAudioMaxDebt >= 0L) {
+        "Benchmark audio maximum debt must be non-negative"
+      }
+      require(benchmarkAudioApuReads >= 0L) {
+        "Benchmark audio APU read count must be non-negative"
+      }
+      require(benchmarkAudioApuWrites >= 0L) {
+        "Benchmark audio APU write count must be non-negative"
+      }
+      require(benchmarkAudioFrameSequencerCommits >= 0L) {
+        "Benchmark audio frame-sequencer commit count must be non-negative"
+      }
+      require(benchmarkAudioDroppedChannelTicks >= 0L) {
+        "Benchmark audio dropped channel tick count must be non-negative"
+      }
     }
   }
 
@@ -395,10 +448,14 @@ interface Controller : AutoCloseable {
    * observed the materialized/paused session and captured its compositor baseline.  It is not
    * emitted or consumed by ordinary sessions.
    */
-  data class BenchmarkArmEvent(
+  data class BenchmarkArmEvent
+  @JvmOverloads
+  constructor(
       val generation: Long,
       val token: String,
       val sessionGeneration: Long,
+      /** The selected silent policy token is carried through rejected arms as well. */
+      val policy: String = "canonical",
   ) : Event {
     init {
       require(generation > 0L) { "Benchmark generation must be positive" }
@@ -406,6 +463,11 @@ interface Controller : AutoCloseable {
         "Benchmark arm token must be opaque and parser-safe"
       }
       require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
+      require(policy == "canonical"
+          || policy == BenchmarkSilentPcmPolicyEvent.POLICY
+          || policy == BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY) {
+        "Unsupported benchmark audio policy"
+      }
     }
   }
 
@@ -425,6 +487,53 @@ interface Controller : AutoCloseable {
         "Benchmark arm token must be opaque and parser-safe"
       }
       require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
+    }
+  }
+
+  /**
+   * Generation-bound host-audio policy decision.  The controller owns the only call that enables
+   * the transient silent calendar; Android posts this event before the matching Resume event.
+   */
+  data class BenchmarkSilentPcmPolicyEvent
+  @JvmOverloads
+  constructor(
+      val requested: Boolean,
+      val generation: Long,
+      val sessionGeneration: Long,
+      val accepted: Boolean = true,
+      val policy: String = if (requested) POLICY else "canonical",
+  ) : Event {
+    init {
+      require(generation > 0L) { "Benchmark generation must be positive" }
+      require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
+      require(policy == "canonical" && !requested
+          || policy == POLICY || policy == RELAXED_APU_POLICY) {
+        "Unsupported benchmark audio policy"
+      }
+      require(!accepted || requested || policy == "canonical") {
+        "Accepted benchmark audio policy must request canonical OFF or a silent calendar"
+      }
+    }
+
+    companion object {
+      const val POLICY: String = "silent-pcm-v1"
+      const val RELAXED_APU_POLICY: String = "silent-pcm-relaxed-apu-v1"
+    }
+  }
+
+  /** Owner-thread fence for a read-only system-audio failure detected during a frame callback. */
+  data class BenchmarkSystemAudioViolationEvent(
+      val generation: Long,
+      val sessionGeneration: Long,
+      val policy: String,
+  ) : Event {
+    init {
+      require(generation > 0L) { "Benchmark generation must be positive" }
+      require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
+      require(policy == BenchmarkSilentPcmPolicyEvent.POLICY
+          || policy == BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY) {
+        "Unsupported benchmark audio policy"
+      }
     }
   }
 
@@ -782,6 +891,32 @@ interface Controller : AutoCloseable {
   data class ControllerState(val state: MachineState, val rom: Rom)
 
   companion object {
+    /**
+     * Benchmark resume interlock. Ordinary/pre-arm resumes retain the historical behavior;
+     * once an arm is accepted, a matching policy decision must have been processed before the
+     * measured core can run. Canonical audio is an accepted decision with requested=false;
+     * rejection or lifecycle revocation is accepted=false and cannot resume the generation.
+     */
+    internal fun benchmarkResumePolicyAllows(
+        benchmarkPolicyEnabled: Boolean,
+        benchmarkArmed: Boolean,
+        benchmarkCoreFrozen: Boolean,
+        policyProcessed: Boolean,
+        policyAccepted: Boolean,
+        policyGenerationMatches: Boolean,
+        policyRequested: Boolean,
+        calendarEnabled: Boolean,
+    ): Boolean {
+      if (!benchmarkPolicyEnabled || !benchmarkArmed) {
+        return true
+      }
+      if (benchmarkCoreFrozen || !policyProcessed || !policyAccepted
+          || !policyGenerationMatches) {
+        return false
+      }
+      return !policyRequested || calendarEnabled
+    }
+
     fun createGameboyConfig(
       properties: EmulatorProperties,
       rom: Rom,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -166,6 +166,52 @@ interface Controller : AutoCloseable {
   class ResumeEmulationEvent : Event
 
   /**
+   * Arms benchmark-only stop-aware execution until a native display endpoint requests an exact
+   * pause. PERFORMANCE keeps its scheduler semantics; the session generation prevents a delayed
+   * Android owner callback from controlling a replacement session.
+   */
+  data class BenchmarkGameplayScenarioStartEvent(
+      val sessionGeneration: Long,
+      val expectedFrames: Int,
+  ) : Event {
+    init {
+      require(sessionGeneration > 0L) { "Session generation must be positive" }
+      require(expectedFrames > 0) { "Benchmark scenario frame count must be positive" }
+    }
+  }
+
+  /**
+   * Synchronous endpoint raised from a native Display callback on the controller owner thread.
+   * Unlike [PauseEmulationEvent], this is not queued until the current runTicks tail completes.
+   */
+  data class BenchmarkGameplayScenarioEndpointEvent(
+      val sessionGeneration: Long,
+      val completedFrames: Int,
+  ) : Event {
+    init {
+      require(sessionGeneration > 0L) { "Session generation must be positive" }
+      require(completedFrames > 0) { "Benchmark scenario frame count must be positive" }
+    }
+  }
+
+  /** Exact controller-owned completion evidence for one benchmark preconditioning scenario. */
+  data class BenchmarkGameplayScenarioCompletedEvent(
+      val sessionGeneration: Long,
+      val completedFrames: Int,
+      val expectedFrames: Int,
+      val completed: Boolean,
+  ) : Event {
+    init {
+      require(sessionGeneration > 0L) { "Session generation must be positive" }
+      require(completedFrames > 0) { "Completed frame count must be positive" }
+      require(expectedFrames > 0) { "Expected frame count must be positive" }
+      require(!completed || completedFrames == expectedFrames) {
+        "Successful benchmark scenario evidence must have an exact frame count"
+      }
+    }
+  }
+
+  /**
    * Captures the active cartridge at the controller's frame-safe point and persists it on the
    * controller-owned worker. Hosts can request a bounded background flush without observing a
    * live machine or blocking their UI thread.
@@ -258,6 +304,12 @@ interface Controller : AutoCloseable {
       val speedMode: Int,
       val performanceBulkSpans: Long = 0L,
       val performanceBulkTicks: Long = 0L,
+      val performanceEpochCount: Long = 0L,
+      val performanceEpochTicks: Long = 0L,
+      val performanceEpochMaxTicks: Int = 0,
+      val performanceEpochRasterFastTicks: Long = 0L,
+      val performanceEpochMode2ReplayTicks: Long = 0L,
+      val performanceEpochMode2BulkTicks: Long = 0L,
   ) : Event {
     /** Java/source compatibility for callers that predate bulk telemetry. */
     constructor(
@@ -267,11 +319,74 @@ interface Controller : AutoCloseable {
         speedMode: Int,
     ) : this(frame, effectiveGbc, effectiveDmgCompat, speedMode, 0L, 0L)
 
+    /** Java/source compatibility for callers that supply the original bulk telemetry pair. */
+    constructor(
+        frame: Long,
+        effectiveGbc: Boolean,
+        effectiveDmgCompat: Boolean,
+        speedMode: Int,
+        performanceBulkSpans: Long,
+        performanceBulkTicks: Long,
+    ) : this(
+        frame,
+        effectiveGbc,
+        effectiveDmgCompat,
+        speedMode,
+        performanceBulkSpans,
+        performanceBulkTicks,
+        0L,
+        0L,
+        0,
+        0L,
+        0L,
+        0L,
+    )
+
+    /** Java/source compatibility for callers that predate the mode-2 bulk subset metric. */
+    constructor(
+        frame: Long,
+        effectiveGbc: Boolean,
+        effectiveDmgCompat: Boolean,
+        speedMode: Int,
+        performanceBulkSpans: Long,
+        performanceBulkTicks: Long,
+        performanceEpochCount: Long,
+        performanceEpochTicks: Long,
+        performanceEpochMaxTicks: Int,
+        performanceEpochRasterFastTicks: Long,
+        performanceEpochMode2ReplayTicks: Long,
+    ) : this(
+        frame,
+        effectiveGbc,
+        effectiveDmgCompat,
+        speedMode,
+        performanceBulkSpans,
+        performanceBulkTicks,
+        performanceEpochCount,
+        performanceEpochTicks,
+        performanceEpochMaxTicks,
+        performanceEpochRasterFastTicks,
+        performanceEpochMode2ReplayTicks,
+        0L,
+    )
+
     init {
       require(frame > 0) { "Benchmark frame must be positive" }
       require(speedMode == 1 || speedMode == 2) { "Benchmark speed mode must be 1 or 2" }
       require(performanceBulkSpans >= 0L) { "Benchmark bulk span count must be non-negative" }
       require(performanceBulkTicks >= 0L) { "Benchmark bulk tick count must be non-negative" }
+      require(performanceEpochCount >= 0L) { "Benchmark epoch count must be non-negative" }
+      require(performanceEpochTicks >= 0L) { "Benchmark epoch tick count must be non-negative" }
+      require(performanceEpochMaxTicks >= 0) { "Benchmark epoch maximum must be non-negative" }
+      require(performanceEpochRasterFastTicks >= 0L) {
+        "Benchmark epoch raster fast tick count must be non-negative"
+      }
+      require(performanceEpochMode2ReplayTicks >= 0L) {
+        "Benchmark epoch mode-2 replay tick count must be non-negative"
+      }
+      require(performanceEpochMode2BulkTicks >= 0L) {
+        "Benchmark epoch mode-2 bulk tick count must be non-negative"
+      }
     }
   }
 
@@ -283,12 +398,14 @@ interface Controller : AutoCloseable {
   data class BenchmarkArmEvent(
       val generation: Long,
       val token: String,
+      val sessionGeneration: Long,
   ) : Event {
     init {
       require(generation > 0L) { "Benchmark generation must be positive" }
       require(token.matches(Regex("[a-z0-9][a-z0-9._-]{15,63}"))) {
         "Benchmark arm token must be opaque and parser-safe"
       }
+      require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
     }
   }
 
@@ -297,12 +414,17 @@ interface Controller : AutoCloseable {
    * Android uses this boundary to sample controller CPU/priority/environment state and to start
    * the measured frame epoch before posting Resume.
    */
-  data class BenchmarkArmAcknowledgedEvent(val generation: Long, val token: String) : Event {
+  data class BenchmarkArmAcknowledgedEvent(
+      val generation: Long,
+      val token: String,
+      val sessionGeneration: Long,
+  ) : Event {
     init {
       require(generation > 0L) { "Benchmark generation must be positive" }
       require(token.matches(Regex("[a-z0-9][a-z0-9._-]{15,63}"))) {
         "Benchmark arm token must be opaque and parser-safe"
       }
+      require(sessionGeneration > 0L) { "Benchmark session generation must be positive" }
     }
   }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller
 
 import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.properties.RuntimeWarmupFlavor
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootState
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
@@ -65,7 +66,11 @@ internal class RomSessionPreparer(
     // the disposable 120-frame run would delay first presentation; null retains the desktop
     // default and avoids making this policy persistent.
     if (properties.overrides.runtimeWarmupEnabled != false) {
-      val warmed = warmRuntime(config, properties.overrides.benchmarkPolicyEnabled)
+      val warmed = warmRuntime(
+          config,
+          properties.overrides.benchmarkPolicyEnabled,
+          properties.overrides.runtimeWarmupFlavor,
+      )
       if (properties.overrides.benchmarkPolicyEnabled && !warmed) {
         throw IllegalStateException("Benchmark runtime warmup was unavailable")
       }
@@ -94,9 +99,13 @@ internal class RomSessionPreparer(
    * This is intentionally best-effort: a failed disposable machine must never reject a playable
    * ROM. Cancellation remains observable because a superseded load must not continue preparing.
    */
-  private fun warmRuntime(config: GameboyConfiguration, benchmarkPolicy: Boolean): Boolean {
+  private fun warmRuntime(
+      config: GameboyConfiguration,
+      benchmarkPolicy: Boolean,
+      flavor: RuntimeWarmupFlavor,
+  ): Boolean {
     try {
-      return runtimeWarmupCache.warm(config, ::ensureActive)
+      return runtimeWarmupCache.warm(config, flavor, ::ensureActive)
     } catch (error: CancellationException) {
       throw error
     } catch (error: VirtualMachineError) {
@@ -127,6 +136,13 @@ internal class RomSessionPreparer(
 /** Invokes a disposable, service-free machine without making tests execute millions of ticks. */
 internal fun interface RuntimeWarmupExecutor {
   fun warm(config: GameboyConfiguration, ticks: Int, ensureActive: () -> Unit)
+
+  fun warm(
+      config: GameboyConfiguration,
+      ticks: Int,
+      flavor: RuntimeWarmupFlavor,
+      ensureActive: () -> Unit,
+  ) = warm(config, ticks, ensureActive)
 }
 
 /**
@@ -162,8 +178,15 @@ internal class RuntimeWarmupCache(
    * Performs at most one successful warmup per shape. Waiters observe a completed owner run or
    * take ownership after its cancellation/failure; only successful, still-active runs are cached.
    */
-  fun warm(config: GameboyConfiguration, ensureActive: () -> Unit): Boolean {
-    val key = RuntimeWarmupKey.from(config) ?: return false
+  fun warm(config: GameboyConfiguration, ensureActive: () -> Unit): Boolean =
+      warm(config, RuntimeWarmupFlavor.SCALAR, ensureActive)
+
+  fun warm(
+      config: GameboyConfiguration,
+      flavor: RuntimeWarmupFlavor,
+      ensureActive: () -> Unit,
+  ): Boolean {
+    val key = RuntimeWarmupKey.from(config, flavor) ?: return false
     ensureActive()
     synchronized(monitor) {
       while (true) {
@@ -188,7 +211,7 @@ internal class RuntimeWarmupCache(
       val warmupConfig = config.forRuntimeWarmup().setPlayerInputSource(PlayerInputHub())
       val ticks = Math.multiplyExact(WARMUP_FRAMES, warmupConfig.clockSpec.controllerTicksPerFrame())
       require(ticks > 0) { "Runtime warmup must contain positive controller ticks" }
-      executor.warm(warmupConfig, ticks, ensureActive)
+      executor.warm(warmupConfig, ticks, flavor, ensureActive)
       ensureActive()
       synchronized(monitor) {
         completed[key] = Unit
@@ -203,6 +226,8 @@ internal class RuntimeWarmupCache(
   }
 
   private data class RuntimeWarmupKey(
+      val executionMode: eu.rekawek.coffeegb.core.ExecutionMode,
+      val flavor: RuntimeWarmupFlavor,
       val profileId: String,
       val mapper: Mapper,
       val cartridgeType: CartridgeType,
@@ -215,7 +240,10 @@ internal class RuntimeWarmupCache(
       val codeBreakerRumble: Boolean,
   ) {
     companion object {
-      fun from(config: GameboyConfiguration): RuntimeWarmupKey? {
+      fun from(
+          config: GameboyConfiguration,
+          flavor: RuntimeWarmupFlavor,
+      ): RuntimeWarmupKey? {
         val rom = config.rom
         if (config.bootstrapMode != BootstrapMode.SKIP ||
             config.slotRom != null ||
@@ -223,8 +251,16 @@ internal class RuntimeWarmupCache(
             !isOrdinaryNonRtcCartridge(rom.type)) {
           return null
         }
+        if (flavor == RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1
+            && (config.executionMode != eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE
+                || config.hardwareProfile.id() != "cgb"
+                || rom.gameboyColorFlag == Rom.GameboyColorFlag.NON_CGB)) {
+          return null
+        }
         val cartridgeFeatures = Feature.values().filter(rom.cartridgeProperties::has)
         return RuntimeWarmupKey(
+            config.executionMode,
+            flavor,
             config.hardwareProfile.id(),
             rom.cartridgeProperties.mapper,
             rom.type,
@@ -240,8 +276,17 @@ internal class RuntimeWarmupCache(
     }
   }
 
-  private object GameboyRuntimeWarmupExecutor : RuntimeWarmupExecutor {
+  internal object GameboyRuntimeWarmupExecutor : RuntimeWarmupExecutor {
     override fun warm(config: GameboyConfiguration, ticks: Int, ensureActive: () -> Unit) {
+      warm(config, ticks, RuntimeWarmupFlavor.SCALAR, ensureActive)
+    }
+
+    override fun warm(
+        config: GameboyConfiguration,
+        ticks: Int,
+        flavor: RuntimeWarmupFlavor,
+        ensureActive: () -> Unit,
+    ) {
       val delegate = EventBusImpl(null, "runtime-warmup", false)
       val eventBus = StagedEventBus(delegate)
       var gameboy: Gameboy? = null
@@ -255,16 +300,76 @@ internal class RuntimeWarmupCache(
         )
         // Match the live Session receiver shape without attaching any UI/audio subscribers.
         eventBus.activate()
-        repeat(ticks) { tick ->
-          if (tick % CANCELLATION_CHECK_TICKS == 0) {
-            ensureActive()
+        if (flavor == RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1) {
+          val frameTicks = config.clockSpec.controllerTicksPerFrame()
+          require(frameTicks > 0) { "Runtime warmup frame must contain positive controller ticks" }
+          val gate = BenchmarkCoreFrozenGate()
+          gameboy.sound.setPerformanceSystemMutedAudioMode(
+              eu.rekawek.coffeegb.core.sound.Sound.PerformanceSystemMutedAudioMode.EXACT)
+          gameboy.resetPerformanceBulkCounters()
+          gameboy.sound.resetPerformanceSystemMutedAudioCalendarCounters()
+          var fullTicks = 0L
+          repeat(WARMUP_FRAMES) { frame ->
+            if (frame % CANCELLATION_CHECK_FRAMES == 0) {
+              ensureActive()
+            }
+            val executed = gameboy.runMeasuredTicksUntilStop(frameTicks, gate)
+            require(executed == frameTicks) {
+              "Shadow measured warmup stopped after $executed/$frameTicks ticks"
+            }
+            fullTicks += executed.toLong()
           }
-          gameboy.tick()
+          ensureActive()
+          val totalTicks = Math.multiplyExact(WARMUP_FRAMES.toLong(), frameTicks.toLong())
+          require(ticks.toLong() == totalTicks) {
+            "Shadow measured warmup received an unexpected tick budget"
+          }
+          require(fullTicks == totalTicks) {
+            "Shadow measured warmup did not execute its full tick budget"
+          }
+          val sound = gameboy.sound
+          require(sound.getPerformanceSystemMutedAudioCalendarSkippedTicks() == totalTicks) {
+            "Shadow measured warmup did not account every tick in EXACT mode"
+          }
+          require(sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots() > 0L) {
+            "Shadow measured warmup emitted no silent PCM slots"
+          }
+          require(sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks() == 0L) {
+            "Shadow measured warmup dropped channel ticks"
+          }
+          require(sound.getPerformanceSystemMutedAudioCalendarZeroSampleEvents() > 0L) {
+            "Shadow measured warmup emitted no silent PCM events"
+          }
+          require(sound.getPerformanceSystemMutedAudioCalendarMaxPendingTicks() > 0L) {
+            "Shadow measured warmup did not accumulate an EXACT span"
+          }
+          require(sound.getPerformanceSystemMutedAudioCalendarFrameSequencerCommits() > 0L) {
+            "Shadow measured warmup did not commit the frame sequencer"
+          }
+          require(gameboy.getPerformanceEpochCount() > 0L
+              && gameboy.getPerformanceEpochTicks() > 0L
+              && gameboy.getPerformanceEpochMaxTicks() <= MAX_NATIVE_EPOCH_TICKS) {
+            "Shadow measured warmup did not exercise bounded native epochs"
+          }
+        } else {
+          repeat(ticks) { tick ->
+            if (tick % CANCELLATION_CHECK_TICKS == 0) {
+              ensureActive()
+            }
+            gameboy.tick()
+          }
         }
         ensureActive()
       } finally {
         try {
-          gameboy?.discardUnstarted()
+          gameboy?.let {
+            try {
+              it.sound.setPerformanceSystemMutedAudioMode(
+                  eu.rekawek.coffeegb.core.sound.Sound.PerformanceSystemMutedAudioMode.OFF)
+            } finally {
+              it.discardUnstarted()
+            }
+          }
         } finally {
           eventBus.close()
         }
@@ -275,6 +380,8 @@ internal class RuntimeWarmupCache(
   companion object {
     const val WARMUP_FRAMES = 120
     const val CANCELLATION_CHECK_TICKS = 4_096
+    const val CANCELLATION_CHECK_FRAMES = 8
+    const val MAX_NATIVE_EPOCH_TICKS = 54
     const val DEFAULT_CAPACITY = 8
 
     internal val shared = RuntimeWarmupCache()

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -9,6 +9,12 @@ import java.nio.file.Path
 import java.util.Collections
 import java.util.EnumMap
 
+/** Process-local shape selector for the disposable runtime warmup; never persisted. */
+enum class RuntimeWarmupFlavor {
+  SCALAR,
+  SHADOW_MEASURED_EXACT_V1,
+}
+
 /** Immutable, validated desktop settings independent from their on-disk representation. */
 data class ApplicationSettings(
     val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
@@ -626,6 +632,7 @@ data class ApplicationSettingsOverrides(
     val suppressCloseAutosave: Boolean = false,
     val rewindEnabled: Boolean? = null,
     val runtimeWarmupEnabled: Boolean? = null,
+    val runtimeWarmupFlavor: RuntimeWarmupFlavor = RuntimeWarmupFlavor.SCALAR,
     /** Transient benchmark policy; never persisted into user settings or save state. */
     val benchmarkPolicyEnabled: Boolean = false,
     /** Transient execution-mode selection; it takes precedence over persisted settings. */

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -32,6 +32,7 @@ import eu.rekawek.coffeegb.core.persistence.AtomicFileWriter
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay
+import eu.rekawek.coffeegb.core.sound.Sound
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
@@ -44,6 +45,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import java.util.function.BooleanSupplier
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -55,6 +57,101 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class BasicControllerTest {
+
+  @Test
+  fun benchmarkResumePolicyInterlockCoversPreArmAcceptedCanonicalRevokedMismatchAndFrozen() {
+    assertTrue(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = false,
+            benchmarkCoreFrozen = false,
+            policyProcessed = false,
+            policyAccepted = false,
+            policyGenerationMatches = false,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "pre-arm resume must retain ordinary behavior",
+    )
+    assertFalse(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = false,
+            policyProcessed = false,
+            policyAccepted = false,
+            policyGenerationMatches = true,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "an armed generation cannot resume before policy processing",
+    )
+    assertTrue(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = false,
+            policyProcessed = true,
+            policyAccepted = true,
+            policyGenerationMatches = true,
+            policyRequested = true,
+            calendarEnabled = true,
+        ),
+        "matching enabled policy permits resume",
+    )
+    assertTrue(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = false,
+            policyProcessed = true,
+            policyAccepted = true,
+            policyGenerationMatches = true,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "accepted canonical policy permits resume",
+    )
+    assertFalse(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = false,
+            policyProcessed = true,
+            policyAccepted = false,
+            policyGenerationMatches = true,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "revoked or rejected policy cannot resume",
+    )
+    assertFalse(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = false,
+            policyProcessed = true,
+            policyAccepted = true,
+            policyGenerationMatches = false,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "stale policy decisions cannot resume a newer generation",
+    )
+    assertFalse(
+        Controller.benchmarkResumePolicyAllows(
+            benchmarkPolicyEnabled = true,
+            benchmarkArmed = true,
+            benchmarkCoreFrozen = true,
+            policyProcessed = true,
+            policyAccepted = true,
+            policyGenerationMatches = true,
+            policyRequested = false,
+            calendarEnabled = false,
+        ),
+        "frame-600 frozen core cannot resume",
+    )
+  }
 
   @Test
   fun closeDeadlineBoundsBlockedTimingThreadAndAllowsRetry() {
@@ -1727,6 +1824,326 @@ class BasicControllerTest {
       assertEquals(0L, fourArgument.performanceEpochCount)
       assertEquals(0L, sixArgument.performanceEpochTicks)
     } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun benchmarkPreArmResumeReleasesTheAnchorPause() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val playback = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.SessionPlaybackStateEvent>(playback::add)
+    val rom = namedRom("BENCHMARK_PRE_ARM_RESUME")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val controller =
+        BasicController(
+            eventBus,
+            properties,
+            null,
+            SessionPreparer { currentProperties, event ->
+              val config =
+                  Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                      .setBootstrapMode(BootstrapMode.SKIP)
+                      .setExecutionMode(ExecutionMode.PERFORMANCE)
+              PreparedSession.Ready(config, Gameboy(config))
+            })
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      // The benchmark session starts paused so the host can capture its anchor. Before ARM the
+      // normal lifecycle command must still release that pause.
+      eventBus.post(Controller.ResumeEmulationEvent())
+      val resumed =
+          generateSequence { playback.poll(100, TimeUnit.MILLISECONDS) }
+              .first { !it.paused }
+      assertFalse(resumed.paused)
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun benchmarkPhysicalBoundaryStopsMeasuredPerformanceBatchWithoutOneMoreTick() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val acknowledged = LinkedBlockingQueue<Controller.BenchmarkArmAcknowledgedEvent>()
+    val boundary = LinkedBlockingQueue<Controller.BenchmarkFrameBoundaryEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.BenchmarkArmAcknowledgedEvent>(acknowledged::add)
+    eventBus.register<Controller.BenchmarkFrameBoundaryEvent>(boundary::add)
+    val executedTicks = AtomicInteger()
+    val boundaryPosted = AtomicInteger()
+    val generation = AtomicLong()
+    val rom = namedRom("BENCHMARK_MEASURED_STOP")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.PERFORMANCE)
+          val gameboy =
+              object : Gameboy(config) {
+                override fun runMeasuredTicksUntilStop(
+                    ticks: Int,
+                    stop: BooleanSupplier,
+                ): Int {
+                  var executed = 0
+                  while (executed < ticks && !stop.asBoolean) {
+                    executed++
+                    executedTicks.incrementAndGet()
+                    if (executed == 5 && boundaryPosted.compareAndSet(0, 1)) {
+                      eventBus.post(
+                          Controller.BenchmarkPhysicalFrameBoundaryEvent(
+                              600L,
+                              generation.get(),
+                          ))
+                    }
+                  }
+                  return executed
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      val session = assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val sessionGeneration = assertNotNull(session.sessionGeneration)
+      val benchmarkGeneration = 97L
+      generation.set(benchmarkGeneration)
+      eventBus.post(
+          Controller.BenchmarkArmEvent(
+              benchmarkGeneration,
+              "stage8-measured-stop-0001",
+              sessionGeneration,
+          ))
+      assertNotNull(acknowledged.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      eventBus.post(Controller.ResumeEmulationEvent())
+      Thread.sleep(100)
+      assertEquals(0, executedTicks.get(), "armed benchmark resumed before policy processing")
+      eventBus.post(
+          Controller.BenchmarkSilentPcmPolicyEvent(
+              false,
+              benchmarkGeneration,
+              sessionGeneration,
+          ))
+      eventBus.post(Controller.ResumeEmulationEvent())
+
+      assertNotNull(
+          boundary.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "measured batch did not reach the synchronous frame boundary",
+      )
+      assertEquals(5, executedTicks.get())
+      Thread.sleep(100)
+      assertEquals(5, executedTicks.get(), "a post-boundary measured tick was executed")
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun benchmarkSystemAudioViolationFreezesRelaxedMeasuredBatchSynchronously() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val acknowledged = LinkedBlockingQueue<Controller.BenchmarkArmAcknowledgedEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.BenchmarkArmAcknowledgedEvent>(acknowledged::add)
+    val executedTicks = AtomicInteger()
+    val measuredReturned = CountDownLatch(1)
+    val generation = 99L
+    val sessionGenerationRef = AtomicLong()
+    val gameboyRef = AtomicReference<Gameboy>()
+    val rom = namedRom("BENCHMARK_SYSTEM_AUDIO_VIOLATION")
+    val properties = EmulatorProperties(
+        ApplicationSettingsOverrides(
+            benchmarkPolicyEnabled = true,
+            executionMode = ExecutionMode.PERFORMANCE,
+        ))
+    val preparer = SessionPreparer { currentProperties, event ->
+      val config = Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+          .setBootstrapMode(BootstrapMode.SKIP)
+          .setExecutionMode(ExecutionMode.PERFORMANCE)
+      val gameboy = object : Gameboy(config) {
+        override fun runMeasuredTicksUntilStop(ticks: Int, stop: BooleanSupplier): Int {
+          var executed = 0
+          while (executed < ticks && !stop.asBoolean) {
+            executed++
+            executedTicks.incrementAndGet()
+            if (executed == 5) {
+              eventBus.post(Controller.BenchmarkSystemAudioViolationEvent(
+                  generation,
+                  sessionGenerationRef.get(),
+                  Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY,
+              ))
+            }
+          }
+          measuredReturned.countDown()
+          return executed
+        }
+      }
+      gameboyRef.set(gameboy)
+      PreparedSession.Ready(config, gameboy)
+    }
+    val controller = BasicController(eventBus, properties, null, preparer)
+    try {
+      controller.startController()
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      val session = assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val sessionGeneration = assertNotNull(session.sessionGeneration)
+      sessionGenerationRef.set(sessionGeneration)
+      // The relaxed token is selected at ARM and is immutable for this generation.
+      eventBus.post(Controller.BenchmarkArmEvent(
+          generation, "system-audio-violation-01", sessionGeneration,
+          Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY))
+      assertNotNull(acknowledged.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      eventBus.post(Controller.BenchmarkSilentPcmPolicyEvent(
+          true, generation, sessionGeneration, true,
+          Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY))
+      eventBus.post(Controller.ResumeEmulationEvent())
+      assertTrue(measuredReturned.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(5, executedTicks.get(), "mute violation allowed a measured tick tail")
+      val sound = gameboyRef.get().sound
+      assertEquals(Sound.PerformanceSystemMutedAudioMode.OFF,
+          sound.getPerformanceSystemMutedAudioMode())
+      assertFalse(sound.isPerformanceSystemMutedAudioCalendarEnabled())
+      // A stale generation and a non-owner post cannot mutate the already frozen generation.
+      eventBus.post(Controller.BenchmarkSystemAudioViolationEvent(
+          generation + 1L, sessionGeneration,
+          Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY))
+      val nonOwner = Thread {
+        eventBus.post(Controller.BenchmarkSystemAudioViolationEvent(
+            generation, sessionGeneration,
+            Controller.BenchmarkSilentPcmPolicyEvent.RELAXED_APU_POLICY))
+      }
+      nonOwner.start()
+      nonOwner.join(TIMEOUT_SECONDS * 1_000L)
+      assertEquals(5, executedTicks.get())
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun benchmarkRejectedAudioPolicyFreezesRunningCoreBeforeOrdinaryBatch() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val acknowledged = LinkedBlockingQueue<Controller.BenchmarkArmAcknowledgedEvent>()
+    val playback = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.BenchmarkArmAcknowledgedEvent>(acknowledged::add)
+    eventBus.register<Controller.SessionPlaybackStateEvent>(playback::add)
+    val measuredEntered = CountDownLatch(1)
+    val releaseMeasured = CountDownLatch(1)
+    val measuredCalls = AtomicInteger()
+    val ordinaryBatches = AtomicInteger()
+    val rom = namedRom("BENCHMARK_POLICY_REVOKE")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.PERFORMANCE)
+          val gameboy =
+              object : Gameboy(config) {
+                override fun runMeasuredTicksUntilStop(
+                    ticks: Int,
+                    stop: BooleanSupplier,
+                ): Int {
+                  measuredCalls.incrementAndGet()
+                  measuredEntered.countDown()
+                  releaseMeasured.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  return 1
+                }
+
+                override fun runTicks(ticks: Int): Int {
+                  ordinaryBatches.incrementAndGet()
+                  return 0
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      val session = assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val sessionGeneration = assertNotNull(session.sessionGeneration)
+      val benchmarkGeneration = 98L
+      eventBus.post(
+          Controller.BenchmarkArmEvent(
+              benchmarkGeneration,
+              "stage8-policy-revoke-0001",
+              sessionGeneration,
+          ))
+      assertNotNull(acknowledged.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      eventBus.post(
+          Controller.BenchmarkSilentPcmPolicyEvent(
+              false,
+              benchmarkGeneration,
+              sessionGeneration,
+          ))
+      eventBus.post(Controller.ResumeEmulationEvent())
+      assertTrue(
+          measuredEntered.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "accepted benchmark policy did not start the measured batch",
+      )
+
+      playback.clear()
+      eventBus.post(
+          Controller.BenchmarkSilentPcmPolicyEvent(
+              false,
+              benchmarkGeneration,
+              sessionGeneration,
+              accepted = false,
+          ))
+      releaseMeasured.countDown()
+
+      val paused = assertNotNull(playback.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertTrue(paused.paused, "revocation was not an owner-thread terminal pause")
+      assertEquals(1, measuredCalls.get())
+      assertEquals(
+          0,
+          ordinaryBatches.get(),
+          "revocation fell through to an ordinary runTicks batch",
+      )
+    } finally {
+      releaseMeasured.countDown()
       controller.close()
       properties.close()
       eventBus.close()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -9,10 +9,12 @@ import eu.rekawek.coffeegb.controller.Controller.RomLoadingEvent
 import eu.rekawek.coffeegb.controller.Controller.HardwareProfileEvent
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides
 import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
 import eu.rekawek.coffeegb.controller.state.StateCodec
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.ExecutionMode
 import eu.rekawek.coffeegb.core.debug.Console
 import eu.rekawek.coffeegb.core.debug.DebugPort
 import eu.rekawek.coffeegb.core.events.Event
@@ -41,6 +43,8 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.function.BooleanSupplier
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -1647,6 +1651,160 @@ class BasicControllerTest {
     } finally {
       controller.close()
       eventBus.close()
+    }
+  }
+
+  @Test
+  fun benchmarkBoundaryCarriesPerformanceEpochTelemetry() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val acknowledged = LinkedBlockingQueue<Controller.BenchmarkArmAcknowledgedEvent>()
+    val boundaries = LinkedBlockingQueue<Controller.BenchmarkFrameBoundaryEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.BenchmarkArmAcknowledgedEvent>(acknowledged::add)
+    eventBus.register<Controller.BenchmarkFrameBoundaryEvent>(boundaries::add)
+    val rom = namedRom("BENCHMARK_EPOCH")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.PERFORMANCE)
+          val gameboy =
+              object : Gameboy(config) {
+                override fun getPerformanceBulkSpanCount() = 11L
+
+                override fun getPerformanceBulkTicks() = 22L
+
+                override fun getPerformanceEpochCount() = 33L
+
+                override fun getPerformanceEpochTicks() = 44L
+
+                override fun getPerformanceEpochMaxTicks() = 55
+
+                override fun getPerformanceEpochRasterFastTicks() = 66L
+
+                override fun getPerformanceEpochMode2ReplayTicks() = 77L
+
+                override fun getPerformanceEpochMode2BulkTicks() = 70L
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      val session = assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val sessionGeneration = assertNotNull(session.sessionGeneration)
+      val benchmarkGeneration = 83L
+      val token = "stage8-epoch-token-0001"
+      eventBus.post(
+          Controller.BenchmarkArmEvent(benchmarkGeneration, token, sessionGeneration))
+      assertNotNull(acknowledged.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      eventBus.post(
+          Controller.BenchmarkPhysicalFrameBoundaryEvent(600L, benchmarkGeneration))
+
+      val boundary = assertNotNull(boundaries.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(11L, boundary.performanceBulkSpans)
+      assertEquals(22L, boundary.performanceBulkTicks)
+      assertEquals(33L, boundary.performanceEpochCount)
+      assertEquals(44L, boundary.performanceEpochTicks)
+      assertEquals(55, boundary.performanceEpochMaxTicks)
+      assertEquals(66L, boundary.performanceEpochRasterFastTicks)
+      assertEquals(77L, boundary.performanceEpochMode2ReplayTicks)
+      assertEquals(70L, boundary.performanceEpochMode2BulkTicks)
+
+      val fourArgument = Controller.BenchmarkFrameBoundaryEvent(600L, false, false, 1)
+      val sixArgument =
+          Controller.BenchmarkFrameBoundaryEvent(600L, false, false, 1, 5L, 6L)
+      assertEquals(0L, fourArgument.performanceEpochCount)
+      assertEquals(0L, sixArgument.performanceEpochTicks)
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun benchmarkScenarioEndpointStopsCurrentPerformanceBatchWithoutOneMoreTick() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val completed = LinkedBlockingQueue<Controller.BenchmarkGameplayScenarioCompletedEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.BenchmarkGameplayScenarioCompletedEvent>(completed::add)
+    val executedTicks = AtomicInteger()
+    val endpointSession = AtomicLong()
+    val endpointPosted = AtomicInteger()
+    val rom = namedRom("BENCHMARK_ENDPOINT")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.PERFORMANCE)
+          val gameboy =
+              object : Gameboy(config) {
+                override fun runTicksUntilStop(ticks: Int, stop: BooleanSupplier): Int {
+                  var executed = 0
+                  while (executed < ticks && !stop.asBoolean) {
+                    executed++
+                    executedTicks.incrementAndGet()
+                    if (executed == 5 && endpointPosted.compareAndSet(0, 1)) {
+                      eventBus.post(
+                          Controller.BenchmarkGameplayScenarioEndpointEvent(
+                              endpointSession.get(),
+                              313,
+                          ))
+                    }
+                  }
+                  return executed
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      val session = assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val generation = assertNotNull(session.sessionGeneration)
+      endpointSession.set(generation)
+      eventBus.post(Controller.BenchmarkGameplayScenarioStartEvent(generation, 313))
+      eventBus.post(Controller.ResumeEmulationEvent())
+
+      val evidence =
+          assertNotNull(
+              completed.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+              "ticks=${executedTicks.get()} endpointPosts=${endpointPosted.get()}",
+          )
+      assertEquals(generation, evidence.sessionGeneration)
+      assertEquals(313, evidence.completedFrames)
+      assertEquals(313, evidence.expectedFrames)
+      assertTrue(evidence.completed)
+      assertEquals(5, executedTicks.get())
+      Thread.sleep(100)
+      assertEquals(5, executedTicks.get(), "paused controller executed a post-endpoint tick")
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller
 import eu.rekawek.coffeegb.controller.Controller.LoadRomEvent
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.properties.RuntimeWarmupFlavor
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.BatteryStore
 import eu.rekawek.coffeegb.controller.state.FileStateStore
@@ -26,6 +27,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertContentEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -246,6 +248,74 @@ class RomSessionPreparerTest {
   }
 
   @Test
+  fun shadowMeasuredWarmupIsCgbPerformanceOnlyAndHasAnIsolatedCacheKey() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(8, executor)
+    val cgbPerformance =
+        skipConfig(cgbNativeImage())
+            .setHardwareProfile(HardwareProfileRegistry.CGB)
+            .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)
+
+    assertFalse(cache.warm(skipConfig(), RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1) {})
+    assertFalse(
+        cache.warm(
+            skipConfig().setHardwareProfile(HardwareProfileRegistry.DMG),
+            RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+        ) {})
+    assertFalse(
+        cache.warm(
+            skipConfig(cgbNativeImage())
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.ACCURACY),
+            RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+        ) {})
+    assertFalse(
+        cache.warm(
+            skipConfig(cgbNativeImage())
+                .setHardwareProfile(HardwareProfileRegistry.CGB0)
+                .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE),
+            RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+        ) {})
+    assertFalse(
+        cache.warm(
+            skipConfig(cgbNativeImage())
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)
+                .setBootstrapMode(BootstrapMode.FAST_FORWARD),
+            RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+        ) {})
+    assertTrue(cache.warm(cgbPerformance, RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1) {})
+    assertTrue(cache.warm(cgbPerformance, RuntimeWarmupFlavor.SCALAR) {})
+    assertEquals(2, executor.calls.size)
+    assertEquals(2, cache.size)
+  }
+
+  @Test
+  fun benchmarkCoreFrozenGateHasOwnerThreadLifecycleSemantics() {
+    val gate = BenchmarkCoreFrozenGate()
+    assertFalse(gate.asBoolean)
+    gate.setFrozen(true)
+    assertTrue(gate.asBoolean)
+    gate.setFrozen(false)
+    assertFalse(gate.asBoolean)
+  }
+
+  @Test
+  fun productionShadowMeasuredExecutorRunsItsValidatedFrameAndCleanupPath() {
+    val config =
+        skipConfig(cgbNativeImage())
+            .setHardwareProfile(HardwareProfileRegistry.CGB)
+            .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)
+    val originalConfigRom = config.rom.rom.copyOf()
+    RuntimeWarmupCache.GameboyRuntimeWarmupExecutor.warm(
+        config.forRuntimeWarmup(),
+        120 * config.clockSpec.controllerTicksPerFrame(),
+        RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+    ) {}
+    assertContentEquals(originalConfigRom, config.rom.rom)
+  }
+
+  @Test
   fun runtimeWarmupUsesAccessOrderedBoundedCache() {
     val executor = RecordingWarmupExecutor()
     val cache = RuntimeWarmupCache(2, executor)
@@ -382,6 +452,25 @@ class RomSessionPreparerTest {
 
   private fun exoticRtcImage(): RomImage =
       RomImage.memory(ROM.readBytes().also { it[0x147] = 0x0f }, "rtc.gb")
+
+  private fun cgbNativeImage(): RomImage =
+      RomImage.memory(
+          ByteArray(0x8000).also {
+            // CGB double-speed loop: request KEY1, switch on STOP, then keep a stable
+            // instruction stream for the native PERFORMANCE epoch lane.
+            it[0x100] = 0x3e
+            it[0x101] = 0x01
+            it[0x102] = 0xe0.toByte()
+            it[0x103] = 0x4d
+            it[0x104] = 0x10
+            it[0x105] = 0x00
+            it[0x106] = 0xc3.toByte()
+            it[0x107] = 0x06
+            it[0x108] = 0x01
+            it[0x143] = 0x80.toByte()
+          },
+          "cgb-native.gb",
+      )
 
   private fun mbc5Image(): RomImage = RomImage.memory(mbc5Bytes(), "mbc5.gb")
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -77,6 +77,7 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
+import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -230,6 +231,41 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     /** Largest long DMG settled-HALT PERFORMANCE packet in this session (diagnostic only). */
     private transient int performanceBulkMaxTicks;
+
+    /** Bounded coarse CPU-epoch diagnostics; absent from portable state. */
+    private transient long performanceEpochCount;
+
+    private transient long performanceEpochTicks;
+
+    private transient int performanceEpochMaxTicks;
+
+    private transient long performanceEpochRasterFastTicks;
+
+    private transient long performanceEpochMode2ReplayTicks;
+
+    /** Subset of mode-2 epoch ticks committed by the allocation-free OAM transaction. */
+    private transient long performanceEpochMode2BulkTicks;
+
+    /** Raster transaction selected before the CPU observes its frozen peripheral view. */
+    private transient PerformanceEpochPpuPlan performanceEpochPpuPlan =
+            PerformanceEpochPpuPlan.NONE;
+
+    private transient int performanceEpochPrefixCommitted;
+
+    private transient boolean performanceEpochDirectRaster;
+
+    private transient boolean performanceEpochSteadyRaster;
+
+    private transient IntConsumer performanceEpochPrefixCommitter;
+
+    private transient IntConsumer performancePhysicalDmgEpochPrefixCommitter;
+
+    private enum PerformanceEpochPpuPlan {
+        NONE,
+        TRUSTED_RASTER,
+        MODE2_BULK,
+        MODE2_REPLAY
+    }
 
     public Gameboy(Rom rom) {
         this(new GameboyConfiguration(rom));
@@ -561,6 +597,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient volatile boolean warmResetRequested;
 
+    /** One-shot native-CGB PERFORMANCE scalar-prologue token; deliberately absent from mementos. */
+    private transient boolean nativeCgbScalarOwner;
+
     /** Cartridge hardware pulsing the console reset line (Datel Action Replay launch). */
     public void requestWarmReset(boolean nonCgbCart) {
         warmResetNonCgbCart = nonCgbCart;
@@ -568,6 +607,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     private void applyWarmReset() {
+        nativeCgbScalarOwner = false;
         // the boot ROM leaves the LCD running with the DMG-compatible defaults
         interruptManager.disableInterrupts(false);
         mmu.setByte(0xffff, 0x00);
@@ -666,6 +706,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (warmResetRequested) {
             warmResetRequested = false;
             applyWarmReset();
+            // applyWarmReset() clears the owner before its hardware writes. Keep the
+            // scheduler-side invariant explicit for a reset observed in this tick.
+            nativeCgbScalarOwner = false;
         }
         if (cartridgeClocked) {
             cartridge.tick();
@@ -773,6 +816,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && debugInstrumentation == null
                 && !debugRetirementTrackingActive
                 && !debugHistoryReplay) {
+            if (isNativeCgbPerformanceEpochTopology()) {
+                return runNativeCgbPerformanceTicks(ticks);
+            }
+            if (isPhysicalDmgPerformanceEpochTopology()) {
+                return runPhysicalDmgPerformanceTicks(ticks);
+            }
             return runPerformanceTicks(ticks);
         }
         long frameEvents = 0;
@@ -782,6 +831,46 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             }
         }
         return frameEvents;
+    }
+
+    /**
+     * Advances at most {@code ticks}, stopping before the first tick for which {@code stop}
+     * returns true. This owner-thread seam is used by benchmark preconditioning to stop exactly
+     * after a synchronous native-frame callback without changing PERFORMANCE raster semantics.
+     *
+     * @return the exact number of master ticks executed
+     */
+    public int runTicksUntilStop(int ticks, BooleanSupplier stop) {
+        if (ticks < 0) {
+            throw new IllegalArgumentException("ticks must be non-negative");
+        }
+        Objects.requireNonNull(stop, "stop");
+        if (executionMode == ExecutionMode.PERFORMANCE
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && !debugHistoryReplay) {
+            // Benchmark preconditioning needs the PERFORMANCE compositor but must stop at the
+            // exact synchronous frame callback. Keep this rare seam scalar so neither a coarse
+            // CPU epoch nor the ordinary fused boundary can retire a post-endpoint tick.
+            gpu.setPerformanceScanlineEnabled(true);
+            try {
+                int executed = 0;
+                while (executed < ticks && !stop.getAsBoolean()) {
+                    tick();
+                    executed++;
+                }
+                return executed;
+            } finally {
+                sound.materializePendingPerformanceTicks();
+                gpu.setPerformanceScanlineEnabled(false);
+            }
+        }
+        int executed = 0;
+        while (executed < ticks && !stop.getAsBoolean()) {
+            tick();
+            executed++;
+        }
+        return executed;
     }
 
     /**
@@ -804,57 +893,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     }
                 }
                 int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
-                // Build one primitive packet plan.  Every component horizon is evaluated once
-                // against the already-shortened tail; the trusted commits below must not repeat
-                // those walks on each normal-speed three-tick phase.
-                int span = cpuSpanLimit;
-                boolean directRasterSpan = false;
-                boolean steadyRasterSpan = false;
-                if (span > 0) {
-                    span = Math.min(span, timer.performanceQuietSpanLimit(span));
-                    span = Math.min(span, serialPort.performanceQuietSpanLimit(span));
-                    span = Math.min(span, joypad.performanceQuietSpanLimit(span));
-                    span = Math.min(span, sound.performanceQuietSpanLimit(span));
-                    if (cartridgeClocked) {
-                        span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
-                    }
-                    if (slotCartridgeClocked) {
-                        span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
-                    }
-                    if (gbc) {
-                        span = Math.min(span, infraredPort.performanceQuietSpanLimit(span));
-                    }
-                    int gpuSpanLimit = gpu.performanceQuietSpanLimit();
-                    span = Math.min(span, gpuSpanLimit);
-                    directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
-                    steadyRasterSpan = span > 0 && !directRasterSpan
-                            && gpu.isPerformanceSteadyCursorActive();
-                    span = Math.min(span, statRegister.performanceQuietSpanLimit(span));
-                }
-                // The two subsystem limits are int-sized, while runTicks accepts a long. A small
-                // final request must never consume past its caller-visible budget (or return a
-                // negative remainder) merely because a whole quiet span was available.
-                if (remaining < span) {
-                    span = (int) remaining;
-                }
+                int span = tryPerformancePhaseOnlySpan(remaining, cpuSpanLimit);
                 boolean reachesCpuBoundary = span > 0 && span == cpuSpanLimit;
-                if (span > 0
-                        && !warmResetRequested
-                        && speedSwitchTailTicks == 0
-                        && cpu.performancePhaseOnlySpanEligible()
-                        && cpu.performanceNoPendingPpuReadPhase()
-                        && !dma.isTransferInProgress()
-                        && !dma.requiresClockTick(cpu.getState() == Cpu.State.HALTED)
-                        && (!gbc || !hdma.hasActiveOrPendingTransfer())
-                        // This is intentionally the one post-preflight volatile Joypad check.
-                        // A legacy/debug/input mutation published after the horizon walk must
-                        // fall back to one scalar tick; a PlayerInputHub snapshot update does not
-                        // clear its eligibility and remains invisible until the next poll.
-                        && joypad.isPerformanceQuietSpanStillEligible()) {
-                    tickPerformanceQuietSpan(span, directRasterSpan, steadyRasterSpan);
+                if (span > 0) {
                     remaining -= span;
-                    performanceBulkSpanCount++;
-                    performanceBulkTicks += span;
                     // The fourth tick is still the scalar CPU-boundary authority. Fuse it here
                     // only when the bulk span consumed the whole phase distance; a peripheral
                     // horizon-shortened span must return through the normal preflight loop.
@@ -886,9 +928,442 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
+     * Native-CGB double-speed scheduler. Transient event seams consume one scalar tick and then
+     * retry the epoch; DMA, STAT, audio, and raster boundaries therefore cannot disable the lane
+     * for the rest of a controller batch. If a STOP instruction leaves double speed, the
+     * untouched ordinary scheduler owns the remainder.
+     *
+     * <p>This is the explicit coarse contract of PERFORMANCE mode: for at most 54 master dots,
+     * ordinary CPU work observes a frozen peripheral view and peripheral IRQ visibility is
+     * coalesced at the packet boundary. An actual external read flushes the completed prefix
+     * before it is delegated, while an external write is published once after the current
+     * machine-cycle packet. Thus an access can retain at most the current dot's pre-CPU skew;
+     * mode/line, audio-sample, input-poll, timer-overflow, DMA, and frame callbacks remain scalar.
+     * ACCURACY and every observation/history/stop-aware path bypass this scheduler.</p>
+     */
+    private long runNativeCgbPerformanceTicks(long ticks) {
+        gpu.setPerformanceScanlineEnabled(true);
+        long frameEvents = 0;
+        long remaining = ticks;
+        try {
+            while (remaining > 0 && isNativeCgbPerformanceEpochTopology()) {
+                int committed = tryPerformanceEpoch(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+                nativeCgbScalarOwner = !warmResetRequested
+                        && debugInstrumentation == null
+                        && !debugRetirementTrackingActive
+                        && !debugHistoryReplay;
+                if (tick()) {
+                    frameEvents++;
+                }
+                remaining--;
+            }
+        } finally {
+            nativeCgbScalarOwner = false;
+            sound.materializePendingPerformanceTicks();
+            gpu.setPerformanceScanlineEnabled(false);
+        }
+        if (remaining > 0) {
+            frameEvents += runPerformanceTicks(remaining);
+        }
+        return frameEvents;
+    }
+
+    /**
+     * Physical-DMG normal-speed coarse scheduler. Only the trusted rendered raster may join a
+     * CPU epoch; mode 2, STAT/line edges, DMA, IRQ/HALT, and every rejected topology retain the
+     * established normal-speed PERFORMANCE scheduler.
+     */
+    private long runPhysicalDmgPerformanceTicks(long ticks) {
+        gpu.setPerformanceScanlineEnabled(true);
+        long frameEvents = 0;
+        long remaining = ticks;
+        try {
+            while (remaining > 0 && isPhysicalDmgPerformanceEpochTopology()) {
+                int committed = tryPhysicalDmgPerformanceEpoch(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+
+                // Preserve the pre-existing long settled-HALT side entrance before falling
+                // back to the ordinary scalar/phase scheduler.
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
+                }
+
+                // On a mode-2/checkpoint/event miss, retain the legacy 1-3-dot normal-speed
+                // packet rather than regressing every non-boundary dot to the scalar forest.
+                int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
+                int phaseSpan = tryPerformancePhaseOnlySpan(remaining, cpuSpanLimit);
+                if (phaseSpan > 0) {
+                    remaining -= phaseSpan;
+                    continue;
+                }
+
+                if (tick()) {
+                    frameEvents++;
+                }
+                remaining--;
+            }
+        } finally {
+            sound.materializePendingPerformanceTicks();
+            gpu.setPerformanceScanlineEnabled(false);
+        }
+        if (remaining > 0) {
+            frameEvents += runPerformanceTicks(remaining);
+        }
+        return frameEvents;
+    }
+
+    /**
+     * Attempts one non-owning normal-speed phase-only packet. The enclosing run loop owns Sound
+     * materialization and the PERFORMANCE scanline-enable lifecycle.
+     */
+    private int tryPerformancePhaseOnlySpan(long remaining, int cpuSpanLimit) {
+        // Build one primitive packet plan. Every component horizon is evaluated once against
+        // the already-shortened tail; trusted commits do not repeat the walks.
+        int span = cpuSpanLimit;
+        boolean directRasterSpan = false;
+        boolean steadyRasterSpan = false;
+        if (span > 0) {
+            span = Math.min(span, timer.performanceQuietSpanLimit(span));
+            span = Math.min(span, serialPort.performanceQuietSpanLimit(span));
+            span = Math.min(span, joypad.performanceQuietSpanLimit(span));
+            span = Math.min(span, sound.performanceQuietSpanLimit(span));
+            if (cartridgeClocked) {
+                span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+            }
+            if (slotCartridgeClocked) {
+                span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+            }
+            if (gbc) {
+                span = Math.min(span, infraredPort.performanceQuietSpanLimit(span));
+            }
+            int gpuSpanLimit = gpu.performanceQuietSpanLimit();
+            span = Math.min(span, gpuSpanLimit);
+            directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+            steadyRasterSpan = span > 0 && !directRasterSpan
+                    && gpu.isPerformanceSteadyCursorActive();
+            span = Math.min(span, statRegister.performanceQuietSpanLimit(span));
+        }
+        if (remaining < span) {
+            span = (int) remaining;
+        }
+        if (span <= 0
+                || warmResetRequested
+                || speedSwitchTailTicks != 0
+                || !cpu.performancePhaseOnlySpanEligible()
+                || !cpu.performanceNoPendingPpuReadPhase()
+                || dma.isTransferInProgress()
+                || dma.requiresClockTick(cpu.getState() == Cpu.State.HALTED)
+                || gbc && hdma.hasActiveOrPendingTransfer()
+                // This is intentionally the one post-preflight volatile Joypad check.
+                || !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
+        tickPerformanceQuietSpan(span, directRasterSpan, steadyRasterSpan);
+        performanceBulkSpanCount++;
+        performanceBulkTicks += span;
+        return span;
+    }
+
+    /** Stable topology only; every tick-local blocker stays in {@link #canStartPerformanceEpoch()}. */
+    private boolean isNativeCgbPerformanceEpochTopology() {
+        return gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 2;
+    }
+
+    /** Physical DMG/MGB only; CGB compatibility and both SGB clocks retain the legacy lane. */
+    private boolean isPhysicalDmgPerformanceEpochTopology() {
+        return hardwareProfile.family() == HardwareProfile.Family.DMG
+                && speedMode.getSpeedMode() == 1;
+    }
+
+    private boolean canStartPerformanceEpoch() {
+        return !warmResetRequested
+                && speedSwitchTailTicks == 0
+                && !debugHistoryReplay
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && gpu.isLcdEnabled()
+                && !dma.isTransferInProgress()
+                && !dma.requiresClockTick(false)
+                && !hdma.hasActiveOrPendingTransfer()
+                && !cartridgeClocked
+                && !slotCartridgeClocked
+                && serialPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS)
+                && infraredPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
+    }
+
+    /** Stable physical-DMG topology; tick-local CPU, timer, raster and STAT guards follow. */
+    private boolean canStartPhysicalDmgPerformanceEpoch() {
+        return !warmResetRequested
+                && speedSwitchTailTicks == 0
+                && !debugHistoryReplay
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && gpu.isLcdEnabled()
+                && !dma.isTransferInProgress()
+                && !dma.requiresClockTick(false)
+                && !cartridgeClocked
+                && !slotCartridgeClocked
+                && serialPort.performancePhysicalDmgEpochIdle(
+                        Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
+    }
+
+    /** Attempts and commits one bounded native-CGB epoch, returning its consumed ticks. */
+    private int tryPerformanceEpoch(long remaining) {
+        if (remaining <= 0 || !cpu.performanceEpochEntryEligible()
+                || !canStartPerformanceEpoch()) {
+            return 0;
+        }
+        int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
+        span = Math.min(span, timer.performanceEpochSpanLimit(span));
+        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+
+        PerformanceEpochPpuPlan ppuPlan;
+        int rasterSpan = gpu.performanceEpochSpanLimit(span);
+        if (rasterSpan > 0) {
+            span = Math.min(span, rasterSpan);
+            ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+        } else {
+            int mode2BulkSpan = gpu.performanceEpochMode2BulkSpanLimit(span);
+            if (mode2BulkSpan > 0) {
+                span = Math.min(span, mode2BulkSpan);
+                ppuPlan = PerformanceEpochPpuPlan.MODE2_BULK;
+            } else {
+                span = Math.min(span, gpu.performanceEpochMode2ReplaySpanLimit(span));
+                ppuPlan = PerformanceEpochPpuPlan.MODE2_REPLAY;
+            }
+        }
+        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
+        if (span <= 0) {
+            return 0;
+        }
+
+        // Linearization point for asynchronous host/reset mutations. A legacy input event that
+        // invalidated the horizon, or a reset published before this read, keeps the CPU scalar;
+        // a publication after it belongs to the next completed PERFORMANCE packet.
+        if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
+
+        performanceEpochDirectRaster = gpu.isPerformanceScanlineCursorActive();
+        performanceEpochSteadyRaster = !performanceEpochDirectRaster
+                && gpu.isPerformanceSteadyCursorActive();
+        performanceEpochPpuPlan = ppuPlan;
+        performanceEpochPrefixCommitted = 0;
+        if (performanceEpochPrefixCommitter == null) {
+            performanceEpochPrefixCommitter = this::commitPerformanceEpochPrefix;
+        }
+        cpu.setPerformanceEpochPrefixCommitter(performanceEpochPrefixCommitter);
+        int elapsed;
+        try {
+            elapsed = cpu.runPerformanceEpoch(span);
+        } finally {
+            cpu.setPerformanceEpochPrefixCommitter(null);
+        }
+        if (elapsed <= 0) {
+            return 0;
+        }
+        int suffix = elapsed - performanceEpochPrefixCommitted;
+        if (suffix > 0) {
+            commitPerformanceEpochPeripherals(suffix);
+        }
+        // The observer defers an unsafe write.  Replaying after the complete old-state
+        // prefix preserves the boundary semantics and guarantees one delegated write.
+        cpu.replayPerformanceEpochJournal();
+        boolean divReset = timer.consumeDivReset();
+        if (divReset) {
+            sound.tickFrameSequencer(true);
+            sound.commitFrameSequencerClock();
+            serialPort.onDivReset();
+        }
+        hdma.onCpuHaltState(cpu.getState() == Cpu.State.HALTED);
+        if (cpu.hasPendingPeripheralSample()) {
+            // The epoch can retire HALT immediately before the caller's budget ends. Publish
+            // the otherwise-inactive OAM-DMA pause latch in the same rare branch which already
+            // owns HALT's post-peripheral sample, so ordinary epochs gain no new hot check.
+            if (cpu.getState() == Cpu.State.HALTED && dma.requiresClockTick(true)) {
+                dma.tick(true, true);
+            }
+            cpu.onPeripheralsTicked();
+        }
+
+        performanceEpochCount++;
+        performanceEpochTicks += elapsed;
+        performanceEpochMaxTicks = Math.max(performanceEpochMaxTicks, elapsed);
+        return elapsed;
+    }
+
+    /** Attempts one trusted-raster-only physical-DMG epoch. */
+    private int tryPhysicalDmgPerformanceEpoch(long remaining) {
+        if (remaining <= 0 || !cpu.performancePhysicalDmgEpochEntryEligible()
+                || !canStartPhysicalDmgPerformanceEpoch()) {
+            return 0;
+        }
+        int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
+        span = Math.min(span, timer.performancePhysicalDmgEpochSpanLimit(span));
+        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+
+        int rasterSpan = gpu.performancePhysicalDmgEpochSpanLimit(span);
+        if (rasterSpan <= 0) {
+            return 0;
+        }
+        span = Math.min(span, rasterSpan);
+        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
+        if (span <= 0) {
+            return 0;
+        }
+
+        if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
+
+        performanceEpochDirectRaster = gpu.isPerformanceScanlineCursorActive();
+        performanceEpochSteadyRaster = !performanceEpochDirectRaster
+                && gpu.isPerformanceSteadyCursorActive();
+        performanceEpochPpuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+        performanceEpochPrefixCommitted = 0;
+        if (performancePhysicalDmgEpochPrefixCommitter == null) {
+            performancePhysicalDmgEpochPrefixCommitter =
+                    this::commitPhysicalDmgPerformanceEpochPrefix;
+        }
+        cpu.setPerformanceEpochPrefixCommitter(performancePhysicalDmgEpochPrefixCommitter);
+        int elapsed;
+        try {
+            elapsed = cpu.runPhysicalDmgPerformanceEpoch(span);
+        } finally {
+            cpu.setPerformanceEpochPrefixCommitter(null);
+        }
+        if (elapsed <= 0) {
+            return 0;
+        }
+        int suffix = elapsed - performanceEpochPrefixCommitted;
+        if (suffix > 0) {
+            commitPhysicalDmgPerformanceEpochPeripherals(suffix);
+        }
+        settlePhysicalDmgPerformanceEpochDmaHaltLatch();
+        cpu.replayPerformanceEpochJournal();
+        boolean divReset = timer.consumeDivReset();
+        if (divReset) {
+            sound.tickFrameSequencer(true);
+            sound.commitFrameSequencerClock();
+            serialPort.onDivReset();
+        }
+        if (cpu.hasPendingPeripheralSample()) {
+            cpu.onPeripheralsTicked();
+        }
+
+        performanceEpochCount++;
+        performanceEpochTicks += elapsed;
+        performanceEpochMaxTicks = Math.max(performanceEpochMaxTicks, elapsed);
+        return elapsed;
+    }
+
+    /** Publishes the inactive OAM-DMA pause latch when an epoch retires HALT. */
+    private void settlePhysicalDmgPerformanceEpochDmaHaltLatch() {
+        if (cpu.getState() == Cpu.State.HALTED && dma.requiresClockTick(true)) {
+            // The scalar owner calls this after the HALT-fetch CPU boundary. Keep it before
+            // deferred FF46 replay so the existing journal's declared next-dot skew is intact.
+            dma.tick(true, true);
+        }
+    }
+
+    private void commitPerformanceEpochPrefix(int ticks) {
+        if (ticks <= performanceEpochPrefixCommitted) {
+            return;
+        }
+        commitPerformanceEpochPeripherals(ticks - performanceEpochPrefixCommitted);
+        performanceEpochPrefixCommitted = ticks;
+    }
+
+    /** Commits one old-state prefix without invoking the CPU synchronizer callback. */
+    private void commitPerformanceEpochPeripherals(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        timer.tickPerformanceEpochTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed a PERFORMANCE epoch";
+        sound.commitFrameSequencerClock();
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformanceEpochIdle(ticks);
+        infraredPort.tickPerformanceEpochIdle(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+
+        switch (performanceEpochPpuPlan) {
+            case TRUSTED_RASTER -> {
+                gpu.advancePerformanceEpochQuietSpanTrusted(
+                        ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                performanceEpochRasterFastTicks += ticks;
+            }
+            case MODE2_BULK -> {
+                gpu.advancePerformanceMode2QuietSpanTrusted(ticks);
+                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                performanceEpochMode2ReplayTicks += ticks;
+                performanceEpochMode2BulkTicks += ticks;
+            }
+            case MODE2_REPLAY -> {
+                // The CPU and independently clocked peripherals have already consumed their
+                // frozen-view packet. Preserve scalar PPU ordering inside mode 2 so OAM-reader
+                // and STAT state are published dot-for-dot before the scalar hand-off tick.
+                for (int i = 0; i < ticks; i++) {
+                    gpu.tick();
+                    statRegister.tick();
+                }
+                performanceEpochMode2ReplayTicks += ticks;
+            }
+            case NONE -> throw new IllegalStateException(
+                    "PERFORMANCE epoch committed without a PPU plan");
+        }
+        hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                gpu.isStatModeLatchRephasedBySpeedSwitch());
+    }
+
+    private void commitPhysicalDmgPerformanceEpochPrefix(int ticks) {
+        if (ticks <= performanceEpochPrefixCommitted) {
+            return;
+        }
+        commitPhysicalDmgPerformanceEpochPeripherals(
+                ticks - performanceEpochPrefixCommitted);
+        performanceEpochPrefixCommitted = ticks;
+    }
+
+    /** Physical-DMG prefix commit; CGB-only IR/HDMA state is deliberately absent. */
+    private void commitPhysicalDmgPerformanceEpochPeripherals(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        timer.tickPerformancePhysicalDmgEpochTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed a physical-DMG PERFORMANCE epoch";
+        sound.commitFrameSequencerClock();
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformancePhysicalDmgEpochIdle(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+        gpu.advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
+                ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+        statRegister.tickPerformanceQuietSpanTrusted(ticks);
+        performanceEpochRasterFastTicks += ticks;
+    }
+
+    /**
      * Attempts the long settled-HALT packet used only by the DMG PERFORMANCE side entrance.
      * Every horizon and volatile guard is read before the commit, so a zero result leaves the
-     * machine untouched and lets the ordinary Stage4 scheduler handle the next scalar phase.
+     * machine untouched and lets the ordinary PERFORMANCE scheduler handle the next scalar phase.
      */
     private int tryPerformanceSettledDmgHaltSpan(long remaining) {
         if (remaining <= 0 || !cpu.performanceSettledHaltSpanEligible()) {
@@ -1000,6 +1475,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceBulkSpanCount = 0L;
         performanceBulkTicks = 0L;
         performanceBulkMaxTicks = 0;
+        performanceEpochCount = 0L;
+        performanceEpochTicks = 0L;
+        performanceEpochMaxTicks = 0;
+        performanceEpochRasterFastTicks = 0L;
+        performanceEpochMode2ReplayTicks = 0L;
+        performanceEpochMode2BulkTicks = 0L;
+        performanceEpochPpuPlan = PerformanceEpochPpuPlan.NONE;
+        cpu.resetPerformanceEpochTelemetry();
     }
 
     /** Number of all-subsystem PERFORMANCE bulk spans taken by the current session. */
@@ -1017,14 +1500,44 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return performanceBulkMaxTicks;
     }
 
+    public long getPerformanceEpochCount() {
+        return performanceEpochCount;
+    }
+
+    public long getPerformanceEpochTicks() {
+        return performanceEpochTicks;
+    }
+
+    public int getPerformanceEpochMaxTicks() {
+        return performanceEpochMaxTicks;
+    }
+
+    public long getPerformanceEpochRasterFastTicks() {
+        return performanceEpochRasterFastTicks;
+    }
+
+    public long getPerformanceEpochMode2ReplayTicks() {
+        return performanceEpochMode2ReplayTicks;
+    }
+
+    public long getPerformanceEpochMode2BulkTicks() {
+        return performanceEpochMode2BulkTicks;
+    }
+
     private Mode tickSubsystems() {
+        boolean nativeCgbScalarOwnerTick = nativeCgbScalarOwner;
         int statReadPhaseFlags = cpu.getStatReadPhaseFlags();
-        boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(statReadPhaseFlags);
-        statRegister.finishCpuReadPhase(
-                cpu.getInterruptFlagReadMaskTicks(mode0InterruptEdgeNextTick),
-                cpu.isMode0InterruptDispatchPhased(mode0InterruptEdgeNextTick),
-                cpu.doesMode0InstructionWinInterruptAcceptance(
-                        mode0InterruptEdgeNextTick));
+        if (nativeCgbScalarOwnerTick) {
+            nativeCgbScalarOwner = false;
+            tickNativeCgbPerformanceStatPrologue(statReadPhaseFlags);
+        } else {
+            boolean mode0InterruptEdgeNextTick = statRegister.beginCpuReadPhase(statReadPhaseFlags);
+            statRegister.finishCpuReadPhase(
+                    cpu.getInterruptFlagReadMaskTicks(mode0InterruptEdgeNextTick),
+                    cpu.isMode0InterruptDispatchPhased(mode0InterruptEdgeNextTick),
+                    cpu.doesMode0InstructionWinInterruptAcceptance(
+                            mode0InterruptEdgeNextTick));
+        }
         boolean speedSwitching = cpu.isSpeedSwitching();
         boolean speedSwitchTail = speedSwitchTailTicks > 0;
         Cpu.State initialCpuState = cpu.getState();
@@ -1231,8 +1744,20 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         } else {
             statRegister.tick();
         }
-        cpu.onPeripheralsTicked();
+        if (cpu.hasPendingPeripheralSample()) {
+            cpu.onPeripheralsTicked();
+        }
         return mode;
+    }
+
+    /** Specialized native-CGB CPU/STAT seam; called only by the one-shot scalar owner token. */
+    private void tickNativeCgbPerformanceStatPrologue(int statReadPhaseFlags) {
+        int phaseWord = gpu.getNativeCgbPerformancePhaseWord();
+        boolean mode0InterruptEdgeNextTick =
+                statRegister.beginNativeCgbPerformanceReadPhase(statReadPhaseFlags, phaseWord);
+        statRegister.finishNativeCgbPerformanceReadPhase(
+                mode0InterruptEdgeNextTick ? cpu.getInterruptFlagReadMaskTicks(true) : 0,
+                phaseWord);
     }
 
     /**
@@ -1328,8 +1853,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     private void updatePerformanceObservationBlocker() {
-        gpu.setPerformanceObservationBlocked(
-                debugInstrumentation != null || debugRetirementTrackingActive);
+        boolean blocked = debugInstrumentation != null || debugRetirementTrackingActive;
+        if (blocked) {
+            // A synchronous callback may install observation while runNative is between dots.
+            // The following scalar tick must use the generic prologue and observation path.
+            nativeCgbScalarOwner = false;
+        }
+        gpu.setPerformanceObservationBlocked(blocked);
     }
 
     /**
@@ -2041,6 +2571,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     private void restoreMachineState(GameboyState mem, boolean restoreCartridge) {
+        nativeCgbScalarOwner = false;
         biosShadow.restoreState(mem.biosShadowMemento());
         if (restoreCartridge) {
             cartridge.restoreState(mem.cartridgeMemento());

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -267,6 +267,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         MODE2_REPLAY
     }
 
+    /** PPU commit selected for a normal-speed, phase-only PERFORMANCE packet. */
+    private enum PerformancePhasePpuPlan {
+        QUIET,
+        PHYSICAL_DMG_MODE2
+    }
+
     public Gameboy(Rom rom) {
         this(new GameboyConfiguration(rom));
     }
@@ -874,6 +880,208 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
+     * Advances one measured benchmark window, preserving the PERFORMANCE scheduler while
+     * allowing a synchronous native-frame callback to terminate the window immediately.
+     *
+     * <p>This is intentionally a separate seam from {@link #runTicksUntilStop(int,
+     * BooleanSupplier)}.  Preconditioning and other callers retain the public stop-aware API;
+     * only the benchmark's armed measurement uses this owner-thread boundary.  In PERFORMANCE
+     * mode the same epoch/scanline bulk paths as {@link #runTicks(long)} are used, and the stop
+     * predicate is checked at each scalar hand-off so a frame-600 callback cannot be followed by
+     * another scalar tick or bulk packet.</p>
+     *
+     * @return the exact number of master ticks executed
+     */
+    public int runMeasuredTicksUntilStop(int ticks, BooleanSupplier stop) {
+        if (ticks < 0) {
+            throw new IllegalArgumentException("ticks must be non-negative");
+        }
+        Objects.requireNonNull(stop, "stop");
+        if (executionMode == ExecutionMode.PERFORMANCE
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && !debugHistoryReplay) {
+            return Math.toIntExact(runPerformanceTicksUntilStop(ticks, stop));
+        }
+        int executed = 0;
+        while (executed < ticks && !stop.getAsBoolean()) {
+            tick();
+            executed++;
+        }
+        return executed;
+    }
+
+    /** Stop-aware counterpart of the ordinary PERFORMANCE frame loop. */
+    private long runPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
+        if (isNativeCgbPerformanceEpochTopology()) {
+            return runNativeCgbPerformanceTicksUntilStop(ticks, stop);
+        }
+        if (isPhysicalDmgPerformanceEpochTopology()) {
+            return runPhysicalDmgPerformanceTicksUntilStop(ticks, stop);
+        }
+        return runFallbackPerformanceTicksUntilStop(ticks, stop);
+    }
+
+    /** Fallback PERFORMANCE scheduler used by CGB compatibility, SGB, and other topologies. */
+    private long runFallbackPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
+        gpu.setPerformanceScanlineEnabled(true);
+        long remaining = ticks;
+        try {
+            while (remaining > 0 && !stop.getAsBoolean()) {
+                if (!gbc && cpu.getState() == Cpu.State.HALTED) {
+                    int committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
+                }
+                int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
+                int span = tryPerformancePhaseOnlySpan(remaining, cpuSpanLimit);
+                boolean reachesCpuBoundary = span > 0 && span == cpuSpanLimit;
+                if (span > 0) {
+                    remaining -= span;
+                    if (reachesCpuBoundary && remaining > 0) {
+                        if (stop.getAsBoolean()) {
+                            break;
+                        }
+                        tick();
+                        remaining--;
+                        if (stop.getAsBoolean()) {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+                tick();
+                remaining--;
+                // A synchronous frame callback may have changed the stop predicate during tick.
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+            }
+        } finally {
+            sound.materializePendingPerformanceTicks();
+            gpu.setPerformanceScanlineEnabled(false);
+        }
+        return ticks - remaining;
+    }
+
+    /** Stop-aware native-CGB epoch scheduler; bulk packets never publish frame callbacks. */
+    private long runNativeCgbPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
+        gpu.setPerformanceScanlineEnabled(true);
+        long remaining = ticks;
+        try {
+            while (remaining > 0 && !stop.getAsBoolean()
+                    && isNativeCgbPerformanceEpochTopology()) {
+                int committed = tryPerformanceEpoch(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+                if (committed < 0) {
+                    int deadline = -committed;
+                    do {
+                        if (stop.getAsBoolean()) {
+                            break;
+                        }
+                        nativeCgbScalarOwner = !warmResetRequested
+                                && debugInstrumentation == null
+                                && !debugRetirementTrackingActive
+                                && !debugHistoryReplay;
+                        tick();
+                        remaining--;
+                        deadline--;
+                        if (stop.getAsBoolean()) {
+                            break;
+                        }
+                    } while (deadline > 0 && remaining > 0
+                            && canContinueNativeCgbNegativeStatLease());
+                    if (remaining > 0 && !isNativeCgbPerformanceEpochTopology()) {
+                        break;
+                    }
+                    continue;
+                }
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    committed = tryPerformanceSettledNativeCgbHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
+                }
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+                nativeCgbScalarOwner = !warmResetRequested
+                        && debugInstrumentation == null
+                        && !debugRetirementTrackingActive
+                        && !debugHistoryReplay;
+                tick();
+                remaining--;
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+            }
+        } finally {
+            nativeCgbScalarOwner = false;
+            sound.materializePendingPerformanceTicks();
+            gpu.setPerformanceScanlineEnabled(false);
+        }
+        if (remaining > 0 && !stop.getAsBoolean()
+                && !isNativeCgbPerformanceEpochTopology()) {
+            return (ticks - remaining) + runFallbackPerformanceTicksUntilStop(remaining, stop);
+        }
+        return ticks - remaining;
+    }
+
+    /** Stop-aware physical-DMG scheduler; mode-3 packets retain their raster fast path. */
+    private long runPhysicalDmgPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
+        gpu.setPerformanceScanlineEnabled(true);
+        long remaining = ticks;
+        try {
+            while (remaining > 0 && !stop.getAsBoolean()
+                    && isPhysicalDmgPerformanceEpochTopology()) {
+                int committed = tryPhysicalDmgPerformanceEpoch(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
+                }
+                int cpuSpanLimit = cpu.performancePhaseOnlySpanLimit();
+                int phaseSpan = tryPerformancePhaseOnlySpan(remaining, cpuSpanLimit);
+                if (phaseSpan > 0) {
+                    remaining -= phaseSpan;
+                    continue;
+                }
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+                tick();
+                remaining--;
+                if (stop.getAsBoolean()) {
+                    break;
+                }
+            }
+        } finally {
+            sound.materializePendingPerformanceTicks();
+            gpu.setPerformanceScanlineEnabled(false);
+        }
+        if (remaining > 0 && !stop.getAsBoolean()
+                && !isPhysicalDmgPerformanceEpochTopology()) {
+            return (ticks - remaining) + runFallbackPerformanceTicksUntilStop(remaining, stop);
+        }
+        return ticks - remaining;
+    }
+
+    /**
      * PERFORMANCE-only frame loop. At a normal-speed CPU boundary the scalar tick remains the
      * authority; between boundaries, a short span can advance the independent peripherals while
      * the CPU/PPU/STAT hot paths use their bulk phase methods. ACCURACY retains the exact scalar
@@ -951,6 +1159,32 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 if (committed > 0) {
                     remaining -= committed;
                     continue;
+                }
+                if (committed < 0) {
+                    int deadline = -committed;
+                    do {
+                        nativeCgbScalarOwner = !warmResetRequested
+                                && debugInstrumentation == null
+                                && !debugRetirementTrackingActive
+                                && !debugHistoryReplay;
+                        if (tick()) {
+                            frameEvents++;
+                        }
+                        remaining--;
+                        deadline--;
+                    } while (deadline > 0 && remaining > 0
+                            && canContinueNativeCgbNegativeStatLease());
+                    if (remaining > 0 && !isNativeCgbPerformanceEpochTopology()) {
+                        break;
+                    }
+                    continue;
+                }
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    committed = tryPerformanceSettledNativeCgbHaltSpan(remaining);
+                    if (committed > 0) {
+                        remaining -= committed;
+                        continue;
+                    }
                 }
                 nativeCgbScalarOwner = !warmResetRequested
                         && debugInstrumentation == null
@@ -1031,6 +1265,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // Build one primitive packet plan. Every component horizon is evaluated once against
         // the already-shortened tail; trusted commits do not repeat the walks.
         int span = cpuSpanLimit;
+        PerformancePhasePpuPlan ppuPlan = PerformancePhasePpuPlan.QUIET;
         boolean directRasterSpan = false;
         boolean steadyRasterSpan = false;
         if (span > 0) {
@@ -1048,10 +1283,26 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 span = Math.min(span, infraredPort.performanceQuietSpanLimit(span));
             }
             int gpuSpanLimit = gpu.performanceQuietSpanLimit();
-            span = Math.min(span, gpuSpanLimit);
-            directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
-            steadyRasterSpan = span > 0 && !directRasterSpan
-                    && gpu.isPerformanceSteadyCursorActive();
+            if (gpuSpanLimit > 0) {
+                span = Math.min(span, gpuSpanLimit);
+                directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+                steadyRasterSpan = span > 0 && !directRasterSpan
+                        && gpu.isPerformanceSteadyCursorActive();
+            } else if (isPhysicalDmgPerformanceEpochTopology()) {
+                // Physical-DMG mode 2 has no quiet-output horizon: the OAM reader itself is
+                // the only PPU work in these one-to-three non-CPU dots.  Keep this explicit
+                // plan separate from the settled quiet path so CGB/compat sessions cannot
+                // accidentally enter the DMG arithmetic lane.
+                int mode2SpanLimit = gpu.performancePhysicalDmgMode2PhaseSpanLimit(span);
+                if (mode2SpanLimit > 0) {
+                    span = Math.min(span, mode2SpanLimit);
+                    ppuPlan = PerformancePhasePpuPlan.PHYSICAL_DMG_MODE2;
+                } else {
+                    span = 0;
+                }
+            } else {
+                span = 0;
+            }
             span = Math.min(span, statRegister.performanceQuietSpanLimit(span));
         }
         if (remaining < span) {
@@ -1069,7 +1320,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || !joypad.isPerformanceQuietSpanStillEligible()) {
             return 0;
         }
-        tickPerformanceQuietSpan(span, directRasterSpan, steadyRasterSpan);
+        tickPerformanceQuietSpan(span, ppuPlan, directRasterSpan, steadyRasterSpan);
         performanceBulkSpanCount++;
         performanceBulkTicks += span;
         return span;
@@ -1078,6 +1329,28 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Stable topology only; every tick-local blocker stays in {@link #canStartPerformanceEpoch()}. */
     private boolean isNativeCgbPerformanceEpochTopology() {
         return gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 2;
+    }
+
+    private boolean canContinueNativeCgbNegativeStatLease() {
+        if (!isNativeCgbPerformanceEpochTopology()) {
+            return false;
+        }
+        Cpu.State state = cpu.getState();
+        if (state == Cpu.State.HALTED || state == Cpu.State.STOPPED
+                || state == Cpu.State.SPEED_SWITCH || state == Cpu.State.LOCKED) {
+            return false;
+        }
+        if (warmResetRequested
+                || debugInstrumentation != null
+                || debugHistoryReplay
+                || debugRetirementTrackingActive
+                || speedSwitchTailTicks != 0) {
+            return false;
+        }
+        if (statRegister.performanceSettledHaltSpanLimit(1) == 0) {
+            return true;
+        }
+        return !cpu.performanceEpochEntryEligible();
     }
 
     /** Physical DMG/MGB only; CGB compatibility and both SGB clocks retain the legacy lane. */
@@ -1118,7 +1391,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                         Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
     }
 
-    /** Attempts and commits one bounded native-CGB epoch, returning its consumed ticks. */
+    /**
+     * Attempts one bounded native-CGB epoch.
+     *
+     * @return committed ticks when positive, zero for an ordinary rejection, or the negative
+     *         uncommitted scalar deadline when only STAT rejected an otherwise valid plan
+     */
     private int tryPerformanceEpoch(long remaining) {
         if (remaining <= 0 || !cpu.performanceEpochEntryEligible()
                 || !canStartPerformanceEpoch()) {
@@ -1144,14 +1422,22 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 ppuPlan = PerformanceEpochPpuPlan.MODE2_REPLAY;
             }
         }
-        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
         if (span <= 0) {
             return 0;
         }
 
-        // Linearization point for asynchronous host/reset mutations. A legacy input event that
-        // invalidated the horizon, or a reset published before this read, keeps the CPU scalar;
-        // a publication after it belongs to the next completed PERFORMANCE packet.
+        int statSpan = statRegister.performanceSettledHaltSpanLimit(span);
+        if (statSpan == 0) {
+            if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
+                return 0;
+            }
+            return -span;
+        }
+        span = Math.min(span, statSpan);
+        if (span <= 0) {
+            return 0;
+        }
+
         if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
             return 0;
         }
@@ -1202,6 +1488,124 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochTicks += elapsed;
         performanceEpochMaxTicks = Math.max(performanceEpochMaxTicks, elapsed);
         return elapsed;
+    }
+
+    /**
+     * Attempts one native-CGB double-speed settled-HALT packet. HALT has no CPU bus work once
+     * its entry and wake samples have settled, but the packet still stops before every timer,
+     * audio, input, PPU, STAT, DMA, and frame boundary. Unlike the ordinary epoch this path does
+     * not borrow a ROM mapping or change the CPU instruction sequencer.
+     */
+    private int tryPerformanceSettledNativeCgbHaltSpan(long remaining) {
+        if (remaining <= 0 || !cpu.performanceNativeCgbSettledHaltSpanEligible()
+                || !canStartNativeCgbSettledHaltSpan()) {
+            return 0;
+        }
+        int span = (int) Math.min((long) SETTLED_HALT_PERFORMANCE_MAX_SPAN, remaining);
+        span = Math.min(span, timer.performanceEpochSpanLimit(span));
+        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+        if (span <= 0 || !serialPort.performanceEpochIdle(span)
+                || !infraredPort.performanceEpochIdle(span)) {
+            return 0;
+        }
+        PerformanceEpochPpuPlan ppuPlan;
+        int rasterSpan = gpu.performanceEpochSpanLimit(span);
+        if (rasterSpan > 0) {
+            span = Math.min(span, rasterSpan);
+            ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+        } else {
+            int mode2BulkSpan = gpu.performanceEpochMode2BulkSpanLimit(span);
+            if (mode2BulkSpan > 0) {
+                span = Math.min(span, mode2BulkSpan);
+                ppuPlan = PerformanceEpochPpuPlan.MODE2_BULK;
+            } else {
+                span = Math.min(span, gpu.performanceEpochMode2ReplaySpanLimit(span));
+                ppuPlan = PerformanceEpochPpuPlan.MODE2_REPLAY;
+            }
+        }
+        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
+        if (span <= 0) {
+            return 0;
+        }
+
+        // Keep the final volatile reads adjacent to the commit. A host reset/input mutation
+        // published before this point belongs to the scalar owner; one published afterwards is
+        // visible to the next packet, just as in the ordinary native epoch.
+        if (warmResetRequested
+                || speedSwitchTailTicks != 0
+                || !cpu.performanceNoPendingPpuReadPhase()
+                || !serialPort.performanceEpochIdle(span)
+                || !infraredPort.performanceEpochIdle(span)
+                || !joypad.isPerformanceQuietSpanStillEligible()
+                || !canStartNativeCgbSettledHaltSpan()) {
+            return 0;
+        }
+
+        boolean directRaster = gpu.isPerformanceScanlineCursorActive();
+        boolean steadyRaster = !directRaster && gpu.isPerformanceSteadyCursorActive();
+        tickPerformanceSettledNativeCgbHaltSpan(span, ppuPlan, directRaster, steadyRaster);
+        performanceBulkSpanCount++;
+        performanceBulkTicks += span;
+        performanceBulkMaxTicks = Math.max(performanceBulkMaxTicks, span);
+        return span;
+    }
+
+    private boolean canStartNativeCgbSettledHaltSpan() {
+        return isNativeCgbPerformanceEpochTopology()
+                && !warmResetRequested
+                && speedSwitchTailTicks == 0
+                && !debugHistoryReplay
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && gpu.isLcdEnabled()
+                && !dma.isTransferInProgress()
+                && !dma.requiresClockTick(true)
+                && !hdma.hasActiveOrPendingTransfer()
+                && !hdma.hasPendingHblankTransfer()
+                && !hdma.isHaltRequestLatched()
+                && !hdma.holdsHblankSpeedSwitchTail()
+                && !hdma.pausesOamDmaForSpeedSwitchBurst()
+                && !hdma.requiresCpuHdmaPhaseFlags()
+                && !cartridgeClocked
+                && !slotCartridgeClocked;
+    }
+
+    private void tickPerformanceSettledNativeCgbHaltSpan(
+            int ticks, PerformanceEpochPpuPlan ppuPlan, boolean directRaster,
+            boolean steadyRaster) {
+        timer.tickPerformanceEpochTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed a native-CGB settled-HALT span";
+        sound.commitFrameSequencerClock();
+        cpu.advancePerformanceNativeCgbSettledHaltSpanTrusted(ticks);
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformanceEpochIdle(ticks);
+        infraredPort.tickPerformanceEpochIdle(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+
+        switch (ppuPlan) {
+            case TRUSTED_RASTER -> {
+                gpu.advancePerformanceEpochQuietSpanTrusted(ticks, directRaster, steadyRaster);
+                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+            }
+            case MODE2_BULK -> {
+                gpu.advancePerformanceMode2QuietSpanTrusted(ticks);
+                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+            }
+            case MODE2_REPLAY -> {
+                for (int i = 0; i < ticks; i++) {
+                    gpu.tick();
+                    statRegister.tick();
+                }
+            }
+            case NONE -> throw new IllegalStateException(
+                    "native-CGB settled-HALT span has no PPU plan");
+        }
+        hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                gpu.isStatModeLatchRephasedBySpeedSwitch());
+        cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
     }
 
     /** Attempts one trusted-raster-only physical-DMG epoch. */
@@ -1433,6 +1837,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Advances the non-CPU-bus peripherals for one preflighted quiet span. */
     private void tickPerformanceQuietSpan(int ticks, boolean directRasterSpan,
                                           boolean steadyRasterSpan) {
+        tickPerformanceQuietSpan(
+                ticks, PerformancePhasePpuPlan.QUIET, directRasterSpan, steadyRasterSpan);
+    }
+
+    /** Advances the non-CPU-bus peripherals for one explicit phase-only PPU plan. */
+    private void tickPerformanceQuietSpan(
+            int ticks, PerformancePhasePpuPlan ppuPlan,
+            boolean directRasterSpan, boolean steadyRasterSpan) {
         if (cartridgeClocked) {
             cartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
@@ -1459,7 +1871,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // No CPU bus boundary exists inside this span. Advance the free-running phase once;
         // running state, or settled HALT, proves Cpu.onPeripheralsTicked() is a no-op here.
         cpu.advancePerformancePhaseOnlyTrusted(ticks);
-        gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        if (ppuPlan == PerformancePhasePpuPlan.PHYSICAL_DMG_MODE2) {
+            gpu.advancePerformancePhysicalDmgMode2PhaseSpanTrusted(ticks);
+        } else {
+            gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         if (gbc) {
             // Scalar tick() publishes these post-GPU timing latches on every dot.  A packet
@@ -1739,7 +2155,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         boolean performanceQuietRaster = performanceSteadyCursor
                 && gpu.isPerformanceSteadyTickQuiet();
         Mode mode = performanceSteadyCursor ? gpu.tickPerformanceSteady() : gpu.tick();
-        if (performanceQuietRaster && mode == null) {
+        if (nativeCgbScalarOwnerTick) {
+            // The native scalar owner has already run the pre-CPU STAT seam. Complete the
+            // post-GPU phase with the allocation-free native timing facts; every other path
+            // remains on the established generic evaluator.
+            statRegister.tickNativeCgbPerformancePostGpu();
+        } else if (performanceQuietRaster && mode == null) {
             statRegister.tickPerformanceQuietIfSafe();
         } else {
             statRegister.tick();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -9,14 +9,28 @@ import eu.rekawek.coffeegb.core.debug.DebugMemoryAccess;
 import eu.rekawek.coffeegb.core.cpu.op.Op;
 import eu.rekawek.coffeegb.core.cpu.opcode.Opcode;
 import eu.rekawek.coffeegb.core.gpu.*;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
 import eu.rekawek.coffeegb.core.state.MachineStateCapture;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 import eu.rekawek.coffeegb.core.timer.Timer;
 
 import java.util.List;
+import java.util.function.IntConsumer;
 
 public class Cpu implements StatefulComponent<Cpu> {
+
+    /** Maximum bounded PERFORMANCE epoch in master ticks. */
+    public static final int PERFORMANCE_EPOCH_MAX_TICKS = 54;
+
+    private static final int FLAG_Z = 0x80;
+
+    private static final int FLAG_N = 0x40;
+
+    private static final int FLAG_H = 0x20;
+
+    private static final int FLAG_C = 0x10;
 
     public static final int STAT_READ_PHASE_SYNCHRONOUS_HALT_ENTRY = 1;
 
@@ -49,7 +63,42 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private final AddressSpace baseAddressSpace;
 
+    /** Immutable typed entrance to the optional native-CGB physical ROM mapping chain. */
+    private final PerformanceRomAccessProvider performanceRomAccessProvider;
+
     private AddressSpace addressSpace;
+
+    /** Reused CPU-bus observer for the native-CGB coarse PERFORMANCE epoch. */
+    private transient PerformanceEpochBus performanceEpochBus;
+
+    /** Borrowed direct ROM mapping retained only for one bounded native-CGB epoch. */
+    private transient PerformanceRomAccess performanceEpochRomAccess;
+
+    private transient AddressSpace performanceEpochTarget;
+
+    private transient boolean performanceEpochActive;
+
+    private transient boolean performanceEpochTerminal;
+
+    private transient boolean performanceEpochJournalValid;
+
+    private transient int performanceEpochJournalAddress;
+
+    private transient int performanceEpochJournalValue;
+
+    private transient long performanceEpochCount;
+
+    private transient long performanceEpochTicks;
+
+    private transient long performanceEpochAccesses;
+
+    private transient long performanceEpochTerminalAccesses;
+
+    private transient IntConsumer performanceEpochPrefixCommitter;
+
+    private transient int performanceEpochElapsed;
+
+    private transient int performanceEpochPrefixTicks;
 
     private transient DebugCpuAddressSpace debugAddressSpace;
 
@@ -154,12 +203,318 @@ public class Cpu implements StatefulComponent<Cpu> {
                Display display, Timer timer) {
         this.registers = new Registers();
         this.baseAddressSpace = addressSpace;
+        this.performanceRomAccessProvider = addressSpace instanceof PerformanceRomAccessProvider provider
+                ? provider
+                : null;
         this.addressSpace = addressSpace;
         this.interruptManager = interruptManager;
         this.gpu = gpu;
         this.speedMode = speedMode;
         this.display = display;
         this.timer = timer;
+        this.performanceEpochBus = new PerformanceEpochBus(this);
+    }
+
+    /**
+     * Runs a bounded PERFORMANCE epoch with the CPU bus observed by a
+     * reusable address-space wrapper.  The wrapper deliberately does not speculate:
+     * safe ROM/WRAM/echo/HRAM accesses continue, while the first external access ends
+     * the epoch after the real CPU operation has observed that access.  An external
+     * write is retained in the one-slot journal and is replayed by the owning Gameboy
+     * after its frozen peripheral prefix has been committed.
+     *
+     * <p>This is an intentionally relaxed coordination boundary.  It may end in the
+     * middle of an instruction and therefore must never be used by ACCURACY, debug,
+     * history-replay, or stop-aware callers.</p>
+     *
+     * @return master ticks consumed by the CPU epoch
+     */
+    public int runPerformanceEpoch(int maxMasterTicks) {
+        if (maxMasterTicks <= 0 || !performanceEpochEntryEligible()) {
+            return 0;
+        }
+        int requested = Math.min(maxMasterTicks, PERFORMANCE_EPOCH_MAX_TICKS);
+        if (requested <= 0) {
+            return 0;
+        }
+        PerformanceEpochBus bus = performanceEpochBus;
+        if (bus == null) {
+            bus = new PerformanceEpochBus(this);
+            performanceEpochBus = bus;
+        }
+        AddressSpace target = addressSpace;
+        int elapsed = 0;
+        performanceEpochRomAccess = acquirePerformanceEpochRomAccess();
+        try {
+            performanceEpochTarget = target;
+            performanceEpochTerminal = false;
+            performanceEpochJournalValid = false;
+            performanceEpochJournalAddress = 0;
+            performanceEpochJournalValue = 0;
+            performanceEpochElapsed = 0;
+            performanceEpochPrefixTicks = 0;
+            performanceEpochActive = true;
+            bus.resetForEpoch(target);
+            addressSpace = bus;
+            while (elapsed < requested) {
+                if (clockCycle == 0) {
+                    clockCycle = 1;
+                    elapsed++;
+                    if (elapsed >= requested) {
+                        break;
+                    }
+                }
+
+                // Fence the next fetch/operand window before the native epoch may use its
+                // borrowed ROM mapping. Scalar and physical-DMG fetches remain on the base bus.
+                if (!performanceEpochPrefetchSafe()) {
+                    performanceEpochTerminal = true;
+                    break;
+                }
+
+                State stateBeforeTick = state;
+                performanceEpochElapsed = elapsed;
+                clockCycle = 0;
+                int directTailTicks = tickPerformanceEpochInstructionPipelineAtMachineCycle(
+                        requested - elapsed);
+                elapsed += 1 + directTailTicks;
+                if (stateBeforeTick == State.OPCODE
+                        && (opcode1 == 0x10 || opcode1 == 0x76
+                        || opcode1 == 0xf3 || opcode1 == 0xfb || opcode1 == 0xd9)) {
+                    performanceEpochTerminal = true;
+                }
+                if (performanceEpochTerminal || isPerformanceEpochLifecycleState()) {
+                    break;
+                }
+            }
+        } finally {
+            performanceEpochRomAccess = null;
+            addressSpace = target;
+            performanceEpochActive = false;
+            performanceEpochAccesses += bus.accesses();
+            performanceEpochTerminalAccesses += bus.terminalAccesses();
+            performanceEpochTicks += elapsed;
+            if (elapsed > 0) {
+                performanceEpochCount++;
+            }
+            performanceEpochPrefixCommitter = null;
+        }
+        return elapsed;
+    }
+
+    /**
+     * Physical-DMG counterpart to {@link #runPerformanceEpoch(int)}. This path is
+     * deliberately separate so native CGB retains its fixed two-dot hot loop.
+     *
+     * @return master ticks consumed by the CPU epoch
+     */
+    public int runPhysicalDmgPerformanceEpoch(int maxMasterTicks) {
+        if (maxMasterTicks <= 0 || !performancePhysicalDmgEpochEntryEligible()) {
+            return 0;
+        }
+        int requested = Math.min(maxMasterTicks, PERFORMANCE_EPOCH_MAX_TICKS);
+        if (requested <= 0) {
+            return 0;
+        }
+        PerformanceEpochBus bus = performanceEpochBus;
+        AddressSpace target = addressSpace;
+        performanceEpochTarget = target;
+        performanceEpochTerminal = false;
+        performanceEpochJournalValid = false;
+        performanceEpochJournalAddress = 0;
+        performanceEpochJournalValue = 0;
+        performanceEpochElapsed = 0;
+        performanceEpochPrefixTicks = 0;
+        performanceEpochActive = true;
+        bus.resetForEpoch(target);
+        addressSpace = bus;
+        int elapsed = 0;
+        try {
+            while (elapsed < requested) {
+                int phaseDots = 3 - clockCycle;
+                if (phaseDots > 0) {
+                    int advanced = Math.min(phaseDots, requested - elapsed);
+                    clockCycle += advanced;
+                    elapsed += advanced;
+                    if (elapsed >= requested) {
+                        break;
+                    }
+                }
+
+                if (!performanceEpochPrefetchSafe()) {
+                    performanceEpochTerminal = true;
+                    break;
+                }
+
+                State stateBeforeTick = state;
+                performanceEpochElapsed = elapsed;
+                clockCycle = 0;
+                int directTailTicks = tickPerformancePhysicalDmgEpochInstructionPipelineAtMachineCycle(
+                        requested - elapsed);
+                elapsed += 1 + directTailTicks;
+                if (stateBeforeTick == State.OPCODE
+                        && (opcode1 == 0x10 || opcode1 == 0x76
+                        || opcode1 == 0xf3 || opcode1 == 0xfb || opcode1 == 0xd9)) {
+                    performanceEpochTerminal = true;
+                }
+                if (performanceEpochTerminal || isPerformanceEpochLifecycleState()) {
+                    break;
+                }
+            }
+        } finally {
+            addressSpace = target;
+            performanceEpochActive = false;
+            performanceEpochAccesses += bus.accesses();
+            performanceEpochTerminalAccesses += bus.terminalAccesses();
+            performanceEpochTicks += elapsed;
+            if (elapsed > 0) {
+                performanceEpochCount++;
+            }
+            performanceEpochPrefixCommitter = null;
+        }
+        return elapsed;
+    }
+
+    private boolean performanceEpochPrefetchSafe() {
+        return switch (state) {
+            // HALT samples the following opcode in the same fetch boundary, so PC+1
+            // remains part of this fence. Ordinary operand bytes are classified at
+            // their own later machine-cycle boundaries; PC+2 was redundant.
+            case OPCODE -> PerformanceEpochBus.isSafeRead(registers.getPC())
+                    && PerformanceEpochBus.isSafeRead(registers.getPC() + 1);
+            // An IME=0 HALT wake changes to OPCODE and fetches on this same boundary.
+            // Conservatively include IME=1/held-prefetch wakes as well; priority and
+            // arbitration are resolved only after this zero-dot fence.
+            case HALTED -> !interruptManager.isInterruptRequestedForHalt()
+                    || PerformanceEpochBus.isSafeRead(registers.getPC())
+                    && PerformanceEpochBus.isSafeRead(registers.getPC() + 1);
+            case EXT_OPCODE -> PerformanceEpochBus.isSafeRead(registers.getPC());
+            case OPERAND -> currentOpcode == null || operandIndex >= currentOperandLength
+                    || PerformanceEpochBus.isSafeRead(registers.getPC());
+            default -> true;
+        };
+    }
+
+    /** Cheap state-only entrance check used before the owner walks peripheral horizons. */
+    public boolean performanceEpochEntryEligible() {
+        if (debugAddressSpace != null || debugHooks != null || debugRetirementTracker != null
+                || state == State.HALTED || state == State.STOPPED
+                || state == State.SPEED_SWITCH || state == State.LOCKED
+                || state == State.IRQ_WAIT_1 || state == State.IRQ_WAIT_2
+                || state == State.IRQ_PUSH_1 || state == State.IRQ_PUSH_2
+                || state == State.IRQ_JUMP
+                || state == State.EXT_OPCODE && opcode1 == 0x10
+                || state != State.OPCODE && opcode1 == 0xd9
+                || clockCycle < 0 || clockCycle > 1
+                || haltBugMode || haltEntrySampleTicks != 0
+                || phasedPpuInputHigh || fastPhasedPpuDispatch
+                || hdmaOpcodePrefetched || hdmaArbitrationOpcodeValid
+                || haltOpcodePrefetchValid || speedSwitchPaddingReplayValid
+                || interruptManager.hasPendingCpuReadPhase()
+                || interruptManager.hasPpuTickSignals()
+                || interruptManager.isInterruptEnablePending()
+                || interruptManager.hasRawPendingEnabledInterrupt()) {
+            return false;
+        }
+        return speedMode.getSpeedMode() == 2
+                && speedMode.isGbc()
+                && !speedMode.isDmgCompat();
+    }
+
+    /** Cheap state-only entrance check for the fixed-width physical-DMG epoch. */
+    public boolean performancePhysicalDmgEpochEntryEligible() {
+        if (debugAddressSpace != null || debugHooks != null || debugRetirementTracker != null
+                || state == State.HALTED || state == State.STOPPED
+                || state == State.SPEED_SWITCH || state == State.LOCKED
+                || state == State.IRQ_WAIT_1 || state == State.IRQ_WAIT_2
+                || state == State.IRQ_PUSH_1 || state == State.IRQ_PUSH_2
+                || state == State.IRQ_JUMP
+                || state == State.EXT_OPCODE && opcode1 == 0x10
+                || state != State.OPCODE && opcode1 == 0xd9
+                || clockCycle < 0 || clockCycle > 3
+                || haltBugMode || haltEntrySampleTicks != 0
+                || phasedPpuInputHigh || fastPhasedPpuDispatch
+                || hdmaOpcodePrefetched || hdmaArbitrationOpcodeValid
+                || haltOpcodePrefetchValid || speedSwitchPaddingReplayValid
+                || interruptManager.hasPendingCpuReadPhase()
+                || interruptManager.hasPpuTickSignals()
+                || interruptManager.isInterruptEnablePending()
+                || interruptManager.hasRawPendingEnabledInterrupt()) {
+            return false;
+        }
+        return speedMode.getSpeedMode() == 1 && !speedMode.isGbc();
+    }
+
+    private boolean isPerformanceEpochLifecycleState() {
+        return state == State.HALTED || state == State.STOPPED || state == State.SPEED_SWITCH
+                || state == State.LOCKED;
+    }
+
+    /** Replays the single unsafe write retained by the most recent epoch, once. */
+    public boolean replayPerformanceEpochJournal() {
+        if (!performanceEpochJournalValid || performanceEpochTarget == null) {
+            return false;
+        }
+        int address = performanceEpochJournalAddress;
+        int value = performanceEpochJournalValue;
+        performanceEpochJournalValid = false;
+        performanceEpochTarget.setByte(address, value);
+        return true;
+    }
+
+    public boolean hasPerformanceEpochJournal() {
+        return performanceEpochJournalValid;
+    }
+
+    /** Installs the owner callback used to flush the frozen peripheral prefix before an unsafe read. */
+    public void setPerformanceEpochPrefixCommitter(IntConsumer committer) {
+        performanceEpochPrefixCommitter = committer;
+    }
+
+    private void flushPerformanceEpochPrefix() {
+        if (performanceEpochElapsed <= performanceEpochPrefixTicks) {
+            return;
+        }
+        performanceEpochPrefixTicks = performanceEpochElapsed;
+        IntConsumer committer = performanceEpochPrefixCommitter;
+        if (committer != null) {
+            committer.accept(performanceEpochElapsed);
+        }
+    }
+
+    private void journalPerformanceEpochWrite(int address, int value) {
+        if (!performanceEpochJournalValid) {
+            performanceEpochJournalAddress = address & 0xffff;
+            performanceEpochJournalValue = value & 0xff;
+            performanceEpochJournalValid = true;
+        }
+    }
+
+    private void markPerformanceEpochTerminal() {
+        performanceEpochTerminal = true;
+    }
+
+    public void resetPerformanceEpochTelemetry() {
+        performanceEpochCount = 0L;
+        performanceEpochTicks = 0L;
+        performanceEpochAccesses = 0L;
+        performanceEpochTerminalAccesses = 0L;
+    }
+
+    public long getPerformanceEpochCount() {
+        return performanceEpochCount;
+    }
+
+    public long getPerformanceEpochTicks() {
+        return performanceEpochTicks;
+    }
+
+    public long getPerformanceEpochAccesses() {
+        return performanceEpochAccesses;
+    }
+
+    public long getPerformanceEpochTerminalAccesses() {
+        return performanceEpochTerminalAccesses;
     }
 
     /**
@@ -631,6 +986,1657 @@ public class Cpu implements StatefulComponent<Cpu> {
         }
     }
 
+    /** PERFORMANCE fetch/decode front end for the primitive direct tier. */
+    private int tickPerformanceEpochInstructionPipelineAtMachineCycle(int remainingMasterTicks) {
+        int pc = registers.getPC();
+        switch (state) {
+            case OPCODE:
+                clearState();
+                opcode1 = readPerformanceEpochInstructionByte(pc);
+                if (opcode1 == 0xcb) {
+                    state = State.EXT_OPCODE;
+                } else if (opcode1 == 0x10) {
+                    setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                    state = State.EXT_OPCODE;
+                } else {
+                    state = State.OPERAND;
+                    setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                    if (currentOpcode == null) {
+                        state = State.LOCKED;
+                        markDebugRetirement();
+                        return 0;
+                    }
+                }
+                registers.incrementPC();
+                if (executePerformanceDirectBaseOpcode(opcode1)) {
+                    return 0;
+                }
+                int directTailTicks = executePerformanceDirectWholeInstruction(
+                        opcode1, remainingMasterTicks);
+                if (directTailTicks >= 0) {
+                    return directTailTicks;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(true);
+                return 0;
+
+            case EXT_OPCODE:
+                opcode2 = readPerformanceEpochInstructionByte(pc);
+                if (currentOpcode == null) {
+                    setCurrentOpcode(Opcodes.EXT_COMMANDS.get(opcode2));
+                }
+                if (currentOpcode == null) {
+                    state = State.LOCKED;
+                    markDebugRetirement();
+                    return 0;
+                }
+                state = State.OPERAND;
+                registers.incrementPC();
+                if (opcode1 == 0xcb
+                        && executePerformanceDirectExtendedOpcode(opcode2)) {
+                    return 0;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(true);
+                return 0;
+
+            case OPERAND:
+                boolean fetchedOperand = false;
+                if (operandIndex < currentOperandLength) {
+                    operand[operandIndex++] = readPerformanceEpochInstructionByte(pc);
+                    registers.incrementPC();
+                    fetchedOperand = true;
+                    if (operandIndex < currentOperandLength) {
+                        return 0;
+                    }
+                }
+                if (executePerformanceDirectOperandOpcode(opcode1)) {
+                    return 0;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(fetchedOperand);
+                return 0;
+
+            case RUNNING:
+                tickPerformanceEpochContinuationAtMachineCycle(false);
+                return 0;
+
+            default:
+                markPerformanceEpochTerminal();
+                return 0;
+        }
+    }
+
+    /** Physical-DMG fetch/decode front end for its fixed four-dot direct tier. */
+    private int tickPerformancePhysicalDmgEpochInstructionPipelineAtMachineCycle(
+            int remainingMasterTicks) {
+        int pc = registers.getPC();
+        switch (state) {
+            case OPCODE:
+                clearState();
+                opcode1 = readInstructionByte(pc);
+                if (opcode1 == 0xcb) {
+                    state = State.EXT_OPCODE;
+                } else if (opcode1 == 0x10) {
+                    setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                    state = State.EXT_OPCODE;
+                } else {
+                    state = State.OPERAND;
+                    setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                    if (currentOpcode == null) {
+                        state = State.LOCKED;
+                        markDebugRetirement();
+                        return 0;
+                    }
+                }
+                registers.incrementPC();
+                if (executePerformancePhysicalDmgDirectBaseOpcode(opcode1)) {
+                    return 0;
+                }
+                int directTailTicks = executePerformancePhysicalDmgDirectWholeInstruction(
+                        opcode1, remainingMasterTicks);
+                if (directTailTicks >= 0) {
+                    return directTailTicks;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(true);
+                return 0;
+
+            case EXT_OPCODE:
+                opcode2 = readInstructionByte(pc);
+                if (currentOpcode == null) {
+                    setCurrentOpcode(Opcodes.EXT_COMMANDS.get(opcode2));
+                }
+                if (currentOpcode == null) {
+                    state = State.LOCKED;
+                    markDebugRetirement();
+                    return 0;
+                }
+                state = State.OPERAND;
+                registers.incrementPC();
+                if (opcode1 == 0xcb
+                        && executePerformancePhysicalDmgDirectExtendedOpcode(opcode2)) {
+                    return 0;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(true);
+                return 0;
+
+            case OPERAND:
+                boolean fetchedOperand = false;
+                if (operandIndex < currentOperandLength) {
+                    operand[operandIndex++] = readInstructionByte(pc);
+                    registers.incrementPC();
+                    fetchedOperand = true;
+                    if (operandIndex < currentOperandLength) {
+                        return 0;
+                    }
+                }
+                if (executePerformancePhysicalDmgDirectOperandOpcode(opcode1)) {
+                    return 0;
+                }
+                tickPerformanceEpochContinuationAtMachineCycle(fetchedOperand);
+                return 0;
+
+            case RUNNING:
+                tickPerformanceEpochContinuationAtMachineCycle(false);
+                return 0;
+
+            default:
+                markPerformanceEpochTerminal();
+                return 0;
+        }
+    }
+
+    /**
+     * Runs the decoded instruction pipeline for one machine-cycle boundary. The
+     * caller supplies whether an authoritative fetch already consumed this
+     * boundary's bus slot.
+     */
+    private void tickPerformanceEpochContinuationAtMachineCycle(boolean accessedMemory) {
+        while (true) {
+            int pc = registers.getPC();
+            switch (state) {
+                case OPCODE:
+                    boolean useHdmaHaltPrefetch = haltOpcodePrefetchValid;
+                    boolean useSpeedSwitchPadding = speedSwitchPaddingReplayValid;
+                    boolean useHdmaArbitrationOpcode = hdmaArbitrationOpcodeValid;
+                    haltOpcodePrefetchValid = false;
+                    speedSwitchPaddingReplayValid = false;
+                    hdmaArbitrationOpcodeValid = false;
+                    if (useHdmaHaltPrefetch) {
+                        // A request acknowledged by HALT owns the bus before the held
+                        // opcode may run, just like the ordinary DMA prefetch below.
+                        hdmaOpcodePrefetched = true;
+                    }
+                    beginDebugInstruction(pc);
+                    clearState();
+                    opcode1 = useHdmaHaltPrefetch
+                            ? haltPrefetchedOpcode
+                            : useSpeedSwitchPadding
+                            ? speedSwitchPaddingOpcode
+                            : useHdmaArbitrationOpcode
+                            ? hdmaArbitrationOpcode
+                            : readInstructionByte(pc);
+                    accessedMemory = true;
+                    notifyOpcodeFetched(pc, false, opcode1);
+                    if (opcode1 == 0xcb) {
+                        state = State.EXT_OPCODE;
+                    } else if (opcode1 == 0x10) {
+                        setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                        state = State.EXT_OPCODE;
+                    } else {
+                        state = State.OPERAND;
+                        setCurrentOpcode(Opcodes.COMMANDS.get(opcode1));
+                        if (currentOpcode == null) {
+                            // an illegal opcode freezes the CPU on hardware; do the
+                            // same instead of crashing the emulation thread
+                            state = State.LOCKED;
+                            markDebugRetirement();
+                            return;
+                        }
+                    }
+                    if (useHdmaHaltPrefetch || useSpeedSwitchPadding) {
+                        // HALT samples the next opcode without advancing PC. If an
+                        // already-latched HDMA request takes the bus, that sampled byte
+                        // is consumed after wake while PC still addresses the same byte.
+                        // STOP's padding byte has already advanced PC, so its held replay
+                        // likewise must not advance the counter a second time.
+                    } else if (!haltBugMode) {
+                        registers.incrementPC();
+                    } else {
+                        haltBugMode = false;
+                    }
+                    break;
+
+                case EXT_OPCODE:
+                    if (accessedMemory) {
+                        return;
+                    }
+                    accessedMemory = true;
+                    opcode2 = readInstructionByte(pc);
+                    if (opcode1 == 0xcb) {
+                        notifyOpcodeFetched(debugInstructionPc, true, opcode2);
+                    }
+                    if (currentOpcode == null) {
+                        setCurrentOpcode(Opcodes.EXT_COMMANDS.get(opcode2));
+                    }
+                    if (currentOpcode == null) {
+                        state = State.LOCKED;
+                        markDebugRetirement();
+                        return;
+                    }
+                    state = State.OPERAND;
+                    registers.incrementPC();
+                    break;
+
+                case OPERAND:
+                    while (operandIndex < currentOperandLength) {
+                        if (accessedMemory) {
+                            return;
+                        }
+                        accessedMemory = true;
+                        operand[operandIndex++] = readInstructionByte(pc);
+                        registers.incrementPC();
+                    }
+                    ops = currentOpcode.getOps();
+                    state = State.RUNNING;
+                    break;
+
+                case RUNNING:
+                    if (opcode1 == 0x10) {
+                        boolean exitByJoypad = isJoypadLineLow();
+                        if (!exitByJoypad && speedMode.onStop()) {
+                            if (timer != null) {
+                                timer.onSpeedSwitch();
+                            }
+                            // A CGB speed switch resets and freezes DIV while the CPU clock
+                            // is stopped. The PPU remains in its independent clock domain.
+                            addressSpace.setByte(0xff04, 0);
+                            speedSwitchTicks = SPEED_SWITCH_DELAY;
+                            state = State.SPEED_SWITCH;
+                        } else if (exitByJoypad) {
+                            // A selected, asserted P10-P13 input wins over KEY1 and makes
+                            // STOP exit immediately. In particular, do not consume the
+                            // pending speed-switch request in this case.
+                            state = State.OPCODE;
+                        } else {
+                            state = State.STOPPED;
+                            // A stopped DMG drives color 0 (white). A CGB outside mode 3
+                            // loses VRAM access and drives color 0 (black); during mode 3 it
+                            // retains the picture that is already being scanned out.
+                            if (gpu == null || !gpu.isGbc() || gpu.getMode() != Mode.PixelTransfer) {
+                                stopFrameBlankRequested = true;
+                            }
+                            display.disableLcd();
+                        }
+                        markDebugRetirement();
+                        return;
+                    } else if (opcode1 == 0x76) {
+                        // HALT always samples the next opcode. It is normally fetched
+                        // again on wake, but a simultaneously acknowledged HDMA request
+                        // turns this sample into the held pipeline opcode.
+                        haltPrefetchedOpcode = readInstructionByte(registers.getPC());
+                        haltOpcodePrefetchValid = false;
+                        // committing a pending EI happens even when entering halt, so
+                        // "ei; halt" halts with IME=1 (no halt bug, wake dispatches)
+                        boolean imeBeforeHalt = interruptManager.isIme();
+                        boolean interruptPendingBeforeHalt = interruptManager.isInterruptRequestedForHalt();
+                        interruptManager.onInstructionFinished();
+                        if (!imeBeforeHalt && interruptPendingBeforeHalt && interruptManager.isIme()) {
+                            // HALT was fetched while EI's delayed enable was still pending.
+                            // The interrupt is accepted at instruction completion, but hardware
+                            // pushes HALT's address so RETI executes it again.
+                            registers.setPC((registers.getPC() - 1) & 0xffff);
+                            synchronousHaltEntryStatPhase = true;
+                            asynchronousHaltEntryStatPhase = false;
+                            ordinaryHaltWakeStatPhase = false;
+                            state = State.OPCODE;
+                            markDebugRetirement();
+                            return;
+                        }
+                        if (interruptManager.isHaltBug()) {
+                            if (timer != null) {
+                                timer.onHaltBug();
+                            }
+                            state = State.OPCODE;
+                            haltBugMode = true;
+                            synchronousHaltEntryStatPhase = true;
+                            asynchronousHaltEntryStatPhase = false;
+                            ordinaryHaltWakeStatPhase = false;
+                            markDebugRetirement();
+                            return;
+                        } else {
+                            state = State.HALTED;
+                            synchronousHaltEntryStatPhase = false;
+                            asynchronousHaltEntryStatPhase = false;
+                            ordinaryHaltWakeStatPhase = false;
+                            haltedCpuCycles = 0;
+                            haltEntrySampleTicks = speedMode.isGbc() ? 2 : 4;
+                            markDebugRetirement();
+                            return;
+                        }
+                    }
+
+                    int opCount = currentOpCount;
+                    if (opIndex < opCount) {
+                        boolean opAccessesMemory = currentOpAccessesMemory[opIndex];
+                        if (accessedMemory && opAccessesMemory) {
+                            return;
+                        }
+                        Op op = currentExecutionOps[opIndex];
+                        opIndex++;
+
+                        SpriteBug.CorruptionType corruptionType = op.causesOemBug(registers, opContext);
+                        if (corruptionType != null) {
+                            if (!speedMode.isGbc()) {
+                                // Physical DMG OAM corruption observes the live PPU reader at
+                                // this CPU boundary. Publish the frozen prefix before mutating
+                                // OAM, then end the packet after this exact machine cycle.
+                                flushPerformanceEpochPrefix();
+                                markPerformanceEpochTerminal();
+                            }
+                            handleSpriteBug(corruptionType);
+                        }
+                        opContext = op.execute(registers, addressSpace, operand, opContext);
+                        op.switchInterrupts(interruptManager);
+
+                        if (!op.proceed(registers)) {
+                            opIndex = opCount;
+                            break;
+                        }
+
+                        if (op.forceFinishCycle()) {
+                            return;
+                        }
+
+                        if (opAccessesMemory) {
+                            accessedMemory = true;
+                        }
+                    }
+
+                    if (opIndex >= opCount) {
+                        state = State.OPCODE;
+                        operandIndex = 0;
+                        interruptManager.onInstructionFinished();
+                        markDebugRetirement();
+                        return;
+                    }
+                    break;
+
+                case HALTED:
+                case STOPPED:
+                case SPEED_SWITCH:
+                    return;
+            }
+        }
+    }
+
+    /**
+     * Executes the high-frequency one-cycle register-only base opcodes without
+     * walking their anonymous {@link Op} chains. The authoritative opcode fetch,
+     * decode, PC update, and illegal-opcode handling have already happened.
+     */
+    private boolean executePerformanceDirectBaseOpcode(int opcode) {
+        if (opcode == 0x00) {
+            finishPerformanceDirectInstruction(0);
+            return true;
+        }
+
+        int register = (opcode >>> 3) & 0x07;
+        if ((opcode & 0xc7) == 0x04 && register != 6) {
+            int value = readPerformanceRegister(register);
+            int result = (value + 1) & 0xff;
+            int flags = registers.getFlags().getFlagsByte() & FLAG_C;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if ((value & 0x0f) == 0x0f) {
+                flags |= FLAG_H;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            writePerformanceRegister(register, result);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if ((opcode & 0xc7) == 0x05 && register != 6) {
+            int value = readPerformanceRegister(register);
+            int result = (value - 1) & 0xff;
+            int flags = (registers.getFlags().getFlagsByte() & FLAG_C) | FLAG_N;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if ((value & 0x0f) == 0) {
+                flags |= FLAG_H;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            writePerformanceRegister(register, result);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if (opcode == 0x07 || opcode == 0x0f || opcode == 0x17 || opcode == 0x1f) {
+            int value = registers.getA();
+            int oldFlags = registers.getFlags().getFlagsByte();
+            int result;
+            int carry;
+            switch (opcode) {
+                case 0x07 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | carry) & 0xff;
+                }
+                case 0x0f -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (carry << 7);
+                }
+                case 0x17 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | ((oldFlags & FLAG_C) >>> 4)) & 0xff;
+                }
+                default -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | ((oldFlags & FLAG_C) << 3);
+                }
+            }
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(carry == 0 ? 0 : FLAG_C);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if (opcode == 0x27) {
+            int value = registers.getA();
+            int oldFlags = registers.getFlags().getFlagsByte();
+            boolean subtract = (oldFlags & FLAG_N) != 0;
+            boolean carry = (oldFlags & FLAG_C) != 0;
+            int result = value;
+            if (subtract) {
+                if ((oldFlags & FLAG_H) != 0) {
+                    result = (result - 0x06) & 0xff;
+                }
+                if (carry) {
+                    result = (result - 0x60) & 0xff;
+                }
+            } else {
+                if ((oldFlags & FLAG_H) != 0 || (result & 0x0f) > 9) {
+                    result += 0x06;
+                }
+                if (carry || result > 0x9f) {
+                    result += 0x60;
+                    carry = true;
+                }
+            }
+            result &= 0xff;
+            int flags = subtract ? FLAG_N : 0;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if (carry) {
+                flags |= FLAG_C;
+            }
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0x2f) {
+            int result = (~registers.getA()) & 0xff;
+            int flags = (registers.getFlags().getFlagsByte() & (FLAG_Z | FLAG_C))
+                    | FLAG_N | FLAG_H;
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0x37) {
+            int flags = (registers.getFlags().getFlagsByte() & FLAG_Z) | FLAG_C;
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(registers.getA());
+            return true;
+        }
+        if (opcode == 0x3f) {
+            int oldFlags = registers.getFlags().getFlagsByte();
+            int flags = oldFlags & FLAG_Z;
+            if ((oldFlags & FLAG_C) == 0) {
+                flags |= FLAG_C;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(registers.getA());
+            return true;
+        }
+
+        if (opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76) {
+            int destination = (opcode >>> 3) & 0x07;
+            int source = opcode & 0x07;
+            if (destination != 6 && source != 6) {
+                int value = readPerformanceRegister(source);
+                writePerformanceRegister(destination, value);
+                finishPerformanceDirectInstruction(value);
+                return true;
+            }
+        }
+        if (opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) != 6) {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07,
+                    readPerformanceRegister(opcode & 0x07));
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0xe9) {
+            int target = registers.getHL();
+            registers.setPCTrusted(target);
+            finishPerformanceDirectInstruction(target);
+            return true;
+        }
+        return false;
+    }
+
+    /** Physical-DMG copy keeps the native-CGB direct helper single-caller and inlineable. */
+    private boolean executePerformancePhysicalDmgDirectBaseOpcode(int opcode) {
+        if (opcode == 0x00) {
+            finishPerformanceDirectInstruction(0);
+            return true;
+        }
+
+        int register = (opcode >>> 3) & 0x07;
+        if ((opcode & 0xc7) == 0x04 && register != 6) {
+            int value = readPerformanceRegister(register);
+            int result = (value + 1) & 0xff;
+            int flags = registers.getFlags().getFlagsByte() & FLAG_C;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if ((value & 0x0f) == 0x0f) {
+                flags |= FLAG_H;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            writePerformanceRegister(register, result);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if ((opcode & 0xc7) == 0x05 && register != 6) {
+            int value = readPerformanceRegister(register);
+            int result = (value - 1) & 0xff;
+            int flags = (registers.getFlags().getFlagsByte() & FLAG_C) | FLAG_N;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if ((value & 0x0f) == 0) {
+                flags |= FLAG_H;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            writePerformanceRegister(register, result);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if (opcode == 0x07 || opcode == 0x0f || opcode == 0x17 || opcode == 0x1f) {
+            int value = registers.getA();
+            int oldFlags = registers.getFlags().getFlagsByte();
+            int result;
+            int carry;
+            switch (opcode) {
+                case 0x07 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | carry) & 0xff;
+                }
+                case 0x0f -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (carry << 7);
+                }
+                case 0x17 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | ((oldFlags & FLAG_C) >>> 4)) & 0xff;
+                }
+                default -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | ((oldFlags & FLAG_C) << 3);
+                }
+            }
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(carry == 0 ? 0 : FLAG_C);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if (opcode == 0x27) {
+            int value = registers.getA();
+            int oldFlags = registers.getFlags().getFlagsByte();
+            boolean subtract = (oldFlags & FLAG_N) != 0;
+            boolean carry = (oldFlags & FLAG_C) != 0;
+            int result = value;
+            if (subtract) {
+                if ((oldFlags & FLAG_H) != 0) {
+                    result = (result - 0x06) & 0xff;
+                }
+                if (carry) {
+                    result = (result - 0x60) & 0xff;
+                }
+            } else {
+                if ((oldFlags & FLAG_H) != 0 || (result & 0x0f) > 9) {
+                    result += 0x06;
+                }
+                if (carry || result > 0x9f) {
+                    result += 0x60;
+                    carry = true;
+                }
+            }
+            result &= 0xff;
+            int flags = subtract ? FLAG_N : 0;
+            if (result == 0) {
+                flags |= FLAG_Z;
+            }
+            if (carry) {
+                flags |= FLAG_C;
+            }
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0x2f) {
+            int result = (~registers.getA()) & 0xff;
+            int flags = (registers.getFlags().getFlagsByte() & (FLAG_Z | FLAG_C))
+                    | FLAG_N | FLAG_H;
+            registers.setATrusted(result);
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0x37) {
+            int flags = (registers.getFlags().getFlagsByte() & FLAG_Z) | FLAG_C;
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(registers.getA());
+            return true;
+        }
+        if (opcode == 0x3f) {
+            int oldFlags = registers.getFlags().getFlagsByte();
+            int flags = oldFlags & FLAG_Z;
+            if ((oldFlags & FLAG_C) == 0) {
+                flags |= FLAG_C;
+            }
+            registers.getFlags().setFlagsByteTrusted(flags);
+            finishPerformanceDirectInstruction(registers.getA());
+            return true;
+        }
+
+        if (opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76) {
+            int destination = (opcode >>> 3) & 0x07;
+            int source = opcode & 0x07;
+            if (destination != 6 && source != 6) {
+                int value = readPerformanceRegister(source);
+                writePerformanceRegister(destination, value);
+                finishPerformanceDirectInstruction(value);
+                return true;
+            }
+        }
+        if (opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) != 6) {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07,
+                    readPerformanceRegister(opcode & 0x07));
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+        if (opcode == 0xe9) {
+            int target = registers.getHL();
+            registers.setPCTrusted(target);
+            finishPerformanceDirectInstruction(target);
+            return true;
+        }
+        return false;
+    }
+
+    /** Direct final-operand suffix for register/immediate and untaken branch forms. */
+    private boolean executePerformanceDirectOperandOpcode(int opcode) {
+        if ((opcode & 0xcf) == 0x01) {
+            int value = operand[0] | operand[1] << 8;
+            switch ((opcode >>> 4) & 0x03) {
+                case 0 -> registers.setBCTrusted(value);
+                case 1 -> registers.setDETrusted(value);
+                case 2 -> registers.setHLTrusted(value);
+                default -> registers.setSPTrusted(value);
+            }
+            finishPerformanceDirectInstruction(value);
+            return true;
+        }
+
+        int register = (opcode >>> 3) & 0x07;
+        if ((opcode & 0xc7) == 0x06 && register != 6) {
+            int value = operand[0];
+            writePerformanceRegister(register, value);
+            finishPerformanceDirectInstruction(value);
+            return true;
+        }
+        if ((opcode & 0xc7) == 0xc6) {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07, operand[0]);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if ((opcode & 0xe7) == 0x20) { // JR cc,r8
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(registers.getPC());
+                return true;
+            }
+        } else if ((opcode & 0xe7) == 0xc2) { // JP cc,a16
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(operand[0] | operand[1] << 8);
+                return true;
+            }
+        } else if ((opcode & 0xe7) == 0xc4) { // CALL cc,a16
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(0);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Physical-DMG copy keeps the native-CGB operand helper single-caller and inlineable. */
+    private boolean executePerformancePhysicalDmgDirectOperandOpcode(int opcode) {
+        if ((opcode & 0xcf) == 0x01) {
+            int value = operand[0] | operand[1] << 8;
+            switch ((opcode >>> 4) & 0x03) {
+                case 0 -> registers.setBCTrusted(value);
+                case 1 -> registers.setDETrusted(value);
+                case 2 -> registers.setHLTrusted(value);
+                default -> registers.setSPTrusted(value);
+            }
+            finishPerformanceDirectInstruction(value);
+            return true;
+        }
+
+        int register = (opcode >>> 3) & 0x07;
+        if ((opcode & 0xc7) == 0x06 && register != 6) {
+            int value = operand[0];
+            writePerformanceRegister(register, value);
+            finishPerformanceDirectInstruction(value);
+            return true;
+        }
+        if ((opcode & 0xc7) == 0xc6) {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07, operand[0]);
+            finishPerformanceDirectInstruction(result);
+            return true;
+        }
+
+        if ((opcode & 0xe7) == 0x20) { // JR cc,r8
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(registers.getPC());
+                return true;
+            }
+        } else if ((opcode & 0xe7) == 0xc2) { // JP cc,a16
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(operand[0] | operand[1] << 8);
+                return true;
+            }
+        } else if ((opcode & 0xe7) == 0xc4) { // CALL cc,a16
+            int condition = (opcode >>> 3) & 0x03;
+            if (!performanceConditionHolds(condition)) {
+                finishPerformanceDirectInstruction(0);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Executes a complete high-frequency instruction transaction after its real
+     * opcode fetch. Each additional machine-cycle boundary is charged at native
+     * CGB's fixed two-master-dot width. Instruction bytes are fetched in program
+     * order through the epoch's borrowed ROM mapping when available; an unsafe data
+     * access is left in the canonical RUNNING state for the ordinary epoch sequencer.
+     *
+     * @return additional master ticks, or {@code -1} when this opcode/budget is not
+     *         admitted by the complete-instruction tier
+     */
+    private int executePerformanceDirectWholeInstruction(
+            int opcode, int remainingMasterTicks) {
+        int machineCycles = performanceDirectWholeMachineCycles(opcode);
+        if (machineCycles == 0
+                || remainingMasterTicks < 1 + 2 * (machineCycles - 1)) {
+            return -1;
+        }
+        int operandLength = currentOperandLength;
+        int operandPc = registers.getPC();
+        for (int i = 0; i < operandLength; i++) {
+            if (!PerformanceEpochBus.isSafeRead(operandPc + i)) {
+                return -1;
+            }
+        }
+
+        int extraTicks = 0;
+        while (operandIndex < operandLength) {
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            operand[operandIndex++] = readPerformanceEpochInstructionByte(registers.getPC());
+            registers.incrementPC();
+        }
+        ops = currentOpcode.getOps();
+        state = State.RUNNING;
+
+        if (opcode == 0x18 || (opcode & 0xe7) == 0x20) {
+            int pc = registers.getPC();
+            if (opcode != 0x18
+                    && !performanceConditionHolds((opcode >>> 3) & 0x03)) {
+                finishPerformanceDirectInstruction(pc);
+                return extraTicks;
+            }
+            int target = (pc + (byte) operand[0]) & 0xffff;
+            opContext = target;
+            opIndex = opcode == 0x18 ? 2 : 3;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            registers.setPCTrusted(target);
+            finishPerformanceDirectInstruction(target);
+            return extraTicks;
+        }
+
+        if (opcode == 0xc3 || (opcode & 0xe7) == 0xc2) {
+            int target = operand[0] | operand[1] << 8;
+            if (opcode != 0xc3
+                    && !performanceConditionHolds((opcode >>> 3) & 0x03)) {
+                finishPerformanceDirectInstruction(target);
+                return extraTicks;
+            }
+            registers.setPCTrusted(target);
+            opContext = target;
+            opIndex = opcode == 0xc3 ? 2 : 3;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            finishPerformanceDirectInstruction(target);
+            return extraTicks;
+        }
+
+        if ((opcode & 0xcf) == 0x03 || (opcode & 0xcf) == 0x0b) {
+            int pair = (opcode >>> 4) & 0x03;
+            int value = readPerformanceRegisterPair(pair);
+            if (isPerformanceOamArea(value)) {
+                return -1;
+            }
+            int result = (value + ((opcode & 0x08) == 0 ? 1 : -1)) & 0xffff;
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            writePerformanceRegisterPair(pair, result);
+            finishPerformanceDirectInstruction(result);
+            return extraTicks;
+        }
+
+        if ((opcode & 0xcf) == 0x09) {
+            int left = registers.getHL();
+            int right = readPerformanceRegisterPair((opcode >>> 4) & 0x03);
+            int sum = left + right;
+            int flags = registers.getFlags().getFlagsByte() & FLAG_Z;
+            if ((left & 0x0fff) + (right & 0x0fff) > 0x0fff) {
+                flags |= FLAG_H;
+            }
+            if (sum > 0xffff) {
+                flags |= FLAG_C;
+            }
+            int result = sum & 0xffff;
+            registers.getFlags().setFlagsByteTrusted(flags);
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            registers.setHLTrusted(result);
+            finishPerformanceDirectInstruction(result);
+            return extraTicks;
+        }
+
+        if (opcode == 0xf9) {
+            int value = registers.getHL();
+            registers.setSPTrusted(value);
+            opContext = value;
+            opIndex = 2;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            finishPerformanceDirectInstruction(value);
+            return extraTicks;
+        }
+
+        int address;
+        boolean read;
+        int context;
+        int runningOp;
+        if (opcode == 0x02 || opcode == 0x12) {
+            address = opcode == 0x02 ? registers.getBC() : registers.getDE();
+            read = false;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x0a || opcode == 0x1a) {
+            address = opcode == 0x0a ? registers.getBC() : registers.getDE();
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode == 0x22 || opcode == 0x32) {
+            address = registers.getHL();
+            if (isPerformanceOamArea(address)) {
+                return -1;
+            }
+            read = false;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x2a || opcode == 0x3a) {
+            address = registers.getHL();
+            if (isPerformanceOamArea(address)) {
+                return -1;
+            }
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode == 0x34 || opcode == 0x35) {
+            address = registers.getHL();
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76) {
+            int destination = (opcode >>> 3) & 0x07;
+            int source = opcode & 0x07;
+            address = registers.getHL();
+            read = source == 6;
+            context = read ? 0 : readPerformanceRegister(source);
+            runningOp = read ? 0 : 1;
+        } else if (opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) == 6) {
+            address = registers.getHL();
+            read = true;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x36) {
+            address = registers.getHL();
+            read = false;
+            context = operand[0];
+            runningOp = 1;
+        } else if (opcode == 0xe0 || opcode == 0xf0) {
+            address = 0xff00 | operand[0];
+            read = opcode == 0xf0;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else if (opcode == 0xe2 || opcode == 0xf2) {
+            address = 0xff00 | registers.getC();
+            read = opcode == 0xf2;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else if (opcode == 0xea || opcode == 0xfa) {
+            address = operand[0] | operand[1] << 8;
+            read = opcode == 0xfa;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else {
+            return -1;
+        }
+
+        opContext = context;
+        opIndex = runningOp;
+        if (read ? !PerformanceEpochBus.isSafeRead(address)
+                : !PerformanceEpochBus.isSafeWrite(address)) {
+            return extraTicks;
+        }
+        performanceEpochElapsed += 2;
+        extraTicks += 2;
+
+        if (!read) {
+            addressSpace.setByte(address, context);
+            if (opcode == 0x22 || opcode == 0x32) {
+                int result = (registers.getHL() + (opcode == 0x22 ? 1 : -1)) & 0xffff;
+                registers.setHLTrusted(result);
+                finishPerformanceDirectInstruction(result);
+            } else {
+                finishPerformanceDirectInstruction(context);
+            }
+            return extraTicks;
+        }
+
+        int value = addressSpace.getByte(address);
+        if (opcode == 0x0a || opcode == 0x1a || opcode == 0xf0
+                || opcode == 0xf2 || opcode == 0xfa) {
+            registers.setATrusted(value);
+            finishPerformanceDirectInstruction(value);
+        } else if (opcode == 0x2a || opcode == 0x3a) {
+            registers.setATrusted(value);
+            int result = (registers.getHL() + (opcode == 0x2a ? 1 : -1)) & 0xffff;
+            registers.setHLTrusted(result);
+            finishPerformanceDirectInstruction(result);
+        } else if (opcode == 0x34 || opcode == 0x35) {
+            int result = executePerformanceIncDec(value, opcode == 0x35);
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 2;
+            extraTicks += 2;
+            addressSpace.setByte(address, result);
+            finishPerformanceDirectInstruction(result);
+        } else if (opcode >= 0x40 && opcode <= 0x7f) {
+            writePerformanceRegister((opcode >>> 3) & 0x07, value);
+            finishPerformanceDirectInstruction(value);
+        } else {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07, value);
+            finishPerformanceDirectInstruction(result);
+        }
+        return extraTicks;
+    }
+
+    /** Fixed four-master-dot physical-DMG counterpart to the native-CGB direct tier. */
+    private int executePerformancePhysicalDmgDirectWholeInstruction(
+            int opcode, int remainingMasterTicks) {
+        int machineCycles = performancePhysicalDmgDirectWholeMachineCycles(opcode);
+        if (machineCycles == 0
+                || remainingMasterTicks < 1 + 4 * (machineCycles - 1)) {
+            return -1;
+        }
+        int operandLength = currentOperandLength;
+        int operandPc = registers.getPC();
+        for (int i = 0; i < operandLength; i++) {
+            if (!PerformanceEpochBus.isSafeRead(operandPc + i)) {
+                return -1;
+            }
+        }
+
+        int extraTicks = 0;
+        while (operandIndex < operandLength) {
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            operand[operandIndex++] = readInstructionByte(registers.getPC());
+            registers.incrementPC();
+        }
+        ops = currentOpcode.getOps();
+        state = State.RUNNING;
+
+        if (opcode == 0x18 || (opcode & 0xe7) == 0x20) {
+            int pc = registers.getPC();
+            if (opcode != 0x18
+                    && !performanceConditionHolds((opcode >>> 3) & 0x03)) {
+                finishPerformanceDirectInstruction(pc);
+                return extraTicks;
+            }
+            int target = (pc + (byte) operand[0]) & 0xffff;
+            opContext = target;
+            opIndex = opcode == 0x18 ? 2 : 3;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            registers.setPCTrusted(target);
+            finishPerformanceDirectInstruction(target);
+            return extraTicks;
+        }
+
+        if (opcode == 0xc3 || (opcode & 0xe7) == 0xc2) {
+            int target = operand[0] | operand[1] << 8;
+            if (opcode != 0xc3
+                    && !performanceConditionHolds((opcode >>> 3) & 0x03)) {
+                finishPerformanceDirectInstruction(target);
+                return extraTicks;
+            }
+            registers.setPCTrusted(target);
+            opContext = target;
+            opIndex = opcode == 0xc3 ? 2 : 3;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            finishPerformanceDirectInstruction(target);
+            return extraTicks;
+        }
+
+        if ((opcode & 0xcf) == 0x03 || (opcode & 0xcf) == 0x0b) {
+            int pair = (opcode >>> 4) & 0x03;
+            int value = readPerformancePhysicalDmgRegisterPair(pair);
+            if (isPerformanceOamArea(value)) {
+                return -1;
+            }
+            int result = (value + ((opcode & 0x08) == 0 ? 1 : -1)) & 0xffff;
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            writePerformanceRegisterPair(pair, result);
+            finishPerformanceDirectInstruction(result);
+            return extraTicks;
+        }
+
+        if ((opcode & 0xcf) == 0x09) {
+            int left = registers.getHL();
+            int right = readPerformancePhysicalDmgRegisterPair((opcode >>> 4) & 0x03);
+            int sum = left + right;
+            int flags = registers.getFlags().getFlagsByte() & FLAG_Z;
+            if ((left & 0x0fff) + (right & 0x0fff) > 0x0fff) {
+                flags |= FLAG_H;
+            }
+            if (sum > 0xffff) {
+                flags |= FLAG_C;
+            }
+            int result = sum & 0xffff;
+            registers.getFlags().setFlagsByteTrusted(flags);
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            registers.setHLTrusted(result);
+            finishPerformanceDirectInstruction(result);
+            return extraTicks;
+        }
+
+        if (opcode == 0xf9) {
+            int value = registers.getHL();
+            registers.setSPTrusted(value);
+            opContext = value;
+            opIndex = 2;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            finishPerformanceDirectInstruction(value);
+            return extraTicks;
+        }
+
+        int address;
+        boolean read;
+        int context;
+        int runningOp;
+        if (opcode == 0x02 || opcode == 0x12) {
+            address = opcode == 0x02 ? registers.getBC() : registers.getDE();
+            read = false;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x0a || opcode == 0x1a) {
+            address = opcode == 0x0a ? registers.getBC() : registers.getDE();
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode == 0x22 || opcode == 0x32) {
+            address = registers.getHL();
+            if (isPerformanceOamArea(address)) {
+                return -1;
+            }
+            read = false;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x2a || opcode == 0x3a) {
+            address = registers.getHL();
+            if (isPerformanceOamArea(address)) {
+                return -1;
+            }
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode == 0x34 || opcode == 0x35) {
+            address = registers.getHL();
+            read = true;
+            context = 0;
+            runningOp = 0;
+        } else if (opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76) {
+            int destination = (opcode >>> 3) & 0x07;
+            int source = opcode & 0x07;
+            address = registers.getHL();
+            read = source == 6;
+            context = read ? 0 : readPerformanceRegister(source);
+            runningOp = read ? 0 : 1;
+        } else if (opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) == 6) {
+            address = registers.getHL();
+            read = true;
+            context = registers.getA();
+            runningOp = 1;
+        } else if (opcode == 0x36) {
+            address = registers.getHL();
+            read = false;
+            context = operand[0];
+            runningOp = 1;
+        } else if (opcode == 0xe0 || opcode == 0xf0) {
+            address = 0xff00 | operand[0];
+            read = opcode == 0xf0;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else if (opcode == 0xe2 || opcode == 0xf2) {
+            address = 0xff00 | registers.getC();
+            read = opcode == 0xf2;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else if (opcode == 0xea || opcode == 0xfa) {
+            address = operand[0] | operand[1] << 8;
+            read = opcode == 0xfa;
+            context = read ? 0 : registers.getA();
+            runningOp = read ? 0 : 1;
+        } else {
+            return -1;
+        }
+
+        opContext = context;
+        opIndex = runningOp;
+        if (read ? !PerformanceEpochBus.isSafeRead(address)
+                : !PerformanceEpochBus.isSafeWrite(address)) {
+            return extraTicks;
+        }
+        performanceEpochElapsed += 4;
+        extraTicks += 4;
+
+        if (!read) {
+            addressSpace.setByte(address, context);
+            if (opcode == 0x22 || opcode == 0x32) {
+                int result = (registers.getHL() + (opcode == 0x22 ? 1 : -1)) & 0xffff;
+                registers.setHLTrusted(result);
+                finishPerformanceDirectInstruction(result);
+            } else {
+                finishPerformanceDirectInstruction(context);
+            }
+            return extraTicks;
+        }
+
+        int value = addressSpace.getByte(address);
+        if (opcode == 0x0a || opcode == 0x1a || opcode == 0xf0
+                || opcode == 0xf2 || opcode == 0xfa) {
+            registers.setATrusted(value);
+            finishPerformanceDirectInstruction(value);
+        } else if (opcode == 0x2a || opcode == 0x3a) {
+            registers.setATrusted(value);
+            int result = (registers.getHL() + (opcode == 0x2a ? 1 : -1)) & 0xffff;
+            registers.setHLTrusted(result);
+            finishPerformanceDirectInstruction(result);
+        } else if (opcode == 0x34 || opcode == 0x35) {
+            int result = executePerformancePhysicalDmgIncDec(value, opcode == 0x35);
+            opContext = result;
+            opIndex = 2;
+            performanceEpochElapsed += 4;
+            extraTicks += 4;
+            addressSpace.setByte(address, result);
+            finishPerformanceDirectInstruction(result);
+        } else if (opcode >= 0x40 && opcode <= 0x7f) {
+            writePerformanceRegister((opcode >>> 3) & 0x07, value);
+            finishPerformanceDirectInstruction(value);
+        } else {
+            int result = executePerformanceAlu((opcode >>> 3) & 0x07, value);
+            finishPerformanceDirectInstruction(result);
+        }
+        return extraTicks;
+    }
+
+    private int performanceDirectWholeMachineCycles(int opcode) {
+        if (opcode == 0x18) {
+            return 3;
+        }
+        if ((opcode & 0xe7) == 0x20) {
+            return performanceConditionHolds((opcode >>> 3) & 0x03) ? 3 : 2;
+        }
+        if (opcode == 0xc3) {
+            return 4;
+        }
+        if ((opcode & 0xe7) == 0xc2) {
+            return performanceConditionHolds((opcode >>> 3) & 0x03) ? 4 : 3;
+        }
+        if ((opcode & 0xcf) == 0x03 || (opcode & 0xcf) == 0x0b
+                || (opcode & 0xcf) == 0x09 || opcode == 0xf9
+                || opcode == 0x02 || opcode == 0x12 || opcode == 0x0a || opcode == 0x1a
+                || opcode == 0x22 || opcode == 0x2a || opcode == 0x32 || opcode == 0x3a
+                || opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76
+                        && (((opcode >>> 3) & 0x07) == 6 || (opcode & 0x07) == 6)
+                || opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) == 6
+                || opcode == 0xe2 || opcode == 0xf2) {
+            return 2;
+        }
+        if (opcode == 0x34 || opcode == 0x35 || opcode == 0x36
+                || opcode == 0xe0 || opcode == 0xf0) {
+            return 3;
+        }
+        if (opcode == 0xea || opcode == 0xfa) {
+            return 4;
+        }
+        return 0;
+    }
+
+    private int performancePhysicalDmgDirectWholeMachineCycles(int opcode) {
+        if (opcode == 0x18) {
+            return 3;
+        }
+        if ((opcode & 0xe7) == 0x20) {
+            return performanceConditionHolds((opcode >>> 3) & 0x03) ? 3 : 2;
+        }
+        if (opcode == 0xc3) {
+            return 4;
+        }
+        if ((opcode & 0xe7) == 0xc2) {
+            return performanceConditionHolds((opcode >>> 3) & 0x03) ? 4 : 3;
+        }
+        if ((opcode & 0xcf) == 0x03 || (opcode & 0xcf) == 0x0b
+                || (opcode & 0xcf) == 0x09 || opcode == 0xf9
+                || opcode == 0x02 || opcode == 0x12 || opcode == 0x0a || opcode == 0x1a
+                || opcode == 0x22 || opcode == 0x2a || opcode == 0x32 || opcode == 0x3a
+                || opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76
+                        && (((opcode >>> 3) & 0x07) == 6 || (opcode & 0x07) == 6)
+                || opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) == 6
+                || opcode == 0xe2 || opcode == 0xf2) {
+            return 2;
+        }
+        if (opcode == 0x34 || opcode == 0x35 || opcode == 0x36
+                || opcode == 0xe0 || opcode == 0xf0) {
+            return 3;
+        }
+        if (opcode == 0xea || opcode == 0xfa) {
+            return 4;
+        }
+        return 0;
+    }
+
+    private int executePerformanceIncDec(int value, boolean decrement) {
+        int result = (value + (decrement ? -1 : 1)) & 0xff;
+        int flags = registers.getFlags().getFlagsByte() & FLAG_C;
+        if (decrement) {
+            flags |= FLAG_N;
+        }
+        if (result == 0) {
+            flags |= FLAG_Z;
+        }
+        if (decrement ? (value & 0x0f) == 0 : (value & 0x0f) == 0x0f) {
+            flags |= FLAG_H;
+        }
+        registers.getFlags().setFlagsByteTrusted(flags);
+        return result;
+    }
+
+    private int executePerformancePhysicalDmgIncDec(int value, boolean decrement) {
+        int result = (value + (decrement ? -1 : 1)) & 0xff;
+        int flags = registers.getFlags().getFlagsByte() & FLAG_C;
+        if (decrement) {
+            flags |= FLAG_N;
+        }
+        if (result == 0) {
+            flags |= FLAG_Z;
+        }
+        if (decrement ? (value & 0x0f) == 0 : (value & 0x0f) == 0x0f) {
+            flags |= FLAG_H;
+        }
+        registers.getFlags().setFlagsByteTrusted(flags);
+        return result;
+    }
+
+    private int readPerformanceRegisterPair(int pair) {
+        return switch (pair) {
+            case 0 -> registers.getBC();
+            case 1 -> registers.getDE();
+            case 2 -> registers.getHL();
+            default -> registers.getSP();
+        };
+    }
+
+    private int readPerformancePhysicalDmgRegisterPair(int pair) {
+        return switch (pair) {
+            case 0 -> registers.getBC();
+            case 1 -> registers.getDE();
+            case 2 -> registers.getHL();
+            default -> registers.getSP();
+        };
+    }
+
+    private void writePerformanceRegisterPair(int pair, int value) {
+        switch (pair) {
+            case 0 -> registers.setBCTrusted(value);
+            case 1 -> registers.setDETrusted(value);
+            case 2 -> registers.setHLTrusted(value);
+            default -> registers.setSPTrusted(value);
+        }
+    }
+
+    private static boolean isPerformanceOamArea(int address) {
+        int a = address & 0xffff;
+        return a >= 0xfe00 && a <= 0xfeff;
+    }
+
+    /** Executes every CB-prefixed register target; (HL) remains on the observed bus path. */
+    private boolean executePerformanceDirectExtendedOpcode(int opcode) {
+        int target = opcode & 0x07;
+        if (target == 6) {
+            return false;
+        }
+        int value = readPerformanceRegister(target);
+        int operationClass = opcode >>> 6;
+        int operation = (opcode >>> 3) & 0x07;
+        int result = value;
+        int flags = registers.getFlags().getFlagsByte();
+        if (operationClass == 0) {
+            int carry;
+            switch (operation) {
+                case 0 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | carry) & 0xff;
+                }
+                case 1 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (carry << 7);
+                }
+                case 2 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | ((flags & FLAG_C) >>> 4)) & 0xff;
+                }
+                case 3 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | ((flags & FLAG_C) << 3);
+                }
+                case 4 -> {
+                    carry = value >>> 7;
+                    result = (value << 1) & 0xff;
+                }
+                case 5 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (value & 0x80);
+                }
+                case 6 -> {
+                    carry = 0;
+                    result = (value << 4 | value >>> 4) & 0xff;
+                }
+                default -> {
+                    carry = value & 1;
+                    result = value >>> 1;
+                }
+            }
+            flags = result == 0 ? FLAG_Z : 0;
+            if (carry != 0) {
+                flags |= FLAG_C;
+            }
+            writePerformanceRegister(target, result);
+        } else if (operationClass == 1) {
+            flags = (flags & FLAG_C) | FLAG_H;
+            if ((value & (1 << operation)) == 0) {
+                flags |= FLAG_Z;
+            }
+        } else if (operationClass == 2) {
+            result = value & ~(1 << operation);
+            writePerformanceRegister(target, result);
+        } else {
+            result = value | 1 << operation;
+            writePerformanceRegister(target, result);
+        }
+        registers.getFlags().setFlagsByteTrusted(flags);
+        finishPerformanceDirectInstruction(result);
+        return true;
+    }
+
+    /** Physical-DMG copy keeps the native-CGB CB helper single-caller and inlineable. */
+    private boolean executePerformancePhysicalDmgDirectExtendedOpcode(int opcode) {
+        int target = opcode & 0x07;
+        if (target == 6) {
+            return false;
+        }
+        int value = readPerformanceRegister(target);
+        int operationClass = opcode >>> 6;
+        int operation = (opcode >>> 3) & 0x07;
+        int result = value;
+        int flags = registers.getFlags().getFlagsByte();
+        if (operationClass == 0) {
+            int carry;
+            switch (operation) {
+                case 0 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | carry) & 0xff;
+                }
+                case 1 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (carry << 7);
+                }
+                case 2 -> {
+                    carry = value >>> 7;
+                    result = ((value << 1) | ((flags & FLAG_C) >>> 4)) & 0xff;
+                }
+                case 3 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | ((flags & FLAG_C) << 3);
+                }
+                case 4 -> {
+                    carry = value >>> 7;
+                    result = (value << 1) & 0xff;
+                }
+                case 5 -> {
+                    carry = value & 1;
+                    result = (value >>> 1) | (value & 0x80);
+                }
+                case 6 -> {
+                    carry = 0;
+                    result = (value << 4 | value >>> 4) & 0xff;
+                }
+                default -> {
+                    carry = value & 1;
+                    result = value >>> 1;
+                }
+            }
+            flags = result == 0 ? FLAG_Z : 0;
+            if (carry != 0) {
+                flags |= FLAG_C;
+            }
+            writePerformanceRegister(target, result);
+        } else if (operationClass == 1) {
+            flags = (flags & FLAG_C) | FLAG_H;
+            if ((value & (1 << operation)) == 0) {
+                flags |= FLAG_Z;
+            }
+        } else if (operationClass == 2) {
+            result = value & ~(1 << operation);
+            writePerformanceRegister(target, result);
+        } else {
+            result = value | 1 << operation;
+            writePerformanceRegister(target, result);
+        }
+        registers.getFlags().setFlagsByteTrusted(flags);
+        finishPerformanceDirectInstruction(result);
+        return true;
+    }
+
+    /** Returns the canonical Op-chain context result and updates A/flags. */
+    private int executePerformanceAlu(int operation, int value) {
+        int accumulator = registers.getA();
+        int oldFlags = registers.getFlags().getFlagsByte();
+        int carry = (oldFlags & FLAG_C) >>> 4;
+        int result;
+        int flags;
+        switch (operation) {
+            case 0 -> {
+                int sum = accumulator + value;
+                result = sum & 0xff;
+                flags = result == 0 ? FLAG_Z : 0;
+                if ((accumulator & 0x0f) + (value & 0x0f) > 0x0f) {
+                    flags |= FLAG_H;
+                }
+                if (sum > 0xff) {
+                    flags |= FLAG_C;
+                }
+            }
+            case 1 -> {
+                int sum = accumulator + value + carry;
+                result = sum & 0xff;
+                flags = result == 0 ? FLAG_Z : 0;
+                if ((accumulator & 0x0f) + (value & 0x0f) + carry > 0x0f) {
+                    flags |= FLAG_H;
+                }
+                if (sum > 0xff) {
+                    flags |= FLAG_C;
+                }
+            }
+            case 2 -> {
+                result = (accumulator - value) & 0xff;
+                flags = FLAG_N | (result == 0 ? FLAG_Z : 0);
+                if ((value & 0x0f) > (accumulator & 0x0f)) {
+                    flags |= FLAG_H;
+                }
+                if (value > accumulator) {
+                    flags |= FLAG_C;
+                }
+            }
+            case 3 -> {
+                int difference = accumulator - value - carry;
+                result = difference & 0xff;
+                flags = FLAG_N | (result == 0 ? FLAG_Z : 0);
+                if (((accumulator ^ value ^ result) & 0x10) != 0) {
+                    flags |= FLAG_H;
+                }
+                if (difference < 0) {
+                    flags |= FLAG_C;
+                }
+            }
+            case 4 -> {
+                result = accumulator & value;
+                flags = FLAG_H | (result == 0 ? FLAG_Z : 0);
+            }
+            case 5 -> {
+                result = (accumulator ^ value) & 0xff;
+                flags = result == 0 ? FLAG_Z : 0;
+            }
+            case 6 -> {
+                result = accumulator | value;
+                flags = result == 0 ? FLAG_Z : 0;
+            }
+            default -> {
+                int difference = (accumulator - value) & 0xff;
+                flags = FLAG_N | (difference == 0 ? FLAG_Z : 0);
+                if ((value & 0x0f) > (accumulator & 0x0f)) {
+                    flags |= FLAG_H;
+                }
+                if (value > accumulator) {
+                    flags |= FLAG_C;
+                }
+                result = accumulator;
+            }
+        }
+        if (operation != 7) {
+            registers.setATrusted(result);
+        }
+        registers.getFlags().setFlagsByteTrusted(flags);
+        return result;
+    }
+
+    private boolean performanceConditionHolds(int condition) {
+        int flags = registers.getFlags().getFlagsByte();
+        return switch (condition) {
+            case 0 -> (flags & FLAG_Z) == 0;
+            case 1 -> (flags & FLAG_Z) != 0;
+            case 2 -> (flags & FLAG_C) == 0;
+            default -> (flags & FLAG_C) != 0;
+        };
+    }
+
+    private int readPerformanceRegister(int register) {
+        return switch (register) {
+            case 0 -> registers.getB();
+            case 1 -> registers.getC();
+            case 2 -> registers.getD();
+            case 3 -> registers.getE();
+            case 4 -> registers.getH();
+            case 5 -> registers.getL();
+            case 7 -> registers.getA();
+            default -> throw new IllegalArgumentException("(HL) is not a direct register target");
+        };
+    }
+
+    private void writePerformanceRegister(int register, int value) {
+        switch (register) {
+            case 0 -> registers.setBTrusted(value);
+            case 1 -> registers.setCTrusted(value);
+            case 2 -> registers.setDTrusted(value);
+            case 3 -> registers.setETrusted(value);
+            case 4 -> registers.setHTrusted(value);
+            case 5 -> registers.setLTrusted(value);
+            case 7 -> registers.setATrusted(value);
+            default -> throw new IllegalArgumentException("(HL) is not a direct register target");
+        }
+    }
+
+    private void finishPerformanceDirectInstruction(int context) {
+        opContext = context;
+        ops = currentOpcode.getOps();
+        opIndex = currentOpCount;
+        state = State.OPCODE;
+        operandIndex = 0;
+        interruptManager.onInstructionFinished();
+    }
+
     /** Advances one master tick, retaining the historical scalar entry point. */
     public void tick() {
         if (!tickPhaseOnly()) {
@@ -640,6 +2646,11 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private boolean isJoypadLineLow() {
         return (addressSpace.getByte(0xff00) & 0x0f) != 0x0f;
+    }
+
+    /** Cheap guard for owners that can skip the normally dormant peripheral callback. */
+    public boolean hasPendingPeripheralSample() {
+        return haltEntrySampleTicks > 0;
     }
 
     /** Completes HALT's entry sample after this tick's peripheral edges settle. */
@@ -878,6 +2889,24 @@ public class Cpu implements StatefulComponent<Cpu> {
         return observed == null
                 ? baseAddressSpace.getByte(address)
                 : observed.getByte(address, DebugMemoryAccess.EXECUTE);
+    }
+
+    /** Acquires one borrowed mapping after the native epoch entrance proof has passed. */
+    private PerformanceRomAccess acquirePerformanceEpochRomAccess() {
+        PerformanceRomAccessProvider provider = performanceRomAccessProvider;
+        return provider == null ? null : provider.acquirePerformanceRomAccess();
+    }
+
+    /** Native-CGB epoch-only instruction fetch through its borrowed physical ROM mapping. */
+    private int readPerformanceEpochInstructionByte(int address) {
+        PerformanceRomAccess romAccess = performanceEpochRomAccess;
+        if (romAccess != null && address >= 0 && address < 0x8000) {
+            int value = romAccess.readCpuByte(address);
+            if (value >= 0) {
+                return value;
+            }
+        }
+        return readInstructionByte(address);
     }
 
     private void notifyInterruptAccepted(InterruptManager.InterruptType interrupt) {
@@ -1433,6 +3462,97 @@ public class Cpu implements StatefulComponent<Cpu> {
         currentOpWritesMemory = opcode.getWritesMemory();
         currentOpCount = currentExecutionOps.length;
         currentOperandLength = opcode.getOperandLength();
+    }
+
+    /**
+     * Allocation-free transient bus fence used only while a PERFORMANCE epoch owns the
+     * CPU. Safe accesses continue through the real bus. An external read is delegated once
+     * after the prefix callback; an external write is deferred to the one-slot journal.
+     */
+    private static final class PerformanceEpochBus implements AddressSpace {
+
+        private final Cpu owner;
+
+        private AddressSpace target;
+
+        private int accesses;
+
+        private int terminalAccesses;
+
+        private PerformanceEpochBus(Cpu owner) {
+            this.owner = owner;
+        }
+
+        private void resetForEpoch(AddressSpace target) {
+            this.target = target;
+            accesses = 0;
+            terminalAccesses = 0;
+        }
+
+        private int accesses() {
+            return accesses;
+        }
+
+        private int terminalAccesses() {
+            return terminalAccesses;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return target.accepts(address);
+        }
+
+        @Override
+        public int getByte(int address) {
+            accesses++;
+            if (!isSafeRead(address)) {
+                terminalAccesses++;
+                owner.markPerformanceEpochTerminal();
+                owner.flushPerformanceEpochPrefix();
+            }
+            return target.getByte(address);
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            accesses++;
+            if (!isSafeWrite(address)) {
+                int a = address & 0xffff;
+                if (!owner.speedMode.isGbc() && a >= 0xfe00 && a <= 0xfeff) {
+                    // DMG OAM writes must observe the corruption-suppression latch and access
+                    // lock at this exact CPU boundary. The preceding corruption callback has
+                    // already flushed the prefix for PUSH-class writes; plain LD writes flush
+                    // here. Never defer either through the post-PPU journal.
+                    owner.markPerformanceEpochTerminal();
+                    terminalAccesses++;
+                    owner.flushPerformanceEpochPrefix();
+                    target.setByte(address, value);
+                    return;
+                }
+                // Record before dispatching.  The CPU operation itself is allowed to finish,
+                // but the external write is deferred so the owner can replay it exactly once
+                // after committing the frozen peripheral prefix.
+                owner.journalPerformanceEpochWrite(address, value);
+                owner.markPerformanceEpochTerminal();
+                terminalAccesses++;
+                owner.flushPerformanceEpochPrefix();
+                return;
+            }
+            target.setByte(address, value);
+        }
+
+        private static boolean isSafeRead(int address) {
+            int a = address & 0xffff;
+            return a < 0x8000
+                    || a >= 0xc000 && a <= 0xfdff
+                    || a >= 0xff80 && a <= 0xfffd;
+        }
+
+        private static boolean isSafeWrite(int address) {
+            int a = address & 0xffff;
+            return a >= 0xc000 && a <= 0xfdff
+                    || a >= 0xff80 && a <= 0xfffd;
+        }
     }
 
     private record CpuState(ComponentState<Registers> registersMemento, int opcode1, int opcode2, int[] operand,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -518,6 +518,37 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     /**
+     * Returns whether a native CGB double-speed HALT is settled enough to own a multi-dot
+     * PERFORMANCE packet.  This is intentionally separate from the normal-speed HALT lane:
+     * double speed has a two-dot CPU machine-cycle phase and its PPU/interrupt synchronizers
+     * have additional residue which must remain on the scalar owner.
+     */
+    public boolean performanceNativeCgbSettledHaltSpanEligible() {
+        return speedMode.getSpeedMode() == 2
+                && speedMode.isGbc()
+                && !speedMode.isDmgCompat()
+                && state == State.HALTED
+                && clockCycle >= 0
+                && clockCycle < 2
+                && haltEntrySampleTicks == 0
+                && !synchronousHaltEntryStatPhase
+                && !asynchronousHaltEntryStatPhase
+                && !ordinaryHaltWakeStatPhase
+                && !haltBugMode
+                && !phasedPpuInputHigh
+                && !fastPhasedPpuDispatch
+                && !hdmaOpcodePrefetched
+                && !hdmaArbitrationOpcodeValid
+                && !haltOpcodePrefetchValid
+                && !speedSwitchPaddingReplayValid
+                && !interruptManager.hasPendingCpuReadPhase()
+                && !interruptManager.hasPpuTickSignals()
+                && !interruptManager.isInterruptEnablePending()
+                && !interruptManager.hasRawPendingEnabledInterrupt()
+                && !interruptManager.isInterruptRequestedForHalt()
+                && !interruptManager.isInterruptRequestedWhileHaltWakeBlocked();
+    }
+    /**
      * Advances the CPU clock phase without entering the instruction sequencer when this
      * master tick is not a CPU machine-cycle boundary.
      *
@@ -659,6 +690,20 @@ public class Cpu implements StatefulComponent<Cpu> {
         int completedBoundaries = ticks >= distanceToBoundary
                 ? 1 + (ticks - distanceToBoundary) / 4 : 0;
         clockCycle = (clockCycle + ticks) & 0x03;
+        haltedCpuCycles = Math.min(2, haltedCpuCycles + completedBoundaries);
+    }
+
+    /** Advances a preflighted native-CGB double-speed settled-HALT span on the two-dot phase. */
+    public void advancePerformanceNativeCgbSettledHaltSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        hdmaOpcodePrefetched = false;
+        updatePhasedPpuInput();
+        int distanceToBoundary = 2 - clockCycle;
+        int completedBoundaries = ticks >= distanceToBoundary
+                ? 1 + (ticks - distanceToBoundary) / 2 : 0;
+        clockCycle = (clockCycle + ticks) % 2;
         haltedCpuCycles = Math.min(2, haltedCpuCycles + completedBoundaries);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Flags.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Flags.java
@@ -55,6 +55,11 @@ public class Flags  {
         this.flags = flags & 0xf0;
     }
 
+    /** Trusted counterpart for the package-local PERFORMANCE CPU executor. */
+    void setFlagsByteTrusted(int value) {
+        flags = value & 0xf0;
+    }
+
     @Override
     public String toString() {
         return String.valueOf(isZ() ? 'Z' : '-')

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/InterruptManager.java
@@ -401,6 +401,16 @@ public class InterruptManager implements AddressSpace, StatefulComponent<Interru
                 & ~cpuInstructionBlockedInterrupts & 0x1f) != 0;
     }
 
+    /**
+     * Returns whether any enabled source is stored in IF, before the CPU acceptance
+     * synchronizers are applied.  A PERFORMANCE epoch must stop even when a source is
+     * currently instruction-blocked, because that block can clear at an instruction
+     * retirement inside the epoch.
+     */
+    public boolean hasRawPendingEnabledInterrupt() {
+        return (interruptFlag & interruptEnabled & 0x1f) != 0;
+    }
+
     public boolean isInterruptRequestedForHalt() {
         return (interruptFlag & interruptEnabled & ~cpuBlockedInterrupts
                 & ~cpuInstructionBlockedInterrupts

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Registers.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Registers.java
@@ -141,6 +141,46 @@ public class Registers implements StatefulComponent<Registers> {
         this.pc = pc;
     }
 
+    /*
+     * Trusted setters used by the native-CGB PERFORMANCE instruction executor.
+     * The executor masks every ALU/address result before publication and is covered
+     * by scalar state differentials.  Keeping these package-private preserves the
+     * validation contract of the public/debug API without paying a Guava precondition
+     * on every hot register write.
+     */
+    void setATrusted(int value) { a = value & 0xff; }
+
+    void setBTrusted(int value) { b = value & 0xff; }
+
+    void setCTrusted(int value) { c = value & 0xff; }
+
+    void setDTrusted(int value) { d = value & 0xff; }
+
+    void setETrusted(int value) { e = value & 0xff; }
+
+    void setHTrusted(int value) { h = value & 0xff; }
+
+    void setLTrusted(int value) { l = value & 0xff; }
+
+    void setBCTrusted(int value) {
+        b = (value >>> 8) & 0xff;
+        c = value & 0xff;
+    }
+
+    void setDETrusted(int value) {
+        d = (value >>> 8) & 0xff;
+        e = value & 0xff;
+    }
+
+    void setHLTrusted(int value) {
+        h = (value >>> 8) & 0xff;
+        l = value & 0xff;
+    }
+
+    void setSPTrusted(int value) { sp = value & 0xffff; }
+
+    void setPCTrusted(int value) { pc = value & 0xffff; }
+
     public void incrementPC() {
         pc = (pc + 1) & 0xffff;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/genie/Genie.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/genie/Genie.java
@@ -4,6 +4,8 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
@@ -12,11 +14,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Genie implements AddressSpace, StatefulComponent<Genie> {
+public class Genie implements AddressSpace, StatefulComponent<Genie>, PerformanceRomAccessProvider {
 
     private final AddressSpace delegate;
 
     private final Map<Integer, List<CheatPatch>> patches = new HashMap<>();
+
+    /**
+     * Fail-closed publication fence for a bounded ROM lease acquisition. Event delivery normally
+     * mutates cheats on the emulation owner, but publish this bit before touching the map so an
+     * acquisition racing that boundary cannot bypass a newly active patch.
+     */
+    private volatile boolean patchesPresent;
 
     private final boolean gbc;
 
@@ -32,6 +41,7 @@ public class Genie implements AddressSpace, StatefulComponent<Genie> {
     }
 
     private void addPatch(CheatPatch patch) {
+        patchesPresent = true;
         patches.computeIfAbsent(patch.getAddress(), k -> new ArrayList<>()).add(patch);
     }
 
@@ -67,6 +77,15 @@ public class Genie implements AddressSpace, StatefulComponent<Genie> {
         return applyPatches(address, value);
     }
 
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        if (patchesPresent
+                || !(delegate instanceof PerformanceRomAccessProvider provider)) {
+            return null;
+        }
+        return provider.acquirePerformanceRomAccess();
+    }
+
     private int applyPatches(int address, int value) {
         List<CheatPatch> addressPatches = patches.get(address);
         if (addressPatches == null) {
@@ -92,9 +111,14 @@ public class Genie implements AddressSpace, StatefulComponent<Genie> {
         if (!(state instanceof GenieState mem)) {
             throw new IllegalArgumentException("Invalid state type");
         }
+        boolean restoredPatchesPresent = !mem.patches.isEmpty();
+        if (restoredPatchesPresent) {
+            patchesPresent = true;
+        }
         patches.clear();
         mem.patches.forEach((k, v) ->
                 patches.put(k, new ArrayList<>(v.stream().map(Genie::restorePatch).toList())));
+        patchesPresent = restoredPatchesPresent;
     }
 
     private static PatchState capturePatch(CheatPatch patch) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifo.java
@@ -173,6 +173,19 @@ public class ColorPixelFifo implements PixelFifo, StatefulComponent<ColorPixelFi
         }
     }
 
+    @Override
+    public boolean isPerformanceOutputIdle() {
+        return delaySize == 0;
+    }
+
+    @Override
+    public void advancePerformanceOutputIdleSpanTrusted(int ticks) {
+        if (ticks < 0 || delaySize != 0) {
+            throw new IllegalStateException("CGB output delay is not idle");
+        }
+        outputTicks += ticks;
+    }
+
     private int resolvePixel(int entry) {
         int bgPixel = entry & 0b11;
         int bgPaletteIndex = (entry >> 2) & 0b111;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -329,6 +329,19 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
     }
 
     @Override
+    public boolean isPerformanceOutputIdle() {
+        return delaySize == 0 && firstEntry < 0;
+    }
+
+    @Override
+    public void advancePerformanceOutputIdleSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceOutputIdle()) {
+            throw new IllegalStateException("DMG output delay is not idle");
+        }
+        outputTicks += ticks;
+    }
+
+    @Override
     public void resetForMissingState() {
         pixels.clear();
         spriteFifo.clear();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/DmgPixelFifo.java
@@ -335,9 +335,6 @@ public class DmgPixelFifo implements PixelFifo, StatefulComponent<DmgPixelFifo> 
 
     @Override
     public void advancePerformanceOutputIdleSpanTrusted(int ticks) {
-        if (ticks < 0 || !isPerformanceOutputIdle()) {
-            throw new IllegalStateException("DMG output delay is not idle");
-        }
         outputTicks += ticks;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -95,6 +95,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     // direct Gpu.tick() probes and ACCURACY remain on their calibrated dot pipelines.
     private final boolean performanceScanlineCapable;
 
+    // Exact construction-time permission for the short mode-2 phase packet. Keep this narrower
+    // than the monochrome pixel/timing cursors: the public Gpu horizon must fail closed for SGB,
+    // SGB2, and every compatibility profile even when their clock happens to be normal speed.
+    private final boolean performancePhysicalDmgMode2;
+
     private final ColorPalette bgPalette;
 
     private final ColorPalette oamPalette;
@@ -158,6 +163,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     static final int NATIVE_CGB_PHASE_LINE_MASK = 0xff;
     static final int NATIVE_CGB_PHASE_MODE0_EDGE_NEXT = 1 << 8;
     static final int NATIVE_CGB_PHASE_MODE0_READ_PREVIEW = 1 << 9;
+
+    // Packed post-GPU STAT facts. The validity bit is deliberately derived from the committed
+    // PPU state, so a CPU speed/compatibility transition during the owner tick fails closed.
+    static final int NATIVE_CGB_POST_STAT_FACTS_VALID = 1 << 31;
+    static final int NATIVE_CGB_POST_STAT_CHECKPOINT = 1 << 30;
 
     // Switching the CGB CPU clock remaps the PPU timestamp and rephases the CPU-side
     // STAT mode latch. Until that happens, the boot-time latch has its five-dot tail.
@@ -337,6 +347,10 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || hardwareProfile == HardwareProfileRegistry.MGB
                 || hardwareProfile == HardwareProfileRegistry.CGB
                 || hardwareProfile == HardwareProfileRegistry.CGB0);
+        this.performancePhysicalDmgMode2 = executionMode == ExecutionMode.PERFORMANCE
+                && !debugHistoryReplay
+                && (hardwareProfile == HardwareProfileRegistry.DMG
+                || hardwareProfile == HardwareProfileRegistry.MGB);
         this.r.setGbc(gbc);
         this.r.setSpeedMode(speedMode);
         this.lcdc.setGbc(gbc);
@@ -990,7 +1004,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             pixelMachine.setWindowLineCounterForPerformance(performanceWindowLineCounter);
         }
         if (performanceRenderOutput) {
-            performanceScanlineRenderer.renderLine(display, line, windowLine);
+            performanceScanlineRenderer.renderLinePerformanceBoundary(display, line, windowLine);
         }
         // The ordinary mode-3 starts above have initialized both machines for their state
         // shape. They must not remain active after the direct composition or their delayed
@@ -1291,6 +1305,64 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         ticksInLine += ticks;
         timingGeneration += ticks;
         cpuLyReadAcrossLineEdge = false;
+        synchronizePerformanceWindowLineCounter();
+    }
+
+    /**
+     * Horizon for a short physical-DMG mode-2 phase packet.  Only the non-CPU dots before the
+     * next normal-speed machine-cycle boundary use this lane; the dot-79-to-80 handoff remains
+     * scalar so the existing OAM/PixelTransfer transition and renderer arm stay authoritative.
+     */
+    public int performancePhysicalDmgMode2PhaseSpanLimit(int requested) {
+        if (!performancePhysicalDmgMode2 || requested <= 0 || gbc || speedModeValue != 1
+                || !lcdEnabled || firstLine
+                || line >= 144 || mode != Mode.OamSearch || phase != oamSearchPhase
+                || performanceScanlineCursor || performanceScanlineLine || dma == null
+                || dma.isTransferInProgress() || dma.ownsOamForPpu()
+                || dma.hasPpuOamOwnershipTransitionThisTick()) {
+            return 0;
+        }
+        if (!performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !bootCompatibilityResolved || displayEnabledDelay != 0 || steadyTimingCursor
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
+                || !pixelTransferPhase.isPerformanceDmgIdleOutput()
+                || !pixelMachine.isPerformanceDmgIdleOutput()
+                || !oamSearchPhase.isPerformancePhysicalDmgMode2SpanEligible(
+                ticksInLine, lcdc.getSpriteHeight())) {
+            return 0;
+        }
+        return Math.min(requested, Math.max(0, 79 - ticksInLine));
+    }
+
+    /** Advances a preflighted physical-DMG mode-2 prefix without entering the dot loops. */
+    public void advancePerformancePhysicalDmgMode2PhaseSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        int startTick = ticksInLine;
+        if (startTick + ticks > 79) {
+            throw new IllegalStateException(
+                    "GPU is not eligible for a physical-DMG PERFORMANCE mode-2 span");
+        }
+        assert performancePhysicalDmgMode2PhaseSpanLimit(ticks) >= ticks
+                : "trusted physical-DMG mode-2 proof changed before commit";
+
+        lcdc.advancePerformancePhysicalDmgMode2FixedPointSpanTrusted(ticks);
+        pixelTransferPhase.advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+        pixelMachine.advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+        oamSearchPhase.advancePerformancePhysicalDmgMode2SpanTrusted(
+                startTick, ticks, lcdc.getSpriteHeight());
+
+        ticksInLine += ticks;
+        timingGeneration += ticks;
+        cpuLyReadAcrossLineEdge = false;
+        directOamReadCorruptionThisTick = false;
+        suppressNextDirectOamReadCorruption = false;
+        directOamWriteCorruptionThisTick = false;
+        suppressNextDirectOamWriteCorruption = false;
         synchronizePerformanceWindowLineCounter();
     }
 
@@ -2000,6 +2072,76 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || (gbc && !target.dmgCompat && line == 153 && ticksInLine >= 454)
                 || ((!gbc || target.dmgCompat) && !firstLine && line == 0
                 && ticksInLine < 4));
+    }
+
+    /**
+     * Captures the post-GPU STAT facts for the native-CGB PERFORMANCE scalar owner.
+     *
+     * <p>This is intentionally the same formula used by the ordinary scheduler snapshot. The
+     * native owner calls it after the PPU dot has committed, so StatRegister can avoid the
+     * timing-generation probe and the generic cross-object capture dispatch while retaining
+     * exactly the same values at every raster position (including LCD-off and first-line
+     * states).</p>
+     */
+    long captureNativeCgbPerformancePostStatTiming(GpuTimingSnapshot target) {
+        int currentLine = line;
+        int currentTicksInLine = ticksInLine;
+        boolean currentLcdEnabled = lcdEnabled;
+        boolean currentFirstLine = firstLine;
+        int earlyLineEdgeTick = currentFirstLine ? 451 : 448;
+        boolean visibleVblankTail = currentLine == 153;
+        boolean visibleLine = currentLine < 144;
+
+        target.line = currentLine;
+        target.ticksInLine = currentTicksInLine;
+        target.lcdEnabled = currentLcdEnabled;
+        target.firstLine = currentFirstLine;
+        target.statModeLatchRephasedBySpeedSwitch = statModeLatchRephasedBySpeedSwitch;
+        target.earlyLineEdgeTick = earlyLineEdgeTick;
+        target.setNativeCgbDoubleSpeed();
+
+        int visibleLyLineEdgeTick = currentFirstLine ? 451 : 454;
+        if (!currentLcdEnabled) {
+            target.visibleLy = 0;
+        } else if (visibleVblankTail) {
+            target.visibleLy = currentTicksInLine < 2 ? 153 : 0;
+        } else {
+            target.visibleLy = currentTicksInLine >= visibleLyLineEdgeTick
+                    ? currentLine + 1 : currentLine;
+        }
+
+        target.mode0InterruptTick = mode0IntFrom;
+        target.mode0HaltWakeTick = currentLcdEnabled && visibleLine
+                && currentTicksInLine == target.mode0InterruptTick + 2;
+        target.mode0IntWindow = currentLcdEnabled && visibleLine
+                && currentTicksInLine >= target.mode0InterruptTick;
+        target.mode1IntWindow = currentLcdEnabled
+                && (mode == Mode.VBlank || currentLine == 143 && currentTicksInLine >= 448);
+        target.mode2IntWindow = currentLcdEnabled
+                && ((visibleLine && currentTicksInLine >= earlyLineEdgeTick)
+                || (visibleVblankTail && currentTicksInLine >= 454));
+        return timingGeneration;
+    }
+
+    /**
+     * Packs the native post-GPU facts directly from the committed PPU state. The VALID bit
+     * fails closed if a CPU instruction changed speed/compatibility during this scalar dot.
+     */
+    int getNativeCgbPerformancePostStatFacts() {
+        if (!gbc || dmgCompatValue || speedModeValue != 2) {
+            return 0;
+        }
+        int mode0InterruptTick = mode0IntFrom;
+        int facts = NATIVE_CGB_POST_STAT_FACTS_VALID;
+        boolean checkpoint = lcdEnabled
+                && (ticksInLine < 13 || ticksInLine >= 448
+                || ticksInLine == mode0InterruptTick
+                || (line < 144 && mode0InterruptTick != Integer.MAX_VALUE
+                && ticksInLine == mode0InterruptTick + 2));
+        if (checkpoint) {
+            facts |= NATIVE_CGB_POST_STAT_CHECKPOINT;
+        }
+        return facts;
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -152,6 +152,13 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     // It can rise while an object at X=167 is still extending the physical transfer.
     private int mode0IntFrom = Integer.MAX_VALUE;
 
+    // Native-CGB scalar ticks use this compact read-phase word instead of materializing the
+    // general STAT timing snapshot. The low byte is the current line; the two high bits are the
+    // only native double-speed mode-0 lookahead facts consumed by StatRegister.
+    static final int NATIVE_CGB_PHASE_LINE_MASK = 0xff;
+    static final int NATIVE_CGB_PHASE_MODE0_EDGE_NEXT = 1 << 8;
+    static final int NATIVE_CGB_PHASE_MODE0_READ_PREVIEW = 1 << 9;
+
     // Switching the CGB CPU clock remaps the PPU timestamp and rephases the CPU-side
     // STAT mode latch. Until that happens, the boot-time latch has its five-dot tail.
     private boolean statModeLatchRephasedBySpeedSwitch;
@@ -1065,6 +1072,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || !pendingPpuWrites.isEmpty()
                 || r.hasPendingConflictLatches()
                 || lcdc.hasPendingConflictLatches()
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
                 || dma == null
                 || dma.isTransferInProgress()
                 || dma.ownsOamForPpu()
@@ -1099,11 +1107,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || !pendingPpuWrites.isEmpty()
                 || r.hasPendingConflictLatches()
                 || lcdc.hasPendingConflictLatches()
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
                 || mode != Mode.HBlank && mode != Mode.VBlank
                 // A scalar/steady PixelTransfer line can still have delayed output pixels in
                 // its HBlank tail. Only a line rendered by the direct compositor has proven
                 // that both machines were abandoned with an empty output tail.
                 || mode == Mode.HBlank && !performanceScanlineLine
+                || !gbc && !isPerformanceDmgIdleOutput()
+                || gbc && !isPerformanceNativeCgbIdleOutput()
                 || !lcdEnabled
                 || !bootCompatibilityResolved
                 || dma == null
@@ -1114,7 +1125,173 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             return 0;
         }
         int lineLength = firstLine ? 455 : 456;
-        return Math.max(0, lineLength - ticksInLine - 1);
+        int limit = Math.max(0, lineLength - ticksInLine - 1);
+        if (mode == Mode.VBlank && line == 153 && (!gbc || speedModeValue == 1)) {
+            // Scalar tick() samples the frame-window checkpoint on old dot 454 before
+            // publishing the line edge. Leave that dot to the exact path.
+            limit = Math.min(limit, 454 - ticksInLine);
+        }
+        return Math.max(0, limit);
+    }
+
+    /** Native-CGB coarse epoch horizon; HDMA is unconditionally part of this contract. */
+    public int performanceEpochSpanLimit(int requested) {
+        if (requested <= 0 || !lcdEnabled || dma == null || dma.isTransferInProgress()
+                || dma.ownsOamForPpu() || dma.hasPpuOamOwnershipTransitionThisTick()
+                || hdma == null || hdma.hasActiveOrPendingTransfer()) {
+            return 0;
+        }
+        if (!performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
+                || !bootCompatibilityResolved) {
+            return 0;
+        }
+        int limit;
+        if (mode == Mode.PixelTransfer) {
+            // Direct rendered mode 3 is the only mode-3 cursor admitted here.  Unlike the
+            // older scheduler horizon, this coarse transaction cannot yet advance HDMA's
+            // HBlank-request synchronizer, so even an armed transfer remains fail-closed.
+            if (!performanceScanlineCursor
+                    || ticksInLine + 1 >= performanceScanlineEndTick) {
+                return 0;
+            }
+            limit = performanceScanlineEndTick - ticksInLine - 1;
+        } else if (mode == Mode.HBlank || mode == Mode.VBlank) {
+            if (mode == Mode.HBlank && !performanceScanlineLine
+                    || !isPerformanceNativeCgbIdleOutput()) {
+                return 0;
+            }
+            int lineLength = firstLine ? 455 : 456;
+            limit = Math.max(0, lineLength - ticksInLine - 1);
+            if (mode == Mode.VBlank && line == 153 && (!gbc || speedModeValue == 1)) {
+                limit = Math.min(limit, 454 - ticksInLine);
+            }
+        } else {
+            return 0;
+        }
+        return Math.min(requested, Math.max(0, limit));
+    }
+
+    /**
+     * Physical-DMG counterpart of {@link #performanceEpochSpanLimit(int)}. The empty output
+     * clocks are part of the proof in HBlank/VBlank; IR, HDMA, mode 2 and scalar mode 3 are not.
+     */
+    public int performancePhysicalDmgEpochSpanLimit(int requested) {
+        if (requested <= 0 || !lcdEnabled || dma == null || dma.isTransferInProgress()
+                || dma.ownsOamForPpu() || dma.hasPpuOamOwnershipTransitionThisTick()) {
+            return 0;
+        }
+        if (!performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
+                || !bootCompatibilityResolved) {
+            return 0;
+        }
+        int limit;
+        if (mode == Mode.PixelTransfer) {
+            if (!performanceScanlineCursor
+                    || ticksInLine + 1 >= performanceScanlineEndTick) {
+                return 0;
+            }
+            limit = performanceScanlineEndTick - ticksInLine - 1;
+        } else if (mode == Mode.HBlank || mode == Mode.VBlank) {
+            if (mode == Mode.HBlank && !performanceScanlineLine
+                    || !isPerformanceDmgIdleOutput()) {
+                return 0;
+            }
+            int lineLength = firstLine ? 455 : 456;
+            limit = Math.max(0, lineLength - ticksInLine - 1);
+            if (mode == Mode.VBlank && line == 153) {
+                limit = Math.min(limit, 454 - ticksInLine);
+            }
+        } else {
+            return 0;
+        }
+        return Math.min(requested, Math.max(0, limit));
+    }
+
+    /**
+     * Horizon for exact per-dot OAM-search replay inside a native-CGB coarse CPU epoch.
+     * The caller must additionally intersect this with STAT's checkpoint horizon. The last
+     * mode-2 dot remains scalar because its OAM-search tick performs the mode-3 hand-off and
+     * can arm the direct scanline compositor.
+     */
+    public int performanceEpochMode2ReplaySpanLimit(int requested) {
+        if (requested <= 0 || !gbc || dmgCompatValue || speedModeValue != 2
+                || !lcdEnabled || firstLine || line >= 144 || mode != Mode.OamSearch
+                || phase != oamSearchPhase || performanceScanlineCursor
+                || performanceScanlineLine || dma == null || dma.isTransferInProgress()
+                || dma.ownsOamForPpu() || dma.hasPpuOamOwnershipTransitionThisTick()
+                || hdma == null || hdma.hasActiveOrPendingTransfer()) {
+            return 0;
+        }
+        if (!performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !bootCompatibilityResolved) {
+            return 0;
+        }
+        return Math.min(requested, Math.max(0, 79 - ticksInLine));
+    }
+
+    /**
+     * Horizon for the allocation-free native-CGB OAM-search transaction.
+     *
+     * <p>The broad mode-2 proof above remains the authoritative DMA/HDMA, write, observation,
+     * and dot-79 cap.  This narrower proof additionally requires every otherwise per-dot PPU
+     * component to be at a fixed point.  A recent LCDC/window write or a non-canonical restored
+     * reader state therefore retains the exact {@link #tick()} replay.</p>
+     */
+    public int performanceEpochMode2BulkSpanLimit(int requested) {
+        int limit = performanceEpochMode2ReplaySpanLimit(requested);
+        if (limit > 0 && line == 0 && ticksInLine <= 1) {
+            // The scalar mode-2 tick samples the frame-window checkpoint at old dot 1.
+            // Keep the exact replay lane through that edge before admitting bulk mode 2.
+            return 0;
+        }
+        if (limit <= 0 || displayEnabledDelay != 0 || steadyTimingCursor
+                || !lcdc.isPerformanceMode2FixedPoint()
+                || !pixelTransferPhase.isPerformanceNativeCgbMode2IdleOutput()
+                || !pixelMachine.isPerformanceNativeCgbMode2IdleOutput()
+                || !oamSearchPhase.isPerformanceNoDmaStableSpanEligible(
+                ticksInLine, lcdc.getSpriteHeight())) {
+            return 0;
+        }
+        return limit;
+    }
+
+    /**
+     * Advances a preflighted mode-2 prefix without entering the general GPU or STAT dot loops.
+     * The caller retains the scalar dot-80 handoff, where the last sprite is committed and the
+     * direct scanline renderer may arm.
+     */
+    public void advancePerformanceMode2QuietSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        int startTick = ticksInLine;
+        if (startTick + ticks > 79) {
+            throw new IllegalStateException("GPU is not eligible for a PERFORMANCE mode-2 span");
+        }
+        assert performanceEpochMode2BulkSpanLimit(ticks) >= ticks
+                : "trusted PERFORMANCE mode-2 proof changed before commit";
+
+        lcdc.advancePerformanceMode2FixedPointSpanTrusted(ticks);
+        pixelTransferPhase.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
+        pixelMachine.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
+        oamSearchPhase.advancePerformanceNoDmaStableSpanTrusted(
+                startTick, ticks, lcdc.getSpriteHeight());
+
+        ticksInLine += ticks;
+        timingGeneration += ticks;
+        cpuLyReadAcrossLineEdge = false;
+        synchronizePerformanceWindowLineCounter();
     }
 
     /** Advances a preflighted raster span without entering either PixelTransfer machine. */
@@ -1153,6 +1330,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         int limit = performanceQuietSpanLimit();
         if (limit <= 0 || ticks > limit) {
             return false;
+        }
+        if (!gbc) {
+            advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+        } else {
+            advancePerformanceNativeCgbIdleOutputSpanTrusted(ticks);
+        }
+        if (mode == Mode.VBlank && ticksInLine < 79) {
+            replayPerformanceOamReaderPrefix(ticks);
         }
         ticksInLine += ticks;
         timingGeneration += ticks;
@@ -1198,6 +1383,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             timingGeneration += ticks;
             performanceSteadyFastTicks += ticks;
         } else {
+            if (!gbc) {
+                advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+            } else {
+                advancePerformanceNativeCgbIdleOutputSpanTrusted(ticks);
+            }
+            if (mode == Mode.VBlank && ticksInLine < 79) {
+                replayPerformanceOamReaderPrefix(ticks);
+            }
             ticksInLine += ticks;
             timingGeneration += ticks;
             performanceScanlineFastTicks += ticks;
@@ -1210,9 +1403,115 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         }
     }
 
+    /** Native-CGB trusted epoch commit with no physical-DMG output/OAM branches. */
+    public void advancePerformanceEpochQuietSpanTrusted(
+            int ticks, boolean directRaster, boolean steadyRaster) {
+        if (ticks <= 0) {
+            return;
+        }
+        if (directRaster && steadyRaster) {
+            throw new IllegalStateException("conflicting PERFORMANCE raster cursor kinds");
+        }
+        if (directRaster) {
+            if (!performanceScanlineCursor) {
+                throw new IllegalStateException("direct PERFORMANCE cursor changed in epoch");
+            }
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceScanlineFastTicks += ticks;
+        } else if (steadyRaster) {
+            if (!steadyTimingCursor) {
+                throw new IllegalStateException("steady PERFORMANCE cursor changed in epoch");
+            }
+            steadyTimingTicks += ticks;
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceSteadyFastTicks += ticks;
+        } else {
+            advancePerformanceNativeCgbIdleOutputSpanTrusted(ticks);
+            if (mode == Mode.VBlank && ticksInLine < 79) {
+                replayPerformanceOamReaderPrefix(ticks);
+            }
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceScanlineFastTicks += ticks;
+        }
+    }
+
+    /** Physical-DMG trusted epoch commit with canonical empty output-clock advancement. */
+    public void advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
+            int ticks, boolean directRaster, boolean steadyRaster) {
+        if (ticks <= 0) {
+            return;
+        }
+        if (directRaster && steadyRaster) {
+            throw new IllegalStateException("conflicting physical-DMG raster cursor kinds");
+        }
+        if (directRaster) {
+            if (!performanceScanlineCursor) {
+                throw new IllegalStateException("direct physical-DMG cursor changed in epoch");
+            }
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceScanlineFastTicks += ticks;
+        } else if (steadyRaster) {
+            if (!steadyTimingCursor) {
+                throw new IllegalStateException("steady physical-DMG cursor changed in epoch");
+            }
+            steadyTimingTicks += ticks;
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceSteadyFastTicks += ticks;
+        } else {
+            advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+            if (mode == Mode.VBlank && ticksInLine < 79) {
+                replayPerformanceOamReaderPrefix(ticks);
+            }
+            ticksInLine += ticks;
+            timingGeneration += ticks;
+            performanceScanlineFastTicks += ticks;
+        }
+        directOamReadCorruptionThisTick = false;
+        suppressNextDirectOamReadCorruption = false;
+        directOamWriteCorruptionThisTick = false;
+        suppressNextDirectOamWriteCorruption = false;
+    }
+
     /** Whether the broad line-at-a-time cursor is active. */
     public boolean isPerformanceScanlineCursorActive() {
         return performanceScanlineCursor;
+    }
+
+    private boolean isPerformanceDmgIdleOutput() {
+        return pixelTransferPhase.isPerformanceDmgIdleOutput()
+                && pixelMachine.isPerformanceDmgIdleOutput();
+    }
+
+    private boolean isPerformanceNativeCgbIdleOutput() {
+        return gbc
+                && pixelTransferPhase.isPerformanceNativeCgbMode2IdleOutput()
+                && pixelMachine.isPerformanceNativeCgbMode2IdleOutput();
+    }
+
+    /** Replays the persistent OAM reader's early-line prefix before a trusted span advances. */
+    private void replayPerformanceOamReaderPrefix(int ticks) {
+        if (ticks <= 0 || mode != Mode.VBlank || ticksInLine >= 79) {
+            return;
+        }
+        int end = Math.min(80, ticksInLine + ticks + 1);
+        for (int position = ticksInLine + 1; position < end; position++) {
+            oamSearchPhase.trackDmaSource(position);
+        }
+    }
+
+    private void advancePerformanceDmgIdleOutputSpanTrusted(int ticks) {
+        pixelTransferPhase.advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+        pixelMachine.advancePerformanceDmgIdleOutputSpanTrusted(ticks);
+    }
+
+    private void advancePerformanceNativeCgbIdleOutputSpanTrusted(int ticks) {
+        pixelTransferPhase.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
+        pixelMachine.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
     }
 
     /**
@@ -1292,7 +1591,8 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 && debugHooks == null
                 && pendingPpuWrites.isEmpty()
                 && !r.hasPendingConflictLatches()
-                && !lcdc.hasPendingConflictLatches();
+                && !lcdc.hasPendingConflictLatches()
+                && lcdc.isPerformanceQuietSpanFixedPoint();
     }
 
     /** Number of following dots that remain strictly inside the deferred steady span. */
@@ -1700,6 +2000,25 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || (gbc && !target.dmgCompat && line == 153 && ticksInLine >= 454)
                 || ((!gbc || target.dmgCompat) && !firstLine && line == 0
                 && ticksInLine < 4));
+    }
+
+    /**
+     * Returns the allocation-free native-CGB CPU/STAT phase facts needed before this dot's CPU
+     * bus callback. Native PERFORMANCE scalar misses are already topology-checked by Gameboy;
+     * keeping this word local to the GPU avoids taking the general timing snapshot on that path.
+     */
+    public int getNativeCgbPerformancePhaseWord() {
+        // Native double-speed scalar CPU callbacks never take the normal-speed line-edge
+        // handoff. Capture the same settled value as captureCpuLyReadPhase() would.
+        cpuLyReadAcrossLineEdge = false;
+        int phaseWord = line & NATIVE_CGB_PHASE_LINE_MASK;
+        if (line < 144 && ticksInLine + 1 == mode0IntFrom) {
+            phaseWord |= NATIVE_CGB_PHASE_MODE0_EDGE_NEXT;
+        }
+        if (line < 144 && ticksInLine + 2 == mode0IntFrom) {
+            phaseWord |= NATIVE_CGB_PHASE_MODE0_READ_PREVIEW;
+        }
+        return phaseWord;
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshot.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/GpuTimingSnapshot.java
@@ -19,4 +19,12 @@ final class GpuTimingSnapshot {
     boolean mode2IntWindow;
     boolean doubleSpeed;
     boolean nativeDoubleSpeed;
+
+    /** Fixed half of a native-CGB double-speed timing capture. */
+    void setNativeCgbDoubleSpeed() {
+        dmgCompat = false;
+        cpuMachineCycleDots = 2;
+        doubleSpeed = true;
+        nativeDoubleSpeed = true;
+    }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
@@ -15,6 +15,10 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     private static final int CONFLICT_HISTORY_LENGTH = 8;
 
+    // Keep the fixed-point proof O(1) on PERFORMANCE horizons. A write conservatively
+    // reopens the history window; tickConflicts drains it one dot at a time.
+    private static final int PERFORMANCE_FIXED_POINT_DRAIN = CONFLICT_HISTORY_LENGTH + 1;
+
     private boolean gbc;
 
     private final boolean mealybugDmgBlob;
@@ -50,6 +54,9 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
     // Both histories advance together in tickConflicts(). Logical index 0 is the newest value;
     // this cursor maps it to the corresponding physical slot in the two circular buffers.
     private int historyHead;
+
+    // PERFORMANCE-only eligibility metadata; the portable memento restores conservatively.
+    private transient int performanceFixedPointDrain;
 
     // The transient machine-state path borrows primitive arrays synchronously. Linearize the
     // circular histories into these owner-thread scratch arrays so the state schema remains
@@ -93,6 +100,31 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
         return mixValue >= 0 || pendingMixValue >= 0 || tileSelectGlitchWrite;
     }
 
+    /**
+     * Whether every per-dot LCDC latch is already at the native-CGB mode-2 fixed point.
+     *
+     * <p>{@link #hasPendingConflictLatches()} intentionally ignores history that is still
+     * visible to delayed consumers.  A coarse OAM scan must additionally prove that the
+     * tile-select pulse has drained and every delayed LCDC.2 sample equals the live value.
+     * Once this predicate holds, rotating the uniform circular histories is behaviorally a
+     * no-op (the cursor itself is neither serialized nor otherwise observable).</p>
+     */
+    boolean isPerformanceMode2FixedPoint() {
+        return gbc && isPerformanceQuietSpanFixedPoint();
+    }
+
+    /** Whether all delayed LCDC histories are uniform at the current value. */
+    boolean isPerformanceQuietSpanFixedPoint() {
+        return performanceFixedPointDrain == 0 && !hasPendingConflictLatches();
+    }
+
+    /** The fixed-point histories remain identical for an arbitrary positive quiet span. */
+    void advancePerformanceMode2FixedPointSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceMode2FixedPoint()) {
+            throw new IllegalStateException("LCDC is not at its PERFORMANCE mode-2 fixed point");
+        }
+    }
+
     /** Called once per GPU tick: the mix value lives for the single tick after the write. */
     void tickConflicts() {
         dmgBlobBackgroundEnable = pendingDmgBlobBackgroundEnable;
@@ -103,9 +135,13 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
         tileSelectGlitchHistory[historyHead] = tileSelectGlitchWrite;
         tileSelectGlitchWrite = false;
         oamSizeHistory[historyHead] = value;
+        if (performanceFixedPointDrain > 0) {
+            performanceFixedPointDrain--;
+        }
     }
 
     void triggerTileSelectGlitch() {
+        performanceFixedPointDrain = PERFORMANCE_FIXED_POINT_DRAIN;
         tileSelectGlitchWrite = true;
     }
 
@@ -178,6 +214,7 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
      *     in the conflict-mix T-cycle instead of one T-cycle later
      */
     public void set(int value, boolean dropObjEnInMix) {
+        performanceFixedPointDrain = PERFORMANCE_FIXED_POINT_DRAIN;
         if (gbc) {
             // the CGB applies LCDC writes cleanly, without the DMG's conflict mix
             this.value = value;
@@ -202,6 +239,7 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
 
     public void setGbc(boolean gbc) {
         this.gbc = gbc;
+        performanceFixedPointDrain = PERFORMANCE_FIXED_POINT_DRAIN;
     }
 
     public int get() {
@@ -253,6 +291,7 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
         }
         System.arraycopy(mem.oamSizeHistory, 0, oamSizeHistory, 0, oamSizeHistory.length);
         this.historyHead = 0;
+        this.performanceFixedPointDrain = PERFORMANCE_FIXED_POINT_DRAIN;
     }
 
     private int historyIndex(int dotsAgo) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Lcdc.java
@@ -125,6 +125,14 @@ public class Lcdc implements AddressSpace, StatefulComponent<Lcdc> {
         }
     }
 
+    /** Physical-DMG counterpart of the native-CGB fixed-point span commit. */
+    void advancePerformancePhysicalDmgMode2FixedPointSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceQuietSpanFixedPoint()) {
+            throw new IllegalStateException(
+                    "LCDC is not at its physical-DMG PERFORMANCE mode-2 fixed point");
+        }
+    }
+
     /** Called once per GPU tick: the mix value lives for the single tick after the write. */
     void tickConflicts() {
         dmgBlobBackgroundEnable = pendingDmgBlobBackgroundEnable;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.core.gpu;
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.BGP;
@@ -64,15 +65,9 @@ public final class PerformanceScanlineRenderer {
 
     private final int[] spriteOrder;
 
+    private final int[] spriteOverlay = new int[SCREEN_WIDTH];
+
     private int spriteCount;
-
-    // The renderer is owner-threaded by the emulator. Keep the current background sample in
-    // primitive fields instead of returning a temporary record for every visible pixel.
-    private int currentBackgroundRaw;
-
-    private int currentBackgroundPalette;
-
-    private boolean currentBackgroundPriority;
 
     /**
      * Creates a line renderer over the live PPU memory/register objects.
@@ -156,6 +151,8 @@ public final class PerformanceScanlineRenderer {
             throw new IllegalArgumentException("Scanline output must contain 160 pixels");
         }
         prepareSprites(ly);
+        boolean objEnabled = lcdc.isObjDisplay();
+        prepareSpriteOverlay(objEnabled);
 
         int scx = registers.get(SCX) & 0xff;
         int scy = registers.get(SCY) & 0xff;
@@ -170,6 +167,20 @@ public final class PerformanceScanlineRenderer {
         int windowY = windowLine >= 0 ? windowLine : Math.max(0, ly - wy);
         int bgMap = lcdc.getBgTileMapDisplay();
         int windowMap = lcdc.getWindowTileMapDisplay();
+        boolean signedTileIds = lcdc.isBgWindowTileDataSigned();
+        boolean dmgPaletteMapping = !gbc || dmgCompat;
+        int bgp = dmgPaletteMapping ? registers.get(BGP) : 0;
+        int obp0 = dmgPaletteMapping && objEnabled ? registers.get(OBP0) : 0;
+        int obp1 = dmgPaletteMapping && objEnabled ? registers.get(OBP1) : 0;
+        boolean cached = false;
+        boolean cachedWindow = false;
+        int cachedMapAddress = -1;
+        int cachedSourceRow = -1;
+        int cachedLow = 0;
+        int cachedHigh = 0;
+        int cachedPalette = 0;
+        boolean cachedPriority = false;
+        boolean cachedXFlip = false;
 
         for (int screenX = 0; screenX < SCREEN_WIDTH; screenX++) {
             boolean useWindow = windowEnabled && screenX >= windowLeft;
@@ -185,16 +196,53 @@ public final class PerformanceScanlineRenderer {
                 mapY = (scy + ly) & 0xff;
                 mapBase = bgMap;
             }
-            sampleBackground(mapBase, mapX, mapY);
-            if (!gbc || dmgCompat) {
-                if (!bgEnabled) {
-                    currentBackgroundRaw = 0;
-                    currentBackgroundPriority = false;
+
+            int mapAddress = mapBase + (((mapY >> 3) & 0x1f) << 5)
+                    + ((mapX >> 3) & 0x1f);
+            int sourceRow = mapY & 7;
+            if (!cached
+                    || cachedWindow != useWindow
+                    || cachedMapAddress != mapAddress
+                    || cachedSourceRow != sourceRow) {
+                int tileId = videoRam0.getByte(mapAddress) & 0xff;
+                int attributes = 0;
+                if (gbc && videoRam1 != null) {
+                    attributes = videoRam1.getByte(mapAddress) & 0xff;
                 }
+                int tileRow = (attributes & 0x40) == 0 ? sourceRow : 7 - sourceRow;
+                int bank = gbc ? (attributes >> 3) & 1 : 0;
+                int tileAddress = tileAddress(tileId, tileRow, signedTileIds);
+                cachedLow = readVideo(bank, tileAddress);
+                cachedHigh = readVideo(bank, tileAddress + 1);
+                cachedPalette = attributes & 7;
+                cachedPriority = (attributes & 0x80) != 0;
+                cachedXFlip = (attributes & 0x20) != 0;
+                cachedWindow = useWindow;
+                cachedMapAddress = mapAddress;
+                cachedSourceRow = sourceRow;
+                cached = true;
             }
 
-            int sprite = spriteAt(screenX);
-            output[screenX] = resolvePixel(sprite, bgEnabled);
+            int tilePixel = mapX & 7;
+            int bit = cachedXFlip ? tilePixel : 7 - tilePixel;
+            int backgroundRaw = ((cachedLow >> bit) & 1) | (((cachedHigh >> bit) & 1) << 1);
+            boolean backgroundPriority = cachedPriority;
+            if ((!gbc || dmgCompat) && !bgEnabled) {
+                backgroundRaw = 0;
+                backgroundPriority = false;
+            }
+
+            int overlay = spriteOverlay[screenX];
+            output[screenX] = resolvePixel(
+                    (overlay >> 2) - 1,
+                    overlay & 3,
+                    backgroundRaw,
+                    cachedPalette,
+                    backgroundPriority,
+                    bgEnabled,
+                    bgp,
+                    obp0,
+                    obp1);
         }
     }
 
@@ -238,100 +286,105 @@ public final class PerformanceScanlineRenderer {
         return Math.min(455, result);
     }
 
-    private void sampleBackground(int mapBase, int x, int y) {
-        int tileX = (x >> 3) & 0x1f;
-        int tileY = (y >> 3) & 0x1f;
-        int mapAddress = mapBase + (tileY << 5) + tileX;
-        int tileId = videoRam0.getByte(mapAddress) & 0xff;
-        int attributeValue = 0;
-        if (gbc && videoRam1 != null) {
-            attributeValue = videoRam1.getByte(mapAddress) & 0xff;
-        }
-        TileAttributes attributes = TileAttributes.valueOf(attributeValue);
-        int row = y & 7;
-        if (attributes.isYflip()) {
-            row = 7 - row;
-        }
-        int bank = gbc ? attributes.getBank() : 0;
-        int address = tileAddress(tileId, row, lcdc.isBgWindowTileDataSigned());
-        int low = readVideo(bank, address);
-        int high = readVideo(bank, address + 1);
-        int bit = attributes.isXflip() ? x & 7 : 7 - (x & 7);
-        currentBackgroundRaw = ((low >> bit) & 1) | (((high >> bit) & 1) << 1);
-        currentBackgroundPalette = attributes.getColorPaletteIndex();
-        currentBackgroundPriority = attributes.isPriority();
-    }
-
-    private int spriteAt(int x) {
-        if (!lcdc.isObjDisplay()) {
-            return -1;
-        }
-        for (int order = 0; order < spriteCount; order++) {
-            SpriteLine sprite = spriteLines[spriteOrder[order]];
-            int pixelX = x - sprite.left;
-            if (pixelX < 0 || pixelX >= 8) {
-                continue;
-            }
-            int bit = sprite.xFlip ? pixelX : 7 - pixelX;
-            int raw = ((sprite.low >> bit) & 1) | (((sprite.high >> bit) & 1) << 1);
-            if (raw != 0) {
-                sprite.pixel = raw;
-                return spriteOrder[order];
-            }
-        }
-        return -1;
-    }
-
-    private int resolvePixel(int spriteIndex, boolean bgEnabled) {
+    private int resolvePixel(
+            int spriteIndex,
+            int spritePixel,
+            int backgroundRaw,
+            int backgroundPalette,
+            boolean backgroundPriority,
+            boolean bgEnabled,
+            int bgp,
+            int obp0,
+            int obp1) {
         if (!gbc) {
             if (spriteIndex >= 0) {
                 SpriteLine sprite = spriteLines[spriteIndex];
-                if (!(sprite.priority && currentBackgroundRaw != 0)) {
-                    int palette = sprite.palette == 0 ? registers.get(OBP0) : registers.get(OBP1);
-                    return (palette >> (sprite.pixel * 2)) & 0x03;
+                if (!sprite.priority || backgroundRaw == 0) {
+                    int palette = sprite.palette == 0 ? obp0 : obp1;
+                    return (palette >> (spritePixel * 2)) & 0x03;
                 }
             }
-            return resolveDmgBackground();
+            return (bgp >> (backgroundRaw * 2)) & 0x03;
         }
-        return resolveCgb(spriteIndex, bgEnabled);
+        return resolveCgb(
+                spriteIndex,
+                spritePixel,
+                backgroundRaw,
+                backgroundPalette,
+                backgroundPriority,
+                bgEnabled,
+                bgp,
+                obp0,
+                obp1);
     }
 
-    private int resolveDmgBackground() {
-        return (registers.get(BGP) >> (currentBackgroundRaw * 2)) & 0x03;
-    }
-
-    private int resolveCgb(int spriteIndex, boolean bgEnabled) {
+    private int resolveCgb(
+            int spriteIndex,
+            int spritePixel,
+            int backgroundRaw,
+            int backgroundPalette,
+            boolean backgroundPriority,
+            boolean bgEnabled,
+            int bgp,
+            int obp0,
+            int obp1) {
         if (spriteIndex >= 0) {
             SpriteLine sprite = spriteLines[spriteIndex];
-            if (sprite.pixel != 0 && cgbSpriteIsVisible(sprite, bgEnabled)) {
-                int pixel = sprite.pixel;
+            if (spritePixel != 0
+                    && cgbSpriteIsVisible(sprite, backgroundRaw, backgroundPriority, bgEnabled)) {
+                int pixel = spritePixel;
                 if (dmgCompat) {
-                    int obp = registers.get(sprite.palette == 0 ? OBP0 : OBP1);
+                    int obp = sprite.palette == 0 ? obp0 : obp1;
                     pixel = (obp >> (pixel * 2)) & 0x03;
                     return oamPalette.getPalette(sprite.palette)[pixel];
                 }
                 return oamPalette.getPalette(sprite.palette)[pixel];
             }
         }
-        int pixel = currentBackgroundRaw;
+        int pixel = backgroundRaw;
         if (dmgCompat) {
             if (!bgEnabled) {
                 pixel = 0;
             } else {
-                pixel = (registers.get(BGP) >> (pixel * 2)) & 0x03;
+                pixel = (bgp >> (pixel * 2)) & 0x03;
             }
         }
-        return bgPalette.getPalette(currentBackgroundPalette)[pixel];
+        return bgPalette.getPalette(backgroundPalette)[pixel];
     }
 
-    private boolean cgbSpriteIsVisible(SpriteLine sprite, boolean bgEnabled) {
+    private boolean cgbSpriteIsVisible(
+            SpriteLine sprite,
+            int backgroundRaw,
+            boolean backgroundPriority,
+            boolean bgEnabled) {
         if (!bgEnabled && !dmgCompat) {
             return true;
         }
-        if (currentBackgroundPriority || sprite.priority) {
-            return currentBackgroundRaw == 0;
+        if (backgroundPriority || sprite.priority) {
+            return backgroundRaw == 0;
         }
         return true;
+    }
+
+    private void prepareSpriteOverlay(boolean objEnabled) {
+        Arrays.fill(spriteOverlay, 0);
+        if (!objEnabled) {
+            return;
+        }
+        for (int order = spriteCount - 1; order >= 0; order--) {
+            int spriteIndex = spriteOrder[order];
+            SpriteLine sprite = spriteLines[spriteIndex];
+            int start = Math.max(0, sprite.left);
+            int end = Math.min(SCREEN_WIDTH, sprite.left + 8);
+            for (int x = start; x < end; x++) {
+                int pixelX = x - sprite.left;
+                int bit = sprite.xFlip ? pixelX : 7 - pixelX;
+                int raw = ((sprite.low >> bit) & 1) | (((sprite.high >> bit) & 1) << 1);
+                if (raw != 0) {
+                    spriteOverlay[x] = ((spriteIndex + 1) << 2) | raw;
+                }
+            }
+        }
     }
 
     private void prepareSprites(int ly) {
@@ -370,9 +423,6 @@ public final class PerformanceScanlineRenderer {
             int address = tileAddress(tileId, row, false);
             line.low = readVideo(bank, address);
             line.high = readVideo(bank, address + 1);
-            line.pixel = 0;
-            // Find a non-transparent pixel only to keep the candidate's palette and priority
-            // available to the composition loop. The exact pixel is refreshed in spriteAt.
             spriteOrder[spriteCount] = spriteCount;
             spriteCount++;
         }
@@ -422,6 +472,5 @@ public final class PerformanceScanlineRenderer {
         private int palette;
         private boolean priority;
         private boolean xFlip;
-        private int pixel;
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memory.Ram;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -34,6 +35,12 @@ public final class PerformanceScanlineRenderer {
 
     private static final int SCREEN_WIDTH = Display.DISPLAY_WIDTH;
 
+    private static final int COLOR_MASK = 0xffff;
+
+    private static final int SPRITE_VALID = 1 << 16;
+
+    private static final int SPRITE_PRIORITY = 1 << 17;
+
     private final AddressSpace videoRam0;
 
     private final AddressSpace videoRam1;
@@ -49,6 +56,16 @@ public final class PerformanceScanlineRenderer {
     private final ColorPalette oamPalette;
 
     private final boolean gbc;
+
+    /** Direct aliases are deliberately enabled only for the exact production RAM shape. */
+    private final int[] nativeVideoRam0;
+
+    private final int[] nativeVideoRam1;
+
+    /** Palette rows are live references, so palette writes remain visible after construction. */
+    private final int[][] nativeBgPalettes;
+
+    private final int[][] nativeOamPalettes;
 
     // KEY0 can switch a live CGB between native and DMG-compatible output after boot. Keep this
     // line renderer session-owned but refresh the mode at the same owner-thread boundary as the
@@ -105,6 +122,21 @@ public final class PerformanceScanlineRenderer {
         this.gbc = gbc;
         this.dmgCompat = dmgCompat;
         this.sprites = Objects.requireNonNull(sprites, "sprites");
+        this.nativeVideoRam0 = exactVram(videoRam0);
+        this.nativeVideoRam1 = exactVram(videoRam1);
+        if (gbc
+                && bgPalette.getClass() == ColorPalette.class
+                && oamPalette.getClass() == ColorPalette.class) {
+            this.nativeBgPalettes = new int[8][];
+            this.nativeOamPalettes = new int[8][];
+            for (int i = 0; i < 8; i++) {
+                nativeBgPalettes[i] = bgPalette.getPalette(i);
+                nativeOamPalettes[i] = oamPalette.getPalette(i);
+            }
+        } else {
+            this.nativeBgPalettes = null;
+            this.nativeOamPalettes = null;
+        }
         if (sprites.length > 10) {
             throw new IllegalArgumentException("A Game Boy line can select at most 10 sprites");
         }
@@ -149,6 +181,14 @@ public final class PerformanceScanlineRenderer {
         Objects.requireNonNull(output, "output");
         if (output.length < SCREEN_WIDTH) {
             throw new IllegalArgumentException("Scanline output must contain 160 pixels");
+        }
+        if (gbc && !dmgCompat
+                && nativeVideoRam0 != null
+                && nativeVideoRam1 != null
+                && nativeBgPalettes != null
+                && nativeOamPalettes != null) {
+            renderNativeCgbLine(ly, windowLine, output);
+            return;
         }
         prepareSprites(ly);
         boolean objEnabled = lcdc.isObjDisplay();
@@ -243,6 +283,92 @@ public final class PerformanceScanlineRenderer {
                     bgp,
                     obp0,
                     obp1);
+        }
+    }
+
+    /**
+     * Stable owner-side boundary for the PERFORMANCE scanline call. R8 keeps this small method
+     * as a separate optimization unit so the generic scheduler cannot absorb the renderer body.
+     */
+    void renderLinePerformanceBoundary(Display display, int ly, int windowLine) {
+        renderLine(display, ly, windowLine);
+    }
+
+    private void renderNativeCgbLine(int ly, int windowLine, int[] output) {
+        prepareSprites(ly);
+        prepareNativeSpriteOverlay(lcdc.isObjDisplay());
+
+        int scx = registers.get(SCX) & 0xff;
+        int scy = registers.get(SCY) & 0xff;
+        int wy = registers.get(WY) & 0xff;
+        int wx = registers.get(WX) & 0xff;
+        boolean bgEnabled = lcdc.isBgAndWindowDisplay();
+        boolean windowEnabled = lcdc.isWindowDisplay()
+                && ly >= wy
+                && wx < 167;
+        int windowLeft = wx <= 7 ? 0 : wx - 7;
+        int windowY = windowLine >= 0 ? windowLine : Math.max(0, ly - wy);
+        int bgMap = lcdc.getBgTileMapDisplay();
+        int windowMap = lcdc.getWindowTileMapDisplay();
+        boolean signedTileIds = lcdc.isBgWindowTileDataSigned();
+        int bgMapY = (scy + ly) & 0xff;
+
+        if (windowEnabled && windowLeft > 0) {
+            renderNativeTileRun(0, windowLeft, scx, bgMapY, bgMap, signedTileIds, bgEnabled, output);
+            renderNativeTileRun(windowLeft, SCREEN_WIDTH, 0, windowY, windowMap,
+                    signedTileIds, bgEnabled, output);
+        } else if (windowEnabled) {
+            renderNativeTileRun(0, SCREEN_WIDTH, 0, windowY, windowMap,
+                    signedTileIds, bgEnabled, output);
+        } else {
+            renderNativeTileRun(0, SCREEN_WIDTH, scx, bgMapY, bgMap,
+                    signedTileIds, bgEnabled, output);
+        }
+    }
+
+    private void renderNativeTileRun(
+            int startX,
+            int endX,
+            int mapX,
+            int mapY,
+            int mapBase,
+            boolean signedTileIds,
+            boolean bgEnabled,
+            int[] output) {
+        int x = startX;
+        mapX &= 0xff;
+        int mapRow = ((mapY >> 3) & 0x1f) << 5;
+        int sourceRow = mapY & 7;
+        while (x < endX) {
+            int mapAddress = mapBase + mapRow + ((mapX >> 3) & 0x1f);
+            int tileId = nativeVideoRam0[mapAddress - 0x8000] & 0xff;
+            int attributes = nativeVideoRam1[mapAddress - 0x8000] & 0xff;
+            int tileRow = (attributes & 0x40) == 0 ? sourceRow : 7 - sourceRow;
+            int bank = (attributes >> 3) & 1;
+            int address = tileAddress(tileId, tileRow, signedTileIds) - 0x8000;
+            int low = (bank == 0 ? nativeVideoRam0 : nativeVideoRam1)[address] & 0xff;
+            int high = (bank == 0 ? nativeVideoRam0 : nativeVideoRam1)[address + 1] & 0xff;
+            int palette = attributes & 7;
+            boolean backgroundPriority = (attributes & 0x80) != 0;
+            boolean xFlip = (attributes & 0x20) != 0;
+            int pixels = Math.min(endX - x, 8 - (mapX & 7));
+            int bit = xFlip ? mapX & 7 : 7 - (mapX & 7);
+            int step = xFlip ? 1 : -1;
+            int[] paletteRow = nativeBgPalettes[palette];
+            for (int i = 0; i < pixels; i++) {
+                int backgroundRaw = ((low >> bit) & 1) | (((high >> bit) & 1) << 1);
+                int packedSprite = spriteOverlay[x];
+                int color = paletteRow[backgroundRaw] & COLOR_MASK;
+                if ((packedSprite & SPRITE_VALID) != 0
+                        && (!bgEnabled
+                        || backgroundRaw == 0
+                        || (!backgroundPriority && (packedSprite & SPRITE_PRIORITY) == 0))) {
+                    color = packedSprite & COLOR_MASK;
+                }
+                output[x++] = color;
+                bit += step;
+            }
+            mapX = (mapX + pixels) & 0xff;
         }
     }
 
@@ -387,6 +513,31 @@ public final class PerformanceScanlineRenderer {
         }
     }
 
+    private void prepareNativeSpriteOverlay(boolean objEnabled) {
+        Arrays.fill(spriteOverlay, 0);
+        if (!objEnabled) {
+            return;
+        }
+        // CGB priority is OAM-index based. Painting high indices first and allowing lower
+        // indices to overwrite preserves the first (lowest-address) non-transparent pixel.
+        for (int order = spriteCount - 1; order >= 0; order--) {
+            SpriteLine sprite = spriteLines[spriteOrder[order]];
+            int start = Math.max(0, sprite.left);
+            int end = Math.min(SCREEN_WIDTH, sprite.left + 8);
+            int[] palette = nativeOamPalettes[sprite.palette];
+            for (int x = start; x < end; x++) {
+                int pixelX = x - sprite.left;
+                int bit = sprite.xFlip ? pixelX : 7 - pixelX;
+                int raw = ((sprite.low >> bit) & 1) | (((sprite.high >> bit) & 1) << 1);
+                if (raw != 0) {
+                    spriteOverlay[x] = (palette[raw] & COLOR_MASK)
+                            | SPRITE_VALID
+                            | (sprite.priority ? SPRITE_PRIORITY : 0);
+                }
+            }
+        }
+    }
+
     private void prepareSprites(int ly) {
         spriteCount = 0;
         int spriteHeight = lcdc.getSpriteHeight();
@@ -462,6 +613,21 @@ public final class PerformanceScanlineRenderer {
             return videoRam1.getByte(address) & 0xff;
         }
         return videoRam0.getByte(address) & 0xff;
+    }
+
+    private static int[] exactVram(AddressSpace space) {
+        if (space == null || space.getClass() != Ram.class) {
+            return null;
+        }
+        Ram ram = (Ram) space;
+        if (ram.getSpace().length != 0x2000
+                || !ram.accepts(0x8000)
+                || !ram.accepts(0x9fff)
+                || ram.accepts(0x7fff)
+                || ram.accepts(0xa000)) {
+            return null;
+        }
+        return ram.getSpace();
     }
 
     private final class SpriteLine {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PixelFifo.java
@@ -14,6 +14,23 @@ public interface PixelFifo {
     }
 
     /**
+     * Whether the LCD output delay line is empty and its absolute clock can therefore be
+     * advanced without resolving or publishing a pixel.
+     *
+     * <p>This is deliberately fail-closed by default.  Native-CGB PERFORMANCE mode 2 uses
+     * the specialized implementations below only after the owning pixel machine has stopped;
+     * every other FIFO family keeps its calibrated scalar output path.</p>
+     */
+    default boolean isPerformanceOutputIdle() {
+        return false;
+    }
+
+    /** Advances only the absolute LCD output clock after {@link #isPerformanceOutputIdle()}. */
+    default void advancePerformanceOutputIdleSpanTrusted(int ticks) {
+        throw new IllegalStateException("FIFO has no PERFORMANCE idle-output span");
+    }
+
+    /**
      * Steps the LCD x pointer back one pixel (the DMG WX==position+6 window activation
      * desync): the next emitted pixel overwrites the previous output slot.
      */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ScalarTimingColorPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ScalarTimingColorPixelFifo.java
@@ -58,6 +58,19 @@ public final class ScalarTimingColorPixelFifo implements PixelFifo {
     }
 
     @Override
+    public boolean isPerformanceOutputIdle() {
+        return delaySize == 0;
+    }
+
+    @Override
+    public void advancePerformanceOutputIdleSpanTrusted(int ticks) {
+        if (ticks < 0 || delaySize != 0) {
+            throw new IllegalStateException("CGB timing output delay is not idle");
+        }
+        outputTicks += ticks;
+    }
+
+    @Override
     public void rewindOnePixel() {
         if (linePixels == 0) {
             return;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ScalarTimingDmgPixelFifo.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/ScalarTimingDmgPixelFifo.java
@@ -149,6 +149,19 @@ public final class ScalarTimingDmgPixelFifo implements PixelFifo {
     }
 
     @Override
+    public boolean isPerformanceOutputIdle() {
+        return delaySize == 0 && !firstEntryPresent;
+    }
+
+    @Override
+    public void advancePerformanceOutputIdleSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceOutputIdle()) {
+            throw new IllegalStateException("DMG timing output delay is not idle");
+        }
+        outputTicks += ticks;
+    }
+
+    @Override
     public void resetForMissingState() {
         clear();
         java.util.Arrays.fill(delayStamp, 0L);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -790,6 +790,41 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         return isMode0InterruptEdgeNextTickPrepared();
     }
 
+    /**
+     * Native-CGB PERFORMANCE equivalent of {@link #beginCpuReadPhase(int)}. The native owner
+     * supplies the current line and the two double-speed mode-0 lookahead bits directly, so the
+     * common scalar miss does not construct or refresh the general GPU timing snapshot.
+     */
+    public boolean beginNativeCgbPerformanceReadPhase(int statReadPhaseFlags, int phaseWord) {
+        captureNativeCgbPerformanceReadPhasePrepared(statReadPhaseFlags);
+        if (!canPublishMode0InterruptEdge()
+                || (phaseWord & Gpu.NATIVE_CGB_PHASE_MODE0_EDGE_NEXT) == 0) {
+            return false;
+        }
+        return !((mode0IrqStatLatch & 0x40) != 0
+                && (phaseWord & Gpu.NATIVE_CGB_PHASE_LINE_MASK) == mode0IrqLycLatch);
+    }
+
+    /** Native owner-side copy of the packed CPU phase bookkeeping. */
+    private void captureNativeCgbPerformanceReadPhasePrepared(int statReadPhaseFlags) {
+        boolean ordinaryHaltWakePhase = (statReadPhaseFlags
+                & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0;
+        if (ordinaryHaltWakePhase && !previousOrdinaryHaltWakePhase) {
+            ordinaryHaltWakeStatClock = lycIrqClock;
+        }
+        previousOrdinaryHaltWakePhase = ordinaryHaltWakePhase;
+        boolean recentOrdinaryHaltWakePhase = ordinaryHaltWakePhase
+                && ordinaryHaltWakeStatClock != NO_LYC_IRQ_EVENT
+                && lycIrqClock - ordinaryHaltWakeStatClock
+                <= ORDINARY_HALT_WAKE_STAT_HOLD_TICKS;
+        statReadPhaseFlags &= ~STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
+        if (recentOrdinaryHaltWakePhase) {
+            statReadPhaseFlags |= STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
+        }
+        cpuStatReadPhaseFlags = statReadPhaseFlags;
+        cpuStatModeOverride = CPU_STAT_MODE_UNRESOLVED;
+    }
+
     /** Completes the production pre-CPU STAT phase after refreshing only if it needs timing. */
     public void finishCpuReadPhase(int interruptFlagReadMaskTicks,
                                    boolean mode0InterruptDispatchPhased,
@@ -806,6 +841,25 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
         captureCpuInterruptReadPhasePrepared(interruptFlagReadMaskTicks,
                 mode0InterruptDispatchPhased, mode0InstructionWinsAcceptance);
         publishFrameLyc0Mode2HandoffBeforeCpuPrepared();
+    }
+
+    /** Completes the native-CGB PERFORMANCE CPU/STAT phase without a timing snapshot. */
+    public void finishNativeCgbPerformanceReadPhase(int interruptFlagReadMaskTicks,
+                                                    int phaseWord) {
+        cpuInterruptFlagReadMaskTicks = interruptFlagReadMaskTicks;
+        cpuMode0InterruptDispatchPhased = false;
+        cpuMode0InstructionWinsAcceptance = false;
+        boolean mode0Enabled = isMode0InterruptPreviewEnabled();
+        if (!mode0Enabled && !pendingCgbMode2Interrupt && enableBits != 0x20) {
+            return;
+        }
+        int line = phaseWord & Gpu.NATIVE_CGB_PHASE_LINE_MASK;
+        boolean mode0SourceEnabled = mode0Enabled
+                && !((mode0IrqStatLatch & 0x40) != 0 && line == mode0IrqLycLatch);
+        boolean doubleSpeedMode0 = mode0SourceEnabled
+                && enableBits == 0x48
+                && (phaseWord & Gpu.NATIVE_CGB_PHASE_MODE0_READ_PREVIEW) != 0;
+        interruptManager.setCpuReadPpuInterruptPreview(doubleSpeedMode0, false);
     }
 
     /** Captures the PPU mux phase before this tick's CPU memory callback. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -569,6 +569,316 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     }
 
     /**
+     * Completes a native-CGB PERFORMANCE scalar dot after the GPU owner has advanced it.
+     *
+     * <p>The CPU-side native prologue has already captured this dot's read phase. Capture the
+     * post-GPU timing directly into the reusable snapshot, then run the byte-for-byte scalar
+     * evaluator. All non-native paths continue to call {@link #tick()} unchanged.</p>
+     */
+    public void tickNativeCgbPerformancePostGpu() {
+        int nativePostGpuFacts = gpu.getNativeCgbPerformancePostStatFacts();
+        if ((nativePostGpuFacts & Gpu.NATIVE_CGB_POST_STAT_FACTS_VALID) == 0) {
+            tick();
+            return;
+        }
+        interruptManager.finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview();
+        lycIrqClock++;
+        clearCpuStatReadPhase();
+        int ppuTickSignals = interruptManager.consumePpuTickSignals();
+        boolean statEventCheckpoint =
+                (nativePostGpuFacts & Gpu.NATIVE_CGB_POST_STAT_CHECKPOINT) != 0;
+        boolean scheduledEvent = nextLycIrqEvent == lycIrqClock
+                || pendingLycWriteIrq == lycIrqClock
+                || pendingLycComparatorIrq == lycIrqClock;
+        boolean hasPendingModeRegisterClock = pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingModeIrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqLycClock != NO_LYC_IRQ_EVENT;
+        if (!statEvaluationDirty && !statEventCheckpoint && ppuTickSignals == 0
+                && !pendingCgbMode0Interrupt && !hasPendingModeRegisterClock
+                && !scheduledEvent) {
+            return;
+        }
+
+        timingGeneration = gpu.captureNativeCgbPerformancePostStatTiming(timing);
+        int currentLine = timing.line;
+        int currentTicksInLine = timing.ticksInLine;
+        boolean currentGbc = gbc;
+        boolean currentDmgCompat = timing.dmgCompat;
+        boolean currentLcdEnabled = timing.lcdEnabled;
+        boolean currentFirstLine = timing.firstLine;
+        int currentMode0InterruptTick = timing.mode0InterruptTick;
+        int currentCpuMachineCycleDots = timing.cpuMachineCycleDots;
+        boolean currentDoubleSpeed = timing.doubleSpeed;
+        boolean currentNativeDoubleSpeed = timing.nativeDoubleSpeed;
+        boolean mustEvaluateStat = statEvaluationDirty || statEventCheckpoint
+                || ppuTickSignals != 0;
+        if ((ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_ACKNOWLEDGE) != 0) {
+            lastLcdcInterruptAcknowledgeClock = lycIrqClock;
+            if (currentNativeDoubleSpeed
+                    && previousMode0Window
+                    && currentTicksInLine == currentMode0InterruptTick + 1
+                    && mode0EventArmed
+                    && ((enableBits | mode0IrqStatLatch) & 0x08) != 0
+                    && !((mode0IrqStatLatch & 0x40) != 0
+                    && currentLine == mode0IrqLycLatch)) {
+                // In native double speed, the mode-0 set latch owns the CPU
+                // acknowledge slot immediately following its event. A later
+                // acknowledge still consumes the stored request normally.
+                interruptManager.requestInterruptBeforeHaltWake(InterruptType.LCDC);
+            }
+        }
+        if ((ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_VBLANK_INTERRUPT_ACKNOWLEDGE) != 0) {
+            lastVBlankInterruptAcknowledgeClock = lycIrqClock;
+        }
+        boolean lcdcInterruptFlagWriteClear = (ppuTickSignals
+                & InterruptManager.PPU_TICK_SIGNAL_LCDC_INTERRUPT_FLAG_WRITE_CLEAR) != 0;
+        if (lcdcInterruptFlagWriteClear
+                && currentGbc && !currentDmgCompat
+                && previousMode0Window
+                && (currentTicksInLine == currentMode0InterruptTick
+                + (currentDoubleSpeed ? 2 : 1)
+                || currentDoubleSpeed && currentTicksInLine
+                == currentMode0InterruptTick + 3)
+                && mode0EventArmed
+                && ((enableBits | mode0IrqStatLatch) & 0x08) != 0
+                && !((mode0IrqStatLatch & 0x40) != 0
+                && currentLine == mode0IrqLycLatch)) {
+            // An FF0F clear and the normal-speed CGB mode-0 set share this bus
+            // slot. The captured PPU set wins; a clear in the next slot does not.
+            interruptManager.requestInterruptBeforeHaltWake(InterruptType.LCDC);
+        }
+        if (pendingCgbMode0Interrupt) {
+            interruptManager.requestInterruptBeforeHaltWake(InterruptType.LCDC);
+            pendingCgbMode0Interrupt = false;
+            mustEvaluateStat = true;
+        }
+        boolean pendingModeLatchChanged = false;
+        if (pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingModeIrqLycClock != NO_LYC_IRQ_EVENT) {
+            pendingModeLatchChanged = commitPendingModeIrqRegisters();
+        }
+        if (pendingMode0IrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqLycClock != NO_LYC_IRQ_EVENT) {
+            pendingModeLatchChanged |= commitPendingMode0IrqRegisters();
+        }
+        mustEvaluateStat |= pendingModeLatchChanged;
+        mustEvaluateStat |= scheduledEvent;
+        boolean suppressNaturalModeEdge = mustEvaluateStat
+                && updateModeIrqEvents(lcdcInterruptFlagWriteClear);
+        if (pendingCgbMode2Interrupt && currentTicksInLine == 452) {
+            publishPendingCgbMode2Event();
+        }
+        if (pendingCgbMode2LateReplay && currentTicksInLine == 455) {
+            publishPendingCgbMode2Replay();
+        }
+        if (pendingCgbMode2LateReplay && retractableCgbMode2Interrupt
+                && cgbMode2CapturedAtLineEdge && (modeIrqStatLatch & 0x40) == 0
+                && currentTicksInLine == 454) {
+            interruptManager.maskLcdcUntilNextPeripheralTick();
+        }
+        boolean publishCgbFrameMode2 = pendingCgbFrameMode2Interrupt && !currentDoubleSpeed
+                && ((getNormalSpeedClockPhase() == 0
+                && currentLine == 153 && currentTicksInLine == 455)
+                || (getNormalSpeedClockPhase() == 1
+                && currentLine == 0 && currentTicksInLine == 0));
+        if (publishCgbFrameMode2) {
+            // The normal-speed frame mode-2 event captures FF41/FF45 at dot 454.
+            // A speed-switch clock rephase moves publication across the rollover.
+            if (getNormalSpeedClockPhase() == 1) {
+                interruptManager.requestInterruptBeforeCpuAcceptanceUnphased(
+                        InterruptType.LCDC);
+            } else {
+                interruptManager.requestMode2InterruptBeforeCpuAcceptance(false);
+            }
+            pendingCgbFrameMode2Interrupt = false;
+        }
+        if (retractableCgbMode2Interrupt && currentTicksInLine > 454) {
+            retractableCgbMode2Interrupt = false;
+        }
+        if (!mustEvaluateStat) {
+            return;
+        }
+        boolean settlingLycLine = false;
+        if (currentLcdEnabled) {
+            int ticksInLine = currentTicksInLine;
+            if (suppressedLycIrqLine >= 0
+                    && registeredLy != suppressedLycIrqLine
+                    && timing.visibleLy != suppressedLycIrqLine
+                    && !(suppressedLycIrqLine == 153 && currentLine == 153)) {
+                suppressedLycIrqLine = -1;
+            }
+            if (modeBlockedLycIrqLine >= 0
+                    && registeredLy != modeBlockedLycIrqLine
+                    && timing.visibleLy != modeBlockedLycIrqLine) {
+                modeBlockedLycIrqLine = -1;
+            }
+            boolean lycComparePhase = (currentLine != 153 && ticksInLine == 454)
+                    || (currentLine == 153 && ticksInLine == 6);
+            if (lycComparePhase) {
+                int comparedLy = comparedLycIrqLine();
+                int comparedLyc = nextLycIrqEvent == lycIrqClock
+                        ? lycIrqValueLatch
+                        : lycIrqValueSource;
+                lycComparatorSignal = comparedLyc == comparedLy;
+            }
+            if (releaseTailLycCpuAcceptance && ticksInLine == 455) {
+                if (currentGbc || gpu.hasObjectsOnLine()) {
+                    interruptManager.releaseCpuAcceptance(InterruptType.LCDC);
+                } else {
+                    interruptManager.releaseHaltWake(InterruptType.LCDC);
+                }
+                releaseTailLycCpuAcceptance = false;
+            }
+            if (nextLycIrqEvent == lycIrqClock) {
+                fireLycIrqEvent();
+            }
+            if (pendingLycWriteIrq == lycIrqClock) {
+                interruptManager.requestInterrupt(InterruptType.LCDC);
+                pendingLycWriteIrq = NO_LYC_IRQ_EVENT;
+            }
+            if (pendingLycComparatorIrq == lycIrqClock) {
+                interruptManager.requestInterruptBeforeHaltWake(InterruptType.LCDC);
+                pendingLycComparatorIrq = NO_LYC_IRQ_EVENT;
+            }
+            boolean nativeDoubleTailLycLatch = currentNativeDoubleSpeed
+                    && ticksInLine == CGB_DOUBLE_TAIL_LATCH
+                    && currentLine != 153;
+            // In double-speed mode the PPU's line-144 request is readable during
+            // the last two dots of line 143. CPU acceptance remains synchronized
+            // to the internal rollover, preserving ordinary VBlank dispatch timing.
+            if (currentNativeDoubleSpeed && currentLine == 143
+                    && ticksInLine == CGB_DOUBLE_TAIL_LATCH) {
+                if (!recentVBlankAcknowledgeWins()) {
+                    interruptManager.requestInterruptBeforeCpuAcceptanceUnphased(
+                            InterruptType.VBlank);
+                }
+            }
+            if (timing.mode0HaltWakeTick) {
+                interruptManager.releaseHaltWake(InterruptType.LCDC);
+            }
+            if (currentGbc && ticksInLine == currentCpuMachineCycleDots) {
+                interruptManager.releaseHaltWake(InterruptType.LCDC);
+            }
+            // The LY=0 comparison reaches IF four dots after readable LY falls
+            // (dot 8 normally, dot 6 in native double speed), then crosses the
+            // CPU/HALT input synchronizer one CPU M-cycle later.
+            if (currentLine == 153 && ticksInLine == getNewFrameLycCpuAcceptTick()) {
+                interruptManager.releaseHaltWake(InterruptType.LCDC);
+            }
+            if ((currentLine <= 144 || currentGbc) && ticksInLine == 0) {
+                // Release a request latched in the preceding line's tail before a
+                // possible new edge is registered below. Native double speed also
+                // latches LYC requests this way during VBlank (for example 151->152).
+                // PixelTransfer still describes the preceding line here. On DMG an
+                // object-stalled line holds the early mode-2 edge away from both CPU
+                // inputs until rollover; a BG-only line only holds the HALT path.
+                if (currentGbc || gpu.hasObjectsOnLine()) {
+                    interruptManager.releaseCpuAcceptance(InterruptType.LCDC);
+                } else {
+                    interruptManager.releaseHaltWake(InterruptType.LCDC);
+                }
+            }
+            if (lycWriteSuppressed
+                    && ((currentLine != 153 && ticksInLine == 0)
+                    || (currentLine == 153 && ticksInLine == getNewFrameLycEdgeTick()))) {
+                lycWriteSuppressed = false;
+            }
+            // The normal comparison uses LY registered at the line start. Native
+            // double speed has a separate tail latch at dot 454; the extra speed-scaled
+            // latch handles the LY=153 -> 0 transition during line 153.
+            if (ticksInLine == 0 || ticksInLine == getNewFrameLycEdgeTick()
+                    || nativeDoubleTailLycLatch) {
+                // On monochrome hardware LY has already returned to 0 when line 153
+                // starts, but the comparator still samples the short-lived 153 value.
+                registeredLy = currentLine == 153 && ticksInLine == 0
+                        ? 153
+                        : timing.visibleLy;
+            }
+            coincidence = registeredLy == registers.get(LYC);
+            int coincidenceReleaseTick = currentFirstLine ? 452 : 454;
+            boolean coincidenceRelease = currentGbc
+                    && !(currentFirstLine && !currentDoubleSpeed)
+                    ? ticksInLine > coincidenceReleaseTick
+                    : ticksInLine >= coincidenceReleaseTick;
+            boolean nativeDoubleTailComparison = currentNativeDoubleSpeed
+                    && ticksInLine >= CGB_DOUBLE_TAIL_LATCH
+                    && currentLine != 153;
+            if ((coincidenceRelease && !nativeDoubleTailComparison
+                    && currentLine != 153)
+                    || (!currentGbc && currentLine == 153
+                    && ticksInLine >= 4 && ticksInLine < getNewFrameLycEdgeTick())
+                    || lycWriteSuppressed) {
+                // when LY changes, the comparison result reads 0 until the new value
+                // is registered at the beginning of the next line (lcdon_timing-GS);
+                // at the end of line 153 the comparison stays valid: LY already flipped
+                // to 0 at tick 8 and keeps that value into line 0, so an LYC=0
+                // interrupt fires only once per frame there
+                coincidence = false;
+            }
+
+            intCoincidence = coincidence;
+            boolean suppressedLycComparison = registeredLy == suppressedLycIrqLine
+                    || timing.visibleLy == suppressedLycIrqLine;
+            if (suppressedLycComparison) {
+                intCoincidence = false;
+            }
+            if (ticksInLine < 4 && currentLine != 0
+                    && currentLine != 144 && currentLine != 153) {
+                intCoincidence = false;
+                settlingLycLine = coincidence
+                        && !suppressedLycComparison
+                        && (enableBits & 0b01000000) != 0;
+                boolean mode0ToLycPrecedence = intLine
+                        && (enableBits & 0x08) != 0
+                        && (enableBits & 0x20) == 0;
+                if (ticksInLine == 0 && settlingLycLine
+                        && (!intLine || mode0ToLycPrecedence)) {
+                    // The comparison edge reaches IF at the line-start latch,
+                    // before its level contribution to the STAT line settles. A mode-0
+                    // source retiring on this boundary does not mask the higher-priority
+                    // LYC edge unless mode 2 is selected too. Keep the edge detector
+                    // latched across the settling window: if IRQ dispatch clears IF
+                    // before tick 4, the comparison must not be observed twice.
+                    if (timing.nativeDoubleSpeed) {
+                        interruptManager.requestInterrupt(InterruptType.LCDC);
+                    } else if (currentGbc) {
+                        interruptManager.requestPhasedInterruptBeforeHaltWake(InterruptType.LCDC);
+                    } else {
+                        interruptManager.requestInterrupt(InterruptType.LCDC);
+                    }
+                    intLine = true;
+                }
+            }
+            if (currentLine == 144 && ticksInLine == 0) {
+                if (timing.nativeDoubleSpeed) {
+                    interruptManager.releaseCpuAcceptance(InterruptType.VBlank);
+                } else if (!recentVBlankAcknowledgeWins()) {
+                    interruptManager.requestInterrupt(InterruptType.VBlank);
+                }
+            }
+        }
+
+        boolean holdModeBlockedLycLine = modeBlockedLycIrqLine >= 0
+                && (registeredLy == modeBlockedLycIrqLine
+                || timing.visibleLy == modeBlockedLycIrqLine)
+                && !intCoincidence && intLine;
+        if (!settlingLycLine && !holdModeBlockedLycLine) {
+            boolean newLine = computeIntLine(enableBits);
+            if (suppressNaturalModeEdge) {
+                // Keep the shared level latch synchronized without recreating
+                // an edge that the captured FF41/FF45 copies masked.
+                intLine = newLine;
+            } else {
+                updateIntLine(newLine);
+            }
+        }
+        statEvaluationDirty = false;
+    }
+
+    /**
      * Performs the invariant portion of a quiet PERFORMANCE STAT tick.
      *
      * <p>During a proven sprite/window-free mode-3 span no STAT source, event checkpoint, or

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -272,7 +272,24 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
      * or externally observed non-canonical phase stays on the exact dot path.</p>
      */
     public boolean isPerformanceNoDmaStableSpanEligible(int readerPosition, int spriteHeight) {
-        if (!registers.isGbc() || registers.getSpeedMode() != 2
+        return isPerformanceMode2SpanEligible(readerPosition, spriteHeight, true, 2);
+    }
+
+    /**
+     * Whether a bounded physical-DMG mode-2 span can use the allocation-free OAM scanner.
+     *
+     * <p>The DMG and native-CGB readers share the same two-dot Y/X slot arithmetic.  Their
+     * topology and speed are kept as explicit arguments here so the fast path cannot silently
+     * widen to CGB compatibility or another clock domain.</p>
+     */
+    public boolean isPerformancePhysicalDmgMode2SpanEligible(
+            int readerPosition, int spriteHeight) {
+        return isPerformanceMode2SpanEligible(readerPosition, spriteHeight, false, 1);
+    }
+
+    private boolean isPerformanceMode2SpanEligible(
+            int readerPosition, int spriteHeight, boolean expectedGbc, int expectedSpeedMode) {
+        if (registers.isGbc() != expectedGbc || registers.getSpeedMode() != expectedSpeedMode
                 || readerPosition < 0 || readerPosition >= 79
                 || !selectSprites || !oamReaderInitialized || oamReaderDmaSource
                 || !(oemRam instanceof Ram)
@@ -299,9 +316,21 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
      */
     public void advancePerformanceNoDmaStableSpanTrusted(
             int readerPosition, int ticks, int currentSpriteHeight) {
+        advancePerformanceMode2SpanTrusted(readerPosition, ticks, currentSpriteHeight, true, 2);
+    }
+
+    /** Advances a preflighted physical-DMG mode-2 prefix using the same exact slot arithmetic. */
+    public void advancePerformancePhysicalDmgMode2SpanTrusted(
+            int readerPosition, int ticks, int currentSpriteHeight) {
+        advancePerformanceMode2SpanTrusted(readerPosition, ticks, currentSpriteHeight, false, 1);
+    }
+
+    private void advancePerformanceMode2SpanTrusted(
+            int readerPosition, int ticks, int currentSpriteHeight,
+            boolean expectedGbc, int expectedSpeedMode) {
         if (ticks < 0 || readerPosition + ticks > 79
-                || !isPerformanceNoDmaStableSpanEligible(
-                readerPosition, currentSpriteHeight)) {
+                || !isPerformanceMode2SpanEligible(
+                readerPosition, currentSpriteHeight, expectedGbc, expectedSpeedMode)) {
             throw new IllegalStateException("OAM reader is not eligible for a PERFORMANCE span");
         }
         if (ticks == 0) {
@@ -317,24 +346,24 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
         if ((position & 1) != 0) {
             position++;
             samplePerformanceOamWord(oam, position / 2);
-            commitPerformanceXHalf(currentSpriteHeight);
+            commitPerformanceXHalf(currentSpriteHeight, expectedGbc);
             remaining--;
         }
 
         // At an even stored position the search is aligned to a complete two-dot slot.
         while (remaining >= 2) {
             position++;
-            latchPerformanceYHalf(currentSpriteHeight);
+            latchPerformanceYHalf(currentSpriteHeight, expectedGbc);
             position++;
             samplePerformanceOamWord(oam, position / 2);
-            commitPerformanceXHalf(currentSpriteHeight);
+            commitPerformanceXHalf(currentSpriteHeight, expectedGbc);
             remaining -= 2;
         }
 
         if (remaining != 0) {
             // The cap at stored dot 79 deliberately leaves entry 39's X half for the scalar
             // dot-80 mode-3 handoff.
-            latchPerformanceYHalf(currentSpriteHeight);
+            latchPerformanceYHalf(currentSpriteHeight, expectedGbc);
         }
 
         previousOamSpriteHeight = currentSpriteHeight;
@@ -349,15 +378,21 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
         oamReaderX[entry] = oamReaderBusX;
     }
 
-    private void latchPerformanceYHalf(int currentSpriteHeight) {
+    private void latchPerformanceYHalf(int currentSpriteHeight, boolean expectedGbc) {
         spriteY = oamReaderY[i];
         spriteX = oamReaderX[i];
-        spriteHeight = currentSpriteHeight;
+        // Native CGB latches the size source with the Y half. DMG leaves the previous
+        // spriteHeight bus value alone until the X half assigns the live height.
+        if (expectedGbc) {
+            spriteHeight = currentSpriteHeight;
+        }
         state = State.READING_X;
     }
 
-    private void commitPerformanceXHalf(int currentSpriteHeight) {
-        spriteHeight = Math.max(spriteHeight, currentSpriteHeight);
+    private void commitPerformanceXHalf(int currentSpriteHeight, boolean expectedGbc) {
+        spriteHeight = expectedGbc
+                ? Math.max(spriteHeight, currentSpriteHeight)
+                : currentSpriteHeight;
         boolean candidate = between(spriteY, registers.get(GpuRegister.LY) + 16,
                 spriteY + spriteHeight);
         spriteCandidateSeen |= candidate;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -10,6 +10,7 @@ import eu.rekawek.coffeegb.core.state.MachineStateCapture;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 import eu.rekawek.coffeegb.core.memory.Dma;
+import eu.rekawek.coffeegb.core.memory.Ram;
 
 import java.util.Arrays;
 
@@ -261,6 +262,110 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
     /** Whether the persistent OAM reader has captured its initial OAM contents. */
     public boolean isOamReaderInitialized() {
         return oamReaderInitialized;
+    }
+
+    /**
+     * Whether a bounded native-CGB mode-2 span can use the allocation-free OAM scanner.
+     *
+     * <p>The GPU owns the broader DMA/HDMA and observation proof.  This local predicate pins
+     * the persistent reader and half-slot state to the current raster position, so a restored
+     * or externally observed non-canonical phase stays on the exact dot path.</p>
+     */
+    public boolean isPerformanceNoDmaStableSpanEligible(int readerPosition, int spriteHeight) {
+        if (!registers.isGbc() || registers.getSpeedMode() != 2
+                || readerPosition < 0 || readerPosition >= 79
+                || !selectSprites || !oamReaderInitialized || oamReaderDmaSource
+                || !(oemRam instanceof Ram)
+                || dma.isTransferInProgress() || dma.ownsOamForPpu()
+                || dma.hasPpuOamOwnershipTransitionThisTick()
+                || previousOamSpriteHeight != spriteHeight) {
+            return false;
+        }
+        int expectedIndex = readerPosition / 2;
+        State expectedState = (readerPosition & 1) == 0
+                ? State.READING_Y : State.READING_X;
+        return i == expectedIndex
+                && state == expectedState
+                && (state != State.READING_X || this.spriteHeight == spriteHeight);
+    }
+
+    /**
+     * Advances an already-preflighted, constant-height, no-DMA OAM-search prefix.
+     *
+     * <p>A mode-2 slot consists of an odd Y half followed by an even X half.  The even reader
+     * position samples the next OAM word before the current candidate is committed.  Handling
+     * a possible leading/trailing half-slot around a two-dot loop preserves that ordering while
+     * removing the general phase, DMA-source, and delayed-LCDC checks from every dot.</p>
+     */
+    public void advancePerformanceNoDmaStableSpanTrusted(
+            int readerPosition, int ticks, int currentSpriteHeight) {
+        if (ticks < 0 || readerPosition + ticks > 79
+                || !isPerformanceNoDmaStableSpanEligible(
+                readerPosition, currentSpriteHeight)) {
+            throw new IllegalStateException("OAM reader is not eligible for a PERFORMANCE span");
+        }
+        if (ticks == 0) {
+            return;
+        }
+
+        int[] oam = ((Ram) oemRam).getSpace();
+        int position = readerPosition;
+        int remaining = ticks;
+
+        // An odd stored position has already latched Y.  The next even position samples the
+        // following reader word and then commits the current X half.
+        if ((position & 1) != 0) {
+            position++;
+            samplePerformanceOamWord(oam, position / 2);
+            commitPerformanceXHalf(currentSpriteHeight);
+            remaining--;
+        }
+
+        // At an even stored position the search is aligned to a complete two-dot slot.
+        while (remaining >= 2) {
+            position++;
+            latchPerformanceYHalf(currentSpriteHeight);
+            position++;
+            samplePerformanceOamWord(oam, position / 2);
+            commitPerformanceXHalf(currentSpriteHeight);
+            remaining -= 2;
+        }
+
+        if (remaining != 0) {
+            // The cap at stored dot 79 deliberately leaves entry 39's X half for the scalar
+            // dot-80 mode-3 handoff.
+            latchPerformanceYHalf(currentSpriteHeight);
+        }
+
+        previousOamSpriteHeight = currentSpriteHeight;
+        oamReaderSourceChangeTicks = Math.max(0, oamReaderSourceChangeTicks - ticks);
+    }
+
+    private void samplePerformanceOamWord(int[] oam, int entry) {
+        int address = 4 * entry;
+        oamReaderBusY = oam[address];
+        oamReaderBusX = oam[address + 1];
+        oamReaderY[entry] = oamReaderBusY;
+        oamReaderX[entry] = oamReaderBusX;
+    }
+
+    private void latchPerformanceYHalf(int currentSpriteHeight) {
+        spriteY = oamReaderY[i];
+        spriteX = oamReaderX[i];
+        spriteHeight = currentSpriteHeight;
+        state = State.READING_X;
+    }
+
+    private void commitPerformanceXHalf(int currentSpriteHeight) {
+        spriteHeight = Math.max(spriteHeight, currentSpriteHeight);
+        boolean candidate = between(spriteY, registers.get(GpuRegister.LY) + 16,
+                spriteY + spriteHeight);
+        spriteCandidateSeen |= candidate;
+        if (candidate && spritePosIndex < sprites.length) {
+            sprites[spritePosIndex++].enable(spriteX, spriteY, 0xfe00 + 4 * i);
+        }
+        i++;
+        state = State.READING_Y;
     }
 
     /** Reconnects the persistent reader after its clock was stopped with the LCD. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -660,6 +660,55 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
         fifo.clearOutput();
     }
 
+    /**
+     * Native-CGB mode-2 fixed point used by the coarse CPU epoch.  The pixel machine is
+     * stopped between scanlines, so only its absolute LCD output clock normally changes.
+     * Recent window writes and a non-empty delay line deliberately keep the exact dot path.
+     */
+    public boolean isPerformanceNativeCgbMode2IdleOutput() {
+        // Gpu's native mode-2 preflight already proves CGB, non-compat, double-speed
+        // topology. Keeping that proof out of both pixel-machine predicates avoids paying
+        // the same immutable topology branch twice on every native epoch.
+        return isPerformanceIdleOutput();
+    }
+
+    /** Empty physical-DMG LCD output stage used by trusted direct-line HBlank/VBlank spans. */
+    public boolean isPerformanceDmgIdleOutput() {
+        return !gbc && isPerformanceIdleOutput();
+    }
+
+    private boolean isPerformanceIdleOutput() {
+        return
+                // The timing skeleton is driven directly through Gpu.phase.tick(); its
+                // historical machineActive marker remains set after a scalar mode-3 end, but
+                // mode 2 calls only outputTick() and the next start() rebuilds the machine.
+                (timingSkeleton || !machineActive)
+                && fifo.isPerformanceOutputIdle()
+                && pendingWindowDisplayWrites.isEmpty()
+                && pendingWindowXWrites.isEmpty()
+                && windowWyDelay < 0
+                && windowWyOldOnWriteTick < 0;
+    }
+
+    /**
+     * Advances the empty LCD output clock after
+     * {@link #isPerformanceNativeCgbMode2IdleOutput()} under the caller's native-CGB proof.
+     */
+    public void advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceNativeCgbMode2IdleOutput()) {
+            throw new IllegalStateException("Pixel machine is not idle in PERFORMANCE mode 2");
+        }
+        fifo.advancePerformanceOutputIdleSpanTrusted(ticks);
+    }
+
+    /** Advances the empty physical-DMG LCD clock without entering either FIFO dot path. */
+    public void advancePerformanceDmgIdleOutputSpanTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceDmgIdleOutput()) {
+            throw new IllegalStateException("DMG pixel output is not idle in PERFORMANCE span");
+        }
+        fifo.advancePerformanceOutputIdleSpanTrusted(ticks);
+    }
+
     public int getPosition() {
         return position;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -703,9 +703,6 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     /** Advances the empty physical-DMG LCD clock without entering either FIFO dot path. */
     public void advancePerformanceDmgIdleOutputSpanTrusted(int ticks) {
-        if (ticks < 0 || !isPerformanceDmgIdleOutput()) {
-            throw new IllegalStateException("DMG pixel output is not idle in PERFORMANCE span");
-        }
         fifo.advancePerformanceOutputIdleSpanTrusted(ticks);
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -129,6 +129,22 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         // input. There is no arithmetic state to advance, so the trusted commit is a no-op.
     }
 
+    /** True when the native-CGB epoch may treat IR as an idle no-op. */
+    public boolean performanceEpochIdle(int requested) {
+        return gbc
+                && speedMode.getSpeedMode() == 2
+                && requested > 0
+                && !fullChangerActive
+                && endpoint == InfraredEndpoint.NULL_ENDPOINT
+                && serialEndpoint.canTickPerformanceQuietSpan(requested)
+                && debugHooks == null;
+    }
+
+    /** The idle epoch has no IR state to advance. */
+    public void tickPerformanceEpochIdle(int ticks) {
+        // Intentionally empty: the null endpoint and inactive FullChanger were preflighted.
+    }
+
     @Override
     public boolean accepts(int address) {
         return address == 0xff56;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -84,6 +84,15 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      */
     private transient volatile boolean playerInputHubFastPathEligible;
 
+    /**
+     * Complete cached eligibility for a PERFORMANCE span. The ordinary input shortcuts above
+     * intentionally cover a few states (for example a settled legacy button) which still need
+     * scalar packet observation. Keeping that distinction here lets the hot scheduler perform
+     * one volatile read instead of walking the {@link CopyOnWriteArraySet} and observer guards
+     * for every epoch.
+     */
+    private transient volatile boolean performanceSpanFastPathEligible;
+
     /** Owner-thread observation only; deliberately absent from portable machine state. */
     private transient DebugHooks debugHooks;
 
@@ -285,13 +294,8 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      * path.</p>
      */
     public int performanceQuietSpanLimit(int requested) {
-        if (requested <= 0
-                || inputChangedSinceLastTick
-                || !buttons.isEmpty()
-                || players != 0
-                || inputTimelineObserver != null
-                || debugHooks != null
-                || isSgb) {
+        if (requested <= 0 || inputChangedSinceLastTick
+                || !performanceSpanFastPathEligible) {
             return 0;
         }
         if (releasedInputFastPathEligible && playerInputSource == PlayerInputSource.RELEASED) {
@@ -318,13 +322,8 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      * only by that poll, preserving the scalar visibility contract.
      */
     public int performanceSettledHaltSpanLimit(int requested) {
-        if (requested <= 0
-                || inputChangedSinceLastTick
-                || !buttons.isEmpty()
-                || players != 0
-                || inputTimelineObserver != null
-                || debugHooks != null
-                || isSgb) {
+        if (requested <= 0 || inputChangedSinceLastTick
+                || !performanceSpanFastPathEligible) {
             return 0;
         }
         if (releasedInputFastPathEligible && playerInputSource == PlayerInputSource.RELEASED) {
@@ -377,7 +376,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
 
     /** One cheap owner-thread commit guard for the packet scheduler. */
     public boolean isPerformanceQuietSpanStillEligible() {
-        return releasedInputFastPathEligible || playerInputHubFastPathEligible;
+        return !inputChangedSinceLastTick && performanceSpanFastPathEligible;
     }
 
     /** Naming alias for schedulers which use the GPU's advance-oriented bulk vocabulary. */
@@ -518,6 +517,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
     private void invalidateInputFastPaths() {
         releasedInputFastPathEligible = false;
         playerInputHubFastPathEligible = false;
+        performanceSpanFastPathEligible = false;
     }
 
     private void refreshReleasedInputFastPathEligibility() {
@@ -528,6 +528,10 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 && buttons.isEmpty()
                 && inputHistory == SETTLED_HISTORY[0x0f]
                 && filteredInputLines == 0x0f;
+        performanceSpanFastPathEligible = releasedInputFastPathEligible
+                && inputTimelineObserver == null
+                && debugHooks == null
+                && !isSgb;
         // Hub eligibility additionally depends on the current selector and filtered electrical
         // lines. It is recomputed only after this tick has calculated those values.
         playerInputHubFastPathEligible = false;
@@ -538,6 +542,13 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 && !inputChangedSinceLastTick
                 && inputHistory == SETTLED_HISTORY[inputLines]
                 && filteredInputLines == inputLines;
+        performanceSpanFastPathEligible = performanceSpanFastPathEligible
+                || playerInputHubFastPathEligible
+                && players == 0
+                && buttons.isEmpty()
+                && inputTimelineObserver == null
+                && debugHooks == null
+                && !isSgb;
     }
 
     private static int[] createSettledHistory() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/BiosShadow.java
@@ -7,7 +7,8 @@ import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 
-public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow> {
+public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow>,
+        PerformanceRomAccessProvider {
 
     private final Bios bios;
 
@@ -60,6 +61,11 @@ public class BiosShadow implements AddressSpace, StatefulComponent<BiosShadow> {
         } else {
             return cartridge.getByte(address);
         }
+    }
+
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        return isEnabled ? null : cartridge.acquirePerformanceRomAccess();
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/DmaCpuAddressSpace.java
@@ -3,7 +3,7 @@ package eu.rekawek.coffeegb.core.memory;
 import eu.rekawek.coffeegb.core.AddressSpace;
 
 /** Applies OAM DMA bus conflicts to memory accesses made by the CPU. */
-public class DmaCpuAddressSpace implements AddressSpace {
+public class DmaCpuAddressSpace implements AddressSpace, PerformanceRomAccessProvider {
 
     private final AddressSpace addressSpace;
 
@@ -65,5 +65,14 @@ public class DmaCpuAddressSpace implements AddressSpace {
             return highBusValue;
         }
         return addressSpace.getByte(dma.mapUnblockedCpuAddress(address));
+    }
+
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        if (dma.hasCpuBusSpecialState()
+                || !(addressSpace instanceof PerformanceRomAccessProvider provider)) {
+            return null;
+        }
+        return provider.acquirePerformanceRomAccess();
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Mmu.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static eu.rekawek.coffeegb.core.cpu.BitUtils.checkByteArgument;
 import static eu.rekawek.coffeegb.core.cpu.BitUtils.checkWordArgument;
 
-public class Mmu implements AddressSpace, StatefulComponent<Mmu> {
+public class Mmu implements AddressSpace, StatefulComponent<Mmu>, PerformanceRomAccessProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(Mmu.class);
 
@@ -49,6 +49,9 @@ public class Mmu implements AddressSpace, StatefulComponent<Mmu> {
     private final UndocumentedGbcRegisters undocumentedGbcRegisters = new UndocumentedGbcRegisters();
 
     private AddressSpace[] addressToSpace;
+
+    /** Derived once with the address-space index; null unless one provider owns all CPU ROM. */
+    private PerformanceRomAccessProvider performanceRomAccessProvider;
 
     // the Sachen MMC2 cart watches pre-header WRAM writes to tell a CGB boot from a DMG
     // one; null for every other cartridge (see SachenMmc)
@@ -142,6 +145,15 @@ public class Mmu implements AddressSpace, StatefulComponent<Mmu> {
                 }
             }
         }
+        AddressSpace romWindow = addressToSpace[0x0000];
+        for (int address = 0x0001; address < 0x8000; address++) {
+            if (addressToSpace[address] != romWindow) {
+                performanceRomAccessProvider = null;
+                return;
+            }
+        }
+        performanceRomAccessProvider = romWindow instanceof PerformanceRomAccessProvider provider
+                ? provider : null;
     }
 
     @Override
@@ -180,6 +192,12 @@ public class Mmu implements AddressSpace, StatefulComponent<Mmu> {
     public int getByte(int address) {
         checkWordArgument("address", address);
         return getSpace(address).getByte(address);
+    }
+
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        return performanceRomAccessProvider == null
+                ? null : performanceRomAccessProvider.acquirePerformanceRomAccess();
     }
 
     /** Returns the owner-held SVBK value without routing a read through the MMU bus. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccess.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccess.java
@@ -1,0 +1,23 @@
+package eu.rekawek.coffeegb.core.memory;
+
+/**
+ * Borrowed, read-only view of one stable CPU ROM mapping for a bounded PERFORMANCE transaction.
+ *
+ * <p>The provider may reuse and mutate the returned object on the next acquisition. Callers must
+ * therefore neither retain it beyond their transaction nor assume that a later acquisition has
+ * the same bank mapping. ROM contents themselves are immutable.</p>
+ */
+public interface PerformanceRomAccess {
+
+    /** Returns the immutable ROM-image offset for {@code cpuAddress}, or {@code -1}. */
+    int physicalOffset(int cpuAddress);
+
+    /** Reads one immutable ROM-image byte. Implementations return the cartridge open value past EOF. */
+    int readPhysicalByte(int physicalOffset);
+
+    /** Maps and reads one CPU ROM byte, returning {@code -1} when the address is not mapped. */
+    default int readCpuByte(int cpuAddress) {
+        int offset = physicalOffset(cpuAddress);
+        return offset < 0 ? -1 : readPhysicalByte(offset);
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessProvider.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessProvider.java
@@ -1,0 +1,12 @@
+package eu.rekawek.coffeegb.core.memory;
+
+/** Supplies a borrowed ROM mapping only when every bypassed address-space layer is inert. */
+public interface PerformanceRomAccessProvider {
+
+    /**
+     * Acquires an allocation-free ROM mapping for one bounded PERFORMANCE transaction.
+     *
+     * @return a borrowed mapping, or {@code null} when ordinary bus dispatch remains authoritative
+     */
+    PerformanceRomAccess acquirePerformanceRomAccess();
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -16,11 +16,14 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.RealTimeClock;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.SystemTimeSource;
 import eu.rekawek.coffeegb.core.memory.cart.rtc.TimeSource;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
 import eu.rekawek.coffeegb.core.memory.cart.type.*;
 import java.io.File;
 import java.nio.file.Path;
 
-public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
+public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
+        PerformanceRomAccessProvider {
 
     private final MemoryController addressSpace;
 
@@ -177,6 +180,14 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge> {
     @Override
     public int getByte(int address) {
         return addressSpace.getByte(address);
+    }
+
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {
+            return null;
+        }
+        return provider.acquirePerformanceRomAccess();
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc5.java
@@ -11,11 +11,13 @@ import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 
 import java.util.Arrays;
 
-public class Mbc5 implements MemoryController {
+public class Mbc5 implements MemoryController, PerformanceRomAccessProvider {
 
     private final int romBanks;
 
@@ -51,6 +53,10 @@ public class Mbc5 implements MemoryController {
     private final boolean gateRamWrites;
 
     private transient DebugHooks debugHooks;
+
+    /** Reused snapshot; a caller borrows it only until its bounded transaction completes. */
+    private final Mbc5PerformanceRomAccess performanceRomAccess =
+            new Mbc5PerformanceRomAccess();
 
     public Mbc5(Rom rom, Battery battery) {
         this.cartridge = rom.getRom();
@@ -155,6 +161,18 @@ public class Mbc5 implements MemoryController {
     }
 
     @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        // LoaderMbc5 and any future subclasses may add mapping semantics outside this base
+        // controller. Direct PERFORMANCE access opts in only the plain, immutable MBC5 view.
+        if (getClass() != Mbc5.class || debugHooks != null) {
+            return null;
+        }
+        performanceRomAccess.lowerWindowBase = getRomBankFor0x0000() * 0x4000;
+        performanceRomAccess.upperWindowBase = getRomBankFor0x4000() * 0x4000;
+        return performanceRomAccess;
+    }
+
+    @Override
     public void flushRam() {
         if (ramUpdated) {
             battery.saveRam(ram);
@@ -190,6 +208,41 @@ public class Mbc5 implements MemoryController {
             return cartridge[cartOffset];
         } else {
             return 0xff;
+        }
+    }
+
+    private final class Mbc5PerformanceRomAccess implements PerformanceRomAccess {
+
+        private int lowerWindowBase;
+
+        private int upperWindowBase;
+
+        @Override
+        public int physicalOffset(int cpuAddress) {
+            if (cpuAddress < 0 || cpuAddress >= 0x8000) {
+                return -1;
+            }
+            return cpuAddress < 0x4000
+                    ? lowerWindowBase + cpuAddress
+                    : upperWindowBase + cpuAddress - 0x4000;
+        }
+
+        @Override
+        public int readPhysicalByte(int physicalOffset) {
+            return physicalOffset >= 0 && physicalOffset < cartridge.length
+                    ? cartridge[physicalOffset]
+                    : 0xff;
+        }
+
+        @Override
+        public int readCpuByte(int cpuAddress) {
+            if (cpuAddress < 0 || cpuAddress >= 0x8000) {
+                return -1;
+            }
+            int physicalOffset = cpuAddress < 0x4000
+                    ? lowerWindowBase + cpuAddress
+                    : upperWindowBase + cpuAddress - 0x4000;
+            return physicalOffset < cartridge.length ? cartridge[physicalOffset] : 0xff;
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -64,13 +64,18 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
 
     public void tick() {
         // Link-port peripherals such as GPS receivers have their own wall clock and keep
-        // driving the input pin even when no hardware serial transfer is armed.
-        if (serialEndpoint != SerialEndpoint.NULL_ENDPOINT) {
-            serialEndpoint.tick();
+        // driving the input pin even when no hardware serial transfer is armed. A built-in
+        // endpoint which advertises a quiet span has explicitly guaranteed that tick(), the
+        // inactive external-transfer callback, and the input pin are inert; use that same
+        // capability on scalar event ticks instead of identity-checking only NULL_ENDPOINT.
+        SerialEndpoint endpoint = serialEndpoint;
+        boolean quietEndpoint = endpoint.canTickPerformanceQuietSpan(1);
+        if (!quietEndpoint && endpoint != SerialEndpoint.NULL_ENDPOINT) {
+            endpoint.tick();
         }
         acknowledgeInterruptIfNeeded();
         int speed = speedMode.getSpeedMode();
-        if (serialEndpoint == SerialEndpoint.NULL_ENDPOINT
+        if (quietEndpoint
                 && (sc & 0x80) == 0
                 && haltWakeDelay == 0) {
             serialClocks = (serialClocks + speed) & 0xff;
@@ -148,6 +153,46 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         }
         // The packet preflight has already established an idle quiet endpoint and no pending
         // acknowledge/transfer edge.  Do not repeat that walk on the hot commit path.
+        acknowledgeInterruptIfNeeded();
+        serialClocks = (serialClocks + ticks) & 0xff;
+    }
+
+    /** Native-CGB double-speed epoch guard; transfers and callbacks remain scalar. */
+    public boolean performanceEpochIdle(int requested) {
+        return requested > 0
+                && speedMode.getSpeedMode() == 2
+                && serialEndpoint.canTickPerformanceQuietSpan(requested)
+                && (sc & 0x80) == 0
+                && haltWakeDelay == 0
+                && debugHooks == null;
+    }
+
+    /** Applies the preflighted idle serial phase without a per-dot loop. */
+    public void tickPerformanceEpochIdle(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        acknowledgeInterruptIfNeeded();
+        serialClocks = (serialClocks + ticks * 2) & 0xff;
+    }
+
+
+    /** Physical-DMG normal-speed epoch guard; transfers and callbacks remain scalar. */
+    public boolean performancePhysicalDmgEpochIdle(int requested) {
+        return requested > 0
+                && speedMode.getSpeedMode() == 1
+                && !speedMode.isGbc()
+                && serialEndpoint.canTickPerformanceQuietSpan(requested)
+                && (sc & 0x80) == 0
+                && haltWakeDelay == 0
+                && debugHooks == null;
+    }
+
+    /** Applies a preflighted physical-DMG idle serial phase at one clock per master tick. */
+    public void tickPerformancePhysicalDmgEpochIdle(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
         acknowledgeInterruptIfNeeded();
         serialClocks = (serialClocks + ticks) & 0xff;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/PolynomialCounter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/PolynomialCounter.java
@@ -105,7 +105,7 @@ public class PolynomialCounter implements StatefulComponent<PolynomialCounter> {
         int steps = 0;
         alignment = (alignment + edgeCount) & 3;
         if (!backgroundActive) {
-            clock2Mhz = (ticks & 1) != 0 ? !clock2Mhz : clock2Mhz;
+            clock2Mhz ^= (ticks & 1) != 0;
             return 0;
         }
         // Until the next prescaler reload, the active noise state is only a countdown. Avoid
@@ -113,26 +113,32 @@ public class PolynomialCounter implements StatefulComponent<PolynomialCounter> {
         if (edgeCount > 0 && counterCountdown > edgeCount) {
             counterCountdown -= edgeCount;
             countdownReloaded = false;
-            clock2Mhz = (ticks & 1) != 0 ? !clock2Mhz : clock2Mhz;
+            clock2Mhz ^= (ticks & 1) != 0;
             return 0;
         }
-        for (int edge = 0; edge < edgeCount; edge++) {
-            if (--counterCountdown > 0) {
-                countdownReloaded = false;
-                continue;
-            }
-            int divisor = (nr43 & 0b111) << 2;
-            counterCountdown = divisor == 0 ? 2 : divisor;
-            int mask = 1 << (nr43 >> 4);
-            boolean oldBit = (counter & mask) != 0;
-            counter = (counter + 1) & 0x3fff;
-            boolean newBit = (counter & mask) != 0;
-            countdownReloaded = true;
-            if (!oldBit && newBit) {
-                steps++;
-            }
+        if (edgeCount == 0) {
+            clock2Mhz ^= (ticks & 1) != 0;
+            return 0;
         }
-        clock2Mhz = (ticks & 1) != 0 ? !clock2Mhz : clock2Mhz;
+
+        int reload = (nr43 & 0b111) << 2;
+        if (reload == 0) {
+            reload = 2;
+        }
+        int after = edgeCount - counterCountdown;
+        int increments = 1 + after / reload;
+        int tail = after - (increments - 1) * reload;
+        counterCountdown = tail == 0 ? reload : reload - tail;
+        countdownReloaded = tail == 0;
+
+        int shift = nr43 >>> 4;
+        if (shift < 14) {
+            int mask = 1 << shift;
+            steps = ((counter + increments + mask) >>> (shift + 1))
+                    - ((counter + mask) >>> (shift + 1));
+        }
+        counter = (counter + increments) & 0x3fff;
+        clock2Mhz ^= (ticks & 1) != 0;
         return steps;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -24,6 +24,17 @@ import java.util.Objects;
 public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     /**
+     * Host-only PERFORMANCE audio calendars. OFF is the normal path, EXACT preserves the APU
+     * channel clock state at every materialization boundary, and RELAXED_APU keeps the frame
+     * sequencer/control-plane calendar while deliberately dropping deferred channel clocks.
+     */
+    public enum PerformanceSystemMutedAudioMode {
+        OFF,
+        EXACT,
+        RELAXED_APU
+    }
+
+    /**
      * PERFORMANCE audio is intentionally represented at one fifty-fifth of the master-tick
      * rate. The source is sampled at approximately 76.26 kHz, which is still comfortably above
      * the host audio band and gives the emulator a 55-master-tick quiet window in which to batch
@@ -99,6 +110,31 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
      * SoundState: captureState() materializes it first and restoreState() always resets it.
      */
     private transient int pendingPerformanceTicks;
+
+    /**
+     * Host-controlled PERFORMANCE-only calendar for a system-muted benchmark. It skips per-tick
+     * channel dispatch and emits zero PCM while retaining sample cadence; deferred channel clocks
+     * are materialized canonically at every existing APU boundary. It is never part of machine
+     * state and is disabled by default.
+     */
+    private transient PerformanceSystemMutedAudioMode performanceSystemMutedAudioMode =
+            PerformanceSystemMutedAudioMode.OFF;
+
+    private transient long performanceSystemMutedAudioCalendarSkippedTicks;
+
+    private transient long performanceSystemMutedAudioCalendarZeroSampleSlots;
+
+    private transient long performanceSystemMutedAudioCalendarZeroSampleEvents;
+
+    private transient long performanceSystemMutedAudioCalendarMaxPendingTicks;
+
+    private transient long performanceSystemMutedAudioCalendarDroppedChannelTicks;
+
+    private transient long performanceSystemMutedAudioCalendarApuReads;
+
+    private transient long performanceSystemMutedAudioCalendarApuWrites;
+
+    private transient long performanceSystemMutedAudioCalendarFrameSequencerCommits;
 
     private final Timer timer;
 
@@ -235,6 +271,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (ticks <= 0) {
             return;
         }
+        if (performanceSystemMutedAudioCalendarUsable()) {
+            accumulateSilentPcmTicks(ticks);
+            return;
+        }
         if (!performanceAudio || debugHooks != null || outputObserver != null
                 || performanceSamplePhase + ticks >= performanceAudioDecimation) {
             materializePendingPerformanceTicks();
@@ -261,6 +301,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             return;
         }
         pendingPerformanceTicks = 0;
+        if (performanceSystemMutedAudioMode == PerformanceSystemMutedAudioMode.RELAXED_APU) {
+            performanceSystemMutedAudioCalendarDroppedChannelTicks += ticks;
+            return;
+        }
         if (!enabled) {
             return;
         }
@@ -365,6 +409,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (firedStep < 0) {
             return;
         }
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            performanceSystemMutedAudioCalendarFrameSequencerCommits++;
+        }
         materializePendingPerformanceTicks();
         int enabledBefore = getDebugEnabledChannelMask();
         notifyDebugEvent(ApuTrace.Kind.FRAME_SEQUENCER_STEP, -1, -1, firedStep);
@@ -396,6 +443,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
                 || pendingFrameSequencerStep >= 0) {
             return 0;
         }
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            return requested;
+        }
         return Math.min(requested,
                 performanceAudioDecimation - performanceSamplePhase - 1);
     }
@@ -413,6 +463,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (!performanceAudio) {
             return requested;
         }
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            return requested;
+        }
         return Math.min(requested,
                 performanceAudioDecimation - performanceSamplePhase - 1);
     }
@@ -424,6 +477,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
      * accessors; only the next compact-output boundary needs to run this tick immediately.
      */
     public void tickPerformanceBoundary(boolean divReset) {
+        if (performanceSystemMutedAudioCalendarUsable()) {
+            accumulateSilentPcmTicks(1);
+            return;
+        }
         if (!performanceAudio || debugHooks != null || outputObserver != null
                 || performanceSamplePhase + 1 >= performanceAudioDecimation) {
             tick(divReset);
@@ -438,6 +495,116 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     public void onSpeedSwitch() {
         materializePendingPerformanceTicks();
         frameSequencerClockPhase = (frameSequencerClockPhase + 1) & 3;
+    }
+
+    /**
+     * Compatibility setter for the original silent-pcm-v1 policy. True selects EXACT; false
+     * selects OFF. New callers should use {@link #setPerformanceSystemMutedAudioMode}.
+     */
+    public void setPerformanceSystemMutedAudioCalendar(boolean enabled) {
+        setPerformanceSystemMutedAudioMode(enabled
+                ? PerformanceSystemMutedAudioMode.EXACT
+                : PerformanceSystemMutedAudioMode.OFF);
+    }
+
+    /** Sets the transient owner-thread system-muted PERFORMANCE audio calendar mode. */
+    public void setPerformanceSystemMutedAudioMode(PerformanceSystemMutedAudioMode mode) {
+        Objects.requireNonNull(mode, "mode");
+        if (mode == performanceSystemMutedAudioMode) {
+            return;
+        }
+        if (mode != PerformanceSystemMutedAudioMode.OFF && !performanceAudio) {
+            throw new IllegalStateException(
+                    "system-muted audio calendar requires PERFORMANCE audio");
+        }
+        // Materialize using the old mode before changing policy. This preserves exact channel
+        // state when arming relaxed mode and records any intentionally dropped debt when turning
+        // relaxed mode off.
+        materializePendingPerformanceTicks();
+        if (mode != PerformanceSystemMutedAudioMode.OFF) {
+            Arrays.fill(buffer, 0);
+        }
+        performanceSystemMutedAudioMode = mode;
+    }
+
+    public boolean isPerformanceSystemMutedAudioCalendarEnabled() {
+        return performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF;
+    }
+
+    public PerformanceSystemMutedAudioMode getPerformanceSystemMutedAudioMode() {
+        return performanceSystemMutedAudioMode;
+    }
+
+    public void resetPerformanceSystemMutedAudioCalendarCounters() {
+        performanceSystemMutedAudioCalendarSkippedTicks = 0L;
+        performanceSystemMutedAudioCalendarZeroSampleSlots = 0L;
+        performanceSystemMutedAudioCalendarZeroSampleEvents = 0L;
+        performanceSystemMutedAudioCalendarMaxPendingTicks = 0L;
+        performanceSystemMutedAudioCalendarDroppedChannelTicks = 0L;
+        performanceSystemMutedAudioCalendarApuReads = 0L;
+        performanceSystemMutedAudioCalendarApuWrites = 0L;
+        performanceSystemMutedAudioCalendarFrameSequencerCommits = 0L;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarSkippedTicks() {
+        return performanceSystemMutedAudioCalendarSkippedTicks;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarZeroSampleSlots() {
+        return performanceSystemMutedAudioCalendarZeroSampleSlots;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarZeroSampleEvents() {
+        return performanceSystemMutedAudioCalendarZeroSampleEvents;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarMaxPendingTicks() {
+        return performanceSystemMutedAudioCalendarMaxPendingTicks;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarDroppedChannelTicks() {
+        return performanceSystemMutedAudioCalendarDroppedChannelTicks;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarApuReads() {
+        return performanceSystemMutedAudioCalendarApuReads;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarApuWrites() {
+        return performanceSystemMutedAudioCalendarApuWrites;
+    }
+
+    public long getPerformanceSystemMutedAudioCalendarFrameSequencerCommits() {
+        return performanceSystemMutedAudioCalendarFrameSequencerCommits;
+    }
+
+    private boolean performanceSystemMutedAudioCalendarUsable() {
+        return performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF
+                && performanceAudio
+                && debugHooks == null && outputObserver == null
+                && pendingFrameSequencerStep < 0;
+    }
+
+    private void accumulateSilentPcmTicks(int ticks) {
+        pendingPerformanceTicks += ticks;
+        performanceSystemMutedAudioCalendarSkippedTicks += ticks;
+        performanceSystemMutedAudioCalendarMaxPendingTicks = Math.max(
+                performanceSystemMutedAudioCalendarMaxPendingTicks, pendingPerformanceTicks);
+
+        long phaseTicks = (long) performanceSamplePhase + ticks;
+        int sampleSlots = (int) (phaseTicks / performanceAudioDecimation);
+        performanceSamplePhase = (int) (phaseTicks % performanceAudioDecimation);
+        performanceSystemMutedAudioCalendarZeroSampleSlots += sampleSlots;
+        for (int slot = 0; slot < sampleSlots; slot++) {
+            buffer[i] = 0;
+            buffer[i + 1] = 0;
+            i += 2;
+            if (i == buffer.length) {
+                performanceSystemMutedAudioCalendarZeroSampleEvents++;
+                eventBus.post(new SoundSampleEvent(buffer, outputClockSpec));
+                i = 0;
+            }
+        }
     }
 
     /** Package-private so the disabled exact-output hot path can be allocation-regression tested. */
@@ -485,6 +652,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     @Override
     public void setByte(int address, int value) {
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            performanceSystemMutedAudioCalendarApuWrites++;
+        }
         materializePendingPerformanceTicks();
         if (address == 0xff26) {
             int enabledBefore = getDebugEnabledChannelMask();
@@ -689,6 +859,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
 
     @Override
     public int getByte(int address) {
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            performanceSystemMutedAudioCalendarApuReads++;
+        }
         materializePendingPerformanceTicks();
 
         int result;
@@ -845,6 +1018,8 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         this.frameSequencerDivOffset = mem.frameSequencerDivOffset;
         this.performanceSamplePhase = pendingAudioFits ? mem.performanceSamplePhase : 0;
         this.pendingPerformanceTicks = 0;
+        this.performanceSystemMutedAudioMode = PerformanceSystemMutedAudioMode.OFF;
+        resetPerformanceSystemMutedAudioCalendarCounters();
         this.mixerDirty = true;
 
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -243,7 +243,11 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             }
             return;
         }
-        pendingPerformanceTicks = Math.addExact(pendingPerformanceTicks, ticks);
+        // The PERFORMANCE horizon stops before the next decimated sample, where the
+        // pending span is materialized.  Consequently this accumulator is bounded by
+        // performanceAudioDecimation - 1 (54 today), so an overflow-checked add in the
+        // 1.7M-packets-per-sample hot path cannot provide any additional protection.
+        pendingPerformanceTicks += ticks;
         performanceSamplePhase += ticks;
     }
 
@@ -397,6 +401,24 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     }
 
     /**
+     * Horizon used by the native-CGB coarse epoch.  With lazy PERFORMANCE audio enabled,
+     * stop immediately before the next compact sample; with audio disabled there is no host
+     * sample boundary to cross and the regular per-tick state update remains exact.
+     */
+    public int performanceEpochSpanLimit(int requested) {
+        if (requested <= 0 || debugHooks != null || outputObserver != null
+                || pendingFrameSequencerStep >= 0) {
+            return 0;
+        }
+        if (!performanceAudio) {
+            return requested;
+        }
+        return Math.min(requested,
+                performanceAudioDecimation - performanceSamplePhase - 1);
+    }
+
+
+    /**
      * Defers the Sound clock belonging to a scalar PERFORMANCE scheduler boundary. CPU-visible
      * work in that tick has already had a chance to materialize pending clocks through get/set
      * accessors; only the next compact-output boundary needs to run this tick immediately.
@@ -407,7 +429,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             tick(divReset);
             return;
         }
-        pendingPerformanceTicks = Math.addExact(pendingPerformanceTicks, 1);
+        // The branch above materializes on the sample boundary, bounding the pending
+        // count to the same sub-decimation interval as tickPerformanceQuietSpan().
+        pendingPerformanceTicks++;
         performanceSamplePhase++;
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/SoundMode1.java
@@ -139,10 +139,11 @@ public class SoundMode1 extends AbstractSoundMode {
         // ordinary spans (the hot path) are handled as 2-MHz events below.
         int calculationAt = frequencySweep.calculationExpiryOffset(ticks);
         if (calculationAt > 0) {
+            int output = getCurrentOutput();
             for (int i = 0; i < ticks; i++) {
-                tick(false);
+                output = tick(false);
             }
-            return getCurrentOutput();
+            return output;
         }
 
         frequencySweep.tickPerformanceSpan(ticks);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -19,6 +19,9 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
      */
     private static final int PERFORMANCE_MAX_QUIET_SPAN = 3;
 
+    /** Maximum bounded CPU epoch in master ticks. */
+    private static final int PERFORMANCE_EPOCH_MAX_TICKS = 54;
+
     private static final int FRAME_SEQUENCER_DIV_BIT = 12;
 
     private final SpeedMode speedMode;
@@ -105,6 +108,104 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         for (int i = 0; i < speed; i++) {
             tickCpuClock();
         }
+    }
+
+    /**
+     * Returns the largest exact native-CGB double-speed CPU epoch. The request is measured in
+     * master ticks, each of which advances two CPU clocks. The result stops before an
+     * overflow/reload, divider ripple, APU frame-sequencer tap, or any transient/debug state
+     * which still needs the scalar clock ordering.
+     */
+    public int performanceEpochSpanLimit(int requested) {
+        if (requested <= 0 || speedMode.getSpeedMode() != 2 || debugHooks != null
+                || divReset || overflow || haltWakeDelay != 0
+                || haltBugDivRippleVisible || suppressNextInterruptRequest
+                || previousBit != timerInput(div, tac)) {
+            return 0;
+        }
+        int span = Math.min(requested, PERFORMANCE_EPOCH_MAX_TICKS);
+        span = capBeforeMasterTicks(span, clocksToOverflowFallingEdge(), 2);
+        span = capBeforeMasterTicks(span, clocksToPendingDividerRipple(), 2);
+        span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(0), 2);
+        span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(2), 2);
+        return Math.max(0, span);
+    }
+
+    /** Applies a preflighted CPU epoch without visiting each CPU clock. */
+    public boolean tickPerformanceEpoch(int ticks) {
+        if (ticks <= 0 || performanceEpochSpanLimit(ticks) < ticks) {
+            return false;
+        }
+        tickPerformanceEpochTrusted(ticks);
+        return true;
+    }
+
+    /** Applies an epoch after the caller has passed {@link #performanceEpochSpanLimit(int)}. */
+    public void tickPerformanceEpochTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        // The acknowledge edge is still at the beginning of the first master tick, matching
+        // tick(); the preflight excludes every interior interrupt-producing edge.
+        acknowledgeInterruptIfNeeded();
+        divReset = false;
+        long cpuClocks = (long) ticks * 2;
+        int fallingEdges = nativeCgbEpochTimerFallingEdges(ticks);
+        tima = (int) ((tima + fallingEdges) & 0xff);
+        div = (int) ((div + cpuClocks) & 0xffff);
+        previousBit = timerInput(div, tac);
+        if (ticksSinceDivReset != Integer.MAX_VALUE) {
+            ticksSinceDivReset = (int) Math.min(Integer.MAX_VALUE,
+                    ticksSinceDivReset + cpuClocks);
+        }
+        // A one-tick visible ripple is cleared at the beginning of every scalar clock.  The
+        // preflight prevents the pending carry itself from being crossed, so its pending latch
+        // remains intact for the next scalar boundary.
+        haltBugDivRippleVisible = false;
+    }
+
+
+    /** Physical-DMG normal-speed counterpart of {@link #performanceEpochSpanLimit(int)}. */
+    public int performancePhysicalDmgEpochSpanLimit(int requested) {
+        if (requested <= 0 || speedMode.getSpeedMode() != 1 || speedMode.isGbc()
+                || debugHooks != null || divReset || overflow || haltWakeDelay != 0
+                || haltBugDivRippleVisible || suppressNextInterruptRequest
+                || previousBit != timerInput(div, tac)) {
+            return 0;
+        }
+        int span = Math.min(requested, PERFORMANCE_EPOCH_MAX_TICKS);
+        span = capBeforeMasterTicks(span, clocksToOverflowFallingEdge(), 1);
+        span = capBeforeMasterTicks(span, clocksToPendingDividerRipple(), 1);
+        span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(0), 1);
+        return Math.max(0, span);
+    }
+
+    /** Applies a checked physical-DMG CPU epoch without visiting each CPU clock. */
+    public boolean tickPerformancePhysicalDmgEpoch(int ticks) {
+        if (ticks <= 0 || performancePhysicalDmgEpochSpanLimit(ticks) < ticks) {
+            return false;
+        }
+        tickPerformancePhysicalDmgEpochTrusted(ticks);
+        return true;
+    }
+
+    /** Applies a preflighted physical-DMG epoch at one CPU clock per master tick. */
+    public void tickPerformancePhysicalDmgEpochTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        acknowledgeInterruptIfNeeded();
+        divReset = false;
+        long cpuClocks = ticks;
+        int fallingEdges = physicalDmgEpochTimerFallingEdges(ticks);
+        tima = (int) ((tima + fallingEdges) & 0xff);
+        div = (int) ((div + cpuClocks) & 0xffff);
+        previousBit = timerInput(div, tac);
+        if (ticksSinceDivReset != Integer.MAX_VALUE) {
+            ticksSinceDivReset = (int) Math.min(Integer.MAX_VALUE,
+                    ticksSinceDivReset + cpuClocks);
+        }
+        haltBugDivRippleVisible = false;
     }
 
     /**
@@ -241,6 +342,17 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         return Math.min(currentLimit, (int) Math.max(0, eventDistance - 1));
     }
 
+    private static int capBeforeMasterTicks(
+            int currentLimit, long cpuClockDistance, int cpuClocksPerMaster) {
+        if (cpuClockDistance == Long.MAX_VALUE) {
+            return currentLimit;
+        }
+        // Exclude the master tick which reaches the event. Dividing distance-1 by the active
+        // CPU clocks per master tick yields the largest safe frozen-peripheral prefix.
+        return Math.min(currentLimit, (int) Math.max(
+                0, (cpuClockDistance - 1) / cpuClocksPerMaster));
+    }
+
     /** Distance to the next falling edge of the selected TIMA input. */
     private long clocksToTimerFallingEdge() {
         boolean enabled = (tac & 0x04) != 0;
@@ -262,6 +374,43 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         // With a low previous latch, the next falling edge is the next low-boundary after a full
         // period.  This remains correct whether the current sampled input is low or high.
         return period - phase;
+    }
+
+    /** Distance in CPU clocks to the falling edge which would overflow TIMA. */
+    private long clocksToOverflowFallingEdge() {
+        if ((tac & 0x04) == 0) {
+            return Long.MAX_VALUE;
+        }
+        long first = clocksToTimerFallingEdge();
+        int period = 1 << (FREQ_TO_BIT[tac & 0x03] + 1);
+        return first + (long) (0x100 - tima - 1) * period;
+    }
+
+    /** Fixed-x2 native-CGB falling-edge count; single-caller so R8 can inline it. */
+    private int nativeCgbEpochTimerFallingEdges(int masterTicks) {
+        int cpuClocks = masterTicks * 2;
+        if ((tac & 0x04) == 0) {
+            return 0;
+        }
+        long first = clocksToTimerFallingEdge();
+        if (first > cpuClocks) {
+            return 0;
+        }
+        int period = 1 << (FREQ_TO_BIT[tac & 0x03] + 1);
+        return 1 + (int) ((cpuClocks - first) / period);
+    }
+
+    /** Fixed-x1 physical-DMG falling-edge count, kept separate from the native hot path. */
+    private int physicalDmgEpochTimerFallingEdges(int masterTicks) {
+        if ((tac & 0x04) == 0) {
+            return 0;
+        }
+        long first = clocksToTimerFallingEdge();
+        if (first > masterTicks) {
+            return 0;
+        }
+        int period = 1 << (FREQ_TO_BIT[tac & 0x03] + 1);
+        return 1 + (int) ((masterTicks - first) / period);
     }
 
     /** Distance to a potential low transition of the selected DIV/APU tap. */

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -1,0 +1,435 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.cpu.Cpu;
+import eu.rekawek.coffeegb.core.gpu.Mode;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Focused native-CGB smoke coverage for the coarse PERFORMANCE epoch entrance. */
+public final class GameboyPerformanceEpochTest {
+
+    @Test
+    public void nativeDoubleSpeedLoopUsesEpochLane() throws Exception {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build()) {
+            // The first batch performs the speed-switch countdown on the legacy scheduler;
+            // the next owner batch starts in native double speed and enters the epoch lane.
+            gameboy.runTicks(160_000);
+            gameboy.runTicks(100_000);
+            assertTrue("test ROM did not enter CGB double speed",
+                    gameboy.getSpeedMode().getSpeedMode() == 2);
+            assertTrue("native CGB epoch lane did not run speed="
+                            + gameboy.getSpeedMode().getSpeedMode()
+                            + " cpu=" + gameboy.getCpu().getState()
+                            + " mode=" + gameboy.getGpu().getMode()
+                            + " line=" + gameboy.getGpu().getLine()
+                            + " lcd=" + gameboy.getGpu().isLcdEnabled()
+                            + " cpuEpoch=" + gameboy.getCpu().getPerformanceEpochCount()
+                            + " cpuTicks=" + gameboy.getCpu().getPerformanceEpochTicks()
+                            + " accesses=" + gameboy.getCpu().getPerformanceEpochAccesses(),
+                    gameboy.getPerformanceEpochTicks() > 0);
+        }
+    }
+
+    @Test
+    public void stopAwarePreconditioningNeverUsesEpochLane() throws Exception {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build()) {
+            gameboy.runTicks(160_000);
+            assertEquals(2, gameboy.getSpeedMode().getSpeedMode());
+            gameboy.resetPerformanceBulkCounters();
+
+            assertEquals(4_096, gameboy.runTicksUntilStop(4_096, () -> false));
+            assertEquals(0L, gameboy.getPerformanceEpochCount());
+            assertEquals(0L, gameboy.getPerformanceEpochTicks());
+        }
+    }
+
+    @Test
+    public void physicalDmgEntersEpochWhileCgbCompatibilityStaysLegacy() throws Exception {
+        byte[] loop = new byte[0x8000];
+        loop[0x100] = (byte) 0xc3;
+        loop[0x101] = 0x00;
+        loop[0x102] = 0x01;
+        try (Gameboy dmg = new Gameboy.GameboyConfiguration(new Rom(loop))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setGameboyType(GameboyType.DMG)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build();
+             Gameboy compat = new Gameboy.GameboyConfiguration(new Rom(loop))
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setGameboyType(GameboyType.CGB)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setSupportBatterySave(false)
+                     .build()) {
+            dmg.runTicks(100_000);
+            compat.runTicks(100_000);
+            assertTrue("physical DMG did not enter the coarse epoch lane",
+                    dmg.getPerformanceEpochTicks() > 0);
+            assertEquals(0L, compat.getPerformanceEpochTicks());
+            assertTrue(compat.getSpeedMode().isDmgCompat());
+        }
+    }
+
+    @Test
+    public void physicalDmgRomWramLoopMatchesLegacySchedulerWithEpochCoverage()
+            throws Exception {
+        byte[] image = dmgRomWramLoop();
+        try (Gameboy scalar = physicalDmgSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = physicalDmgSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("physical-DMG frame callbacks", scalarFrames, candidateFrames);
+            assertEquals("custom-source oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("physical-DMG ROM/WRAM loop had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000);
+            assertEquals("physical DMG used a non-raster epoch plan",
+                    candidate.getPerformanceEpochTicks(),
+                    candidate.getPerformanceEpochRasterFastTicks());
+            assertEquals(0L, candidate.getPerformanceEpochMode2ReplayTicks());
+            assertEquals(scalar.getAddressSpace().getByte(0xc000),
+                    candidate.getAddressSpace().getByte(0xc000));
+            assertDeepStateEquals("physical-DMG ROM/WRAM loop",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void physicalDmgPlainOamWritesDelegateImmediatelyAndMatchScalar() throws Exception {
+        assertPhysicalDmgOamLoopMatchesScalar(dmgPlainOamWriteLoop(), 120_000,
+                "plain LD-to-OAM");
+    }
+
+    @Test
+    public void physicalDmgPushOamCorruptionAndSuppressionMatchScalar() throws Exception {
+        assertPhysicalDmgOamLoopMatchesScalar(dmgPushOamLoop(), 120_000,
+                "PUSH OAM-bug suppression");
+    }
+
+    @Test
+    public void physicalDmgEpochRetiringHaltPublishesDmaPauseLatch() throws Exception {
+        byte[] image = dmgRomWramLoop();
+        image[0x200] = 0x76; // HALT, selected after reaching a trusted raster span
+        try (Gameboy scalar = physicalDmgSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = physicalDmgSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 0
+                    && candidate.getCpu().performancePhysicalDmgEpochEntryEligible())
+                    && guard++ < 200_000) {
+                assertEquals("HALT setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not reach a trusted physical-DMG HALT entry", guard < 200_000);
+            assertDeepStateEquals("before physical-DMG HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("HALT frame callback", scalar.runTicks(8), candidate.runTicks(8));
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertTrue("HALT fetch did not retire inside a physical-DMG epoch",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("after physical-DMG HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void accuracyAndSgbProfilesStayOutsidePhysicalDmgEpoch() throws Exception {
+        byte[] image = dmgRomWramLoop();
+        try (Gameboy accuracy = physicalDmgSession(
+                image, PlayerInputSource.RELEASED, ExecutionMode.ACCURACY);
+             Gameboy sgb = new Gameboy.GameboyConfiguration(new Rom(image))
+                     .setHardwareProfile(HardwareProfileRegistry.SGB)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setSupportBatterySave(false)
+                     .build()) {
+            accuracy.runTicks(100_000);
+            sgb.runTicks(100_000);
+            assertEquals(0L, accuracy.getPerformanceEpochTicks());
+            assertEquals(0L, sgb.getPerformanceEpochTicks());
+        }
+    }
+
+    @Test
+    public void mode2ReplayMatchesScalarAndLeavesTheHandoffTickScalar() throws Exception {
+        try (Gameboy scalar = nativeDoubleSpeedSession();
+             Gameboy replay = nativeDoubleSpeedSession()) {
+            advanceScalarToMode2ReplayStart(scalar);
+            advanceScalarToMode2ReplayStart(replay);
+            assertDeepStateEquals("mode-2 start", scalar.captureStateWithoutTimeSource(),
+                    replay.captureStateWithoutTimeSource());
+            replay.getGpu().setPerformanceScanlineEnabled(true);
+            int mode2Limit = replay.getGpu().performanceEpochMode2ReplaySpanLimit(54);
+            replay.getGpu().setPerformanceScanlineEnabled(false);
+            assertTrue("mode-2 replay preflight rejected start: limit="
+                            + mode2Limit
+                            + " cpu=" + replay.getCpu().performanceEpochEntryEligible()
+                            + " mode=" + replay.getGpu().getMode()
+                            + " dot=" + replay.getGpu().getTicksInLine()
+                            + " cursor=" + replay.getGpu().isPerformanceScanlineCursorActive(),
+                    mode2Limit > 0);
+            assertTrue("CPU did not settle after the speed-switch countdown",
+                    replay.getCpu().performanceEpochEntryEligible());
+
+            scalar.resetPerformanceBulkCounters();
+            replay.resetPerformanceBulkCounters();
+            int replayDots = 79 - replay.getGpu().getTicksInLine();
+            for (int i = 0; i < replayDots; i++) {
+                scalar.tick();
+            }
+            assertEquals(0, replay.runTicks(replayDots));
+
+            assertEquals(Mode.OamSearch, replay.getGpu().getMode());
+            assertEquals(79, replay.getGpu().getTicksInLine());
+            assertTrue("mode-2 epoch coverage was too small: "
+                            + replay.getPerformanceEpochMode2ReplayTicks(),
+                    replay.getPerformanceEpochMode2ReplayTicks() >= 40);
+            assertEquals("mode-2 epochs used the arithmetic raster plan",
+                    replay.getPerformanceEpochTicks(),
+                    replay.getPerformanceEpochMode2ReplayTicks());
+            assertEquals("mode-2 epoch fell back to the per-dot PPU replay",
+                    replay.getPerformanceEpochMode2ReplayTicks(),
+                    replay.getPerformanceEpochMode2BulkTicks());
+            assertEquals(0L, replay.getPerformanceEpochRasterFastTicks());
+            assertDeepStateEquals("mode-2 dot 79", scalar.captureStateWithoutTimeSource(),
+                    replay.captureStateWithoutTimeSource());
+
+            long replayedBeforeHandoff = replay.getPerformanceEpochMode2ReplayTicks();
+            assertEquals(scalar.runTicks(1), replay.runTicks(1));
+            assertEquals("mode-3 handoff was replayed inside the mode-2 transaction",
+                    replayedBeforeHandoff, replay.getPerformanceEpochMode2ReplayTicks());
+            assertEquals("mode-3 handoff was included in the mode-2 bulk counter",
+                    replayedBeforeHandoff, replay.getPerformanceEpochMode2BulkTicks());
+            assertEquals(Mode.PixelTransfer, replay.getGpu().getMode());
+            assertTrue("scalar handoff did not arm the direct renderer",
+                    replay.getGpu().isPerformanceScanlineCursorActive());
+            assertDeepStateEquals("mode-3 handoff", scalar.captureStateWithoutTimeSource(),
+                    replay.captureStateWithoutTimeSource());
+        }
+    }
+
+    private static Gameboy nativeDoubleSpeedSession() throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy physicalDmgSession(
+            byte[] image, PlayerInputSource inputSource, ExecutionMode executionMode)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(HardwareProfileRegistry.DMG)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static void assertPhysicalDmgOamLoopMatchesScalar(
+            byte[] image, int ticks, String label) throws Exception {
+        try (Gameboy scalar = physicalDmgSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = physicalDmgSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            // SKIP boot can already be inside mode 2, where ordinary OAM writes are locked.
+            // Expose OAM explicitly and prove the non-uniform seed took effect so PUSH-class
+            // corruption cannot collapse into an all-zero fixed point.
+            int scalarLcdc = scalar.getAddressSpace().getByte(0xff40);
+            int candidateLcdc = candidate.getAddressSpace().getByte(0xff40);
+            assertEquals(label + " initial LCDC", scalarLcdc, candidateLcdc);
+            scalar.getAddressSpace().setByte(0xff40, 0x00);
+            candidate.getAddressSpace().setByte(0xff40, 0x00);
+            for (int offset = 0; offset < 0xa0; offset++) {
+                int value = (offset * 37 + 11) & 0xff;
+                scalar.getAddressSpace().setByte(0xfe00 + offset, value);
+                candidate.getAddressSpace().setByte(0xfe00 + offset, value);
+                assertEquals(label + " scalar OAM seed " + offset,
+                        value, scalar.getAddressSpace().getByte(0xfe00 + offset));
+                assertEquals(label + " candidate OAM seed " + offset,
+                        value, candidate.getAddressSpace().getByte(0xfe00 + offset));
+            }
+            scalar.getAddressSpace().setByte(0xff40, scalarLcdc);
+            candidate.getAddressSpace().setByte(0xff40, candidateLcdc);
+
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < ticks / 4_000; chunk++) {
+                scalarFrames += scalar.runTicks(4_000);
+                candidateFrames += candidate.runTicks(4_000);
+            }
+
+            assertEquals(label + " frame callbacks", scalarFrames, candidateFrames);
+            assertTrue(label + " did not exercise a coarse epoch",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertTrue(label + " did not terminate an epoch on an OAM access",
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses() > 0);
+            assertDeepStateEquals(label,
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    private static void advanceScalarToMode2ReplayStart(Gameboy gameboy) {
+        int guard = 0;
+        int stableDoubleSpeedTicks = 0;
+        while (!(stableDoubleSpeedTicks >= 1_000
+                && !gameboy.getGpu().isFirstLine()
+                && gameboy.getGpu().getLine() < 144
+                && gameboy.getGpu().getMode() == Mode.OamSearch
+                && gameboy.getGpu().getTicksInLine() == 13)
+                && guard++ < 400_000) {
+            gameboy.tick();
+            if (gameboy.getSpeedMode().getSpeedMode() == 2
+                    && gameboy.getCpu().getState() != Cpu.State.SPEED_SWITCH) {
+                stableDoubleSpeedTicks++;
+            } else {
+                stableDoubleSpeedTicks = 0;
+            }
+        }
+        assertTrue("test did not reach a settled native-CGB mode-2 dot", guard < 400_000);
+    }
+
+    /** Record/array-aware equality for the private immutable component-state graph. */
+    private static void assertDeepStateEquals(String path, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        assertEquals(path + " type", expected.getClass(), actual.getClass());
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            assertEquals(path + " length", length, Array.getLength(actual));
+            for (int i = 0; i < length; i++) {
+                assertDeepStateEquals(path + '[' + i + ']',
+                        Array.get(expected, i), Array.get(actual, i));
+            }
+            return;
+        }
+        if (expected instanceof List<?> expectedList) {
+            List<?> actualList = (List<?>) actual;
+            assertEquals(path + " size", expectedList.size(), actualList.size());
+            for (int i = 0; i < expectedList.size(); i++) {
+                assertDeepStateEquals(path + '[' + i + ']',
+                        expectedList.get(i), actualList.get(i));
+            }
+            return;
+        }
+        if (!type.isRecord()) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        try {
+            for (RecordComponent component : type.getRecordComponents()) {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                assertDeepStateEquals(path + '.' + component.getName(),
+                        accessor.invoke(expected), accessor.invoke(actual));
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Cannot compare " + path, e);
+        }
+    }
+
+    private static byte[] doubleSpeedLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF4D),A
+        image[0x103] = 0x4d;
+        image[0x104] = 0x10; // STOP + padding
+        image[0x105] = 0x00;
+        image[0x106] = (byte) 0xc3; // JP 0106
+        image[0x107] = 0x06;
+        image[0x108] = 0x01;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] dmgRomWramLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x21; // LD HL,C000
+        image[0x101] = 0x00;
+        image[0x102] = (byte) 0xc0;
+        image[0x103] = 0x7e; // LD A,(HL)
+        image[0x104] = 0x3c; // INC A
+        image[0x105] = 0x77; // LD (HL),A
+        image[0x106] = 0x18; // JR 0103
+        image[0x107] = (byte) 0xfb;
+        image[0x143] = 0x00;
+        return image;
+    }
+
+    private static byte[] dmgPlainOamWriteLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x21; // LD HL,FE00
+        image[0x101] = 0x00;
+        image[0x102] = (byte) 0xfe;
+        image[0x103] = 0x3e; // LD A,55
+        image[0x104] = 0x55;
+        image[0x105] = 0x77; // LD (HL),A
+        image[0x106] = 0x3c; // INC A
+        image[0x107] = 0x18; // JR 0105
+        image[0x108] = (byte) 0xfc;
+        image[0x143] = 0x00;
+        return image;
+    }
+
+    private static byte[] dmgPushOamLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x31; // LD SP,FE08
+        image[0x101] = 0x08;
+        image[0x102] = (byte) 0xfe;
+        image[0x103] = 0x01; // LD BC,1234
+        image[0x104] = 0x34;
+        image[0x105] = 0x12;
+        image[0x106] = (byte) 0xc5; // PUSH BC (three DMG write corruptions)
+        image[0x107] = (byte) 0xc3; // JP 0100
+        image[0x108] = 0x00;
+        image[0x109] = 0x01;
+        image[0x143] = 0x00;
+        return image;
+    }
+
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -62,6 +62,23 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void stopAwareMeasuredWindowRetainsPerformanceEpochLane() throws Exception {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build()) {
+            gameboy.runTicks(160_000);
+            assertEquals(2, gameboy.getSpeedMode().getSpeedMode());
+            gameboy.resetPerformanceBulkCounters();
+
+            assertEquals(4_096, gameboy.runMeasuredTicksUntilStop(4_096, () -> false));
+            assertTrue("measured stop-aware PERFORMANCE path lost native epoch coverage",
+                    gameboy.getPerformanceEpochTicks() > 0L);
+        }
+    }
+
+    @Test
     public void physicalDmgEntersEpochWhileCgbCompatibilityStaysLegacy() throws Exception {
         byte[] loop = new byte[0x8000];
         loop[0x100] = (byte) 0xc3;

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -1,0 +1,377 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.gpu.Mode;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Differential coverage for the short physical-DMG mode-2 phase packet. */
+public final class GameboyPerformanceMode2PhaseTest {
+
+    /** Deliberately non-identity source: PERFORMANCE's input horizon must reject this leg. */
+    private static final PlayerInputSource SCALAR_INPUT = PlayerInputSnapshot::released;
+
+    private record Mode2ExclusionCase(String label, HardwareProfile profile,
+                                      ExecutionMode executionMode, boolean nativeColor,
+                                      boolean scanlineCapable) {
+    }
+
+    @Test
+    public void physicalDmgAndMgbMode2PacketsMatchScalarForBothSpriteHeights()
+            throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[] {
+                HardwareProfileRegistry.DMG, HardwareProfileRegistry.MGB
+        }) {
+            for (boolean tallSprites : new boolean[] {false, true}) {
+                for (int start : new int[] {0, 1, 2, 3, 13, 20, 76, 77, 78}) {
+                    int[] spans = {1, 2, 3};
+                    for (int requested : spans) {
+                        if (start + requested > 79) {
+                            continue;
+                        }
+                        PlayerInputHub candidateHub = new PlayerInputHub();
+                        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                                Gameboy scalar = session(profile, SCALAR_INPUT);
+                                Gameboy candidate = session(profile, candidateHub)) {
+                            reachMode2Start(scalar, candidate, start, tallSprites);
+                            scalar.getGpu().setPerformanceScanlineEnabled(true);
+                            candidate.getGpu().setPerformanceScanlineEnabled(true);
+                            assertEquals("mode-2 quiet span was unexpectedly admitted",
+                                    0, candidate.getGpu().performanceQuietSpanLimit());
+                            assertTrue("DMG mode-2 preflight rejected profile="
+                                            + profile.id() + " tall=" + tallSprites
+                                            + " start=" + start + " span=" + requested,
+                                    candidate.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(
+                                            requested) > 0);
+                            int cpuPhaseLimit = candidate.getCpu().performancePhaseOnlySpanLimit();
+                            String caseDetails = "profile=" + profile.id()
+                                    + " tall=" + tallSprites + " start=" + start
+                                    + " requested=" + requested + " cpuPhaseLimit="
+                                    + cpuPhaseLimit + " cpuState=" + candidate.getCpu().getState()
+                                    + " gpuMode=" + candidate.getGpu().getMode()
+                                    + " gpuDot=" + candidate.getGpu().getTicksInLine();
+                            candidate.resetPerformanceBulkCounters();
+
+                            for (int i = 0; i < requested; i++) {
+                                scalar.tick();
+                            }
+                            assertEquals("candidate frame callback",
+                                    0, candidate.runTicks(requested));
+                            if (start >= 13 && requested <= cpuPhaseLimit) {
+                                assertTrue("mode-2 packet was not selected (" + caseDetails
+                                                + ", bulkTicks="
+                                                + candidate.getPerformanceBulkTicks() + ")",
+                                        candidate.getPerformanceBulkTicks() > 0);
+                            } else if (start <= 3) {
+                                assertEquals("early mode-2 STAT checkpoint took a bulk packet ("
+                                                + caseDetails + ")", 0,
+                                        candidate.getPerformanceBulkTicks());
+                            }
+                            assertDeepStateEquals("profile=" + profile.id()
+                                            + " tall=" + tallSprites + " start=" + start
+                                            + " span=" + requested,
+                                    scalar.captureStateWithoutTimeSource(),
+                                    candidate.captureStateWithoutTimeSource());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void physicalDmgMode2LeavesDot79To80Scalar() throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy scalar = session(HardwareProfileRegistry.DMG, SCALAR_INPUT);
+                Gameboy candidate = session(HardwareProfileRegistry.DMG, candidateHub)) {
+            reachMode2Start(scalar, candidate, 76, false);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.resetPerformanceBulkCounters();
+
+            for (int i = 0; i < 3; i++) {
+                scalar.tick();
+            }
+            assertEquals(0, candidate.runTicks(3));
+            assertEquals(79, candidate.getGpu().getTicksInLine());
+            assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
+            long packetTicks = candidate.getPerformanceBulkTicks();
+            assertTrue("mode-2 prefix was not bulk committed", packetTicks > 0);
+
+            scalar.tick();
+            assertEquals(0, candidate.runTicks(1));
+            assertEquals(80, candidate.getGpu().getTicksInLine());
+            assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
+            assertEquals("mode-3 handoff entered the mode-2 packet", packetTicks,
+                    candidate.getPerformanceBulkTicks());
+            assertDeepStateEquals("dot-79 handoff", scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void physicalDmgMode2RejectsAnActiveDmaTransfer() throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy gameboy = session(HardwareProfileRegistry.DMG, candidateHub)) {
+            reachMode2Start(gameboy, gameboy, 20, false);
+            gameboy.getGpu().setPerformanceScanlineEnabled(true);
+            gameboy.getAddressSpace().setByte(0xff46, 0x80);
+            assertEquals(0,
+                    gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(3));
+        }
+    }
+
+    @Test
+    public void physicalDmgMode2RestoreFailsClosedThenMatchesScalar() throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy scalar = session(HardwareProfileRegistry.DMG, SCALAR_INPUT);
+                Gameboy candidate = session(HardwareProfileRegistry.DMG, candidateHub)) {
+            reachMode2Start(scalar, candidate, 20, true);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            var checkpoint = candidate.captureState();
+            candidate.restoreState(checkpoint);
+
+            // Restored LCDC history is intentionally conservative for nine dots. The scalar
+            // fallback during that drain must remain observationally equivalent.
+            for (int i = 0; i < 9; i++) {
+                scalar.tick();
+                candidate.runTicks(1);
+            }
+            assertDeepStateEquals("restore mode-2 drain",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void physicalDmgMode2ExcludesOtherProfilesAtAnOtherwiseEligibleMode2Point()
+            throws Exception {
+        // The positive DMG control proves that this exact non-first-line mode-2 fixture has
+        // settled LCDC/output/OAM state. Every row below reaches the same point; only the
+        // construction-time profile or execution-mode permission is changed.
+        PlayerInputHub controlHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = controlHub.openSource(0);
+                Gameboy control = session(HardwareProfileRegistry.DMG, controlHub)) {
+            reachMode2Start(control, control, 20, false);
+            advanceToPerformanceCpuPhase(control);
+            control.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue("DMG control fixture was not otherwise eligible",
+                    control.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(3) > 0);
+        }
+
+        Mode2ExclusionCase[] cases = {
+                new Mode2ExclusionCase("sgb", HardwareProfileRegistry.SGB,
+                        ExecutionMode.PERFORMANCE, false, false),
+                new Mode2ExclusionCase("sgb2", HardwareProfileRegistry.SGB2,
+                        ExecutionMode.PERFORMANCE, false, false),
+                new Mode2ExclusionCase("cgb-native", HardwareProfileRegistry.CGB,
+                        ExecutionMode.PERFORMANCE, true, true),
+                new Mode2ExclusionCase("cgb0-native", HardwareProfileRegistry.CGB0,
+                        ExecutionMode.PERFORMANCE, true, true),
+                new Mode2ExclusionCase("cgb-compat", HardwareProfileRegistry.CGB,
+                        ExecutionMode.PERFORMANCE, false, true),
+                new Mode2ExclusionCase("accuracy-dmg", HardwareProfileRegistry.DMG,
+                        ExecutionMode.ACCURACY, false, false)
+        };
+        for (Mode2ExclusionCase exclusion : cases) {
+            PlayerInputHub hub = new PlayerInputHub();
+            try (PlayerInputHub.SourceHandle ignored = hub.openSource(0);
+                    Gameboy gameboy = session(exclusion.profile(), hub,
+                            exclusion.executionMode(), exclusion.nativeColor())) {
+                reachMode2Start(gameboy, gameboy, 20, false);
+                assertEquals(exclusion.label() + " mode", Mode.OamSearch,
+                        gameboy.getGpu().getMode());
+                assertEquals(exclusion.label() + " line", 1, gameboy.getGpu().getLine());
+                assertEquals(exclusion.label() + " dot", 20,
+                        gameboy.getGpu().getTicksInLine());
+                assertTrue(exclusion.label() + " LCD disabled", gameboy.getGpu().isLcdEnabled());
+                assertEquals(exclusion.label() + " speed", 1,
+                        gameboy.getSpeedMode().getSpeedMode());
+                assertEquals(exclusion.label() + " mode-2 quiet path unexpectedly active", 0,
+                        gameboy.getGpu().performanceQuietSpanLimit());
+                if (exclusion.scanlineCapable()) {
+                    advanceToPerformanceCpuPhase(gameboy);
+                    gameboy.getGpu().setPerformanceScanlineEnabled(true);
+                    assertTrue(exclusion.label() + " CPU phase is not available",
+                            gameboy.getCpu().performancePhaseOnlySpanLimit() > 0);
+                }
+                assertEquals(exclusion.label() + " entered the physical-DMG mode-2 plan", 0,
+                        gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(3));
+            }
+        }
+    }
+
+    private static void advanceToPerformanceCpuPhase(Gameboy gameboy) {
+        int guard = 0;
+        while (gameboy.getCpu().performancePhaseOnlySpanLimit() == 0 && guard++ < 4) {
+            gameboy.tick();
+        }
+        assertTrue("mode-2 exclusion fixture left the CPU on a boundary",
+                gameboy.getCpu().performancePhaseOnlySpanLimit() > 0);
+        assertEquals(Mode.OamSearch, gameboy.getGpu().getMode());
+        assertTrue("mode-2 exclusion fixture crossed the OAM horizon",
+                gameboy.getGpu().getTicksInLine() < 79);
+    }
+
+    @Test
+    public void priorHblankHeightChangePreservesDmgYHalfStateAtNextLineDotZero()
+            throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy scalar = session(HardwareProfileRegistry.DMG, SCALAR_INPUT);
+                Gameboy candidate = session(HardwareProfileRegistry.DMG, candidateHub)) {
+            reachMode2Start(scalar, candidate, 0, false);
+            int guard = 0;
+            while (scalar.getGpu().getMode() != Mode.HBlank && guard++ < 456) {
+                scalar.tick();
+                candidate.tick();
+            }
+            assertTrue("did not reach line-1 HBlank", guard < 456);
+
+            int oldLcdc = scalar.getGpu().getByte(0xff40);
+            scalar.getGpu().setByte(0xff40, oldLcdc | 0x04);
+            candidate.getGpu().setByte(0xff40, oldLcdc | 0x04);
+            guard = 0;
+            while ((scalar.getGpu().getLine() != 2
+                            || scalar.getGpu().getTicksInLine() != 0)
+                    && guard++ < 456) {
+                scalar.tick();
+                candidate.tick();
+            }
+            assertTrue("did not reach next-line dot zero", guard < 456);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue(candidate.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(1) > 0);
+
+            scalar.tick();
+            assertEquals(0, candidate.runTicks(1));
+            assertDeepStateEquals("prior-HBlank LCDC.2 transition",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    private static void reachMode2Start(Gameboy scalar, Gameboy candidate,
+                                         int targetDot, boolean tallSprites) {
+        int guard = 0;
+        while (scalar.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
+            scalar.tick();
+            if (candidate != scalar) {
+                candidate.tick();
+            }
+        }
+        assertTrue("mode-2 setup did not reach VBlank", guard < 456 * 155);
+
+        int lcdc = scalar.getGpu().getByte(0xff40);
+        int requestedLcdc = tallSprites ? lcdc | 0x04 : lcdc & ~0x04;
+        scalar.getGpu().setByte(0xff40, requestedLcdc);
+        if (candidate != scalar) {
+            candidate.getGpu().setByte(0xff40, requestedLcdc);
+        }
+        // Two selected sprites exercise the same Y/X commit path without relying on an OAM
+        // DMA burst.  Their Y covers line 1 for both 8- and 16-pixel modes.
+        for (int index = 0; index < 2; index++) {
+            int address = 0xfe00 + index * 4;
+            scalar.getGpu().setByte(address, 17);
+            scalar.getGpu().setByte(address + 1, 8 + index * 16);
+            if (candidate != scalar) {
+                candidate.getGpu().setByte(address, 17);
+                candidate.getGpu().setByte(address + 1, 8 + index * 16);
+            }
+        }
+
+        guard = 0;
+        while ((scalar.getGpu().getLine() != 1
+                        || scalar.getGpu().getTicksInLine() != targetDot)
+                && guard++ < 456 * 12) {
+            scalar.tick();
+            if (candidate != scalar) {
+                candidate.tick();
+            }
+        }
+        assertTrue("mode-2 setup did not reach line 1 dot " + targetDot,
+                guard < 456 * 12);
+        assertEquals(Mode.OamSearch, scalar.getGpu().getMode());
+        assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
+    }
+
+    private static Gameboy session(HardwareProfile profile, PlayerInputSource inputSource)
+            throws Exception {
+        return session(profile, inputSource, ExecutionMode.PERFORMANCE, false);
+    }
+
+    private static Gameboy session(HardwareProfile profile, PlayerInputSource inputSource,
+                                   ExecutionMode executionMode, boolean nativeColor)
+            throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = (byte) 0xc3;
+        image[0x101] = 0;
+        image[0x102] = 1;
+        if (nativeColor) {
+            image[0x143] = (byte) 0x80;
+        }
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(profile)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static void assertDeepStateEquals(String path, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        assertEquals(path + " type", expected.getClass(), actual.getClass());
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            assertEquals(path + " length", length, Array.getLength(actual));
+            for (int i = 0; i < length; i++) {
+                assertDeepStateEquals(path + '[' + i + ']', Array.get(expected, i),
+                        Array.get(actual, i));
+            }
+            return;
+        }
+        if (expected instanceof List<?> expectedList) {
+            List<?> actualList = (List<?>) actual;
+            assertEquals(path + " size", expectedList.size(), actualList.size());
+            for (int i = 0; i < expectedList.size(); i++) {
+                assertDeepStateEquals(path + '[' + i + ']', expectedList.get(i),
+                        actualList.get(i));
+            }
+            return;
+        }
+        if (!type.isRecord()) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        try {
+            for (RecordComponent component : type.getRecordComponents()) {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                assertDeepStateEquals(path + '.' + component.getName(),
+                        accessor.invoke(expected), accessor.invoke(actual));
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Cannot compare " + path, e);
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceS1Test.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceS1Test.java
@@ -1,0 +1,131 @@
+package eu.rekawek.coffeegb.core;
+
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Focused routing coverage for the native-CGB scalar STAT/PPU prologue. */
+public final class GameboyPerformanceS1Test {
+
+    @Test
+    public void nativeOwnerMatchesGenericScalarTicksAndWarmResetDropsOwner() throws Exception {
+        try (Gameboy generic = nativeSession(); Gameboy specialized = nativeSession()) {
+            generic.runTicks(160_000);
+            specialized.runTicks(160_000);
+            assertTrue(generic.getSpeedMode().getSpeedMode() == 2);
+            assertTrue(specialized.getSpeedMode().getSpeedMode() == 2);
+            assertDeepStateEquals("initial native state",
+                    generic.captureStateWithoutTimeSource(),
+                    specialized.captureStateWithoutTimeSource());
+
+            for (int i = 0; i < 96; i++) {
+                generic.tick();
+                setNativeOwner(specialized, true);
+                specialized.tick();
+                assertDeepStateEquals("native scalar dot " + i,
+                        generic.captureStateWithoutTimeSource(),
+                        specialized.captureStateWithoutTimeSource());
+            }
+
+            generic.requestWarmReset(false);
+            specialized.requestWarmReset(false);
+            generic.tick();
+            setNativeOwner(specialized, true);
+            specialized.tick();
+            assertFalse(nativeOwner(specialized));
+            assertDeepStateEquals("warm reset generic handoff",
+                    generic.captureStateWithoutTimeSource(),
+                    specialized.captureStateWithoutTimeSource());
+        }
+    }
+
+    private static Gameboy nativeSession() throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static void setNativeOwner(Gameboy gameboy, boolean value) throws Exception {
+        Field field = Gameboy.class.getDeclaredField("nativeCgbScalarOwner");
+        field.setAccessible(true);
+        field.setBoolean(gameboy, value);
+    }
+
+    private static boolean nativeOwner(Gameboy gameboy) throws Exception {
+        Field field = Gameboy.class.getDeclaredField("nativeCgbScalarOwner");
+        field.setAccessible(true);
+        return field.getBoolean(gameboy);
+    }
+
+    private static byte[] doubleSpeedLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e;
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0;
+        image[0x103] = 0x4d;
+        image[0x104] = 0x10;
+        image[0x105] = 0x00;
+        image[0x106] = (byte) 0xc3;
+        image[0x107] = 0x06;
+        image[0x108] = 0x01;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static void assertDeepStateEquals(String path, Object expected, Object actual)
+            throws Exception {
+        if (expected == null || actual == null) {
+            if (expected != actual) {
+                throw new AssertionError(path + " expected=" + expected + " actual=" + actual);
+            }
+            return;
+        }
+        if (!expected.getClass().equals(actual.getClass())) {
+            throw new AssertionError(path + " type expected=" + expected.getClass()
+                    + " actual=" + actual.getClass());
+        }
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            if (length != Array.getLength(actual)) {
+                throw new AssertionError(path + " array length");
+            }
+            for (int i = 0; i < length; i++) {
+                assertDeepStateEquals(path + '[' + i + ']', Array.get(expected, i),
+                        Array.get(actual, i));
+            }
+            return;
+        }
+        if (expected instanceof java.util.List<?> expectedList) {
+            java.util.List<?> actualList = (java.util.List<?>) actual;
+            if (expectedList.size() != actualList.size()) {
+                throw new AssertionError(path + " list size");
+            }
+            for (int i = 0; i < expectedList.size(); i++) {
+                assertDeepStateEquals(path + '[' + i + ']', expectedList.get(i),
+                        actualList.get(i));
+            }
+            return;
+        }
+        if (!type.isRecord()) {
+            if (!expected.equals(actual)) {
+                throw new AssertionError(path + " expected=" + expected + " actual=" + actual);
+            }
+            return;
+        }
+        for (RecordComponent component : type.getRecordComponents()) {
+            component.getAccessor().setAccessible(true);
+            assertDeepStateEquals(path + '.' + component.getName(),
+                    component.getAccessor().invoke(expected),
+                    component.getAccessor().invoke(actual));
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -61,9 +61,10 @@ public final class GameboyPlayerInputHubPerformanceTest {
                         assertRasterEquivalent(scalar, performance,
                                 "cgb=" + cgb + ", held=" + held + ", chunk=" + chunkIndex);
                     }
-                    assertTrue("hub performance path had no bulk coverage cgb=" + cgb
+                    assertTrue("hub performance path had no fast coverage cgb=" + cgb
                                     + ", held=" + held,
-                            performance.getPerformanceBulkTicks() > 0);
+                            performance.getPerformanceBulkTicks()
+                                    + performance.getPerformanceEpochTicks() > 0);
 
                     ComponentState<Gameboy> saved = performance.captureState();
                     int savedHash = stateHash(saved);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -306,6 +306,170 @@ public final class GameboyPlayerInputHubPerformanceTest {
         }
     }
 
+    @Test
+    public void nativeDoubleSpeedSettledHaltMatchesScalarAcrossPacketTails() throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        performanceHub.openSource(0);
+        try (Gameboy performance = nativeDoubleSpeedHaltSession(performanceHub);
+                Gameboy scalar = nativeDoubleSpeedHaltSession(
+                        () -> PlayerInputSnapshot.released())) {
+            settleNativeDoubleSpeedHalt(performance, scalar);
+            ComponentState<Gameboy> settledPerformance = performance.captureState();
+            ComponentState<Gameboy> settledScalar = scalar.captureState();
+            int[] tails = {1, 2, 3, 17, 53, 54, 55};
+            for (int tail : tails) {
+                performance.restoreState(settledPerformance);
+                scalar.restoreState(settledScalar);
+                assertEquals("native HALT tail=" + tail + " frame events",
+                        runScalarTicks(scalar, tail), performance.runTicks(tail));
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "native HALT tail=" + tail);
+                assertRasterEquivalent(scalar, performance, "native HALT tail=" + tail);
+            }
+
+            performance.restoreState(settledPerformance);
+            scalar.restoreState(settledScalar);
+            performance.resetPerformanceBulkCounters();
+            assertEquals("native HALT 1000-dot frame events", runScalarTicks(scalar, 1_000),
+                    performance.runTicks(1_000));
+            assertTrue("native double-speed HALT did not cross a CPU phase boundary",
+                    performance.getPerformanceBulkMaxTicks() > 3);
+            assertTrue("native double-speed HALT had no substantial packet coverage",
+                    performance.getPerformanceBulkTicks() > 3);
+            assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                    "native HALT 54-dot packet");
+        }
+    }
+
+    @Test
+    public void nativeDoubleSpeedSettledHaltWakeEdgesMatchScalarForAllTails() throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        performanceHub.openSource(0);
+        try (Gameboy performance = nativeDoubleSpeedHaltSession(performanceHub);
+                Gameboy scalar = nativeDoubleSpeedHaltSession(
+                        () -> PlayerInputSnapshot.released())) {
+            settleNativeDoubleSpeedHalt(performance, scalar);
+            ComponentState<Gameboy> settledPerformance = performance.captureState();
+            ComponentState<Gameboy> settledScalar = scalar.captureState();
+            int[] tails = {1, 2, 3, 17, 53, 54, 55};
+            for (WakeSource wakeSource : WakeSource.values()) {
+                for (int tail : tails) {
+                    performance.restoreState(settledPerformance);
+                    scalar.restoreState(settledScalar);
+                    armWakeSource(performance, wakeSource);
+                    armWakeSource(scalar, wakeSource);
+                    int elapsed = 0;
+                    while (performance.getCpu().getState() == Cpu.State.HALTED
+                            && elapsed < 4_000) {
+                        assertEquals(context(true, wakeSource, tail) + " frame events",
+                                runScalarTicks(scalar, tail), performance.runTicks(tail));
+                        assertEquals(context(true, wakeSource, tail) + " CPU state",
+                                scalar.getCpu().getState(), performance.getCpu().getState());
+                        elapsed += tail;
+                    }
+                    assertTrue(context(true, wakeSource, tail) + " did not wake",
+                            performance.getCpu().getState() != Cpu.State.HALTED);
+                    assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                            context(true, wakeSource, tail) + " wake");
+                    assertRasterEquivalent(scalar, performance,
+                            context(true, wakeSource, tail) + " wake");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void nativeDoubleSpeedSettledHaltPlayerInputPollAndRestoreAtBothCpuPhases()
+            throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        PlayerInputHub.SourceHandle performanceSource = performanceHub.openSource(0);
+        AtomicReference<PlayerInputSnapshot> scalarInput = new AtomicReference<>(
+                PlayerInputSnapshot.released());
+        try (Gameboy performance = nativeDoubleSpeedHaltSession(performanceHub);
+                Gameboy scalar = nativeDoubleSpeedHaltSession(scalarInput::get)) {
+            settleNativeDoubleSpeedHalt(performance, scalar);
+            ComponentState<Gameboy> settledPerformance = performance.captureState();
+            ComponentState<Gameboy> settledScalar = scalar.captureState();
+            for (int phase = 0; phase < 2; phase++) {
+                performance.restoreState(settledPerformance);
+                scalar.restoreState(settledScalar);
+                int guard = 0;
+                while (performance.getCpu().getDebugMachineCycle() != phase
+                        && guard++ < 4) {
+                    assertEquals("phase setup frame", scalar.tick(), performance.tick());
+                }
+                assertEquals("native HALT phase setup", phase,
+                        performance.getCpu().getDebugMachineCycle());
+                ComponentState<Gameboy> phasePerformance = performance.captureState();
+                ComponentState<Gameboy> phaseScalar = scalar.captureState();
+                assertStateEquivalent(phaseScalar, phasePerformance,
+                        "native HALT saved phase=" + phase);
+
+                assertEquals("native HALT restore frame phase=" + phase,
+                        runScalarTicks(scalar, 17), performance.runTicks(17));
+                performance.restoreState(phasePerformance);
+                scalar.restoreState(phaseScalar);
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "native HALT restored phase=" + phase);
+                assertEquals("native HALT restored tail phase=" + phase,
+                        runScalarTicks(scalar, 55), performance.runTicks(55));
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "native HALT restored run phase=" + phase);
+
+                performance.restoreState(phasePerformance);
+                scalar.restoreState(phaseScalar);
+                performance.runTicks(11);
+                scalar.runTicks(11);
+                Set<Button> held = Set.of(Button.A, Button.LEFT);
+                performanceSource.update(held);
+                while ((joypadTick(performance) & 63L) != 0) {
+                    assertEquals("native HALT hub pre-poll phase=" + phase,
+                            runScalarTicks(scalar, 1), performance.runTicks(1));
+                    assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                            "native HALT hub pre-poll phase=" + phase);
+                }
+                scalarInput.set(snapshot(held));
+                assertEquals("native HALT hub poll phase=" + phase,
+                        runScalarTicks(scalar, 1), performance.runTicks(1));
+                assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                        "native HALT hub poll phase=" + phase);
+                scalarInput.set(PlayerInputSnapshot.released());
+                performanceSource.update(Set.of());
+                // sampledInput is intentionally host-only and is not serialized. Let both
+                // hosts observe the release through their ordinary poll before the next phase
+                // restore, so the memento restore starts from the same physical source state.
+                for (int tick = 0; tick < 80; tick++) {
+                    scalar.tick();
+                    performance.tick();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void nativeDoubleSpeedSettledHaltRejectsActiveOamDma() throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        performanceHub.openSource(0);
+        try (Gameboy performance = nativeDoubleSpeedHaltSession(performanceHub);
+                Gameboy scalar = nativeDoubleSpeedHaltSession(
+                        () -> PlayerInputSnapshot.released())) {
+            settleNativeDoubleSpeedHalt(performance, scalar);
+            performance.resetPerformanceBulkCounters();
+            scalar.resetPerformanceBulkCounters();
+            performance.getAddressSpace().setByte(0xff46, 0xc0);
+            scalar.getAddressSpace().setByte(0xff46, 0xc0);
+            assertEquals("active OAM DMA state",
+                    recordComponentHash(scalar.captureState(), "dmaMemento"),
+                    recordComponentHash(performance.captureState(), "dmaMemento"));
+            assertEquals("active OAM DMA frame events", runScalarTicks(scalar, 54),
+                    performance.runTicks(54));
+            assertEquals("active OAM DMA must reject HALT packets", 0L,
+                    performance.getPerformanceBulkTicks());
+            assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                    "active OAM DMA HALT");
+        }
+    }
+
     private static Gameboy session(boolean cgb, ExecutionMode mode, PlayerInputHub hub)
             throws Exception {
         return session(cgb, mode, (PlayerInputSource) hub);
@@ -353,6 +517,33 @@ public final class GameboyPlayerInputHubPerformanceTest {
         return gameboy;
     }
 
+    private static Gameboy nativeDoubleSpeedHaltSession(PlayerInputSource inputSource)
+            throws Exception {
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(nativeDoubleSpeedHaltRom()))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+        gameboy.init(new EventBusImpl(null, null, false), new Peer2PeerSerialEndpoint(), null);
+        return gameboy;
+    }
+
+    private static void settleNativeDoubleSpeedHalt(Gameboy performance, Gameboy scalar) {
+        int guard = 0;
+        while (!(performance.getSpeedMode().getSpeedMode() == 2
+                        && performance.getCpu().getState() == Cpu.State.HALTED
+                        && performance.getCpu().performanceNativeCgbSettledHaltSpanEligible())
+                && guard++ < 300_000) {
+            assertEquals("native HALT setup frame events", scalar.tick(), performance.tick());
+        }
+        assertTrue("native double-speed HALT setup did not settle", guard < 300_000);
+        assertEquals(Cpu.State.HALTED, scalar.getCpu().getState());
+        assertEquals(2, scalar.getSpeedMode().getSpeedMode());
+        assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                "native double-speed HALT settled");
+    }
+
     private static void settleHalt(Gameboy performance, Gameboy scalar, boolean cgb,
                                    WakeSource wakeSource, int tail) {
         performance.runTicks(128);
@@ -395,6 +586,20 @@ public final class GameboyPlayerInputHubPerformanceTest {
         }
     }
 
+    private static byte[] nativeDoubleSpeedHaltRom() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF4D),A
+        image[0x103] = 0x4d;
+        image[0x104] = 0x10; // STOP + padding: enters CGB double speed
+        image[0x105] = 0x00;
+        image[0x106] = 0x76; // HALT after the speed-switch countdown
+        image[0x107] = 0x00;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
     private static long runScalarTicks(Gameboy scalar, int ticks) {
         long frameEvents = 0;
         for (int tick = 0; tick < ticks; tick++) {
@@ -419,6 +624,10 @@ public final class GameboyPlayerInputHubPerformanceTest {
     }
 
     private static int recordComponentHash(Object value, String componentName) {
+        return stateHash(recordComponentValue(value, componentName));
+    }
+
+    private static Object recordComponentValue(Object value, String componentName) {
         for (RecordComponent component : value.getClass().getRecordComponents()) {
             if (!component.getName().equals(componentName)) {
                 continue;
@@ -426,12 +635,17 @@ public final class GameboyPlayerInputHubPerformanceTest {
             try {
                 var accessor = component.getAccessor();
                 accessor.setAccessible(true);
-                return stateHash(accessor.invoke(value));
+                return accessor.invoke(value);
             } catch (ReflectiveOperationException e) {
                 throw new AssertionError("Cannot hash state component " + component, e);
             }
         }
         throw new AssertionError("Missing record component " + componentName);
+    }
+
+    private static long joypadTick(Gameboy gameboy) {
+        Object memento = recordComponentValue(gameboy.captureState(), "joypadMemento");
+        return ((Number) recordComponentValue(memento, "tick")).longValue();
     }
 
     private enum WakeSource {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -1,0 +1,871 @@
+package eu.rekawek.coffeegb.core.cpu;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Contract tests for the allocation-free native-CGB and physical-DMG CPU bus fences. */
+public final class CpuPerformanceEpochTest {
+
+    @Test
+    public void unsafeWriteIsDeferredAndReplayedOnce() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x3e; // LD A,1
+        memory.bytes[1] = 0x01;
+        memory.bytes[2] = (byte) 0xe0; // LDH (FF40),A
+        memory.bytes[3] = 0x40;
+        InterruptManager interrupts = new InterruptManager(true);
+        SpeedMode speed = new SpeedMode(true);
+        speed.setByte(0xff4d, 1);
+        assertTrue(speed.onStop());
+        Cpu cpu = new Cpu(memory, interrupts, null, speed, new Display(false));
+
+        int elapsed = cpu.runPerformanceEpoch(54);
+
+        assertTrue(elapsed > 0);
+        assertEquals("unsafe write must not reach the target before replay", 0, memory.writes);
+        assertTrue(cpu.hasPerformanceEpochJournal());
+        assertTrue(cpu.replayPerformanceEpochJournal());
+        assertEquals(1, memory.writes);
+        assertEquals(0xff40, memory.lastWriteAddress);
+        assertEquals(1, cpu.getPerformanceEpochTerminalAccesses());
+        assertTrue("journal is one-shot", !cpu.replayPerformanceEpochJournal());
+    }
+
+    @Test
+    public void normalSpeedNeverEntersNativeEpoch() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x00;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                new SpeedMode(true), new Display(false));
+        assertEquals(0, cpu.runPerformanceEpoch(54));
+        assertEquals(0L, cpu.getPerformanceEpochCount());
+    }
+
+    @Test
+    public void physicalDmgFourDotEpochMatchesScalarRomWramLoopAtEveryBudget()
+            throws Exception {
+        for (int entryPhase = 0; entryPhase < 4; entryPhase++) {
+            for (int budget = 1; budget <= Cpu.PERFORMANCE_EPOCH_MAX_TICKS; budget++) {
+                ParityMemory directMemory = new ParityMemory();
+                directMemory.bytes[0x0000] = 0x21; // LD HL,C000
+                directMemory.bytes[0x0001] = 0x00;
+                directMemory.bytes[0x0002] = (byte) 0xc0;
+                directMemory.bytes[0x0003] = 0x7e; // LD A,(HL)
+                directMemory.bytes[0x0004] = 0x3c; // INC A
+                directMemory.bytes[0x0005] = 0x77; // LD (HL),A
+                directMemory.bytes[0x0006] = 0x18; // JR 0003
+                directMemory.bytes[0x0007] = (byte) 0xfb;
+                directMemory.bytes[0xc000] = 0x23;
+                ParityMemory scalarMemory = new ParityMemory();
+                System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                        directMemory.bytes.length);
+
+                InterruptManager directInterrupts = new InterruptManager(false);
+                InterruptManager scalarInterrupts = new InterruptManager(false);
+                Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                        new SpeedMode(false), new Display(false));
+                Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                        new SpeedMode(false), new Display(false));
+                CpuPair pair = new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                        directMemory, scalarMemory);
+
+                for (int tick = 0; tick < entryPhase; tick++) {
+                    direct.tick();
+                    scalar.tick();
+                }
+
+                assertEquals("physical-DMG phase " + entryPhase + " budget " + budget, budget,
+                        direct.runPhysicalDmgPerformanceEpoch(budget));
+                for (int tick = 0; tick < budget; tick++) {
+                    scalar.tick();
+                }
+                assertCpuPairEquals(pair);
+            }
+        }
+    }
+
+    @Test
+    public void nativeCgbAndPhysicalDmgEntryPointsAreTopologyIsolated() {
+        Cpu physicalDmg = new Cpu(new CountingMemory(), new InterruptManager(false), null,
+                new SpeedMode(false), new Display(false));
+        assertFalse(physicalDmg.performanceEpochEntryEligible());
+        assertEquals(0, physicalDmg.runPerformanceEpoch(54));
+        assertTrue(physicalDmg.performancePhysicalDmgEpochEntryEligible());
+
+        Cpu nativeCgb = new Cpu(new CountingMemory(), new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        assertTrue(nativeCgb.performanceEpochEntryEligible());
+        assertFalse(nativeCgb.performancePhysicalDmgEpochEntryEligible());
+        assertEquals(0, nativeCgb.runPhysicalDmgPerformanceEpoch(54));
+    }
+
+    @Test
+    public void nativeEpochRomLeaseMatchesScalarAcrossCpuBankBoundary() throws Exception {
+        LeasedMemory directMemory = new LeasedMemory(0x4000, 0xc000);
+        directMemory.bytes[0x3fff] = 0x3e; // LD A,d8
+        directMemory.bytes[0x4000] = 0x5a;
+        directMemory.physicalBytes[0x7fff] = 0x3e;
+        directMemory.physicalBytes[0xc000] = 0x5a;
+        ParityMemory scalarMemory = new ParityMemory();
+        System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                directMemory.bytes.length);
+
+        InterruptManager directInterrupts = new InterruptManager(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                doubleSpeed(), new Display(false));
+        Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                doubleSpeed(), new Display(false));
+        direct.getRegisters().setPC(0x3fff);
+        scalar.restoreState(direct.captureState());
+
+        assertEquals(4, direct.runPerformanceEpoch(4));
+        for (int i = 0; i < 4; i++) {
+            scalar.tick();
+        }
+
+        assertDeepEquals("cpu", scalar.captureState(), direct.captureState());
+        assertDeepEquals("interrupts", scalarInterrupts.captureState(),
+                directInterrupts.captureState());
+        assertEquals(0x5a, direct.getRegisters().getA());
+        assertEquals(1, directMemory.leaseAcquisitions);
+        assertEquals(2, directMemory.leaseReads);
+        assertEquals(0x7fff, directMemory.physicalReadOffsets[0]);
+        assertEquals(0xc000, directMemory.physicalReadOffsets[1]);
+        assertEquals("leased instruction bytes bypass the CPU bus", 0,
+                directMemory.busReads);
+        assertEquals(2, scalarMemory.reads);
+    }
+
+    @Test
+    public void unavailableOrUnmappedRomLeaseFallsBackToAuthoritativeBus() {
+        LeasedMemory unavailable = new LeasedMemory(0, 0x4000);
+        unavailable.leaseAvailable = false;
+        unavailable.bytes[0] = 0x3e; // LD A,d8
+        unavailable.bytes[1] = 0x61;
+        Cpu unavailableCpu = new Cpu(unavailable, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+
+        assertEquals(4, unavailableCpu.runPerformanceEpoch(4));
+        assertEquals(0x61, unavailableCpu.getRegisters().getA());
+        assertEquals(1, unavailable.leaseAcquisitions);
+        assertEquals(2, unavailable.busReads);
+        assertEquals(0, unavailable.leaseReads);
+
+        LeasedMemory unmapped = new LeasedMemory(0, 0x4000);
+        unmapped.mapRom = false;
+        unmapped.bytes[0] = 0x3e; // LD A,d8
+        unmapped.bytes[1] = 0x72;
+        Cpu unmappedCpu = new Cpu(unmapped, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+
+        assertEquals(4, unmappedCpu.runPerformanceEpoch(4));
+        assertEquals(0x72, unmappedCpu.getRegisters().getA());
+        assertEquals(1, unmapped.leaseAcquisitions);
+        assertEquals(2, unmapped.leaseMapProbes);
+        assertEquals(2, unmapped.busReads);
+        assertEquals(0, unmapped.leaseReads);
+    }
+
+    @Test
+    public void mapperWriteTerminatesLeaseAndNextEpochReacquiresNewBank() {
+        LeasedMemory memory = new LeasedMemory(0, 0x4000);
+        memory.bankWritesSelectUpperWindow = true;
+        memory.physicalBytes[0x4000] = 0x3e; // LD A,02 in bank 1
+        memory.physicalBytes[0x4001] = 0x02;
+        memory.physicalBytes[0x4002] = (byte) 0xea; // LD (2000),A
+        memory.physicalBytes[0x4003] = 0x00;
+        memory.physicalBytes[0x4004] = 0x20;
+        memory.physicalBytes[0x4005] = 0x3e; // stale-bank sentinel
+        memory.physicalBytes[0x4006] = 0x11;
+        memory.physicalBytes[0x8005] = 0x3e; // LD A,77 in bank 2
+        memory.physicalBytes[0x8006] = 0x77;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        cpu.getRegisters().setPC(0x4000);
+
+        assertTrue(cpu.runPerformanceEpoch(54) > 0);
+        assertTrue(cpu.hasPerformanceEpochJournal());
+        assertEquals("bank must not change before journal replay", 0x4000,
+                memory.selectedUpperWindowBase);
+        assertTrue(cpu.replayPerformanceEpochJournal());
+        assertEquals(0x8000, memory.selectedUpperWindowBase);
+
+        assertEquals(4, cpu.runPerformanceEpoch(4));
+        assertEquals(0x77, cpu.getRegisters().getA());
+        assertEquals(2, memory.leaseAcquisitions);
+        assertEquals(0x8005, memory.physicalReadOffsets[memory.leaseReads - 2]);
+        assertEquals(0x8006, memory.physicalReadOffsets[memory.leaseReads - 1]);
+    }
+
+    @Test
+    public void scalarAndPhysicalDmgFetchesNeverAcquireNativeRomLease() {
+        LeasedMemory scalarMemory = new LeasedMemory(0, 0x4000);
+        scalarMemory.bytes[0] = 0x00; // NOP on the authoritative bus
+        scalarMemory.physicalBytes[0] = 0x76; // HALT only in the lease
+        Cpu scalar = new Cpu(scalarMemory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+
+        scalar.tick();
+        scalar.tick();
+
+        assertEquals(Cpu.State.OPCODE, scalar.getState());
+        assertEquals(1, scalar.getRegisters().getPC());
+        assertEquals(0, scalarMemory.leaseAcquisitions);
+        assertEquals(1, scalarMemory.busReads);
+
+        LeasedMemory physicalDmgMemory = new LeasedMemory(0, 0x4000);
+        physicalDmgMemory.bytes[0] = 0x00;
+        physicalDmgMemory.physicalBytes[0] = 0x76;
+        Cpu physicalDmg = new Cpu(physicalDmgMemory, new InterruptManager(false), null,
+                new SpeedMode(false), new Display(false));
+
+        assertEquals(4, physicalDmg.runPhysicalDmgPerformanceEpoch(4));
+        assertEquals(Cpu.State.OPCODE, physicalDmg.getState());
+        assertEquals(1, physicalDmg.getRegisters().getPC());
+        assertEquals(0, physicalDmgMemory.leaseAcquisitions);
+        assertEquals(1, physicalDmgMemory.busReads);
+    }
+
+    @Test
+    public void physicalDmgOamWriteFlushesPrefixAndIsNeverJournaled() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x3e; // LD A,42
+        memory.bytes[1] = 0x42;
+        memory.bytes[2] = (byte) 0xea; // LD (FE00),A
+        memory.bytes[3] = 0x00;
+        memory.bytes[4] = (byte) 0xfe;
+        Cpu cpu = new Cpu(memory, new InterruptManager(false), null,
+                new SpeedMode(false), new Display(false));
+        int[] committedPrefix = {0};
+        cpu.setPerformanceEpochPrefixCommitter(ticks -> committedPrefix[0] = ticks);
+
+        int elapsed = cpu.runPhysicalDmgPerformanceEpoch(54);
+
+        assertTrue(elapsed > committedPrefix[0]);
+        assertTrue(committedPrefix[0] > 0);
+        assertEquals(1, memory.writes);
+        assertEquals(0xfe00, memory.lastWriteAddress);
+        assertEquals(0x42, memory.bytes[0xfe00] & 0xff);
+        assertFalse(cpu.hasPerformanceEpochJournal());
+        assertEquals(1, cpu.getPerformanceEpochTerminalAccesses());
+    }
+
+    @Test
+    public void unsafeReadFlushesCompletedPrefixAndDelegatesOnce() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = (byte) 0xf0; // LDH A,(FF00+a8)
+        memory.bytes[1] = 0x44;
+        memory.bytes[0xff44] = 0x66;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        int[] committedPrefix = {0};
+        cpu.setPerformanceEpochPrefixCommitter(ticks -> committedPrefix[0] = ticks);
+
+        int elapsed = cpu.runPerformanceEpoch(54);
+
+        assertTrue(elapsed > committedPrefix[0]);
+        assertTrue("unsafe read did not flush its completed prefix", committedPrefix[0] > 0);
+        assertEquals(1, memory.reads[0xff44]);
+        assertEquals(0x66, cpu.getRegisters().getA());
+        assertEquals(1, cpu.getPerformanceEpochTerminalAccesses());
+        assertFalse(cpu.hasPerformanceEpochJournal());
+    }
+
+    @Test
+    public void stopAndRetiRemainScalarAcrossEpochBoundaries() {
+        CountingMemory stopMemory = new CountingMemory();
+        stopMemory.bytes[0] = 0x10;
+        stopMemory.bytes[1] = 0x00;
+        Cpu stop = new Cpu(stopMemory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        assertTrue(stop.runPerformanceEpoch(54) > 0);
+        assertEquals(Cpu.State.EXT_OPCODE, stop.getState());
+        assertEquals("pending STOP padding must remain scalar", 0, stop.runPerformanceEpoch(54));
+
+        CountingMemory retiMemory = new CountingMemory();
+        retiMemory.bytes[0] = (byte) 0xd9;
+        Cpu reti = new Cpu(retiMemory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        assertTrue(reti.runPerformanceEpoch(54) > 0);
+        assertTrue(reti.getState() != Cpu.State.OPCODE);
+        assertEquals("pending RETI retirement must remain scalar", 0, reti.runPerformanceEpoch(54));
+    }
+
+    @Test
+    public void anyPendingEnabledInterruptRejectsEpochBeforeHaltBugDecode() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x76; // HALT
+        InterruptManager interrupts = new InterruptManager(true);
+        interrupts.setByte(0xffff, 1);
+        interrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        Cpu cpu = new Cpu(memory, interrupts, null, doubleSpeed(), new Display(false));
+
+        assertFalse(cpu.performanceEpochEntryEligible());
+        assertEquals(0, cpu.runPerformanceEpoch(54));
+        assertEquals(0, cpu.getRegisters().getPC());
+    }
+
+    @Test
+    public void instructionBlockedPendingInterruptStillRejectsEpoch() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x00;
+        InterruptManager interrupts = new InterruptManager(true);
+        interrupts.setByte(0xffff, 1);
+        interrupts.requestPhasedInterruptAfterInstruction(
+                InterruptManager.InterruptType.VBlank);
+        Cpu cpu = new Cpu(memory, interrupts, null, doubleSpeed(), new Display(false));
+
+        assertFalse(cpu.performanceEpochEntryEligible());
+        assertEquals(0, cpu.runPerformanceEpoch(54));
+        assertEquals(0, cpu.getRegisters().getPC());
+    }
+
+    @Test
+    public void directBaseOpcodesMatchScalarPipelineForRandomizedState() throws Exception {
+        Random random = new Random(0x5a17a9e1L);
+        for (int opcode = 0; opcode < 0x100; opcode++) {
+            if (!isDirectBaseOpcode(opcode)) {
+                continue;
+            }
+            for (int iteration = 0; iteration < 8; iteration++) {
+                assertDirectMatchesScalar(random, opcode, -1, 0, 2, -1);
+            }
+        }
+    }
+
+    @Test
+    public void directOperandOpcodesMatchScalarPipelineForRandomizedState() throws Exception {
+        Random random = new Random(0x0b9e4d31L);
+        for (int opcode = 0; opcode < 0x100; opcode++) {
+            int operandLength = directOperandLength(opcode);
+            if (operandLength == 0) {
+                continue;
+            }
+            for (int iteration = 0; iteration < 8; iteration++) {
+                int flags = random.nextInt(0x10) << 4;
+                if (isConditionalDirectOperandOpcode(opcode)) {
+                    flags = forceCondition(flags, (opcode >>> 3) & 0x03, false);
+                }
+                assertDirectMatchesScalar(random, opcode, -1, operandLength,
+                        (operandLength + 1) * 2, flags);
+            }
+        }
+    }
+
+    @Test
+    public void directExtendedOpcodesMatchScalarPipelineForRandomizedState() throws Exception {
+        Random random = new Random(0x6cb17e42L);
+        for (int opcode = 0; opcode < 0x100; opcode++) {
+            if ((opcode & 0x07) == 6) {
+                continue;
+            }
+            for (int iteration = 0; iteration < 8; iteration++) {
+                assertDirectMatchesScalar(random, 0xcb, opcode, 0, 4, -1);
+            }
+        }
+    }
+
+    @Test
+    public void directDaaMatchesScalarForEveryAccumulatorAndFlagCombination() throws Exception {
+        Random random = new Random(0xdaaffeL);
+        for (int accumulator = 0; accumulator < 0x100; accumulator++) {
+            for (int flags = 0; flags < 0x100; flags += 0x10) {
+                CpuPair pair = newCpuPair(random, 0x27, -1, 0, flags);
+                pair.direct.getRegisters().setA(accumulator);
+                pair.scalar.getRegisters().setA(accumulator);
+                assertPairAfterTicks(pair, 2);
+            }
+        }
+    }
+
+    @Test
+    public void directCbBitPreservesCarry() throws Exception {
+        Random random = new Random(0xb17ca44eL);
+        for (int bit = 0; bit < 8; bit++) {
+            for (int target = 0; target < 8; target++) {
+                if (target == 6) {
+                    continue;
+                }
+                int opcode = 0x40 | bit << 3 | target;
+                CpuPair pair = newCpuPair(random, 0xcb, opcode, 0, 0x10);
+                assertPairAfterTicks(pair, 4);
+                assertTrue(pair.direct.getRegisters().getFlags().isC());
+            }
+        }
+    }
+
+    @Test
+    public void completeDirectBranchesMatchScalarAtEveryBudget() throws Exception {
+        Random random = new Random(0xb12a9c4eL);
+        int[] opcodes = {0x18, 0x20, 0x28, 0x30, 0x38,
+                0xc2, 0xca, 0xd2, 0xda, 0xc3};
+        for (int opcode : opcodes) {
+            for (boolean taken : new boolean[]{false, true}) {
+                if (opcode == 0x18 || opcode == 0xc3) {
+                    if (!taken) {
+                        continue;
+                    }
+                }
+                int operandLength = opcode < 0x40 ? 1 : 2;
+                int machineCycles = operandLength + 1 + (taken ? 1 : 0);
+                for (int budget = 1; budget <= machineCycles * 2; budget++) {
+                    CpuPair pair = newCpuPair(random, opcode, -1, operandLength, 0);
+                    if (opcode != 0x18 && opcode != 0xc3) {
+                        int condition = (opcode >>> 3) & 0x03;
+                        int flags = forceCondition(random.nextInt(0x10) << 4,
+                                condition, taken);
+                        pair.direct.getRegisters().getFlags().setFlagsByte(flags);
+                        pair.scalar.getRegisters().getFlags().setFlagsByte(flags);
+                    }
+                    assertPairAfterTicks(pair, budget);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void completeDirectMemoryInstructionsMatchScalarAtEveryBudget() throws Exception {
+        Random random = new Random(0x5afe4eadL);
+        int[] opcodes = {0x02, 0x12, 0x0a, 0x1a, 0x22, 0x2a, 0x32, 0x3a,
+                0x34, 0x35, 0x36, 0x46, 0x70, 0x7e, 0x77,
+                0x86, 0x8e, 0x96, 0x9e, 0xa6, 0xae, 0xb6, 0xbe,
+                0xe0, 0xf0, 0xe2, 0xf2, 0xea, 0xfa};
+        for (int opcode : opcodes) {
+            int operandLength = opcode == 0xea || opcode == 0xfa ? 2
+                    : opcode == 0x36 || opcode == 0xe0 || opcode == 0xf0 ? 1 : 0;
+            int machineCycles = 2 + operandLength + (opcode == 0x34 || opcode == 0x35 ? 1 : 0);
+            for (int budget = 1; budget <= machineCycles * 2; budget++) {
+                CpuPair pair = newCpuPair(random, opcode, -1, operandLength, -1);
+                configureSafeMemoryInstruction(pair, opcode);
+                assertPairAfterTicks(pair, budget);
+            }
+        }
+    }
+
+    @Test
+    public void completeDirectWordInstructionsMatchScalarAtEveryBudget() throws Exception {
+        Random random = new Random(0x16b17a11L);
+        int[] opcodes = {0x03, 0x13, 0x23, 0x33, 0x0b, 0x1b, 0x2b, 0x3b,
+                0x09, 0x19, 0x29, 0x39, 0xf9};
+        for (int opcode : opcodes) {
+            for (int budget = 1; budget <= 4; budget++) {
+                CpuPair pair = newCpuPair(random, opcode, -1, 0, -1);
+                setWordRegisters(pair, 0xc120, 0xc240, 0xc360, 0xc480);
+                assertPairAfterTicks(pair, budget);
+            }
+        }
+    }
+
+    @Test
+    public void oddEpochBudgetLeavesTheScalarClockPhaseContinuation() throws Exception {
+        Random random = new Random(0x0ddc10cL);
+        CpuPair pair = newCpuPair(random, 0x00, -1, 0, 0);
+        int initialPc = pair.direct.getRegisters().getPC();
+
+        assertEquals(1, pair.direct.runPerformanceEpoch(1));
+        pair.scalar.tick();
+        assertCpuPairEquals(pair);
+        assertEquals("first dot is phase-only", pair.scalar.getRegisters().getPC(),
+                pair.direct.getRegisters().getPC());
+
+        assertEquals(1, pair.direct.runPerformanceEpoch(1));
+        pair.scalar.tick();
+        assertCpuPairEquals(pair);
+        assertEquals("second dot reaches the opcode boundary", (initialPc + 1) & 0xffff,
+                pair.direct.getRegisters().getPC());
+    }
+
+    @Test
+    public void twoByteUnsafeStoreStopsAtEachJournalSlot() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x08; // LD (a16),SP
+        memory.bytes[1] = 0x40;
+        memory.bytes[2] = (byte) 0xff;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        cpu.getRegisters().setSP(0x1234);
+
+        assertTrue(cpu.runPerformanceEpoch(54) > 0);
+        assertTrue(cpu.replayPerformanceEpochJournal());
+        assertEquals(1, memory.writes);
+        assertEquals(0xff40, memory.lastWriteAddress);
+        assertEquals(0x34, memory.bytes[0xff40] & 0xff);
+
+        assertTrue(cpu.runPerformanceEpoch(54) > 0);
+        assertTrue(cpu.replayPerformanceEpochJournal());
+        assertEquals(2, memory.writes);
+        assertEquals(0xff41, memory.lastWriteAddress);
+        assertEquals(0x12, memory.bytes[0xff41] & 0xff);
+        assertEquals(Cpu.State.OPCODE, cpu.getState());
+    }
+
+    private static void assertDirectMatchesScalar(Random random, int opcode, int extendedOpcode,
+                                                   int operandLength, int ticks, int flags)
+            throws Exception {
+        CpuPair pair = newCpuPair(random, opcode, extendedOpcode, operandLength, flags);
+        assertPairAfterTicks(pair, ticks);
+        CpuPair physicalDmgPair = newCpuPair(
+                random, opcode, extendedOpcode, operandLength, flags, false);
+        assertPhysicalDmgPairAfterTicks(physicalDmgPair, ticks * 2);
+    }
+
+    private static CpuPair newCpuPair(Random random, int opcode, int extendedOpcode,
+                                      int operandLength, int forcedFlags) {
+        return newCpuPair(random, opcode, extendedOpcode, operandLength, forcedFlags, true);
+    }
+
+    private static CpuPair newCpuPair(Random random, int opcode, int extendedOpcode,
+                                      int operandLength, int forcedFlags, boolean gbc) {
+        int pc = 0x0100 + random.nextInt(0x7000);
+        ParityMemory directMemory = new ParityMemory();
+        directMemory.bytes[pc] = (byte) opcode;
+        int next = (pc + 1) & 0xffff;
+        if (extendedOpcode >= 0) {
+            directMemory.bytes[next] = (byte) extendedOpcode;
+        } else {
+            for (int i = 0; i < operandLength; i++) {
+                directMemory.bytes[(next + i) & 0xffff] = (byte) random.nextInt(0x100);
+            }
+        }
+        ParityMemory scalarMemory = new ParityMemory();
+        System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                directMemory.bytes.length);
+
+        InterruptManager directInterrupts = new InterruptManager(gbc);
+        InterruptManager scalarInterrupts = new InterruptManager(gbc);
+        SpeedMode directSpeed = gbc ? doubleSpeed() : new SpeedMode(false);
+        SpeedMode scalarSpeed = gbc ? doubleSpeed() : new SpeedMode(false);
+        Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                directSpeed, new Display(false));
+        Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                scalarSpeed, new Display(false));
+        Registers registers = direct.getRegisters();
+        registers.setA(random.nextInt(0x100));
+        registers.setB(random.nextInt(0x100));
+        registers.setC(random.nextInt(0x100));
+        registers.setD(random.nextInt(0x100));
+        registers.setE(random.nextInt(0x100));
+        registers.setH(random.nextInt(0x100));
+        registers.setL(random.nextInt(0x100));
+        registers.setSP(random.nextInt(0x10000));
+        registers.setPC(pc);
+        registers.getFlags().setFlagsByte(forcedFlags >= 0
+                ? forcedFlags : random.nextInt(0x10) << 4);
+        scalar.restoreState(direct.captureState());
+        scalarInterrupts.restoreState(directInterrupts.captureState());
+        return new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                directMemory, scalarMemory);
+    }
+
+    private static void assertPairAfterTicks(CpuPair pair, int ticks) throws Exception {
+        assertEquals("epoch should consume the complete safe instruction", ticks,
+                pair.direct.runPerformanceEpoch(ticks));
+        for (int i = 0; i < ticks; i++) {
+            pair.scalar.tick();
+        }
+        assertCpuPairEquals(pair);
+    }
+
+    private static void assertPhysicalDmgPairAfterTicks(CpuPair pair, int ticks)
+            throws Exception {
+        assertEquals("physical-DMG epoch should consume the complete safe instruction", ticks,
+                pair.direct.runPhysicalDmgPerformanceEpoch(ticks));
+        for (int i = 0; i < ticks; i++) {
+            pair.scalar.tick();
+        }
+        assertCpuPairEquals(pair);
+    }
+
+    private static void configureSafeMemoryInstruction(CpuPair pair, int opcode) {
+        setWordRegisters(pair, 0xc100, 0xc120, 0xc140, 0xc300);
+        if (opcode == 0xe0 || opcode == 0xf0) {
+            int pc = (pair.direct.getRegisters().getPC() + 1) & 0xffff;
+            pair.directMemory.bytes[pc] = (byte) 0x80;
+            pair.scalarMemory.bytes[pc] = (byte) 0x80;
+        } else if (opcode == 0xe2 || opcode == 0xf2) {
+            pair.direct.getRegisters().setC(0x80);
+            pair.scalar.getRegisters().setC(0x80);
+        } else if (opcode == 0xea || opcode == 0xfa) {
+            int pc = (pair.direct.getRegisters().getPC() + 1) & 0xffff;
+            pair.directMemory.bytes[pc] = 0x60;
+            pair.directMemory.bytes[(pc + 1) & 0xffff] = (byte) 0xc1;
+            pair.scalarMemory.bytes[pc] = 0x60;
+            pair.scalarMemory.bytes[(pc + 1) & 0xffff] = (byte) 0xc1;
+        }
+        for (int address : new int[]{0xc100, 0xc120, 0xc140, 0xc160, 0xff80}) {
+            int value = (address >>> 3 ^ opcode * 37) & 0xff;
+            pair.directMemory.bytes[address] = (byte) value;
+            pair.scalarMemory.bytes[address] = (byte) value;
+        }
+    }
+
+    private static void setWordRegisters(CpuPair pair, int bc, int de, int hl, int sp) {
+        pair.direct.getRegisters().setBC(bc);
+        pair.direct.getRegisters().setDE(de);
+        pair.direct.getRegisters().setHL(hl);
+        pair.direct.getRegisters().setSP(sp);
+        pair.scalar.getRegisters().setBC(bc);
+        pair.scalar.getRegisters().setDE(de);
+        pair.scalar.getRegisters().setHL(hl);
+        pair.scalar.getRegisters().setSP(sp);
+    }
+
+    private static void assertCpuPairEquals(CpuPair pair) throws Exception {
+        assertDeepEquals("cpu", pair.scalar.captureState(), pair.direct.captureState());
+        assertDeepEquals("interrupts", pair.scalarInterrupts.captureState(),
+                pair.directInterrupts.captureState());
+        assertArrayEquals("memory", pair.scalarMemory.bytes, pair.directMemory.bytes);
+        assertEquals("read count", pair.scalarMemory.reads, pair.directMemory.reads);
+        assertEquals("last read", pair.scalarMemory.lastReadAddress,
+                pair.directMemory.lastReadAddress);
+        assertEquals("write count", pair.scalarMemory.writes, pair.directMemory.writes);
+        assertEquals("last write", pair.scalarMemory.lastWriteAddress,
+                pair.directMemory.lastWriteAddress);
+    }
+
+    private static void assertDeepEquals(String path, Object expected, Object actual)
+            throws Exception {
+        if (expected == actual) {
+            return;
+        }
+        assertNotNull(path + " actual", actual);
+        assertNotNull(path + " expected", expected);
+        assertEquals(path + " type", expected.getClass(), actual.getClass());
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            assertEquals(path + " length", length, Array.getLength(actual));
+            for (int i = 0; i < length; i++) {
+                assertDeepEquals(path + '[' + i + ']', Array.get(expected, i),
+                        Array.get(actual, i));
+            }
+            return;
+        }
+        if (type.isRecord()) {
+            for (RecordComponent component : type.getRecordComponents()) {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                assertDeepEquals(path + '.' + component.getName(),
+                        accessor.invoke(expected), accessor.invoke(actual));
+            }
+            return;
+        }
+        assertEquals(path, expected, actual);
+    }
+
+    private static boolean isDirectBaseOpcode(int opcode) {
+        if (opcode == 0x00 || opcode == 0x07 || opcode == 0x0f
+                || opcode == 0x17 || opcode == 0x1f || opcode == 0x27
+                || opcode == 0x2f || opcode == 0x37 || opcode == 0x3f
+                || opcode == 0xe9) {
+            return true;
+        }
+        int register = (opcode >>> 3) & 0x07;
+        if (((opcode & 0xc7) == 0x04 || (opcode & 0xc7) == 0x05)
+                && register != 6) {
+            return true;
+        }
+        if (opcode >= 0x40 && opcode <= 0x7f && opcode != 0x76) {
+            return register != 6 && (opcode & 0x07) != 6;
+        }
+        return opcode >= 0x80 && opcode <= 0xbf && (opcode & 0x07) != 6;
+    }
+
+    private static int directOperandLength(int opcode) {
+        if ((opcode & 0xcf) == 0x01) {
+            return 2;
+        }
+        int register = (opcode >>> 3) & 0x07;
+        if ((opcode & 0xc7) == 0x06 && register != 6 || (opcode & 0xc7) == 0xc6) {
+            return 1;
+        }
+        if ((opcode & 0xe7) == 0x20) {
+            return 1;
+        }
+        if ((opcode & 0xe7) == 0xc2 || (opcode & 0xe7) == 0xc4) {
+            return 2;
+        }
+        return 0;
+    }
+
+    private static boolean isConditionalDirectOperandOpcode(int opcode) {
+        return (opcode & 0xe7) == 0x20
+                || (opcode & 0xe7) == 0xc2
+                || (opcode & 0xe7) == 0xc4;
+    }
+
+    private static int forceCondition(int flags, int condition, boolean value) {
+        int mask = condition < 2 ? 0x80 : 0x10;
+        boolean flagMustBeSet = (condition & 1) == 1 ? value : !value;
+        return flagMustBeSet ? flags | mask : flags & ~mask;
+    }
+
+    private static SpeedMode doubleSpeed() {
+        SpeedMode speed = new SpeedMode(true);
+        speed.setByte(0xff4d, 1);
+        assertTrue(speed.onStop());
+        return speed;
+    }
+
+    private static final class CpuPair {
+        private final Cpu direct;
+        private final Cpu scalar;
+        private final InterruptManager directInterrupts;
+        private final InterruptManager scalarInterrupts;
+        private final ParityMemory directMemory;
+        private final ParityMemory scalarMemory;
+
+        private CpuPair(Cpu direct, Cpu scalar,
+                        InterruptManager directInterrupts, InterruptManager scalarInterrupts,
+                        ParityMemory directMemory, ParityMemory scalarMemory) {
+            this.direct = direct;
+            this.scalar = scalar;
+            this.directInterrupts = directInterrupts;
+            this.scalarInterrupts = scalarInterrupts;
+            this.directMemory = directMemory;
+            this.scalarMemory = scalarMemory;
+        }
+    }
+
+    private static final class ParityMemory implements AddressSpace {
+        private final byte[] bytes = new byte[0x10000];
+        private int reads;
+        private int lastReadAddress = -1;
+        private int writes;
+        private int lastWriteAddress = -1;
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address <= 0xffff;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            writes++;
+            lastWriteAddress = address & 0xffff;
+            bytes[lastWriteAddress] = (byte) value;
+        }
+
+        @Override
+        public int getByte(int address) {
+            reads++;
+            lastReadAddress = address & 0xffff;
+            return bytes[lastReadAddress] & 0xff;
+        }
+    }
+
+    private static final class CountingMemory implements AddressSpace {
+        private final byte[] bytes = new byte[0x10000];
+        private int writes;
+        private int lastWriteAddress;
+        private final int[] reads = new int[0x10000];
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address <= 0xffff;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            writes++;
+            lastWriteAddress = address & 0xffff;
+            bytes[address & 0xffff] = (byte) value;
+        }
+
+        @Override
+        public int getByte(int address) {
+            reads[address & 0xffff]++;
+            return bytes[address & 0xffff] & 0xff;
+        }
+    }
+
+    private static final class LeasedMemory
+            implements AddressSpace, PerformanceRomAccessProvider {
+
+        private final byte[] bytes = new byte[0x10000];
+        private final byte[] physicalBytes = new byte[0x10001];
+        private final int lowerWindowBase;
+        private int selectedUpperWindowBase;
+        private int leasedUpperWindowBase;
+        private final int[] physicalReadOffsets = new int[64];
+        private boolean leaseAvailable = true;
+        private boolean mapRom = true;
+        private boolean bankWritesSelectUpperWindow;
+        private int leaseAcquisitions;
+        private int leaseMapProbes;
+        private int leaseReads;
+        private int busReads;
+
+        private final PerformanceRomAccess lease = new PerformanceRomAccess() {
+            @Override
+            public int physicalOffset(int cpuAddress) {
+                leaseMapProbes++;
+                if (!mapRom || cpuAddress < 0 || cpuAddress >= 0x8000) {
+                    return -1;
+                }
+                return cpuAddress < 0x4000
+                        ? lowerWindowBase + cpuAddress
+                        : leasedUpperWindowBase + cpuAddress - 0x4000;
+            }
+
+            @Override
+            public int readPhysicalByte(int physicalOffset) {
+                physicalReadOffsets[leaseReads++] = physicalOffset;
+                return physicalBytes[physicalOffset] & 0xff;
+            }
+        };
+
+        private LeasedMemory(int lowerWindowBase, int upperWindowBase) {
+            this.lowerWindowBase = lowerWindowBase;
+            this.selectedUpperWindowBase = upperWindowBase;
+            this.leasedUpperWindowBase = upperWindowBase;
+        }
+
+        @Override
+        public PerformanceRomAccess acquirePerformanceRomAccess() {
+            leaseAcquisitions++;
+            leasedUpperWindowBase = selectedUpperWindowBase;
+            return leaseAvailable ? lease : null;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address <= 0xffff;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            if (bankWritesSelectUpperWindow && address >= 0x2000 && address < 0x4000) {
+                selectedUpperWindowBase = (value & 0xff) * 0x4000;
+                return;
+            }
+            bytes[address & 0xffff] = (byte) value;
+        }
+
+        @Override
+        public int getByte(int address) {
+            busReads++;
+            if (bankWritesSelectUpperWindow && address >= 0 && address < 0x8000) {
+                int physicalOffset = address < 0x4000
+                        ? lowerWindowBase + address
+                        : selectedUpperWindowBase + address - 0x4000;
+                return physicalBytes[physicalOffset] & 0xff;
+            }
+            return bytes[address & 0xffff] & 0xff;
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoOutputTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/ColorPixelFifoOutputTest.java
@@ -8,6 +8,8 @@ import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ColorPixelFifoOutputTest {
 
@@ -125,6 +127,48 @@ public class ColorPixelFifoOutputTest {
         assertEquals(intField(general.fifo, "delaySize"), intField(fast.fifo, "delaySize"));
         assertArrayEquals(arrayField(general.fifo, "delayEntry"), arrayField(fast.fifo, "delayEntry"));
         assertArrayEquals(longArrayField(general.fifo, "delayStamp"), longArrayField(fast.fifo, "delayStamp"));
+    }
+
+    @Test
+    public void emptyPerformanceSpanMatchesRepeatedColorOutputTicks() {
+        Fixture scalar = new Fixture();
+        Fixture bulk = new Fixture();
+        for (int i = 0; i < 54; i++) {
+            scalar.fifo.outputTick();
+        }
+
+        assertTrue(bulk.fifo.isPerformanceOutputIdle());
+        bulk.fifo.advancePerformanceOutputIdleSpanTrusted(54);
+
+        assertEquals(longField(scalar.fifo, "outputTicks"),
+                longField(bulk.fifo, "outputTicks"));
+        assertEquals(intField(scalar.fifo, "delayHead"), intField(bulk.fifo, "delayHead"));
+        assertEquals(intField(scalar.fifo, "delaySize"), intField(bulk.fifo, "delaySize"));
+    }
+
+    @Test
+    public void pendingColorOutputRejectsPerformanceSpan() {
+        Fixture fixture = new Fixture();
+        fixture.enqueuePixels();
+        fixture.putPixels(1);
+
+        assertFalse(fixture.fifo.isPerformanceOutputIdle());
+    }
+
+    @Test
+    public void emptyPerformanceSpanMatchesRepeatedScalarTimingOutputTicks() {
+        ScalarTimingColorPixelFifo scalar = new ScalarTimingColorPixelFifo();
+        ScalarTimingColorPixelFifo bulk = new ScalarTimingColorPixelFifo();
+        for (int i = 0; i < 54; i++) {
+            scalar.outputTick();
+        }
+
+        assertTrue(bulk.isPerformanceOutputIdle());
+        bulk.advancePerformanceOutputIdleSpanTrusted(54);
+
+        assertEquals(longField(scalar, "outputTicks"), longField(bulk, "outputTicks"));
+        assertEquals(intField(scalar, "delayHead"), intField(bulk, "delayHead"));
+        assertEquals(intField(scalar, "delaySize"), intField(bulk, "delaySize"));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/LcdcHistoryTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/LcdcHistoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class LcdcHistoryTest {
 
@@ -115,6 +116,51 @@ public class LcdcHistoryTest {
                         oamSizeHistory(state).clone()));
         assertArrayEquals(reference.tileSelectGlitchHistory, pooled.tileSelectGlitchHistory);
         assertArrayEquals(reference.oamSizeHistory, pooled.oamSizeHistory);
+    }
+
+    @Test
+    public void performanceMode2FixedPointRejectsRecentSizeAndTileHistory() {
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(true);
+        for (int i = 0; i < HISTORY_LENGTH + 1; i++) {
+            lcdc.tickConflicts();
+        }
+        assertTrue(lcdc.isPerformanceMode2FixedPoint());
+
+        lcdc.set(0x95);
+        for (int i = 0; i < HISTORY_LENGTH - 1; i++) {
+            lcdc.tickConflicts();
+        }
+        assertFalse(lcdc.isPerformanceMode2FixedPoint());
+        lcdc.tickConflicts();
+        assertFalse(lcdc.isPerformanceMode2FixedPoint());
+        lcdc.tickConflicts();
+        assertTrue(lcdc.isPerformanceMode2FixedPoint());
+
+        lcdc.triggerTileSelectGlitch();
+        lcdc.tickConflicts();
+        for (int i = 0; i < HISTORY_LENGTH - 1; i++) {
+            lcdc.tickConflicts();
+        }
+        assertFalse(lcdc.isPerformanceMode2FixedPoint());
+        lcdc.tickConflicts();
+        assertTrue(lcdc.isPerformanceMode2FixedPoint());
+    }
+
+    @Test
+    public void performanceMode2FixedPointSpanPreservesLogicalHistory() {
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(true);
+        for (int i = 0; i < HISTORY_LENGTH + 1; i++) {
+            lcdc.tickConflicts();
+        }
+        ComponentState<Lcdc> before = lcdc.captureState();
+
+        lcdc.advancePerformanceMode2FixedPointSpanTrusted(54);
+
+        ComponentState<Lcdc> after = lcdc.captureState();
+        assertArrayEquals(tileSelectGlitchHistory(before), tileSelectGlitchHistory(after));
+        assertArrayEquals(oamSizeHistory(before), oamSizeHistory(after));
     }
 
     private static void tick(Lcdc lcdc, HistoryReference reference, int dot) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
@@ -88,7 +88,7 @@ public final class PerformanceScanlineIntegrationTest {
     }
 
     @Test
-    public void stopAwarePerformanceRunExecutesNoTickAfterNativeFrameCallback() throws Exception {
+    public void measuredPerformanceRunExecutesNoTickAfterNativeFrameCallback() throws Exception {
         try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = session(false)) {
             AtomicBoolean stop = new AtomicBoolean();
             AtomicInteger callbacks = new AtomicInteger();
@@ -104,7 +104,7 @@ public final class PerformanceScanlineIntegrationTest {
             }, Display.DmgFrameReadyEvent.class);
             gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
 
-            int executed = gameboy.runTicksUntilStop(2 * 456 * 154, stop::get);
+            int executed = gameboy.runMeasuredTicksUntilStop(2 * 456 * 154, stop::get);
 
             assertTrue("native endpoint was not reached", stop.get());
             assertEquals("endpoint callback repeated", 1, callbacks.get());

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
@@ -2,8 +2,19 @@ package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.ExecutionMode;
 import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.WX;
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.WY;
@@ -73,6 +84,38 @@ public final class PerformanceScanlineIntegrationTest {
                 assertEquals("frame tail " + i, scalarFrame, batched.runTicks(1) != 0);
                 assertEquivalent(scalar, batched, "frame tail " + i);
             }
+        }
+    }
+
+    @Test
+    public void stopAwarePerformanceRunExecutesNoTickAfterNativeFrameCallback() throws Exception {
+        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = session(false)) {
+            AtomicBoolean stop = new AtomicBoolean();
+            AtomicInteger callbacks = new AtomicInteger();
+            AtomicInteger endpointLine = new AtomicInteger();
+            AtomicInteger endpointDot = new AtomicInteger();
+            AtomicLong endpointGpuGeneration = new AtomicLong();
+            eventBus.register(event -> {
+                callbacks.incrementAndGet();
+                endpointLine.set(gameboy.getGpu().getLine());
+                endpointDot.set(gameboy.getGpu().getTicksInLine());
+                endpointGpuGeneration.set(gameboy.getGpu().getTimingGeneration());
+                stop.set(true);
+            }, Display.DmgFrameReadyEvent.class);
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+
+            int executed = gameboy.runTicksUntilStop(2 * 456 * 154, stop::get);
+
+            assertTrue("native endpoint was not reached", stop.get());
+            assertEquals("endpoint callback repeated", 1, callbacks.get());
+            assertTrue("stop-aware run consumed the full two-frame budget",
+                    executed > 0 && executed < 2 * 456 * 154);
+            assertEquals("a post-endpoint tick changed LY",
+                    endpointLine.get(), gameboy.getGpu().getLine());
+            assertEquals("a post-endpoint tick changed the line dot",
+                    endpointDot.get(), gameboy.getGpu().getTicksInLine());
+            assertEquals("a post-endpoint tick changed GPU generation",
+                    endpointGpuGeneration.get(), gameboy.getGpu().getTimingGeneration());
         }
     }
 
@@ -226,6 +269,288 @@ public final class PerformanceScanlineIntegrationTest {
         }
     }
 
+    @Test
+    public void nativeCgbVblankHorizonAdmitsOamReaderPrefixAfterTrustedReplay() throws Exception {
+        try (Gameboy gameboy = nativeCgbSession()) {
+            settleNativeDoubleSpeed(gameboy);
+            gameboy.getGpu().setPerformanceScanlineEnabled(true);
+            int guard = 0;
+            while (gameboy.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
+                gameboy.tick();
+            }
+            assertTrue("native CGB setup did not reach VBlank", guard < 456 * 155);
+            assertEquals(0, gameboy.getGpu().getTicksInLine());
+            for (int dot = 0; dot < 79; dot++) {
+                assertTrue("native epoch VBlank dot " + dot,
+                        gameboy.getGpu().performanceEpochSpanLimit(1) > 0);
+                assertTrue("generic VBlank dot " + dot,
+                        gameboy.getGpu().performanceQuietSpanLimit() > 0);
+                gameboy.tick();
+            }
+            assertEquals(79, gameboy.getGpu().getTicksInLine());
+            assertTrue("native epoch VBlank dot 79->80 was not admitted",
+                    gameboy.getGpu().performanceEpochSpanLimit(1) > 0);
+            assertTrue("generic VBlank dot 79->80 was not admitted",
+                    gameboy.getGpu().performanceQuietSpanLimit() > 0);
+        }
+    }
+
+    @Test
+    public void physicalDmgVblankHorizonAdmitsOamReaderPrefixAfterTrustedReplay() throws Exception {
+        try (Gameboy gameboy = session(false)) {
+            gameboy.getGpu().setPerformanceScanlineEnabled(true);
+            int guard = 0;
+            while (gameboy.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
+                gameboy.tick();
+            }
+            assertTrue("DMG setup did not reach VBlank", guard < 456 * 155);
+            assertEquals(0, gameboy.getGpu().getTicksInLine());
+            for (int dot = 0; dot < 79; dot++) {
+                assertTrue("physical-DMG VBlank dot " + dot,
+                        gameboy.getGpu().performancePhysicalDmgEpochSpanLimit(1) > 0);
+                assertTrue("generic VBlank dot " + dot,
+                        gameboy.getGpu().performanceQuietSpanLimit() > 0);
+                gameboy.tick();
+            }
+            assertEquals(79, gameboy.getGpu().getTicksInLine());
+            assertTrue("physical-DMG VBlank dot 79->80 was not admitted",
+                    gameboy.getGpu().performancePhysicalDmgEpochSpanLimit(1) > 0);
+            assertTrue("generic VBlank dot 79->80 was not admitted",
+                    gameboy.getGpu().performanceQuietSpanLimit() > 0);
+        }
+    }
+
+    @Test
+    public void cgbLcdcSizeAndTileHistoryFailClosedUntilNineDotsDrain() throws Exception {
+        try (Gameboy gameboy = nativeCgbSession()) {
+            settleNativeDoubleSpeed(gameboy);
+            gameboy.getGpu().setPerformanceScanlineEnabled(true);
+            int guard = 0;
+            while (gameboy.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
+                gameboy.tick();
+            }
+            assertTrue("native CGB setup did not reach VBlank", guard < 456 * 155);
+            for (int i = 0; i < 79; i++) {
+                gameboy.tick();
+            }
+            assertTrue(gameboy.getGpu().performanceEpochSpanLimit(1) > 0);
+            int lcdc = gameboy.getGpu().getByte(0xff40);
+            gameboy.getGpu().setByte(0xff40, lcdc ^ 0x14);
+            assertEquals("recent LCDC.2/.4 history was admitted",
+                    0, gameboy.getGpu().performanceEpochSpanLimit(1));
+            var checkpoint = gameboy.captureState();
+            gameboy.restoreState(checkpoint);
+            assertEquals("restored LCDC history was admitted",
+                    0, gameboy.getGpu().performanceEpochSpanLimit(1));
+            for (int i = 0; i < 9; i++) {
+                gameboy.tick();
+            }
+            assertTrue("LCDC history did not re-admit after its drain",
+                    gameboy.getGpu().performanceEpochSpanLimit(1) > 0);
+        }
+    }
+
+    @Test
+    public void trustedVblankReplayPreservesResidualOamSourceChangeAge() throws Exception {
+        try (Gameboy scalar = session(false); Gameboy candidate = session(false)) {
+            reachVblankDot(scalar, 0, false);
+            reachVblankDot(candidate, 0, false);
+            setOamReaderSourceChangeTicks(scalar, 3);
+            setOamReaderSourceChangeTicks(candidate, 3);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            for (int i = 0; i < 3; i++) {
+                scalar.getGpu().tick();
+            }
+            candidate.getGpu().advancePerformanceQuietSpanTrusted(3, false, false);
+            assertDeepStateEquals("residual OAM source age",
+                    scalar.getGpu().captureState(), candidate.getGpu().captureState());
+        }
+    }
+
+    @Test
+    public void line153WindowCheckpointRemainsScalarAndRestorable() throws Exception {
+        for (boolean cgb : new boolean[] {false, true}) {
+            try (Gameboy scalar = session(cgb); Gameboy candidate = session(cgb)) {
+                int guard = 0;
+                while ((scalar.getGpu().getLine() != 153
+                        || scalar.getGpu().getTicksInLine() != 453)
+                        && guard++ < 456 * 154) {
+                    scalar.tick();
+                    candidate.tick();
+                }
+                assertTrue("line-153 setup did not reach old dot 453", guard < 456 * 154);
+                candidate.getGpu().setPerformanceScanlineEnabled(true);
+                assertEquals(1, candidate.getGpu().performanceQuietSpanLimit());
+                if (cgb) {
+                    assertEquals(1, candidate.getGpu().performanceEpochSpanLimit(2));
+                } else {
+                    assertEquals(1, candidate.getGpu().performancePhysicalDmgEpochSpanLimit(2));
+                }
+
+                var checkpoint = candidate.captureState();
+                scalar.tick();
+                candidate.restoreState(checkpoint);
+                candidate.tick();
+                assertDeepStateEquals("line153 dot454 restore",
+                        scalar.captureState(), candidate.captureState());
+                assertEquals(0, candidate.getGpu().performanceQuietSpanLimit());
+                scalar.tick();
+                candidate.tick();
+                assertDeepStateEquals("line153 dot455 scalar handoff",
+                        scalar.captureState(), candidate.captureState());
+            }
+        }
+    }
+
+    private static void setOamReaderSourceChangeTicks(Gameboy gameboy, int ticks)
+            throws ReflectiveOperationException {
+        Field phaseField = Gpu.class.getDeclaredField("oamSearchPhase");
+        phaseField.setAccessible(true);
+        Object phase = phaseField.get(gameboy.getGpu());
+        Field ageField = phase.getClass().getDeclaredField("oamReaderSourceChangeTicks");
+        ageField.setAccessible(true);
+        ageField.setInt(phase, ticks);
+    }
+
+    @Test
+    public void trustedVblankSpansMatchScalarGpuStateAndCheckpointRestore() throws Exception {
+        int[] starts = {0, 1, 3, 78, 79, 80};
+        int[] spans = {1, 3, 54};
+        for (boolean cgb : new boolean[] {false, true}) {
+            for (boolean epochPath : new boolean[] {false, true}) {
+                if (epochPath && !cgb) {
+                    // The physical-DMG epoch is covered by the explicit physical path below;
+                    // native epochs are only available on CGB hardware.
+                    continue;
+                }
+                for (int start : starts) {
+                    for (int requested : spans) {
+                        int ticks = Math.min(requested, 456 - start - 1);
+                        if (ticks <= 0) {
+                            continue;
+                        }
+                        try (Gameboy scalar = cgb ? nativeCgbSession() : session(false);
+                                Gameboy candidate = cgb ? nativeCgbSession() : session(false)) {
+                            reachVblankDot(scalar, start, cgb);
+                            reachVblankDot(candidate, start, cgb);
+                            candidate.getGpu().setPerformanceScanlineEnabled(true);
+                            var checkpoint = candidate.captureState();
+                            for (int i = 0; i < ticks; i++) {
+                                scalar.getGpu().tick();
+                            }
+                            advanceTrustedVblankSpan(candidate, ticks, cgb, epochPath);
+                            assertDeepStateEquals("VBlank " + cgb + " path " + epochPath
+                                            + " dot " + start + " span " + ticks,
+                                    scalar.getGpu().captureState(), candidate.getGpu().captureState());
+
+                            candidate.restoreState(checkpoint);
+                            advanceTrustedVblankSpan(candidate, ticks, cgb, epochPath);
+                            assertDeepStateEquals("VBlank restore " + cgb + " path " + epochPath
+                                            + " dot " + start + " span " + ticks,
+                                    scalar.getGpu().captureState(), candidate.getGpu().captureState());
+                        }
+                    }
+                }
+            }
+            if (!cgb) {
+                for (int start : starts) {
+                    for (int requested : spans) {
+                        int ticks = Math.min(requested, 456 - start - 1);
+                        if (ticks <= 0) {
+                            continue;
+                        }
+                        try (Gameboy scalar = session(false); Gameboy candidate = session(false)) {
+                            reachVblankDot(scalar, start, false);
+                            reachVblankDot(candidate, start, false);
+                            candidate.getGpu().setPerformanceScanlineEnabled(true);
+                            var checkpoint = candidate.captureState();
+                            for (int i = 0; i < ticks; i++) {
+                                scalar.getGpu().tick();
+                            }
+                            advanceTrustedVblankSpan(candidate, ticks, false, true);
+                            assertDeepStateEquals("VBlank physical dot " + start
+                                            + " span " + ticks,
+                                    scalar.getGpu().captureState(), candidate.getGpu().captureState());
+                            candidate.restoreState(checkpoint);
+                            advanceTrustedVblankSpan(candidate, ticks, false, true);
+                            assertDeepStateEquals("VBlank physical restore dot " + start
+                                            + " span " + ticks,
+                                    scalar.getGpu().captureState(), candidate.getGpu().captureState());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void advanceTrustedVblankSpan(
+            Gameboy gameboy, int ticks, boolean cgb, boolean epochPath) {
+        if (cgb && epochPath) {
+            gameboy.getGpu().advancePerformanceEpochQuietSpanTrusted(ticks, false, false);
+        } else if (!cgb && epochPath) {
+            gameboy.getGpu().advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
+                    ticks, false, false);
+        } else {
+            gameboy.getGpu().advancePerformanceQuietSpanTrusted(ticks, false, false);
+        }
+    }
+
+    private static void reachVblankDot(Gameboy gameboy, int dot, boolean nativeCgb) {
+        if (nativeCgb) {
+            settleNativeDoubleSpeed(gameboy);
+        }
+        int guard = 0;
+        while (gameboy.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
+            gameboy.tick();
+        }
+        assertTrue("VBlank setup did not reach VBlank", guard < 456 * 155);
+        for (int i = 0; i < dot; i++) {
+            gameboy.getGpu().tick();
+        }
+        assertEquals(dot, gameboy.getGpu().getTicksInLine());
+    }
+
+    private static void assertDeepStateEquals(String path, Object expected, Object actual) {
+        if (expected == null || actual == null) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        assertEquals(path + " type", expected.getClass(), actual.getClass());
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            assertEquals(path + " length", length, Array.getLength(actual));
+            for (int i = 0; i < length; i++) {
+                assertDeepStateEquals(path + '[' + i + ']', Array.get(expected, i),
+                        Array.get(actual, i));
+            }
+            return;
+        }
+        if (expected instanceof List<?> expectedList) {
+            List<?> actualList = (List<?>) actual;
+            assertEquals(path + " size", expectedList.size(), actualList.size());
+            for (int i = 0; i < expectedList.size(); i++) {
+                assertDeepStateEquals(path + '[' + i + ']', expectedList.get(i),
+                        actualList.get(i));
+            }
+            return;
+        }
+        if (!type.isRecord()) {
+            assertEquals(path, expected, actual);
+            return;
+        }
+        try {
+            for (RecordComponent component : type.getRecordComponents()) {
+                var accessor = component.getAccessor();
+                accessor.setAccessible(true);
+                assertDeepStateEquals(path + '.' + component.getName(),
+                        accessor.invoke(expected), accessor.invoke(actual));
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Cannot compare " + path, e);
+        }
+    }
+
     private static void assertEquivalent(Gameboy expected, Gameboy actual, String context) {
         assertEquals(context + " LY", expected.getGpu().getLine(), actual.getGpu().getLine());
         assertEquals(context + " line ticks", expected.getGpu().getTicksInLine(), actual.getGpu().getTicksInLine());
@@ -251,5 +576,43 @@ public final class PerformanceScanlineIntegrationTest {
                 .setExecutionMode(ExecutionMode.PERFORMANCE)
                 .setSupportBatterySave(false)
                 .build();
+    }
+
+    private static Gameboy nativeCgbSession() throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF4D),A
+        image[0x103] = 0x4d;
+        image[0x104] = 0x10; // STOP + padding
+        image[0x105] = 0;
+        image[0x106] = (byte) 0xc3; // JP 0106
+        image[0x107] = 0x06;
+        image[0x108] = 0x01;
+        image[0x143] = (byte) 0x80;
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static void settleNativeDoubleSpeed(Gameboy gameboy) {
+        int guard = 0;
+        int stable = 0;
+        while (!(stable >= 1_000
+                && gameboy.getGpu().getMode() == Mode.OamSearch
+                && gameboy.getGpu().getLine() < 144
+                && gameboy.getGpu().getTicksInLine() == 13)
+                && guard++ < 400_000) {
+            gameboy.tick();
+            if (gameboy.getSpeedMode().getSpeedMode() == 2
+                    && gameboy.getCpu().getState() != eu.rekawek.coffeegb.core.cpu.Cpu.State.SPEED_SWITCH) {
+                stable++;
+            } else {
+                stable = 0;
+            }
+        }
+        assertTrue("native CGB setup did not settle", guard < 400_000);
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRendererTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRendererTest.java
@@ -1,8 +1,13 @@
 package eu.rekawek.coffeegb.core.gpu;
 
+import eu.rekawek.coffeegb.core.AddressSpace;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
 import eu.rekawek.coffeegb.core.memory.Ram;
+import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
 
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.BGP;
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.OBP0;
@@ -12,6 +17,7 @@ import static eu.rekawek.coffeegb.core.gpu.GpuRegister.WX;
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.WY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class PerformanceScanlineRendererTest {
 
@@ -152,6 +158,319 @@ public class PerformanceScanlineRendererTest {
         assertEquals(260, visibleOnly);
     }
 
+    @Test
+    public void nativeCgbTileRunsMatchWrappedGenericRendererAcrossCoherentLines() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        PerformanceScanlineRenderer nativeRenderer = fixture.renderer();
+        PerformanceScanlineRenderer genericRenderer = fixture.renderer(true);
+        Random random = new Random(0x18a1f00dL);
+        int[] nativePixels = new int[160];
+        int[] genericPixels = new int[160];
+
+        for (int line = 0; line < 320; line++) {
+            int lcdc = 0x80
+                    | (random.nextBoolean() ? 0x01 : 0)
+                    | (random.nextBoolean() ? 0x02 : 0)
+                    | (random.nextBoolean() ? 0x04 : 0)
+                    | (random.nextBoolean() ? 0x08 : 0)
+                    | (random.nextBoolean() ? 0x10 : 0)
+                    | (random.nextBoolean() ? 0x20 : 0)
+                    | (random.nextBoolean() ? 0x40 : 0);
+            fixture.lcdc.set(lcdc);
+            fixture.registers.put(SCX, random.nextInt(256));
+            fixture.registers.put(SCY, random.nextInt(256));
+            fixture.registers.put(WY, random.nextInt(256));
+            fixture.registers.put(WX, random.nextInt(256));
+            for (int i = 0; i < fixture.vram0.getSpace().length; i++) {
+                fixture.vram0.getSpace()[i] = random.nextInt(256);
+                fixture.vram1.getSpace()[i] = random.nextInt(256);
+            }
+            for (int palette = 0; palette < 8; palette++) {
+                for (int color = 0; color < 4; color++) {
+                    fixture.bgPalette.getPalette(palette)[color] = random.nextInt(0x10000);
+                    fixture.oamPalette.getPalette(palette)[color] = random.nextInt(0x10000);
+                }
+            }
+            fixture.configureRandomSprites(random);
+
+            int windowLine = random.nextBoolean() ? -1 : random.nextInt(256);
+            nativeRenderer.renderLine(line & 0xff, windowLine, nativePixels);
+            genericRenderer.renderLine(line & 0xff, windowLine, genericPixels);
+            assertArrayEquals("line " + line, genericPixels, nativePixels);
+        }
+    }
+
+    @Test
+    public void nativeCgbPreservesFullWidthSixteenBitBgAndObjectColors() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x93);
+        fixture.fillTile(0, 0xff, 0x00);
+        fixture.fillTile(1, 0xff, 0x00);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.bgPalette.getPalette(0)[1] = 0x8001;
+        fixture.oamPalette.getPalette(0)[1] = 0xffff;
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 8);
+        fixture.oam.setByte(0xfe02, 1);
+        fixture.oam.setByte(0xfe03, 0);
+        fixture.sprites[0].enable(8, 16, 0xfe00);
+
+        int[] pixels = new int[160];
+        fixture.renderer().renderLine(0, -1, pixels);
+
+        for (int i = 0; i < pixels.length; i++) {
+            assertEquals(i < 8 ? 0xffff : 0x8001, pixels[i]);
+        }
+    }
+
+    @Test
+    public void nativeCgbSpritePriorityMatchesBackgroundPriorityAndLcdc0TruthTable() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.fillTile(0, 0xff, 0x00);
+        fixture.fillTile(1, 0xff, 0x00);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.bgPalette.getPalette(0)[1] = 0x1111;
+        fixture.oamPalette.getPalette(0)[1] = 0x2222;
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 8);
+        fixture.oam.setByte(0xfe02, 1);
+        fixture.sprites[0].enable(8, 16, 0xfe00);
+        int[] pixels = new int[160];
+
+        fixture.lcdc.set(0x93);
+        fixture.oam.setByte(0xfe03, 0);
+        fixture.vram1.setByte(0x9800, 0);
+        fixture.renderer().renderLine(0, -1, pixels);
+        assertEquals(0x2222, pixels[0]);
+
+        fixture.vram1.setByte(0x9800, 0x80);
+        fixture.renderer().renderLine(0, -1, pixels);
+        assertEquals(0x1111, pixels[0]);
+
+        fixture.vram1.setByte(0x9800, 0);
+        fixture.oam.setByte(0xfe03, 0x80);
+        fixture.renderer().renderLine(0, -1, pixels);
+        assertEquals(0x1111, pixels[0]);
+
+        fixture.lcdc.set(0x92); // Native CGB keeps BG pixels, but OBJ wins when LCDC.0 is clear.
+        fixture.vram1.setByte(0x9800, 0x80);
+        fixture.renderer().renderLine(0, -1, pixels);
+        assertEquals(0x2222, pixels[0]);
+
+        fixture.vram0.setByte(0x8000, 0x00);
+        fixture.vram0.setByte(0x8001, 0x00);
+        fixture.lcdc.set(0x93);
+        fixture.renderer().renderLine(0, -1, pixels);
+        assertEquals(0x2222, pixels[0]);
+    }
+
+    @Test
+    public void nativeCgbOverlappingSpritesUseLowestOamAddress() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x93);
+        fixture.fillTile(0, 0x00, 0x00);
+        fixture.fillTile(1, 0xff, 0x00);
+        fixture.fillTile(2, 0xff, 0x00);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 8);
+        fixture.oam.setByte(0xfe02, 1);
+        fixture.oam.setByte(0xfe03, 0);
+        fixture.oam.setByte(0xfe04, 16);
+        fixture.oam.setByte(0xfe05, 8);
+        fixture.oam.setByte(0xfe06, 2);
+        fixture.oam.setByte(0xfe07, 1);
+        // Deliberately pass the selected entries in reverse order. The native overlay must use
+        // OAM addresses, not selection-array order, to choose the winning non-transparent pixel.
+        fixture.sprites[0].enable(8, 16, 0xfe04);
+        fixture.sprites[1].enable(8, 16, 0xfe00);
+        fixture.oamPalette.getPalette(0)[1] = 0x1111;
+        fixture.oamPalette.getPalette(1)[1] = 0x2222;
+        int[] pixels = new int[160];
+
+        fixture.renderer().renderLine(0, -1, pixels);
+
+        assertEquals(0x1111, pixels[0]);
+    }
+
+    @Test
+    public void nativeCgbTransparentLowerOamSpriteFallsThroughToOpaqueHigherSprite() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x93);
+        fixture.fillTile(0, 0x00, 0x00);
+        fixture.fillTile(1, 0x00, 0x00); // lower OAM sprite is transparent
+        fixture.fillTile(2, 0xff, 0x00); // higher OAM sprite is raw color 1
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.oam.setByte(0xfe00, 16);
+        fixture.oam.setByte(0xfe01, 8);
+        fixture.oam.setByte(0xfe02, 1);
+        fixture.oam.setByte(0xfe03, 0);
+        fixture.oam.setByte(0xfe04, 16);
+        fixture.oam.setByte(0xfe05, 8);
+        fixture.oam.setByte(0xfe06, 2);
+        fixture.oam.setByte(0xfe07, 0);
+        fixture.sprites[0].enable(8, 16, 0xfe00);
+        fixture.sprites[1].enable(8, 16, 0xfe04);
+        fixture.oamPalette.getPalette(0)[1] = 0x2222;
+        int[] pixels = new int[160];
+
+        fixture.renderer().renderLine(0, -1, pixels);
+
+        assertEquals(0x2222, pixels[0]);
+    }
+
+    @Test
+    public void wrappedMemoryAndPalettesForceGenericPathWithoutChangingPixels() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0xf3);
+        fixture.registers.put(SCX, 255);
+        fixture.registers.put(SCY, 251);
+        fixture.registers.put(WY, 1);
+        fixture.registers.put(WX, 166);
+        fixture.fillTile(0, 0x5a, 0xa5);
+        fixture.fillTile(1, 0xa5, 0x5a);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, tile & 1);
+            fixture.vram1.setByte(0x9800 + tile, (tile & 7) | (tile << 3 & 0x78));
+        }
+        for (int i = 0; i < 8; i++) {
+            Arrays.fill(fixture.bgPalette.getPalette(i), 0x3000 + i);
+            Arrays.fill(fixture.oamPalette.getPalette(i), 0x4000 + i);
+        }
+        fixture.configureRandomSprites(new Random(0x18));
+        int[] nativePixels = new int[160];
+        int[] genericPixels = new int[160];
+        fixture.renderer().renderLine(42, 19, nativePixels);
+        fixture.renderer(true).renderLine(42, 19, genericPixels);
+        assertArrayEquals(genericPixels, nativePixels);
+    }
+
+    @Test
+    public void compatibilityModeFallsBackAndCanSwitchBackToNative() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x91);
+        fixture.fillTile(0, 0xff, 0x00);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.bgPalette.getPalette(0)[1] = 0x7654;
+        fixture.bgPalette.getPalette(0)[3] = 0x7654;
+        fixture.registers.put(BGP, 0x0c);
+        PerformanceScanlineRenderer renderer = fixture.renderer();
+        int[] nativePixels = new int[160];
+        int[] compatPixels = new int[160];
+        renderer.renderLine(0, -1, nativePixels);
+        renderer.setDmgCompat(true);
+        renderer.renderLine(0, -1, compatPixels);
+        assertEquals(0x7654, nativePixels[0]);
+        assertEquals(0x7654, compatPixels[0]);
+        fixture.bgPalette.getPalette(0)[3] = 0x1234;
+        renderer.renderLine(0, -1, compatPixels);
+        assertEquals(0x1234, compatPixels[0]);
+        renderer.setDmgCompat(false);
+        renderer.renderLine(0, -1, nativePixels);
+        assertEquals(0x7654, nativePixels[0]);
+    }
+
+    @Test
+    public void nativeAliasesAndPaletteRowsRemainLiveAfterConstructionAndRestore() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x91);
+        fixture.fillTile(0, 0xff, 0x00);
+        fixture.fillTile(1, 0x00, 0xff);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+        }
+        fixture.bgPalette.getPalette(0)[1] = 0x1111;
+        fixture.bgPalette.getPalette(0)[2] = 0x2222;
+        PerformanceScanlineRenderer renderer = fixture.renderer();
+        ComponentState<Ram> vramState = fixture.vram0.captureState();
+        ComponentState<ColorPalette> bgPaletteState = fixture.bgPalette.captureState();
+        ComponentState<ColorPalette> oamPaletteState = fixture.oamPalette.captureState();
+        int[] first = new int[160];
+        int[] changedVram = new int[160];
+        int[] changedPalette = new int[160];
+        int[] restored = new int[160];
+        renderer.renderLine(0, -1, first);
+
+        // Mutate the selected tile map after construction. The cached native alias must observe
+        // the new tile and produce its distinct raw color.
+        fixture.vram0.setByte(0x9800, 1);
+        renderer.renderLine(0, -1, changedVram);
+        assertEquals(0x2222, changedVram[0]);
+        assertNotEquals(first[0], changedVram[0]);
+
+        // Mutate both palette components through their live rows. The output must observe the BG
+        // row, while the OAM row is restored below as an independent capture/restore check.
+        fixture.bgPalette.getPalette(0)[2] = 0x3333;
+        fixture.oamPalette.getPalette(0)[0] = 0x4444;
+        renderer.renderLine(0, -1, changedPalette);
+        assertEquals(0x3333, changedPalette[0]);
+
+        fixture.vram0.restoreState(vramState);
+        fixture.bgPalette.restoreState(bgPaletteState);
+        fixture.oamPalette.restoreState(oamPaletteState);
+        renderer.renderLine(0, -1, restored);
+
+        assertEquals(0x1111, first[0]);
+        assertArrayEquals(first, restored);
+    }
+
+    @Test
+    public void nonCanonicalVramShapeUsesGenericAddressSpaceReads() {
+        Fixture fixture = new Fixture(true, false);
+        fixture.lcdc.setGbc(true);
+        fixture.registers.setGbc(true);
+        fixture.lcdc.set(0x91);
+        fixture.fillTile(0, 0xff, 0x00);
+        for (int tile = 0; tile < 32; tile++) {
+            fixture.vram0.setByte(0x9800 + tile, 0);
+            fixture.vram1.setByte(0x9800 + tile, 0);
+        }
+        fixture.bgPalette.getPalette(0)[1] = 0x1234;
+
+        Ram shifted0 = new Ram(0x7fff, 0x2000); // accepts neither exact endpoint shape
+        Ram shifted1 = new Ram(0x7fff, 0x2000);
+        copyRam(fixture.vram0, shifted0, 0x8000, 0x9ffe);
+        copyRam(fixture.vram1, shifted1, 0x8000, 0x9ffe);
+        PerformanceScanlineRenderer shifted = new PerformanceScanlineRenderer(
+                shifted0, shifted1, fixture.oam, fixture.lcdc, fixture.registers,
+                fixture.bgPalette, fixture.oamPalette, true, false, fixture.sprites);
+        int[] shiftedPixels = new int[160];
+        shifted.renderLine(0, -1, shiftedPixels);
+        assertEquals(0x1234, shiftedPixels[0]);
+    }
+
+    private static void copyRam(Ram source, Ram target, int first, int last) {
+        for (int address = first; address <= last; address++) {
+            target.setByte(address, source.getByte(address));
+        }
+    }
+
     private static final class Fixture {
         private final Ram vram0 = new Ram(0x8000, 0x2000);
         private final Ram vram1;
@@ -176,9 +495,37 @@ public class PerformanceScanlineRendererTest {
         }
 
         private PerformanceScanlineRenderer renderer() {
+            return renderer(false);
+        }
+
+        private PerformanceScanlineRenderer renderer(boolean wrapped) {
             return new PerformanceScanlineRenderer(
-                    vram0, vram1, oam, lcdc, registers, bgPalette, oamPalette,
+                    wrapped ? new ForwardingAddressSpace(vram0) : vram0,
+                    vram1 == null ? null : wrapped ? new ForwardingAddressSpace(vram1) : vram1,
+                    wrapped ? new ForwardingAddressSpace(oam) : oam,
+                    lcdc, registers,
+                    wrapped ? new WrappedColorPalette(bgPalette) : bgPalette,
+                    wrapped ? new WrappedColorPalette(oamPalette) : oamPalette,
                     gbc, dmgCompat, sprites);
+        }
+
+        private void configureRandomSprites(Random random) {
+            lcdc.set(lcdc.get() | 0x02);
+            for (int i = 0; i < sprites.length; i++) {
+                int address = 0xfe00 + i * 4;
+                if (random.nextBoolean()) {
+                    int x = random.nextInt(176);
+                    int y = random.nextInt(176);
+                    int attributes = random.nextInt(256);
+                    oam.setByte(address, y);
+                    oam.setByte(address + 1, x);
+                    oam.setByte(address + 2, random.nextInt(256));
+                    oam.setByte(address + 3, attributes);
+                    sprites[i].enable(x, y, address);
+                } else {
+                    sprites[i].disable();
+                }
+            }
         }
 
         private void fillTile(int tile, int low, int high) {
@@ -186,6 +533,58 @@ public class PerformanceScanlineRendererTest {
                 vram0.setByte(0x8000 + tile * 16 + row * 2, low);
                 vram0.setByte(0x8001 + tile * 16 + row * 2, high);
             }
+        }
+    }
+
+    private static final class ForwardingAddressSpace implements AddressSpace {
+        private final AddressSpace delegate;
+
+        private ForwardingAddressSpace(AddressSpace delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return delegate.accepts(address);
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            delegate.setByte(address, value);
+        }
+
+        @Override
+        public int getByte(int address) {
+            return delegate.getByte(address);
+        }
+    }
+
+    private static final class WrappedColorPalette extends ColorPalette {
+        private final ColorPalette delegate;
+
+        private WrappedColorPalette(ColorPalette delegate) {
+            super(0xff68);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return delegate.accepts(address);
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            delegate.setByte(address, value);
+        }
+
+        @Override
+        public int getByte(int address) {
+            return delegate.getByte(address);
+        }
+
+        @Override
+        public int[] getPalette(int index) {
+            return delegate.getPalette(index);
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -544,6 +544,184 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void nativeCgbPackedReadPhaseMatchesGenericPhaseAcrossEdgesAndInputs()
+            throws Exception {
+        Fixture probe = new Fixture(true, true);
+        probe.gpu.onSpeedSwitch();
+        probe.advanceTo(1, 100);
+        int mode0 = probe.gpu.getMode0InterruptTick();
+        int mode0Target = mode0 == Integer.MAX_VALUE ? 250 : mode0;
+        int[] targets = {100, Math.max(13, mode0Target - 2), Math.max(13, mode0Target - 1),
+                mode0Target, Math.min(447, mode0Target + 2)};
+        int[] enables = {0x00, 0x08, 0x20, 0x48};
+
+        for (int target : targets) {
+            for (int enable : enables) {
+                for (int flags = 0; flags < 16; flags++) {
+                    Fixture generic = new Fixture(true, true);
+                    Fixture nativeCgb = new Fixture(true, true);
+                    generic.gpu.onSpeedSwitch();
+                    nativeCgb.gpu.onSpeedSwitch();
+                    generic.stat.setByte(StatRegister.ADDRESS, enable);
+                    nativeCgb.stat.setByte(StatRegister.ADDRESS, enable);
+                    generic.gpu.setByte(GpuRegister.LYC.getAddress(), 1);
+                    nativeCgb.gpu.setByte(GpuRegister.LYC.getAddress(), 1);
+                    generic.advanceTo(1, target);
+                    nativeCgb.advanceTo(1, target);
+
+                    boolean genericEdge = generic.stat.beginCpuReadPhase(flags);
+                    generic.stat.finishCpuReadPhase(0, false, false);
+                    int phaseWord = nativeCgb.gpu.getNativeCgbPerformancePhaseWord();
+                    long nativeTimingGeneration = statTimingGeneration(nativeCgb.stat);
+                    boolean nativeEdge = nativeCgb.stat.beginNativeCgbPerformanceReadPhase(
+                            flags, phaseWord);
+                    nativeCgb.stat.finishNativeCgbPerformanceReadPhase(0, phaseWord);
+                    assertEquals(nativeTimingGeneration, statTimingGeneration(nativeCgb.stat));
+
+                    assertEquals("mode-0 edge target=" + target + " enable=" + enable
+                                    + " flags=" + flags,
+                            genericEdge, nativeEdge);
+                    assertEquals("STAT state target=" + target + " enable=" + enable
+                                    + " flags=" + flags,
+                            generic.stat.captureState(), nativeCgb.stat.captureState());
+                    assertEquals("IF state target=" + target + " enable=" + enable
+                                    + " flags=" + flags,
+                            generic.interrupts.captureState(), nativeCgb.interrupts.captureState());
+                    assertEquals("STAT read target=" + target + " enable=" + enable
+                                    + " flags=" + flags,
+                            generic.stat.getByte(StatRegister.ADDRESS),
+                            nativeCgb.stat.getByte(StatRegister.ADDRESS));
+                }
+            }
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void nativeCgbUnblockedMode0PreviewMatchesGenericAtMinusTwo() {
+        Fixture generic = new Fixture(true, true);
+        Fixture nativeCgb = new Fixture(true, true);
+        generic.gpu.onSpeedSwitch();
+        nativeCgb.gpu.onSpeedSwitch();
+        generic.stat.setByte(StatRegister.ADDRESS, 0x48);
+        nativeCgb.stat.setByte(StatRegister.ADDRESS, 0x48);
+        // Keep the LYC source enabled but unblocked at the mode-0 preview dot.
+        generic.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        nativeCgb.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+
+        int phaseWord = nativeCgb.gpu.getNativeCgbPerformancePhaseWord();
+        int remaining = 2 * 456;
+        while ((phaseWord & Gpu.NATIVE_CGB_PHASE_MODE0_READ_PREVIEW) == 0
+                && remaining-- > 0) {
+            generic.tick();
+            nativeCgb.tick();
+            phaseWord = nativeCgb.gpu.getNativeCgbPerformancePhaseWord();
+        }
+        assertTrue("native mode-0 preview was not reached", remaining >= 0);
+
+        boolean genericEdge = generic.stat.beginCpuReadPhase(0);
+        generic.stat.finishCpuReadPhase(0, false, false);
+        boolean nativeEdge = nativeCgb.stat.beginNativeCgbPerformanceReadPhase(0, phaseWord);
+        nativeCgb.stat.finishNativeCgbPerformanceReadPhase(0, phaseWord);
+
+        assertFalse(genericEdge);
+        assertEquals(genericEdge, nativeEdge);
+        assertEquals(generic.interrupts.captureState(), nativeCgb.interrupts.captureState());
+        assertEquals(generic.interrupts.getByte(0xff0f), nativeCgb.interrupts.getByte(0xff0f));
+    }
+
+    @Test(timeout = 5_000)
+    public void nativeCgbMode0IfReadMaskMatchesGenericBusOrdering() {
+        Fixture generic = new Fixture(true, true);
+        Fixture nativeCgb = new Fixture(true, true);
+        generic.gpu.onSpeedSwitch();
+        nativeCgb.gpu.onSpeedSwitch();
+        generic.stat.setByte(StatRegister.ADDRESS, 0x48);
+        nativeCgb.stat.setByte(StatRegister.ADDRESS, 0x48);
+        generic.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        nativeCgb.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        generic.advanceTo(1, 100);
+        nativeCgb.advanceTo(1, 100);
+        int mode0Tick = nativeCgb.gpu.getMode0InterruptTick();
+        int previewTick = (mode0Tick == Integer.MAX_VALUE ? 250 : mode0Tick) - 2;
+        generic.advanceTo(1, previewTick - 4);
+        nativeCgb.advanceTo(1, previewTick - 4);
+        generic.interrupts.requestInterrupt(LCDC);
+        nativeCgb.interrupts.requestInterrupt(LCDC);
+        generic.interrupts.clearInterrupt(LCDC);
+        nativeCgb.interrupts.clearInterrupt(LCDC);
+        generic.tick();
+        nativeCgb.tick();
+        generic.advanceTo(1, previewTick);
+        nativeCgb.advanceTo(1, previewTick);
+        int phaseWord = nativeCgb.gpu.getNativeCgbPerformancePhaseWord();
+        assertTrue((phaseWord & Gpu.NATIVE_CGB_PHASE_MODE0_READ_PREVIEW) != 0);
+
+        generic.stat.beginCpuReadPhase(0);
+        generic.stat.finishCpuReadPhase(2, false, false);
+        nativeCgb.stat.beginNativeCgbPerformanceReadPhase(0, phaseWord);
+        nativeCgb.stat.finishNativeCgbPerformanceReadPhase(2, phaseWord);
+        generic.tick();
+        nativeCgb.tick();
+        generic.tick();
+        nativeCgb.tick();
+
+        assertEquals(generic.stat.captureState(), nativeCgb.stat.captureState());
+        assertEquals(generic.interrupts.captureState(), nativeCgb.interrupts.captureState());
+        assertTrue(generic.interrupts.isInterruptFlagSet(LCDC));
+        assertTrue(nativeCgb.interrupts.isInterruptFlagSet(LCDC));
+        assertEquals(0, generic.lcdInterruptFlag());
+        assertEquals(0, nativeCgb.lcdInterruptFlag());
+        assertEquals(1 << LCDC.ordinal(), generic.lcdInterruptFlag());
+        assertEquals(1 << LCDC.ordinal(), nativeCgb.lcdInterruptFlag());
+    }
+
+    @Test
+    public void nativeCgbSpecializedReadResolvesAfterRestoreLikeGeneric() throws Exception {
+        Fixture generic = new Fixture(true, true);
+        Fixture nativeCgb = new Fixture(true, true);
+        generic.gpu.onSpeedSwitch();
+        nativeCgb.gpu.onSpeedSwitch();
+        generic.stat.setByte(StatRegister.ADDRESS, 0x48);
+        nativeCgb.stat.setByte(StatRegister.ADDRESS, 0x48);
+        generic.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        nativeCgb.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        generic.advanceTo(1, 100);
+        nativeCgb.advanceTo(1, 100);
+
+        var genericGpuState = generic.gpu.captureState();
+        var genericStatState = generic.stat.captureState();
+        var genericInterruptState = generic.interrupts.captureState();
+        var nativeGpuState = nativeCgb.gpu.captureState();
+        var nativeStatState = nativeCgb.stat.captureState();
+        var nativeInterruptState = nativeCgb.interrupts.captureState();
+
+        for (int flags = 0; flags < 16; flags++) {
+            generic.gpu.restoreState(genericGpuState);
+            generic.stat.restoreState(genericStatState);
+            generic.interrupts.restoreState(genericInterruptState);
+            nativeCgb.gpu.restoreState(nativeGpuState);
+            nativeCgb.stat.restoreState(nativeStatState);
+            nativeCgb.interrupts.restoreState(nativeInterruptState);
+
+            boolean genericEdge = generic.stat.beginCpuReadPhase(flags);
+            generic.stat.finishCpuReadPhase(0, false, false);
+            int phaseWord = nativeCgb.gpu.getNativeCgbPerformancePhaseWord();
+            boolean nativeEdge = nativeCgb.stat.beginNativeCgbPerformanceReadPhase(
+                    flags, phaseWord);
+            nativeCgb.stat.finishNativeCgbPerformanceReadPhase(0, phaseWord);
+
+            assertEquals("edge flags=" + flags, genericEdge, nativeEdge);
+            assertEquals("FF41 flags=" + flags,
+                    generic.stat.getByte(StatRegister.ADDRESS),
+                    nativeCgb.stat.getByte(StatRegister.ADDRESS));
+            assertEquals("STAT flags=" + flags,
+                    generic.stat.captureState(), nativeCgb.stat.captureState());
+            assertEquals("IF flags=" + flags,
+                    generic.interrupts.captureState(), nativeCgb.interrupts.captureState());
+        }
+    }
+
+    @Test
     public void stalePackedCpuStatReadPhaseIsHiddenUntilTheNextCapture() throws Exception {
         Fixture fixture = new Fixture(true);
         fixture.advanceTo(1, 78);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -8,6 +8,8 @@ import eu.rekawek.coffeegb.core.memory.Ram;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
 
 import static eu.rekawek.coffeegb.core.cpu.InterruptManager.InterruptType.LCDC;
 import static eu.rekawek.coffeegb.core.cpu.InterruptManager.InterruptType.VBlank;
@@ -61,6 +63,139 @@ public class StatRegisterTest {
             scheduled.tick();
         }
         assertStatTimingMatchesGpu(scheduled);
+    }
+
+    @Test(timeout = 10_000)
+    public void nativePostGpuFactsAndTimingMatchGenericAtEveryNativeFrameDot() throws Exception {
+        Fixture generic = nativeStressFixture();
+        Fixture specialized = nativeStressFixture();
+        Set<Integer> mode0Endpoints = new HashSet<>();
+        int frameTicks = 154 * 456;
+
+        for (int dot = 0; dot < frameTicks; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            assertNativeGpuDot(generic, specialized, dot);
+            if (generic.gpu.getMode0InterruptTick() != Integer.MAX_VALUE) {
+                mode0Endpoints.add(generic.gpu.getMode0InterruptTick());
+            }
+        }
+
+        assertEquals("one complete native frame", 0, generic.gpu.getLine());
+        assertEquals("one complete native frame dot", 1, generic.gpu.getTicksInLine());
+        assertTrue("stress OAM must exercise variable mode-0 endpoints",
+                mode0Endpoints.size() > 1);
+    }
+
+    @Test(timeout = 10_000)
+    public void nativePostGpuStatTickMatchesGenericAtEveryDotForNativeFrame() {
+        Fixture generic = nativeStressFixture();
+        Fixture specialized = nativeStressFixture();
+        int frameTicks = 154 * 456;
+
+        for (int dot = 0; dot < frameTicks; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals("STAT memento at dot " + dot,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals("interrupt memento at dot " + dot,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void nativePostGpuFirstLineAfterLcdEnableMatchesGeneric() throws Exception {
+        Fixture generic = nativeStressFixture();
+        Fixture specialized = nativeStressFixture();
+        generic.gpu.setByte(0xff40, 0x00);
+        specialized.gpu.setByte(0xff40, 0x00);
+        generic.gpu.setByte(0xff40, 0x91);
+        specialized.gpu.setByte(0xff40, 0x91);
+
+        for (int dot = 0; dot < 455 + 8; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            assertNativeGpuDot(generic, specialized, dot);
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals("first-line STAT at dot " + dot,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals("first-line IF at dot " + dot,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void nativePostGpuLcdOffOnRestartMatchesGeneric() throws Exception {
+        Fixture generic = nativeStressFixture();
+        Fixture specialized = nativeStressFixture();
+        advanceGpuPair(generic, specialized, 3 * 456 + 200);
+        generic.gpu.setByte(0xff40, 0x00);
+        specialized.gpu.setByte(0xff40, 0x00);
+        for (int dot = 0; dot < 12; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            assertNativeGpuDot(generic, specialized, dot);
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals("LCD-off STAT at dot " + dot,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals("LCD-off IF at dot " + dot,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
+        generic.gpu.setByte(0xff40, 0x91);
+        specialized.gpu.setByte(0xff40, 0x91);
+
+        for (int dot = 0; dot < 455 + 16; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            assertNativeGpuDot(generic, specialized, dot);
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals("LCD restart STAT at dot " + dot,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals("LCD restart IF at dot " + dot,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void nativePostGpuFallbackIsGenericAfterNormalSpeedOrCompatibility() {
+        Fixture normalGeneric = new Fixture(true, false);
+        Fixture normalSpecialized = new Fixture(true, false);
+        assertNativePostGpuFallback(normalGeneric, normalSpecialized, "normal speed");
+
+        Fixture compatGeneric = new Fixture(true, true);
+        Fixture compatSpecialized = new Fixture(true, true);
+        compatGeneric.speedMode.setDmgCompat(true);
+        compatSpecialized.speedMode.setDmgCompat(true);
+        assertNativePostGpuFallback(compatGeneric, compatSpecialized, "compatibility");
+    }
+
+    @Test(timeout = 5_000)
+    public void nativePostGpuContinuationMatchesAfterCaptureRestore() {
+        Fixture generic = nativeStressFixture();
+        Fixture specialized = nativeStressFixture();
+        advanceNativePair(generic, specialized, 8_192, "warmup");
+
+        var genericGpuState = generic.gpu.captureState();
+        var genericStatState = generic.stat.captureState();
+        var genericInterruptState = generic.interrupts.captureState();
+        var specializedGpuState = specialized.gpu.captureState();
+        var specializedStatState = specialized.stat.captureState();
+        var specializedInterruptState = specialized.interrupts.captureState();
+
+        advanceNativePair(generic, specialized, 2_048, "uninterrupted continuation");
+
+        generic.gpu.restoreState(genericGpuState);
+        generic.stat.restoreState(genericStatState);
+        generic.interrupts.restoreState(genericInterruptState);
+        specialized.gpu.restoreState(specializedGpuState);
+        specialized.stat.restoreState(specializedStatState);
+        specialized.interrupts.restoreState(specializedInterruptState);
+        advanceNativePair(generic, specialized, 2_048, "restored continuation");
     }
 
     @Test
@@ -673,6 +808,47 @@ public class StatRegisterTest {
         assertEquals(0, nativeCgb.lcdInterruptFlag());
         assertEquals(1 << LCDC.ordinal(), generic.lcdInterruptFlag());
         assertEquals(1 << LCDC.ordinal(), nativeCgb.lcdInterruptFlag());
+    }
+
+    @Test(timeout = 5_000)
+    public void nativePostGpuConsumesMode0ReadMaskAndPpuSignalLikeGeneric() {
+        Fixture generic = new Fixture(true, true);
+        Fixture specialized = new Fixture(true, true);
+        generic.gpu.onSpeedSwitch();
+        specialized.gpu.onSpeedSwitch();
+        generic.stat.setByte(StatRegister.ADDRESS, 0x48);
+        specialized.stat.setByte(StatRegister.ADDRESS, 0x48);
+        generic.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        specialized.gpu.setByte(GpuRegister.LYC.getAddress(), 0x22);
+        generic.advanceTo(1, 100);
+        specialized.advanceTo(1, 100);
+
+        int mode0Tick = specialized.gpu.getMode0InterruptTick();
+        int target = mode0Tick == Integer.MAX_VALUE ? 250 : Math.max(100, mode0Tick - 1);
+        generic.advanceTo(1, target);
+        specialized.advanceTo(1, target);
+
+        generic.interrupts.requestInterrupt(LCDC);
+        specialized.interrupts.requestInterrupt(LCDC);
+        generic.interrupts.clearInterrupt(LCDC);
+        specialized.interrupts.clearInterrupt(LCDC);
+        generic.interrupts.maskMode0LcdcReadForTicks(2);
+        specialized.interrupts.maskMode0LcdcReadForTicks(2);
+        assertTrue(generic.interrupts.hasPendingCpuReadPhase());
+        assertTrue(specialized.interrupts.hasPendingCpuReadPhase());
+
+        for (int dot = 0; dot < 5; dot++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals("PPU-signal STAT at dot " + dot,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals("PPU-signal IF at dot " + dot,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+            assertEquals("PPU-signal FF0F at dot " + dot,
+                    generic.interrupts.getByte(0xff0f), specialized.interrupts.getByte(0xff0f));
+        }
     }
 
     @Test
@@ -2623,6 +2799,106 @@ public class StatRegisterTest {
 
     private static int cpuStatModeOverride(StatRegister stat) {
         return intField(stat, "cpuStatModeOverride");
+    }
+
+    private static Fixture nativeStressFixture() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x78);
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), 0x47);
+        fixture.interrupts.setByte(0xffff, 0x1f);
+        for (int i = 0; i < 40; i++) {
+            int address = 0xfe00 + i * 4;
+            fixture.oam.setByte(address, 16 + (i * 11) % 128);
+            fixture.oam.setByte(address + 1, 8 + (i * 17) % 168);
+            fixture.oam.setByte(address + 2, i * 3);
+            fixture.oam.setByte(address + 3, i & 0x0f);
+        }
+        return fixture;
+    }
+
+    private static void assertNativeGpuDot(Fixture generic, Fixture specialized, int dot)
+            throws Exception {
+        int genericFacts = generic.gpu.getNativeCgbPerformancePostStatFacts();
+        int specializedFacts = specialized.gpu.getNativeCgbPerformancePostStatFacts();
+        assertEquals("native facts at dot " + dot, genericFacts, specializedFacts);
+        assertEquals("native facts validity at dot " + dot,
+                (genericFacts & Gpu.NATIVE_CGB_POST_STAT_FACTS_VALID) != 0,
+                (specializedFacts & Gpu.NATIVE_CGB_POST_STAT_FACTS_VALID) != 0);
+        assertEquals("native facts checkpoint at dot " + dot,
+                generic.gpu.isStatEventCheckpointForTick(),
+                (specializedFacts & Gpu.NATIVE_CGB_POST_STAT_CHECKPOINT) != 0);
+        GpuTimingSnapshot expected = new GpuTimingSnapshot();
+        GpuTimingSnapshot actual = new GpuTimingSnapshot();
+        generic.gpu.captureStatTimingForTick(expected);
+        specialized.gpu.captureNativeCgbPerformancePostStatTiming(actual);
+        assertEquals("generic coincidence release at dot " + dot,
+                expected.firstLine ? 452 : 454, generic.gpu.getCoincidenceReleaseTick());
+        assertTimingSnapshotsEqual("GPU timing at dot " + dot, expected, actual);
+    }
+
+    private static void assertTimingSnapshotsEqual(
+            String path, GpuTimingSnapshot expected, GpuTimingSnapshot actual) {
+        assertEquals(path + ".line", expected.line, actual.line);
+        assertEquals(path + ".ticksInLine", expected.ticksInLine, actual.ticksInLine);
+        assertEquals(path + ".visibleLy", expected.visibleLy, actual.visibleLy);
+        assertEquals(path + ".earlyLineEdgeTick", expected.earlyLineEdgeTick,
+                actual.earlyLineEdgeTick);
+        assertEquals(path + ".mode0InterruptTick", expected.mode0InterruptTick,
+                actual.mode0InterruptTick);
+        assertEquals(path + ".cpuMachineCycleDots", expected.cpuMachineCycleDots,
+                actual.cpuMachineCycleDots);
+        assertEquals(path + ".dmgCompat", expected.dmgCompat, actual.dmgCompat);
+        assertEquals(path + ".lcdEnabled", expected.lcdEnabled, actual.lcdEnabled);
+        assertEquals(path + ".firstLine", expected.firstLine, actual.firstLine);
+        assertEquals(path + ".statModeLatchRephasedBySpeedSwitch",
+                expected.statModeLatchRephasedBySpeedSwitch,
+                actual.statModeLatchRephasedBySpeedSwitch);
+        assertEquals(path + ".mode0HaltWakeTick", expected.mode0HaltWakeTick,
+                actual.mode0HaltWakeTick);
+        assertEquals(path + ".mode0IntWindow", expected.mode0IntWindow, actual.mode0IntWindow);
+        assertEquals(path + ".mode1IntWindow", expected.mode1IntWindow, actual.mode1IntWindow);
+        assertEquals(path + ".mode2IntWindow", expected.mode2IntWindow, actual.mode2IntWindow);
+        assertEquals(path + ".doubleSpeed", expected.doubleSpeed, actual.doubleSpeed);
+        assertEquals(path + ".nativeDoubleSpeed", expected.nativeDoubleSpeed,
+                actual.nativeDoubleSpeed);
+    }
+
+    private static void advanceGpuPair(Fixture generic, Fixture specialized, int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+        }
+    }
+
+    private static void advanceNativePair(
+            Fixture generic, Fixture specialized, int ticks, String path) {
+        for (int i = 0; i < ticks; i++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals(path + " STAT at dot " + i,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals(path + " IF at dot " + i,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
+    }
+
+    private static void assertNativePostGpuFallback(
+            Fixture generic, Fixture specialized, String path) {
+        for (int i = 0; i < 1_024; i++) {
+            generic.gpu.tick();
+            specialized.gpu.tick();
+            int facts = specialized.gpu.getNativeCgbPerformancePostStatFacts();
+            assertEquals(path + " facts invalid at dot " + i, 0,
+                    facts & Gpu.NATIVE_CGB_POST_STAT_FACTS_VALID);
+            generic.stat.tick();
+            specialized.stat.tickNativeCgbPerformancePostGpu();
+            assertEquals(path + " STAT at dot " + i,
+                    generic.stat.captureState(), specialized.stat.captureState());
+            assertEquals(path + " IF at dot " + i,
+                    generic.interrupts.captureState(), specialized.interrupts.captureState());
+        }
     }
 
     private static int intField(StatRegister stat, String name) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearchTest.java
@@ -7,6 +7,7 @@ import eu.rekawek.coffeegb.core.gpu.Lcdc;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.memory.Dma;
 import eu.rekawek.coffeegb.core.memory.Ram;
+import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -404,6 +405,91 @@ public class OamSearchTest {
         assertFalse(restored.search.hadSpriteHeightTransition());
     }
 
+    @Test
+    public void performanceNoDmaSpanMatchesScalarAcrossHalfSlotBoundaries() {
+        int[] starts = {13, 14, 27, 38, 77, 78};
+        int[] requestedLengths = {1, 2, 3, 7, 19, 54};
+        for (int start : starts) {
+            for (int requested : requestedLengths) {
+                int ticks = Math.min(requested, 79 - start);
+                if (ticks <= 0) {
+                    continue;
+                }
+                Fixture scalar = performanceFixture();
+                Fixture bulk = performanceFixture();
+                for (int i = 0; i < start; i++) {
+                    scalar.tickSearch();
+                    bulk.tickSearch();
+                }
+                assertTrue("bulk preflight rejected dot " + start,
+                        bulk.search.isPerformanceNoDmaStableSpanEligible(
+                                start, bulk.lcdc.getSpriteHeight()));
+
+                for (int i = 0; i < ticks; i++) {
+                    scalar.tickSearch();
+                }
+                bulk.search.advancePerformanceNoDmaStableSpanTrusted(
+                        start, ticks, bulk.lcdc.getSpriteHeight());
+
+                assertSearchStateEquals("dot " + start + " + " + ticks,
+                        scalar.search, bulk.search);
+            }
+        }
+    }
+
+    private static Fixture performanceFixture() {
+        Fixture fixture = new Fixture(true, true);
+        fixture.registers.put(GpuRegister.LY, 24);
+        fixture.lcdc.set(0x97);
+        fixture.settleLcdc();
+        for (int entry = 0; entry < 40; entry++) {
+            int y = entry % 3 == 0 ? 32 : entry % 3 == 1 ? 40 : 8;
+            fixture.oam.setByte(0xfe00 + 4 * entry, y);
+            fixture.oam.setByte(0xfe01 + 4 * entry, 8 + entry);
+        }
+        fixture.beginSearchLine();
+        return fixture;
+    }
+
+    private static void assertSearchStateEquals(
+            String message, OamSearch expected, OamSearch actual) {
+        assertArrayEquals(message + " reader Y",
+                intArrayField(expected, "oamReaderY"), intArrayField(actual, "oamReaderY"));
+        assertArrayEquals(message + " reader X",
+                intArrayField(expected, "oamReaderX"), intArrayField(actual, "oamReaderX"));
+        String[] intFields = {
+                "spritePosIndex", "spriteY", "spriteHeight", "previousOamSpriteHeight",
+                "spriteX", "oamReaderBusY", "oamReaderBusX",
+                "oamReaderSourceChangeTicks", "i"
+        };
+        for (String name : intFields) {
+            assertEquals(message + ' ' + name, intField(expected, name), intField(actual, name));
+        }
+        String[] booleanFields = {
+                "oamReaderInitialized", "oamReaderDmaSource",
+                "spriteHeightTransitionThisLine", "dmaBlockedThisLine",
+                "selectSprites", "spriteCandidateSeen"
+        };
+        for (String name : booleanFields) {
+            assertEquals(message + ' ' + name,
+                    booleanField(expected, name), booleanField(actual, name));
+        }
+        assertEquals(message + " half-slot state",
+                objectField(expected, "state"), objectField(actual, "state"));
+        for (int i = 0; i < expected.getSprites().length; i++) {
+            SpritePosition expectedSprite = expected.getSprites()[i];
+            SpritePosition actualSprite = actual.getSprites()[i];
+            assertEquals(message + " sprite " + i + " enabled",
+                    expectedSprite.isEnabled(), actualSprite.isEnabled());
+            assertEquals(message + " sprite " + i + " x",
+                    expectedSprite.getX(), actualSprite.getX());
+            assertEquals(message + " sprite " + i + " y",
+                    expectedSprite.getY(), actualSprite.getY());
+            assertEquals(message + " sprite " + i + " address",
+                    expectedSprite.getAddress(), actualSprite.getAddress());
+        }
+    }
+
     private static Field field(OamSearch search, String name) {
         try {
             Field field = OamSearch.class.getDeclaredField(name);
@@ -433,6 +519,14 @@ public class OamSearchTest {
     private static boolean booleanField(OamSearch search, String name) {
         try {
             return field(search, name).getBoolean(search);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Object objectField(OamSearch search, String name) {
+        try {
+            return field(search, name).get(search);
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }
@@ -472,7 +566,16 @@ public class OamSearchTest {
         }
 
         private Fixture(boolean gbc) {
-            speedMode = new SpeedMode(gbc);
+            this(gbc, false);
+        }
+
+        private Fixture(boolean gbc, boolean doubleSpeed) {
+            speedMode = doubleSpeed ? new SpeedMode(gbc) {
+                @Override
+                public int getSpeedMode() {
+                    return 2;
+                }
+            } : new SpeedMode(gbc);
             dma = new Dma(memory, oam, speedMode);
             registers.setGbc(gbc);
             registers.setSpeedMode(speedMode);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadPerformanceSpanTest.java
@@ -69,6 +69,27 @@ public class JoypadPerformanceSpanTest {
         assertEquals(0, sgb.performanceQuietSpanLimit(1));
     }
 
+    @Test
+    public void cachedHubSpanRejectsLegacyMutationUntilScalarReconciliation() {
+        PlayerInputHub hub = new PlayerInputHub();
+        Joypad joypad = new Joypad(
+                new InterruptManager(false), EventBus.NULL_EVENT_BUS, false, hub);
+        joypad.tick();
+        assertTrue(joypad.performanceSettledHaltSpanLimit(54) > 3);
+
+        joypad.setPressedButtons(java.util.Set.of(Button.A));
+        assertEquals(0, joypad.performanceSettledHaltSpanLimit(54));
+        assertFalse(joypad.isPerformanceQuietSpanStillEligible());
+
+        joypad.setPressedButtons(java.util.Set.of());
+        assertEquals(0, joypad.performanceSettledHaltSpanLimit(54));
+        joypad.tick();
+        assertEquals("the mutation edge itself remains scalar", 0,
+                joypad.performanceSettledHaltSpanLimit(54));
+        joypad.tick();
+        assertTrue(joypad.performanceSettledHaltSpanLimit(54) > 3);
+    }
+
     private static void assertEquivalent(Joypad scalar, Joypad bulk) {
         assertEquals(scalar.getByte(0xff00), bulk.getByte(0xff00));
         assertEquals(scalar.getSampledInput(), bulk.getSampledInput());

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
@@ -1,0 +1,237 @@
+package eu.rekawek.coffeegb.core.memory;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.TestDebugHooks;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.genie.AddPatches;
+import eu.rekawek.coffeegb.core.genie.GameGenieCheat;
+import eu.rekawek.coffeegb.core.genie.Genie;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
+import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class PerformanceRomAccessTest {
+
+    @Test
+    public void plainMbc5LeaseSnapshotsBothWindowsAndIsReused() throws IOException {
+        Mbc5 mapper = plainMbc5();
+
+        PerformanceRomAccess lease = mapper.acquirePerformanceRomAccess();
+
+        assertNotNull(lease);
+        assertEquals(0x20, lease.readCpuByte(0x0000));
+        assertEquals(0x40, lease.readCpuByte(0x3fff));
+        assertEquals(0x21, lease.readCpuByte(0x4000));
+        assertEquals(0x41, lease.readCpuByte(0x7fff));
+        assertEquals(0x80, lease.readCpuByte(0x0100));
+        assertEquals(0x81, lease.readCpuByte(0x4100));
+        assertEquals(0x0100, lease.physicalOffset(0x0100));
+        assertEquals(0x4100, lease.physicalOffset(0x4100));
+        assertEquals(-1, lease.physicalOffset(0x8000));
+        assertEquals(-1, lease.readCpuByte(-1));
+        assertEquals(0xff, lease.readPhysicalByte(Integer.MAX_VALUE));
+
+        mapper.setByte(0x2000, 0x03);
+        assertEquals("borrowed mapping remains stable until reacquisition",
+                0x81, lease.readCpuByte(0x4100));
+
+        PerformanceRomAccess reacquired = mapper.acquirePerformanceRomAccess();
+        assertSame("plain MBC5 acquisition must not allocate", lease, reacquired);
+        assertEquals(0x83, reacquired.readCpuByte(0x4100));
+        assertEquals(0xc100, reacquired.physicalOffset(0x4100));
+    }
+
+    @Test
+    public void mapperUsesNinthBankBitModuloAndOpenBusForPartialFinalBank()
+            throws IOException {
+        byte[] rom = new byte[0x9000];
+        rom[0x0000] = 0x50;
+        rom[0x8000] = 0x52;
+        rom[0x8fff] = 0x5f;
+        rom[0x0147] = 0x19;
+        rom[0x0148] = 0x00;
+        Mbc5 mapper = new Mbc5(new Rom(rom), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2000, 0x02);
+        PerformanceRomAccess partialBank = mapper.acquirePerformanceRomAccess();
+        assertEquals(0x52, partialBank.readCpuByte(0x4000));
+        assertEquals(0x5f, partialBank.readCpuByte(0x4fff));
+        assertEquals(0xff, partialBank.readCpuByte(0x5000));
+        assertEquals(0x9000, partialBank.physicalOffset(0x5000));
+
+        mapper.setByte(0x3000, 0x01);
+        PerformanceRomAccess ninthBitBank = mapper.acquirePerformanceRomAccess();
+        assertSame(partialBank, ninthBitBank);
+        assertEquals("0x102 wraps over the physical three-bank image to bank zero",
+                0x50, ninthBitBank.readCpuByte(0x4000));
+        assertEquals(0x0000, ninthBitBank.physicalOffset(0x4000));
+    }
+
+    @Test
+    public void plainMbc5LeaseFailsClosedForDerivedMapperAndDebugHooks() throws IOException {
+        Mbc5 derivedMapper = new Mbc5(new Rom(mbc5Rom()), Battery.NULL_BATTERY) {
+        };
+        assertNull(derivedMapper.acquirePerformanceRomAccess());
+
+        Mbc5 debuggedMapper = plainMbc5();
+        debuggedMapper.setDebugHooks(new TestDebugHooks());
+        assertNull(debuggedMapper.acquirePerformanceRomAccess());
+    }
+
+    @Test
+    public void productionWrapperPathRejectsBootOverlayCheatsAndActiveDma() throws IOException {
+        Cartridge cartridge = new Cartridge(new Rom(mbc5Rom()), Battery.NULL_BATTERY);
+        BiosShadow biosShadow = new BiosShadow(
+                new Bios(HardwareProfileRegistry.CGB), cartridge);
+        Mmu mmu = new Mmu(true);
+        mmu.addAddressSpace(biosShadow);
+        mmu.indexSpaces();
+
+        Genie genie = new Genie(mmu, true);
+        SpeedMode speedMode = new SpeedMode(true);
+        Dma dma = new Dma(genie, new Ram(0xfe00, 0xa0), speedMode);
+        DmaCpuAddressSpace cpuBus = new DmaCpuAddressSpace(genie, dma, true);
+
+        assertNull("boot ROM overlay remains authoritative", cpuBus.acquirePerformanceRomAccess());
+
+        biosShadow.setByte(0xff50, 0x01);
+        PerformanceRomAccess lease = cpuBus.acquirePerformanceRomAccess();
+        assertNotNull(lease);
+        assertEquals(0x20, lease.readCpuByte(0x0000));
+        assertEquals(0x40, lease.readCpuByte(0x3fff));
+        assertEquals(0x21, lease.readCpuByte(0x4000));
+        assertEquals(0x41, lease.readCpuByte(0x7fff));
+        assertEquals(0x81, lease.readCpuByte(0x4100));
+
+        try (EventBusImpl eventBus = new EventBusImpl(null, null, false)) {
+            genie.init(eventBus);
+            eventBus.post(new AddPatches(List.of(new GameGenieCheat(0x55, 0x4100, -1))));
+            assertNull("active cheat must retain ordinary bus reads",
+                    cpuBus.acquirePerformanceRomAccess());
+        }
+
+        Genie unpatchedGenie = new Genie(mmu, true);
+        Dma activeDma = new Dma(unpatchedGenie, new Ram(0xfe00, 0xa0), speedMode);
+        DmaCpuAddressSpace activeDmaBus =
+                new DmaCpuAddressSpace(unpatchedGenie, activeDma, true);
+        assertNotNull(activeDmaBus.acquirePerformanceRomAccess());
+
+        activeDma.setByte(0xff46, 0x40);
+        assertNull("active OAM DMA must retain conflict routing",
+                activeDmaBus.acquirePerformanceRomAccess());
+    }
+
+    @Test
+    public void mmuRejectsAProviderWhenAnyRomAddressHasAnotherOwner() {
+        PerformanceRomAccess access = new ConstantPerformanceRomAccess();
+        Mmu mmu = new Mmu(true);
+        mmu.addAddressSpace(new SingleAddressSpace(0x2345));
+        mmu.addAddressSpace(new RomProviderAddressSpace(access));
+        mmu.indexSpaces();
+
+        assertNull(mmu.acquirePerformanceRomAccess());
+    }
+
+    @Test
+    public void nonMbc5CartridgeHasSafeNullFallback() throws IOException {
+        byte[] rom = new byte[0x8000];
+        rom[0x0147] = 0x00;
+
+        Cartridge cartridge = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
+
+        assertNull(cartridge.acquirePerformanceRomAccess());
+    }
+
+    private static Mbc5 plainMbc5() throws IOException {
+        return new Mbc5(new Rom(mbc5Rom()), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] mbc5Rom() {
+        byte[] rom = new byte[0x40000];
+        for (int bank = 0; bank < 16; bank++) {
+            rom[bank * 0x4000] = (byte) (0x20 + bank);
+            rom[bank * 0x4000 + 0x3fff] = (byte) (0x40 + bank);
+            rom[bank * 0x4000 + 0x0100] = (byte) (0x80 + bank);
+        }
+        rom[0x0147] = 0x19;
+        rom[0x0148] = 0x04;
+        return rom;
+    }
+
+    private static final class ConstantPerformanceRomAccess implements PerformanceRomAccess {
+
+        @Override
+        public int physicalOffset(int cpuAddress) {
+            return cpuAddress >= 0 && cpuAddress < 0x8000 ? cpuAddress : -1;
+        }
+
+        @Override
+        public int readPhysicalByte(int physicalOffset) {
+            return 0x42;
+        }
+    }
+
+    private static final class RomProviderAddressSpace
+            implements AddressSpace, PerformanceRomAccessProvider {
+
+        private final PerformanceRomAccess access;
+
+        private RomProviderAddressSpace(PerformanceRomAccess access) {
+            this.access = access;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address < 0x8000;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+        }
+
+        @Override
+        public int getByte(int address) {
+            return access.readCpuByte(address);
+        }
+
+        @Override
+        public PerformanceRomAccess acquirePerformanceRomAccess() {
+            return access;
+        }
+    }
+
+    private static final class SingleAddressSpace implements AddressSpace {
+
+        private final int address;
+
+        private SingleAddressSpace(int address) {
+            this.address = address;
+        }
+
+        @Override
+        public boolean accepts(int address) {
+            return address == this.address;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+        }
+
+        @Override
+        public int getByte(int address) {
+            return 0xff;
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
@@ -14,6 +14,77 @@ import static org.junit.Assert.assertTrue;
 public class SerialPortPerformanceSpanTest {
 
     @Test
+    public void physicalDmgIdleEpochMatchesScalarNormalSpeedTicks() {
+        Random random = new Random(0xd06e51a1L);
+        for (int iteration = 0; iteration < 1_000; iteration++) {
+            InterruptManager scalarInterrupts = new InterruptManager(false);
+            InterruptManager bulkInterrupts = new InterruptManager(false);
+            SerialPort scalar = new SerialPort(
+                    scalarInterrupts, false, new SpeedMode(false));
+            SerialPort bulk = new SerialPort(
+                    bulkInterrupts, false, new SpeedMode(false));
+            int phaseTicks = random.nextInt(0x100);
+            for (int tick = 0; tick < phaseTicks; tick++) {
+                scalar.tick();
+                bulk.tick();
+            }
+            int sc = random.nextInt(0x80);
+            scalar.setByte(0xff02, sc);
+            bulk.setByte(0xff02, sc);
+            int span = 1 + random.nextInt(54);
+
+            assertFalse(bulk.performanceEpochIdle(span));
+            assertTrue(bulk.performancePhysicalDmgEpochIdle(span));
+            for (int tick = 0; tick < span; tick++) {
+                scalar.tick();
+            }
+            bulk.tickPerformancePhysicalDmgEpochIdle(span);
+
+            assertEquals(scalar.captureState(), bulk.captureState());
+            assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+        }
+    }
+
+    @Test
+    public void cgbNormalSpeedRemainsOutsideEpochIdleContract() {
+        SerialPort cgbNormal = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        assertFalse(cgbNormal.performanceEpochIdle(54));
+        assertFalse(cgbNormal.performancePhysicalDmgEpochIdle(54));
+    }
+
+    @Test
+    public void nativeCgbIdleEpochMatchesScalarDoubleSpeedTicks()
+            throws ReflectiveOperationException {
+        Random random = new Random(0xc6b5e71a1L);
+        for (int iteration = 0; iteration < 1_000; iteration++) {
+            InterruptManager scalarInterrupts = new InterruptManager(true);
+            InterruptManager bulkInterrupts = new InterruptManager(true);
+            SerialPort scalar = new SerialPort(scalarInterrupts, true, doubleSpeed());
+            SerialPort bulk = new SerialPort(bulkInterrupts, true, doubleSpeed());
+            int phaseTicks = random.nextInt(0x100);
+            for (int tick = 0; tick < phaseTicks; tick++) {
+                scalar.tick();
+                bulk.tick();
+            }
+            int sc = random.nextInt(0x80);
+            scalar.setByte(0xff02, sc);
+            bulk.setByte(0xff02, sc);
+            int span = 1 + random.nextInt(54);
+
+            assertTrue(bulk.performanceEpochIdle(span));
+            assertFalse(bulk.performancePhysicalDmgEpochIdle(span));
+            for (int tick = 0; tick < span; tick++) {
+                scalar.tick();
+            }
+            bulk.tickPerformanceEpochIdle(span);
+
+            assertEquals(scalar.captureState(), bulk.captureState());
+            assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+        }
+    }
+
+    @Test
     public void randomizedIdleNullEndpointSpansMatchScalarTicks() {
         Random random = new Random(0x5e71a1L);
         for (int i = 0; i < 1_000; i++) {
@@ -96,6 +167,35 @@ public class SerialPortPerformanceSpanTest {
         assertEquals(0, first.performanceQuietSpanLimit(3));
     }
 
+    @Test
+    public void disconnectedPeerScalarIdlePathMatchesNullEndpointAtBothSpeeds()
+            throws ReflectiveOperationException {
+        for (int speed = 1; speed <= 2; speed++) {
+            SpeedMode nullSpeed = new SpeedMode(true);
+            SpeedMode peerSpeed = new SpeedMode(true);
+            if (speed == 2) {
+                nullSpeed.setByte(0xff4d, 1);
+                peerSpeed.setByte(0xff4d, 1);
+                var onStop = SpeedMode.class.getDeclaredMethod("onStop");
+                onStop.setAccessible(true);
+                assertTrue((boolean) onStop.invoke(nullSpeed));
+                assertTrue((boolean) onStop.invoke(peerSpeed));
+            }
+            InterruptManager nullInterrupts = new InterruptManager(true);
+            InterruptManager peerInterrupts = new InterruptManager(true);
+            SerialPort nullPort = new SerialPort(nullInterrupts, true, nullSpeed);
+            SerialPort peerPort = new SerialPort(peerInterrupts, true, peerSpeed);
+            peerPort.init(new Peer2PeerSerialEndpoint());
+
+            for (int tick = 0; tick < 1_000; tick++) {
+                nullPort.tick();
+                peerPort.tick();
+            }
+            assertEquals(nullPort.captureState(), peerPort.captureState());
+            assertEquals(nullInterrupts.captureState(), peerInterrupts.captureState());
+        }
+    }
+
     private static final class NoopEndpoint implements SerialEndpoint {
         @Override
         public void setSb(int sb) {
@@ -124,5 +224,14 @@ public class SerialPortPerformanceSpanTest {
         public void restoreState(
                 eu.rekawek.coffeegb.core.state.ComponentState<SerialEndpoint> state) {
         }
+    }
+
+    private static SpeedMode doubleSpeed() throws ReflectiveOperationException {
+        SpeedMode speed = new SpeedMode(true);
+        speed.setByte(0xff4d, 1);
+        var onStop = SpeedMode.class.getDeclaredMethod("onStop");
+        onStop.setAccessible(true);
+        assertTrue((boolean) onStop.invoke(speed));
+        return speed;
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
@@ -1,0 +1,663 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.ExecutionMode;
+import eu.rekawek.coffeegb.core.TestDebugHooks;
+import eu.rekawek.coffeegb.core.cpu.InterruptManager;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.timer.Timer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Focused checks for the transient system-muted PERFORMANCE audio calendar. */
+public final class PerformanceSystemMutedAudioCalendarTest {
+
+    @Test
+    public void silentCalendarPreservesZeroCadenceAtEveryInitialPhase() {
+        for (int phase = 0; phase < 55; phase++) {
+            Sound sound = newSound();
+            List<Sound.SoundSampleEvent> events = new ArrayList<>();
+            EventBusImpl eventBus = new EventBusImpl(null, null, false);
+            eventBus.register(events::add, Sound.SoundSampleEvent.class);
+            sound.init(eventBus);
+            sound.setPerformanceSystemMutedAudioCalendar(true);
+            sound.resetPerformanceSystemMutedAudioCalendarCounters();
+
+            sound.tickPerformanceQuietSpan(phase);
+            sound.tickPerformanceQuietSpan(55);
+            assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
+            assertEquals(1, events.size());
+            assertAllZero(events.get(0).buffer());
+
+            sound.tickPerformanceQuietSpan(55 - phase);
+            assertEquals(2L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
+            assertEquals(2, events.size());
+            assertAllZero(events.get(1).buffer());
+            assertEquals(110L, sound.getPerformanceSystemMutedAudioCalendarSkippedTicks());
+            assertEquals(110L, sound.getPerformanceSystemMutedAudioCalendarMaxPendingTicks());
+
+            sound.materializePendingPerformanceTicks();
+        }
+    }
+
+    @Test
+    public void silentCalendarBoundaryAndFrameSequencerKeepCadenceAndBoundaries() {
+        Sound sound = newSound();
+        sound.setPerformanceSystemMutedAudioCalendar(true);
+        sound.resetPerformanceSystemMutedAudioCalendarCounters();
+
+        assertEquals(100, sound.performanceQuietSpanLimit(100));
+        assertEquals(100, sound.performanceEpochSpanLimit(100));
+        sound.tickPerformanceBoundary(false);
+        sound.tickPerformanceQuietSpan(54);
+        assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
+
+        Timer timer = timerOf(sound);
+        timer.presetDiv(0x1000);
+        sound.tickFrameSequencer(false);
+        timer.presetDiv(0);
+        sound.tickFrameSequencer(false);
+        sound.commitFrameSequencerClock();
+        assertTrue(sound.getPerformanceSystemMutedAudioCalendarFrameSequencerCommits() >= 1L);
+    }
+
+    @Test
+    public void defaultCalendarRemainsOffAndRetainsExistingAudioCeilings() {
+        Sound sound = newSound();
+        assertFalse(sound.isPerformanceSystemMutedAudioCalendarEnabled());
+        assertEquals(Sound.PerformanceSystemMutedAudioMode.OFF,
+                sound.getPerformanceSystemMutedAudioMode());
+        assertEquals(54, sound.performanceQuietSpanLimit(100));
+        assertEquals(54, sound.performanceEpochSpanLimit(100));
+        sound.tickPerformanceQuietSpan(54);
+        assertEquals(0L, sound.getPerformanceSystemMutedAudioCalendarSkippedTicks());
+        sound.materializePendingPerformanceTicks();
+
+        Sound accuracy = newSound(ExecutionMode.ACCURACY);
+        try {
+            accuracy.setPerformanceSystemMutedAudioCalendar(true);
+            fail("accuracy mode must reject the silent PCM calendar");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void booleanSetterRetainsExactPolicyAndExplicitModesRoundTrip() {
+        Sound sound = newSound();
+        sound.setPerformanceSystemMutedAudioCalendar(true);
+        assertEquals(Sound.PerformanceSystemMutedAudioMode.EXACT,
+                sound.getPerformanceSystemMutedAudioMode());
+        sound.setPerformanceSystemMutedAudioMode(
+                Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+        assertEquals(Sound.PerformanceSystemMutedAudioMode.RELAXED_APU,
+                sound.getPerformanceSystemMutedAudioMode());
+        sound.setPerformanceSystemMutedAudioCalendar(false);
+        assertEquals(Sound.PerformanceSystemMutedAudioMode.OFF,
+                sound.getPerformanceSystemMutedAudioMode());
+    }
+
+    @Test
+    public void relaxedCalendarPreservesZeroCadenceAndDropsOnlyDeferredChannelTicks() {
+        for (int phase = 0; phase < 55; phase++) {
+            Sound sound = newSound();
+            List<Sound.SoundSampleEvent> events = new ArrayList<>();
+            EventBusImpl eventBus = new EventBusImpl(null, null, false);
+            eventBus.register(events::add, Sound.SoundSampleEvent.class);
+            sound.init(eventBus);
+            sound.setPerformanceSystemMutedAudioMode(
+                    Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+            sound.resetPerformanceSystemMutedAudioCalendarCounters();
+
+            sound.tickPerformanceQuietSpan(phase);
+            sound.tickPerformanceQuietSpan(55);
+            assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
+            assertEquals(1, events.size());
+            assertAllZero(events.get(0).buffer());
+            assertEquals(0L,
+                    sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+
+            sound.setByte(0xff24, 0x77);
+            assertEquals(phase + 55L,
+                    sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+            assertEquals(sound.getPerformanceSystemMutedAudioCalendarSkippedTicks(),
+                    sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+            assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarApuWrites());
+            assertEquals(1, events.size());
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void relaxedCalendarKeepsFrameSequencerAndApuAccessBoundaries() throws Exception {
+        Sound sound = newSound();
+        sound.setPerformanceSystemMutedAudioMode(
+                Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+        sound.resetPerformanceSystemMutedAudioCalendarCounters();
+        sound.tickPerformanceQuietSpan(12);
+
+        Timer timer = timerOf(sound);
+        timer.presetDiv(0x1000);
+        sound.tickFrameSequencer(false);
+        timer.presetDiv(0);
+        sound.tickFrameSequencer(false);
+        sound.commitFrameSequencerClock();
+
+        assertTrue(sound.getPerformanceSystemMutedAudioCalendarFrameSequencerCommits() >= 1L);
+        assertTrue(sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks() >= 12L);
+        assertEquals(0x80, sound.getByte(0xff26) & 0x80);
+        assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarApuReads());
+    }
+
+    @Test
+    public void relaxedDisableDropsLiveDebtAndRestoreTurnsModeOff() throws Exception {
+        try (SoundPair pair = pair(true)) {
+            pair.silent.setPerformanceSystemMutedAudioMode(
+                    Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+            pair.silent.resetPerformanceSystemMutedAudioCalendarCounters();
+            pair.silent.tickPerformanceQuietSpan(8192);
+            pair.silent.setPerformanceSystemMutedAudioMode(
+                    Sound.PerformanceSystemMutedAudioMode.OFF);
+            assertEquals(Sound.PerformanceSystemMutedAudioMode.OFF,
+                    pair.silent.getPerformanceSystemMutedAudioMode());
+            assertEquals(8192L,
+                    pair.silent.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+
+            var state = pair.silent.captureState();
+            pair.silent.setPerformanceSystemMutedAudioMode(
+                    Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+            pair.silent.restoreState(state);
+            assertEquals(Sound.PerformanceSystemMutedAudioMode.OFF,
+                    pair.silent.getPerformanceSystemMutedAudioMode());
+            assertFalse(pair.silent.isPerformanceSystemMutedAudioCalendarEnabled());
+        }
+    }
+
+    @Test
+    public void relaxedCalendarDeliberatelyDivergesFromExactChannelState() throws Exception {
+        try (SoundPair pair = pair(true)) {
+            pair.silent.setPerformanceSystemMutedAudioMode(
+                    Sound.PerformanceSystemMutedAudioMode.RELAXED_APU);
+            pair.silent.resetPerformanceSystemMutedAudioCalendarCounters();
+            int debt = 8192;
+            advanceScalar(pair.scalar, debt);
+            pair.silent.tickPerformanceQuietSpan(debt);
+            pair.scalar.materializePendingPerformanceTicks();
+            pair.silent.setByte(0xff24, 0x77);
+
+            assertEquals((long) debt,
+                    pair.silent.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+            assertEquals(pair.silent.getPerformanceSystemMutedAudioCalendarSkippedTicks(),
+                    pair.silent.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+            assertNotEquals("relaxed mode must not advance deferred channel state",
+                    canonicalDigest(pair.scalar.captureState()),
+                    canonicalDigest(pair.silent.captureState()));
+        }
+    }
+
+    @Test
+    public void calendarCountsApuBoundariesAndMaterializesDebtBeforeCpuVisibleAccess() {
+        Sound sound = newSound();
+        sound.setPerformanceSystemMutedAudioCalendar(true);
+        sound.resetPerformanceSystemMutedAudioCalendarCounters();
+        sound.tickPerformanceQuietSpan(12);
+        assertEquals(0x80, sound.getByte(0xff26) & 0x80);
+        sound.setByte(0xff24, 0x77);
+        assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarApuReads());
+        assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarApuWrites());
+    }
+
+    @Test
+    public void randomizedDebtsThrough8192MaterializeTheCanonicalApuCalendar() throws Exception {
+        int[] fixedDebts = {1, 2, 3, 54, 55, 56, 127, 511, 1023, 2047, 4095, 8191, 8192};
+        Random random = new Random(0x5a17c0deL);
+        for (boolean gbc : new boolean[]{false, true}) {
+            for (int sample = 0; sample < 96; sample++) {
+                int debt = sample < fixedDebts.length
+                        ? fixedDebts[sample] : 1 + random.nextInt(8192);
+                try (SoundPair pair = pair(gbc)) {
+                    int warmup = random.nextInt(41);
+                    for (int i = 0; i < warmup; i++) {
+                        pair.scalar.tick(false);
+                        pair.silent.tickPerformanceQuietSpan(1);
+                    }
+                    advanceScalar(pair.scalar, debt);
+                    pair.silent.tickPerformanceQuietSpan(debt);
+                    switch (sample & 3) {
+                        case 0 -> assertEquals(pair.scalar.getByte(0xff26), pair.silent.getByte(0xff26));
+                        case 1 -> {
+                            pair.scalar.setByte(0xff24, 0x31 + sample);
+                            pair.silent.setByte(0xff24, 0x31 + sample);
+                        }
+                        case 2 -> commitFrameSequencer(pair);
+                        case 3 -> {
+                            pair.scalar.materializePendingPerformanceTicks();
+                            pair.silent.materializePendingPerformanceTicks();
+                        }
+                        default -> throw new AssertionError();
+                    }
+                    assertExact(pair, "gbc=" + gbc + " debt=" + debt + " sample=" + sample);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void sweepExpiryOffsetsOneThroughFortyAndPulseReloadsStayExact() throws Exception {
+        for (int offset = 1; offset <= 40; offset++) {
+            try (SoundPair pair = pair(true)) {
+                Object scalarSweep = field(field(pair.scalar, "mode1"), "frequencySweep");
+                Object silentSweep = field(field(pair.silent, "mode1"), "frequencySweep");
+                setIntField(scalarSweep, "calculationDelay", offset);
+                setIntField(silentSweep, "calculationDelay", offset);
+                setBooleanField(scalarSweep, "unshiftedCalculation", true);
+                setBooleanField(silentSweep, "unshiftedCalculation", true);
+                int debt = offset + 17;
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "sweep offset=" + offset);
+            }
+        }
+
+        for (int reload = 1; reload <= 40; reload++) {
+            try (SoundPair pair = pair(true)) {
+                setIntField(field(pair.scalar, "mode1"), "freqDivider", reload);
+                setIntField(field(pair.silent, "mode1"), "freqDivider", reload);
+                setIntField(field(pair.scalar, "mode1"), "phase", 1);
+                setIntField(field(pair.silent, "mode1"), "phase", 1);
+                int debt = reload + 19;
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "pulse reload=" + reload);
+            }
+        }
+    }
+
+    @Test
+    public void waveTriggerFetchWindowAndNoisePolynomialConfigurationsStayExact() throws Exception {
+        int[] waveDebts = {1, 2, 3, 4, 7, 15, 31, 63, 127};
+        for (int debt : waveDebts) {
+            try (SoundPair pair = pair(true)) {
+                for (int address = 0xff30; address <= 0xff3f; address++) {
+                    pair.scalar.setByte(address, address ^ 0x5a);
+                    pair.silent.setByte(address, address ^ 0x5a);
+                }
+                pair.scalar.setByte(0xff1a, 0x80);
+                pair.silent.setByte(0xff1a, 0x80);
+                pair.scalar.setByte(0xff1b, 0x20);
+                pair.silent.setByte(0xff1b, 0x20);
+                pair.scalar.setByte(0xff1c, 0x60);
+                pair.silent.setByte(0xff1c, 0x60);
+                pair.scalar.setByte(0xff1d, 0x42);
+                pair.silent.setByte(0xff1d, 0x42);
+                pair.scalar.setByte(0xff1e, 0x87);
+                pair.silent.setByte(0xff1e, 0x87);
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "wave debt=" + debt);
+            }
+        }
+
+        int[] nr43Values = {0x00, 0x01, 0x07, 0x10, 0x17, 0x20, 0x2f, 0x37, 0x3f, 0xff};
+        for (int nr43 : nr43Values) {
+            try (SoundPair pair = pair(true)) {
+                pair.scalar.setByte(0xff21, 0xf3);
+                pair.silent.setByte(0xff21, 0xf3);
+                pair.scalar.setByte(0xff22, nr43);
+                pair.silent.setByte(0xff22, nr43);
+                pair.scalar.setByte(0xff23, 0x80);
+                pair.silent.setByte(0xff23, 0x80);
+                int debt = 11 + (nr43 & 7);
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "noise NR43=" + nr43);
+            }
+        }
+    }
+
+    @Test
+    public void apuAccessFrameSequencerDivDebugObserverAndRestoreBoundariesStayExact()
+            throws Exception {
+        for (int interruption = 0; interruption < 7; interruption++) {
+            try (SoundPair pair = pair(true)) {
+                advanceScalar(pair.scalar, 8192);
+                pair.silent.tickPerformanceQuietSpan(8192);
+                switch (interruption) {
+                    case 0 -> assertEquals(pair.scalar.getByte(0xff26), pair.silent.getByte(0xff26));
+                    case 1 -> {
+                        pair.scalar.setByte(0xff24, 0x42);
+                        pair.silent.setByte(0xff24, 0x42);
+                    }
+                    case 2 -> commitFrameSequencer(pair);
+                    case 3 -> {
+                        pair.scalarTimer.presetDiv(0);
+                        pair.silentTimer.presetDiv(0);
+                        pair.scalar.tickFrameSequencer(true);
+                        pair.silent.tickFrameSequencer(true);
+                        pair.scalar.commitFrameSequencerClock();
+                        pair.silent.commitFrameSequencerClock();
+                    }
+                    case 4 -> {
+                        pair.scalar.setDebugHooks(new TestDebugHooks());
+                        pair.silent.setDebugHooks(new TestDebugHooks());
+                    }
+                    case 5 -> {
+                        SoundOutputObserver scalarObserver = (left, right) -> { };
+                        SoundOutputObserver silentObserver = (left, right) -> { };
+                        assertTrue(pair.scalar.attachOutputObserver(scalarObserver));
+                        assertTrue(pair.silent.attachOutputObserver(silentObserver));
+                    }
+                    case 6 -> {
+                        var scalarState = pair.scalar.captureState();
+                        var silentState = pair.silent.captureState();
+                        pair.scalar.restoreState(scalarState);
+                        pair.silent.restoreState(silentState);
+                        assertFalse(pair.silent.isPerformanceSystemMutedAudioCalendarEnabled());
+                    }
+                    default -> throw new AssertionError();
+                }
+                assertExact(pair, "interruption=" + interruption);
+            }
+        }
+    }
+
+    @Test
+    public void explicitDisableWithLiveDebtMaterializesExactlyAndTurnsCalendarOff() throws Exception {
+        try (SoundPair pair = pair(true)) {
+            advanceScalar(pair.scalar, 8192);
+            pair.silent.tickPerformanceQuietSpan(8192);
+            pair.silent.setPerformanceSystemMutedAudioCalendar(false);
+            assertFalse(pair.silent.isPerformanceSystemMutedAudioCalendarEnabled());
+            assertExact(pair, "disable with live debt");
+        }
+    }
+
+    @Test
+    public void foreignStateRestoreClearsLiveCalendarDebtAndTransientFlag() throws Exception {
+        try (SoundPair pair = pair(true)) {
+            advanceScalar(pair.scalar, 137);
+            var foreignState = pair.scalar.captureState();
+            pair.silent.tickPerformanceQuietSpan(8192);
+            pair.silent.restoreState(foreignState);
+            assertFalse(pair.silent.isPerformanceSystemMutedAudioCalendarEnabled());
+            assertEquals(canonicalDigest(foreignState),
+                    canonicalDigest(pair.silent.captureState()));
+            assertEquals(component(foreignState, "i"),
+                    component(pair.silent.captureState(), "i"));
+        }
+    }
+
+    @Test
+    public void nr52OffOnTransitionMaterializesDebtAcrossDisabledApu() throws Exception {
+        try (SoundPair pair = pair(true)) {
+            advanceScalar(pair.scalar, 211);
+            pair.silent.tickPerformanceQuietSpan(211);
+            pair.scalar.setByte(0xff26, 0x00);
+            pair.silent.setByte(0xff26, 0x00);
+            advanceScalar(pair.scalar, 73);
+            pair.silent.tickPerformanceQuietSpan(73);
+            pair.scalar.setByte(0xff26, 0x80);
+            pair.silent.setByte(0xff26, 0x80);
+            advanceScalar(pair.scalar, 149);
+            pair.silent.tickPerformanceQuietSpan(149);
+            pair.silent.materializePendingPerformanceTicks();
+            assertExact(pair, "NR52 off/on");
+        }
+    }
+
+    @Test
+    public void dmgSweepExpiryAndNonOverflowDelayedCalculationOffsetsStayExact() throws Exception {
+        for (int offset = 1; offset <= 40; offset++) {
+            try (SoundPair pair = pair(false)) {
+                Object scalarSweep = field(field(pair.scalar, "mode1"), "frequencySweep");
+                Object silentSweep = field(field(pair.silent, "mode1"), "frequencySweep");
+                setIntField(scalarSweep, "calculationDelay", offset);
+                setIntField(silentSweep, "calculationDelay", offset);
+                setBooleanField(scalarSweep, "unshiftedCalculation", true);
+                setBooleanField(silentSweep, "unshiftedCalculation", true);
+                int debt = offset + 13;
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "DMG sweep expiry offset=" + offset);
+            }
+        }
+
+        for (int offset = 1; offset <= 40; offset++) {
+            try (SoundPair pair = pair(false)) {
+                Object scalarSweep = field(field(pair.scalar, "mode1"), "frequencySweep");
+                Object silentSweep = field(field(pair.silent, "mode1"), "frequencySweep");
+                setIntField(scalarSweep, "calculationDelay", offset);
+                setIntField(silentSweep, "calculationDelay", offset);
+                setBooleanField(scalarSweep, "unshiftedCalculation", true);
+                setBooleanField(silentSweep, "unshiftedCalculation", true);
+                int debt = Math.max(1, offset - 1);
+                advanceScalar(pair.scalar, debt);
+                pair.silent.tickPerformanceQuietSpan(debt);
+                pair.silent.materializePendingPerformanceTicks();
+                assertExact(pair, "DMG non-overflow offset=" + offset);
+            }
+        }
+    }
+
+    private static void advanceScalar(Sound sound, int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            sound.tick(false);
+        }
+    }
+
+    private static void commitFrameSequencer(SoundPair pair) throws Exception {
+        pair.scalarTimer.presetDiv(0x1000);
+        pair.silentTimer.presetDiv(0x1000);
+        pair.scalar.tickFrameSequencer(false);
+        pair.silent.tickFrameSequencer(false);
+        pair.scalarTimer.presetDiv(0);
+        pair.silentTimer.presetDiv(0);
+        pair.scalar.tickFrameSequencer(false);
+        pair.silent.tickFrameSequencer(false);
+        pair.scalar.commitFrameSequencerClock();
+        pair.silent.commitFrameSequencerClock();
+    }
+
+    private static SoundPair pair(boolean gbc) throws Exception {
+        Sound scalar = configured(gbc);
+        Sound silent = configured(gbc);
+        EventBusImpl scalarBus = new EventBusImpl(null, null, false);
+        EventBusImpl silentBus = new EventBusImpl(null, null, false);
+        List<int[]> scalarEvents = new ArrayList<>();
+        List<int[]> silentEvents = new ArrayList<>();
+        scalarBus.register(event -> scalarEvents.add(event.buffer().clone()), Sound.SoundSampleEvent.class);
+        silentBus.register(event -> silentEvents.add(event.buffer().clone()), Sound.SoundSampleEvent.class);
+        scalar.init(scalarBus);
+        silent.init(silentBus);
+        silent.setPerformanceSystemMutedAudioCalendar(true);
+        silent.resetPerformanceSystemMutedAudioCalendarCounters();
+        return new SoundPair(scalar, silent, timerOf(scalar), timerOf(silent), scalarBus, silentBus,
+                scalarEvents, silentEvents);
+    }
+
+    private static void assertExact(SoundPair pair, String label) throws Exception {
+        Object scalarState = pair.scalar.captureState();
+        Object silentState = pair.silent.captureState();
+        assertEquals(label, canonicalDigest(scalarState), canonicalDigest(silentState));
+        assertEquals(label + " sample phase", component(scalarState, "performanceSamplePhase"),
+                component(silentState, "performanceSamplePhase"));
+        assertEquals(label + " buffer index", component(scalarState, "i"), component(silentState, "i"));
+        assertEquals(label + " event count", pair.scalarEvents.size(), pair.silentEvents.size());
+        for (int[] event : pair.silentEvents) {
+            assertAllZero(event);
+        }
+        assertAllZero((int[]) component(silentState, "buffer"));
+    }
+
+    private record SoundPair(Sound scalar, Sound silent, Timer scalarTimer, Timer silentTimer,
+                             EventBusImpl scalarBus, EventBusImpl silentBus,
+                             List<int[]> scalarEvents, List<int[]> silentEvents)
+            implements AutoCloseable {
+        @Override
+        public void close() {
+            scalarBus.close();
+            silentBus.close();
+        }
+    }
+
+    private static Sound newSound() {
+        return newSound(ExecutionMode.PERFORMANCE);
+    }
+
+    private static Sound newSound(ExecutionMode mode) {
+        SpeedMode speedMode = new SpeedMode(true);
+        Timer timer = new Timer(new InterruptManager(true), speedMode);
+        return new Sound(timer, speedMode, true, new ClockSpec(55, 1, 1), mode);
+    }
+
+    private static Sound configured(boolean gbc) {
+        SpeedMode speedMode = new SpeedMode(gbc);
+        Timer timer = new Timer(new InterruptManager(gbc), speedMode);
+        Sound sound = new Sound(timer, speedMode, gbc,
+                new ClockSpec(1_100_000, 1, 100, 1), ExecutionMode.PERFORMANCE);
+        sound.setByte(0xff26, 0x80);
+        sound.setByte(0xff24, 0x77);
+        sound.setByte(0xff25, 0xff);
+        sound.setByte(0xff11, 0xc0);
+        sound.setByte(0xff12, 0xf3);
+        sound.setByte(0xff10, 0x11);
+        sound.setByte(0xff13, 0xff);
+        sound.setByte(0xff14, 0x87);
+        sound.setByte(0xff16, 0x80);
+        sound.setByte(0xff17, 0xa3);
+        sound.setByte(0xff18, 0xff);
+        sound.setByte(0xff19, 0x84);
+        sound.setByte(0xff1a, 0x80);
+        sound.setByte(0xff1b, 0x20);
+        sound.setByte(0xff1c, 0x60);
+        sound.setByte(0xff1d, 0xff);
+        sound.setByte(0xff1e, 0x83);
+        sound.setByte(0xff20, 0x3f);
+        sound.setByte(0xff21, 0xf3);
+        sound.setByte(0xff22, 0x30);
+        sound.setByte(0xff23, 0x80);
+        return sound;
+    }
+
+    private static Timer timerOf(Sound sound) {
+        try {
+            var field = Sound.class.getDeclaredField("timer");
+            field.setAccessible(true);
+            return (Timer) field.get(sound);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Object field(Object receiver, String name) throws Exception {
+        var field = receiver instanceof Sound
+                ? Sound.class.getDeclaredField(name)
+                : receiver.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(receiver);
+    }
+
+    private static void setIntField(Object receiver, String name, int value) throws Exception {
+        var field = receiver.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.setInt(receiver, value);
+    }
+
+    private static void setBooleanField(Object receiver, String name, boolean value)
+            throws Exception {
+        var field = receiver.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.setBoolean(receiver, value);
+    }
+
+    private static Object component(Object record, String name) throws Exception {
+        for (RecordComponent component : record.getClass().getRecordComponents()) {
+            if (component.getName().equals(name)) {
+                component.getAccessor().trySetAccessible();
+                return component.getAccessor().invoke(record);
+            }
+        }
+        throw new AssertionError("missing component " + name + " in " + record.getClass());
+    }
+
+    private static long canonicalDigest(Object state) throws Exception {
+        Digest digest = new Digest();
+        visit(state, digest, true);
+        return digest.value;
+    }
+
+    private static void visit(Object value, Digest digest, boolean root)
+            throws IllegalAccessException, InvocationTargetException {
+        if (value == null) {
+            digest.mix(0);
+            return;
+        }
+        Class<?> type = value.getClass();
+        if (type.isArray()) {
+            digest.mix(type.getName().hashCode());
+            int length = Array.getLength(value);
+            digest.mix(length);
+            for (int i = 0; i < length; i++) {
+                Object element = Array.get(value, i);
+                if (type.getComponentType().isPrimitive()) {
+                    digest.mix(element.hashCode());
+                } else {
+                    visit(element, digest, false);
+                }
+            }
+            return;
+        }
+        if (value instanceof Number || value instanceof Boolean || value instanceof Character
+                || value instanceof String || value instanceof Enum<?>) {
+            digest.mix(type.getName().hashCode());
+            digest.mix(value.hashCode());
+            return;
+        }
+        if (!type.isRecord()) {
+            throw new AssertionError("unexpected state type " + type.getName());
+        }
+        digest.mix(type.getName().hashCode());
+        for (RecordComponent component : type.getRecordComponents()) {
+            if (root && type.getSimpleName().equals("SoundState")
+                    && component.getName().equals("buffer")) {
+                continue;
+            }
+            digest.mix(component.getName().hashCode());
+            component.getAccessor().trySetAccessible();
+            visit(component.getAccessor().invoke(value), digest, false);
+        }
+    }
+
+    private static final class Digest {
+        private long value = 0xcbf29ce484222325L;
+
+        private void mix(long next) {
+            value ^= next + 0x9e3779b97f4a7c15L + (value << 6) + (value >>> 2);
+        }
+    }
+
+    private static void assertAllZero(int[] buffer) {
+        assertTrue("silent PCM event must contain only zeros", Arrays.stream(buffer)
+                .allMatch(value -> value == 0));
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/PolynomialCounterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/PolynomialCounterTest.java
@@ -1,0 +1,196 @@
+package eu.rekawek.coffeegb.core.sound;
+
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+
+/** Differential coverage for the closed-form polynomial-counter quiet-span advance. */
+public final class PolynomialCounterTest {
+
+    private static final int[] EDGE_COUNTERS = {0, 1, 0x1fff, 0x2000, 0x3ffe, 0x3fff};
+
+    private static final Field NR43 = field("nr43");
+    private static final Field COUNTER = field("counter");
+    private static final Field COUNTDOWN = field("counterCountdown");
+    private static final Field CLOCK_2_MHZ = field("clock2Mhz");
+    private static final Field ALIGNMENT = field("alignment");
+    private static final Field BACKGROUND_ACTIVE = field("backgroundActive");
+    private static final Field COUNTDOWN_RELOADED = field("countdownReloaded");
+
+    @Test
+    public void allNr43FieldsAndCountdownBoundariesMatchScalarForLongSpan() throws Exception {
+        for (boolean clock2Mhz : new boolean[]{false, true}) {
+            for (int alignment = 0; alignment < 4; alignment++) {
+                for (int nr43 = 0; nr43 <= 0xff; nr43++) {
+                    int reload = reload(nr43);
+                    int[] countdowns = {1, reload - 1, reload, reload + 1,
+                            reload * 2, reload * 2 + 1};
+                    for (int counter : EDGE_COUNTERS) {
+                        for (int countdown : countdowns) {
+                            for (boolean countdownReloaded : new boolean[]{false, true}) {
+                                assertMatchesScalar("phase=" + clock2Mhz
+                                                + ", alignment=" + alignment
+                                                + ", nr43=" + Integer.toHexString(nr43)
+                                                + ", counter=" + counter
+                                                + ", countdown=" + countdown
+                                                + ", reloaded=" + countdownReloaded,
+                                        state(nr43, counter, countdown, clock2Mhz, alignment,
+                                                true, countdownReloaded),
+                                        54);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void everyTickLengthZeroThrough54MatchesScalarAcrossBothClockPhases() throws Exception {
+        for (boolean clock2Mhz : new boolean[]{false, true}) {
+            for (int alignment = 0; alignment < 4; alignment++) {
+                for (int nr43 = 0; nr43 <= 0xff; nr43++) {
+                    int reload = reload(nr43);
+                    int[] countdowns = {1, reload, reload + 1};
+                    for (int counter : new int[]{0, 0x3fff}) {
+                        for (int countdown : countdowns) {
+                            PolynomialCounter scalar = state(nr43, counter, countdown,
+                                    clock2Mhz, alignment, true, false);
+                            ComponentState<PolynomialCounter> initial = scalar.captureState();
+                            PolynomialCounter bulk = new PolynomialCounter();
+                            for (int ticks = 0; ticks <= 54; ticks++) {
+                                scalar.restoreState(initial);
+                                bulk.restoreState(initial);
+                                int expected = advanceScalar(scalar, ticks);
+                                int actual = bulk.advancePerformanceSpan(ticks);
+                                assertEquals("phase=" + clock2Mhz + ", alignment=" + alignment
+                                                + ", nr43=" + Integer.toHexString(nr43)
+                                                + ", counter=" + counter + ", countdown="
+                                                + countdown + ", ticks=" + ticks,
+                                        expected, actual);
+                                assertEquals("state phase=" + clock2Mhz + ", alignment="
+                                                + alignment + ", nr43=" + Integer.toHexString(nr43)
+                                                + ", counter=" + counter + ", countdown="
+                                                + countdown + ", ticks=" + ticks,
+                                        scalar.captureState(), bulk.captureState());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void inactiveAndZeroEdgeSpansRetainScalarState() throws Exception {
+        for (boolean clock2Mhz : new boolean[]{false, true}) {
+            for (int alignment = 0; alignment < 4; alignment++) {
+                PolynomialCounter scalar = state(0x8f, 0x3fff, 0, clock2Mhz, alignment,
+                        false, true);
+                ComponentState<PolynomialCounter> initial = scalar.captureState();
+                PolynomialCounter bulk = new PolynomialCounter();
+                for (int ticks = 0; ticks <= 54; ticks++) {
+                    scalar.restoreState(initial);
+                    bulk.restoreState(initial);
+                    int expected = advanceScalar(scalar, ticks);
+                    int actual = bulk.advancePerformanceSpan(ticks);
+                    assertEquals("inactive phase=" + clock2Mhz + ", alignment=" + alignment
+                                    + ", ticks=" + ticks, expected, actual);
+                    assertEquals("inactive state phase=" + clock2Mhz + ", alignment="
+                                    + alignment + ", ticks=" + ticks,
+                            scalar.captureState(), bulk.captureState());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void nr43WriteAtReloadAndRestoreContinueExactlyAsScalar() throws Exception {
+        for (int alignment = 0; alignment < 4; alignment++) {
+            for (int oldNr43 = 0; oldNr43 <= 0xff; oldNr43 += 17) {
+                PolynomialCounter scalar = state(oldNr43, 0x3ffe, reload(oldNr43), false,
+                        alignment, true, true);
+                PolynomialCounter bulk = state(oldNr43, 0x3ffe, reload(oldNr43), false,
+                        alignment, true, true);
+
+                int newNr43 = (oldNr43 * 29 + 0x53) & 0xff;
+                scalar.setNr43(newNr43);
+                bulk.setNr43(newNr43);
+                ComponentState<PolynomialCounter> checkpoint = scalar.captureState();
+                assertEquals("NR43 write alignment=" + alignment + ", old="
+                                + Integer.toHexString(oldNr43),
+                        scalar.captureState(), bulk.captureState());
+
+                for (int ticks = 0; ticks <= 54; ticks++) {
+                    scalar.restoreState(checkpoint);
+                    bulk.restoreState(checkpoint);
+                    int expected = advanceScalar(scalar, ticks);
+                    int actual = bulk.advancePerformanceSpan(ticks);
+                    assertEquals("NR43 write alignment=" + alignment + ", old="
+                                    + Integer.toHexString(oldNr43) + ", new="
+                                    + Integer.toHexString(newNr43) + ", ticks=" + ticks,
+                            expected, actual);
+                    assertEquals("NR43 state alignment=" + alignment + ", old="
+                                    + Integer.toHexString(oldNr43) + ", new="
+                                    + Integer.toHexString(newNr43) + ", ticks=" + ticks,
+                            scalar.captureState(), bulk.captureState());
+                }
+            }
+        }
+    }
+
+    private static PolynomialCounter state(int nr43, int counter, int countdown,
+                                           boolean clock2Mhz, int alignment,
+                                           boolean backgroundActive,
+                                           boolean countdownReloaded) throws Exception {
+        PolynomialCounter result = new PolynomialCounter();
+        result.start();
+        NR43.setInt(result, nr43);
+        COUNTER.setInt(result, counter);
+        COUNTDOWN.setInt(result, countdown);
+        CLOCK_2_MHZ.setBoolean(result, clock2Mhz);
+        ALIGNMENT.setInt(result, alignment);
+        BACKGROUND_ACTIVE.setBoolean(result, backgroundActive);
+        COUNTDOWN_RELOADED.setBoolean(result, countdownReloaded);
+        return result;
+    }
+
+    private static int advanceScalar(PolynomialCounter counter, int ticks) {
+        int steps = 0;
+        for (int tick = 0; tick < ticks; tick++) {
+            if (counter.tick()) {
+                steps++;
+            }
+        }
+        return steps;
+    }
+
+    private static void assertMatchesScalar(String label, PolynomialCounter scalar,
+                                             int ticks) {
+        ComponentState<PolynomialCounter> initial = scalar.captureState();
+        PolynomialCounter bulk = new PolynomialCounter();
+        bulk.restoreState(initial);
+        int expected = advanceScalar(scalar, ticks);
+        int actual = bulk.advancePerformanceSpan(ticks);
+        assertEquals(label + " steps", expected, actual);
+        assertEquals(label + " state", scalar.captureState(), bulk.captureState());
+    }
+
+    private static int reload(int nr43) {
+        int reload = (nr43 & 0b111) << 2;
+        return reload == 0 ? 2 : reload;
+    }
+
+    private static Field field(String name) {
+        try {
+            Field field = PolynomialCounter.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
@@ -1,0 +1,168 @@
+package eu.rekawek.coffeegb.core.cpu;
+
+import eu.rekawek.coffeegb.core.TestDebugHooks;
+import eu.rekawek.coffeegb.core.timer.Timer;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Focused contract tests for the native-CGB double-speed timer epoch. */
+public final class TimerPerformanceEpochTest {
+
+    @Test
+    public void randomizedEligibleEpochsMatchScalarDoubleSpeedTicks() {
+        Random random = new Random(0x8e701L);
+        int matched = 0;
+        for (int i = 0; i < 8_000; i++) {
+            InterruptManager scalarInterrupts = new InterruptManager(true);
+            InterruptManager bulkInterrupts = new InterruptManager(true);
+            SpeedMode scalarSpeed = doubleSpeed();
+            SpeedMode bulkSpeed = doubleSpeed();
+            Timer scalar = new Timer(scalarInterrupts, scalarSpeed);
+            Timer bulk = new Timer(bulkInterrupts, bulkSpeed);
+            int div = random.nextInt(0x10000);
+            int tma = random.nextInt(0x100);
+            int tima = random.nextInt(0x100);
+            int tac = random.nextInt(8);
+            scalar.presetDiv(div);
+            bulk.presetDiv(div);
+            scalar.setByte(0xff06, tma);
+            bulk.setByte(0xff06, tma);
+            scalar.setByte(0xff05, tima);
+            bulk.setByte(0xff05, tima);
+            scalar.setByte(0xff07, tac);
+            bulk.setByte(0xff07, tac);
+
+            assertEquals(0, bulk.performancePhysicalDmgEpochSpanLimit(54));
+            int limit = bulk.performanceEpochSpanLimit(54);
+            if (limit == 0) {
+                continue;
+            }
+            int span = 1 + random.nextInt(limit);
+            for (int tick = 0; tick < span; tick++) {
+                scalar.tick();
+            }
+            assertTrue("eligible epoch was rejected", bulk.tickPerformanceEpoch(span));
+            assertEquals(scalar.captureState(), bulk.captureState());
+            assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+            matched++;
+        }
+        assertTrue("randomized setup produced no eligible epochs", matched > 2_000);
+    }
+
+    @Test
+    public void randomizedPhysicalDmgEpochsMatchScalarNormalSpeedTicks() {
+        Random random = new Random(0xd06e701L);
+        int matched = 0;
+        for (int i = 0; i < 4_000; i++) {
+            InterruptManager scalarInterrupts = new InterruptManager(false);
+            InterruptManager bulkInterrupts = new InterruptManager(false);
+            Timer scalar = new Timer(scalarInterrupts, new SpeedMode(false));
+            Timer bulk = new Timer(bulkInterrupts, new SpeedMode(false));
+            int div = random.nextInt(0x10000);
+            int tma = random.nextInt(0x100);
+            int tima = random.nextInt(0x100);
+            int tac = random.nextInt(8);
+            scalar.presetDiv(div);
+            bulk.presetDiv(div);
+            scalar.setByte(0xff06, tma);
+            bulk.setByte(0xff06, tma);
+            scalar.setByte(0xff05, tima);
+            bulk.setByte(0xff05, tima);
+            scalar.setByte(0xff07, tac);
+            bulk.setByte(0xff07, tac);
+
+            assertEquals(0, bulk.performanceEpochSpanLimit(54));
+            int limit = bulk.performancePhysicalDmgEpochSpanLimit(54);
+            if (limit == 0) {
+                continue;
+            }
+            int span = 1 + random.nextInt(limit);
+            for (int tick = 0; tick < span; tick++) {
+                scalar.tick();
+            }
+            assertTrue("eligible physical-DMG epoch was rejected",
+                    bulk.tickPerformancePhysicalDmgEpoch(span));
+            assertEquals(scalar.captureState(), bulk.captureState());
+            assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+            matched++;
+        }
+        assertTrue("randomized DMG setup produced no eligible epochs", matched > 1_000);
+    }
+
+    @Test
+    public void nonOverflowTimerEdgesAreCountedInsideEpoch() {
+        Timer scalar = new Timer(new InterruptManager(true), doubleSpeed());
+        Timer bulk = new Timer(new InterruptManager(true), doubleSpeed());
+        scalar.presetDiv(0);
+        bulk.presetDiv(0);
+        scalar.setByte(0xff05, 1);
+        bulk.setByte(0xff05, 1);
+        scalar.setByte(0xff07, 0x05); // enable, 16 CPU-clock period
+        bulk.setByte(0xff07, 0x05);
+
+        assertTrue(bulk.performanceEpochSpanLimit(54) >= 8);
+        for (int i = 0; i < 8; i++) {
+            scalar.tick();
+        }
+        assertTrue(bulk.tickPerformanceEpoch(8));
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(2, bulk.getDebugTima());
+    }
+
+    @Test
+    public void physicalDmgCountsMultipleNonOverflowTimerEdgesInsideEpoch() {
+        Timer scalar = new Timer(new InterruptManager(false), new SpeedMode(false));
+        Timer bulk = new Timer(new InterruptManager(false), new SpeedMode(false));
+        scalar.presetDiv(0);
+        bulk.presetDiv(0);
+        scalar.setByte(0xff05, 1);
+        bulk.setByte(0xff05, 1);
+        scalar.setByte(0xff07, 0x05); // enable, 16 CPU-clock period
+        bulk.setByte(0xff07, 0x05);
+
+        assertTrue(bulk.performancePhysicalDmgEpochSpanLimit(54) >= 32);
+        for (int i = 0; i < 32; i++) {
+            scalar.tick();
+        }
+        assertTrue(bulk.tickPerformancePhysicalDmgEpoch(32));
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(3, bulk.getDebugTima());
+    }
+
+    @Test
+    public void rejectsWrongSpeedTransientStateAndOverflow() {
+        Timer normal = new Timer(new InterruptManager(true), new SpeedMode(true));
+        assertEquals(0, normal.performanceEpochSpanLimit(54));
+        assertEquals(0, normal.performancePhysicalDmgEpochSpanLimit(54));
+
+        Timer debug = new Timer(new InterruptManager(true), doubleSpeed());
+        debug.setDebugHooks(new TestDebugHooks());
+        assertEquals(0, debug.performanceEpochSpanLimit(54));
+
+        Timer reset = new Timer(new InterruptManager(true), doubleSpeed());
+        reset.setByte(0xff04, 0);
+        assertEquals(0, reset.performanceEpochSpanLimit(54));
+
+        Timer overflow = new Timer(new InterruptManager(true), doubleSpeed());
+        overflow.presetDiv(0x000f);
+        overflow.setByte(0xff05, 0xff);
+        overflow.setByte(0xff07, 0x05);
+        overflow.tick();
+        assertTrue(overflow.isDebugOverflowPending());
+        assertEquals(0, overflow.performanceEpochSpanLimit(54));
+        assertFalse(overflow.tickPerformanceEpoch(1));
+    }
+
+
+    private static SpeedMode doubleSpeed() {
+        SpeedMode speed = new SpeedMode(true);
+        speed.setByte(0xff4d, 1);
+        assertTrue(speed.onStop());
+        return speed;
+    }
+}


### PR DESCRIPTION
## Summary
- Optimize native CGB PERFORMANCE execution, timing, and renderer paths while retaining canonical fallbacks.
- Add an exact, diagnostics-only system-muted PCM calendar with lifecycle-safe Android benchmark handling.
- Add measured warmup, stop-aware frame boundaries, and stricter benchmark validation.

## Validation
- `/opt/maven/bin/mvn -pl core test`
- `/opt/maven/bin/mvn -pl controller -am test`
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2`
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg`
- `:app:testBenchmarkUnitTest` and `:app:testDebugUnitTest`
- `android/benchmark-device-matrix-test.sh`

The Android system-muted path is diagnostics-only; it does not modify device volume or mute settings.