### PR TITLE
Fix Android ROM switching persistence

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -61,6 +61,24 @@ private val forbiddenZipEntrySuffixes = listOf(
     ".cgbstate",
 )
 
+// These runtime types cross a portable-state reflection boundary by binary name. A release APK
+// may optimize their implementations, but renaming any reachable entry makes ROM-switch autosave
+// fail only after R8, which debug/instrumentation builds cannot reproduce.
+private val releaseStableStateClassNames = listOf(
+    "eu.rekawek.coffeegb.core.serial.SerialEndpoint\$1",
+    "eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint",
+    "eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint",
+    "eu.rekawek.coffeegb.core.serial.GpsReceiverSerialEndpoint",
+    "eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint",
+    "eu.rekawek.coffeegb.core.serial.mobile.MobileAdapterSerialEndpoint",
+    "eu.rekawek.coffeegb.core.genie.Genie\$GameGeniePatchState",
+    "eu.rekawek.coffeegb.core.gpu.Gpu\$PendingPpuWriteState",
+    "eu.rekawek.coffeegb.core.cpu.Cpu\$State",
+    "eu.rekawek.coffeegb.core.gpu.Mode",
+    "eu.rekawek.coffeegb.core.genie.Genie\$GenieMemento",
+    "eu.rekawek.coffeegb.core.genie.GameGeniePatch",
+)
+
 private fun portabilityViolations(sourceFiles: Collection<File>, classpath: Collection<File>): List<String> {
   val violations = mutableListOf<String>()
   sourceFiles.filter(File::isFile).sorted().forEach { source ->
@@ -368,6 +386,43 @@ androidComponents {
     tasks.configureEach {
       if (name == "assembleDebug") {
         dependsOn(verifyPermissions)
+      }
+    }
+  }
+  onVariants(selector().withBuildType("release")) { variant ->
+    val mapping = variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+    val verifyStateNames = tasks.register("verifyReleaseStateReflectionNames") {
+      group = "verification"
+      description = "Rejects R8 renaming at portable-state reflection boundaries."
+      inputs.file(mapping)
+      doLast {
+        val classMappings = mapping.get().asFile.useLines { lines ->
+          lines.mapNotNull { line ->
+            if (line.isBlank() || line.first().isWhitespace() || !line.endsWith(':')) {
+              return@mapNotNull null
+            }
+            val separator = line.indexOf(" -> ")
+            if (separator < 0) {
+              return@mapNotNull null
+            }
+            line.substring(0, separator) to line.substring(separator + 4, line.length - 1)
+          }.toMap()
+        }
+        val missing = releaseStableStateClassNames.filterNot(classMappings::containsKey)
+        check(missing.isEmpty()) {
+          "Release mapping omitted portable-state boundary classes: $missing"
+        }
+        val renamed = releaseStableStateClassNames.mapNotNull { original ->
+          classMappings[original]?.takeIf { it != original }?.let { "$original -> $it" }
+        }
+        check(renamed.isEmpty()) {
+          "R8 renamed portable-state boundary classes: $renamed"
+        }
+      }
+    }
+    tasks.configureEach {
+      if (name == "assembleRelease") {
+        dependsOn(verifyStateNames)
       }
     }
   }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -5,11 +5,31 @@
 # desktop APIs.
 -dontwarn java.io.ObjectInputFilter
 
-# Portable save states reflect over every ComponentState record's canonical constructor and
-# component fields. Keep their names and Java parameter metadata stable after R8 so a state file
-# created by a release build has the same schema as a debug or desktop build.
+# Portable save states reflect over every audited record's canonical constructor and component
+# fields. Most roots implement ComponentState, but registered child records (for example cheat
+# patches and delayed PPU writes) deliberately do not. StateTypeRegistry resolves all of them by
+# their stable binary names, so keep both roots and nested record types intact after R8.
 -keepattributes MethodParameters,Signature
 -keep class * implements eu.rekawek.coffeegb.core.state.ComponentState { <fields>; <init>(...); }
+-keep class eu.rekawek.coffeegb.core.**$*State { <fields>; <init>(...); }
+
+# Session snapshots classify installed link peripherals by their audited binary class names. Keep
+# only those names stable; implementations may still be shrunk and optimized normally.
+-keepnames class * implements eu.rekawek.coffeegb.core.serial.SerialEndpoint
+
+# The bounded legacy importer resolves its allowlisted compatibility records by their released
+# names. These classes are otherwise reflection-only and would be removed from a minified build.
+-keep class eu.rekawek.coffeegb.core.**$*Memento { <fields>; <init>(...); }
+-keep class eu.rekawek.coffeegb.core.genie.GameGeniePatch { <fields>; <init>(...); }
+-keep class eu.rekawek.coffeegb.core.genie.GameSharkPatch { <fields>; <init>(...); }
+-keep class eu.rekawek.coffeegb.core.gpu.Gpu$PendingPpuWrite { <fields>; <init>(...); }
+-keep class eu.rekawek.coffeegb.core.gpu.phase.PixelTransfer$DelayedWindowWrite {
+    <fields>;
+    <init>(...);
+}
+
+# Audited enum classes are also resolved by stable binary name before their ordinals are encoded.
+-keep enum eu.rekawek.coffeegb.core.** { *; }
 
 # Keep the normal-speed monochrome/compatibility settled-HALT lane bodies visible to R8's call
 # graph without pinning their class or method names. The tiny selector remains free to inline.

--- a/android/app/src/androidTest/AndroidManifest.xml
+++ b/android/app/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <provider
         android:name="eu.rekawek.coffeegb.android.FixtureRomProvider"
         android:authorities="eu.rekawek.coffeegb.android.test.fixture"
+        android:process=":fixture"
         android:exported="true" />
   </application>
 </manifest>

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidBatteryPersistenceSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidBatteryPersistenceSmokeTest.java
@@ -1,0 +1,59 @@
+package eu.rekawek.coffeegb.android;
+
+import static org.junit.Assert.fail;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryFlush;
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryPersistenceResult;
+import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage;
+import eu.rekawek.coffeegb.core.memory.cart.battery.FileBattery;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class AndroidBatteryPersistenceSmokeTest {
+
+    @Test
+    public void managedBatteryCanBeWrittenInAppPrivateStorage() throws Exception {
+        Path managedRoot = ApplicationProvider.getApplicationContext().getNoBackupFilesDir()
+                .toPath().resolve("coffee-gb");
+        Files.createDirectories(managedRoot);
+        Path testDirectory = Files.createTempDirectory(managedRoot, "battery-smoke-");
+        try {
+            Path target = testDirectory.resolve("game").resolve("battery.sav");
+            BatteryStorage storage = new BatteryStorage(
+                    BatteryStorage.Source.appPrivate(target, managedRoot), List.of());
+            FileBattery battery = new FileBattery(storage, 0x2000);
+            int[] ram = new int[0x2000];
+            ram[0] = 0x5a;
+            battery.saveRam(ram);
+            BatteryFlush flush = battery.prepareFlush(() -> { });
+            BatteryPersistenceResult result = flush.persist();
+            if (result instanceof BatteryPersistenceResult.Failure failure) {
+                throw new AssertionError("App-private battery write failed", failure.cause());
+            }
+            flush.complete(result);
+        } finally {
+            if (Files.exists(testDirectory)) {
+                try (var paths = Files.walk(testDirectory)) {
+                    paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (Exception failure) {
+                            fail("Unable to clean battery smoke-test storage: "
+                                    + failure.getClass().getSimpleName());
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AndroidRuntimeEndToEndSmokeTest.java
@@ -5,10 +5,13 @@ import android.view.KeyEvent;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.controller.state.StateEntryKey;
 import eu.rekawek.coffeegb.controller.state.StateOperation;
 import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent;
 import eu.rekawek.coffeegb.controller.state.StateOperationFailedEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
+import eu.rekawek.coffeegb.controller.state.StateResumeAvailableEvent;
+import eu.rekawek.coffeegb.controller.state.StateResumeDecisionEvent;
 import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import org.junit.Test;
@@ -90,6 +93,7 @@ public class AndroidRuntimeEndToEndSmokeTest {
                     stateRestored.countDown();
                 }
             }, StateOperationFailedEvent.class);
+            assertAutosaveOfferAccepted(events);
             runtime.openRom(FixtureRomProvider.URI, 0);
             awaitFixtureStart(runtime, loadFailure);
 
@@ -114,6 +118,29 @@ public class AndroidRuntimeEndToEndSmokeTest {
                     STATE_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
             assertFrame(runtime, "after state restore");
 
+            // The in-screen menu owns the pause it creates. A successful game choice transfers
+            // that ownership to the replacement request instead of leaving the new game paused
+            // behind a hidden menu.
+            runtime.pause();
+            await("pause before ROM replacement",
+                    () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
+            long firstGeneration = runtime.state().sessionGeneration();
+            runtime.openRom(FixtureRomProvider.SECOND_URI, 0, true);
+            await("playing ROM replacement", () -> runtime.state().phase()
+                    == RuntimeState.Phase.RUNNING
+                    && runtime.state().sessionGeneration() > firstGeneration);
+            assertEquals("CI SMOKE CGB", runtime.state().romTitle());
+            assertFrame(runtime, "after ROM replacement");
+
+            runtime.pause();
+            await("pause before reset",
+                    () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
+            long replacementGeneration = runtime.state().sessionGeneration();
+            runtime.reset(true);
+            await("playing reset", () -> runtime.state().phase() == RuntimeState.Phase.RUNNING
+                    && runtime.state().sessionGeneration() > replacementGeneration);
+            assertFrame(runtime, "after reset");
+
             runtime.onHostNotVisible();
             await("background pause", () -> runtime.state().phase() == RuntimeState.Phase.PAUSED);
             runtime.onHostVisible();
@@ -122,6 +149,41 @@ public class AndroidRuntimeEndToEndSmokeTest {
             runtime.stop();
             await("runtime stop", () -> runtime.state().phase() == RuntimeState.Phase.STOPPED);
         }
+    }
+
+    private static void assertAutosaveOfferAccepted(EventBus events) throws Exception {
+        long requestId = 8_001L;
+        long sessionId = 8_002L;
+        CountDownLatch decisionReceived = new CountDownLatch(1);
+        AtomicReference<StateResumeDecisionEvent> decision = new AtomicReference<>();
+        events.register(event -> {
+            if (event.getRequestId() == requestId && event.getExpectedSessionId() == sessionId) {
+                decision.set(event);
+                decisionReceived.countDown();
+            }
+        }, StateResumeDecisionEvent.class);
+
+        // The portable controller defaults to ASK. Android has no corresponding prompt, so the
+        // runtime must answer the offer or a reopened game remains paused on its first frame.
+        StateResumeAvailableEvent offer = new StateResumeAvailableEvent(
+                requestId,
+                sessionId,
+                new StateEntryKey(StateRef.Autosave.INSTANCE, 0),
+                null,
+                null);
+        long deadline = SystemClock.elapsedRealtime() + STATE_REQUEST_TIMEOUT_MILLIS;
+        do {
+            // The runtime publishes its EventBus before createController has registered every
+            // listener. Retry this synthetic probe until owner initialization reaches the Android
+            // resume handler; production ROM requests are already serialized behind initialization.
+            events.post(offer);
+            if (decisionReceived.await(50L, TimeUnit.MILLISECONDS)) {
+                break;
+            }
+        } while (SystemClock.elapsedRealtime() < deadline);
+
+        assertEquals("Android autosave resume decision", 0L, decisionReceived.getCount());
+        assertTrue("Android accepts managed autosave", decision.get().getAccept());
     }
 
     private static void assertFixtureReadable() throws Exception {

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -25,7 +25,10 @@ import java.nio.charset.StandardCharsets;
 public final class FixtureRomProvider extends ContentProvider {
 
     static final Uri URI = Uri.parse("content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke.gb");
+    static final Uri SECOND_URI = Uri.parse(
+            "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-cgb.gbc");
     private static final String DISPLAY_NAME = "coffee-gb-ci-smoke.gb";
+    private static final String SECOND_DISPLAY_NAME = "coffee-gb-ci-smoke-cgb.gbc";
     private static final int ROM_SIZE = 0x8000;
 
     @Override
@@ -39,7 +42,7 @@ public final class FixtureRomProvider extends ContentProvider {
         assertFixture(uri);
         MatrixCursor cursor = new MatrixCursor(new String[]{
                 OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE});
-        cursor.addRow(new Object[]{DISPLAY_NAME, ROM_SIZE});
+        cursor.addRow(new Object[]{displayName(uri), ROM_SIZE});
         return cursor;
     }
 
@@ -60,10 +63,12 @@ public final class FixtureRomProvider extends ContentProvider {
             if (context == null) {
                 throw new FileNotFoundException("The CI fixture provider is not initialized");
             }
-            File fixture = new File(context.getCacheDir(), DISPLAY_NAME);
+            File fixture = new File(context.getCacheDir(), displayName(uri));
             if (!fixture.isFile() || fixture.length() != ROM_SIZE) {
                 try (FileOutputStream output = new FileOutputStream(fixture)) {
-                    output.write(fixtureBytes());
+                    output.write(fixtureBytes(
+                            uri.equals(SECOND_URI) ? "CI SMOKE CGB" : "CI SMOKE",
+                            uri.equals(SECOND_URI)));
                 }
             }
             return ParcelFileDescriptor.open(fixture, ParcelFileDescriptor.MODE_READ_ONLY);
@@ -88,18 +93,24 @@ public final class FixtureRomProvider extends ContentProvider {
     }
 
     private static void assertFixture(Uri uri) {
-        if (!URI.equals(uri)) {
+        if (!URI.equals(uri) && !SECOND_URI.equals(uri)) {
             throw new IllegalArgumentException("Unknown CI fixture");
         }
     }
 
-    private static byte[] fixtureBytes() {
+    private static String displayName(Uri uri) {
+        assertFixture(uri);
+        return uri.equals(SECOND_URI) ? SECOND_DISPLAY_NAME : DISPLAY_NAME;
+    }
+
+    private static byte[] fixtureBytes(String fixtureTitle, boolean cgb) {
         byte[] rom = new byte[ROM_SIZE];
         rom[0x0100] = (byte) 0xc3; // JP 0x0150
         rom[0x0101] = 0x50;
         rom[0x0102] = 0x01;
-        byte[] title = "CI SMOKE".getBytes(StandardCharsets.US_ASCII);
+        byte[] title = fixtureTitle.getBytes(StandardCharsets.US_ASCII);
         System.arraycopy(title, 0, rom, 0x0134, title.length);
+        rom[0x0143] = cgb ? (byte) 0x80 : 0x00;
         rom[0x0147] = 0x00; // ROM only
         rom[0x0148] = 0x00; // 32 KiB
         rom[0x0149] = 0x00; // no RAM

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -443,12 +443,12 @@ public class MainActivitySmokeTest {
                             + "$PendingDocumentResult");
                     java.lang.reflect.Constructor<?> constructor = type.getDeclaredConstructor(
                             eu.rekawek.coffeegb.android.menu.MenuExternalSurfaceState.Action.class,
-                            int.class, Uri.class, int.class);
+                            int.class, Uri.class, int.class, boolean.class);
                     constructor.setAccessible(true);
                     Object pending = constructor.newInstance(
                             eu.rekawek.coffeegb.android.menu.MenuExternalSurfaceState.Action
                                     .EXPORT_STATE_0,
-                            5, FixtureRomProvider.URI, 0x43);
+                            5, FixtureRomProvider.URI, 0x43, true);
                     Field field = MainActivity.class.getDeclaredField("pendingDocumentResult");
                     field.setAccessible(true);
                     field.set(activity, pending);
@@ -469,6 +469,7 @@ public class MainActivitySmokeTest {
                     assertEquals(FixtureRomProvider.URI,
                             recordValue(type, restored, "uri"));
                     assertEquals(0x43, recordValue(type, restored, "flags"));
+                    assertEquals(true, recordValue(type, restored, "releaseMenuPause"));
                 } catch (ReflectiveOperationException failure) {
                     throw new AssertionError(failure);
                 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -19,6 +19,8 @@ import eu.rekawek.coffeegb.controller.state.StateIdentity;
 import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateRef;
 import eu.rekawek.coffeegb.controller.state.StateRepository;
+import eu.rekawek.coffeegb.controller.state.StateResumeAvailableEvent;
+import eu.rekawek.coffeegb.controller.state.StateResumeDecisionEvent;
 import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent;
 import eu.rekawek.coffeegb.controller.state.StateOperation;
 import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent;
@@ -131,6 +133,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private AndroidRomPersistenceStore persistenceStore;
     private RomSourceSnapshot pendingSnapshot;
     private Uri pendingSource;
+    /** Carries pause ownership through a multi-entry archive chooser. */
+    private boolean pendingSnapshotReleasesMenuPause;
     private List<Uri> pendingRecents = List.of();
     private List<RecentSafDocuments.Entry> pendingRecentGames = List.of();
     private Uri currentSource;
@@ -641,11 +645,19 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     /** Resets only the active emulator session through its portable controller event. */
     public void reset() {
+        reset(false);
+    }
+
+    /** Resets after an in-screen menu action, releasing only the pause owned by that menu. */
+    void reset(boolean releaseMenuPause) {
         if (rejectBenchmarkMutation()) {
             return;
         }
         submit(() -> {
             if (controller != null && activeLayout != null) {
+                if (releaseMenuPause) {
+                    preparePlayingReplacement();
+                }
                 eventBus.post(new Controller.ResetEmulationEvent());
             }
         });
@@ -765,10 +777,15 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     /** Opens the user-selected SAF document; all metadata, archive and ROM work stays off-main. */
     public void openRom(Uri uri, int resultFlags) {
+        openRom(uri, resultFlags, false);
+    }
+
+    /** Opens a document selected from a menu that may own the current session's pause. */
+    void openRom(Uri uri, int resultFlags, boolean releaseMenuPause) {
         Uri checked = Objects.requireNonNull(uri, "uri");
         submit(() -> {
             retainReadPermission(checked, resultFlags);
-            openRom(checked);
+            openRom(checked, releaseMenuPause);
         });
     }
 
@@ -783,9 +800,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         List.of(), false, false, false);
                 return;
             }
+            boolean releaseMenuPause = pendingSnapshotReleasesMenuPause;
             pendingSnapshot = null;
             pendingSource = null;
-            activateSnapshot(snapshot, token, source);
+            pendingSnapshotReleasesMenuPause = false;
+            activateSnapshot(snapshot, token, source, releaseMenuPause);
         });
     }
 
@@ -836,7 +855,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     }
 
     /** Opens one opaque Recent Games token published by {@link #requestRecentGames(Consumer)}. */
-    void selectRecentGame(long token) {
+    void selectRecentGame(long token, boolean releaseMenuPause) {
         submit(() -> {
             if (token < 0 || token >= pendingRecentGames.size()) {
                 publish(RuntimeState.Phase.FAILED,
@@ -846,7 +865,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             }
             RecentSafDocuments.Entry entry = pendingRecentGames.get((int) token);
             pendingRecentGames = List.of();
-            openRecentGame(entry);
+            openRecentGame(entry, releaseMenuPause);
         });
     }
 
@@ -878,7 +897,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 publishBenchmarkScenarioInputFailure();
                 return;
             }
-            openRecentGame(recent);
+            openRecentGame(recent, false);
         });
     }
 
@@ -893,7 +912,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             }
             Uri uri = pendingRecents.get((int) token);
             pendingRecents = List.of();
-            openRom(uri);
+            openRom(uri, false);
         });
     }
 
@@ -1017,25 +1036,39 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             if (controller == null || activeLayout == null) {
                 return;
             }
-            AndroidAudioSink activeAudio = audio;
-            if (activeAudio != null) {
-                activeAudio.resume();
-            }
-            AndroidRumbleSink activeRumble = rumble;
-            if (activeRumble != null) {
-                activeRumble.resume();
-            }
-            AndroidTiltSink activeTilt = tilt;
-            if (activeTilt != null) {
-                activeTilt.resume();
-            }
-            AndroidCameraSource activeCamera = camera;
-            if (activeCamera != null) {
-                activeCamera.resume();
-            }
-            lifecycle.resumedByUser();
-            eventBus.post(new Controller.ResumeEmulationEvent());
+            resumeSession();
         });
