### PR TITLE
Accelerate Android DMG compatibility and SGB performance

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -201,10 +201,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     static ApplicationSettingsOverrides androidSettingsOverrides(DiagnosticsOptions options) {
         DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
         HardwareProfile profile = checked.enabled ? checked.hardware.profileOverride() : null;
-        // Benchmark sessions must not inherit NORMAL boot from user settings: the profile event
-        // is emitted at session materialization and needs the actual post-boot KEY0/GPU mode.
+        // Benchmark sessions use their transiently requested bootstrap mode: the profile event
+        // is emitted only after the actual post-boot KEY0/GPU mode has been reached.
         // Release/non-diagnostic callers retain the ordinary settings path unchanged.
-        BootstrapMode bootstrapMode = checked.enabled ? BootstrapMode.SKIP : null;
+        BootstrapMode bootstrapMode = checked.enabled ? checked.bootstrapMode : null;
         return new ApplicationSettingsOverrides(profile, bootstrapMode,
                 checked.enabled ? false : null, false, false, false,
                 checked.enabled && checked.runtimeWarmup, runtimeWarmupFlavor(checked), checked.enabled,

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/DiagnosticsOptions.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.android;
 import android.content.Intent;
 
 import eu.rekawek.coffeegb.core.ExecutionMode;
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.sound.Sound;
@@ -48,6 +49,8 @@ final class DiagnosticsOptions {
     static final String EXTRA_BENCHMARK_ARM_TOKEN = "coffee_gb_benchmark_arm_token";
     /** Session execution strategy; Accuracy is the compatibility-safe default. */
     static final String EXTRA_EXECUTION_MODE = "coffee_gb_execution_mode";
+    /** Benchmark-only BIOS bootstrap strategy; skip is the compatibility-safe default. */
+    static final String EXTRA_BOOTSTRAP = "coffee_gb_bootstrap";
     /** Benchmark-only deterministic gameplay preconditioning contract. */
     static final String EXTRA_BENCHMARK_SCENARIO = "coffee_gb_benchmark_scenario";
     /** Host-audio evidence policy; canonical is the compatibility-safe default. */
@@ -267,7 +270,8 @@ final class DiagnosticsOptions {
             false, Hardware.AUTO, true, Render.PRESENTATION, false, false,
             "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN, RunSide.UNKNOWN,
             UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-            ExecutionMode.ACCURACY, BenchmarkScenario.NONE, AudioPolicy.CANONICAL);
+            ExecutionMode.ACCURACY, BootstrapMode.SKIP, BenchmarkScenario.NONE,
+            AudioPolicy.CANONICAL);
 
     final boolean enabled;
     final Hardware hardware;
@@ -293,6 +297,8 @@ final class DiagnosticsOptions {
     final int recentSlot;
     /** Core-owned session strategy. This is not persisted in a save state. */
     final ExecutionMode executionMode;
+    /** Benchmark-only BIOS bootstrap strategy; ordinary launches do not use this field. */
+    final BootstrapMode bootstrapMode;
     /** Deterministic benchmark-only input contract; never persisted or exposed to release UI. */
     final BenchmarkScenario benchmarkScenario;
     /** Explicit host-audio evidence policy; never persisted or exposed to release UI. */
@@ -303,7 +309,8 @@ final class DiagnosticsOptions {
             String pairId, String matrixBlock, int rowOrder, RunSide runSide,
             RunSide firstSide, String deviceBuild, String thermalWindow, boolean thermalValid,
             String workloadNonce, int displayTargetHz, int recentSlot, ExecutionMode executionMode,
-            BenchmarkScenario benchmarkScenario, AudioPolicy audioPolicy) {
+            BootstrapMode bootstrapMode, BenchmarkScenario benchmarkScenario,
+            AudioPolicy audioPolicy) {
         this.enabled = enabled;
         this.hardware = hardware;
         this.audioOutput = audioOutput;
@@ -324,6 +331,7 @@ final class DiagnosticsOptions {
         this.surfaceContentRateMillihz = contentRateMillihz(hardware);
         this.recentSlot = recentSlot >= 0 && recentSlot < 10 ? recentSlot : -1;
         this.executionMode = executionMode == null ? ExecutionMode.ACCURACY : executionMode;
+        this.bootstrapMode = bootstrapMode == null ? BootstrapMode.SKIP : bootstrapMode;
         this.benchmarkScenario = enabled && benchmarkScenario != null
                 ? benchmarkScenario : BenchmarkScenario.NONE;
         AudioPolicy requestedPolicy = audioPolicy == null ? AudioPolicy.CANONICAL : audioPolicy;
@@ -360,7 +368,7 @@ final class DiagnosticsOptions {
         return new DiagnosticsOptions(false, Hardware.AUTO, true, Render.PRESENTATION, false,
                 false, "disabled", UNKNOWN_TOKEN, UNKNOWN_TOKEN, -1, RunSide.UNKNOWN,
                 RunSide.UNKNOWN, UNKNOWN_TOKEN, UNKNOWN_TOKEN, false, UNKNOWN_TOKEN, -1, -1,
-                selected, BenchmarkScenario.NONE, AudioPolicy.CANONICAL);
+                selected, BootstrapMode.SKIP, BenchmarkScenario.NONE, AudioPolicy.CANONICAL);
     }
 
     static ExecutionMode parseExecutionMode(String value) {
@@ -370,6 +378,29 @@ final class DiagnosticsOptions {
 
     static String executionModeValue(ExecutionMode mode) {
         return mode == ExecutionMode.PERFORMANCE ? "performance" : "accuracy";
+    }
+
+    static BootstrapMode parseBootstrapMode(String value) {
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        if ("fast-forward".equals(normalized) || "fast_forward".equals(normalized)
+                || "fastforward".equals(normalized) || "ff".equals(normalized)) {
+            return BootstrapMode.FAST_FORWARD;
+        }
+        if ("full".equals(normalized) || "normal".equals(normalized)
+                || "authentic".equals(normalized)) {
+            return BootstrapMode.NORMAL;
+        }
+        return BootstrapMode.SKIP;
+    }
+
+    static String bootstrapModeValue(BootstrapMode mode) {
+        if (mode == BootstrapMode.FAST_FORWARD) {
+            return "fast-forward";
+        }
+        if (mode == BootstrapMode.NORMAL) {
+            return "normal";
+        }
+        return "skip";
     }
 
     private static int contentRateMillihz(Hardware hardware) {
@@ -426,7 +457,8 @@ final class DiagnosticsOptions {
                 intExtra(intent, EXTRA_RECENT_SLOT, -1),
                 stringExtra(intent, EXTRA_EXECUTION_MODE),
                 stringExtra(intent, EXTRA_BENCHMARK_SCENARIO),
-                stringExtra(intent, EXTRA_AUDIO_POLICY));
+                stringExtra(intent, EXTRA_AUDIO_POLICY),
+                stringExtra(intent, EXTRA_BOOTSTRAP));
     }
 
     static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
@@ -508,6 +540,19 @@ final class DiagnosticsOptions {
             String runSide, String firstSide, String deviceBuild, String thermalWindow,
             boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
             String executionModeValue, String benchmarkScenarioValue, String audioPolicyValue) {
+        return parseValues(diagnosticsEnabled, hardwareValue, audioValue, renderValue, warmup,
+                recent, frameSink, buildId, pairId, matrixBlock, rowOrder, runSide, firstSide,
+                deviceBuild, thermalWindow, thermalValid, workloadNonce, displayTargetHz,
+                recentSlot, executionModeValue, benchmarkScenarioValue, audioPolicyValue, null);
+    }
+
+    static DiagnosticsOptions parseValues(boolean diagnosticsEnabled, String hardwareValue,
+            Object audioValue, String renderValue, boolean warmup, boolean recent,
+            boolean frameSink, String buildId, String pairId, String matrixBlock, int rowOrder,
+            String runSide, String firstSide, String deviceBuild, String thermalWindow,
+            boolean thermalValid, String workloadNonce, int displayTargetHz, int recentSlot,
+            String executionModeValue, String benchmarkScenarioValue, String audioPolicyValue,
+            String bootstrapModeValue) {
         if (!diagnosticsEnabled) {
             return disabled(parseExecutionMode(executionModeValue));
         }
@@ -526,6 +571,7 @@ final class DiagnosticsOptions {
                 safeToken(deviceBuild, UNKNOWN_TOKEN), safeToken(thermalWindow, UNKNOWN_TOKEN),
                 thermalValid, safeToken(workloadNonce, UNKNOWN_TOKEN), rate, recentSlot,
                 parseExecutionMode(executionModeValue),
+                parseBootstrapMode(bootstrapModeValue),
                 BenchmarkScenario.fromExternalValue(benchmarkScenarioValue),
                 AudioPolicy.fromExternalValue(audioPolicyValue));
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -66,6 +66,11 @@ public final class EmulationService extends Service implements AudioManager.OnAu
         return checked.audioPolicy.externalValue();
     }
 
+    static String bootstrapModeExtraValue(DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return DiagnosticsOptions.bootstrapModeValue(checked.bootstrapMode);
+    }
+
     private static Intent populateStartIntent(Intent intent, DiagnosticsOptions checked) {
         nextStartOptions = checked;
         return intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK, checked.enabled)
@@ -90,6 +95,8 @@ public final class EmulationService extends Service implements AudioManager.OnAu
                 .putExtra(DiagnosticsOptions.EXTRA_RECENT_SLOT, checked.recentSlot)
                 .putExtra(DiagnosticsOptions.EXTRA_EXECUTION_MODE,
                         DiagnosticsOptions.executionModeValue(checked.executionMode))
+                .putExtra(DiagnosticsOptions.EXTRA_BOOTSTRAP,
+                        bootstrapModeExtraValue(checked))
                 .putExtra(DiagnosticsOptions.EXTRA_BENCHMARK_SCENARIO,
                         benchmarkScenarioExtraValue(checked))
                 .putExtra(DiagnosticsOptions.EXTRA_AUDIO_POLICY,

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/NativeFrameStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/NativeFrameStore.java
@@ -26,6 +26,10 @@ final class NativeFrameStore implements AutoCloseable {
     static final int MAX_WIDTH = SuperGameboy.SGB_DISPLAY_WIDTH;
     static final int MAX_HEIGHT = SuperGameboy.SGB_DISPLAY_HEIGHT;
     private static final int SLOT_COUNT = 3;
+    private static final int SLOT_INDEX_BITS = 2;
+    private static final long SLOT_INDEX_MASK = (1L << SLOT_INDEX_BITS) - 1L;
+    private static final long MAX_RESERVATION_TOKEN =
+            Long.MAX_VALUE >>> SLOT_INDEX_BITS;
 
     interface Listener {
         /** Signals availability only; consumers must call {@link #takeLatest()} themselves. */
@@ -45,6 +49,8 @@ final class NativeFrameStore implements AutoCloseable {
     private final LongConsumer benchmarkBoundary;
 
     private long nextSequence;
+    private long nextReservationToken;
+    private long reservationGeneration;
     private long droppedFrames;
     private long benchmarkEpoch;
     private volatile boolean grayscale;
@@ -64,7 +70,7 @@ final class NativeFrameStore implements AutoCloseable {
         this.diagnostics = diagnostics;
         this.benchmarkBoundary = benchmarkBoundary;
         for (int index = 0; index < slots.length; index++) {
-            slots[index] = new Slot();
+            slots[index] = new Slot(index);
         }
     }
 
@@ -97,17 +103,18 @@ final class NativeFrameStore implements AutoCloseable {
         if (BuildConfig.DIAGNOSTICS_ENABLED && diagnostics != null && diagnostics.frameSink()) {
             return;
         }
-        Slot slot = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
-        if (slot == null) {
+        long claim = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+        if (claim == 0L) {
             return;
         }
+        Slot slot = slotForClaim(claim);
         int[] palette = grayscale ? Display.DmgFrameReadyEvent.COLORS_GRAYSCALE
                 : Display.DmgFrameReadyEvent.COLORS;
         int[] source = event.pixels();
         for (int index = 0; index < source.length; index++) {
             slot.pixels[index] = palette[source[index]] | 0xff000000;
         }
-        publish(slot);
+        publish(claim);
     }
 
     void publish(Display.GbcFrameReadyEvent event) {
@@ -117,16 +124,17 @@ final class NativeFrameStore implements AutoCloseable {
         if (BuildConfig.DIAGNOSTICS_ENABLED && diagnostics != null && diagnostics.frameSink()) {
             return;
         }
-        Slot slot = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
-        if (slot == null) {
+        long claim = reserve(Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+        if (claim == 0L) {
             return;
         }
+        Slot slot = slotForClaim(claim);
         int[] source = event.pixels();
         for (int index = 0; index < source.length; index++) {
             slot.pixels[index] = Display.GbcFrameReadyEvent.translateGbcRgb(source[index])
                     | 0xff000000;
         }
-        publish(slot);
+        publish(claim);
     }
 
     /** Applies the Android DMG palette choice to future native frames. */
@@ -153,13 +161,27 @@ final class NativeFrameStore implements AutoCloseable {
         }
         int width = event.includeBorder() ? SuperGameboy.SGB_DISPLAY_WIDTH : Display.DISPLAY_WIDTH;
         int height = event.includeBorder() ? SuperGameboy.SGB_DISPLAY_HEIGHT : Display.DISPLAY_HEIGHT;
-        Slot slot = reserve(width, height);
-        if (slot == null) {
+        long claim = reserve(width, height);
+        if (claim == 0L) {
             return;
         }
-        event.toRgb(slot.pixels, false);
-        makeOpaque(slot.pixels, Math.multiplyExact(width, height));
-        publish(slot);
+        Slot slot = slotForClaim(claim);
+        try {
+            int expectedLength = Math.multiplyExact(width, height);
+            int[] source = event.buffer();
+            if (source == null || source.length != expectedLength) {
+                throw new IllegalArgumentException(
+                        "SGB frame pixel count must be exactly " + expectedLength);
+            }
+            // SgbFrameReadyEvent is callback-scoped; fuse RGB copying and alpha insertion while
+            // the producer still owns the source. A failed conversion must not strand the slot in
+            // WRITING, otherwise one malformed callback permanently reduces the three-slot pool.
+            event.copyToOpaqueArgb(slot.pixels);
+        } catch (RuntimeException | Error failure) {
+            abortWriting(claim);
+            throw failure;
+        }
+        publish(claim);
     }
 
     /**
@@ -223,6 +245,7 @@ final class NativeFrameStore implements AutoCloseable {
         // openRom() clears the presentation before it knows whether the old session will actually
         // be replaced; a failed/rejected load must not let that still-active SGB session publish
         // its raw DMG transfer input. The next HardwareProfileEvent overwrites this gate.
+        reservationGeneration++;
         nextSequence++;
         for (Slot slot : slots) {
             if (slot.state == SlotState.PUBLISHED) {
@@ -246,11 +269,17 @@ final class NativeFrameStore implements AutoCloseable {
             throw new IllegalArgumentException("Benchmark generation must be positive");
         }
         benchmarkEpoch = generation;
+        reservationGeneration++;
         nextSequence = 0L;
         for (Slot slot : slots) {
-            slot.state = SlotState.FREE;
-            slot.presentationConsumed = false;
-            slot.epoch = generation;
+            // A producer may still be converting a callback-scoped frame outside this lock.
+            // Keep its WRITING claim until that owner publishes or aborts; reusing its pixels
+            // here would let the old conversion corrupt a newer reservation.
+            if (slot.state != SlotState.WRITING) {
+                slot.state = SlotState.FREE;
+                slot.presentationConsumed = false;
+                slot.epoch = generation;
+            }
         }
         // The anchor renderer is quiescent at this boundary. Do not wake it with a synthetic
         // null draw: the first real measured publication must schedule the renderer callback,
@@ -318,7 +347,12 @@ final class NativeFrameStore implements AutoCloseable {
         closed = true;
         listeners.clear();
         for (Slot slot : slots) {
-            slot.state = SlotState.FREE;
+            // Leave WRITING claims owned until their conversion returns. No future reservation
+            // can observe a closed store, and releasing the claim here could race a new writer in
+            // a concurrently reused store instance.
+            if (slot.state != SlotState.WRITING) {
+                slot.state = SlotState.FREE;
+            }
         }
     }
 
@@ -331,10 +365,10 @@ final class NativeFrameStore implements AutoCloseable {
         return false;
     }
 
-    private synchronized Slot reserve(int width, int height) {
+    private synchronized long reserve(int width, int height) {
         if (closed || width < 1 || height < 1 || width > MAX_WIDTH || height > MAX_HEIGHT) {
             recordDroppedFrame();
-            return null;
+            return 0L;
         }
         Slot chosen = null;
         for (Slot slot : slots) {
@@ -355,7 +389,7 @@ final class NativeFrameStore implements AutoCloseable {
             // Rendering owns every fixed buffer. Dropping one arriving frame is preferable to
             // blocking the controller thread or allocating a fourth frame.
             recordDroppedFrame();
-            return null;
+            return 0L;
         }
         if (chosen.state == SlotState.PUBLISHED) {
             // Reusing a published slot discards that frame before presentation. Count it here;
@@ -365,16 +399,32 @@ final class NativeFrameStore implements AutoCloseable {
             }
             chosen.presentationConsumed = false;
         }
+        long token = nextReservationToken + 1L;
+        if (token <= 0L || token > MAX_RESERVATION_TOKEN) {
+            token = 1L;
+        }
+        nextReservationToken = token;
+        long claim = (token << SLOT_INDEX_BITS) | chosen.index;
         chosen.state = SlotState.WRITING;
         chosen.width = width;
         chosen.height = height;
         chosen.epoch = benchmarkEpoch;
-        return chosen;
+        chosen.reservationClaim = claim;
+        chosen.reservationGeneration = reservationGeneration;
+        return claim;
     }
 
-    private void publish(Slot slot) {
+    private void publish(long claim) {
+        Slot slot = slotForClaim(claim);
         synchronized (this) {
-            if (closed || slot.state != SlotState.WRITING) {
+            boolean owner = slot.state == SlotState.WRITING
+                    && slot.reservationClaim == claim;
+            boolean current = owner && slot.reservationGeneration == reservationGeneration;
+            if (closed || !current) {
+                if (owner) {
+                    slot.state = SlotState.FREE;
+                    slot.presentationConsumed = false;
+                }
                 recordDroppedFrame();
                 return;
             }
@@ -383,6 +433,19 @@ final class NativeFrameStore implements AutoCloseable {
             slot.state = SlotState.PUBLISHED;
         }
         notifyListeners();
+    }
+
+    private synchronized void abortWriting(long claim) {
+        Slot slot = slotForClaim(claim);
+        if (slot.state == SlotState.WRITING
+                && slot.reservationClaim == claim) {
+            slot.state = SlotState.FREE;
+            slot.presentationConsumed = false;
+        }
+    }
+
+    private Slot slotForClaim(long claim) {
+        return slots[(int) (claim & SLOT_INDEX_MASK)];
     }
 
     private void notifyListeners() {
@@ -405,12 +468,6 @@ final class NativeFrameStore implements AutoCloseable {
         boolean boundary = diagnostics.frameReady();
         if (boundary && benchmarkBoundary != null) {
             benchmarkBoundary.accept(diagnostics.benchmarkGeneration());
-        }
-    }
-
-    private static void makeOpaque(int[] pixels, int length) {
-        for (int index = 0; index < length; index++) {
-            pixels[index] |= 0xff000000;
         }
     }
 
@@ -472,13 +529,21 @@ final class NativeFrameStore implements AutoCloseable {
     }
 
     private static final class Slot {
+        private final int index;
         private final int[] pixels = new int[MAX_WIDTH * MAX_HEIGHT];
         private SlotState state = SlotState.FREE;
         private int width;
         private int height;
         private long sequence;
         private long epoch;
+        private long reservationClaim;
+        private long reservationGeneration;
         /** True once the renderer has consumed this published frame; prevents double drop counts. */
         private boolean presentationConsumed;
+
+        private Slot(int index) {
+            this.index = index;
+        }
     }
+
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
@@ -237,6 +237,19 @@ public class AndroidEmulationRuntimeTest {
     }
 
     @Test
+    public void benchmarkBootstrapModeReachesControllerSessionOverrides() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null, "normal");
+        try (EmulatorProperties properties = new EmulatorProperties(
+                AndroidEmulationRuntime.androidSettingsOverrides(options))) {
+            assertEquals(BootstrapMode.NORMAL,
+                    properties.getOverrides().getBootstrapMode());
+        }
+    }
+
+    @Test
     public void shadowMeasuredWarmupSelectorIsOnlyNativeCgbPerformanceSilentScenario() {
         DiagnosticsOptions eligible = DiagnosticsOptions.parseValues(
                 true, "cgb", true, "presentation", true, true, false,

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/DiagnosticsOptionsTest.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.android;
 
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.ExecutionMode;
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode;
 
 import org.junit.Test;
 
@@ -64,7 +65,31 @@ public class DiagnosticsOptionsTest {
         assertTrue(options.runtimeWarmup);
         assertFalse(options.launchRecent);
         assertEquals(ExecutionMode.ACCURACY, options.executionMode);
+        assertEquals(BootstrapMode.SKIP, options.bootstrapMode);
         assertEquals(DiagnosticsOptions.BenchmarkScenario.NONE, options.benchmarkScenario);
+    }
+
+    @Test
+    public void bootstrapModeAcceptsFastForwardAndFullWithSkipFallback() {
+        DiagnosticsOptions fastForward = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null, "fast-forward");
+        DiagnosticsOptions normal = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null, "full");
+        DiagnosticsOptions malformed = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", false, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null, "turbo");
+
+        assertEquals(BootstrapMode.FAST_FORWARD, fastForward.bootstrapMode);
+        assertEquals(BootstrapMode.NORMAL, normal.bootstrapMode);
+        assertEquals(BootstrapMode.SKIP, malformed.bootstrapMode);
+        assertEquals("fast-forward", DiagnosticsOptions.bootstrapModeValue(fastForward.bootstrapMode));
+        assertEquals("normal", DiagnosticsOptions.bootstrapModeValue(normal.bootstrapMode));
+        assertEquals("skip", DiagnosticsOptions.bootstrapModeValue(malformed.bootstrapMode));
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
@@ -25,4 +25,14 @@ public class EmulationServiceTest {
 
         assertEquals("silent-pcm-v1", EmulationService.audioPolicyExtraValue(options));
     }
+
+    @Test
+    public void startWireForwardsRequestedBootstrapMode() {
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null, "full");
+
+        assertEquals("normal", EmulationService.bootstrapModeExtraValue(options));
+    }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/NativeFrameStoreTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/NativeFrameStoreTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class NativeFrameStoreTest {
 
@@ -162,6 +164,84 @@ public class NativeFrameStoreTest {
     }
 
     @Test
+    public void malformedSgbLengthAbortsWritingSlotAndReclaimsPrimarySlot() {
+        NativeFrameStore store = new NativeFrameStore();
+        try {
+            int expected = Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT;
+            assertThrows(IllegalArgumentException.class,
+                    () -> store.publish(new SgbDisplay.SgbFrameReadyEvent(
+                            new int[expected - 1], false)));
+
+            int[] valid = new int[expected];
+            valid[0] = 0x00010203;
+            store.publish(new SgbDisplay.SgbFrameReadyEvent(valid, false));
+            NativeFrameStore.Frame frame = store.takeLatest();
+            assertNotNull(frame);
+            assertSame(store.bufferAt(0), frame.pixels());
+            store.finishDrawing(frame);
+            NativeFrameStore.Snapshot snapshot = requireSnapshot(store);
+            assertEquals(0xff010203, snapshot.pixels()[0]);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void staleReservationCannotPublishOrAbortANewWriter() throws Exception {
+        NativeFrameStore store = new NativeFrameStore();
+        try {
+            long stale = reserve(store);
+            store.beginBenchmarkEpoch(1L);
+            long current = reserve(store);
+            assertTrue((stale & 3L) != (current & 3L));
+
+            // The old owner is allowed to release its preserved WRITING claim after the epoch
+            // reset. A new writer can then claim the same slot.
+            publish(store, stale);
+            long replacement = reserve(store);
+            assertTrue((stale & 3L) == (replacement & 3L));
+            assertTrue(stale != replacement);
+
+            publish(store, stale);
+            assertNull(store.snapshot());
+            abort(store, stale);
+            assertNull(store.snapshot());
+            publish(store, replacement);
+            assertNotNull(store.snapshot());
+            publish(store, current);
+            assertNotNull(store.snapshot());
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void clearInvalidatesAnInFlightReservationBeforeAReplacementPublishes() throws Exception {
+        NativeFrameStore store = new NativeFrameStore();
+        AtomicInteger notifications = new AtomicInteger();
+        NativeFrameStore.Listener listener = notifications::incrementAndGet;
+        store.addListener(listener);
+        try {
+            long stale = reserve(store);
+            store.clear();
+            int afterClear = notifications.get();
+            long current = reserve(store);
+            assertTrue((stale & 3L) != (current & 3L));
+
+            publish(store, stale);
+            assertNull(store.snapshot());
+            assertEquals(afterClear, notifications.get());
+
+            publish(store, current);
+            assertNotNull(store.snapshot());
+            assertEquals(afterClear + 1, notifications.get());
+        } finally {
+            store.removeListener(listener);
+            store.close();
+        }
+    }
+
+    @Test
     public void profileTransitionFromSgbToDmgSurvivesClear() {
         NativeFrameStore store = new NativeFrameStore();
         try {
@@ -228,5 +308,24 @@ public class NativeFrameStoreTest {
         NativeFrameStore.Snapshot frame = store.snapshot();
         assertNotNull(frame);
         return frame;
+    }
+
+    private static long reserve(NativeFrameStore store) throws Exception {
+        var method = NativeFrameStore.class.getDeclaredMethod(
+                "reserve", int.class, int.class);
+        method.setAccessible(true);
+        return (long) method.invoke(store, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+    }
+
+    private static void publish(NativeFrameStore store, long claim) throws Exception {
+        var method = NativeFrameStore.class.getDeclaredMethod("publish", long.class);
+        method.setAccessible(true);
+        method.invoke(store, claim);
+    }
+
+    private static void abort(NativeFrameStore store, long claim) throws Exception {
+        var method = NativeFrameStore.class.getDeclaredMethod("abortWriting", long.class);
+        method.setAccessible(true);
+        method.invoke(store, claim);
     }
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4498,6 +4498,11 @@ class BasicController private constructor(
           null
         }
 
+    if (properties.overrides.benchmarkPolicyEnabled &&
+        !completeBenchmarkBootstrap(session)) {
+      return
+    }
+
     postSessionEventSafely(session, AddPatches(patches))
     postSessionEventSafely(session, Controller.GameboyTypeEvent(session.config.gameboyType))
     val effectiveSpeedMode = session.gameboy.getSpeedMode()
@@ -4567,6 +4572,32 @@ class BasicController private constructor(
         Controller.SerialPeripheralStatus.ATTACHED,
     )
     postInitialMobileAdapterNetworkStatus()
+  }
+
+  /** Completes a requested authentic BIOS handoff while the benchmark anchor remains paused. */
+  private fun completeBenchmarkBootstrap(currentSession: Session): Boolean {
+    val gameboy = currentSession.gameboy
+    var remaining = BENCHMARK_BOOTSTRAP_MAX_TICKS
+    while (!gameboy.isBootstrapReady()) {
+      if (doStop || session !== currentSession) {
+        return false
+      }
+      if (remaining <= 0L) {
+        throw IllegalStateException("Benchmark bootstrap did not reach the cartridge handoff")
+      }
+      val chunk = minOf(remaining, BENCHMARK_BOOTSTRAP_CHUNK_TICKS.toLong()).toInt()
+      val executed = gameboy.runTicksUntilStop(chunk) {
+        doStop || session !== currentSession || gameboy.isBootstrapReady()
+      }
+      remaining -= executed.toLong()
+      if (executed == 0 && !gameboy.isBootstrapReady()) {
+        if (doStop || session !== currentSession) {
+          return false
+        }
+        throw IllegalStateException("Benchmark bootstrap made no progress")
+      }
+    }
+    return !doStop && session === currentSession
   }
 
   /**
@@ -5411,6 +5442,10 @@ class BasicController private constructor(
     const val NO_MOBILE_ADAPTER_CONFIGURATION_REVISION = -1L
 
     const val MAX_DEBUG_COMMANDS_PER_SAFE_POINT = 64
+
+    const val BENCHMARK_BOOTSTRAP_CHUNK_TICKS = 16_384
+
+    const val BENCHMARK_BOOTSTRAP_MAX_TICKS = 40_000_000L
 
     const val MAX_DEBUG_CONTROL_EVENTS_PER_SAFE_POINT = 64
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -245,8 +245,7 @@ internal class RuntimeWarmupCache(
           flavor: RuntimeWarmupFlavor,
       ): RuntimeWarmupKey? {
         val rom = config.rom
-        if (config.bootstrapMode != BootstrapMode.SKIP ||
-            config.slotRom != null ||
+        if (config.slotRom != null ||
             rom.cartridgeProperties.mapper != Mapper.STANDARD ||
             !isOrdinaryNonRtcCartridge(rom.type)) {
           return null

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StagedEventBus.java
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StagedEventBus.java
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller;
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.Subscriber;
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,6 +109,10 @@ final class StagedEventBus implements EventBus {
                 // Core resource cleanup may synchronously silence an output after the owning
                 // session bus has quiesced. Treat that signal as local cleanup, not an error.
                 return true;
+            }
+            if (event instanceof SynchronousBorrowedEvent && (async || state == State.STAGED)) {
+                throw new IllegalArgumentException(
+                        "Borrowed events cannot be posted through a staged event bus");
             }
             if (state == State.ACTIVE) {
                 return false;

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/events/EventQueue.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/events/EventQueue.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.events
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import eu.rekawek.coffeegb.core.events.Subscriber
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent
 import java.util.ArrayDeque
 import java.util.IdentityHashMap
 import java.util.concurrent.CopyOnWriteArrayList
@@ -105,6 +106,10 @@ class EventQueue(
   }
 
   private fun enqueue(event: Event) {
+    if (event is SynchronousBorrowedEvent) {
+      throw IllegalArgumentException(
+          "Borrowed events cannot be retained by an asynchronous event queue")
+    }
     val weight = eventWeight(event)
     if (weight < 0) throw IllegalArgumentException("Negative event weight")
     val source = eventSource(event) ?: LOCAL_SOURCE

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -258,7 +258,7 @@ internal object StateSemantics {
                 it.range("frameSequencerClockPhase", 0, 3)
                 val samplePhase = it.int("performanceSamplePhase")
                 val decimation = it.int("audioDecimation")
-                it.require(decimation == 1 || decimation == 11 || decimation == 55,
+                it.require(decimation == 1 || decimation == 11 || decimation == 55 || decimation == 56,
                     "has unsupported audio decimation")
                 it.require(samplePhase in 0 until decimation,
                     "has invalid audio decimation phase $samplePhase for decimation $decimation")

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.BooleanSupplier
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -1832,6 +1833,65 @@ class BasicControllerTest {
     } finally {
       controller.close()
       eventBus.close()
+    }
+  }
+
+  @Test
+  fun benchmarkBootstrapCompletesBeforeProfileAndStartedEvents() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val profile = LinkedBlockingQueue<HardwareProfileEvent>()
+    val bootstrapCalls = AtomicInteger()
+    val bootstrapReadyAtProfile = AtomicBoolean()
+    eventBus.register<EmulationStartedEvent> {
+      assertTrue(bootstrapReadyAtProfile.get())
+      started.add(it)
+    }
+    eventBus.register<HardwareProfileEvent> {
+      assertTrue(bootstrapCalls.get() > 0)
+      bootstrapReadyAtProfile.set(true)
+      profile.add(it)
+    }
+    val rom = namedRom("BENCHMARK_BOOTSTRAP")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                benchmarkPolicyEnabled = true,
+                executionMode = ExecutionMode.PERFORMANCE,
+            ))
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.PERFORMANCE)
+          val gameboy =
+              object : Gameboy(config) {
+                private var ready = false
+
+                override fun isBootstrapReady(): Boolean = ready
+
+                override fun runTicksUntilStop(ticks: Int, stop: BooleanSupplier): Int {
+                  bootstrapCalls.incrementAndGet()
+                  ready = true
+                  return 1
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      assertNotNull(profile.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(1, bootstrapCalls.get())
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -183,17 +183,14 @@ class RomSessionPreparerTest {
   }
 
   @Test
-  fun unsupportedWarmupShapeDoesNotClaimACompletedWarmup() {
+  fun runtimeWarmupUsesSkipDisposableCopyForNonSkipBootstrap() {
     val executor = RecordingWarmupExecutor()
     val cache = RuntimeWarmupCache(2, executor)
 
-    assertFalse(
-        cache.warm(
-            skipConfig().setBootstrapMode(BootstrapMode.FAST_FORWARD),
-            {},
-        ))
-    assertTrue(executor.calls.isEmpty())
-    assertEquals(0, cache.size)
+    assertTrue(cache.warm(skipConfig().setBootstrapMode(BootstrapMode.FAST_FORWARD), {}))
+    assertEquals(1, executor.calls.size)
+    assertEquals(BootstrapMode.SKIP, executor.calls.single().config.bootstrapMode)
+    assertEquals(1, cache.size)
   }
 
   @Test
@@ -276,7 +273,7 @@ class RomSessionPreparerTest {
                 .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE),
             RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
         ) {})
-    assertFalse(
+    assertTrue(
         cache.warm(
             skipConfig(cgbNativeImage())
                 .setHardwareProfile(HardwareProfileRegistry.CGB)

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/StagedEventBusTest.java
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/StagedEventBusTest.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent;
 import eu.rekawek.coffeegb.core.joypad.Button;
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent;
 import org.junit.Test;
@@ -82,6 +83,30 @@ public class StagedEventBusTest {
         root.close();
     }
 
+    @Test
+    public void borrowedEventsCannotBeStagedOrQueuedButCanPostAfterActivation() {
+        EventBusImpl root = new EventBusImpl(null, null, false);
+        StagedEventBus candidate = new StagedEventBus(root.fork("candidate-borrowed"));
+        AtomicInteger deliveries = new AtomicInteger();
+        candidate.register(event -> deliveries.incrementAndGet(), BorrowedProbe.class);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> candidate.post(new BorrowedProbe()));
+        assertThrows(IllegalArgumentException.class,
+                () -> candidate.postAsync(new BorrowedProbe()));
+        candidate.activate();
+        assertThrows(IllegalArgumentException.class,
+                () -> candidate.postAsync(new BorrowedProbe()));
+        candidate.post(new BorrowedProbe());
+        assertEquals(1, deliveries.get());
+
+        candidate.close();
+        root.close();
+    }
+
     private record ProbeEvent(int value) implements Event {
+    }
+
+    private static final class BorrowedProbe implements SynchronousBorrowedEvent {
     }
 }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/events/EventQueueTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/events/EventQueueTest.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller.events
 
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import org.junit.Test
@@ -189,7 +190,22 @@ class EventQueueTest {
     }
   }
 
+  @Test
+  fun borrowedEventsAreRejectedBeforeTheyCanEscapeTheirSynchronousCallback() {
+    val bus = EventBusImpl()
+    val queue = EventQueue(bus)
+    queue.register<BorrowedEvent> {}
+    try {
+      assertFailsWith<IllegalArgumentException> { bus.post(BorrowedEvent) }
+      assertEquals(false, queue.dispatchOne())
+    } finally {
+      bus.close()
+    }
+  }
+
   private data class WeightedEvent(val bytes: Long, val source: Any = LOCAL) : Event
+
+  private object BorrowedEvent : SynchronousBorrowedEvent
 
   private data class Source(val label: String)
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/ClockOwnedStateSemanticsTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/ClockOwnedStateSemanticsTest.kt
@@ -154,6 +154,36 @@ class ClockOwnedStateSemanticsTest {
   }
 
   @Test
+  fun sgbPerformanceSoundAcceptsCurrentAndLegacyDecimationShapes() {
+    val clock = ClockSpec.SGB
+    val speedMode = SpeedMode(false)
+    val sound = Sound(
+        Timer(InterruptManager(false), speedMode), speedMode, false, clock, ExecutionMode.PERFORMANCE)
+    val base = record(sound.captureState())
+
+    listOf(11, 56).forEach { decimation ->
+      val capacity = Math.multiplyExact(clock.controllerTicksPerFrame() / decimation, 2)
+      val valid =
+          base
+              .replaceField("i", Int32State(capacity - 2))
+              .replaceField("buffer", Int32ArrayState(IntArray(capacity)))
+              .replaceField("performanceSamplePhase", Int32State(decimation - 1))
+              .replaceField("audioDecimation", Int32State(decimation))
+      StateSemantics.validateForClock(soundState(valid), clock)
+    }
+
+    val current =
+        base
+            .replaceField("i", Int32State(1_254 * 2 - 2))
+            .replaceField("buffer", Int32ArrayState(IntArray(1_254 * 2)))
+            .replaceField("performanceSamplePhase", Int32State(56))
+            .replaceField("audioDecimation", Int32State(56))
+    assertFailsWith<StateApplyException> {
+      StateSemantics.validateForClock(soundState(current), clock)
+    }
+  }
+
+  @Test
   fun customClockSoundRejectsIndicesAndFullBufferShapesBeforeMutation() {
     val clock = ClockSpec(8_388_608, 60, 1)
     val capacity = Math.multiplyExact(clock.controllerTicksPerFrame(), 2)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -819,6 +819,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             throw new IllegalArgumentException("ticks must be non-negative");
         }
         if (executionMode == ExecutionMode.PERFORMANCE
+                && bootCompatibilityResolved
                 && debugInstrumentation == null
                 && !debugRetirementTrackingActive
                 && !debugHistoryReplay) {
@@ -852,6 +853,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         Objects.requireNonNull(stop, "stop");
         if (executionMode == ExecutionMode.PERFORMANCE
+                && bootCompatibilityResolved
                 && debugInstrumentation == null
                 && !debugRetirementTrackingActive
                 && !debugHistoryReplay) {
@@ -898,6 +900,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         Objects.requireNonNull(stop, "stop");
         if (executionMode == ExecutionMode.PERFORMANCE
+                && bootCompatibilityResolved
                 && debugInstrumentation == null
                 && !debugRetirementTrackingActive
                 && !debugHistoryReplay) {
@@ -2273,7 +2276,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (dma.requiresClockTick(dmaCpuClockPaused)) {
             dma.tick(dmaCpuClockPaused, halted);
         }
-        if (executionMode == ExecutionMode.PERFORMANCE) {
+        if (executionMode == ExecutionMode.PERFORMANCE && bootCompatibilityResolved) {
             sound.tickPerformanceBoundary(divReset);
         } else {
             sound.tick(divReset);
@@ -2295,6 +2298,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             hdma.advanceHblankRequest();
         }
         boolean performanceSteadyCursor = executionMode == ExecutionMode.PERFORMANCE
+                && bootCompatibilityResolved
                 && gpu.isPerformanceSteadyCursorActive();
         boolean performanceQuietRaster = performanceSteadyCursor
                 && gpu.isPerformanceSteadyTickQuiet();
@@ -2332,6 +2336,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      */
     private void tickCpuPerformanceAware() {
         if (executionMode != ExecutionMode.PERFORMANCE
+                || !bootCompatibilityResolved
                 || debugInstrumentation != null
                 || debugRetirementTrackingActive
                 || debugHistoryReplay) {
@@ -2905,6 +2910,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      */
     public ExecutionMode getExecutionMode() {
         return executionMode;
+    }
+
+    /** Returns true once the BIOS-to-cartridge handoff has settled. */
+    public boolean isBootstrapReady() {
+        return bootCompatibilityResolved;
     }
 
     /** @deprecated Use {@link #getHardwareProfile()}. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1321,11 +1321,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
                 steadyRasterSpan = span > 0 && !directRasterSpan
                         && gpu.isPerformanceSteadyCursorActive();
-            } else if (isPhysicalDmgPerformanceEpochTopology()) {
-                // Physical-DMG mode 2 has no quiet-output horizon: the OAM reader itself is
-                // the only PPU work in these one-to-three non-CPU dots.  Keep this explicit
-                // plan separate from the settled quiet path so CGB/compat sessions cannot
-                // accidentally enter the DMG arithmetic lane.
+            } else if (isPhysicalDmgPerformanceEpochTopology()
+                    || isSgbPerformanceTopology()) {
+                // Physical-DMG and SGB mode 2 have no quiet-output horizon: the OAM reader
+                // itself is the only PPU work in these one-to-three non-CPU dots. Keep this
+                // explicit plan separate from the settled quiet path so CGB/compat sessions
+                // cannot accidentally enter the DMG arithmetic lane.
                 int mode2SpanLimit = gpu.performancePhysicalDmgMode2PhaseSpanLimit(span);
                 if (mode2SpanLimit > 0) {
                     span = Math.min(span, mode2SpanLimit);
@@ -1408,7 +1409,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return !cpu.performanceEpochEntryEligible();
     }
 
-    /** Physical DMG/MGB only; its mode-2 phase lane remains intentionally DMG-only. */
+    /** Physical DMG/MGB only; SGB/SGB2 join just the separately guarded mode-2 phase lane. */
     private boolean isPhysicalDmgPerformanceEpochTopology() {
         return hardwareProfile.family() == HardwareProfile.Family.DMG
                 && speedMode.getSpeedMode() == 1;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -260,6 +260,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient IntConsumer performancePhysicalDmgEpochPrefixCommitter;
 
+    private transient IntConsumer performanceCgbCompatibilityEpochPrefixCommitter;
+
     private enum PerformanceEpochPpuPlan {
         NONE,
         TRUSTED_RASTER,
@@ -826,8 +828,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             if (isNativeCgbPerformanceEpochTopology()) {
                 return runNativeCgbPerformanceTicks(ticks);
             }
-            if (isPhysicalDmgPerformanceEpochTopology()) {
-                return runPhysicalDmgPerformanceTicks(ticks);
+            if (isNormalSpeedPerformanceEpochTopology()) {
+                return runNormalSpeedPerformanceTicks(ticks);
             }
             return runPerformanceTicks(ticks);
         }
@@ -919,8 +921,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (isNativeCgbPerformanceEpochTopology()) {
             return runNativeCgbPerformanceTicksUntilStop(ticks, stop);
         }
-        if (isPhysicalDmgPerformanceEpochTopology()) {
-            return runPhysicalDmgPerformanceTicksUntilStop(ticks, stop);
+        if (isNormalSpeedPerformanceEpochTopology()) {
+            return runNormalSpeedPerformanceTicksUntilStop(ticks, stop);
         }
         return runFallbackPerformanceTicksUntilStop(ticks, stop);
     }
@@ -1039,20 +1041,20 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return ticks - remaining;
     }
 
-    /** Stop-aware physical-DMG scheduler; mode-3 packets retain their raster fast path. */
-    private long runPhysicalDmgPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
+    /** Stop-aware fixed-x1 scheduler; mode-3 packets retain their raster fast path. */
+    private long runNormalSpeedPerformanceTicksUntilStop(long ticks, BooleanSupplier stop) {
         gpu.setPerformanceScanlineEnabled(true);
         long remaining = ticks;
         try {
             while (remaining > 0 && !stop.getAsBoolean()
-                    && isPhysicalDmgPerformanceEpochTopology()) {
-                int committed = tryPhysicalDmgPerformanceEpoch(remaining);
+                    && isNormalSpeedPerformanceEpochTopology()) {
+                int committed = tryNormalSpeedPerformanceEpoch(remaining);
                 if (committed > 0) {
                     remaining -= committed;
                     continue;
                 }
                 if (cpu.getState() == Cpu.State.HALTED) {
-                    committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    committed = tryPerformanceSettledHaltSpan(remaining);
                     if (committed > 0) {
                         remaining -= committed;
                         continue;
@@ -1078,7 +1080,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             gpu.setPerformanceScanlineEnabled(false);
         }
         if (remaining > 0 && !stop.getAsBoolean()
-                && !isPhysicalDmgPerformanceEpochTopology()) {
+                && !isNormalSpeedPerformanceEpochTopology()) {
             return (ticks - remaining) + runFallbackPerformanceTicksUntilStop(remaining, stop);
         }
         return ticks - remaining;
@@ -1210,17 +1212,17 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
-     * Physical-DMG normal-speed coarse scheduler. Only the trusted rendered raster may join a
-     * CPU epoch; mode 2, STAT/line edges, DMA, IRQ/HALT, and every rejected topology retain the
+     * Fixed-x1 normal-speed coarse scheduler. Only the trusted rendered raster may join a CPU
+     * epoch; mode 2, STAT/line edges, DMA, IRQ/HALT, and every rejected topology retain the
      * established normal-speed PERFORMANCE scheduler.
      */
-    private long runPhysicalDmgPerformanceTicks(long ticks) {
+    private long runNormalSpeedPerformanceTicks(long ticks) {
         gpu.setPerformanceScanlineEnabled(true);
         long frameEvents = 0;
         long remaining = ticks;
         try {
-            while (remaining > 0 && isPhysicalDmgPerformanceEpochTopology()) {
-                int committed = tryPhysicalDmgPerformanceEpoch(remaining);
+            while (remaining > 0 && isNormalSpeedPerformanceEpochTopology()) {
+                int committed = tryNormalSpeedPerformanceEpoch(remaining);
                 if (committed > 0) {
                     remaining -= committed;
                     continue;
@@ -1229,7 +1231,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 // Preserve the pre-existing long settled-HALT side entrance before falling
                 // back to the ordinary scalar/phase scheduler.
                 if (cpu.getState() == Cpu.State.HALTED) {
-                    committed = tryPerformanceSettledDmgHaltSpan(remaining);
+                    committed = tryPerformanceSettledHaltSpan(remaining);
                     if (committed > 0) {
                         remaining -= committed;
                         continue;
@@ -1371,6 +1373,18 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return gbc && speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1;
     }
 
+    /** Exact measured epoch row: ordinary CGB only (CGB0 compatibility remains scalar). */
+    private boolean isCgbCompatibilityPerformanceEpochTopology() {
+        return hardwareProfile == HardwareProfileRegistry.CGB
+                && isCgbCompatibilityPerformanceTopology();
+    }
+
+    /** Fixed four-master-dot CPU epoch topologies; CGB compatibility still owns CGB peripherals. */
+    private boolean isNormalSpeedPerformanceEpochTopology() {
+        return isPhysicalDmgPerformanceEpochTopology()
+                || isCgbCompatibilityPerformanceEpochTopology();
+    }
+
     private boolean canContinueNativeCgbNegativeStatLease() {
         if (!isNativeCgbPerformanceEpochTopology()) {
             return false;
@@ -1393,7 +1407,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return !cpu.performanceEpochEntryEligible();
     }
 
-    /** Physical DMG/MGB only; CGB compatibility and both SGB clocks retain the legacy lane. */
+    /** Physical DMG/MGB only; its mode-2 phase lane remains intentionally DMG-only. */
     private boolean isPhysicalDmgPerformanceEpochTopology() {
         return hardwareProfile.family() == HardwareProfile.Family.DMG
                 && speedMode.getSpeedMode() == 1;
@@ -1413,22 +1427,6 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !slotCartridgeClocked
                 && serialPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS)
                 && infraredPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
-    }
-
-    /** Stable physical-DMG topology; tick-local CPU, timer, raster and STAT guards follow. */
-    private boolean canStartPhysicalDmgPerformanceEpoch() {
-        return !warmResetRequested
-                && speedSwitchTailTicks == 0
-                && !debugHistoryReplay
-                && debugInstrumentation == null
-                && !debugRetirementTrackingActive
-                && gpu.isLcdEnabled()
-                && !dma.isTransferInProgress()
-                && !dma.requiresClockTick(false)
-                && !cartridgeClocked
-                && !slotCartridgeClocked
-                && serialPort.performancePhysicalDmgEpochIdle(
-                        Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
     }
 
     /**
@@ -1648,18 +1646,29 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
     }
 
-    /** Attempts one trusted-raster-only physical-DMG epoch. */
-    private int tryPhysicalDmgPerformanceEpoch(long remaining) {
-        if (remaining <= 0 || !cpu.performancePhysicalDmgEpochEntryEligible()
-                || !canStartPhysicalDmgPerformanceEpoch()) {
+    /** Attempts one trusted-raster-only fixed-x1 epoch for DMG or ordinary CGB compatibility. */
+    private int tryNormalSpeedPerformanceEpoch(long remaining) {
+        boolean cgbCompat = isCgbCompatibilityPerformanceEpochTopology();
+        if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbCompat)
+                || !canStartNormalSpeedPerformanceEpoch(cgbCompat)) {
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
-        span = Math.min(span, timer.performancePhysicalDmgEpochSpanLimit(span));
+        span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbCompat));
         span = Math.min(span, sound.performanceEpochSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
+        if (cgbCompat) {
+            span = Math.min(span, serialPort.performanceNormalSpeedEpochIdle(span, true)
+                    ? span : 0);
+            span = Math.min(span, infraredPort.performanceSettledHaltSpanLimit(span));
+        } else {
+            span = Math.min(span, serialPort.performanceNormalSpeedEpochIdle(span, false)
+                    ? span : 0);
+        }
 
-        int rasterSpan = gpu.performancePhysicalDmgEpochSpanLimit(span);
+        int rasterSpan = cgbCompat
+                ? gpu.performanceEpochSpanLimit(span)
+                : gpu.performancePhysicalDmgEpochSpanLimit(span);
         if (rasterSpan <= 0) {
             return 0;
         }
@@ -1678,14 +1687,26 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && gpu.isPerformanceSteadyCursorActive();
         performanceEpochPpuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
         performanceEpochPrefixCommitted = 0;
-        if (performancePhysicalDmgEpochPrefixCommitter == null) {
-            performancePhysicalDmgEpochPrefixCommitter =
-                    this::commitPhysicalDmgPerformanceEpochPrefix;
+        IntConsumer prefixCommitter;
+        if (cgbCompat) {
+            if (performanceCgbCompatibilityEpochPrefixCommitter == null) {
+                performanceCgbCompatibilityEpochPrefixCommitter =
+                        this::commitCgbCompatibilityPerformanceEpochPrefix;
+            }
+            prefixCommitter = performanceCgbCompatibilityEpochPrefixCommitter;
+        } else {
+            if (performancePhysicalDmgEpochPrefixCommitter == null) {
+                performancePhysicalDmgEpochPrefixCommitter =
+                        this::commitPhysicalDmgPerformanceEpochPrefix;
+            }
+            prefixCommitter = performancePhysicalDmgEpochPrefixCommitter;
         }
-        cpu.setPerformanceEpochPrefixCommitter(performancePhysicalDmgEpochPrefixCommitter);
+        cpu.setPerformanceEpochPrefixCommitter(prefixCommitter);
         int elapsed;
         try {
-            elapsed = cpu.runPhysicalDmgPerformanceEpoch(span);
+            elapsed = cgbCompat
+                    ? cpu.runCgbCompatibilityPerformanceEpoch(span)
+                    : cpu.runPhysicalDmgPerformanceEpoch(span);
         } finally {
             cpu.setPerformanceEpochPrefixCommitter(null);
         }
@@ -1694,15 +1715,46 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         int suffix = elapsed - performanceEpochPrefixCommitted;
         if (suffix > 0) {
-            commitPhysicalDmgPerformanceEpochPeripherals(suffix);
+            if (cgbCompat) {
+                commitCgbCompatibilityPerformanceEpochPeripherals(suffix);
+            } else {
+                commitPhysicalDmgPerformanceEpochPeripherals(suffix);
+            }
         }
-        settlePhysicalDmgPerformanceEpochDmaHaltLatch();
-        cpu.replayPerformanceEpochJournal();
+        boolean journalReplayed = cpu.replayPerformanceEpochJournal();
         boolean divReset = timer.consumeDivReset();
         if (divReset) {
             sound.tickFrameSequencer(true);
             sound.commitFrameSequencerClock();
             serialPort.onDivReset();
+        }
+        Cpu.State finalCpuState = cpu.getState();
+        boolean halted = finalCpuState == Cpu.State.HALTED;
+        if (cgbCompat && halted) {
+            hdma.onCpuHaltState(true);
+        }
+        if (halted || journalReplayed) {
+            if (gbc) {
+                // Keep the one-tick VRAM-DMA source sample seam in the same position as scalar
+                // tick() when a journaled write or HALT transition needs the post-CPU seam.
+                dma.setVramDmaBusSample(hdma.consumeSourceBusSample());
+            }
+            boolean dmaCpuClockPaused = halted || finalCpuState == Cpu.State.STOPPED
+                    || finalCpuState == Cpu.State.SPEED_SWITCH
+                    || speedSwitchTailTicks > 0
+                    || gbc && hdma.pausesOamDmaForSpeedSwitchBurst();
+            if (dma.requiresClockTick(dmaCpuClockPaused)) {
+                dma.tick(dmaCpuClockPaused, halted);
+            }
+        }
+        if (cgbCompat && halted) {
+            // The scalar tick publishes the CPU HALT transition before the final GPU/HDMA
+            // timing callback.  Epoch peripheral commits necessarily advance the GPU first,
+            // so replay that post-GPU publication here to clear haltEnteredThisTick and keep
+            // the CPU's held HDMA opcode latch in the same end-of-tick state.
+            hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                    gpu.isStatModeLatchRephasedBySpeedSwitch());
+            cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
         }
         if (cpu.hasPendingPeripheralSample()) {
             cpu.onPeripheralsTicked();
@@ -1714,13 +1766,24 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return elapsed;
     }
 
-    /** Publishes the inactive OAM-DMA pause latch when an epoch retires HALT. */
-    private void settlePhysicalDmgPerformanceEpochDmaHaltLatch() {
-        if (cpu.getState() == Cpu.State.HALTED && dma.requiresClockTick(true)) {
-            // The scalar owner calls this after the HALT-fetch CPU boundary. Keep it before
-            // deferred FF46 replay so the existing journal's declared next-dot skew is intact.
-            dma.tick(true, true);
-        }
+    /** Stable normal-speed epoch topology; transient guards are evaluated by the caller. */
+    private boolean canStartNormalSpeedPerformanceEpoch(boolean cgbCompat) {
+        return !warmResetRequested
+                && speedSwitchTailTicks == 0
+                && !debugHistoryReplay
+                && debugInstrumentation == null
+                && !debugRetirementTrackingActive
+                && gpu.isLcdEnabled()
+                && !dma.isTransferInProgress()
+                && !dma.requiresClockTick(false)
+                && !cartridgeClocked
+                && !slotCartridgeClocked
+                && (!cgbCompat || (!hdma.hasActiveOrPendingTransfer()
+                        && !hdma.hasPendingHblankTransfer()
+                        && !hdma.isHaltRequestLatched()
+                        && !hdma.holdsHblankSpeedSwitchTail()
+                        && !hdma.pausesOamDmaForSpeedSwitchBurst()
+                        && !hdma.requiresCpuHdmaPhaseFlags()));
     }
 
     private void commitPerformanceEpochPrefix(int ticks) {
@@ -1785,23 +1848,54 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochPrefixCommitted = ticks;
     }
 
+    private void commitCgbCompatibilityPerformanceEpochPrefix(int ticks) {
+        if (ticks <= performanceEpochPrefixCommitted) {
+            return;
+        }
+        commitCgbCompatibilityPerformanceEpochPeripherals(
+                ticks - performanceEpochPrefixCommitted);
+        performanceEpochPrefixCommitted = ticks;
+    }
+
     /** Physical-DMG prefix commit; CGB-only IR/HDMA state is deliberately absent. */
     private void commitPhysicalDmgPerformanceEpochPeripherals(int ticks) {
+        commitNormalSpeedPerformanceEpochPeripherals(ticks, false);
+    }
+
+    /** CGB-compatibility prefix commit through the existing CGB quiet epoch plane. */
+    private void commitCgbCompatibilityPerformanceEpochPeripherals(int ticks) {
+        commitNormalSpeedPerformanceEpochPeripherals(ticks, true);
+    }
+
+    /** Shared fixed-x1 epoch peripheral commit; CGB compatibility retains IR/HDMA/CGB PPU state. */
+    private void commitNormalSpeedPerformanceEpochPeripherals(int ticks, boolean cgbCompat) {
         if (ticks <= 0) {
             return;
         }
-        timer.tickPerformancePhysicalDmgEpochTrusted(ticks);
+        timer.tickPerformanceNormalSpeedEpochTrusted(ticks);
         sound.tickFrameSequencer(false);
         assert !sound.hasPendingFrameSequencerClock()
-                : "frame sequencer edge crossed a physical-DMG PERFORMANCE epoch";
+                : "frame sequencer edge crossed a fixed-x1 PERFORMANCE epoch";
         sound.commitFrameSequencerClock();
         sound.tickPerformanceQuietSpan(ticks);
-        serialPort.tickPerformancePhysicalDmgEpochIdle(ticks);
+        serialPort.tickPerformanceNormalSpeedEpochIdle(ticks);
+        if (cgbCompat) {
+            infraredPort.tickPerformanceQuietSpanTrusted(ticks);
+        }
         joypad.tickPerformanceQuietSpanTrusted(ticks);
-        gpu.advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
-                ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+        if (cgbCompat) {
+            gpu.advancePerformanceEpochQuietSpanTrusted(
+                    ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+        } else {
+            gpu.advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
+                    ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+        }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         performanceEpochRasterFastTicks += ticks;
+        if (cgbCompat) {
+            hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                    gpu.isStatModeLatchRephasedBySpeedSwitch());
+        }
     }
 
     /** Selects the normal-speed settled-HALT lane for the current non-native topology. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1382,7 +1382,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Fixed four-master-dot CPU epoch topologies; CGB compatibility still owns CGB peripherals. */
     private boolean isNormalSpeedPerformanceEpochTopology() {
         return isPhysicalDmgPerformanceEpochTopology()
-                || isCgbCompatibilityPerformanceEpochTopology();
+                || isCgbCompatibilityPerformanceEpochTopology()
+                || isSgbPerformanceTopology();
     }
 
     private boolean canContinueNativeCgbNegativeStatLease() {
@@ -1646,9 +1647,34 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
     }
 
-    /** Attempts one trusted-raster-only fixed-x1 epoch for DMG or ordinary CGB compatibility. */
+    /** Routes the fixed-x1 epoch through the SGB raster gate before generic preflight. */
     private int tryNormalSpeedPerformanceEpoch(long remaining) {
+        if (isSgbPerformanceTopology()) {
+            return trySgbPerformanceEpoch(remaining);
+        }
+        return tryFixedNormalSpeedPerformanceEpoch(remaining);
+    }
+
+    /**
+     * SGB/SGB2 running-CPU lane. The direct scanline horizon is cheap to reject while the PPU
+     * is in mode 2 or a scalar mode-3 line, so those dots retain the existing scheduler without
+     * walking the timer/audio/serial/CPU epoch preflight.
+     */
+    private int trySgbPerformanceEpoch(long remaining) {
+        if (remaining <= 0) {
+            return 0;
+        }
+        int requested = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
+        if (gpu.performancePhysicalDmgEpochSpanLimit(requested) <= 0) {
+            return 0;
+        }
+        return tryFixedNormalSpeedPerformanceEpoch(remaining);
+    }
+
+    /** Fixed-width normal-speed epoch implementation shared by SGB and CGB compatibility. */
+    private int tryFixedNormalSpeedPerformanceEpoch(long remaining) {
         boolean cgbCompat = isCgbCompatibilityPerformanceEpochTopology();
+        boolean sgb = isSgbPerformanceTopology();
         if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbCompat)
                 || !canStartNormalSpeedPerformanceEpoch(cgbCompat)) {
             return 0;
@@ -1706,7 +1732,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         try {
             elapsed = cgbCompat
                     ? cpu.runCgbCompatibilityPerformanceEpoch(span)
-                    : cpu.runPhysicalDmgPerformanceEpoch(span);
+                    : sgb
+                            ? cpu.runSgbPerformanceEpoch(span)
+                            : cpu.runPhysicalDmgPerformanceEpoch(span);
         } finally {
             cpu.setPerformanceEpochPrefixCommitter(null);
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -272,7 +272,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** PPU commit selected for a normal-speed, phase-only PERFORMANCE packet. */
     private enum PerformancePhasePpuPlan {
         QUIET,
-        PHYSICAL_DMG_MODE2
+        PHYSICAL_DMG_MODE2,
+        CGB_COMPATIBILITY_MODE2
     }
 
     public Gameboy(Rom rom) {
@@ -1321,6 +1322,18 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
                 steadyRasterSpan = span > 0 && !directRasterSpan
                         && gpu.isPerformanceSteadyCursorActive();
+            } else if (isCgbCompatibilityPerformanceEpochTopology()) {
+                // CGB compatibility keeps the color OAM-reader semantics. Admit only the
+                // existing allocation-free CGB scan transaction; a fixed-point or reader
+                // miss leaves the complete one-to-three-dot phase on the scalar path.
+                int mode2SpanLimit =
+                        gpu.performanceCgbCompatibilityMode2PhaseSpanLimit(span);
+                if (mode2SpanLimit > 0) {
+                    span = Math.min(span, mode2SpanLimit);
+                    ppuPlan = PerformancePhasePpuPlan.CGB_COMPATIBILITY_MODE2;
+                } else {
+                    span = 0;
+                }
             } else if (isPhysicalDmgPerformanceEpochTopology()
                     || isSgbPerformanceTopology()) {
                 // Physical-DMG and SGB mode 2 have no quiet-output horizon: the OAM reader
@@ -2141,10 +2154,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // No CPU bus boundary exists inside this span. Advance the free-running phase once;
         // running state, or settled HALT, proves Cpu.onPeripheralsTicked() is a no-op here.
         cpu.advancePerformancePhaseOnlyTrusted(ticks);
-        if (ppuPlan == PerformancePhasePpuPlan.PHYSICAL_DMG_MODE2) {
-            gpu.advancePerformancePhysicalDmgMode2PhaseSpanTrusted(ticks);
-        } else {
-            gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        switch (ppuPlan) {
+            case QUIET -> gpu.advancePerformanceQuietSpanTrusted(
+                    ticks, directRasterSpan, steadyRasterSpan);
+            case PHYSICAL_DMG_MODE2 ->
+                    gpu.advancePerformancePhysicalDmgMode2PhaseSpanTrusted(ticks);
+            case CGB_COMPATIBILITY_MODE2 -> {
+                hdma.advancePerformanceOamSearchPhaseClockTrusted(ticks);
+                gpu.advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(ticks);
+            }
         }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         if (gbc) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -309,7 +309,21 @@ public class Cpu implements StatefulComponent<Cpu> {
      * @return master ticks consumed by the CPU epoch
      */
     public int runPhysicalDmgPerformanceEpoch(int maxMasterTicks) {
-        if (maxMasterTicks <= 0 || !performancePhysicalDmgEpochEntryEligible()) {
+        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false);
+    }
+
+    /**
+     * Fixed four-master-dot epoch for ordinary CGB hardware in DMG compatibility mode.
+     * The CPU bus and machine-cycle timing are the same normal-speed width as physical DMG,
+     * while the owner supplies the CGB-only peripheral/PPU plane around this transaction.
+     */
+    public int runCgbCompatibilityPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceNormalSpeedEpoch(maxMasterTicks, true);
+    }
+
+    /** Shared fixed-width normal-speed epoch; {@code cgbCompat} is an explicit topology guard. */
+    private int runPerformanceNormalSpeedEpoch(int maxMasterTicks, boolean cgbCompat) {
+        if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbCompat)) {
             return 0;
         }
         int requested = Math.min(maxMasterTicks, PERFORMANCE_EPOCH_MAX_TICKS);
@@ -423,6 +437,19 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     /** Cheap state-only entrance check for the fixed-width physical-DMG epoch. */
     public boolean performancePhysicalDmgEpochEntryEligible() {
+        return performanceNormalSpeedEpochEntryEligible(false);
+    }
+
+    /** Cheap state-only entrance check for ordinary CGB DMG-compatibility epochs. */
+    public boolean performanceCgbCompatibilityEpochEntryEligible() {
+        return performanceNormalSpeedEpochEntryEligible(true);
+    }
+
+    /** Shared state-only entrance check for the fixed-width normal-speed epoch. */
+    public boolean performanceNormalSpeedEpochEntryEligible(boolean cgbCompat) {
+        boolean topologyMatches = cgbCompat
+                ? speedMode.isGbc() && speedMode.isDmgCompat()
+                : !speedMode.isGbc();
         if (debugAddressSpace != null || debugHooks != null || debugRetirementTracker != null
                 || state == State.HALTED || state == State.STOPPED
                 || state == State.SPEED_SWITCH || state == State.LOCKED
@@ -442,7 +469,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                 || interruptManager.hasRawPendingEnabledInterrupt()) {
             return false;
         }
-        return speedMode.getSpeedMode() == 1 && !speedMode.isGbc();
+        return speedMode.getSpeedMode() == 1 && topologyMatches;
     }
 
     private boolean isPerformanceEpochLifecycleState() {
@@ -1109,7 +1136,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         }
     }
 
-    /** Physical-DMG fetch/decode front end for its fixed four-dot direct tier. */
+    /** Normal-speed fetch/decode front end for the fixed four-dot direct tier. */
     private int tickPerformancePhysicalDmgEpochInstructionPipelineAtMachineCycle(
             int remainingMasterTicks) {
         int pc = registers.getPC();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -309,7 +309,17 @@ public class Cpu implements StatefulComponent<Cpu> {
      * @return master ticks consumed by the CPU epoch
      */
     public int runPhysicalDmgPerformanceEpoch(int maxMasterTicks) {
-        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false);
+        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false, false);
+    }
+
+    /**
+     * Fixed-width SGB/SGB2 epoch which leaves observable memory-mapped accesses to the scalar
+     * scheduler. SGB JOYP writes and APU/PPU/DMA accesses are visible during their CPU tick, so
+     * they cannot use the physical-DMG deferred journal ordering. Safe direct-whole accesses
+     * may remain inside the epoch.
+     */
+    public int runSgbPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false, true);
     }
 
     /**
@@ -318,11 +328,12 @@ public class Cpu implements StatefulComponent<Cpu> {
      * while the owner supplies the CGB-only peripheral/PPU plane around this transaction.
      */
     public int runCgbCompatibilityPerformanceEpoch(int maxMasterTicks) {
-        return runPerformanceNormalSpeedEpoch(maxMasterTicks, true);
+        return runPerformanceNormalSpeedEpoch(maxMasterTicks, true, false);
     }
 
-    /** Shared fixed-width normal-speed epoch; {@code cgbCompat} is an explicit topology guard. */
-    private int runPerformanceNormalSpeedEpoch(int maxMasterTicks, boolean cgbCompat) {
+    /** Shared fixed-width normal-speed epoch; topology flags are explicit and allocation-free. */
+    private int runPerformanceNormalSpeedEpoch(
+            int maxMasterTicks, boolean cgbCompat, boolean fenceDecodedMemoryCycles) {
         if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbCompat)) {
             return 0;
         }
@@ -355,7 +366,8 @@ public class Cpu implements StatefulComponent<Cpu> {
                     }
                 }
 
-                if (!performanceEpochPrefetchSafe()) {
+                if (!performanceEpochPrefetchSafe()
+                        || fenceDecodedMemoryCycles && !performanceSgbBoundarySafe()) {
                     performanceEpochTerminal = true;
                     break;
                 }
@@ -387,6 +399,26 @@ public class Cpu implements StatefulComponent<Cpu> {
             performanceEpochPrefixCommitter = null;
         }
         return elapsed;
+    }
+
+    /**
+     * Rejects an SGB epoch before a CPU boundary which can reach a data-memory operation.
+     * Operations before the next force-finish marker execute in the same machine-cycle tick;
+     * scanning the complete group here prevents a partial CPU tick before scalar fallback.
+     */
+    private boolean performanceSgbBoundarySafe() {
+        if (state != State.RUNNING || currentExecutionOps == null) {
+            return true;
+        }
+        for (int i = opIndex; i < currentOpCount; i++) {
+            if (currentOpAccessesMemory[i]) {
+                return false;
+            }
+            if (currentExecutionOps[i].forceFinishCycle()) {
+                break;
+            }
+        }
+        return true;
     }
 
     private boolean performanceEpochPrefetchSafe() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBus.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBus.java
@@ -51,6 +51,10 @@ public interface EventBus extends AutoCloseable {
 
         @Override
         public <E extends Event> void postAsync(E event) {
+            if (event instanceof SynchronousBorrowedEvent) {
+                throw new IllegalArgumentException(
+                        "Borrowed events can only be delivered synchronously");
+            }
         }
 
         @NotNull

--- a/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBusImpl.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/events/EventBusImpl.java
@@ -107,6 +107,10 @@ public class EventBusImpl implements EventBus {
             if (doStop || stopped) {
                 throw new IllegalStateException("This EventBus is no longer active.");
             }
+            if (event instanceof SynchronousBorrowedEvent) {
+                throw new IllegalArgumentException(
+                        "Borrowed events can only be delivered synchronously");
+            }
             asyncEvents.addLast(event);
             asyncEventSignal.release();
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/events/SynchronousBorrowedEvent.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/events/SynchronousBorrowedEvent.java
@@ -1,0 +1,12 @@
+package eu.rekawek.coffeegb.core.events;
+
+/**
+ * Marks an event whose payload is borrowed from its producer for the duration of a synchronous
+ * callback only.
+ *
+ * <p>Such an event must never be queued for asynchronous delivery or retained by a staged event
+ * bus: the producer is allowed to reuse or mutate its payload as soon as the synchronous post
+ * returns.</p>
+ */
+public interface SynchronousBorrowedEvent extends Event {
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -100,9 +100,10 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     // renderer path remains unchanged.
     private final VRamTransfer performanceSgbVramTransfer;
 
-    // Exact construction-time permission for the short mode-2 phase packet. Keep this narrower
-    // than the monochrome pixel/timing cursors: the public Gpu horizon must fail closed for SGB,
-    // SGB2, and every compatibility profile even when their clock happens to be normal speed.
+    // Exact construction-time permission for the short DMG-clocked mode-2 phase packet. Keep
+    // this narrower than the monochrome pixel/timing cursors: only physical DMG/MGB and the
+    // exact SGB/SGB2 profiles may reuse the same OAM-search arithmetic. Compatibility profiles
+    // remain excluded even when their clock happens to be normal speed.
     private final boolean performancePhysicalDmgMode2;
 
     private final ColorPalette bgPalette;
@@ -359,7 +360,9 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         this.performancePhysicalDmgMode2 = executionMode == ExecutionMode.PERFORMANCE
                 && !debugHistoryReplay
                 && (hardwareProfile == HardwareProfileRegistry.DMG
-                || hardwareProfile == HardwareProfileRegistry.MGB);
+                || hardwareProfile == HardwareProfileRegistry.MGB
+                || hardwareProfile == HardwareProfileRegistry.SGB
+                || hardwareProfile == HardwareProfileRegistry.SGB2);
         this.r.setGbc(gbc);
         this.r.setSpeedMode(speedMode);
         this.lcdc.setGbc(gbc);
@@ -1318,9 +1321,10 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
-     * Horizon for a short physical-DMG mode-2 phase packet.  Only the non-CPU dots before the
-     * next normal-speed machine-cycle boundary use this lane; the dot-79-to-80 handoff remains
-     * scalar so the existing OAM/PixelTransfer transition and renderer arm stay authoritative.
+     * Horizon for a short physical-DMG/SGB mode-2 phase packet. Only the non-CPU dots before
+     * the next normal-speed machine-cycle boundary use this lane; the dot-79-to-80 handoff
+     * remains scalar so the existing OAM/PixelTransfer transition and renderer arm stay
+     * authoritative.
      */
     public int performancePhysicalDmgMode2PhaseSpanLimit(int requested) {
         if (!performancePhysicalDmgMode2 || requested <= 0 || gbc || speedModeValue != 1

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1321,6 +1321,63 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
+     * Horizon for a short ordinary-CGB DMG-compatibility mode-2 phase packet. The CGB OAM
+     * reader still uses its Y/X height latch in compatibility mode, but its CPU clock is x1.
+     * Only non-CPU dots before the dot-79-to-80 handoff are admitted; every fixed-point,
+     * observation, DMA, and HDMA miss leaves the complete phase to the scalar scheduler.
+     */
+    public int performanceCgbCompatibilityMode2PhaseSpanLimit(int requested) {
+        if (!performanceDmgCompatTiming || requested <= 0 || !gbc || !dmgCompatValue
+                || speedModeValue != 1 || !lcdEnabled || firstLine || line >= 144
+                || mode != Mode.OamSearch || phase != oamSearchPhase
+                || performanceScanlineCursor || performanceScanlineLine || dma == null
+                || dma.isTransferInProgress() || dma.ownsOamForPpu()
+                || dma.hasPpuOamOwnershipTransitionThisTick()
+                || hdma == null || hdma.hasActiveOrPendingTransfer()
+                || !hdma.isPerformanceOamSearchPhaseClockStable()) {
+            return 0;
+        }
+        if (!performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !bootCompatibilityResolved || displayEnabledDelay != 0
+                || steadyTimingCursor || !lcdc.isPerformanceMode2FixedPoint()
+                || !pixelTransferPhase.isPerformanceNativeCgbMode2IdleOutput()
+                || !pixelMachine.isPerformanceNativeCgbMode2IdleOutput()
+                || !oamSearchPhase.isPerformanceNoDmaStableSpanEligible(
+                ticksInLine, lcdc.getSpriteHeight(), 1)) {
+            return 0;
+        }
+        return Math.min(requested, Math.max(0, 79 - ticksInLine));
+    }
+
+    /** Advances a preflighted ordinary-CGB compatibility mode-2 prefix. */
+    public void advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        int startTick = ticksInLine;
+        if (startTick + ticks > 79) {
+            throw new IllegalStateException(
+                    "GPU is not eligible for a CGB compatibility PERFORMANCE mode-2 span");
+        }
+        assert performanceCgbCompatibilityMode2PhaseSpanLimit(ticks) >= ticks
+                : "trusted CGB compatibility mode-2 proof changed before commit";
+
+        lcdc.advancePerformanceMode2FixedPointSpanTrusted(ticks);
+        pixelTransferPhase.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
+        pixelMachine.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
+        oamSearchPhase.advancePerformanceNoDmaStableSpanTrusted(
+                startTick, ticks, lcdc.getSpriteHeight(), 1);
+
+        ticksInLine += ticks;
+        timingGeneration += ticks;
+        cpuLyReadAcrossLineEdge = false;
+        synchronizePerformanceWindowLineCounter();
+    }
+
+    /**
      * Horizon for a short physical-DMG/SGB mode-2 phase packet. Only the non-CPU dots before
      * the next normal-speed machine-cycle boundary use this lane; the dot-79-to-80 handoff
      * remains scalar so the existing OAM/PixelTransfer transition and renderer arm stay

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -95,6 +95,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     // direct Gpu.tick() probes and ACCURACY remain on their calibrated dot pipelines.
     private final boolean performanceScanlineCapable;
 
+    // Direct SGB/SGB2 lines still feed the host-visible raw DMG pixel stream into the
+    // Super Game Boy VRAM transfer. Keep this alias profile-gated so every other direct
+    // renderer path remains unchanged.
+    private final VRamTransfer performanceSgbVramTransfer;
+
     // Exact construction-time permission for the short mode-2 phase packet. Keep this narrower
     // than the monochrome pixel/timing cursors: the public Gpu horizon must fail closed for SGB,
     // SGB2, and every compatibility profile even when their clock happens to be normal speed.
@@ -346,7 +351,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 && (hardwareProfile == HardwareProfileRegistry.DMG
                 || hardwareProfile == HardwareProfileRegistry.MGB
                 || hardwareProfile == HardwareProfileRegistry.CGB
-                || hardwareProfile == HardwareProfileRegistry.CGB0);
+                || hardwareProfile == HardwareProfileRegistry.CGB0
+                || hardwareProfile == HardwareProfileRegistry.SGB
+                || hardwareProfile == HardwareProfileRegistry.SGB2);
+        this.performanceSgbVramTransfer = hardwareProfile == HardwareProfileRegistry.SGB
+                || hardwareProfile == HardwareProfileRegistry.SGB2 ? vRamTransfer : null;
         this.performancePhysicalDmgMode2 = executionMode == ExecutionMode.PERFORMANCE
                 && !debugHistoryReplay
                 && (hardwareProfile == HardwareProfileRegistry.DMG
@@ -373,7 +382,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         this.oamSearchPhase = new OamSearch(oamRam, dma, lcdc, r);
         this.performanceScanlineRenderer = new PerformanceScanlineRenderer(
                 videoRam0, videoRam1, oamRam, lcdc, r, bgPalette, oamPalette,
-                gbc, false, oamSearchPhase.getSprites());
+                gbc, false, oamSearchPhase.getSprites(), performanceSgbVramTransfer);
         this.pixelTransferPhase = new PixelTransfer(new Display(gbc), videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), null, speedMode, 0, true);
         this.pixelMachine = new PixelTransfer(display, videoRam0, videoRam1, ppuOam, lcdc, r, gbc, bgPalette, oamPalette, oamSearchPhase.getSprites(), vRamTransfer, speedMode, 4);
         this.pixelMachine.setOamReaderBus(oamSearchPhase);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRenderer.java
@@ -74,6 +74,10 @@ public final class PerformanceScanlineRenderer {
 
     private final SpritePosition[] sprites;
 
+    // Only the profile-gated SGB/SGB2 direct-render owner supplies this transfer. Public
+    // renderer fixtures keep the historical null behavior through the constructor below.
+    private final VRamTransfer vRamTransfer;
+
     // Scratch storage is retained across lines. A performance line should not allocate an
     // object for every tile or sprite, especially on Android's controller thread.
     private final int[] linePixels = new int[SCREEN_WIDTH];
@@ -112,6 +116,23 @@ public final class PerformanceScanlineRenderer {
             boolean gbc,
             boolean dmgCompat,
             SpritePosition[] sprites) {
+        this(videoRam0, videoRam1, oamRam, lcdc, registers, bgPalette, oamPalette,
+                gbc, dmgCompat, sprites, null);
+    }
+
+    /** Internal production constructor carrying the nullable SGB raw-pixel transfer. */
+    PerformanceScanlineRenderer(
+            AddressSpace videoRam0,
+            AddressSpace videoRam1,
+            AddressSpace oamRam,
+            Lcdc lcdc,
+            GpuRegisterValues registers,
+            ColorPalette bgPalette,
+            ColorPalette oamPalette,
+            boolean gbc,
+            boolean dmgCompat,
+            SpritePosition[] sprites,
+            VRamTransfer vRamTransfer) {
         this.videoRam0 = Objects.requireNonNull(videoRam0, "videoRam0");
         this.videoRam1 = videoRam1;
         this.oamRam = Objects.requireNonNull(oamRam, "oamRam");
@@ -122,6 +143,7 @@ public final class PerformanceScanlineRenderer {
         this.gbc = gbc;
         this.dmgCompat = dmgCompat;
         this.sprites = Objects.requireNonNull(sprites, "sprites");
+        this.vRamTransfer = vRamTransfer;
         this.nativeVideoRam0 = exactVram(videoRam0);
         this.nativeVideoRam1 = exactVram(videoRam1);
         if (gbc
@@ -178,6 +200,10 @@ public final class PerformanceScanlineRenderer {
      * {@link #renderLine(Display, int, int)} for the output format.
      */
     public void renderLine(int ly, int windowLine, int[] output) {
+        renderLine(ly, windowLine, output, null);
+    }
+
+    private void renderLine(int ly, int windowLine, int[] output, VRamTransfer vRamTransfer) {
         Objects.requireNonNull(output, "output");
         if (output.length < SCREEN_WIDTH) {
             throw new IllegalArgumentException("Scanline output must contain 160 pixels");
@@ -282,7 +308,8 @@ public final class PerformanceScanlineRenderer {
                     bgEnabled,
                     bgp,
                     obp0,
-                    obp1);
+                    obp1,
+                    vRamTransfer);
         }
     }
 
@@ -291,7 +318,17 @@ public final class PerformanceScanlineRenderer {
      * as a separate optimization unit so the generic scheduler cannot absorb the renderer body.
      */
     void renderLinePerformanceBoundary(Display display, int ly, int windowLine) {
-        renderLine(display, ly, windowLine);
+        Objects.requireNonNull(display, "display");
+        renderLine(ly, windowLine, linePixels, vRamTransfer);
+        if (gbc) {
+            for (int pixel : linePixels) {
+                display.putColorPixel(pixel);
+            }
+        } else {
+            for (int pixel : linePixels) {
+                display.putDmgPixel(pixel);
+            }
+        }
     }
 
     private void renderNativeCgbLine(int ly, int windowLine, int[] output) {
@@ -422,15 +459,36 @@ public final class PerformanceScanlineRenderer {
             int bgp,
             int obp0,
             int obp1) {
+        return resolvePixel(
+                spriteIndex, spritePixel, backgroundRaw, backgroundPalette, backgroundPriority,
+                bgEnabled, bgp, obp0, obp1, null);
+    }
+
+    private int resolvePixel(
+            int spriteIndex,
+            int spritePixel,
+            int backgroundRaw,
+            int backgroundPalette,
+            boolean backgroundPriority,
+            boolean bgEnabled,
+            int bgp,
+            int obp0,
+            int obp1,
+            VRamTransfer vRamTransfer) {
         if (!gbc) {
+            int raw = backgroundRaw;
+            int palette = bgp;
             if (spriteIndex >= 0) {
                 SpriteLine sprite = spriteLines[spriteIndex];
                 if (!sprite.priority || backgroundRaw == 0) {
-                    int palette = sprite.palette == 0 ? obp0 : obp1;
-                    return (palette >> (spritePixel * 2)) & 0x03;
+                    raw = spritePixel;
+                    palette = sprite.palette == 0 ? obp0 : obp1;
                 }
             }
-            return (bgp >> (backgroundRaw * 2)) & 0x03;
+            if (vRamTransfer != null) {
+                vRamTransfer.putPixel(raw);
+            }
+            return (palette >> (raw * 2)) & 0x03;
         }
         return resolveCgb(
                 spriteIndex,

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/OamSearch.java
@@ -275,6 +275,13 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
         return isPerformanceMode2SpanEligible(readerPosition, spriteHeight, true, 2);
     }
 
+    /** CGB-reader counterpart with an owner-proven CPU speed. */
+    public boolean isPerformanceNoDmaStableSpanEligible(
+            int readerPosition, int spriteHeight, int expectedSpeedMode) {
+        return isPerformanceMode2SpanEligible(
+                readerPosition, spriteHeight, true, expectedSpeedMode);
+    }
+
     /**
      * Whether a bounded physical-DMG mode-2 span can use the allocation-free OAM scanner.
      *
@@ -317,6 +324,13 @@ public class OamSearch implements GpuPhase, StatefulComponent<OamSearch> {
     public void advancePerformanceNoDmaStableSpanTrusted(
             int readerPosition, int ticks, int currentSpriteHeight) {
         advancePerformanceMode2SpanTrusted(readerPosition, ticks, currentSpriteHeight, true, 2);
+    }
+
+    /** Advances a preflighted CGB-reader span at an owner-proven CPU speed. */
+    public void advancePerformanceNoDmaStableSpanTrusted(
+            int readerPosition, int ticks, int currentSpriteHeight, int expectedSpeedMode) {
+        advancePerformanceMode2SpanTrusted(
+                readerPosition, ticks, currentSpriteHeight, true, expectedSpeedMode);
     }
 
     /** Advances a preflighted physical-DMG mode-2 prefix using the same exact slot arithmetic. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -767,6 +767,32 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
         return transferInProgress;
     }
 
+    /** Whether an inactive OAM-search packet may advance only the serialized request ages. */
+    public boolean isPerformanceOamSearchPhaseClockStable() {
+        return !transferInProgress
+                && gpuMode == Mode.OamSearch
+                && hblankRequestTicks <= 0
+                && nextHblankRequestTicks <= 0
+                && cpuRequestArbitration == CpuRequestArbitration.NONE;
+    }
+
+    /**
+     * Replays the arithmetic part of {@link #advanceHblankRequest()} for a preflighted inactive
+     * OAM-search packet. Zero clocks age once per scalar dot; negative clocks remain invariant.
+     */
+    public void advancePerformanceOamSearchPhaseClockTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceOamSearchPhaseClockStable()) {
+            throw new IllegalStateException(
+                    "HDMA request clock is not stable for an OAM-search PERFORMANCE span");
+        }
+        if (!cpuHalted && hblankRequestTicks == 0) {
+            hblankRequestAge += ticks;
+        }
+        if (nextHblankRequestTicks == 0) {
+            nextHblankRequestAge += ticks;
+        }
+    }
+
     /** Captures the retained HDMA latches and current block progress without bus reads. */
     public DebugHardwareInspection.VramDma captureDebugVramDmaInspection() {
         int sourceAddress = src & 0xfff0;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -179,9 +179,17 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
 
     /** Physical-DMG normal-speed epoch guard; transfers and callbacks remain scalar. */
     public boolean performancePhysicalDmgEpochIdle(int requested) {
+        return performanceNormalSpeedEpochIdle(requested, false);
+    }
+
+    /** Normal-speed epoch guard shared by physical DMG and CGB compatibility. */
+    public boolean performanceNormalSpeedEpochIdle(int requested, boolean cgbCompat) {
+        boolean topologyMatches = cgbCompat
+                ? speedMode.isGbc() && speedMode.isDmgCompat()
+                : !speedMode.isGbc();
         return requested > 0
                 && speedMode.getSpeedMode() == 1
-                && !speedMode.isGbc()
+                && topologyMatches
                 && serialEndpoint.canTickPerformanceQuietSpan(requested)
                 && (sc & 0x80) == 0
                 && haltWakeDelay == 0
@@ -190,6 +198,11 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
 
     /** Applies a preflighted physical-DMG idle serial phase at one clock per master tick. */
     public void tickPerformancePhysicalDmgEpochIdle(int ticks) {
+        tickPerformanceNormalSpeedEpochIdle(ticks);
+    }
+
+    /** Applies a preflighted fixed-x1 normal-speed serial phase. */
+    public void tickPerformanceNormalSpeedEpochIdle(int ticks) {
         if (ticks <= 0) {
             return;
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -4,6 +4,7 @@ import eu.rekawek.coffeegb.core.memento.Memento;
 
 import eu.rekawek.coffeegb.core.events.Event;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent;
 import eu.rekawek.coffeegb.core.gpu.Display.DmgFrameReadyEvent;
 import eu.rekawek.coffeegb.core.state.MachineStateCapture;
 import eu.rekawek.coffeegb.core.state.ComponentState;
@@ -34,6 +35,8 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
 
     private static final int DMG_WINDOW_Y = 40;
 
+    private static final long INVALID_BORDER_GENERATION = Long.MIN_VALUE;
+
     private volatile boolean sgbBorder;
 
     private final boolean sgb;
@@ -48,6 +51,15 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
 
     private final int[] sgbMask = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
 
+    /**
+     * Private, canonical border/base images. These arrays are never published to subscribers;
+     * every render lease copies its geometry's generation into its callback-scoped target before
+     * repainting the Game Boy window.
+     */
+    private final int[] borderedBase;
+
+    private final int[] centerBase;
+
     private final int[][] palettes = new int[4][4];
 
     private final int[][] systemPalettes = new int[512][4];
@@ -61,6 +73,19 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
     private int borderFade;
 
     /**
+     * Border data is derived presentation state. A new generation is published only when a
+     * committed background, an actually different fade, or a state restore changes its source.
+     * Render leases materialize that generation lazily for each synchronous re-entrant depth.
+     */
+    private long borderGeneration = 1;
+
+    private long borderedBaseGeneration = INVALID_BORDER_GENERATION;
+
+    private long centerBaseGeneration = INVALID_BORDER_GENERATION;
+
+    private final transient ThreadLocal<RenderLeasePool> renderLeasePool;
+
+    /**
      * PAL_PRI controls whether later game palette commands reclaim a palette selected in the
      * SNES firmware UI. Coffee GB has no SNES palette-selection UI, so game palettes are always
      * active; retaining this bit is still required for deterministic state and future adapters.
@@ -71,6 +96,9 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
         this.sgbBorder = sgbBorder;
         this.sgb = sgb;
         this.sgbBus = sgbBus;
+        borderedBase = sgb ? new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT] : null;
+        centerBase = sgb ? new int[DISPLAY_WIDTH * DISPLAY_HEIGHT] : null;
+        renderLeasePool = sgb ? ThreadLocal.withInitial(RenderLeasePool::new) : null;
         predefinedPalette = DefinedPalettes.getPalette(rom.getTitle().trim());
     }
 
@@ -79,7 +107,7 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
         if (sgb) {
             this.eventBus = eventBus;
             eventBus.register(this::onSgbBackground, Background.SgbBackgroundReadyEvent.class);
-            eventBus.register(e -> borderFade = e.amount(), Background.SgbBackgroundFadeEvent.class);
+            eventBus.register(this::onSgbBackgroundFade, Background.SgbBackgroundFadeEvent.class);
             eventBus.register(this::onDmgFrame, DmgFrameReadyEvent.class);
             eventBus.register(e -> this.sgbBorder = e.borderEnabled, SetSgbBorder.class);
 
@@ -256,58 +284,113 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
         System.arraycopy(updated, 0, paletteMap, 0, paletteMap.length);
     }
 
+    private void onSgbBackgroundFade(Background.SgbBackgroundFadeEvent event) {
+        int amount = event.amount();
+        if (borderFade != amount) {
+            borderFade = amount;
+            invalidateBorderCache();
+        }
+    }
+
     private void onDmgFrame(DmgFrameReadyEvent dmgFrameReadyEvent) {
         if (screenMask == GameboyScreenMask.FREEZE) {
             return;
         }
-        int offsetX = sgbBorder ? 0 : 48;
-        int offsetY = sgbBorder ? 0 : 40;
-        int width = sgbBorder ? SGB_DISPLAY_WIDTH : DISPLAY_WIDTH;
-        int height = sgbBorder ? SGB_DISPLAY_HEIGHT : DISPLAY_HEIGHT;
-        int[] result = new int[width * height];
+        boolean includeBorder = sgbBorder;
+        RenderLeasePool pool = renderLeasePool.get();
+        RenderLease lease = pool.acquire(includeBorder);
+        try {
+            int[] result = lease.frame;
+            int[] base = canonicalBase(includeBorder);
+            if (includeBorder) {
+                System.arraycopy(base, 0, result, 0, base.length);
+            }
+            renderCenter(result, base, dmgFrameReadyEvent.pixels(), includeBorder);
+            // The leased array remains valid through every synchronous subscriber callback. It is
+            // returned to this depth-specific pool only after the complete post has unwound.
+            eventBus.post(new SgbFrameReadyEvent(result, includeBorder));
+        } finally {
+            pool.release(lease);
+        }
+    }
 
-        for (int y = offsetY; y < offsetY + height; y++) {
-            int sgbRowOffset = y * SGB_DISPLAY_WIDTH;
-            int resultRowOffset = (y - offsetY) * width;
-            for (int x = offsetX; x < offsetX + width; x++) {
-                int sgbPixel = sgbBuffer[x + sgbRowOffset];
-                int mask = sgbMask[x + sgbRowOffset];
-                int dmgPixel;
-                if (x >= DMG_WINDOW_X && x < DMG_WINDOW_X + DISPLAY_WIDTH && y >= DMG_WINDOW_Y && y < DMG_WINDOW_Y + DISPLAY_HEIGHT) {
-                    int dmgX = x - DMG_WINDOW_X;
-                    int dmgY = y - DMG_WINDOW_Y;
-                    int tileX = dmgX / 8;
-                    int tileY = dmgY / 8;
-                    int charId = tileX + tileY * DMG_TILES_WIDTH;
-                    int paletteId = paletteMap[charId];
-                    int p = dmgFrameReadyEvent.pixels()[dmgX + dmgY * DISPLAY_WIDTH];
-                    if (screenMask == GameboyScreenMask.BLANK_COLOR0) {
-                        p = 0;
-                    }
-                    if (p == 0) {
-                        paletteId = 0;
-                    }
-                    dmgPixel = palettes[paletteId][p];
-                    if (screenMask == GameboyScreenMask.BLANK_BLACK) {
-                        dmgPixel = 0;
-                    }
-                } else {
-                    dmgPixel = 0;
-                }
-                int i = (x - offsetX) + resultRowOffset;
-                if (mask == 0) {
-                    result[i] = translateGbcRgb(dmgPixel);
-                } else {
-                    result[i] = translateGbcRgb(fadeBorderColor(sgbPixel, borderFade));
-                }
+    /** Returns the generation-cached canonical base for the requested output geometry. */
+    private int[] canonicalBase(boolean includeBorder) {
+        if (includeBorder) {
+            if (borderedBaseGeneration != borderGeneration) {
+                rebuildBorder(borderedBase, true);
+                borderedBaseGeneration = borderGeneration;
+            }
+            return borderedBase;
+        }
+        if (centerBaseGeneration != borderGeneration) {
+            rebuildBorder(centerBase, false);
+            centerBaseGeneration = borderGeneration;
+        }
+        return centerBase;
+    }
+
+    /** Rebuilds the private canonical border/base image for one output geometry. */
+    private void rebuildBorder(int[] target, boolean includeBorder) {
+        int width = includeBorder ? SGB_DISPLAY_WIDTH : DISPLAY_WIDTH;
+        int height = includeBorder ? SGB_DISPLAY_HEIGHT : DISPLAY_HEIGHT;
+        int sourceOffsetX = includeBorder ? 0 : DMG_WINDOW_X;
+        int sourceOffsetY = includeBorder ? 0 : DMG_WINDOW_Y;
+        for (int y = 0; y < height; y++) {
+            int sourceRow = (y + sourceOffsetY) * SGB_DISPLAY_WIDTH + sourceOffsetX;
+            int targetRow = y * width;
+            for (int x = 0; x < width; x++) {
+                int source = sourceRow + x;
+                target[targetRow + x] = sgbMask[source] == 0
+                        ? 0
+                        : translateGbcRgb(fadeBorderColor(sgbBuffer[source], borderFade));
             }
         }
-        eventBus.post(new SgbFrameReadyEvent(result, sgbBorder));
+    }
+
+    /** Repaints the only part of an SGB output that changes at every Game Boy frame. */
+    private void renderCenter(int[] target, int[] base, int[] dmgPixels,
+                              boolean includeBorder) {
+        int width = includeBorder ? SGB_DISPLAY_WIDTH : DISPLAY_WIDTH;
+        int sourceOffsetX = DMG_WINDOW_X;
+        int sourceOffsetY = DMG_WINDOW_Y;
+        for (int dmgY = 0; dmgY < DISPLAY_HEIGHT; dmgY++) {
+            int sourceRow = (dmgY + sourceOffsetY) * SGB_DISPLAY_WIDTH + sourceOffsetX;
+            int dmgRow = dmgY * DISPLAY_WIDTH;
+            int targetRow = (includeBorder ? dmgY + sourceOffsetY : dmgY) * width
+                    + (includeBorder ? sourceOffsetX : 0);
+            for (int dmgX = 0; dmgX < DISPLAY_WIDTH; dmgX++) {
+                int source = sourceRow + dmgX;
+                int output = targetRow + dmgX;
+                // A nonzero SGB mask keeps the cached border pixel in the Game Boy window.
+                if (sgbMask[source] != 0) {
+                    if (!includeBorder) {
+                        target[output] = base[output];
+                    }
+                    continue;
+                }
+                int p = dmgPixels[dmgRow + dmgX];
+                if (screenMask == GameboyScreenMask.BLANK_COLOR0) {
+                    p = 0;
+                }
+                int paletteId = p == 0 ? 0 : paletteMap[(dmgX / 8) + (dmgY / 8) * DMG_TILES_WIDTH];
+                int dmgPixel = palettes[paletteId][p];
+                if (screenMask == GameboyScreenMask.BLANK_BLACK) {
+                    dmgPixel = 0;
+                }
+                target[output] = translateGbcRgb(dmgPixel);
+            }
+        }
     }
 
     private void onSgbBackground(Background.SgbBackgroundReadyEvent sgbBackgroundReadyEvent) {
         System.arraycopy(sgbBackgroundReadyEvent.buffer(), 0, sgbBuffer, 0, sgbBuffer.length);
         System.arraycopy(sgbBackgroundReadyEvent.mask(), 0, sgbMask, 0, sgbMask.length);
+        invalidateBorderCache();
+    }
+
+    private void invalidateBorderCache() {
+        borderGeneration++;
     }
 
     private static int fadeBorderColor(int color, int fade) {
@@ -392,6 +475,7 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
         this.screenMask = mem.screenMask;
         this.borderFade = mem.borderFade & STATE_BORDER_FADE_MASK;
         this.palettePriority = (mem.borderFade & STATE_PALETTE_PRIORITY) != 0;
+        invalidateBorderCache();
     }
 
     boolean isPalettePriorityEnabled() {
@@ -431,6 +515,53 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
         return clone;
     }
 
+    /** One reusable render target per synchronous re-entrant depth and output geometry. */
+    private static final class RenderLease {
+        private int[] borderedFrame;
+        private int[] centerFrame;
+        private int[] frame;
+
+        private void select(boolean includeBorder) {
+            if (includeBorder) {
+                if (borderedFrame == null) {
+                    borderedFrame = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+                }
+                frame = borderedFrame;
+            } else {
+                if (centerFrame == null) {
+                    centerFrame = new int[DISPLAY_WIDTH * DISPLAY_HEIGHT];
+                }
+                frame = centerFrame;
+            }
+        }
+    }
+
+    private static final class RenderLeasePool {
+        private RenderLease[] leases = new RenderLease[1];
+        private int depth;
+
+        private RenderLease acquire(boolean includeBorder) {
+            int index = depth++;
+            if (index == leases.length) {
+                leases = Arrays.copyOf(leases, leases.length * 2);
+            }
+            RenderLease lease = leases[index];
+            if (lease == null) {
+                lease = new RenderLease();
+                leases[index] = lease;
+            }
+            lease.select(includeBorder);
+            return lease;
+        }
+
+        private void release(RenderLease lease) {
+            if (depth <= 0 || leases[depth - 1] != lease) {
+                throw new IllegalStateException("Unbalanced SGB render lease");
+            }
+            depth--;
+        }
+    }
+
     private record SgbDisplayState(int[] sgbBuffer, int[] sgbMask, int[][] palettes, int[][] systemPalettes,
                                      int[] paletteMap, int[][] attributeFiles, GameboyScreenMask screenMask,
                                      int borderFade) implements ComponentState<SgbDisplay> {
@@ -442,9 +573,29 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
                                      int borderFade) implements Memento<SgbDisplay> {
     }
 
-    public record SgbFrameReadyEvent(int[] buffer, boolean includeBorder) implements Event {
+    /**
+     * SGB output backed by a producer-owned render lease.
+     *
+     * <p>The buffer is valid only for the duration of the synchronous event-bus callback. A
+     * subscriber that needs to retain a frame must copy it before returning; the producer may
+     * reuse this exact array on the next publication (or a nested publication may use another
+     * lease at the same time).</p>
+     */
+    public record SgbFrameReadyEvent(int[] buffer, boolean includeBorder)
+            implements SynchronousBorrowedEvent {
         public void toRgb(int[] target, boolean unused) {
             System.arraycopy(buffer, 0, target, 0, buffer.length);
+        }
+
+        /** Copies this callback-scoped RGB payload into opaque Android-style ARGB storage. */
+        public void copyToOpaqueArgb(int[] target) {
+            if (target == null || target.length < buffer.length) {
+                throw new IllegalArgumentException(
+                        "Target pixel array is shorter than the SGB frame payload");
+            }
+            for (int i = 0; i < buffer.length; i++) {
+                target[i] = buffer[i] | 0xff000000;
+            }
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -35,18 +35,21 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     }
 
     /**
-     * PERFORMANCE audio is intentionally represented at one fifty-fifth of the master-tick
-     * rate. The source is sampled at approximately 76.26 kHz, which is still comfortably above
-     * the host audio band and gives the emulator a 55-master-tick quiet window in which to batch
-     * the PSG. 55 also divides the historical 69,905-T controller chunk exactly (1,271 samples),
-     * so compact audio cannot drift one source tick per frame. The pending span is transient:
-     * CPU-visible operations and state boundaries materialize it before observing or serializing
-     * channel state.
+     * PERFORMANCE audio is intentionally represented at a decimated master-tick rate. The normal
+     * source is sampled at approximately 76.26 kHz, which is still comfortably above the host
+     * audio band and gives the emulator a 54-master-tick quiet window in which to batch the PSG.
+     * SGB-family clocks use a 56-tick decimation, yielding exactly 1,254 samples in their
+     * 70,224-tick frame while retaining a 55-master-tick quiet window. The pending span is
+     * transient: CPU-visible operations and state boundaries materialize it before observing or
+     * serializing channel state.
      */
     private static final int PERFORMANCE_AUDIO_DECIMATION = 55;
 
-    /** SGB frame clocks retain the historical exact-frame compact stream for now. */
-    private static final int SGB_PERFORMANCE_AUDIO_DECIMATION = 11;
+    /** Retained for portable PERFORMANCE states written before SGB decimation was widened. */
+    private static final int LEGACY_SGB_PERFORMANCE_AUDIO_DECIMATION = 11;
+
+    /** SGB/SGB2 compact samples exactly divide their 70,224-tick controller frame. */
+    private static final int SGB_PERFORMANCE_AUDIO_DECIMATION = 56;
 
     private static final int ACCURACY_AUDIO_DECIMATION = 1;
 
@@ -283,10 +286,10 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             }
             return;
         }
-        // The PERFORMANCE horizon stops before the next decimated sample, where the
-        // pending span is materialized.  Consequently this accumulator is bounded by
-        // performanceAudioDecimation - 1 (54 today), so an overflow-checked add in the
-        // 1.7M-packets-per-sample hot path cannot provide any additional protection.
+        // The PERFORMANCE horizon stops before the next decimated sample, where the pending span
+        // is materialized. Consequently this accumulator is bounded by
+        // performanceAudioDecimation - 1, so an overflow-checked add in the hot path cannot
+        // provide any additional protection.
         pendingPerformanceTicks += ticks;
         performanceSamplePhase += ticks;
     }
@@ -982,8 +985,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             throw new IllegalArgumentException("ComponentState buffer length doesn't contain its prefix");
         }
         if (mem.audioDecimation != ACCURACY_AUDIO_DECIMATION
-                && mem.audioDecimation != SGB_PERFORMANCE_AUDIO_DECIMATION
-                && mem.audioDecimation != PERFORMANCE_AUDIO_DECIMATION) {
+                && mem.audioDecimation != LEGACY_SGB_PERFORMANCE_AUDIO_DECIMATION
+                && mem.audioDecimation != PERFORMANCE_AUDIO_DECIMATION
+                && mem.audioDecimation != SGB_PERFORMANCE_AUDIO_DECIMATION) {
             throw new IllegalArgumentException("ComponentState audio decimation is invalid");
         }
         if (mem.performanceSamplePhase < 0

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -167,7 +167,19 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
 
     /** Physical-DMG normal-speed counterpart of {@link #performanceEpochSpanLimit(int)}. */
     public int performancePhysicalDmgEpochSpanLimit(int requested) {
-        if (requested <= 0 || speedMode.getSpeedMode() != 1 || speedMode.isGbc()
+        return performanceNormalSpeedEpochSpanLimit(requested, false);
+    }
+
+    /**
+     * Fixed-x1 normal-speed epoch horizon shared by physical DMG and CGB compatibility.
+     * CGB compatibility retains the later-revision +2 DIV/APU frame-sequencer tap, so that
+     * candidate is stopped before either possible frame-sequencer edge.
+     */
+    public int performanceNormalSpeedEpochSpanLimit(int requested, boolean cgbCompat) {
+        boolean topologyMatches = cgbCompat
+                ? speedMode.isGbc() && speedMode.isDmgCompat()
+                : !speedMode.isGbc();
+        if (requested <= 0 || speedMode.getSpeedMode() != 1 || !topologyMatches
                 || debugHooks != null || divReset || overflow || haltWakeDelay != 0
                 || haltBugDivRippleVisible || suppressNextInterruptRequest
                 || previousBit != timerInput(div, tac)) {
@@ -177,6 +189,11 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         span = capBeforeMasterTicks(span, clocksToOverflowFallingEdge(), 1);
         span = capBeforeMasterTicks(span, clocksToPendingDividerRipple(), 1);
         span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(0), 1);
+        if (cgbCompat) {
+            // The CGB PSG tap is two CPU clocks ahead of the divider until FF04 is reset.
+            // A compatibility epoch must retain that same edge exclusion as native CGB.
+            span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(2), 1);
+        }
         return Math.max(0, span);
     }
 
@@ -191,13 +208,18 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
 
     /** Applies a preflighted physical-DMG epoch at one CPU clock per master tick. */
     public void tickPerformancePhysicalDmgEpochTrusted(int ticks) {
+        tickPerformanceNormalSpeedEpochTrusted(ticks);
+    }
+
+    /** Applies a preflighted fixed-x1 normal-speed epoch. */
+    public void tickPerformanceNormalSpeedEpochTrusted(int ticks) {
         if (ticks <= 0) {
             return;
         }
         acknowledgeInterruptIfNeeded();
         divReset = false;
         long cpuClocks = ticks;
-        int fallingEdges = physicalDmgEpochTimerFallingEdges(ticks);
+        int fallingEdges = normalSpeedEpochTimerFallingEdges(ticks);
         tima = (int) ((tima + fallingEdges) & 0xff);
         div = (int) ((div + cpuClocks) & 0xffff);
         previousBit = timerInput(div, tac);
@@ -400,8 +422,8 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         return 1 + (int) ((cpuClocks - first) / period);
     }
 
-    /** Fixed-x1 physical-DMG falling-edge count, kept separate from the native hot path. */
-    private int physicalDmgEpochTimerFallingEdges(int masterTicks) {
+    /** Fixed-x1 falling-edge count, kept separate from the native hot path. */
+    private int normalSpeedEpochTimerFallingEdges(int masterTicks) {
         if ((tac & 0x04) == 0) {
             return 0;
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyBootStateTest.java
@@ -10,7 +10,9 @@ import java.util.concurrent.CancellationException;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class GameboyBootStateTest {
 
@@ -25,9 +27,10 @@ public class GameboyBootStateTest {
                 AddressSpace bus = gameboy.getAddressSpace();
 
                 assertArrayEquals(
-                        new int[]{0xe0, 0x00, 0x00, 0x70},
+                    new int[]{0xe0, 0x00, 0x00, 0x70},
                         new int[]{bus.getByte(0xff0f), bus.getByte(0xff24),
                                 bus.getByte(0xff25), bus.getByte(0xff26)});
+                assertFalse(gameboy.isBootstrapReady());
             }
         }
     }
@@ -42,9 +45,10 @@ public class GameboyBootStateTest {
             AddressSpace bus = gameboy.getAddressSpace();
 
             assertArrayEquals(
-                    new int[]{0xe1, 0x77, 0x00, 0xf0},
-                    new int[]{bus.getByte(0xff0f), bus.getByte(0xff24),
-                            bus.getByte(0xff25), bus.getByte(0xff26)});
+                        new int[]{0xe1, 0x77, 0x00, 0xf0},
+                        new int[]{bus.getByte(0xff0f), bus.getByte(0xff24),
+                                bus.getByte(0xff25), bus.getByte(0xff26)});
+            assertTrue(gameboy.isBootstrapReady());
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/** Focused native-CGB smoke coverage for the coarse PERFORMANCE epoch entrance. */
+/** Focused native-CGB and CGB-compatibility coverage for the coarse PERFORMANCE epoch entrance. */
 public final class GameboyPerformanceEpochTest {
 
     @Test
@@ -102,6 +102,11 @@ public final class GameboyPerformanceEpochTest {
             assertTrue(gameboy.getSpeedMode().isDmgCompat());
             assertEquals(0L, gameboy.getPerformanceBulkSpanCount());
             assertEquals(0L, gameboy.getPerformanceEpochCount());
+
+            gameboy.resetPerformanceBulkCounters();
+            gameboy.runTicks(4_096);
+            assertTrue("ordinary CGB compatibility did not enter the epoch lane after NORMAL handoff",
+                    gameboy.getPerformanceEpochTicks() > 0);
         }
     }
 
@@ -126,11 +131,16 @@ public final class GameboyPerformanceEpochTest {
             assertTrue(gameboy.getSpeedMode().isDmgCompat());
             assertEquals(0L, gameboy.getPerformanceBulkSpanCount());
             assertEquals(0L, gameboy.getPerformanceEpochCount());
+
+            gameboy.resetPerformanceBulkCounters();
+            gameboy.runTicks(4_096);
+            assertTrue("ordinary CGB compatibility did not enter the epoch lane after FAST_FORWARD handoff",
+                    gameboy.getPerformanceEpochTicks() > 0);
         }
     }
 
     @Test
-    public void physicalDmgEntersEpochWhileCgbCompatibilityStaysLegacy() throws Exception {
+    public void physicalDmgAndCgbCompatibilityEnterTheirEpochLanes() throws Exception {
         byte[] loop = new byte[0x8000];
         loop[0x100] = (byte) 0xc3;
         loop[0x101] = 0x00;
@@ -151,8 +161,124 @@ public final class GameboyPerformanceEpochTest {
             compat.runTicks(100_000);
             assertTrue("physical DMG did not enter the coarse epoch lane",
                     dmg.getPerformanceEpochTicks() > 0);
-            assertEquals(0L, compat.getPerformanceEpochTicks());
+            assertTrue("ordinary CGB compatibility did not enter the coarse epoch lane",
+                    compat.getPerformanceEpochTicks() > 0);
             assertTrue(compat.getSpeedMode().isDmgCompat());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityRomWramLoopMatchesFallbackWithEpochCoverage()
+            throws Exception {
+        byte[] image = dmgRomWramLoop();
+        try (Gameboy scalar = cgbCompatibilitySession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = cgbCompatibilitySession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("CGB compatibility frame callbacks", scalarFrames, candidateFrames);
+            assertEquals("custom-source oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("CGB compatibility ROM/WRAM loop had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000);
+            assertEquals("CGB compatibility used a non-raster epoch plan",
+                    candidate.getPerformanceEpochTicks(),
+                    candidate.getPerformanceEpochRasterFastTicks());
+            assertEquals(0L, candidate.getPerformanceEpochMode2ReplayTicks());
+            assertEquals(scalar.getAddressSpace().getByte(0xc000),
+                    candidate.getAddressSpace().getByte(0xc000));
+            assertDeepStateEquals("CGB compatibility ROM/WRAM loop",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityUnsafeIoWriteMatchesFallbackAndTerminatesEpoch()
+            throws Exception {
+        byte[] image = cgbCompatibilityIoWriteLoop();
+        try (Gameboy scalar = cgbCompatibilitySession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = cgbCompatibilitySession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            for (int chunk = 0; chunk < 12; chunk++) {
+                assertEquals("CGB compatibility IO frame callback", scalar.runTicks(5_000),
+                        candidate.runTicks(5_000));
+            }
+            assertTrue("CGB compatibility IO loop had no coarse coverage epochs="
+                            + candidate.getPerformanceEpochCount()
+                            + " ticks=" + candidate.getPerformanceEpochTicks()
+                            + " bulk=" + candidate.getPerformanceBulkTicks()
+                            + " pc=" + Integer.toHexString(candidate.getCpu().getRegisters().getPC())
+                            + " mode=" + candidate.getGpu().getMode()
+                            + " line=" + candidate.getGpu().getLine()
+                            + " dot=" + candidate.getGpu().getTicksInLine(),
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertTrue("unsafe IO did not terminate a CGB compatibility epoch",
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses() > 0);
+            assertDeepStateEquals("CGB compatibility IO loop",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityOamDmaWriteMatchesFallback() throws Exception {
+        byte[] image = cgbCompatibilityOamDmaWriteLoop();
+        try (Gameboy scalar = cgbCompatibilitySession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = cgbCompatibilitySession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            for (int chunk = 0; chunk < 8; chunk++) {
+                assertEquals("CGB compatibility OAM-DMA frame callback", scalar.runTicks(5_000),
+                        candidate.runTicks(5_000));
+                assertDeepStateEquals("CGB compatibility OAM-DMA chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+            assertTrue("CGB compatibility OAM-DMA loop had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertTrue("CGB compatibility OAM-DMA write did not terminate an epoch",
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses() > 0);
+        }
+    }
+
+    @Test
+    public void unmeasuredNormalSpeedTopologiesStayOutsideFixedEpochLane() throws Exception {
+        byte[] nonColor = dmgRomWramLoop();
+        byte[] nativeColor = dmgRomWramLoop();
+        nativeColor[0x143] = (byte) 0x80;
+        try (Gameboy cgb0 = new Gameboy.GameboyConfiguration(new Rom(nonColor))
+                     .setHardwareProfile(HardwareProfileRegistry.CGB0)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setSupportBatterySave(false)
+                     .build();
+             Gameboy sgb = new Gameboy.GameboyConfiguration(new Rom(nonColor))
+                     .setHardwareProfile(HardwareProfileRegistry.SGB)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setSupportBatterySave(false)
+                     .build();
+             Gameboy nativeSpeed1 = new Gameboy.GameboyConfiguration(new Rom(nativeColor))
+                     .setHardwareProfile(HardwareProfileRegistry.CGB)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setSupportBatterySave(false)
+                     .build()) {
+            cgb0.runTicks(100_000);
+            sgb.runTicks(100_000);
+            nativeSpeed1.runTicks(100_000);
+            assertEquals(0L, cgb0.getPerformanceEpochTicks());
+            assertEquals(0L, sgb.getPerformanceEpochTicks());
+            assertEquals(0L, nativeSpeed1.getPerformanceEpochTicks());
+            assertFalse(nativeSpeed1.getSpeedMode().isDmgCompat());
         }
     }
 
@@ -235,6 +361,57 @@ public final class GameboyPerformanceEpochTest {
             assertDeepStateEquals("after physical-DMG HALT epoch",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityEpochRetiringHaltMatchesScalarDeepState() throws Exception {
+        byte[] image = dmgRomWramLoop();
+        image[0x200] = 0x76; // HALT, selected after reaching a trusted CGB raster span
+        try (Gameboy scalar = cgbCompatibilitySession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = cgbCompatibilitySession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 0
+                    && candidate.getCpu().performanceCgbCompatibilityEpochEntryEligible())
+                    && guard++ < 200_000) {
+                assertEquals("CGB compatibility HALT setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not reach a trusted CGB compatibility HALT entry",
+                    guard < 200_000);
+            assertDeepStateEquals("before CGB compatibility HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("CGB compatibility HALT frame callback", scalar.runTicks(8),
+                    candidate.runTicks(8));
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertTrue("HALT fetch did not retire inside a CGB compatibility epoch",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("after CGB compatibility HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityMeasuredWindowRetainsEpochLane() throws Exception {
+        try (Gameboy gameboy = cgbCompatibilitySession(
+                dmgRomWramLoop(), PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            gameboy.resetPerformanceBulkCounters();
+            assertEquals(4_096, gameboy.runMeasuredTicksUntilStop(4_096, () -> false));
+            assertTrue("measured CGB compatibility window lost epoch coverage",
+                    gameboy.getPerformanceEpochTicks() > 0);
         }
     }
 
@@ -327,6 +504,18 @@ public final class GameboyPerformanceEpochTest {
             throws Exception {
         return new Gameboy.GameboyConfiguration(new Rom(image))
                 .setHardwareProfile(HardwareProfileRegistry.DMG)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy cgbCompatibilitySession(
+            byte[] image, PlayerInputSource inputSource, ExecutionMode executionMode)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(executionMode)
                 .setPlayerInputSource(inputSource)
@@ -493,6 +682,32 @@ public final class GameboyPerformanceEpochTest {
         image[0x105] = 0x77; // LD (HL),A
         image[0x106] = 0x18; // JR 0103
         image[0x107] = (byte) 0xfb;
+        image[0x143] = 0x00;
+        return image;
+    }
+
+    private static byte[] cgbCompatibilityIoWriteLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF47),A
+        image[0x103] = 0x47;
+        image[0x104] = (byte) 0xc3; // JP 0100
+        image[0x105] = 0x00;
+        image[0x106] = 0x01;
+        image[0x143] = 0x00;
+        return image;
+    }
+
+    private static byte[] cgbCompatibilityOamDmaWriteLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF46),A
+        image[0x103] = 0x46;
+        image[0x104] = (byte) 0xc3; // JP 0100
+        image[0x105] = 0x00;
+        image[0x106] = 0x01;
         image[0x143] = 0x00;
         return image;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.RecordComponent;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Focused native-CGB smoke coverage for the coarse PERFORMANCE epoch entrance. */
@@ -75,6 +76,56 @@ public final class GameboyPerformanceEpochTest {
             assertEquals(4_096, gameboy.runMeasuredTicksUntilStop(4_096, () -> false));
             assertTrue("measured stop-aware PERFORMANCE path lost native epoch coverage",
                     gameboy.getPerformanceEpochTicks() > 0L);
+        }
+    }
+
+    @Test
+    public void cgbDmgCompatibilityBootstrapStaysScalarUntilAuthenticHandoff() throws Exception {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(
+                new Rom(validNonColorRom()))
+                .setGameboyType(GameboyType.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.NORMAL)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build()) {
+            assertFalse(gameboy.isBootstrapReady());
+            assertEquals(0L, gameboy.getPerformanceBulkSpanCount());
+            assertEquals(0L, gameboy.getPerformanceEpochCount());
+
+            int executed = gameboy.runTicksUntilStop(40_000_000,
+                    gameboy::isBootstrapReady);
+
+            assertTrue("authentic bootstrap did not reach the cartridge handoff", executed > 0);
+            assertTrue(gameboy.isBootstrapReady());
+            assertEquals(0x0100, gameboy.getCpu().getRegisters().getPC());
+            assertEquals(0xff, gameboy.getAddressSpace().getByte(0xff50));
+            assertTrue(gameboy.getSpeedMode().isDmgCompat());
+            assertEquals(0L, gameboy.getPerformanceBulkSpanCount());
+            assertEquals(0L, gameboy.getPerformanceEpochCount());
+        }
+    }
+
+    @Test
+    public void fastForwardStopsAtTheEntryPointThenSettlesTheHandoffScalar() throws Exception {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(
+                new Rom(validNonColorRom()))
+                .setGameboyType(GameboyType.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setSupportBatterySave(false)
+                .build()) {
+            assertEquals(0x0100, gameboy.getCpu().getRegisters().getPC());
+            assertFalse(gameboy.isBootstrapReady());
+
+            int executed = gameboy.runTicksUntilStop(32, gameboy::isBootstrapReady);
+
+            assertTrue("fast-forward handoff tail did not execute", executed > 0);
+            assertTrue(gameboy.isBootstrapReady());
+            assertEquals(0x0100, gameboy.getCpu().getRegisters().getPC());
+            assertEquals(0xff, gameboy.getAddressSpace().getByte(0xff50));
+            assertTrue(gameboy.getSpeedMode().isDmgCompat());
+            assertEquals(0L, gameboy.getPerformanceBulkSpanCount());
+            assertEquals(0L, gameboy.getPerformanceEpochCount());
         }
     }
 
@@ -387,6 +438,34 @@ public final class GameboyPerformanceEpochTest {
         } catch (ReflectiveOperationException e) {
             throw new AssertionError("Cannot compare " + path, e);
         }
+    }
+
+    private static byte[] validNonColorRom() {
+        byte[] image = new byte[0x8000];
+        int[] logo = {
+                0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+                0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+                0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+                0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+                0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+                0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e,
+        };
+        for (int index = 0; index < logo.length; index++) {
+            image[0x104 + index] = (byte) logo[index];
+        }
+        image[0x100] = (byte) 0xc3; // JP 0100, keep the post-boot fixture alive
+        image[0x101] = 0x00;
+        image[0x102] = 0x01;
+        image[0x143] = 0x00; // non-color cartridge on a CGB profile
+        image[0x147] = 0x00;
+        image[0x148] = 0x00;
+        image[0x149] = 0x00;
+        int checksum = 0;
+        for (int address = 0x134; address <= 0x14c; address++) {
+            checksum = (checksum - (image[address] & 0xff) - 1) & 0xff;
+        }
+        image[0x14d] = (byte) checksum;
+        return image;
     }
 
     private static byte[] doubleSpeedLoop() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core;
 
 import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.gpu.Mode;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
@@ -250,18 +251,12 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
-    public void unmeasuredNormalSpeedTopologiesStayOutsideFixedEpochLane() throws Exception {
+    public void unrelatedNormalSpeedTopologiesStayOutsideFixedEpochLane() throws Exception {
         byte[] nonColor = dmgRomWramLoop();
         byte[] nativeColor = dmgRomWramLoop();
         nativeColor[0x143] = (byte) 0x80;
         try (Gameboy cgb0 = new Gameboy.GameboyConfiguration(new Rom(nonColor))
                      .setHardwareProfile(HardwareProfileRegistry.CGB0)
-                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
-                     .setExecutionMode(ExecutionMode.PERFORMANCE)
-                     .setSupportBatterySave(false)
-                     .build();
-             Gameboy sgb = new Gameboy.GameboyConfiguration(new Rom(nonColor))
-                     .setHardwareProfile(HardwareProfileRegistry.SGB)
                      .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                      .setExecutionMode(ExecutionMode.PERFORMANCE)
                      .setSupportBatterySave(false)
@@ -273,12 +268,40 @@ public final class GameboyPerformanceEpochTest {
                      .setSupportBatterySave(false)
                      .build()) {
             cgb0.runTicks(100_000);
-            sgb.runTicks(100_000);
             nativeSpeed1.runTicks(100_000);
             assertEquals(0L, cgb0.getPerformanceEpochTicks());
-            assertEquals(0L, sgb.getPerformanceEpochTicks());
             assertEquals(0L, nativeSpeed1.getPerformanceEpochTicks());
             assertFalse(nativeSpeed1.getSpeedMode().isDmgCompat());
+        }
+    }
+
+    @Test
+    public void sgbProfilesFencedEpochsMatchScalarAcrossAFrame() throws Exception {
+        byte[] image = dmgRomWramLoop();
+        for (HardwareProfile profile : new HardwareProfile[]{
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2}) {
+            try (Gameboy scalar = sgbSession(image, profile, PlayerInputSnapshot::released);
+                 Gameboy candidate = sgbSession(image, profile, PlayerInputSource.RELEASED)) {
+                long scalarFrames = 0;
+                long candidateFrames = 0;
+                for (int chunk = 0; chunk < 20; chunk++) {
+                    scalarFrames += scalar.runTicks(5_000);
+                    candidateFrames += candidate.runTicks(5_000);
+                }
+
+                assertEquals(profile.id() + " frame callbacks", scalarFrames, candidateFrames);
+                assertEquals(profile.id() + " custom-source oracle entered the epoch lane",
+                        0L, scalar.getPerformanceEpochTicks());
+                assertTrue(profile.id() + " did not enter its fenced epoch lane",
+                        candidate.getPerformanceEpochTicks() > 5_000);
+                assertEquals(profile.id() + " crossed an unsafe memory boundary inside an epoch",
+                        0L, candidate.getCpu().getPerformanceEpochTerminalAccesses());
+                assertEquals(profile.id() + " WRAM loop", scalar.getAddressSpace().getByte(0xc000),
+                        candidate.getAddressSpace().getByte(0xc000));
+                assertDeepStateEquals(profile.id() + " fenced epoch",
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
         }
     }
 
@@ -416,20 +439,12 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
-    public void accuracyAndSgbProfilesStayOutsidePhysicalDmgEpoch() throws Exception {
+    public void accuracyStaysOutsidePhysicalDmgEpoch() throws Exception {
         byte[] image = dmgRomWramLoop();
         try (Gameboy accuracy = physicalDmgSession(
-                image, PlayerInputSource.RELEASED, ExecutionMode.ACCURACY);
-             Gameboy sgb = new Gameboy.GameboyConfiguration(new Rom(image))
-                     .setHardwareProfile(HardwareProfileRegistry.SGB)
-                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
-                     .setExecutionMode(ExecutionMode.PERFORMANCE)
-                     .setSupportBatterySave(false)
-                     .build()) {
+                image, PlayerInputSource.RELEASED, ExecutionMode.ACCURACY)) {
             accuracy.runTicks(100_000);
-            sgb.runTicks(100_000);
             assertEquals(0L, accuracy.getPerformanceEpochTicks());
-            assertEquals(0L, sgb.getPerformanceEpochTicks());
         }
     }
 
@@ -518,6 +533,18 @@ public final class GameboyPerformanceEpochTest {
                 .setHardwareProfile(HardwareProfileRegistry.CGB)
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy sgbSession(
+            byte[] image, HardwareProfile profile, PlayerInputSource inputSource)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(profile)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
                 .setPlayerInputSource(inputSource)
                 .setSupportBatterySave(false)
                 .build();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -4,8 +4,10 @@ import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.gpu.Mode;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
+import eu.rekawek.coffeegb.core.memory.Hdma;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import org.junit.Test;
 
@@ -137,6 +139,45 @@ public final class GameboyPerformanceEpochTest {
             gameboy.runTicks(4_096);
             assertTrue("ordinary CGB compatibility did not enter the epoch lane after FAST_FORWARD handoff",
                     gameboy.getPerformanceEpochTicks() > 0);
+        }
+    }
+
+    @Test
+    public void fastForwardCgbCompatibilityUsesMode2PhasePacketsAfterBootGdma()
+            throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy scalar = fastForwardCgbCompatibilitySession(
+                        PlayerInputSnapshot::released);
+                Gameboy candidate = fastForwardCgbCompatibilitySession(candidateHub)) {
+            assertEquals("FAST_FORWARD handoff tail",
+                    scalar.runTicksUntilStop(32, scalar::isBootstrapReady),
+                    candidate.runTicksUntilStop(32, candidate::isBootstrapReady));
+            assertTrue(scalar.isBootstrapReady());
+            assertTrue(candidate.isBootstrapReady());
+            assertTrue(candidate.getSpeedMode().isDmgCompat());
+            Hdma.HdmaState bootHdma = (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertEquals("authentic boot did not retain the completed-GDMA request clock",
+                    0, bootHdma.hblankRequestTicks());
+
+            advanceScalarPairToVisibleMode2Dot(scalar, candidate, 20);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue("FAST_FORWARD compatibility mode 2 rejected its phase transaction",
+                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            int ticks = 79 - candidate.getGpu().getTicksInLine();
+            for (int i = 0; i < ticks; i++) {
+                scalar.tick();
+            }
+            assertEquals("FAST_FORWARD mode-2 frame callbacks", 0, candidate.runTicks(ticks));
+            assertTrue("FAST_FORWARD compatibility mode 2 had no bulk coverage",
+                    candidate.getPerformanceBulkTicks() > 0);
+            assertDeepStateEquals("FAST_FORWARD compatibility mode-2 dot 79",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
         }
     }
 
@@ -514,6 +555,17 @@ public final class GameboyPerformanceEpochTest {
                 .build();
     }
 
+    private static Gameboy fastForwardCgbCompatibilitySession(PlayerInputSource inputSource)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(validNonColorRom()))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
     private static Gameboy physicalDmgSession(
             byte[] image, PlayerInputSource inputSource, ExecutionMode executionMode)
             throws Exception {
@@ -612,6 +664,25 @@ public final class GameboyPerformanceEpochTest {
             }
         }
         assertTrue("test did not reach a settled native-CGB mode-2 dot", guard < 400_000);
+    }
+
+    private static void advanceScalarPairToVisibleMode2Dot(
+            Gameboy scalar, Gameboy candidate, int targetDot) {
+        int guard = 0;
+        while (!(scalar.getGpu().isLcdEnabled()
+                && !scalar.getGpu().isFirstLine()
+                && scalar.getGpu().getLine() < 144
+                && scalar.getGpu().getMode() == Mode.OamSearch
+                && scalar.getGpu().getTicksInLine() == targetDot)
+                && guard++ < 456 * 160) {
+            assertEquals("FAST_FORWARD mode-2 setup frame callback",
+                    scalar.tick(), candidate.tick());
+        }
+        assertTrue("FAST_FORWARD setup did not reach visible mode-2 dot " + targetDot,
+                guard < 456 * 160);
+        assertDeepStateEquals("FAST_FORWARD visible mode-2 setup",
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
     }
 
     /** Record/array-aware equality for the private immutable component-state graph. */

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/** Differential coverage for the short physical-DMG mode-2 phase packet. */
+/** Differential coverage for the short DMG-clocked mode-2 phase packet. */
 public final class GameboyPerformanceMode2PhaseTest {
 
     /** Deliberately non-identity source: PERFORMANCE's input horizon must reject this leg. */
@@ -30,9 +30,20 @@ public final class GameboyPerformanceMode2PhaseTest {
     @Test
     public void physicalDmgAndMgbMode2PacketsMatchScalarForBothSpriteHeights()
             throws Exception {
-        for (HardwareProfile profile : new HardwareProfile[] {
-                HardwareProfileRegistry.DMG, HardwareProfileRegistry.MGB
-        }) {
+        assertMode2PacketsMatchScalarForBothSpriteHeights(new HardwareProfile[] {
+                HardwareProfileRegistry.DMG, HardwareProfileRegistry.MGB});
+    }
+
+    @Test
+    public void sgbAndSgb2Mode2PacketsMatchScalarForBothSpriteHeights()
+            throws Exception {
+        assertMode2PacketsMatchScalarForBothSpriteHeights(new HardwareProfile[] {
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2});
+    }
+
+    private static void assertMode2PacketsMatchScalarForBothSpriteHeights(
+            HardwareProfile[] profiles) throws Exception {
+        for (HardwareProfile profile : profiles) {
             for (boolean tallSprites : new boolean[] {false, true}) {
                 for (int start : new int[] {0, 1, 2, 3, 13, 20, 76, 77, 78}) {
                     int[] spans = {1, 2, 3};
@@ -49,7 +60,7 @@ public final class GameboyPerformanceMode2PhaseTest {
                             candidate.getGpu().setPerformanceScanlineEnabled(true);
                             assertEquals("mode-2 quiet span was unexpectedly admitted",
                                     0, candidate.getGpu().performanceQuietSpanLimit());
-                            assertTrue("DMG mode-2 preflight rejected profile="
+                            assertTrue("DMG-clocked mode-2 preflight rejected profile="
                                             + profile.id() + " tall=" + tallSprites
                                             + " start=" + start + " span=" + requested,
                                     candidate.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(
@@ -92,10 +103,23 @@ public final class GameboyPerformanceMode2PhaseTest {
 
     @Test
     public void physicalDmgMode2LeavesDot79To80Scalar() throws Exception {
+        assertMode2LeavesDot79To80Scalar(HardwareProfileRegistry.DMG);
+    }
+
+    @Test
+    public void sgbAndSgb2Mode2LeaveDot79To80Scalar() throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[] {
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2}) {
+            assertMode2LeavesDot79To80Scalar(profile);
+        }
+    }
+
+    private static void assertMode2LeavesDot79To80Scalar(HardwareProfile profile)
+            throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(HardwareProfileRegistry.DMG, SCALAR_INPUT);
-                Gameboy candidate = session(HardwareProfileRegistry.DMG, candidateHub)) {
+                Gameboy scalar = session(profile, SCALAR_INPUT);
+                Gameboy candidate = session(profile, candidateHub)) {
             reachMode2Start(scalar, candidate, 76, false);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
@@ -116,16 +140,30 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
             assertEquals("mode-3 handoff entered the mode-2 packet", packetTicks,
                     candidate.getPerformanceBulkTicks());
-            assertDeepStateEquals("dot-79 handoff", scalar.captureStateWithoutTimeSource(),
+            assertDeepStateEquals(profile.id() + " dot-79 handoff",
+                    scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
     }
 
     @Test
     public void physicalDmgMode2RejectsAnActiveDmaTransfer() throws Exception {
+        assertMode2RejectsAnActiveDmaTransfer(HardwareProfileRegistry.DMG);
+    }
+
+    @Test
+    public void sgbAndSgb2Mode2RejectActiveDmaTransfer() throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[] {
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2}) {
+            assertMode2RejectsAnActiveDmaTransfer(profile);
+        }
+    }
+
+    private static void assertMode2RejectsAnActiveDmaTransfer(HardwareProfile profile)
+            throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy gameboy = session(HardwareProfileRegistry.DMG, candidateHub)) {
+                Gameboy gameboy = session(profile, candidateHub)) {
             reachMode2Start(gameboy, gameboy, 20, false);
             gameboy.getGpu().setPerformanceScanlineEnabled(true);
             gameboy.getAddressSpace().setByte(0xff46, 0x80);
@@ -175,10 +213,6 @@ public final class GameboyPerformanceMode2PhaseTest {
         }
 
         Mode2ExclusionCase[] cases = {
-                new Mode2ExclusionCase("sgb", HardwareProfileRegistry.SGB,
-                        ExecutionMode.PERFORMANCE, false, true),
-                new Mode2ExclusionCase("sgb2", HardwareProfileRegistry.SGB2,
-                        ExecutionMode.PERFORMANCE, false, true),
                 new Mode2ExclusionCase("cgb-native", HardwareProfileRegistry.CGB,
                         ExecutionMode.PERFORMANCE, true, true),
                 new Mode2ExclusionCase("cgb0-native", HardwareProfileRegistry.CGB0,
@@ -186,6 +220,10 @@ public final class GameboyPerformanceMode2PhaseTest {
                 new Mode2ExclusionCase("cgb-compat", HardwareProfileRegistry.CGB,
                         ExecutionMode.PERFORMANCE, false, true),
                 new Mode2ExclusionCase("accuracy-dmg", HardwareProfileRegistry.DMG,
+                        ExecutionMode.ACCURACY, false, false),
+                new Mode2ExclusionCase("accuracy-sgb", HardwareProfileRegistry.SGB,
+                        ExecutionMode.ACCURACY, false, false),
+                new Mode2ExclusionCase("accuracy-sgb2", HardwareProfileRegistry.SGB2,
                         ExecutionMode.ACCURACY, false, false)
         };
         for (Mode2ExclusionCase exclusion : cases) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -176,9 +176,9 @@ public final class GameboyPerformanceMode2PhaseTest {
 
         Mode2ExclusionCase[] cases = {
                 new Mode2ExclusionCase("sgb", HardwareProfileRegistry.SGB,
-                        ExecutionMode.PERFORMANCE, false, false),
+                        ExecutionMode.PERFORMANCE, false, true),
                 new Mode2ExclusionCase("sgb2", HardwareProfileRegistry.SGB2,
-                        ExecutionMode.PERFORMANCE, false, false),
+                        ExecutionMode.PERFORMANCE, false, true),
                 new Mode2ExclusionCase("cgb-native", HardwareProfileRegistry.CGB,
                         ExecutionMode.PERFORMANCE, true, true),
                 new Mode2ExclusionCase("cgb0-native", HardwareProfileRegistry.CGB0,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -6,6 +6,7 @@ import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot;
 import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
+import eu.rekawek.coffeegb.core.memory.Hdma;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import org.junit.Test;
 
@@ -41,6 +42,13 @@ public final class GameboyPerformanceMode2PhaseTest {
                 HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2});
     }
 
+    @Test
+    public void cgbCompatibilityMode2PacketsMatchScalarForBothSpriteHeights()
+            throws Exception {
+        assertMode2PacketsMatchScalarForBothSpriteHeights(new HardwareProfile[] {
+                HardwareProfileRegistry.CGB});
+    }
+
     private static void assertMode2PacketsMatchScalarForBothSpriteHeights(
             HardwareProfile[] profiles) throws Exception {
         for (HardwareProfile profile : profiles) {
@@ -60,11 +68,11 @@ public final class GameboyPerformanceMode2PhaseTest {
                             candidate.getGpu().setPerformanceScanlineEnabled(true);
                             assertEquals("mode-2 quiet span was unexpectedly admitted",
                                     0, candidate.getGpu().performanceQuietSpanLimit());
-                            assertTrue("DMG-clocked mode-2 preflight rejected profile="
+                            assertTrue("mode-2 phase preflight rejected profile="
                                             + profile.id() + " tall=" + tallSprites
                                             + " start=" + start + " span=" + requested,
-                                    candidate.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(
-                                            requested) > 0);
+                                    performanceMode2PhaseSpanLimit(
+                                            candidate, profile, requested) > 0);
                             int cpuPhaseLimit = candidate.getCpu().performancePhaseOnlySpanLimit();
                             String caseDetails = "profile=" + profile.id()
                                     + " tall=" + tallSprites + " start=" + start
@@ -114,6 +122,11 @@ public final class GameboyPerformanceMode2PhaseTest {
         }
     }
 
+    @Test
+    public void cgbCompatibilityMode2LeavesDot79To80Scalar() throws Exception {
+        assertMode2LeavesDot79To80Scalar(HardwareProfileRegistry.CGB);
+    }
+
     private static void assertMode2LeavesDot79To80Scalar(HardwareProfile profile)
             throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
@@ -140,6 +153,12 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
             assertEquals("mode-3 handoff entered the mode-2 packet", packetTicks,
                     candidate.getPerformanceBulkTicks());
+            if (profile == HardwareProfileRegistry.CGB) {
+                assertTrue("CGB handoff left DMG compatibility mode",
+                        candidate.getGpu().isDmgCompatMode());
+                assertTrue("scalar CGB compatibility handoff did not arm the color renderer",
+                        candidate.getGpu().isPerformanceScanlineCursorActive());
+            }
             assertDeepStateEquals(profile.id() + " dot-79 handoff",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
@@ -159,30 +178,61 @@ public final class GameboyPerformanceMode2PhaseTest {
         }
     }
 
+    @Test
+    public void cgbCompatibilityMode2RejectsActiveOamDma() throws Exception {
+        assertMode2RejectsAnActiveDmaTransfer(HardwareProfileRegistry.CGB);
+    }
+
     private static void assertMode2RejectsAnActiveDmaTransfer(HardwareProfile profile)
             throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy gameboy = session(profile, candidateHub)) {
-            reachMode2Start(gameboy, gameboy, 20, false);
-            gameboy.getGpu().setPerformanceScanlineEnabled(true);
-            gameboy.getAddressSpace().setByte(0xff46, 0x80);
-            assertEquals(0,
-                    gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(3));
+                Gameboy scalar = session(profile, SCALAR_INPUT);
+                Gameboy candidate = session(profile, candidateHub)) {
+            reachMode2Start(scalar, candidate, 20, false);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            scalar.getAddressSpace().setByte(0xff46, 0x80);
+            candidate.getAddressSpace().setByte(0xff46, 0x80);
+            assertEquals(0, performanceMode2PhaseSpanLimit(candidate, profile, 3));
+            candidate.resetPerformanceBulkCounters();
+
+            for (int i = 0; i < 3; i++) {
+                scalar.tick();
+            }
+            assertEquals(0, candidate.runTicks(3));
+            assertEquals("active OAM DMA entered a mode-2 packet", 0,
+                    candidate.getPerformanceBulkTicks());
+            assertDeepStateEquals(profile.id() + " active OAM DMA",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
         }
     }
 
     @Test
     public void physicalDmgMode2RestoreFailsClosedThenMatchesScalar() throws Exception {
+        assertMode2RestoreFailsClosedThenMatchesScalar(HardwareProfileRegistry.DMG);
+    }
+
+    @Test
+    public void cgbCompatibilityMode2RestoreFailsClosedThenMatchesScalar() throws Exception {
+        assertMode2RestoreFailsClosedThenMatchesScalar(HardwareProfileRegistry.CGB);
+    }
+
+    private static void assertMode2RestoreFailsClosedThenMatchesScalar(
+            HardwareProfile profile) throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(HardwareProfileRegistry.DMG, SCALAR_INPUT);
-                Gameboy candidate = session(HardwareProfileRegistry.DMG, candidateHub)) {
+                Gameboy scalar = session(profile, SCALAR_INPUT);
+                Gameboy candidate = session(profile, candidateHub)) {
             reachMode2Start(scalar, candidate, 20, true);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
             var checkpoint = candidate.captureState();
             candidate.restoreState(checkpoint);
+            assertEquals("restored mode-2 state entered the fixed-point transaction", 0,
+                    performanceMode2PhaseSpanLimit(candidate, profile, 3));
+            candidate.resetPerformanceBulkCounters();
 
             // Restored LCDC history is intentionally conservative for nine dots. The scalar
             // fallback during that drain must remain observationally equivalent.
@@ -190,9 +240,103 @@ public final class GameboyPerformanceMode2PhaseTest {
                 scalar.tick();
                 candidate.runTicks(1);
             }
-            assertDeepStateEquals("restore mode-2 drain",
+            assertEquals("restore drain entered a mode-2 packet", 0,
+                    candidate.getPerformanceBulkTicks());
+            assertDeepStateEquals(profile.id() + " restore mode-2 drain",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityMode2RejectsActiveHdma() throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+                Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT);
+                Gameboy candidate = session(HardwareProfileRegistry.CGB, candidateHub)) {
+            reachMode2Start(scalar, candidate, 20, false);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            startOneBlockGdma(scalar);
+            startOneBlockGdma(candidate);
+            assertEquals(0,
+                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
+            candidate.resetPerformanceBulkCounters();
+
+            for (int i = 0; i < 3; i++) {
+                scalar.tick();
+            }
+            assertEquals(0, candidate.runTicks(3));
+            assertEquals("active HDMA entered a mode-2 packet", 0,
+                    candidate.getPerformanceBulkTicks());
+            assertDeepStateEquals("CGB compatibility active HDMA",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            int guard = 0;
+            while (candidate.getHdma().hasActiveOrPendingTransfer() && guard++ < 64) {
+                scalar.tick();
+                candidate.runTicks(1);
+            }
+            assertTrue("one-block GDMA did not complete inside mode 2", guard < 64);
+            assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
+            assertTrue("GDMA completion crossed the mode-2 packet cap",
+                    candidate.getGpu().getTicksInLine() < 79);
+            Hdma.HdmaState completed = (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertEquals("fixture did not retain the post-GDMA request clock", 0,
+                    completed.hblankRequestTicks());
+
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue("post-GDMA request clock rejected an exact mode-2 packet",
+                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
+            candidate.resetPerformanceBulkCounters();
+            int tail = Math.min(8, 79 - candidate.getGpu().getTicksInLine());
+            for (int i = 0; i < tail; i++) {
+                scalar.tick();
+            }
+            assertEquals(0, candidate.runTicks(tail));
+            assertTrue("completed GDMA tail did not enter a mode-2 packet",
+                    candidate.getPerformanceBulkTicks() > 0);
+            assertDeepStateEquals("CGB compatibility completed-GDMA request clock",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void cgbCompatibilityMode2RejectsCgb0NativeAccuracyAndDebug() throws Exception {
+        Mode2ExclusionCase[] cases = {
+                new Mode2ExclusionCase("cgb0-compat", HardwareProfileRegistry.CGB0,
+                        ExecutionMode.PERFORMANCE, false, true),
+                new Mode2ExclusionCase("cgb-native", HardwareProfileRegistry.CGB,
+                        ExecutionMode.PERFORMANCE, true, true),
+                new Mode2ExclusionCase("accuracy-cgb-compat", HardwareProfileRegistry.CGB,
+                        ExecutionMode.ACCURACY, false, false)
+        };
+        for (Mode2ExclusionCase exclusion : cases) {
+            PlayerInputHub hub = new PlayerInputHub();
+            try (PlayerInputHub.SourceHandle ignored = hub.openSource(0);
+                    Gameboy gameboy = session(exclusion.profile(), hub,
+                            exclusion.executionMode(), exclusion.nativeColor())) {
+                reachMode2Start(gameboy, gameboy, 20, false);
+                if (exclusion.scanlineCapable()) {
+                    gameboy.getGpu().setPerformanceScanlineEnabled(true);
+                }
+                assertEquals(exclusion.label() + " entered CGB compatibility mode 2", 0,
+                        gameboy.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
+            }
+        }
+
+        PlayerInputHub debugHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = debugHub.openSource(0);
+                Gameboy debug = session(HardwareProfileRegistry.CGB, debugHub)) {
+            reachMode2Start(debug, debug, 20, false);
+            debug.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue("ordinary CGB compatibility control was not eligible",
+                    debug.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
+            debug.getGpu().setDebugHooks(new TestDebugHooks());
+            assertEquals("debug hooks entered CGB compatibility mode 2", 0,
+                    debug.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
         }
     }
 
@@ -264,6 +408,13 @@ public final class GameboyPerformanceMode2PhaseTest {
         assertEquals(Mode.OamSearch, gameboy.getGpu().getMode());
         assertTrue("mode-2 exclusion fixture crossed the OAM horizon",
                 gameboy.getGpu().getTicksInLine() < 79);
+    }
+
+    private static int performanceMode2PhaseSpanLimit(
+            Gameboy gameboy, HardwareProfile profile, int requested) {
+        return profile == HardwareProfileRegistry.CGB
+                ? gameboy.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(requested)
+                : gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(requested);
     }
 
     @Test
@@ -370,6 +521,15 @@ public final class GameboyPerformanceMode2PhaseTest {
                 .setPlayerInputSource(inputSource)
                 .setSupportBatterySave(false)
                 .build();
+    }
+
+    private static void startOneBlockGdma(Gameboy gameboy) {
+        var bus = gameboy.getAddressSpace();
+        bus.setByte(0xff51, 0);
+        bus.setByte(0xff52, 0);
+        bus.setByte(0xff53, 0);
+        bus.setByte(0xff54, 0);
+        bus.setByte(0xff55, 0);
     }
 
     private static void assertDeepStateEquals(String path, Object expected, Object actual) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -9,6 +9,7 @@ import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.cpu.Cpu;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import eu.rekawek.coffeegb.core.gpu.Mode;
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
@@ -228,13 +229,13 @@ public final class GameboyPlayerInputHubPerformanceTest {
                             runScalarTickCalls(scalar, 100), performance.runTicks(100));
                     ComponentState<Gameboy> scalarState = scalar.captureState();
                     ComponentState<Gameboy> performanceState = performance.captureState();
-                    // The VRAM transfer is checked at every materialization boundary; the full
-                    // recursive state hash is sampled periodically because it includes large
-                    // display records and would dominate this intentionally long cross-frame run.
-                    assertEquals(profile.id() + " VRAM transfer chunk=" + chunk,
-                            recordComponentHash(scalarState, "vRamTransferMemento"),
-                            recordComponentHash(performanceState, "vRamTransferMemento"));
-                    if ((chunk & 63) == 0 || chunk >= 700) {
+                    // The direct renderer publishes a whole line at mode-3 entry, while the
+                    // scalar oracle fills it dot by dot. Compare the recursive state only at a
+                    // completed-line/VBlank materialization boundary; exact raw SGB transfer payloads
+                    // are checked synchronously by PerformanceScanlineIntegrationTest.
+                    if ((performance.getGpu().getMode() == Mode.OamSearch
+                            || performance.getGpu().getMode() == Mode.VBlank)
+                            && ((chunk & 63) == 0 || chunk >= 700)) {
                         assertStateEquivalent(scalarState, performanceState,
                                 profile.id() + " HALT chunk=" + chunk);
                     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -98,6 +98,51 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
+    public void sgbEpochStopsBeforeUnsafeIoAtEveryPhaseAndBudget() throws Exception {
+        for (int entryPhase = 0; entryPhase < 4; entryPhase++) {
+            for (int budget = 1; budget <= Cpu.PERFORMANCE_EPOCH_MAX_TICKS; budget++) {
+                ParityMemory directMemory = new ParityMemory();
+                directMemory.bytes[0x0000] = 0x7e; // LD A,(HL)
+                directMemory.bytes[0xff40] = 0x23;
+                ParityMemory scalarMemory = new ParityMemory();
+                System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                        directMemory.bytes.length);
+
+                InterruptManager directInterrupts = new InterruptManager(false);
+                InterruptManager scalarInterrupts = new InterruptManager(false);
+                Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                        new SpeedMode(false), new Display(false));
+                Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                        new SpeedMode(false), new Display(false));
+                direct.getRegisters().setHL(0xff40);
+                scalar.getRegisters().setHL(0xff40);
+                CpuPair pair = new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                        directMemory, scalarMemory);
+
+                for (int tick = 0; tick < entryPhase; tick++) {
+                    direct.tick();
+                    scalar.tick();
+                }
+
+                int elapsed = direct.runSgbPerformanceEpoch(budget);
+                assertTrue("SGB phase " + entryPhase + " budget " + budget
+                        + " made no safe progress", elapsed > 0);
+                assertTrue(elapsed <= budget);
+                for (int tick = 0; tick < elapsed; tick++) {
+                    scalar.tick();
+                }
+                assertFalse("SGB epoch deferred a memory access",
+                        direct.hasPerformanceEpochJournal());
+                assertEquals("SGB epoch crossed a terminal memory boundary", 0L,
+                        direct.getPerformanceEpochTerminalAccesses());
+                assertTrue("SGB epoch read the fenced FF40 boundary",
+                        directMemory.lastReadAddress != 0xff40);
+                assertCpuPairEquals(pair);
+            }
+        }
+    }
+
+    @Test
     public void cgbCompatibilityFourDotEpochMatchesScalarAtEveryBudget()
             throws Exception {
         for (int entryPhase = 0; entryPhase < 4; entryPhase++) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -98,6 +98,53 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
+    public void cgbCompatibilityFourDotEpochMatchesScalarAtEveryBudget()
+            throws Exception {
+        for (int entryPhase = 0; entryPhase < 4; entryPhase++) {
+            for (int budget = 1; budget <= Cpu.PERFORMANCE_EPOCH_MAX_TICKS; budget++) {
+                ParityMemory directMemory = new ParityMemory();
+                directMemory.bytes[0x0000] = 0x21; // LD HL,C000
+                directMemory.bytes[0x0001] = 0x00;
+                directMemory.bytes[0x0002] = (byte) 0xc0;
+                directMemory.bytes[0x0003] = 0x7e; // LD A,(HL)
+                directMemory.bytes[0x0004] = 0x3c; // INC A
+                directMemory.bytes[0x0005] = 0x77; // LD (HL),A
+                directMemory.bytes[0x0006] = 0x18; // JR 0003
+                directMemory.bytes[0x0007] = (byte) 0xfb;
+                directMemory.bytes[0xc000] = 0x23;
+                ParityMemory scalarMemory = new ParityMemory();
+                System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                        directMemory.bytes.length);
+
+                InterruptManager directInterrupts = new InterruptManager(true);
+                InterruptManager scalarInterrupts = new InterruptManager(true);
+                SpeedMode directSpeed = new SpeedMode(true);
+                SpeedMode scalarSpeed = new SpeedMode(true);
+                directSpeed.setDmgCompat(true);
+                scalarSpeed.setDmgCompat(true);
+                Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                        directSpeed, new Display(false));
+                Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                        scalarSpeed, new Display(false));
+                CpuPair pair = new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                        directMemory, scalarMemory);
+
+                for (int tick = 0; tick < entryPhase; tick++) {
+                    direct.tick();
+                    scalar.tick();
+                }
+
+                assertEquals("CGB compatibility phase " + entryPhase + " budget " + budget,
+                        budget, direct.runCgbCompatibilityPerformanceEpoch(budget));
+                for (int tick = 0; tick < budget; tick++) {
+                    scalar.tick();
+                }
+                assertCpuPairEquals(pair);
+            }
+        }
+    }
+
+    @Test
     public void nativeCgbAndPhysicalDmgEntryPointsAreTopologyIsolated() {
         Cpu physicalDmg = new Cpu(new CountingMemory(), new InterruptManager(false), null,
                 new SpeedMode(false), new Display(false));
@@ -110,6 +157,11 @@ public final class CpuPerformanceEpochTest {
         assertTrue(nativeCgb.performanceEpochEntryEligible());
         assertFalse(nativeCgb.performancePhysicalDmgEpochEntryEligible());
         assertEquals(0, nativeCgb.runPhysicalDmgPerformanceEpoch(54));
+
+        Cpu nativeNormalSpeed = new Cpu(new CountingMemory(), new InterruptManager(true), null,
+                new SpeedMode(true), new Display(false));
+        assertFalse(nativeNormalSpeed.performanceCgbCompatibilityEpochEntryEligible());
+        assertEquals(0, nativeNormalSpeed.runCgbCompatibilityPerformanceEpoch(54));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/events/EventBusImplTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/events/EventBusImplTest.java
@@ -377,6 +377,18 @@ public class EventBusImplTest {
         assertThrows(IllegalStateException.class, () -> bus.postAsync(new TestEvent()));
     }
 
+    @Test
+    public void borrowedEventsCannotBeQueuedAsynchronously() {
+        EventBusImpl bus = new EventBusImpl(null, "borrowed", true, 1_000);
+        try {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> bus.postAsync(new BorrowedEvent()));
+        } finally {
+            bus.close();
+        }
+    }
+
     private static void await(String description, Condition condition) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (!condition.evaluate() && System.nanoTime() < deadline) {
@@ -391,6 +403,9 @@ public class EventBusImplTest {
     }
 
     private static class TestEvent implements Event {
+    }
+
+    private static class BorrowedEvent implements SynchronousBorrowedEvent {
     }
 
     private static class NestedEvent implements Event {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineIntegrationTest.java
@@ -4,8 +4,11 @@ import eu.rekawek.coffeegb.core.ExecutionMode;
 import eu.rekawek.coffeegb.core.Gameboy;
 import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import org.junit.Test;
 
 import java.lang.reflect.Array;
@@ -43,6 +46,34 @@ public final class PerformanceScanlineIntegrationTest {
                     gameboy.getGpu().getPerformanceScanlineLines() > 0);
             assertTrue("CGB direct/quiet span did not skip raster work",
                     gameboy.getGpu().getPerformanceScanlineFastTicks() > 0);
+        }
+    }
+
+    @Test
+    public void performanceRunTicksActivatesSgbScanlineAndPreservesVblankPayloads()
+            throws Exception {
+        for (HardwareProfile profile : new HardwareProfile[] {
+                HardwareProfileRegistry.SGB, HardwareProfileRegistry.SGB2}) {
+            try (SgbProbe accuracy = new SgbProbe(profile, ExecutionMode.ACCURACY);
+                    SgbProbe performance = new SgbProbe(profile, ExecutionMode.PERFORMANCE)) {
+                accuracy.runToTransfer();
+                performance.runToTransfer();
+
+                assertTrue(profile.id() + " direct scanline path did not activate",
+                        performance.gameboy.getGpu().getPerformanceScanlineLines() > 0);
+                assertTrue(profile.id() + " direct raster path did not skip work",
+                        performance.gameboy.getGpu().getPerformanceScanlineFastTicks() > 0);
+                assertTrue(profile.id() + " accuracy SGB frame was not emitted",
+                        accuracy.sgbFrameCount > 0);
+                assertEquals(profile.id() + " SGB frame count",
+                        accuracy.sgbFrameCount, performance.sgbFrameCount);
+                assertEquals(profile.id() + " SGB frame hash",
+                        accuracy.sgbFrameHash, performance.sgbFrameHash);
+                assertEquals(profile.id() + " VRAM transfer count",
+                        accuracy.transferCount, performance.transferCount);
+                assertEquals(profile.id() + " VRAM transfer hash",
+                        accuracy.transferHash, performance.transferHash);
+            }
         }
     }
 
@@ -576,6 +607,70 @@ public final class PerformanceScanlineIntegrationTest {
                 .setExecutionMode(ExecutionMode.PERFORMANCE)
                 .setSupportBatterySave(false)
                 .build();
+    }
+
+    private static final class SgbProbe implements AutoCloseable {
+        private final EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        private final Gameboy gameboy;
+        private int transferCount;
+        private int sgbFrameCount;
+        private long transferHash = 0xcbf29ce484222325L;
+        private long sgbFrameHash = 0xcbf29ce484222325L;
+
+        private SgbProbe(HardwareProfile profile, ExecutionMode executionMode) throws Exception {
+            eventBus.register(event -> {
+                sgbFrameCount++;
+                for (int pixel : ((SgbDisplay.SgbFrameReadyEvent) event).buffer()) {
+                    sgbFrameHash ^= pixel & 0xffffffffL;
+                    sgbFrameHash *= 0x100000001b3L;
+                }
+            }, SgbDisplay.SgbFrameReadyEvent.class);
+            gameboy = new Gameboy.GameboyConfiguration(new Rom(sgbRom()))
+                    .setHardwareProfile(profile)
+                    .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                    .setExecutionMode(executionMode)
+                    .setSupportBatterySave(false)
+                    .setDisplaySgbBorder(profile.capabilities().superGameboyBorder())
+                    .build();
+            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+            sgbBus(gameboy).register(event -> {
+                transferCount++;
+                for (int pixel : ((VRamTransfer.VRamTransferComplete) event).buffer()) {
+                    transferHash ^= pixel & 0xffffffffL;
+                    transferHash *= 0x100000001b3L;
+                }
+            }, VRamTransfer.VRamTransferComplete.class);
+            for (int address = 0x8000; address < 0xa000; address++) {
+                gameboy.getGpu().writeVideoRam0ForCore(
+                        address, (address * 37 ^ address >>> 3 ^ 0x5a) & 0xff);
+            }
+        }
+
+        private void runToTransfer() {
+            int executed = gameboy.runMeasuredTicksUntilStop(200_000,
+                    () -> transferCount > 0);
+            assertTrue("SGB transfer did not reach VBlank", executed > 0 && transferCount > 0);
+        }
+
+        @Override
+        public void close() {
+            gameboy.closeSilently();
+            eventBus.close();
+        }
+    }
+
+    private static EventBusImpl sgbBus(Gameboy gameboy) throws Exception {
+        Field field = Gameboy.class.getDeclaredField("sgbBus");
+        field.setAccessible(true);
+        return (EventBusImpl) field.get(gameboy);
+    }
+
+    private static byte[] sgbRom() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = (byte) 0xc3;
+        image[0x101] = 0;
+        image[0x102] = 1;
+        return image;
     }
 
     private static Gameboy nativeCgbSession() throws Exception {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRendererTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/PerformanceScanlineRendererTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.gpu;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
 import eu.rekawek.coffeegb.core.memory.Ram;
 import eu.rekawek.coffeegb.core.state.ComponentState;
@@ -8,6 +9,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.BGP;
 import static eu.rekawek.coffeegb.core.gpu.GpuRegister.OBP0;
@@ -74,6 +76,36 @@ public class PerformanceScanlineRendererTest {
         }
         for (int i = 8; i < pixels.length; i++) {
             assertEquals(1, pixels[i]);
+        }
+    }
+
+    @Test
+    public void sgbTransferReceivesSelectedRawPixelsBeforePaletteMapping() {
+        Fixture fixture = new Fixture(false, false);
+        fixture.lcdc.set(0x91);
+        fixture.registers.put(BGP, 0x1b); // reverse 0,1,2,3 into shades 3,2,1,0
+        fixture.fillTile(0, 0x55, 0x33); // raw pixels 0,1,2,3,0,1,2,3
+
+        int[] shades = new int[160];
+        fixture.renderer().renderLine(0, -1, shades);
+        assertArrayEquals(new int[] {3, 2, 1, 0, 3, 2, 1, 0},
+                Arrays.copyOf(shades, 8));
+
+        try (EventBusImpl bus = new EventBusImpl(null, "sgb-transfer", false)) {
+            VRamTransfer transfer = new VRamTransfer(bus);
+            AtomicReference<int[]> payload = new AtomicReference<>();
+            bus.register(event -> payload.set(event.buffer().clone()),
+                    VRamTransfer.VRamTransferComplete.class);
+            PerformanceScanlineRenderer renderer = new PerformanceScanlineRenderer(
+                    fixture.vram0, fixture.vram1, fixture.oam, fixture.lcdc,
+                    fixture.registers, fixture.bgPalette, fixture.oamPalette,
+                    false, false, fixture.sprites, transfer);
+
+            renderer.renderLinePerformanceBoundary(new Display(false), 0, -1);
+            transfer.frameIsReady();
+
+            assertEquals(0x55, payload.get()[0]);
+            assertEquals(0x33, payload.get()[1]);
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
@@ -51,6 +51,30 @@ public class SerialPortPerformanceSpanTest {
                 new InterruptManager(true), true, new SpeedMode(true));
         assertFalse(cgbNormal.performanceEpochIdle(54));
         assertFalse(cgbNormal.performancePhysicalDmgEpochIdle(54));
+        assertFalse(cgbNormal.performanceNormalSpeedEpochIdle(54, true));
+    }
+
+    @Test
+    public void cgbCompatibilityIdleEpochMatchesScalarNormalSpeedTicks() {
+        SpeedMode scalarSpeed = new SpeedMode(true);
+        SpeedMode bulkSpeed = new SpeedMode(true);
+        scalarSpeed.setDmgCompat(true);
+        bulkSpeed.setDmgCompat(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        InterruptManager bulkInterrupts = new InterruptManager(true);
+        SerialPort scalar = new SerialPort(scalarInterrupts, true, scalarSpeed);
+        SerialPort bulk = new SerialPort(bulkInterrupts, true, bulkSpeed);
+        for (int tick = 0; tick < 37; tick++) {
+            scalar.tick();
+            bulk.tick();
+        }
+        assertTrue(bulk.performanceNormalSpeedEpochIdle(54, true));
+        for (int tick = 0; tick < 54; tick++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceNormalSpeedEpochIdle(54);
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayPerformanceTest.java
@@ -1,0 +1,305 @@
+package eu.rekawek.coffeegb.core.sgb;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.events.SynchronousBorrowedEvent;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.memory.cart.Rom;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_HEIGHT;
+import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_WIDTH;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+
+public class SgbDisplayPerformanceTest {
+
+    @Test
+    public void nonSgbDisplayDoesNotAllocateCompositorCaches() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "dmg-render", false);
+        try {
+            SgbDisplay display = new SgbDisplay(testRom(), eventBus, false, false);
+            display.init(eventBus);
+            eventBus.post(new Display.DmgFrameReadyEvent(
+                    new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT]));
+            assertNull(privateField("borderedBase").get(display));
+            assertNull(privateField("centerBase").get(display));
+            assertNull(privateField("renderLeasePool").get(display));
+        } finally {
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void reusesPrimaryGeometryBuffersForStableGeometry() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, "sgb-render", false);
+        SgbDisplay display = new SgbDisplay(testRom(), eventBus, true, false);
+        display.init(eventBus);
+        AtomicReference<int[]> frame = new AtomicReference<>();
+        eventBus.register(event -> frame.set(event.buffer()), SgbDisplay.SgbFrameReadyEvent.class);
+        try {
+            int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            int[] first = frame.get();
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+
+            assertSame(first, frame.get());
+            assertEquals(Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT, first.length);
+        } finally {
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void retainsSeparateExactGeometryBuffersAndSupportsNestedPublication() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, "sgb-nested", false);
+        SgbDisplay display = new SgbDisplay(testRom(), eventBus, true, false);
+        display.init(eventBus);
+        AtomicReference<int[]> center = new AtomicReference<>();
+        AtomicReference<int[]> bordered = new AtomicReference<>();
+        AtomicReference<int[]> outer = new AtomicReference<>();
+        AtomicReference<int[]> nested = new AtomicReference<>();
+        AtomicReference<int[]> outerSnapshot = new AtomicReference<>();
+        AtomicBoolean inOuter = new AtomicBoolean();
+        int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        try {
+            eventBus.register(event -> {
+                if (event.includeBorder()) {
+                    bordered.set(event.buffer());
+                } else if (center.get() == null) {
+                    center.set(event.buffer());
+                }
+                if (outer.compareAndSet(null, event.buffer())) {
+                    outerSnapshot.set(event.buffer().clone());
+                    inOuter.set(true);
+                    eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+                    inOuter.set(false);
+                    assertArrayEquals(outerSnapshot.get(), outer.get());
+                } else if (inOuter.get()) {
+                    nested.set(event.buffer());
+                }
+            }, SgbDisplay.SgbFrameReadyEvent.class);
+
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertNotNull(nested.get());
+            assertNotSame(outer.get(), nested.get());
+
+            eventBus.post(new SgbDisplay.SetSgbBorder(true));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals(SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT, bordered.get().length);
+            assertNotSame(center.get(), bordered.get());
+        } finally {
+            eventBus.close();
+        }
+    }
+
+    @Test
+    public void mutatingPublishedBorderAndMaskedCenterDoesNotCorruptNextFrame() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, "sgb-published-mutation", false);
+        EventBusImpl sgbBus = new EventBusImpl(null, "sgb-published-mutation-commands", false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, true);
+        display.init(eventBus);
+        AtomicReference<int[]> first = new AtomicReference<>();
+        AtomicReference<int[]> next = new AtomicReference<>();
+        AtomicBoolean mutate = new AtomicBoolean(true);
+        int borderIndex = 3 + 2 * SGB_DISPLAY_WIDTH;
+        int centerIndex = 48 + 40 * SGB_DISPLAY_WIDTH;
+        int[] border = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+        int[] mask = new int[border.length];
+        Arrays.fill(border, 0x7fff);
+        mask[borderIndex] = 1;
+        mask[centerIndex] = 1;
+        eventBus.register(event -> {
+            if (mutate.getAndSet(false)) {
+                first.set(event.buffer().clone());
+                event.buffer()[borderIndex] = 0x13572468;
+                event.buffer()[centerIndex] = 0x24681357;
+            } else {
+                next.set(event.buffer().clone());
+            }
+        }, SgbDisplay.SgbFrameReadyEvent.class);
+        try {
+            int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            eventBus.post(new Background.SgbBackgroundReadyEvent(border, mask));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+
+            assertArrayEquals(first.get(), next.get());
+            assertTrue(first.get()[borderIndex] != 0x13572468);
+            assertTrue(first.get()[centerIndex] != 0x24681357);
+        } finally {
+            eventBus.close();
+            sgbBus.close();
+        }
+    }
+
+    @Test
+    public void randomizedBorderAndCenterPixelsMatchTheScalarComposition() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, "sgb-random", false);
+        EventBusImpl sgbBus = new EventBusImpl(null, "sgb-random-commands", false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, true);
+        display.init(eventBus);
+        AtomicReference<int[]> rendered = new AtomicReference<>();
+        eventBus.register(event -> rendered.set(event.buffer().clone()),
+                SgbDisplay.SgbFrameReadyEvent.class);
+        try {
+            Random random = new Random(0x5347422d50455246L);
+            int[] border = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+            int[] mask = new int[border.length];
+            for (int i = 0; i < border.length; i++) {
+                border[i] = random.nextInt(0x8000);
+                mask[i] = random.nextInt(16);
+            }
+            eventBus.post(new Background.SgbBackgroundReadyEvent(border, mask));
+
+            int[] palettes = new int[Commands.TRANSFER_SIZE];
+            int[][] selectedPalettes = new int[4][4];
+            for (int palette = 0; palette < 512; palette++) {
+                for (int color = 0; color < 4; color++) {
+                    int value = random.nextInt(0x8000);
+                    setLittleEndian16(palettes, palette * 8 + color * 2, value);
+                    if (palette < 4) {
+                        selectedPalettes[palette][color] = value;
+                    }
+                }
+            }
+            Commands.PalTrnCmd palTrn = (Commands.PalTrnCmd) Commands.toCommand(commandPacket(0x0b));
+            palTrn.setDataTransfer(palettes);
+            sgbBus.post(palTrn);
+            int[] palSetPacket = commandPacket(0x0a);
+            setLittleEndian16(palSetPacket, 1, 0);
+            setLittleEndian16(palSetPacket, 3, 1);
+            setLittleEndian16(palSetPacket, 5, 2);
+            setLittleEndian16(palSetPacket, 7, 3);
+            sgbBus.post(Commands.toCommand(palSetPacket));
+
+            int[] attributes = new int[Commands.TRANSFER_SIZE];
+            int[] paletteMap = new int[20 * (Display.DISPLAY_HEIGHT / 8)];
+            for (int charId = 0; charId < paletteMap.length; charId++) {
+                paletteMap[charId] = random.nextInt(4);
+                attributes[charId / 4] |= paletteMap[charId] << (2 * (3 - charId % 4));
+            }
+            Commands.AttrTrnCmd attrTrn = (Commands.AttrTrnCmd) Commands.toCommand(commandPacket(0x15));
+            attrTrn.setDataTransfer(attributes);
+            sgbBus.post(attrTrn);
+            sgbBus.post(Commands.toCommand(commandPacket(0x16)));
+
+            int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+            for (int i = 0; i < dmg.length; i++) {
+                dmg[i] = random.nextInt(4);
+            }
+            int[] masks = {0, 2, 3};
+            for (boolean includeBorder : new boolean[]{true, false}) {
+                eventBus.post(new SgbDisplay.SetSgbBorder(includeBorder));
+                for (int fade : new int[]{0, 7, 31}) {
+                    eventBus.post(new Background.SgbBackgroundFadeEvent(fade));
+                    for (int screenMask : masks) {
+                        int[] packet = commandPacket(0x17);
+                        packet[1] = screenMask;
+                        sgbBus.post(Commands.toCommand(packet));
+                        eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+                        assertArrayEquals(
+                                scalarCompose(border, mask, dmg, selectedPalettes, paletteMap,
+                                        fade, screenMask, includeBorder),
+                                rendered.get());
+                    }
+                }
+            }
+        } finally {
+            eventBus.close();
+            sgbBus.close();
+        }
+    }
+
+    @Test
+    public void SgbFramePayloadIsBorrowedAndOpaqueCopyIsFused() {
+        int[] source = {0, 0x00010203, 0x7fffffff};
+        SgbDisplay.SgbFrameReadyEvent event =
+                new SgbDisplay.SgbFrameReadyEvent(source, false);
+        assertTrue(event instanceof SynchronousBorrowedEvent);
+        int[] target = {7, 7, 7, 7};
+        event.copyToOpaqueArgb(target);
+        assertArrayEquals(new int[]{0xff000000, 0xff010203, 0xffffffff, 7}, target);
+        assertThrows(IllegalArgumentException.class,
+                () -> event.copyToOpaqueArgb(new int[source.length - 1]));
+    }
+
+    private static Rom testRom() throws IOException {
+        byte[] bytes = new byte[0x8000];
+        bytes[0x147] = 0;
+        return new Rom(bytes);
+    }
+
+    private static java.lang.reflect.Field privateField(String name) throws Exception {
+        java.lang.reflect.Field field = SgbDisplay.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static int[] scalarCompose(int[] border, int[] mask, int[] dmg,
+                                       int[][] palettes, int[] paletteMap, int fade,
+                                       int screenMask, boolean includeBorder) {
+        int width = includeBorder ? SGB_DISPLAY_WIDTH : Display.DISPLAY_WIDTH;
+        int height = includeBorder ? SGB_DISPLAY_HEIGHT : Display.DISPLAY_HEIGHT;
+        int offsetX = includeBorder ? 0 : 48;
+        int offsetY = includeBorder ? 0 : 40;
+        int[] result = new int[width * height];
+        for (int y = offsetY; y < offsetY + height; y++) {
+            for (int x = offsetX; x < offsetX + width; x++) {
+                int sgbIndex = x + y * SGB_DISPLAY_WIDTH;
+                int dmgPixel = 0;
+                if (x >= 48 && x < 208 && y >= 40 && y < 184) {
+                    int dmgX = x - 48;
+                    int dmgY = y - 40;
+                    int p = dmg[dmgX + dmgY * Display.DISPLAY_WIDTH];
+                    if (screenMask == 3) {
+                        p = 0;
+                    }
+                    int paletteId = paletteMap[(dmgX / 8) + (dmgY / 8) * 20];
+                    if (p == 0) {
+                        paletteId = 0;
+                    }
+                    dmgPixel = palettes[paletteId][p];
+                    if (screenMask == 2) {
+                        dmgPixel = 0;
+                    }
+                }
+                int value;
+                if (mask[sgbIndex] == 0) {
+                    value = Display.GbcFrameReadyEvent.translateGbcRgb(dmgPixel);
+                } else {
+                    int raw = border[sgbIndex];
+                    int red = Math.max(0, (raw & 0x1f) - fade);
+                    int green = Math.max(0, ((raw >> 5) & 0x1f) - fade);
+                    int blue = Math.max(0, ((raw >> 10) & 0x1f) - fade);
+                    value = Display.GbcFrameReadyEvent.translateGbcRgb(
+                            red | (green << 5) | (blue << 10));
+                }
+                result[(x - offsetX) + (y - offsetY) * width] = value;
+            }
+        }
+        return result;
+    }
+
+    private static void setLittleEndian16(int[] target, int offset, int value) {
+        target[offset] = value & 0xff;
+        target[offset + 1] = value >>> 8;
+    }
+
+    private static int[] commandPacket(int code) {
+        int[] packet = new int[16];
+        packet[0] = (code << 3) | 1;
+        return packet;
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbRendererBaselineTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbRendererBaselineTest.java
@@ -72,8 +72,8 @@ public class SgbRendererBaselineTest {
             int[] actualContinuation = fixture.renderCurrentMask(originalDmg);
             assertArrayEquals(expectedContinuation, actualContinuation);
 
-            // Rendering returns a fresh producer buffer. Mutating a delivered event cannot leak
-            // into the display's retained renderer state or the next frame.
+            // Rendering uses callback-scoped producer buffers. Mutating a delivered event cannot
+            // leak into the display's retained canonical base or the next frame.
             int[] exposed = fixture.lastRawFrame.get();
             exposed[0] ^= 0x00ffffff;
             fixture.background.restoreState(backgroundState);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/PerformanceSystemMutedAudioCalendarTest.java
@@ -71,18 +71,20 @@ public final class PerformanceSystemMutedAudioCalendarTest {
             sound.tickPerformanceQuietSpan(sourceClock.controllerTicksPerFrame());
 
             assertEquals(70_224L, sound.getPerformanceSystemMutedAudioCalendarSkippedTicks());
-            assertEquals(6_384L,
+            assertEquals(1_254L,
                     sound.getPerformanceSystemMutedAudioCalendarZeroSampleSlots());
             assertEquals(1L, sound.getPerformanceSystemMutedAudioCalendarZeroSampleEvents());
             assertEquals(0L,
                     sound.getPerformanceSystemMutedAudioCalendarDroppedChannelTicks());
             assertEquals(1, events.size());
-            assertEquals(6_384, events.get(0).clockSpec().controllerTicksPerFrame());
-            assertEquals(sourceClock.ticksPerSecondNumerator(),
-                    events.get(0).clockSpec().ticksPerSecondNumerator());
-            assertEquals(sourceClock.ticksPerSecondDenominator() * 11L,
-                    events.get(0).clockSpec().ticksPerSecondDenominator());
-            assertEquals(6_384 * 2, events.get(0).buffer().length);
+            assertEquals(1_254, events.get(0).clockSpec().controllerTicksPerFrame());
+            assertEquals(new ClockSpec(
+                            sourceClock.ticksPerSecondNumerator(),
+                            sourceClock.ticksPerSecondDenominator() * 56L,
+                            sourceClock.controllerFramesPerSecondNumerator(),
+                            sourceClock.controllerFramesPerSecondDenominator()),
+                    events.get(0).clockSpec());
+            assertEquals(1_254 * 2, events.get(0).buffer().length);
             assertAllZero(events.get(0).buffer());
             eventBus.close();
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceAudioTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceAudioTest.java
@@ -5,9 +5,12 @@ import eu.rekawek.coffeegb.core.cpu.InterruptManager;
 import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.timer.Timer;
 import org.junit.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,6 +65,33 @@ public class SoundPerformanceAudioTest {
         assertEquals(4_194_304L, event.clockSpec().ticksPerSecondNumerator());
         assertEquals(55L, event.clockSpec().ticksPerSecondDenominator());
         assertEquals(1_271 * 2, event.buffer().length);
+    }
+
+    @Test
+    public void sgbPerformanceSourcesEmit1254SamplesPerExactFrame() {
+        for (ClockSpec sourceClock : new ClockSpec[]{ClockSpec.SGB, ClockSpec.SGB2}) {
+            Sound sound = newSound(sourceClock);
+            EventBusImpl eventBus = new EventBusImpl(null, null, false);
+            List<Sound.SoundSampleEvent> events = new ArrayList<>();
+            eventBus.register(events::add, Sound.SoundSampleEvent.class);
+            sound.init(eventBus);
+
+            for (int tick = 0; tick < 70_224; tick++) {
+                sound.play(tick, -tick);
+            }
+
+            assertEquals(1, events.size());
+            Sound.SoundSampleEvent event = events.get(0);
+            assertEquals(1_254, event.clockSpec().controllerTicksPerFrame());
+            assertEquals(new ClockSpec(
+                            sourceClock.ticksPerSecondNumerator(),
+                            sourceClock.ticksPerSecondDenominator() * 56L,
+                            sourceClock.controllerFramesPerSecondNumerator(),
+                            sourceClock.controllerFramesPerSecondDenominator()),
+                    event.clockSpec());
+            assertEquals(1_254 * 2, event.buffer().length);
+            eventBus.close();
+        }
     }
 
     @Test
@@ -139,6 +169,23 @@ public class SoundPerformanceAudioTest {
         assertEquals(1, events.size());
     }
 
+    @Test
+    public void legacySgbDecimationStateIsAcceptedButDropsItsHostAudioPrefix() throws Exception {
+        Sound source = newSound(ClockSpec.SGB);
+        for (int tick = 0; tick < 56; tick++) {
+            source.play(tick, -tick);
+        }
+        var legacyState = withAudioDecimation(source.captureState(), 11);
+
+        Sound restored = newSound(ClockSpec.SGB);
+        restored.restoreState(legacyState);
+
+        assertEquals(0, component(restored.captureState(), "i"));
+        assertEquals(0, component(restored.captureState(), "performanceSamplePhase"));
+        assertEquals(11, component(legacyState, "audioDecimation"));
+        assertEquals(56, component(restored.captureState(), "audioDecimation"));
+    }
+
     private static Sound newSound(ClockSpec sourceClock) {
         return newSound(sourceClock, ExecutionMode.PERFORMANCE);
     }
@@ -147,5 +194,36 @@ public class SoundPerformanceAudioTest {
         SpeedMode speedMode = new SpeedMode(true);
         Timer timer = new Timer(new InterruptManager(true), speedMode);
         return new Sound(timer, speedMode, true, sourceClock, executionMode);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ComponentState<T> withAudioDecimation(
+            ComponentState<T> state, int decimation) throws Exception {
+        Class<?> type = state.getClass();
+        RecordComponent[] components = type.getRecordComponents();
+        Class<?>[] parameterTypes = new Class<?>[components.length];
+        Object[] values = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            RecordComponent component = components[i];
+            parameterTypes[i] = component.getType();
+            component.getAccessor().setAccessible(true);
+            values[i] = component.getAccessor().invoke(state);
+            if (component.getName().equals("audioDecimation")) {
+                values[i] = decimation;
+            }
+        }
+        Constructor<?> constructor = type.getDeclaredConstructor(parameterTypes);
+        constructor.setAccessible(true);
+        return (ComponentState<T>) constructor.newInstance(values);
+    }
+
+    private static Object component(Object state, String name) throws Exception {
+        for (RecordComponent component : state.getClass().getRecordComponents()) {
+            if (component.getName().equals(name)) {
+                component.getAccessor().setAccessible(true);
+                return component.getAccessor().invoke(state);
+            }
+        }
+        throw new AssertionError("Missing state component: " + name);
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
@@ -95,6 +95,21 @@ public final class TimerPerformanceEpochTest {
     }
 
     @Test
+    public void cgbCompatibilityEpochIncludesThePlusTwoApuTap() {
+        SpeedMode speed = new SpeedMode(true);
+        speed.setDmgCompat(true);
+        Timer timer = new Timer(new InterruptManager(true), speed);
+        // DIV+2 is one clock before the bit-12 falling edge; DIV alone is three clocks away.
+        timer.presetDiv(0x1ff9);
+        assertEquals(4, timer.performanceNormalSpeedEpochSpanLimit(54, true));
+
+        SpeedMode nativeSpeed = new SpeedMode(true);
+        Timer nativeTimer = new Timer(new InterruptManager(true), nativeSpeed);
+        nativeTimer.presetDiv(0x1ff9);
+        assertEquals(0, nativeTimer.performanceNormalSpeedEpochSpanLimit(54, true));
+    }
+
+    @Test
     public void nonOverflowTimerEdgesAreCountedInsideEpoch() {
         Timer scalar = new Timer(new InterruptManager(true), doubleSpeed());
         Timer bulk = new Timer(new InterruptManager(true), doubleSpeed());


### PR DESCRIPTION
## Summary

- support benchmark-only full and fast-forward bootstrap while keeping boot execution scalar until the authentic cartridge handoff
- accelerate non-color games on ordinary CGB hardware with normal-speed CPU epochs and CGB mode-2 phase packets
- accelerate SGB/SGB2 with lower-overhead Performance audio sampling, reusable frame composition buffers, direct scanline rendering with exact raw SGB transfers, running CPU epochs, and mode-2 phase packets
- keep Accuracy, CGB0, native-CGB, unsafe bus boundaries, DMA/HDMA transitions, debug replay, and bootstrap execution on their existing exact paths

## Performance evidence

- DMG-on-CGB host workload: +23.86% from the running-CPU epoch, then +14.11% incrementally from mode-2 batching
- DMG-on-CGB Android FAST_FORWARD canary: sustained 59.59–60.56 FPS after startup (last block 59.81), controller utilization 88.9%, 600/600 frames, zero drops/corruption/GC
- SGB Android FULL canary: sustained 61.16–61.18 FPS, matching the 61.1679 Hz SGB clock
- SGB2 Android canary: 59.12 FPS cumulative over 600 frames, 600/600 clean
- SGB direct-scanline host workload: +103.68%; SGB running-CPU epoch: +18.96%; SGB mode-2 batching: +10.84% incremental

All Android runs used the same authorized non-color workload and the existing focused diagnostics path; no ROM data or identity is included.

## Validation

- core unit suite: 1,904 tests, 0 failures/errors (8 skipped fixtures)
- final CGB compatibility focused suite: 135/135
- SGB mode-2 focused suite: 43/43
- direct-scanline focused suite: 53/53
- minified benchmark APK built and exercised on the connected API 35 device
- device integrity for the reported runs: 600 ready / 600 submitted, zero dropped, duplicate, late, corrupt, allocation, and GC deltas
