### PR TITLE
Fix Android ROM switching and picker filter

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -124,6 +124,25 @@ public class AndroidRuntimeEndToEndSmokeTest {
         }
     }
 
+    @Test
+    public void openingASelectedRomReplacesAPausedGameAndStartsImmediately() throws Exception {
+        try (AndroidEmulationRuntime runtime = new AndroidEmulationRuntime(
+                InstrumentationRegistry.getInstrumentation().getTargetContext())) {
+            await("runtime initialization", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
+
+            runtime.openRom(FixtureRomProvider.URI, 0);
+            awaitFixtureStart(runtime, new AtomicReference<>());
+
+            runtime.pause();
+            await("first game pause", () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
+
+            // This mirrors opening a document from the pause menu: the outgoing game is paused,
+            // but that presentation pause must not prevent the replacement from playing.
+            runtime.openRom(FixtureRomProvider.URI, 0);
+            awaitFixtureStart(runtime, new AtomicReference<>());
+        }
+    }
+
     private static void assertFixtureReadable() throws Exception {
         try (InputStream input = InstrumentationRegistry.getInstrumentation().getTargetContext()
                 .getContentResolver().openInputStream(FixtureRomProvider.URI)) {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.android;
 
 import android.app.Instrumentation;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +39,21 @@ import static org.junit.Assert.assertTrue;
 /** Exercises the bound runtime through Activity recreation and a visibility transition. */
 @RunWith(AndroidJUnit4.class)
 public class MainActivitySmokeTest {
+
+    @Test
+    public void romPickerRequestsOnlySupportedRomAndArchiveTypes() throws Exception {
+        java.lang.reflect.Method openRomIntent = MainActivity.class.getDeclaredMethod("openRomIntent");
+        openRomIntent.setAccessible(true);
+        Intent intent = (Intent) openRomIntent.invoke(null);
+
+        assertEquals(Intent.ACTION_OPEN_DOCUMENT, intent.getAction());
+        assertEquals("*/*", intent.getType());
+        assertArrayEquals(new String[]{
+                        "application/x-gameboy-rom", "application/x-gameboy-color-rom",
+                        "application/x-rom", "application/zip", "application/x-zip-compressed",
+                        "application/x-7z-compressed"},
+                intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES));
+    }
 
     @Test
     public void launchesRecreatesAndBackgroundsWithoutStartingACameraOrGame() {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -41,18 +40,14 @@ import static org.junit.Assert.assertTrue;
 public class MainActivitySmokeTest {
 
     @Test
-    public void romPickerRequestsOnlySupportedRomAndArchiveTypes() throws Exception {
+    public void romPickerLeavesUnknownRomMimeTypesSelectable() throws Exception {
         java.lang.reflect.Method openRomIntent = MainActivity.class.getDeclaredMethod("openRomIntent");
         openRomIntent.setAccessible(true);
         Intent intent = (Intent) openRomIntent.invoke(null);
 
         assertEquals(Intent.ACTION_OPEN_DOCUMENT, intent.getAction());
         assertEquals("*/*", intent.getType());
-        assertArrayEquals(new String[]{
-                        "application/x-gameboy-rom", "application/x-gameboy-color-rom",
-                        "application/x-rom", "application/zip", "application/x-zip-compressed",
-                        "application/x-7z-compressed"},
-                intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES));
+        assertNull(intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES));
     }
 
     @Test

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -1888,8 +1888,12 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     || rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.POCKET_CAMERA);
             publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
                     false, true, false);
+            // Opening from the in-screen menu pauses only to keep gameplay from leaking into the
+            // document picker. Do not transfer that UI pause to the selected game. Android also
+            // has no autosave-resume decision surface, so a persisted ASK-policy autosave must
+            // never leave this request permanently paused behind an invisible prompt.
             controllerEventBus().post(new Controller.LoadRomEvent(
-                    image, null, persistenceStore, activeOpenRequestId, !diagnostics.enabled()));
+                    image, null, persistenceStore, activeOpenRequestId, false, false));
         } catch (Exception failure) {
             if (recent == null) {
                 if (!diagnostics.enabled()) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1715,14 +1715,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static Intent openRomIntent() {
         return new Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
-                // EXTRA_MIME_TYPES requires a wildcard primary type. In particular, do not add
-                // application/octet-stream here: it causes DocumentsUI to show every unknown
-                // binary file instead of just supported ROM and archive files.
+                // Redmi's ExternalStorageProvider labels valid GB, GBC, and ROM files as generic
+                // binary data. A MIME filter therefore greys them out before Coffee GB receives
+                // the URI. RomSourceSnapshot validates the selected filename and archive entries,
+                // so leave navigation unrestricted and reject unsupported selections ourselves.
                 .setType("*/*")
-                .putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
-                        "application/x-gameboy-rom", "application/x-gameboy-color-rom",
-                        "application/x-rom", "application/zip", "application/x-zip-compressed",
-                        "application/x-7z-compressed"})
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1715,10 +1715,14 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static Intent openRomIntent() {
         return new Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
-                .setType("application/octet-stream")
+                // EXTRA_MIME_TYPES requires a wildcard primary type. In particular, do not add
+                // application/octet-stream here: it causes DocumentsUI to show every unknown
+                // binary file instead of just supported ROM and archive files.
+                .setType("*/*")
                 .putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
-                        "application/octet-stream", "application/x-gameboy-rom",
-                        "application/zip", "application/x-zip-compressed"})
+                        "application/x-gameboy-rom", "application/x-gameboy-color-rom",
+                        "application/x-rom", "application/zip", "application/x-zip-compressed",
+                        "application/x-7z-compressed"})
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
     }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -2331,7 +2331,7 @@ class BasicController private constructor(
     cancelLoadJob()
     discardReplacement(restorePause = true)
     discardStop(restorePause = true)
-    acquireLoadingPause()
+    acquireLoadingPause(event.preservePauseOnReplacement)
 
     val requestId = nextPersistenceRequestId++
     if (context == null) {
@@ -3023,8 +3023,12 @@ class BasicController private constructor(
     session?.gameboy?.setCartridgeClockPaused(isEffectivelyPaused())
   }
 
-  private fun acquireLoadingPause() {
-    if (pauseStateBeforeLoading == null) {
+  private fun acquireLoadingPause(preservePreviousPause: Boolean = true) {
+    if (!preservePreviousPause) {
+      // A host may pause only to show a transient ROM picker. Its selected replacement must not
+      // inherit that presentation pause, and we must keep the old session frozen until commit.
+      pauseStateBeforeLoading = false
+    } else if (pauseStateBeforeLoading == null) {
       // A resume scan owns a forced pause, so isPaused itself is not the user's desired state.
       pauseStateBeforeLoading = pauseStateBeforeResume ?: isPaused
     }
@@ -3120,7 +3124,7 @@ class BasicController private constructor(
 
     cancelPendingRomSwitch()
     discardStop(restorePause = true)
-    acquireLoadingPause()
+    acquireLoadingPause(event.preservePauseOnReplacement)
     cancelLoadJob()
     discardReplacement(restorePause = false)
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -73,6 +73,12 @@ interface Controller : AutoCloseable {
        * progress.
        */
       val allowAutosaveResume: Boolean = true,
+      /**
+       * Whether an already-paused session transfers that pause to its replacement. Hosts that
+       * pause only to present a ROM picker can set this false so the selected game starts
+       * immediately without briefly resuming the old game.
+       */
+      val preservePauseOnReplacement: Boolean = true,
   ) : Event {
     constructor(
         image: RomImage,
@@ -80,6 +86,7 @@ interface Controller : AutoCloseable {
         persistenceStore: RomPersistenceStore? = null,
         openRequestId: Long? = null,
         allowAutosaveResume: Boolean = true,
+        preservePauseOnReplacement: Boolean = true,
     ) : this(
         image.origin().containerPath().map { it.toFile() }.orElse(File(image.origin().displayName())),
         state,
@@ -87,6 +94,7 @@ interface Controller : AutoCloseable {
         persistenceStore,
         openRequestId,
         allowAutosaveResume,
+        preservePauseOnReplacement,
     )
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1594,6 +1594,56 @@ class BasicControllerTest {
   }
 
   @Test
+  fun replacementCanDiscardAHostOnlyPickerPause() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val playback = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
+    val frames = LinkedBlockingQueue<GbcFrameReadyEvent>()
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.SessionPlaybackStateEvent>(playback::add)
+    eventBus.register<GbcFrameReadyEvent>(frames::add)
+    val nextRom = namedRom("PICKER_NEXT")
+    val controller = BasicController(eventBus, EmulatorProperties(), null)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(ROM, allowAutosaveResume = false))
+      assertEquals("CPU_INSTRS", started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName)
+      playback.clear()
+
+      eventBus.post(Controller.PauseEmulationEvent())
+      assertTrue(
+          assertNotNull(
+                  generateSequence { playback.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+                      .firstOrNull { it.paused })
+              .paused,
+          "the outgoing session must be paused before opening the picker",
+      )
+      frames.clear()
+
+      eventBus.post(
+          LoadRomEvent(
+              nextRom,
+              allowAutosaveResume = false,
+              preservePauseOnReplacement = false,
+          ))
+
+      assertEquals(
+          "PICKER_NEXT",
+          started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)?.romName,
+      )
+      assertNotNull(
+          frames.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "a picker pause must not leave the replacement session stopped",
+      )
+    } finally {
+      controller.close()
+      eventBus.close()
+      nextRom.delete()
+    }
+  }
+
+  @Test
   fun rapidLoadBurstStartsOnlyTheLatestRom() {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()


### PR DESCRIPTION
## Summary
- start a newly selected Android ROM instead of inheriting the document-picker pause
- avoid the unsupported Android autosave-resume prompt path
- narrow the document picker to Game Boy ROM, ZIP, and 7z MIME types

## Verification
- /opt/maven/bin/mvn -q -pl controller -am -Dtest=BasicControllerTest#replacementCanDiscardAHostOnlyPickerPause -Dsurefire.failIfNoSpecifiedTests=false test
- env ANDROID_HOME=/opt/android-sdk ./android/gradlew -p android --no-daemon -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:compileDebugJavaWithJavac :app:compileDebugAndroidTestJavaWithJavac