+    }
+
+    /**
+     * Releases the controller and Android-output pause immediately before a replacement request.
+     * The controller queue orders this event before the following load/reset event, so the
+     * replacement inherits the user's intent to play.
+     */
+    private void preparePlayingReplacement() {
+        clearPauseMenuSnapshotInternal();
+        resumeSession();
+    }
+
+    private void resumeSession() {
+        AndroidAudioSink activeAudio = audio;
+        if (activeAudio != null) {
+            activeAudio.resume();
+        }
+        AndroidRumbleSink activeRumble = rumble;
+        if (activeRumble != null) {
+            activeRumble.resume();
+        }
+        AndroidTiltSink activeTilt = tilt;
+        if (activeTilt != null) {
+            activeTilt.resume();
+        }
+        AndroidCameraSource activeCamera = camera;
+        if (activeCamera != null) {
+            activeCamera.resume();
+        }
+        lifecycle.resumedByUser();
+        eventBus.post(new Controller.ResumeEmulationEvent());
     }
 
     /**
@@ -1677,6 +1710,16 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     }
                 }),
                 Controller.LoadRomFailedEvent.class);
+        // The desktop ASK policy emits a prompt before restoring a managed close autosave.
+        // Android does not expose that desktop prompt, so leaving the offer unanswered freezes
+        // the newly loaded game on its first (usually black) frame. Mobile sessions continue
+        // from their managed autosave automatically; Reset still opts out of resume scanning.
+        eventBus.register(
+                (StateResumeAvailableEvent event) -> {
+                    eventBus.post(new StateResumeDecisionEvent(
+                            event.getRequestId(), event.getSessionId(), true));
+                },
+                StateResumeAvailableEvent.class);
         eventBus.register(
                 (Controller.SessionPlaybackStateEvent event) -> submit(() -> {
                     if (activeLayout == null || state.phase() == RuntimeState.Phase.LOADING) {
@@ -1727,7 +1770,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         controller.startController();
     }
 
-    private void openRom(Uri uri) {
+    private void openRom(Uri uri, boolean releaseMenuPause) {
         persistCurrentRecentGame();
         clearPendingSource();
         frames.clear();
@@ -1740,11 +1783,12 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         snapshot.isArchive()
                                 ? snapshot.candidates().get(0).token()
                                 : RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN,
-                        uri);
+                        uri, releaseMenuPause);
                 return;
             }
             pendingSnapshot = snapshot;
             pendingSource = uri;
+            pendingSnapshotReleasesMenuPause = releaseMenuPause;
             List<RuntimeState.Selection> choices = snapshot.candidates().stream()
                     .map(candidate -> new RuntimeState.Selection(candidate.token(), candidate.displayName()))
                     .collect(Collectors.toList());
@@ -1761,7 +1805,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     }
 
     /** Reopens the exact game-level archive entry retained by the recent catalog. */
