### PR TITLE
Optimize CGB compatibility and SGB performance

### DIFF
--- a/android/README-benchmark.md
+++ b/android/README-benchmark.md
@@ -37,6 +37,12 @@ adjacent parent/candidate runs in 12 randomized seven-row blocks:
 for each mode; the app emits the selected strategy as `execution_mode` in both `matrix_run` and
 `final_result` records. The setting is session-scoped and never enters save-state data.
 
+For muted PERFORMANCE runs, pass `--audio-policy silent-pcm-v1`. This exact silent calendar
+covers the complete seven-row matrix, including SGB and SGB2, while retaining its canonical APU
+semantics. The explicitly relaxed `silent-pcm-relaxed-apu-v1` remains bounded to the five DMG/CGB
+rows until its SGB clock has equivalent evidence. The host only reads the system music-volume/
+mute state and fails closed if it is not already muted; it never changes system audio settings.
+
 The two recent slots are selected by the user for the appropriate color/non-color workload. The
 app assigns and durably persists random opaque workload nonces after selection; the host nonce
 argument is deliberately not part of the workflow. Native CGB and CGB0 are separate rows, and

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -11,9 +11,10 @@
 -keepattributes MethodParameters,Signature
 -keep class * implements eu.rekawek.coffeegb.core.state.ComponentState { <fields>; <init>(...); }
 