-    private void openRecentGame(RecentSafDocuments.Entry recent) {
+    private void openRecentGame(RecentSafDocuments.Entry recent, boolean releaseMenuPause) {
         persistCurrentRecentGame();
         clearPendingSource();
         publish(RuntimeState.Phase.OPENING, "Opening recent game…", List.of(),
@@ -1793,6 +1837,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     } else {
                         pendingSnapshot = snapshot;
                         pendingSource = recent.uri();
+                        pendingSnapshotReleasesMenuPause = releaseMenuPause;
                         List<RuntimeState.Selection> choices = snapshot.candidates().stream()
                                 .map(candidate -> new RuntimeState.Selection(candidate.token(),
                                         candidate.displayName()))
@@ -1817,7 +1862,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 }
                 token = resolved;
             }
-            activateSnapshot(snapshot, token, recent.uri(), recent);
+            activateSnapshot(snapshot, token, recent.uri(), recent, releaseMenuPause);
         } catch (Exception failure) {
             closeQuietly(snapshot);
             recentGameUnavailable(recent,
@@ -1825,12 +1870,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
-    private void activateSnapshot(RomSourceSnapshot snapshot, long token, Uri source) {
-        activateSnapshot(snapshot, token, source, null);
+    private void activateSnapshot(RomSourceSnapshot snapshot, long token, Uri source,
+            boolean releaseMenuPause) {
+        activateSnapshot(snapshot, token, source, null, releaseMenuPause);
     }
 
     private void activateSnapshot(RomSourceSnapshot snapshot, long token, Uri source,
-            RecentSafDocuments.Entry recent) {
+            RecentSafDocuments.Entry recent, boolean releaseMenuPause) {
         try {
             RomSourceSnapshot.ArchiveCandidate candidate = token
                     == RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN ? null
@@ -1888,6 +1934,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     || rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.POCKET_CAMERA);
             publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
                     false, true, false);
+            if (releaseMenuPause) {
+                preparePlayingReplacement();
+            }
             controllerEventBus().post(new Controller.LoadRomEvent(
                     image, null, persistenceStore, activeOpenRequestId, !diagnostics.enabled()));
         } catch (Exception failure) {
@@ -2259,6 +2308,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         RomSourceSnapshot snapshot = pendingSnapshot;
         pendingSnapshot = null;
         pendingSource = null;
+        pendingSnapshotReleasesMenuPause = false;
         pendingRecents = List.of();
         pendingRecentGames = List.of();
         closeQuietly(snapshot);

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomPersistenceStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomPersistenceStore.java
@@ -60,7 +60,7 @@ public final class AndroidRomPersistenceStore implements RomPersistenceStore {
 
     private BatteryStorage battery(StateStorageLayout layout) {
         return new BatteryStorage(
-                BatteryStorage.Source.managed(layout.getBatteryFile(), root),
+                BatteryStorage.Source.appPrivate(layout.getBatteryFile(), root),
                 java.util.List.of());
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -92,6 +92,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final String STATE_PENDING_REQUEST = "document.pending.request";
     private static final String STATE_PENDING_URI = "document.pending.uri";
     private static final String STATE_PENDING_FLAGS = "document.pending.flags";
+    private static final String STATE_PENDING_RELEASE_MENU_PAUSE =
+            "document.pending.release-menu-pause";
     private static final String STATE_OPTIONAL_STATUS = "status.optional-devices";
     private static final String STATE_PRINTER_STATUS = "status.printer";
     private static final String STATE_ABOUT_STATUS = "status.about";
@@ -434,6 +436,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             outState.putInt(STATE_PENDING_REQUEST, pendingDocumentResult.requestCode());
             outState.putString(STATE_PENDING_URI, pendingDocumentResult.uri().toString());
             outState.putInt(STATE_PENDING_FLAGS, pendingDocumentResult.flags());
+            outState.putBoolean(STATE_PENDING_RELEASE_MENU_PAUSE,
+                    pendingDocumentResult.releaseMenuPause());
         }
         super.onSaveInstanceState(outState);
     }
@@ -981,10 +985,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         if (token < 0 || recentGamesLoading) {
             return;
         }
+        boolean releaseMenuPause = menuPauseOwned;
         selectionActionInFlight = true;
         menuPauseOwned = false;
         menuController.hide();
-        active.selectRecentGame(token);
+        active.selectRecentGame(token, releaseMenuPause);
     }
 
     private void handleLibraryItem(String id) {
@@ -1436,8 +1441,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         switch (variant) {
             case RESET -> {
                 if (active != null) {
+                    boolean releaseMenuPause = menuPauseOwned;
                     closeMenuWithoutResume();
-                    active.reset();
+                    active.reset(releaseMenuPause);
                 }
             }
             case STOP -> {
@@ -1747,13 +1753,14 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         Uri uri = data == null ? null : data.getData();
         boolean successful = resultCode == RESULT_OK && uri != null;
         MenuExternalSurfaceState.Action action = externalSurface.action();
+        boolean releaseMenuPause = externalSurface.pauseOwned();
         externalSurface = externalSurface.afterResult(successful);
         if (!successful) {
             restoreExternalSurfaceIfRequested();
             return;
         }
         PendingDocumentResult result = new PendingDocumentResult(
-                action, requestCode, uri, data.getFlags());
+                action, requestCode, uri, data.getFlags(), releaseMenuPause);
         if (runtime == null) {
             pendingDocumentResult = result;
             return;
@@ -1866,7 +1873,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             return;
         }
         switch (result.action()) {
-            case OPEN_ROM -> active.openRom(result.uri(), result.flags());
+            case OPEN_ROM -> active.openRom(
+                    result.uri(), result.flags(), result.releaseMenuPause());
             case IMPORT_BATTERY -> active.importBattery(result.uri());
             case EXPORT_BATTERY -> active.exportBattery(result.uri());
             case IMPORT_STATE_0 -> active.importState(result.uri());
@@ -2715,7 +2723,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 pendingDocumentResult = new PendingDocumentResult(
                         MenuExternalSurfaceState.Action.valueOf(pendingAction),
                         state.getInt(STATE_PENDING_REQUEST, -1), Uri.parse(pendingUri),
-                        state.getInt(STATE_PENDING_FLAGS));
+                        state.getInt(STATE_PENDING_FLAGS),
+                        state.getBoolean(STATE_PENDING_RELEASE_MENU_PAUSE));
             } catch (IllegalArgumentException ignored) {
                 pendingDocumentResult = null;
             }
@@ -2930,7 +2939,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private record PendingDocumentResult(MenuExternalSurfaceState.Action action, int requestCode,
-                                         Uri uri, int flags) {
+                                         Uri uri, int flags, boolean releaseMenuPause) {
     }
 
     private enum StateMenuMode {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -22,6 +22,7 @@ import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
 import eu.rekawek.coffeegb.controller.state.DetachedStateAdapter
 import eu.rekawek.coffeegb.controller.state.ExclusiveWriteRecovery
 import eu.rekawek.coffeegb.controller.state.ResolvedBatteryStorage
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore
 import eu.rekawek.coffeegb.controller.state.StateCatalogReadyEvent
 import eu.rekawek.coffeegb.controller.state.StateCatalogRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateCompression
@@ -413,6 +414,9 @@ class BasicController private constructor(
   private var stateContext: StateWorkerContext? = null
 
   private var currentRomHashes: StateRomHashes? = null
+
+  /** Host persistence identity follows the committed session across reset/profile reloads. */
+  private var currentPersistenceStore: RomPersistenceStore? = null
 
   private var stateSessionId = 0L
 
@@ -809,7 +813,11 @@ class BasicController private constructor(
       session?.config?.rom?.image?.let {
         requestLoad(
             properties,
-            Controller.LoadRomEvent(it, allowAutosaveResume = false),
+            Controller.LoadRomEvent(
+                it,
+                persistenceStore = currentPersistenceStore,
+                allowAutosaveResume = false,
+            ),
             clearPatches = false,
         )
       }
@@ -855,7 +863,11 @@ class BasicController private constructor(
         if (newProfile != config.hardwareProfile ||
             newBootstrapMode != config.bootstrapMode ||
             newExecutionMode != config.executionMode) {
-          eventBus.post(Controller.LoadRomEvent(config.rom.image))
+          eventBus.post(
+              Controller.LoadRomEvent(
+                  config.rom.image,
+                  persistenceStore = currentPersistenceStore,
+              ))
         }
       }
     }
@@ -3614,6 +3626,7 @@ class BasicController private constructor(
     session = committedSession
     commitMobileAdapterAttachment(committedSession)
     currentRomHashes = job.prepared.romHashes
+    currentPersistenceStore = job.event.persistenceStore
     snapshotManager = nextSnapshotManager
     nextSession = null
     nextSnapshotManager = null
@@ -4771,6 +4784,7 @@ class BasicController private constructor(
     console?.setDebugPort(null)
     this.session = null
     currentRomHashes = null
+    currentPersistenceStore = null
     snapshotManager = null
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -11,7 +11,12 @@ import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides
 import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
+import eu.rekawek.coffeegb.controller.state.FileStateStore
+import eu.rekawek.coffeegb.controller.state.RomPersistenceStore
+import eu.rekawek.coffeegb.controller.state.SessionPersistence
 import eu.rekawek.coffeegb.controller.state.StateCodec
+import eu.rekawek.coffeegb.controller.state.StateStorageLayout
+import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.ExecutionMode
@@ -774,6 +779,85 @@ class BasicControllerTest {
       controller.close()
       eventBus.close()
       sgbRom.delete()
+    }
+  }
+
+  @Test
+  fun hostPersistenceStoreSurvivesPathlessProfileReloadsAndReset() {
+    val directory = Files.createTempDirectory("coffee-gb-host-persistence-reload")
+    val eventBus = EventBusImpl()
+    val properties = testProperties()
+    val profileEvents = LinkedBlockingQueue<HardwareProfileEvent>()
+    val stateSessions = LinkedBlockingQueue<StateUxSessionEvent>()
+    val failures = LinkedBlockingQueue<LoadRomFailedEvent>()
+    eventBus.register<HardwareProfileEvent>(profileEvents::add)
+    eventBus.register<StateUxSessionEvent>(stateSessions::add)
+    eventBus.register<LoadRomFailedEvent>(failures::add)
+    val image =
+        RomImage.memory(
+            ROM.readBytes().also { bytes ->
+              bytes[0x143] = 0
+              bytes[0x146] = 0x03
+            },
+            "pathless-profile-reload.gb",
+        )
+    properties.properties[EmulatorProperties.Key.DmgGamesType.propertyName] =
+        HardwareProfileRegistry.SGB.id()
+    val resolveCalls = AtomicInteger()
+    val layout = StateStorageLayout(directory.resolve("games").resolve("pathless"))
+    val persistenceStore =
+        RomPersistenceStore { _, _ ->
+          resolveCalls.incrementAndGet()
+          SessionPersistence(FileStateStore(layout), null, null)
+        }
+    val controller = BasicController(eventBus, properties, null)
+
+    controller.startController()
+    try {
+      eventBus.post(
+          LoadRomEvent(
+              image,
+              persistenceStore = persistenceStore,
+              allowAutosaveResume = false,
+          ))
+      assertEquals(
+          HardwareProfileRegistry.SGB,
+          assertNotNull(profileEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).profile,
+      )
+      assertTrue(assertNotNull(stateSessions.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).available)
+
+      properties.properties[EmulatorProperties.Key.DmgGamesType.propertyName] =
+          HardwareProfileRegistry.DMG.id()
+      eventBus.post(Controller.UpdatedSystemMappingEvent())
+      assertEquals(
+          HardwareProfileRegistry.DMG,
+          assertNotNull(profileEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).profile,
+      )
+      assertTrue(assertNotNull(stateSessions.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).available)
+
+      properties.properties[EmulatorProperties.Key.DmgGamesType.propertyName] =
+          HardwareProfileRegistry.SGB2.id()
+      eventBus.post(Controller.UpdatedSystemMappingEvent())
+      assertEquals(
+          HardwareProfileRegistry.SGB2,
+          assertNotNull(profileEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).profile,
+      )
+      assertTrue(assertNotNull(stateSessions.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).available)
+
+      eventBus.post(Controller.ResetEmulationEvent())
+      assertEquals(
+          HardwareProfileRegistry.SGB2,
+          assertNotNull(profileEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).profile,
+      )
+      assertTrue(assertNotNull(stateSessions.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS)).available)
+
+      assertEquals(4, resolveCalls.get())
+      assertNull(failures.poll(250, TimeUnit.MILLISECONDS))
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      deleteTree(directory)
     }
   }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/BatteryStorage.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/battery/BatteryStorage.java
@@ -167,21 +167,38 @@ public final class BatteryStorage {
 
         private final Path managedRoot;
 
-        private Source(Path path, Path managedRoot) {
+        private final boolean trustedManagedRootAncestors;
+
+        private Source(Path path, Path managedRoot, boolean trustedManagedRootAncestors) {
             this.path = normalizeFile(path);
             this.managedRoot =
                     managedRoot == null ? null : normalizeDirectory(managedRoot, "managedRoot");
+            this.trustedManagedRootAncestors = trustedManagedRootAncestors;
             if (this.managedRoot != null && !this.path.startsWith(this.managedRoot)) {
                 throw new IllegalArgumentException("Battery path escapes its managed root");
             }
         }
 
         public static Source direct(Path path) {
-            return new Source(path, null);
+            return new Source(path, null, false);
         }
 
         public static Source managed(Path path, Path managedRoot) {
-            return new Source(path, Objects.requireNonNull(managedRoot, "managedRoot"));
+            return new Source(path, Objects.requireNonNull(managedRoot, "managedRoot"), false);
+        }
+
+        /**
+         * Constrains a target below a platform-created app-private directory.
+         *
+         * <p>Android deliberately allows an app to traverse its own package directory while
+         * denying metadata access to shared ancestors such as {@code /data/user/0}. The ordinary
+         * managed source validates every ancestor from the filesystem root and therefore cannot
+         * distinguish that policy from an unsafe path. This variant treats only the supplied
+         * managed root's ancestors as platform-trusted; the root itself and every existing
+         * component below it are still checked without following symbolic links.
+         */
+        public static Source appPrivate(Path path, Path managedRoot) {
+            return new Source(path, Objects.requireNonNull(managedRoot, "managedRoot"), true);
         }
 
         public Path path() {
@@ -231,11 +248,15 @@ public final class BatteryStorage {
             if (root == null) {
                 throw new IOException("Managed battery root must be absolute");
             }
-            requireDirectory(root, "Filesystem root");
-            Path rootCursor = root;
-            for (Path component : managedRoot) {
-                rootCursor = rootCursor.resolve(component);
-                requireDirectory(rootCursor, "Battery root component");
+            if (trustedManagedRootAncestors) {
+                requireDirectory(managedRoot, "App-private battery root");
+            } else {
+                requireDirectory(root, "Filesystem root");
+                Path rootCursor = root;
+                for (Path component : managedRoot) {
+                    rootCursor = rootCursor.resolve(component);
+                    requireDirectory(rootCursor, "Battery root component");
+                }
             }
 
             Path parent = path.getParent();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBatteryTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/battery/FileBatteryTest.java
@@ -384,6 +384,48 @@ public class FileBatteryTest {
     }
 
     @Test
+    public void appPrivateTargetWritesBelowItsValidatedManagedRoot() throws Exception {
+        withDirectory(directory -> {
+            Path appPrivateRoot = Files.createDirectory(directory.resolve("app-private"));
+            Path target = appPrivateRoot.resolve("games").resolve("identity").resolve("battery.sav");
+            FileBattery battery = new FileBattery(
+                    new BatteryStorage(
+                            BatteryStorage.Source.appPrivate(target, appPrivateRoot), List.of()),
+                    4);
+            battery.saveRam(new int[] {1, 2, 3, 4});
+
+            BatteryPersistenceResult result = battery.prepareFlush(() -> { }).persist();
+
+            assertTrue(result instanceof BatteryPersistenceResult.Success);
+            assertArrayEquals(new byte[] {1, 2, 3, 4}, Files.readAllBytes(target));
+        });
+    }
+
+    @Test
+    public void appPrivateTargetStillRefusesASymlinkManagedRoot() throws Exception {
+        withDirectory(directory -> {
+            Path actualRoot = Files.createDirectory(directory.resolve("actual"));
+            Path linkedRoot = directory.resolve("app-private-link");
+            try {
+                Files.createSymbolicLink(linkedRoot, actualRoot);
+            } catch (IOException | UnsupportedOperationException unsupported) {
+                return;
+            }
+            Path target = linkedRoot.resolve("battery.sav");
+            FileBattery battery = new FileBattery(
+                    new BatteryStorage(
+                            BatteryStorage.Source.appPrivate(target, linkedRoot), List.of()),
+                    4);
+            battery.saveRam(new int[] {1, 2, 3, 4});
+
+            BatteryPersistenceResult result = battery.prepareFlush(() -> { }).persist();
+
+            assertTrue(result instanceof BatteryPersistenceResult.Failure);
+            assertFalse(Files.exists(actualRoot.resolve("battery.sav")));
+        });
+    }
+
+    @Test
     public void newerPreviousDestinationReplacesStaleActiveTargetWithoutDeletingEitherGeneration()
             throws Exception {
         withDirectory(directory -> {


### PR DESCRIPTION
## Summary
- preserve the Android host persistence store across hardware profile reloads and reset
- transfer menu-owned pause state when replacing a game and automatically accept managed autosave resumes
- support app-private battery storage and keep reflected state names stable in minified release builds
- add controller, storage, and Android device regressions for ROM switching and persistence

## Testing
- `/opt/maven/bin/mvn -pl core,controller -am test` (939 tests, 0 failures, 2 skipped)
- physical Android device: generated DMG to CGB replacement, reset, and app-private battery persistence smoke tests
- physical Android device: Super Mario Land to Super Mario Bros. Deluxe via Recent Games; back via Open ROM; Reset; Auto to DMG profile change without restart
- `ANDROID_HOME=/opt/android-sdk ./gradlew -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:assembleRelease`