-# Keep the DMG settled-HALT side entrance visible to R8's call graph without pinning its class
-# or method name; the ordinary PERFORMANCE scheduler remains free to optimize normally.
+# Keep the normal-speed monochrome/compatibility settled-HALT lane bodies visible to R8's call
+# graph without pinning their class or method names. The tiny selector remains free to inline.
 -keepclassmembers,allowobfuscation class eu.rekawek.coffeegb.core.Gameboy {
+    private int tryPerformanceSettledCgbCompatHaltSpan(long);
     private int tryPerformanceSettledDmgHaltSpan(long);
     private int tryPerformanceSettledNativeCgbHaltSpan(long);
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
@@ -328,16 +328,22 @@ final class DiagnosticsOptions {
                 ? benchmarkScenario : BenchmarkScenario.NONE;
         AudioPolicy requestedPolicy = audioPolicy == null ? AudioPolicy.CANONICAL : audioPolicy;
         // The silent calendar is intentionally unavailable outside the measured PERFORMANCE
-        // topology, when host audio is disabled, or when the explicit profile could resolve to
-        // an SGB clock. The official silent runner is deliberately bounded to DMG/CGB rows;
-        // unknown/AUTO and SGB profiles fail closed to canonical evidence.
+        // topology, when host audio is disabled, or when the hardware profile is unresolved.
+        // Exact silent PCM has an SGB/SGB2 calendar proof; the relaxed APU policy remains bounded
+        // to the five DMG/CGB rows until it has equivalent SGB evidence. AUTO still fails closed
+        // because its clock cannot be proven from the launch request.
         this.audioPolicy = enabled && this.executionMode == ExecutionMode.PERFORMANCE
                 && audioOutput && requestedPolicy.isSilent()
-                && supportsSilentPcmProfile(hardware)
+                && supportsSilentPcmProfile(hardware, requestedPolicy)
                 ? requestedPolicy : AudioPolicy.CANONICAL;
     }
 
-    private static boolean supportsSilentPcmProfile(Hardware hardware) {
+    private static boolean supportsSilentPcmProfile(Hardware hardware, AudioPolicy policy) {
+        if (policy == AudioPolicy.SILENT_PCM_V1) {
+            return hardware == Hardware.DMG || hardware == Hardware.MGB
+                    || hardware == Hardware.CGB || hardware == Hardware.CGB0
+                    || hardware == Hardware.SGB || hardware == Hardware.SGB2;
+        }
         return hardware == Hardware.DMG || hardware == Hardware.MGB
                 || hardware == Hardware.CGB || hardware == Hardware.CGB0;
     }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrix.java
@@ -228,8 +228,12 @@ public final class BenchmarkMatrix {
     private static final List<Row> REQUIRED_ROWS = List.of(
             Row.DMG, Row.MGB, Row.CGB_NATIVE, Row.CGB0_NATIVE,
             Row.CGB_DMG_COMPAT, Row.SGB, Row.SGB2);
-    /** Silent PCM calendars have only the five DMG/CGB performance rows. */
+    /** Exact silent PCM uses the complete seven-row matrix, including SGB and SGB2. */
     private static final List<Row> SILENT_REQUIRED_ROWS = List.of(
+            Row.DMG, Row.MGB, Row.CGB_NATIVE, Row.CGB0_NATIVE, Row.CGB_DMG_COMPAT,
+            Row.SGB, Row.SGB2);
+    /** The intentionally approximate APU calendar remains bounded to the original five rows. */
+    private static final List<Row> RELAXED_SILENT_REQUIRED_ROWS = List.of(
             Row.DMG, Row.MGB, Row.CGB_NATIVE, Row.CGB0_NATIVE, Row.CGB_DMG_COMPAT);
 
     private BenchmarkMatrix() {
@@ -1261,8 +1265,7 @@ public final class BenchmarkMatrix {
             errors.add("line " + lineNumber + ": missing render");
             render = "unknown";
         }
-        int requiredRowCount = "canonical".equals(benchmarkAudioPolicy)
-                ? REQUIRED_ROWS.size() : SILENT_REQUIRED_ROWS.size();
+        int requiredRowCount = requiredRowsForAudioPolicy(benchmarkAudioPolicy).size();
         if (rowOrder < 0 || rowOrder >= requiredRowCount) {
             errors.add("line " + lineNumber + ": row_order is outside selected matrix");
         }
@@ -1281,7 +1284,7 @@ public final class BenchmarkMatrix {
         if (!warmup || !INPUT_CONTRACTS.contains(inputContract)) {
             errors.add("line " + lineNumber + ": run lacks a supported warmup/input contract");
         }
-        if (!validScenarioCompletion(row, inputContract, sessionGeneration,
+        if (!validScenarioCompletion(row, benchmarkAudioPolicy, inputContract, sessionGeneration,
                 scenarioSessionGeneration,
                 scenarioCompleted,
                 scenarioCompletedFrames, scenarioExpectedFrames, scenarioSourceClosed,
@@ -1557,8 +1560,7 @@ public final class BenchmarkMatrix {
         }
         String selectedAudioPolicy = benchmarkAudioPolicies.isEmpty()
                 ? "canonical" : benchmarkAudioPolicies.iterator().next();
-        List<Row> requiredRows = "canonical".equals(selectedAudioPolicy)
-                ? REQUIRED_ROWS : SILENT_REQUIRED_ROWS;
+        List<Row> requiredRows = requiredRowsForAudioPolicy(selectedAudioPolicy);
         LinkedHashMap<Row, List<RunBuilder>> byRow = new LinkedHashMap<>();
         for (Row row : requiredRows) {
             byRow.put(row, new ArrayList<>());
@@ -2206,7 +2208,8 @@ public final class BenchmarkMatrix {
             errors.add(run.key + " final evidence does not match matrix_run");
         }
         validateSystemAudioProof(run, result, errors);
-        if (!validScenarioCompletion(run.row, result.inputContract, result.sessionGeneration,
+        if (!validScenarioCompletion(run.row, run.benchmarkAudioPolicy,
+                result.inputContract, result.sessionGeneration,
                 result.scenarioSessionGeneration, result.scenarioCompleted,
                 result.scenarioCompletedFrames, result.scenarioExpectedFrames,
                 result.scenarioSourceClosed, result.scenarioAudioDrained)) {
@@ -3147,11 +3150,29 @@ public final class BenchmarkMatrix {
         };
     }
 
-    private static boolean validScenarioCompletion(Row row, String inputContract,
+    private static List<Row> requiredRowsForAudioPolicy(String policy) {
+        return switch (policy) {
+            case "canonical" -> REQUIRED_ROWS;
+            case "silent-pcm-v1" -> SILENT_REQUIRED_ROWS;
+            case "silent-pcm-relaxed-apu-v1" -> RELAXED_SILENT_REQUIRED_ROWS;
+            default -> REQUIRED_ROWS;
+        };
+    }
+
+    private static String expectedInputContract(Row row, String audioPolicy) {
+        if ("silent-pcm-v1".equals(audioPolicy)
+                && (row == Row.SGB || row == Row.SGB2)) {
+            return "dmg-action-v1";
+        }
+        return expectedInputContract(row);
+    }
+
+    private static boolean validScenarioCompletion(Row row, String audioPolicy,
+            String inputContract,
             long sessionGeneration, long scenarioSessionGeneration, Boolean completed,
             int completedFrames, int expectedFrames, Boolean sourceClosed, Boolean audioDrained) {
         int contractFrames = expectedScenarioFrames(inputContract);
-        return row != null && expectedInputContract(row).equals(inputContract)
+        return row != null && expectedInputContract(row, audioPolicy).equals(inputContract)
                 && sessionGeneration > 0L
                 && (contractFrames == 0 ? scenarioSessionGeneration == 0L
                         : scenarioSessionGeneration == sessionGeneration)

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BenchmarkMatrixTest.java
@@ -297,8 +297,9 @@ public class BenchmarkMatrixTest {
 
     @Test
     public void relaxedSilentPcmPolicyRequiresDroppedTicksEqualToSkippedTicks() {
-        List<String> exact = withSilentPolicyForSilentRows(
-                omitFinalAudioStartFields(syntheticSilentSummaryLog(61.0, 62.0)));
+        List<String> exact = withSilentPolicyForRows(
+                omitFinalAudioStartFields(syntheticRelaxedSilentSummaryLog(61.0, 62.0)),
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat"));
         List<String> relaxed = exact.stream().map(line -> {
             if (silentRow(line, List.of("dmg", "mgb", "cgb-native", "cgb0-native",
                     "cgb-dmg-compat")) == null) {
@@ -321,17 +322,62 @@ public class BenchmarkMatrixTest {
 
     @Test
     public void rejectsMixedCanonicalAndSilentPolicies() {
-        List<String> mixed = withSilentPolicyForSilentRows(syntheticSummaryLog(61.0, 62.0));
+        List<String> mixed = withSilentPolicyForRows(syntheticSummaryLog(61.0, 62.0),
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat"));
         BenchmarkMatrix.Report report = parse(mixed);
         assertFalse(report.accepted());
         assertContains(report.errors(), "mixed benchmark audio policies");
     }
 
     @Test
-    public void silentPolicyRejectsSgbRows() {
-        List<String> allRows = withSilentPolicyForRows(syntheticSummaryLog(61.0, 62.0),
+    public void silentPolicyAcceptsSgbRows() {
+        List<String> allRows = withSilentPolicyForRows(
+                omitFinalAudioStartFields(syntheticSummaryLog(61.0, 62.0)),
                 List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat",
                         "sgb", "sgb2"));
+        BenchmarkMatrix.Report report = parse(allRows);
+        assertTrue(report.errors().toString(), report.accepted());
+        assertEquals(7, report.rows.size());
+    }
+
+    @Test
+    public void exactSilentPolicyRejectsCanonicalSgbScenarioContract() {
+        List<String> exact = withSilentPolicyForSilentRows(
+                omitFinalAudioStartFields(syntheticSummaryLog(61.0, 62.0)));
+        ArrayList<String> canonicalSgb = new ArrayList<>();
+        for (String original : exact) {
+            String row = silentRow(original, List.of("sgb", "sgb2"));
+            if (row == null) {
+                canonicalSgb.add(original);
+                continue;
+            }
+            if (original.startsWith("event=scenario_complete")) {
+                continue;
+            }
+            canonicalSgb.add(original
+                    .replace("input_contract=dmg-action-v1", "input_contract=none")
+                    .replaceAll(" scenario_session_generation=[^ ]*",
+                            " scenario_session_generation=0")
+                    .replaceAll(" scenario_completed_frames=[^ ]*",
+                            " scenario_completed_frames=0")
+                    .replaceAll(" scenario_expected_frames=[^ ]*",
+                            " scenario_expected_frames=0"));
+        }
+        BenchmarkMatrix.Report report = parse(canonicalSgb);
+        assertFalse(report.accepted());
+        assertContains(report.errors(), "matrix_run scenario completion does not match");
+
+        BenchmarkMatrix.Report canonicalReport = parse(syntheticSummaryLog(61.0, 62.0));
+        assertTrue(canonicalReport.errors().toString(), canonicalReport.accepted());
+    }
+
+    @Test
+    public void relaxedSilentPolicyKeepsSgbRowsOutOfItsFiveRowContract() {
+        List<String> allRows = withSilentPolicyForRows(syntheticSummaryLog(61.0, 62.0),
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat",
+                        "sgb", "sgb2")).stream()
+                .map(line -> line.replace("silent-pcm-v1", "silent-pcm-relaxed-apu-v1"))
+                .collect(java.util.stream.Collectors.toList());
         BenchmarkMatrix.Report report = parse(allRows);
         assertFalse(report.accepted());
         assertContains(report.errors(), "row_order is outside selected matrix");
@@ -1041,9 +1087,20 @@ public class BenchmarkMatrixTest {
     }
 
     private static List<String> syntheticSilentSummaryLog(double parentFps, double candidateFps) {
+        return syntheticSilentSummaryLog(parentFps, candidateFps,
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat",
+                        "sgb", "sgb2"));
+    }
+
+    private static List<String> syntheticRelaxedSilentSummaryLog(
+            double parentFps, double candidateFps) {
+        return syntheticSilentSummaryLog(parentFps, candidateFps,
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat"));
+    }
+
+    private static List<String> syntheticSilentSummaryLog(double parentFps, double candidateFps,
+            List<String> silentRows) {
         List<String> source = syntheticSummaryLog(parentFps, candidateFps);
-        List<String> silentRows = List.of("dmg", "mgb", "cgb-native", "cgb0-native",
-                "cgb-dmg-compat");
         Map<String, Map<String, Integer>> orders = new java.util.LinkedHashMap<>();
         List<String> selected = new ArrayList<>();
         for (String line : source) {
@@ -1444,7 +1501,7 @@ public class BenchmarkMatrixTest {
                 : 4_194_304.0 / 69_905.0;
         // Audio blocks follow emulated physical frames, not elapsed wall time.  Use the exact
         // 70,224-tick LCD cadence so slow Accuracy fixtures remain structurally comparable.
-        long inputEvents = "sgb".equals(row)
+        long inputEvents = ("sgb".equals(row) || "sgb2".equals(row))
                 ? BenchmarkMatrix.REQUIRED_FRAME_COUNT
                 : Math.round(BenchmarkMatrix.REQUIRED_FRAME_COUNT * 70_224.0 / 69_905.0);
         long enqueuedFrames = Math.round(48_000.0 * BenchmarkMatrix.REQUIRED_FRAME_COUNT / fps);
@@ -1475,7 +1532,8 @@ public class BenchmarkMatrixTest {
 
     private static List<String> withSilentPolicyForSilentRows(List<String> source) {
         return withSilentPolicyForRows(source,
-                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat"));
+                List.of("dmg", "mgb", "cgb-native", "cgb0-native", "cgb-dmg-compat",
+                        "sgb", "sgb2"));
     }
 
     private static List<String> withSilentPolicyForRows(List<String> source,
@@ -1483,11 +1541,34 @@ public class BenchmarkMatrixTest {
         String token = "silent-token-001";
         ArrayList<String> result = new ArrayList<>(source.size());
         for (String original : source) {
-            if (silentRow(original, selectedRows) == null) {
+            String row = silentRow(original, selectedRows);
+            if (row == null) {
                 result.add(original);
                 continue;
             }
             String line = original;
+            boolean sgbExactScenario = ("sgb".equals(row) || "sgb2".equals(row));
+            if (sgbExactScenario && line.startsWith("event=matrix_run")) {
+                result.add("event=scenario_complete artifact_id=" + field(line, "artifact_id")
+                        + " pair_id=" + field(line, "pair_id")
+                        + " matrix_block=" + field(line, "matrix_block")
+                        + " row_order=" + field(line, "row_order")
+                        + " run_side=" + field(line, "run_side")
+                        + " session_generation=" + field(line, "session_generation")
+                        + " input_contract=dmg-action-v1 completed=true completed_frames=313"
+                        + " expected_frames=313 source_closed=true audio_drained=true");
+                line = line.replace("input_contract=none", "input_contract=dmg-action-v1")
+                        .replace("scenario_session_generation=0",
+                                "scenario_session_generation=" + field(line, "session_generation"))
+                        .replace("scenario_completed_frames=0", "scenario_completed_frames=313")
+                        .replace("scenario_expected_frames=0", "scenario_expected_frames=313");
+            } else if (sgbExactScenario && line.startsWith("event=final_result")) {
+                line = line.replace("input_contract=none", "input_contract=dmg-action-v1")
+                        .replace("scenario_session_generation=0",
+                                "scenario_session_generation=" + field(line, "session_generation"))
+                        .replace("scenario_completed_frames=0", "scenario_completed_frames=313")
+                        .replace("scenario_expected_frames=0", "scenario_expected_frames=313");
+            }
             if (line.startsWith("event=matrix_run")) {
                 line += " benchmark_token=" + token + " benchmark_audio_policy=silent-pcm-v1"
                         + " audio_start_active=true audio_start_paused=false"

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
@@ -37,6 +37,22 @@ public class DiagnosticsOptionsTest {
     }
 
     @Test
+    public void releaseGateCannotEnableSgbSilentAudioPolicy() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                false, "sgb2", true, "presentation", true, true, false,
+                "build-0001", "pair-0001", "block-0001", 0,
+                "parent", "parent", "device-0001", "thermal-0001", true,
+                "workload-0001", 120, -1, "performance", "dmg-action-v1",
+                "silent-pcm-v1");
+
+        assertFalse(options.enabled);
+        assertEquals(DiagnosticsOptions.Hardware.AUTO, options.hardware);
+        assertEquals(DiagnosticsOptions.BenchmarkScenario.NONE, options.benchmarkScenario);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, options.audioPolicy);
+        assertEquals(ExecutionMode.PERFORMANCE, options.executionMode);
+    }
+
+    @Test
     public void benchmarkOptionsAreTypedAndTransient() {
         DiagnosticsOptions options = DiagnosticsOptions.parseValues(
                 true, "dmg", false, "sink", true, false, false);
@@ -136,6 +152,14 @@ public class DiagnosticsOptionsTest {
                 true, "sgb", true, "presentation", false, true, false,
                 null, null, null, -1, null, null, null, null, false, null, -1, -1,
                 "performance", null, "silent-pcm-v1");
+        DiagnosticsOptions sgb2 = DiagnosticsOptions.parseValues(
+                true, "sgb2", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-v1");
+        DiagnosticsOptions relaxedSgb = DiagnosticsOptions.parseValues(
+                true, "sgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, "silent-pcm-relaxed-apu-v1");
         DiagnosticsOptions auto = DiagnosticsOptions.parseValues(
                 true, "auto", true, "presentation", false, true, false,
                 null, null, null, -1, null, null, null, null, false, null, -1, -1,
@@ -144,7 +168,9 @@ public class DiagnosticsOptionsTest {
         assertEquals(DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1, silent.audioPolicy);
         assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, accuracy.audioPolicy);
         assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, noAudio.audioPolicy);
-        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, sgb.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1, sgb.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1, sgb2.audioPolicy);
+        assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, relaxedSgb.audioPolicy);
         assertEquals(DiagnosticsOptions.AudioPolicy.CANONICAL, auto.audioPolicy);
     }
 

--- a/android/benchmark-device-matrix-test.sh
+++ b/android/benchmark-device-matrix-test.sh
@@ -587,7 +587,7 @@ awk '
   END { if (gate_no != 168) exit 3 }
 ' "$records" || { echo 'compositor gate identity/generation linkage assertion failed' >&2; exit 1; }
 
-# The explicit silent policy is bounded to the five DMG/CGB rows; SGB/SGB2 remain canonical.
+# The explicit silent policy covers the complete seven-row matrix, including SGB/SGB2.
 : >"$records"
 : >"$fake_log"
 printf '0\n' >"$gen_file"
@@ -596,12 +596,16 @@ if ! run_case silent_ok silent-pcm-v1; then
   exit 1
 fi
 silent_launch_count=$(awk '/^launch / { count++ } END { print count + 0 }' "$records")
-[ "$silent_launch_count" -eq 120 ] || {
-  echo "expected 120 silent-policy launches, got $silent_launch_count" >&2
+[ "$silent_launch_count" -eq 168 ] || {
+  echo "expected 168 silent-policy launches, got $silent_launch_count" >&2
   exit 1
 }
-if awk '/^launch / { pair=$0; sub(/^.*pair=/, "", pair); sub(/[[:space:]].*$/, "", pair); row=pair; sub(/^p[0-9]+-/, "", row); if (row == "sgb" || row == "sgb2") bad=1 } END { exit bad ? 0 : 1 }' "$records"; then
-  echo 'silent policy scheduled an unsupported SGB row' >&2
+if ! awk '/^launch / { pair=$0; sub(/^.*pair=/, "", pair); sub(/[[:space:]].*$/, "", pair); row=pair; sub(/^p[0-9]+-/, "", row); if (row == "sgb") sgb=1; if (row == "sgb2") sgb2=1 } END { exit sgb && sgb2 ? 0 : 1 }' "$records"; then
+  echo 'silent policy did not schedule both SGB rows' >&2
+  exit 1
+fi
+if ! awk '/^launch / { pair=$0; sub(/^.*pair=/, "", pair); sub(/[[:space:]].*$/, "", pair); row=pair; sub(/^p[0-9]+-/, "", row); scenario=$0; sub(/^.*scenario=/, "", scenario); sub(/[[:space:]].*$/, "", scenario); if ((row == "sgb" || row == "sgb2") && scenario != "dmg-action-v1") bad=1 } END { exit bad ? 1 : 0 }' "$records"; then
+  echo 'exact silent SGB rows did not use the DMG gameplay precondition' >&2
   exit 1
 fi
 grep -q -- '--es coffee_gb_audio_policy silent-pcm-v1' "$calls" || {
@@ -621,6 +625,10 @@ relaxed_launch_count=$(awk '/^launch / { count++ } END { print count + 0 }' "$re
   echo "expected 120 relaxed silent-policy launches, got $relaxed_launch_count" >&2
   exit 1
 }
+if awk '/^launch / { pair=$0; sub(/^.*pair=/, "", pair); sub(/[[:space:]].*$/, "", pair); row=pair; sub(/^p[0-9]+-/, "", row); if (row == "sgb" || row == "sgb2") bad=1 } END { exit bad ? 0 : 1 }' "$records"; then
+  echo 'relaxed silent policy scheduled an unsupported SGB row' >&2
+  exit 1
+fi
 grep -q -- '--es coffee_gb_audio_policy silent-pcm-relaxed-apu-v1' "$calls" || {
   echo 'relaxed silent audio policy was not passed' >&2
   exit 1

--- a/android/benchmark-device-matrix.sh
+++ b/android/benchmark-device-matrix.sh
@@ -167,11 +167,17 @@ esac
 
 case "$audio_policy" in
   canonical) : ;;
-  silent-pcm-v1|silent-pcm-relaxed-apu-v1)
+  silent-pcm-v1)
     [ "$execution_mode" = performance ] \
       || fatal "silent-pcm-v1 requires PERFORMANCE execution mode"
-    # The silent calendar is a DMG/CGB proof only. SGB/SGB2 have a distinct source clock and
-    # are intentionally retained in the canonical seven-row matrix.
+    # The silent calendar covers the complete seven-row matrix, including the distinct SGB and
+    # SGB2 source clocks. The app and parser retain the same exact/muted proof for every row.
+    ;;
+  silent-pcm-relaxed-apu-v1)
+    [ "$execution_mode" = performance ] \
+      || fatal "silent-pcm-relaxed-apu-v1 requires PERFORMANCE execution mode"
+    # The relaxed calendar remains the five-row DMG/CGB proof until its SGB clock semantics have
+    # equivalent coverage. SGB/SGB2 are excluded from this policy's dataset.
     RUN_ROWS=5
     RUNS_PER_BLOCK=$((RUN_ROWS * 2))
     TOTAL_RUNS=$((RUN_BLOCKS * RUNS_PER_BLOCK))
@@ -970,7 +976,9 @@ row_input_contract() {
     dmg|mgb) printf '%s\n' dmg-action-v1 ;;
     cgb-native|cgb0-native) printf '%s\n' cgb-action-v1 ;;
     cgb-dmg-compat) printf '%s\n' dmg-action-v1 ;;
-    sgb|sgb2) printf '%s\n' none ;;
+    sgb|sgb2)
+      [ "$audio_policy" = silent-pcm-v1 ] && printf '%s\n' dmg-action-v1 || printf '%s\n' none
+      ;;
     *) return 1 ;;
   esac
 }
@@ -979,7 +987,9 @@ row_scenario_frames() {
   case "$1" in
     dmg|mgb|cgb-dmg-compat) printf '%s\n' 313 ;;
     cgb-native|cgb0-native) printf '%s\n' 923 ;;
-    sgb|sgb2) printf '%s\n' 0 ;;
+    sgb|sgb2)
+      [ "$audio_policy" = silent-pcm-v1 ] && printf '%s\n' 313 || printf '%s\n' 0
+      ;;
     *) return 1 ;;
   esac
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -229,7 +229,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient long performanceBulkTicks;
 
-    /** Largest long DMG settled-HALT PERFORMANCE packet in this session (diagnostic only). */
+    /** Largest settled-HALT PERFORMANCE packet in this session (diagnostic only). */
     private transient int performanceBulkMaxTicks;
 
     /** Bounded coarse CPU-epoch diagnostics; absent from portable state. */
@@ -928,8 +928,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         long remaining = ticks;
         try {
             while (remaining > 0 && !stop.getAsBoolean()) {
-                if (!gbc && cpu.getState() == Cpu.State.HALTED) {
-                    int committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    int committed = tryPerformanceSettledHaltSpan(remaining);
                     if (committed > 0) {
                         remaining -= committed;
                         continue;
@@ -1093,8 +1093,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             long frameEvents = 0;
             long remaining = ticks;
             while (remaining > 0) {
-                if (!gbc && cpu.getState() == Cpu.State.HALTED) {
-                    int committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                if (cpu.getState() == Cpu.State.HALTED) {
+                    int committed = tryPerformanceSettledHaltSpan(remaining);
                     if (committed > 0) {
                         remaining -= committed;
                         continue;
@@ -1262,6 +1262,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      * materialization and the PERFORMANCE scanline-enable lifecycle.
      */
     private int tryPerformancePhaseOnlySpan(long remaining, int cpuSpanLimit) {
+        // SGB's JOYP packet receiver has no tick-driven state. When its cached input
+        // eligibility is false, the span cannot commit anyway; reject before walking the
+        // relatively expensive timer/PPU/STAT horizons. Stable SGB sessions remain eligible
+        // through Joypad's exact write-clocked contract below.
+        if (isSgbPerformanceTopology() && !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
         // Build one primitive packet plan. Every component horizon is evaluated once against
         // the already-shortened tail; trusted commits do not repeat the walks.
         int span = cpuSpanLimit;
@@ -1270,17 +1277,38 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         boolean steadyRasterSpan = false;
         if (span > 0) {
             span = Math.min(span, timer.performanceQuietSpanLimit(span));
+            if (span <= 0) {
+                return 0;
+            }
             span = Math.min(span, serialPort.performanceQuietSpanLimit(span));
+            if (span <= 0) {
+                return 0;
+            }
             span = Math.min(span, joypad.performanceQuietSpanLimit(span));
+            if (span <= 0) {
+                return 0;
+            }
             span = Math.min(span, sound.performanceQuietSpanLimit(span));
+            if (span <= 0) {
+                return 0;
+            }
             if (cartridgeClocked) {
                 span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+                if (span <= 0) {
+                    return 0;
+                }
             }
             if (slotCartridgeClocked) {
                 span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+                if (span <= 0) {
+                    return 0;
+                }
             }
             if (gbc) {
                 span = Math.min(span, infraredPort.performanceQuietSpanLimit(span));
+                if (span <= 0) {
+                    return 0;
+                }
             }
             int gpuSpanLimit = gpu.performanceQuietSpanLimit();
             if (gpuSpanLimit > 0) {
@@ -1329,6 +1357,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Stable topology only; every tick-local blocker stays in {@link #canStartPerformanceEpoch()}. */
     private boolean isNativeCgbPerformanceEpochTopology() {
         return gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 2;
+    }
+
+    private boolean isSgbPerformanceTopology() {
+        return hardwareProfile.family() == HardwareProfile.Family.SGB;
+    }
+
+    /** CGB hardware running a non-color cartridge at its normal clock. */
+    private boolean isCgbCompatibilityPerformanceTopology() {
+        return gbc && speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1;
     }
 
     private boolean canContinueNativeCgbNegativeStatLease() {
@@ -1764,8 +1801,115 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochRasterFastTicks += ticks;
     }
 
+    /** Selects the normal-speed settled-HALT lane for the current non-native topology. */
+    private int tryPerformanceSettledHaltSpan(long remaining) {
+        if (isCgbCompatibilityPerformanceTopology()) {
+            return tryPerformanceSettledCgbCompatHaltSpan(remaining);
+        }
+        if (!gbc) {
+            return tryPerformanceSettledDmgHaltSpan(remaining);
+        }
+        return 0;
+    }
+
     /**
-     * Attempts the long settled-HALT packet used only by the DMG PERFORMANCE side entrance.
+     * Attempts a CGB-compatibility settled-HALT packet. This is deliberately separate from
+     * the physical-DMG packet: normal-speed CGB compatibility still clocks the CGB infrared and
+     * HDMA control planes, and their idle guards must remain part of the proof.
+     */
+    private int tryPerformanceSettledCgbCompatHaltSpan(long remaining) {
+        if (remaining <= 0 || !cpu.performanceSettledHaltSpanEligible()) {
+            return 0;
+        }
+        int span = (int) Math.min((long) SETTLED_HALT_PERFORMANCE_MAX_SPAN, remaining);
+        span = Math.min(span, timer.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, serialPort.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+        span = Math.min(span, sound.performanceQuietSpanLimit(span));
+        span = Math.min(span, infraredPort.performanceSettledHaltSpanLimit(span));
+        if (cartridgeClocked) {
+            span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
+        if (slotCartridgeClocked) {
+            span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+        }
+        int gpuSpanLimit = gpu.performanceQuietSpanLimit();
+        span = Math.min(span, gpuSpanLimit);
+        boolean directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+        boolean steadyRasterSpan = span > 0 && !directRasterSpan
+                && gpu.isPerformanceSteadyCursorActive();
+        span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
+        if (span <= 3
+                || warmResetRequested
+                || speedSwitchTailTicks != 0
+                || !cpu.performanceNoPendingPpuReadPhase()
+                || dma.isTransferInProgress()
+                || dma.requiresClockTick(true)
+                || hdma.hasActiveOrPendingTransfer()
+                || hdma.hasPendingHblankTransfer()
+                || hdma.isHaltRequestLatched()
+                || hdma.holdsHblankSpeedSwitchTail()
+                || hdma.pausesOamDmaForSpeedSwitchBurst()
+                || hdma.requiresCpuHdmaPhaseFlags()
+                || !joypad.isPerformanceQuietSpanStillEligible()
+                || !canStartCgbCompatSettledHaltSpan()) {
+            return 0;
+        }
+        tickPerformanceSettledCgbCompatHaltSpan(span, directRasterSpan, steadyRasterSpan);
+        performanceBulkSpanCount++;
+        performanceBulkTicks += span;
+        if (span > performanceBulkMaxTicks) {
+            performanceBulkMaxTicks = span;
+        }
+        return span;
+    }
+
+    private boolean canStartCgbCompatSettledHaltSpan() {
+        return isCgbCompatibilityPerformanceTopology()
+                && !warmResetRequested
+                && speedSwitchTailTicks == 0
+                && !debugHistoryReplay
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && gpu.isLcdEnabled()
+                && !dma.isTransferInProgress()
+                && !dma.requiresClockTick(true)
+                && !hdma.hasActiveOrPendingTransfer()
+                && !hdma.hasPendingHblankTransfer()
+                && !hdma.isHaltRequestLatched()
+                && !hdma.holdsHblankSpeedSwitchTail()
+                && !hdma.pausesOamDmaForSpeedSwitchBurst()
+                && !hdma.requiresCpuHdmaPhaseFlags();
+    }
+
+    /** Commits a CGB-compatibility settled-HALT packet with the complete CGB idle plane. */
+    private void tickPerformanceSettledCgbCompatHaltSpan(
+            int ticks, boolean directRasterSpan, boolean steadyRasterSpan) {
+        if (cartridgeClocked) {
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        timer.tickPerformanceQuietSpanTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed a CGB-compatibility settled-HALT span";
+        sound.commitFrameSequencerClock();
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformanceQuietSpanTrusted(ticks);
+        infraredPort.tickPerformanceQuietSpanTrusted(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+        cpu.advancePerformanceSettledHaltSpanTrusted(ticks);
+        gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        statRegister.tickPerformanceQuietSpanTrusted(ticks);
+        hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                gpu.isStatModeLatchRephasedBySpeedSwitch());
+        cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
+    }
+
+    /**
+     * Attempts the long settled-HALT packet used by the normal-speed monochrome side entrance.
      * Every horizon and volatile guard is read before the commit, so a zero result leaves the
      * machine untouched and lets the ordinary PERFORMANCE scheduler handle the next scalar phase.
      */
@@ -1911,7 +2055,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return performanceBulkTicks;
     }
 
-    /** Largest long DMG settled-HALT PERFORMANCE packet in the current session. */
+    /** Largest settled-HALT PERFORMANCE packet in the current session. */
     public int getPerformanceBulkMaxTicks() {
         return performanceBulkMaxTicks;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -113,6 +113,18 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         return Math.min(requested, PERFORMANCE_MAX_QUIET_SPAN);
     }
 
+    /** Same exact idle proof for a settled normal-speed HALT packet, without the three-dot cap. */
+    public int performanceSettledHaltSpanLimit(int requested) {
+        if (requested <= 0 || !gbc || speedMode.getSpeedMode() != 1
+                || fullChangerActive
+                || endpoint != InfraredEndpoint.NULL_ENDPOINT
+                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
+                || debugHooks != null) {
+            return 0;
+        }
+        return requested;
+    }
+
     public boolean canTickPerformanceQuietSpan(int ticks) {
         return ticks > 0 && performanceQuietSpanLimit(ticks) >= ticks;
     }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/joypad/Joypad.java
@@ -289,9 +289,10 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
      *
      * <p>The released default source cannot produce a poll or a physical transition, and a
      * settled four-sample receiver has no electrical edge to process.  Only the free-running
-     * BOGA clock phase changes, so it can be advanced arithmetically.  Custom sources, SGB packet
-     * receivers, debug/timeline observers, and any pending input mutation stay on the scalar
-     * path.</p>
+     * BOGA clock phase changes, so it can be advanced arithmetically.  Custom sources,
+     * debug/timeline observers, and any pending input mutation stay on the scalar path.  The
+     * SGB packet receiver is clocked by CPU writes to JOYP, not by this free-running tick, so it
+     * remains unchanged inside a preflighted no-bus span.</p>
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0 || inputChangedSinceLastTick
@@ -353,8 +354,8 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
     /**
      * Advances a settled released-input JOYP receiver without polling or filtering each tick.
      *
-     * @return false without mutation when a host input, observer, SGB, or debug edge could make
-     *         a scalar callback observable
+     * @return false without mutation when a host input, observer, or debug edge could make a
+     *         scalar callback observable
      */
     public boolean tickPerformanceQuietSpan(int ticks) {
         if (!canTickPerformanceQuietSpan(ticks)) {
@@ -530,8 +531,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 && filteredInputLines == 0x0f;
         performanceSpanFastPathEligible = releasedInputFastPathEligible
                 && inputTimelineObserver == null
-                && debugHooks == null
-                && !isSgb;
+                && debugHooks == null;
         // Hub eligibility additionally depends on the current selector and filtered electrical
         // lines. It is recomputed only after this tick has calculated those values.
         playerInputHubFastPathEligible = false;
@@ -547,8 +547,7 @@ public class Joypad implements AddressSpace, StatefulComponent<Joypad> {
                 && players == 0
                 && buttons.isEmpty()
                 && inputTimelineObserver == null
-                && debugHooks == null
-                && !isSgb;
+                && debugHooks == null;
     }
 
     private static int[] createSettledHistory() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -7,6 +7,8 @@ import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.cpu.Cpu;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
@@ -162,6 +164,181 @@ public final class GameboyPlayerInputHubPerformanceTest {
                     assertTrue("DMG settled HALT never crossed a machine-cycle boundary"
                                     + " maxSpan=" + performance.getPerformanceBulkMaxTicks(),
                             performance.getPerformanceBulkMaxTicks() > 3);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void cgbCompatibilitySettledHaltMatchesScalarWithCgbIdlePlane() throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[]{
+                HardwareProfileRegistry.CGB, HardwareProfileRegistry.CGB0}) {
+            PlayerInputHub performanceHub = new PlayerInputHub();
+            performanceHub.openSource(0);
+            try (Gameboy performance = haltCgbCompatSession(profile, performanceHub);
+                    Gameboy scalar = haltCgbCompatSession(profile,
+                            () -> PlayerInputSnapshot.released())) {
+                performance.runTicks(128);
+                scalar.runTicks(128);
+                assertTrue(profile.id() + " compatibility setup did not enter DMG-compat mode",
+                        performance.getSpeedMode().isDmgCompat());
+                assertEquals(Cpu.State.HALTED, performance.getCpu().getState());
+                assertEquals(Cpu.State.HALTED, scalar.getCpu().getState());
+
+                performance.resetPerformanceBulkCounters();
+                scalar.resetPerformanceBulkCounters();
+                for (int chunk = 0; chunk < 120; chunk++) {
+                    assertEquals(profile.id() + " compatibility HALT callbacks chunk=" + chunk,
+                            runScalarTicks(scalar, 100), performance.runTicks(100));
+                    assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                            profile.id() + " compatibility HALT chunk=" + chunk);
+                    assertRasterEquivalent(scalar, performance,
+                            profile.id() + " compatibility HALT chunk=" + chunk);
+                }
+                assertTrue(profile.id() + " compatibility settled HALT did not cross a machine cycle",
+                        performance.getPerformanceBulkMaxTicks() > 3);
+                assertTrue(profile.id() + " compatibility settled HALT had no substantial bulk coverage",
+                        performance.getPerformanceBulkTicks() > 1_000);
+            }
+        }
+    }
+
+    @Test
+    public void sgbSettledHaltMatchesScalarForBothClockProfiles() throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[]{
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2}) {
+            PlayerInputHub performanceHub = new PlayerInputHub();
+            performanceHub.openSource(0);
+            try (Gameboy performance = haltProfileSession(profile, performanceHub);
+                    Gameboy scalar = haltProfileSession(profile,
+                            () -> PlayerInputSnapshot.released())) {
+                performance.runTicks(128);
+                scalar.runTicks(128);
+                assertEquals(profile.id() + " CPU state", Cpu.State.HALTED,
+                        performance.getCpu().getState());
+                assertEquals(profile.id() + " scalar CPU state", Cpu.State.HALTED,
+                        scalar.getCpu().getState());
+
+                performance.resetPerformanceBulkCounters();
+                scalar.resetPerformanceBulkCounters();
+                // Run beyond one 70,224-dot frame so the SGB VRAM transfer reaches its
+                // VBlank/materialization boundary while the scalar oracle remains authoritative.
+                for (int chunk = 0; chunk < 800; chunk++) {
+                    assertEquals(profile.id() + " frame callbacks chunk=" + chunk,
+                            runScalarTickCalls(scalar, 100), performance.runTicks(100));
+                    ComponentState<Gameboy> scalarState = scalar.captureState();
+                    ComponentState<Gameboy> performanceState = performance.captureState();
+                    // The VRAM transfer is checked at every materialization boundary; the full
+                    // recursive state hash is sampled periodically because it includes large
+                    // display records and would dominate this intentionally long cross-frame run.
+                    assertEquals(profile.id() + " VRAM transfer chunk=" + chunk,
+                            recordComponentHash(scalarState, "vRamTransferMemento"),
+                            recordComponentHash(performanceState, "vRamTransferMemento"));
+                    if ((chunk & 63) == 0 || chunk >= 700) {
+                        assertStateEquivalent(scalarState, performanceState,
+                                profile.id() + " HALT chunk=" + chunk);
+                    }
+                    assertRasterEquivalent(scalar, performance,
+                            profile.id() + " HALT chunk=" + chunk);
+                }
+                assertTrue(profile.id() + " settled HALT did not cross a machine cycle",
+                        performance.getPerformanceBulkMaxTicks() > 3);
+                assertTrue(profile.id() + " settled HALT had no substantial bulk coverage: "
+                                + performance.getPerformanceBulkTicks(),
+                        performance.getPerformanceBulkTicks() > 100);
+            }
+        }
+    }
+
+    @Test
+    public void cgbCompatibilitySettledHaltRejectsActiveOamDma() throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        performanceHub.openSource(0);
+        try (Gameboy performance = haltCgbCompatSession(
+                HardwareProfileRegistry.CGB, performanceHub);
+                Gameboy scalar = haltCgbCompatSession(
+                        HardwareProfileRegistry.CGB, () -> PlayerInputSnapshot.released())) {
+            performance.runTicks(128);
+            scalar.runTicks(128);
+            performance.resetPerformanceBulkCounters();
+            scalar.resetPerformanceBulkCounters();
+
+            performance.getAddressSpace().setByte(0xff46, 0xc0);
+            scalar.getAddressSpace().setByte(0xff46, 0xc0);
+            assertEquals("active OAM DMA setup",
+                    recordComponentHash(scalar.captureState(), "dmaMemento"),
+                    recordComponentHash(performance.captureState(), "dmaMemento"));
+            assertEquals("active OAM DMA frame callbacks", runScalarTicks(scalar, 54),
+                    performance.runTicks(54));
+            assertEquals("CGB compatibility HALT must not bulk through OAM DMA", 0L,
+                    performance.getPerformanceBulkTicks());
+            assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                    "CGB compatibility active OAM DMA");
+        }
+    }
+
+    @Test
+    public void cgbCompatibilitySettledHaltRejectsActiveHdma() throws Exception {
+        PlayerInputHub performanceHub = new PlayerInputHub();
+        performanceHub.openSource(0);
+        try (Gameboy performance = haltCgbCompatSession(
+                HardwareProfileRegistry.CGB, performanceHub);
+                Gameboy scalar = haltCgbCompatSession(
+                        HardwareProfileRegistry.CGB, () -> PlayerInputSnapshot.released())) {
+            performance.runTicks(128);
+            scalar.runTicks(128);
+            performance.resetPerformanceBulkCounters();
+            scalar.resetPerformanceBulkCounters();
+
+            startOneBlockGdma(performance);
+            startOneBlockGdma(scalar);
+            assertEquals("active HDMA setup",
+                    stateHash(scalar.getHdma().captureState()),
+                    stateHash(performance.getHdma().captureState()));
+            assertEquals("active HDMA frame callbacks", runScalarTicks(scalar, 54),
+                    performance.runTicks(54));
+            assertEquals("CGB compatibility HALT must not bulk through HDMA", 0L,
+                    performance.getPerformanceBulkTicks());
+            assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                    "CGB compatibility active HDMA");
+        }
+    }
+
+    @Test
+    public void cgbCompatibilitySettledHaltWakeEdgesMatchScalarForBothProfiles()
+            throws Exception {
+        int[] tails = {1, 3, 7, 17, 53};
+        for (HardwareProfile profile : new HardwareProfile[]{
+                HardwareProfileRegistry.CGB, HardwareProfileRegistry.CGB0}) {
+            for (WakeSource wakeSource : WakeSource.values()) {
+                for (int tail : tails) {
+                    PlayerInputHub hub = new PlayerInputHub();
+                    hub.openSource(0);
+                    try (Gameboy performance = haltCgbCompatSession(profile, hub);
+                            Gameboy scalar = haltCgbCompatSession(profile,
+                                    () -> PlayerInputSnapshot.released())) {
+                        settleHalt(performance, scalar, true, wakeSource, tail);
+                        armWakeSource(performance, wakeSource);
+                        armWakeSource(scalar, wakeSource);
+                        performance.resetPerformanceBulkCounters();
+                        scalar.resetPerformanceBulkCounters();
+
+                        int elapsed = 0;
+                        while (performance.getCpu().getState() == Cpu.State.HALTED
+                                && elapsed < 2_000) {
+                            assertEquals(profile.id() + " compat " + wakeSource + " tail=" + tail,
+                                    runScalarTicks(scalar, tail), performance.runTicks(tail));
+                            assertEquals(profile.id() + " compat CPU wake tail=" + tail,
+                                    scalar.getCpu().getState(), performance.getCpu().getState());
+                            elapsed += tail;
+                        }
+                        assertTrue(profile.id() + " compat " + wakeSource + " did not wake",
+                                performance.getCpu().getState() != Cpu.State.HALTED);
+                        assertStateEquivalent(scalar.captureState(), performance.captureState(),
+                                profile.id() + " compat " + wakeSource + " tail=" + tail);
+                        assertRasterEquivalent(scalar, performance,
+                                profile.id() + " compat " + wakeSource + " tail=" + tail);
+                    }
                 }
             }
         }
@@ -517,6 +694,42 @@ public final class GameboyPlayerInputHubPerformanceTest {
         return gameboy;
     }
 
+    private static Gameboy haltCgbCompatSession(
+            HardwareProfile profile, PlayerInputSource inputSource) throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x76; // HALT with no interrupt sources enabled
+        image[0x101] = 0x00;
+        image[0x143] = 0;
+        image[0x147] = 0;
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(profile)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+        gameboy.init(new EventBusImpl(null, null, false), new Peer2PeerSerialEndpoint(), null);
+        return gameboy;
+    }
+
+    private static Gameboy haltProfileSession(
+            HardwareProfile profile, PlayerInputSource inputSource) throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x76; // HALT with no interrupt sources enabled
+        image[0x101] = 0x00;
+        image[0x143] = 0;
+        image[0x147] = 0;
+        Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(profile)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+        gameboy.init(new EventBusImpl(null, null, false), new Peer2PeerSerialEndpoint(), null);
+        return gameboy;
+    }
+
     private static Gameboy nativeDoubleSpeedHaltSession(PlayerInputSource inputSource)
             throws Exception {
         Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(nativeDoubleSpeedHaltRom()))
@@ -604,6 +817,17 @@ public final class GameboyPlayerInputHubPerformanceTest {
         long frameEvents = 0;
         for (int tick = 0; tick < ticks; tick++) {
             frameEvents += scalar.runTicks(1);
+        }
+        return frameEvents;
+    }
+
+    /** Exact scalar oracle used by the long SGB boundary test without scheduler setup overhead. */
+    private static long runScalarTickCalls(Gameboy scalar, int ticks) {
+        long frameEvents = 0;
+        for (int tick = 0; tick < ticks; tick++) {
+            if (scalar.tick()) {
+                frameEvents++;
+            }
         }
         return frameEvents;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/InfraredPortTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.ir;
 
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
@@ -45,6 +46,13 @@ public class InfraredPortTest {
 
         port.setSerialEndpoint(new LowSerialInput());
         assertEquals(0, port.performanceQuietSpanLimit(3));
+    }
+
+    @Test
+    public void settledHaltSpanRejectsAnyAttachedInfraredEndpoint() {
+        InfraredPort port = new InfraredPort(true, new SpeedMode(true));
+        port.init(EventBus.NULL_EVENT_BUS, new Peer2PeerInfraredEndpoint());
+        assertEquals(0, port.performanceSettledHaltSpanLimit(54));
     }
 
     private static class LowSerialInput implements SerialEndpoint {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/joypad/JoypadPerformanceSpanTest.java
@@ -3,6 +3,8 @@ package eu.rekawek.coffeegb.core.joypad;
 import eu.rekawek.coffeegb.core.TestDebugHooks;
 import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.sgb.Commands;
 import org.junit.Test;
 
 import java.util.Random;
@@ -40,7 +42,7 @@ public class JoypadPerformanceSpanTest {
     }
 
     @Test
-    public void quietSpanFailsClosedForInputSourcesMutationsObserversAndSgb() {
+    public void quietSpanFailsClosedForInputSourcesMutationsAndObservers() {
         Joypad customSource = new Joypad(
                 new InterruptManager(false), EventBus.NULL_EVENT_BUS, false,
                 PlayerInputSnapshot::released);
@@ -66,7 +68,99 @@ public class JoypadPerformanceSpanTest {
 
         Joypad sgb = new Joypad(
                 new InterruptManager(false), EventBus.NULL_EVENT_BUS, true);
-        assertEquals(0, sgb.performanceQuietSpanLimit(1));
+        assertTrue(sgb.performanceQuietSpanLimit(1) > 0);
+        assertTrue(sgb.performanceSettledHaltSpanLimit(54) > 3);
+    }
+
+    @Test
+    public void sgbReceiverCompletesIdenticallyAcrossASettledBulkGap() {
+        InterruptManager scalarInterrupts = new InterruptManager(false);
+        InterruptManager bulkInterrupts = new InterruptManager(false);
+        Joypad scalar = new Joypad(scalarInterrupts, EventBus.NULL_EVENT_BUS, true);
+        Joypad bulk = new Joypad(bulkInterrupts, EventBus.NULL_EVENT_BUS, true);
+        int[] packet = patternedPacket();
+        writeSelector(scalar, 0x30);
+        writeSelector(bulk, 0x30);
+        writeSelector(scalar, 0x00);
+        writeSelector(bulk, 0x00);
+        writeSelector(scalar, 0x30);
+        writeSelector(bulk, 0x30);
+        writeBits(scalar, packet, 0, 37);
+        writeBits(bulk, packet, 0, 37);
+
+        // The selector writes themselves are CPU-bus mutations. Let both receivers consume the
+        // same settled released-input filter before asking for a HALT horizon; the SGB packet
+        // state remains mid-transfer throughout this reconciliation.
+        for (int i = 0; i < 4 * Joypad.JOYP_CLOCK_TICKS; i++) {
+            scalar.tick();
+            bulk.tick();
+        }
+
+        int span = bulk.performanceSettledHaltSpanLimit(54);
+        assertTrue("SGB settled receiver did not expose its exact idle horizon", span > 3);
+        for (int i = 0; i < span; i++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceQuietSpanTrusted(span);
+
+        writeBits(scalar, packet, 37, 128);
+        writeBits(bulk, packet, 37, 128);
+        writeSelector(scalar, 0x20);
+        writeSelector(bulk, 0x20);
+        writeSelector(scalar, 0x30);
+        writeSelector(bulk, 0x30);
+
+        assertEquivalent(scalar, bulk);
+        assertEquals(scalar.captureDebugJoypadInspection(true),
+                bulk.captureDebugJoypadInspection(true));
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
+    public void sgbMultiplayerControlInvalidatesSettledHaltUntilScalarReconciliation() {
+        try (EventBusImpl sgbBus = new EventBusImpl(null, null, false)) {
+            Joypad joypad = new Joypad(new InterruptManager(false), sgbBus, true);
+            assertTrue(joypad.performanceSettledHaltSpanLimit(54) > 3);
+
+            sgbBus.post(mltReq(1));
+            assertEquals("MLT_REQ players must reject a settled packet", 0,
+                    joypad.performanceSettledHaltSpanLimit(54));
+
+            // Returning to one player is also an event edge. It becomes eligible only after the
+            // next scalar JOYP reconciliation, matching the ordinary input fast-path contract.
+            sgbBus.post(mltReq(0));
+            assertEquals("MLT_REQ reset must still reject before reconciliation", 0,
+                    joypad.performanceSettledHaltSpanLimit(54));
+            joypad.tick();
+            assertTrue("MLT_REQ reset did not restore the settled horizon",
+                    joypad.performanceSettledHaltSpanLimit(54) > 3);
+        }
+    }
+
+    private static Commands.MltReqCmd mltReq(int players) {
+        int[] packet = new int[Commands.PACKET_SIZE];
+        packet[0] = 0x11 * 8 + 1;
+        packet[1] = players;
+        return (Commands.MltReqCmd) Commands.toCommand(packet);
+    }
+
+    private static int[] patternedPacket() {
+        int[] packet = new int[16];
+        for (int i = 0; i < packet.length; i++) {
+            packet[i] = 0x31 + i * 17;
+        }
+        return packet;
+    }
+
+    private static void writeBits(Joypad joypad, int[] packet, int from, int to) {
+        for (int bit = from; bit < to; bit++) {
+            writeSelector(joypad, ((packet[bit / 8] >>> (bit & 7)) & 1) == 0 ? 0x20 : 0x10);
+            writeSelector(joypad, 0x30);
+        }
+    }
+
+    private static void writeSelector(Joypad joypad, int selector) {
+        joypad.setByte(0xff00, selector);
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
@@ -56,6 +56,39 @@ public final class PerformanceSystemMutedAudioCalendarTest {
     }
 
     @Test
+    public void exactSilentCalendarPreservesSgbAndSgb2Cadence() {
+        for (ClockSpec sourceClock : new ClockSpec[]{ClockSpec.SGB, ClockSpec.SGB2}) {
+            SpeedMode speedMode = new SpeedMode(false);
+            Sound sound = new Sound(new Timer(new InterruptManager(false), speedMode),
+                    speedMode, false, sourceClock, ExecutionMode.PERFORMANCE);
+            List<Sound.SoundSampleEvent> events = new ArrayList<>();
+            EventBusImpl eventBus = new EventBusImpl(null, null, false);
+            eventBus.register(events::add, Sound.SoundSampleEvent.class);
+            sound.init(eventBus);
+            sound.setPerformanceSystemMutedAudioCalendar(true);
+            sound.resetPerformanceSystemMutedAudioCalendarCounters();
+
+            sound.tickPerformanceQuietSpan(sourceClock.controllerTicksPerFrame());
+
+            assertEquals(70_224L, sound.getPerformanceSystemMutedAudioCalendarSkippedTicks());
+            assertEquals(6_384L,
+                    sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
+            assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleEvents());
+            assertEquals(0L,
+                    sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
+            assertEquals(1, events.size());
+            assertEquals(6_384, events.get(0).clockSpec().controllerTicksPerFrame());
+            assertEquals(sourceClock.ticksPerSecondNumerator(),
+                    events.get(0).clockSpec().ticksPerSecondNumerator());
+            assertEquals(sourceClock.ticksPerSecondDenominator() * 11L,
+                    events.get(0).clockSpec().ticksPerSecondDenominator());
+            assertEquals(6_384 * 2, events.get(0).buffer().length);
+            assertAllZero(events.get(0).buffer());
+            eventBus.close();
+        }
+    }
+
+    @Test
     public void silentCalendarBoundaryAndFrameSequencerKeepCadenceAndBoundaries() {
         Sound sound = newSound();
         sound.setPerformanceSystemMutedAudioCalendar(true);


### PR DESCRIPTION
## Summary

- add a normal-speed CGB DMG-compatibility settled-HALT PERFORMANCE lane with the CGB infrared, DMA, and HDMA control planes included in its safety proof
- allow SGB/SGB2 JOYP quiet spans when the write-clocked packet receiver is stable, while continuing to invalidate on JOYP/MLT changes
- extend the exact `silent-pcm-v1` Android benchmark policy to SGB and SGB2, including their required 313-frame precondition; the relaxed APU policy remains limited to the original five rows

## Why

CGB compatibility, SGB, and SGB2 all fell through the generic PERFORMANCE scheduler. CGB compatibility had no long settled-HALT path, while SGB's JOYP horizon always collapsed to zero, so the scheduler repeatedly performed rejected horizon walks and then executed scalar ticks.

The new lanes keep scalar execution authoritative at CPU/event boundaries and bulk only across preflighted quiet spans.

## Validation

Controlled host A/B, three alternating pairs with identical workload and tick counts:

- CGB DMG-compatibility: candidate/control throughput GM `1.308261` (`+30.83%`), 3/3 wins
- SGB: candidate/control throughput GM `1.123720` (`+12.37%`), 3/3 wins
- physical DMG non-regression: candidate/control GM `1.016381`, with retained exact scheduler counters

Muted Redmi validation (audio state was only read, never changed):

- strict CGB DMG-compatibility pair accepted with exact policy/audio/calendar/compositor evidence: ready FPS `41.4545 -> 59.4078` (`1.4331x`); candidate bulk counters were positive
- SGB could not produce an authoritative device result because this firmware kept the active display at 60 Hz despite advertising the required 120 Hz mode
- SGB2 app sessions produced exact policy/audio/calendar evidence and exercised the new bulk lane, but SurfaceFlinger rejected the compositor window; no SGB/SGB2 Android throughput claim is made from those runs

## Tests

- full core unit suite: 1,867 tests, 0 failures/errors
- focused scheduler/audio suites: 42 tests, 0 failures/errors
- Mooneye + DMG/CGB Acid2: 132/132
- Blargg suites: 46/46
- Mealybug: 26/26
- Android `BenchmarkMatrixTest` + `DiagnosticsOptionsTest`: 54/54
- `android/benchmark-device-matrix-test.sh`
- minified benchmark/release APK and R8/DEX boundary audit
- `git diff --check`
