### PR TITLE
Accelerate native CGB games at normal speed

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -273,7 +273,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private enum PerformancePhasePpuPlan {
         QUIET,
         PHYSICAL_DMG_MODE2,
-        CGB_COMPATIBILITY_MODE2
+        CGB_NORMAL_SPEED_MODE2
     }
 
     public Gameboy(Rom rom) {
@@ -1322,15 +1322,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
                 steadyRasterSpan = span > 0 && !directRasterSpan
                         && gpu.isPerformanceSteadyCursorActive();
-            } else if (isCgbCompatibilityPerformanceEpochTopology()) {
-                // CGB compatibility keeps the color OAM-reader semantics. Admit only the
-                // existing allocation-free CGB scan transaction; a fixed-point or reader
-                // miss leaves the complete one-to-three-dot phase on the scalar path.
+            } else if (isCgbNormalSpeedPerformanceEpochTopology()) {
+                // Ordinary CGB x1 keeps the color OAM-reader semantics in both native and
+                // compatibility modes. Admit only the existing allocation-free CGB scan
+                // transaction; a fixed-point or reader miss leaves the complete one-to-three-
+                // dot phase on the scalar path.
                 int mode2SpanLimit =
-                        gpu.performanceCgbCompatibilityMode2PhaseSpanLimit(span);
+                        gpu.performanceCgbNormalSpeedMode2PhaseSpanLimit(span);
                 if (mode2SpanLimit > 0) {
                     span = Math.min(span, mode2SpanLimit);
-                    ppuPlan = PerformancePhasePpuPlan.CGB_COMPATIBILITY_MODE2;
+                    ppuPlan = PerformancePhasePpuPlan.CGB_NORMAL_SPEED_MODE2;
                 } else {
                     span = 0;
                 }
@@ -2207,8 +2208,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     ticks, directRasterSpan, steadyRasterSpan);
             case PHYSICAL_DMG_MODE2 ->
                     gpu.advancePerformancePhysicalDmgMode2PhaseSpanTrusted(ticks);
-            case CGB_COMPATIBILITY_MODE2 ->
-                    gpu.advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(ticks);
+            case CGB_NORMAL_SPEED_MODE2 ->
+                    gpu.advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(ticks);
         }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         if (gbc) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -260,7 +260,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient IntConsumer performancePhysicalDmgEpochPrefixCommitter;
 
-    private transient IntConsumer performanceCgbCompatibilityEpochPrefixCommitter;
+    private transient IntConsumer performanceCgbNormalSpeedEpochPrefixCommitter;
 
     private enum PerformanceEpochPpuPlan {
         NONE,
@@ -1362,7 +1362,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || !cpu.performanceNoPendingPpuReadPhase()
                 || dma.isTransferInProgress()
                 || dma.requiresClockTick(cpu.getState() == Cpu.State.HALTED)
-                || gbc && hdma.hasActiveOrPendingTransfer()
+                || gbc && (hdma.hasActiveOrPendingTransfer()
+                        || !hdma.isPerformanceInactiveRequestClockStable())
                 // This is intentionally the one post-preflight volatile Joypad check.
                 || !joypad.isPerformanceQuietSpanStillEligible()) {
             return 0;
@@ -1393,10 +1394,22 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && isCgbCompatibilityPerformanceTopology();
     }
 
-    /** Fixed four-master-dot CPU epoch topologies; CGB compatibility still owns CGB peripherals. */
+    /** Exact native-color fixed-x1 epoch row: ordinary CGB only. */
+    private boolean isNativeCgbNormalSpeedPerformanceEpochTopology() {
+        return hardwareProfile == HardwareProfileRegistry.CGB
+                && gbc && !speedMode.isDmgCompat() && speedMode.getSpeedMode() == 1;
+    }
+
+    /** Ordinary-CGB fixed-x1 CPU epochs retain the complete CGB peripheral plane. */
+    private boolean isCgbNormalSpeedPerformanceEpochTopology() {
+        return isCgbCompatibilityPerformanceEpochTopology()
+                || isNativeCgbNormalSpeedPerformanceEpochTopology();
+    }
+
+    /** Fixed four-master-dot CPU epoch topologies; CGB software still owns CGB peripherals. */
     private boolean isNormalSpeedPerformanceEpochTopology() {
         return isPhysicalDmgPerformanceEpochTopology()
-                || isCgbCompatibilityPerformanceEpochTopology()
+                || isCgbNormalSpeedPerformanceEpochTopology()
                 || isSgbPerformanceTopology();
     }
 
@@ -1438,6 +1451,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !dma.isTransferInProgress()
                 && !dma.requiresClockTick(false)
                 && !hdma.hasActiveOrPendingTransfer()
+                && hdma.isPerformanceInactiveRequestClockStable()
                 && !cartridgeClocked
                 && !slotCartridgeClocked
                 && serialPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS)
@@ -1526,14 +1540,29 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             sound.commitFrameSequencerClock();
             serialPort.onDivReset();
         }
-        hdma.onCpuHaltState(cpu.getState() == Cpu.State.HALTED);
-        if (cpu.hasPendingPeripheralSample()) {
+        boolean halted = cpu.getState() == Cpu.State.HALTED;
+        if (halted) {
+            hdma.reconcilePerformanceRunningEpochHaltEntryTrusted();
+        }
+        hdma.onCpuHaltState(halted);
+        boolean pendingPeripheralSample = cpu.hasPendingPeripheralSample();
+        if (pendingPeripheralSample) {
             // The epoch can retire HALT immediately before the caller's budget ends. Publish
             // the otherwise-inactive OAM-DMA pause latch in the same rare branch which already
             // owns HALT's post-peripheral sample, so ordinary epochs gain no new hot check.
-            if (cpu.getState() == Cpu.State.HALTED && dma.requiresClockTick(true)) {
+            if (halted && dma.requiresClockTick(true)) {
                 dma.tick(true, true);
             }
+        }
+        if (halted) {
+            // Peripheral commits have already published the final GPU dot. Replay the scalar
+            // post-HALT timing seam so HDMA clears haltEnteredThisTick and the CPU observes the
+            // same held-opcode latch at the exact epoch endpoint.
+            hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                    gpu.isStatModeLatchRephasedBySpeedSwitch());
+            cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
+        }
+        if (pendingPeripheralSample) {
             cpu.onPeripheralsTicked();
         }
 
@@ -1620,6 +1649,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !hdma.holdsHblankSpeedSwitchTail()
                 && !hdma.pausesOamDmaForSpeedSwitchBurst()
                 && !hdma.requiresCpuHdmaPhaseFlags()
+                && hdma.isPerformanceInactiveRequestClockStable()
                 && !cartridgeClocked
                 && !slotCartridgeClocked;
     }
@@ -1637,6 +1667,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         serialPort.tickPerformanceEpochIdle(ticks);
         infraredPort.tickPerformanceEpochIdle(ticks);
         joypad.tickPerformanceQuietSpanTrusted(ticks);
+        hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
 
         switch (ppuPlan) {
             case TRUSTED_RASTER -> {
@@ -1685,19 +1716,20 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return tryFixedNormalSpeedPerformanceEpoch(remaining);
     }
 
-    /** Fixed-width normal-speed epoch implementation shared by SGB and CGB compatibility. */
+    /** Fixed-width normal-speed epoch implementation shared by SGB and CGB hardware. */
     private int tryFixedNormalSpeedPerformanceEpoch(long remaining) {
-        boolean cgbCompat = isCgbCompatibilityPerformanceEpochTopology();
+        boolean cgbHardware = isCgbNormalSpeedPerformanceEpochTopology();
+        boolean nativeCgbNormalSpeed = isNativeCgbNormalSpeedPerformanceEpochTopology();
         boolean sgb = isSgbPerformanceTopology();
-        if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbCompat)
-                || !canStartNormalSpeedPerformanceEpoch(cgbCompat)) {
+        if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbHardware)
+                || !canStartNormalSpeedPerformanceEpoch(cgbHardware)) {
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
-        span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbCompat));
+        span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbHardware));
         span = Math.min(span, sound.performanceEpochSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
-        if (cgbCompat) {
+        if (cgbHardware) {
             span = Math.min(span, serialPort.performanceNormalSpeedEpochIdle(span, true)
                     ? span : 0);
             span = Math.min(span, infraredPort.performanceSettledHaltSpanLimit(span));
@@ -1706,7 +1738,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     ? span : 0);
         }
 
-        int rasterSpan = cgbCompat
+        int rasterSpan = cgbHardware
                 ? gpu.performanceEpochSpanLimit(span)
                 : gpu.performancePhysicalDmgEpochSpanLimit(span);
         if (rasterSpan <= 0) {
@@ -1728,12 +1760,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochPpuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
         performanceEpochPrefixCommitted = 0;
         IntConsumer prefixCommitter;
-        if (cgbCompat) {
-            if (performanceCgbCompatibilityEpochPrefixCommitter == null) {
-                performanceCgbCompatibilityEpochPrefixCommitter =
-                        this::commitCgbCompatibilityPerformanceEpochPrefix;
+        if (cgbHardware) {
+            if (performanceCgbNormalSpeedEpochPrefixCommitter == null) {
+                performanceCgbNormalSpeedEpochPrefixCommitter =
+                        this::commitCgbNormalSpeedPerformanceEpochPrefix;
             }
-            prefixCommitter = performanceCgbCompatibilityEpochPrefixCommitter;
+            prefixCommitter = performanceCgbNormalSpeedEpochPrefixCommitter;
         } else {
             if (performancePhysicalDmgEpochPrefixCommitter == null) {
                 performancePhysicalDmgEpochPrefixCommitter =
@@ -1744,8 +1776,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         cpu.setPerformanceEpochPrefixCommitter(prefixCommitter);
         int elapsed;
         try {
-            elapsed = cgbCompat
-                    ? cpu.runCgbCompatibilityPerformanceEpoch(span)
+            elapsed = cgbHardware
+                    ? nativeCgbNormalSpeed
+                            ? cpu.runNativeCgbNormalSpeedPerformanceEpoch(span)
+                            : cpu.runCgbCompatibilityPerformanceEpoch(span)
                     : sgb
                             ? cpu.runSgbPerformanceEpoch(span)
                             : cpu.runPhysicalDmgPerformanceEpoch(span);
@@ -1757,8 +1791,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         int suffix = elapsed - performanceEpochPrefixCommitted;
         if (suffix > 0) {
-            if (cgbCompat) {
-                commitCgbCompatibilityPerformanceEpochPeripherals(suffix);
+            if (cgbHardware) {
+                commitCgbNormalSpeedPerformanceEpochPeripherals(suffix);
             } else {
                 commitPhysicalDmgPerformanceEpochPeripherals(suffix);
             }
@@ -1772,7 +1806,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         Cpu.State finalCpuState = cpu.getState();
         boolean halted = finalCpuState == Cpu.State.HALTED;
-        if (cgbCompat && halted) {
+        if (cgbHardware && halted) {
+            hdma.reconcilePerformanceRunningEpochHaltEntryTrusted();
             hdma.onCpuHaltState(true);
         }
         if (halted || journalReplayed) {
@@ -1789,7 +1824,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 dma.tick(dmaCpuClockPaused, halted);
             }
         }
-        if (cgbCompat && halted) {
+        if (cgbHardware && halted) {
             // The scalar tick publishes the CPU HALT transition before the final GPU/HDMA
             // timing callback.  Epoch peripheral commits necessarily advance the GPU first,
             // so replay that post-GPU publication here to clear haltEnteredThisTick and keep
@@ -1809,7 +1844,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /** Stable normal-speed epoch topology; transient guards are evaluated by the caller. */
-    private boolean canStartNormalSpeedPerformanceEpoch(boolean cgbCompat) {
+    private boolean canStartNormalSpeedPerformanceEpoch(boolean cgbHardware) {
         return !warmResetRequested
                 && speedSwitchTailTicks == 0
                 && !debugHistoryReplay
@@ -1820,12 +1855,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !dma.requiresClockTick(false)
                 && !cartridgeClocked
                 && !slotCartridgeClocked
-                && (!cgbCompat || (!hdma.hasActiveOrPendingTransfer()
+                && (!cgbHardware || (!hdma.hasActiveOrPendingTransfer()
                         && !hdma.hasPendingHblankTransfer()
                         && !hdma.isHaltRequestLatched()
                         && !hdma.holdsHblankSpeedSwitchTail()
                         && !hdma.pausesOamDmaForSpeedSwitchBurst()
-                        && !hdma.requiresCpuHdmaPhaseFlags()));
+                        && !hdma.requiresCpuHdmaPhaseFlags()
+                        && hdma.isPerformanceInactiveRequestClockStable()));
     }
 
     private void commitPerformanceEpochPrefix(int ticks) {
@@ -1850,6 +1886,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         serialPort.tickPerformanceEpochIdle(ticks);
         infraredPort.tickPerformanceEpochIdle(ticks);
         joypad.tickPerformanceQuietSpanTrusted(ticks);
+        hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
 
         switch (performanceEpochPpuPlan) {
             case TRUSTED_RASTER -> {
@@ -1890,11 +1927,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochPrefixCommitted = ticks;
     }
 
-    private void commitCgbCompatibilityPerformanceEpochPrefix(int ticks) {
+    private void commitCgbNormalSpeedPerformanceEpochPrefix(int ticks) {
         if (ticks <= performanceEpochPrefixCommitted) {
             return;
         }
-        commitCgbCompatibilityPerformanceEpochPeripherals(
+        commitCgbNormalSpeedPerformanceEpochPeripherals(
                 ticks - performanceEpochPrefixCommitted);
         performanceEpochPrefixCommitted = ticks;
     }
@@ -1904,13 +1941,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         commitNormalSpeedPerformanceEpochPeripherals(ticks, false);
     }
 
-    /** CGB-compatibility prefix commit through the existing CGB quiet epoch plane. */
-    private void commitCgbCompatibilityPerformanceEpochPeripherals(int ticks) {
+    /** Normal-speed CGB prefix commit through the existing CGB quiet epoch plane. */
+    private void commitCgbNormalSpeedPerformanceEpochPeripherals(int ticks) {
         commitNormalSpeedPerformanceEpochPeripherals(ticks, true);
     }
 
-    /** Shared fixed-x1 epoch peripheral commit; CGB compatibility retains IR/HDMA/CGB PPU state. */
-    private void commitNormalSpeedPerformanceEpochPeripherals(int ticks, boolean cgbCompat) {
+    /** Shared fixed-x1 epoch peripheral commit; CGB hardware retains IR/HDMA/CGB PPU state. */
+    private void commitNormalSpeedPerformanceEpochPeripherals(int ticks, boolean cgbHardware) {
         if (ticks <= 0) {
             return;
         }
@@ -1921,11 +1958,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         sound.commitFrameSequencerClock();
         sound.tickPerformanceQuietSpan(ticks);
         serialPort.tickPerformanceNormalSpeedEpochIdle(ticks);
-        if (cgbCompat) {
+        if (cgbHardware) {
             infraredPort.tickPerformanceQuietSpanTrusted(ticks);
         }
         joypad.tickPerformanceQuietSpanTrusted(ticks);
-        if (cgbCompat) {
+        if (cgbHardware) {
+            // Scalar tick() advances the PPU-to-CPU request clocks after input and before GPU.
+            // The preflight admits only inactive countdowns, so their zero-clock ages are the
+            // complete arithmetic transaction skipped by this fixed-x1 packet.
+            hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
             gpu.advancePerformanceEpochQuietSpanTrusted(
                     ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
         } else {
@@ -1934,16 +1975,17 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         performanceEpochRasterFastTicks += ticks;
-        if (cgbCompat) {
+        if (cgbHardware) {
             hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
                     gpu.isStatModeLatchRephasedBySpeedSwitch());
         }
     }
 
-    /** Selects the normal-speed settled-HALT lane for the current non-native topology. */
+    /** Selects the settled-HALT lane for the current normal-speed topology. */
     private int tryPerformanceSettledHaltSpan(long remaining) {
-        if (isCgbCompatibilityPerformanceTopology()) {
-            return tryPerformanceSettledCgbCompatHaltSpan(remaining);
+        if (isCgbCompatibilityPerformanceTopology()
+                || isNativeCgbNormalSpeedPerformanceEpochTopology()) {
+            return tryPerformanceSettledCgbHaltSpan(remaining);
         }
         if (!gbc) {
             return tryPerformanceSettledDmgHaltSpan(remaining);
@@ -1952,11 +1994,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
-     * Attempts a CGB-compatibility settled-HALT packet. This is deliberately separate from
-     * the physical-DMG packet: normal-speed CGB compatibility still clocks the CGB infrared and
+     * Attempts a normal-speed CGB settled-HALT packet. This is deliberately separate from
+     * the physical-DMG packet: CGB hardware still clocks the CGB infrared and
      * HDMA control planes, and their idle guards must remain part of the proof.
      */
-    private int tryPerformanceSettledCgbCompatHaltSpan(long remaining) {
+    private int tryPerformanceSettledCgbHaltSpan(long remaining) {
         if (remaining <= 0 || !cpu.performanceSettledHaltSpanEligible()) {
             return 0;
         }
@@ -1991,10 +2033,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || hdma.pausesOamDmaForSpeedSwitchBurst()
                 || hdma.requiresCpuHdmaPhaseFlags()
                 || !joypad.isPerformanceQuietSpanStillEligible()
-                || !canStartCgbCompatSettledHaltSpan()) {
+                || !canStartCgbNormalSpeedSettledHaltSpan()) {
             return 0;
         }
-        tickPerformanceSettledCgbCompatHaltSpan(span, directRasterSpan, steadyRasterSpan);
+        tickPerformanceSettledCgbHaltSpan(span, directRasterSpan, steadyRasterSpan);
         performanceBulkSpanCount++;
         performanceBulkTicks += span;
         if (span > performanceBulkMaxTicks) {
@@ -2003,8 +2045,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return span;
     }
 
-    private boolean canStartCgbCompatSettledHaltSpan() {
-        return isCgbCompatibilityPerformanceTopology()
+    private boolean canStartCgbNormalSpeedSettledHaltSpan() {
+        return (isCgbCompatibilityPerformanceTopology()
+                || isNativeCgbNormalSpeedPerformanceEpochTopology())
                 && !warmResetRequested
                 && speedSwitchTailTicks == 0
                 && !debugHistoryReplay
@@ -2018,11 +2061,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !hdma.isHaltRequestLatched()
                 && !hdma.holdsHblankSpeedSwitchTail()
                 && !hdma.pausesOamDmaForSpeedSwitchBurst()
-                && !hdma.requiresCpuHdmaPhaseFlags();
+                && !hdma.requiresCpuHdmaPhaseFlags()
+                && hdma.isPerformanceInactiveRequestClockStable();
     }
 
-    /** Commits a CGB-compatibility settled-HALT packet with the complete CGB idle plane. */
-    private void tickPerformanceSettledCgbCompatHaltSpan(
+    /** Commits a normal-speed CGB settled-HALT packet with the complete CGB idle plane. */
+    private void tickPerformanceSettledCgbHaltSpan(
             int ticks, boolean directRasterSpan, boolean steadyRasterSpan) {
         if (cartridgeClocked) {
             cartridge.tickPerformanceQuietSpanTrusted(ticks);
@@ -2033,13 +2077,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         timer.tickPerformanceQuietSpanTrusted(ticks);
         sound.tickFrameSequencer(false);
         assert !sound.hasPendingFrameSequencerClock()
-                : "frame sequencer edge crossed a CGB-compatibility settled-HALT span";
+                : "frame sequencer edge crossed a normal-speed CGB settled-HALT span";
         sound.commitFrameSequencerClock();
         sound.tickPerformanceQuietSpan(ticks);
         serialPort.tickPerformanceQuietSpanTrusted(ticks);
         infraredPort.tickPerformanceQuietSpanTrusted(ticks);
         joypad.tickPerformanceQuietSpanTrusted(ticks);
         cpu.advancePerformanceSettledHaltSpanTrusted(ticks);
+        hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
         gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
@@ -2154,15 +2199,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         // No CPU bus boundary exists inside this span. Advance the free-running phase once;
         // running state, or settled HALT, proves Cpu.onPeripheralsTicked() is a no-op here.
         cpu.advancePerformancePhaseOnlyTrusted(ticks);
+        if (gbc) {
+            hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
+        }
         switch (ppuPlan) {
             case QUIET -> gpu.advancePerformanceQuietSpanTrusted(
                     ticks, directRasterSpan, steadyRasterSpan);
             case PHYSICAL_DMG_MODE2 ->
                     gpu.advancePerformancePhysicalDmgMode2PhaseSpanTrusted(ticks);
-            case CGB_COMPATIBILITY_MODE2 -> {
-                hdma.advancePerformanceOamSearchPhaseClockTrusted(ticks);
-                gpu.advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(ticks);
-            }
+            case CGB_COMPATIBILITY_MODE2 ->
+                    gpu.advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(ticks);
         }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         if (gbc) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -328,13 +328,24 @@ public class Cpu implements StatefulComponent<Cpu> {
      * while the owner supplies the CGB-only peripheral/PPU plane around this transaction.
      */
     public int runCgbCompatibilityPerformanceEpoch(int maxMasterTicks) {
-        return runPerformanceNormalSpeedEpoch(maxMasterTicks, true, false);
+        return speedMode.isDmgCompat()
+                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, false) : 0;
+    }
+
+    /**
+     * Fixed four-master-dot epoch for native CGB software which remains at normal speed.
+     * Decoded memory boundaries stay scalar so CPU-visible peripheral writes retain their
+     * position before the owner ticks Sound and the remaining peripherals.
+     */
+    public int runNativeCgbNormalSpeedPerformanceEpoch(int maxMasterTicks) {
+        return !speedMode.isDmgCompat()
+                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, true) : 0;
     }
 
     /** Shared fixed-width normal-speed epoch; topology flags are explicit and allocation-free. */
     private int runPerformanceNormalSpeedEpoch(
-            int maxMasterTicks, boolean cgbCompat, boolean fenceDecodedMemoryCycles) {
-        if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbCompat)) {
+            int maxMasterTicks, boolean cgbHardware, boolean fenceDecodedMemoryCycles) {
+        if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbHardware)) {
             return 0;
         }
         int requested = Math.min(maxMasterTicks, PERFORMANCE_EPOCH_MAX_TICKS);
@@ -474,13 +485,18 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     /** Cheap state-only entrance check for ordinary CGB DMG-compatibility epochs. */
     public boolean performanceCgbCompatibilityEpochEntryEligible() {
-        return performanceNormalSpeedEpochEntryEligible(true);
+        return speedMode.isDmgCompat() && performanceNormalSpeedEpochEntryEligible(true);
+    }
+
+    /** Cheap state-only entrance check for native CGB software at the normal clock. */
+    public boolean performanceNativeCgbNormalSpeedEpochEntryEligible() {
+        return performanceNormalSpeedEpochEntryEligible(true) && !speedMode.isDmgCompat();
     }
 
     /** Shared state-only entrance check for the fixed-width normal-speed epoch. */
-    public boolean performanceNormalSpeedEpochEntryEligible(boolean cgbCompat) {
-        boolean topologyMatches = cgbCompat
-                ? speedMode.isGbc() && speedMode.isDmgCompat()
+    public boolean performanceNormalSpeedEpochEntryEligible(boolean cgbHardware) {
+        boolean topologyMatches = cgbHardware
+                ? speedMode.isGbc()
                 : !speedMode.isGbc();
         if (debugAddressSpace != null || debugHooks != null || debugRetirementTracker != null
                 || state == State.HALTED || state == State.STOPPED

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1321,14 +1321,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
-     * Horizon for a short ordinary-CGB DMG-compatibility mode-2 phase packet. The CGB OAM
-     * reader still uses its Y/X height latch in compatibility mode, but its CPU clock is x1.
-     * Only non-CPU dots before the dot-79-to-80 handoff are admitted; every fixed-point,
-     * observation, DMA, and HDMA miss leaves the complete phase to the scalar scheduler.
+     * Horizon for a short ordinary-CGB normal-speed mode-2 phase packet. The CGB OAM reader
+     * uses the same Y/X height latch at x1 in native and compatibility modes. Only non-CPU dots
+     * before the dot-79-to-80 handoff are admitted; every fixed-point, observation, DMA, and
+     * HDMA miss leaves the complete phase to the scalar scheduler.
      */
-    public int performanceCgbCompatibilityMode2PhaseSpanLimit(int requested) {
-        if (!performanceDmgCompatTiming || requested <= 0 || !gbc || !dmgCompatValue
-                || speedModeValue != 1 || !lcdEnabled || firstLine || line >= 144
+    public int performanceCgbNormalSpeedMode2PhaseSpanLimit(int requested) {
+        if (!performanceDmgCompatTiming || requested <= 0 || !gbc || speedModeValue != 1
+                || !lcdEnabled || firstLine || line >= 144
                 || mode != Mode.OamSearch || phase != oamSearchPhase
                 || performanceScanlineCursor || performanceScanlineLine || dma == null
                 || dma.isTransferInProgress() || dma.ownsOamForPpu()
@@ -1352,18 +1352,29 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         return Math.min(requested, Math.max(0, 79 - ticksInLine));
     }
 
-    /** Advances a preflighted ordinary-CGB compatibility mode-2 prefix. */
-    public void advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(int ticks) {
+    /**
+     * @deprecated use {@link #performanceCgbNormalSpeedMode2PhaseSpanLimit(int)}. This
+     * compatibility alias retains the original DMG-compatibility-only contract.
+     */
+    @Deprecated
+    public int performanceCgbCompatibilityMode2PhaseSpanLimit(int requested) {
+        return dmgCompatValue
+                ? performanceCgbNormalSpeedMode2PhaseSpanLimit(requested)
+                : 0;
+    }
+
+    /** Advances a preflighted ordinary-CGB normal-speed mode-2 prefix. */
+    public void advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(int ticks) {
         if (ticks <= 0) {
             return;
         }
         int startTick = ticksInLine;
         if (startTick + ticks > 79) {
             throw new IllegalStateException(
-                    "GPU is not eligible for a CGB compatibility PERFORMANCE mode-2 span");
+                    "GPU is not eligible for a CGB normal-speed PERFORMANCE mode-2 span");
         }
-        assert performanceCgbCompatibilityMode2PhaseSpanLimit(ticks) >= ticks
-                : "trusted CGB compatibility mode-2 proof changed before commit";
+        assert performanceCgbNormalSpeedMode2PhaseSpanLimit(ticks) >= ticks
+                : "trusted CGB normal-speed mode-2 proof changed before commit";
 
         lcdc.advancePerformanceMode2FixedPointSpanTrusted(ticks);
         pixelTransferPhase.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(ticks);
@@ -1375,6 +1386,19 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         timingGeneration += ticks;
         cpuLyReadAcrossLineEdge = false;
         synchronizePerformanceWindowLineCounter();
+    }
+
+    /**
+     * @deprecated use {@link #advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(int)}.
+     */
+    @Deprecated
+    public void advancePerformanceCgbCompatibilityMode2PhaseSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        assert performanceCgbCompatibilityMode2PhaseSpanLimit(ticks) >= ticks
+                : "trusted CGB compatibility mode-2 proof changed before commit";
+        advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(ticks);
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -661,14 +661,15 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     /**
-     * Native-CGB mode-2 fixed point used by the coarse CPU epoch.  The pixel machine is
-     * stopped between scanlines, so only its absolute LCD output clock normally changes.
-     * Recent window writes and a non-empty delay line deliberately keep the exact dot path.
+     * Ordinary-CGB mode-2 fixed point used by the coarse CPU epoch and short phase packet.
+     * The pixel machine is stopped between scanlines, so only its absolute LCD output clock
+     * normally changes. Recent window writes and a non-empty delay line deliberately keep the
+     * exact dot path.
      */
     public boolean isPerformanceNativeCgbMode2IdleOutput() {
-        // Gpu's native mode-2 preflight already proves CGB, non-compat, double-speed
-        // topology. Keeping that proof out of both pixel-machine predicates avoids paying
-        // the same immutable topology branch twice on every native epoch.
+        // Gpu's callers already prove an ordinary-CGB mode-2 topology. Keeping that proof out
+        // of both pixel-machine predicates avoids paying the same immutable topology branch
+        // twice on every epoch or phase packet.
         return isPerformanceIdleOutput();
     }
 
@@ -692,7 +693,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     /**
      * Advances the empty LCD output clock after
-     * {@link #isPerformanceNativeCgbMode2IdleOutput()} under the caller's native-CGB proof.
+     * {@link #isPerformanceNativeCgbMode2IdleOutput()} under the caller's ordinary-CGB proof.
      */
     public void advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(int ticks) {
         if (ticks < 0 || !isPerformanceNativeCgbMode2IdleOutput()) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -767,23 +767,26 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
         return transferInProgress;
     }
 
-    /** Whether an inactive OAM-search packet may advance only the serialized request ages. */
-    public boolean isPerformanceOamSearchPhaseClockStable() {
+    /** Whether an inactive PERFORMANCE packet may advance only the serialized request ages. */
+    public boolean isPerformanceInactiveRequestClockStable() {
         return !transferInProgress
-                && gpuMode == Mode.OamSearch
                 && hblankRequestTicks <= 0
                 && nextHblankRequestTicks <= 0
-                && cpuRequestArbitration == CpuRequestArbitration.NONE;
+                && cpuRequestArbitration == CpuRequestArbitration.NONE
+                && wakeRequestArbitration == WakeRequestArbitration.NONE
+                && !requestOverlappedCpuWrite
+                && !interruptEntryWonArbitration
+                && !cpuRequestAllowsLateInterrupt;
     }
 
     /**
      * Replays the arithmetic part of {@link #advanceHblankRequest()} for a preflighted inactive
-     * OAM-search packet. Zero clocks age once per scalar dot; negative clocks remain invariant.
+     * packet. Zero clocks age once per scalar dot; negative clocks remain invariant.
      */
-    public void advancePerformanceOamSearchPhaseClockTrusted(int ticks) {
-        if (ticks < 0 || !isPerformanceOamSearchPhaseClockStable()) {
+    public void advancePerformanceInactiveRequestClockTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceInactiveRequestClockStable()) {
             throw new IllegalStateException(
-                    "HDMA request clock is not stable for an OAM-search PERFORMANCE span");
+                    "HDMA request clock is not stable for a PERFORMANCE span");
         }
         if (!cpuHalted && hblankRequestTicks == 0) {
             hblankRequestAge += ticks;
@@ -791,6 +794,36 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
         if (nextHblankRequestTicks == 0) {
             nextHblankRequestAge += ticks;
         }
+    }
+
+    /**
+     * Reconciles the final dot after a running CGB epoch retires HALT. The packet initially ages
+     * both inactive zero clocks as running CPU time. Scalar ordering publishes HALT before the
+     * terminal dot's request-clock step, so only the current request age must be undone; the next
+     * request clock ages regardless of HALT and remains untouched.
+     */
+    public void reconcilePerformanceRunningEpochHaltEntryTrusted() {
+        if (!isPerformanceInactiveRequestClockStable() || cpuHalted) {
+            throw new IllegalStateException(
+                    "HDMA request clock is not stable for PERFORMANCE HALT reconciliation");
+        }
+        if (hblankRequestTicks == 0) {
+            hblankRequestAge--;
+        }
+    }
+
+    /** Whether an inactive OAM-search packet may use the generic request-clock transaction. */
+    public boolean isPerformanceOamSearchPhaseClockStable() {
+        return gpuMode == Mode.OamSearch && isPerformanceInactiveRequestClockStable();
+    }
+
+    /** OAM-search compatibility wrapper which retains its mode-specific trusted contract. */
+    public void advancePerformanceOamSearchPhaseClockTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceOamSearchPhaseClockStable()) {
+            throw new IllegalStateException(
+                    "HDMA request clock is not stable for an OAM-search PERFORMANCE span");
+        }
+        advancePerformanceInactiveRequestClockTrusted(ticks);
     }
 
     /** Captures the retained HDMA latches and current block progress without bus reads. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
@@ -35,6 +35,12 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
         return requested > 0 && peer == null ? requested : 0;
     }
 
+    /** A disconnected cable also has no device which can observe an armed external wait. */
+    @Override
+    public int performanceExternalClockWaitSpanLimit(int requested) {
+        return requested > 0 && peer == null ? requested : 0;
+    }
+
     @Override
     public void setSb(int sb) {
         this.sb = sb;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -22,6 +22,16 @@ public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
         return 0;
     }
 
+    /**
+     * Additional opt-in for omitting {@link #setExternalTransfer(boolean)} with a true argument
+     * while the Game Boy waits for an external serial clock. PERFORMANCE combines this with
+     * {@link #performanceQuietSpanLimit(int)}, so the ordinary quiet-endpoint guarantees still
+     * apply. Endpoints which observe active external-clock waits must retain the default zero.
+     */
+    default int performanceExternalClockWaitSpanLimit(int requested) {
+        return 0;
+    }
+
     /** Returns whether the endpoint is quiet for the requested PERFORMANCE span. */
     default boolean canTickPerformanceQuietSpan(int ticks) {
         return ticks > 0 && performanceQuietSpanLimit(ticks) >= ticks;
@@ -124,6 +134,11 @@ public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
 
                 @Override
                 public int performanceQuietSpanLimit(int requested) {
+                    return requested > 0 ? requested : 0;
+                }
+
+                @Override
+                public int performanceExternalClockWaitSpanLimit(int requested) {
                     return requested > 0 ? requested : 0;
                 }
             };

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -65,19 +65,17 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     public void tick() {
         // Link-port peripherals such as GPS receivers have their own wall clock and keep
         // driving the input pin even when no hardware serial transfer is armed. A built-in
-        // endpoint which advertises a quiet span has explicitly guaranteed that tick(), the
-        // inactive external-transfer callback, and the input pin are inert; use that same
+        // endpoint which advertises the matching quiet span has explicitly guaranteed that its
+        // callbacks and input pin are inert; use that same
         // capability on scalar event ticks instead of identity-checking only NULL_ENDPOINT.
         SerialEndpoint endpoint = serialEndpoint;
-        boolean quietEndpoint = endpoint.canTickPerformanceQuietSpan(1);
+        boolean quietEndpoint = canAdvancePerformanceQuietTransfer(1);
         if (!quietEndpoint && endpoint != SerialEndpoint.NULL_ENDPOINT) {
             endpoint.tick();
         }
         acknowledgeInterruptIfNeeded();
         int speed = speedMode.getSpeedMode();
-        if (quietEndpoint
-                && (sc & 0x80) == 0
-                && haltWakeDelay == 0) {
+        if (quietEndpoint && haltWakeDelay == 0) {
             serialClocks = (serialClocks + speed) & 0xff;
             return;
         }
@@ -89,16 +87,16 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     /**
      * Returns the largest exact PERFORMANCE span for an idle link port.
      *
-     * <p>A quiet endpoint has no wall-clock work and a stopped transfer has no serial edge to
-     * deliver. In that state the only serial state which advances is the free-running 8-bit
-     * phase. Other endpoints, active transfers, HALT wake delay, and debug hooks remain scalar so
-     * endpoint callbacks and trace ordering cannot be observed late.</p>
+     * <p>A quiet endpoint has no wall-clock work. A stopped transfer, or an external-clock
+     * transfer whose endpoint guarantees that no input bit arrives, has no serial edge to
+     * deliver. In those states the only serial state which advances is the free-running 8-bit
+     * phase. Other endpoints, internal-clock transfers, HALT wake delay, and debug hooks remain
+     * scalar so endpoint callbacks and trace ordering cannot be observed late.</p>
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0
                 || speedMode.getSpeedMode() != 1
-                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
-                || (sc & 0x80) != 0
+                || !canAdvancePerformanceQuietTransfer(requested)
                 || haltWakeDelay != 0
                 || debugHooks != null) {
             return 0;
@@ -110,8 +108,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     public int performanceSettledHaltSpanLimit(int requested) {
         if (requested <= 0
                 || speedMode.getSpeedMode() != 1
-                || !serialEndpoint.canTickPerformanceQuietSpan(requested)
-                || (sc & 0x80) != 0
+                || !canAdvancePerformanceQuietTransfer(requested)
                 || haltWakeDelay != 0
                 || debugHooks != null) {
             return 0;
@@ -130,9 +127,9 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     }
 
     /**
-     * Advances an idle quiet-endpoint serial port without entering its per-clock callback path.
+     * Advances a quiet-endpoint serial port without entering its per-clock callback path.
      * A pending acknowledge is consumed at the same beginning-of-tick boundary as scalar
-     * execution; no active transfer exists in an eligible span, so this cannot create a hidden
+     * execution; no serial edge can land in an eligible span, so this cannot create a hidden
      * shift or completion event.
      *
      * @return false without mutation when the state is not exactly bulk-safe
@@ -151,23 +148,22 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         if (ticks <= 0) {
             return;
         }
-        // The packet preflight has already established an idle quiet endpoint and no pending
-        // acknowledge/transfer edge.  Do not repeat that walk on the hot commit path.
+        // The packet preflight has already established a quiet endpoint and no pending
+        // acknowledge/transfer edge. Do not repeat that walk on the hot commit path.
         acknowledgeInterruptIfNeeded();
         serialClocks = (serialClocks + ticks) & 0xff;
     }
 
-    /** Native-CGB double-speed epoch guard; transfers and callbacks remain scalar. */
+    /** Native-CGB double-speed epoch guard; edge-producing transfers remain scalar. */
     public boolean performanceEpochIdle(int requested) {
         return requested > 0
                 && speedMode.getSpeedMode() == 2
-                && serialEndpoint.canTickPerformanceQuietSpan(requested)
-                && (sc & 0x80) == 0
+                && canAdvancePerformanceQuietTransfer(requested)
                 && haltWakeDelay == 0
                 && debugHooks == null;
     }
 
-    /** Applies the preflighted idle serial phase without a per-dot loop. */
+    /** Applies the preflighted quiet serial phase without a per-dot loop. */
     public void tickPerformanceEpochIdle(int ticks) {
         if (ticks <= 0) {
             return;
@@ -177,26 +173,25 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     }
 
 
-    /** Physical-DMG normal-speed epoch guard; transfers and callbacks remain scalar. */
+    /** Physical-DMG normal-speed epoch guard; edge-producing transfers remain scalar. */
     public boolean performancePhysicalDmgEpochIdle(int requested) {
         return performanceNormalSpeedEpochIdle(requested, false);
     }
 
-    /** Normal-speed epoch guard shared by physical DMG and CGB compatibility. */
-    public boolean performanceNormalSpeedEpochIdle(int requested, boolean cgbCompat) {
-        boolean topologyMatches = cgbCompat
-                ? speedMode.isGbc() && speedMode.isDmgCompat()
+    /** Normal-speed epoch guard shared by physical DMG and CGB hardware. */
+    public boolean performanceNormalSpeedEpochIdle(int requested, boolean cgbHardware) {
+        boolean topologyMatches = cgbHardware
+                ? speedMode.isGbc()
                 : !speedMode.isGbc();
         return requested > 0
                 && speedMode.getSpeedMode() == 1
                 && topologyMatches
-                && serialEndpoint.canTickPerformanceQuietSpan(requested)
-                && (sc & 0x80) == 0
+                && canAdvancePerformanceQuietTransfer(requested)
                 && haltWakeDelay == 0
                 && debugHooks == null;
     }
 
-    /** Applies a preflighted physical-DMG idle serial phase at one clock per master tick. */
+    /** Applies a preflighted physical-DMG quiet serial phase at one clock per master tick. */
     public void tickPerformancePhysicalDmgEpochIdle(int ticks) {
         tickPerformanceNormalSpeedEpochIdle(ticks);
     }
@@ -208,6 +203,21 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         }
         acknowledgeInterruptIfNeeded();
         serialClocks = (serialClocks + ticks) & 0xff;
+    }
+
+    /** True when scalar CPU clocks cannot shift a bit or expose an endpoint callback. */
+    private boolean canAdvancePerformanceQuietTransfer(int requested) {
+        if (requested <= 0) {
+            return false;
+        }
+        if ((sc & 0x80) == 0) {
+            return serialEndpoint.canTickPerformanceQuietSpan(requested);
+        }
+        if ((sc & 0x01) != 0) {
+            return false;
+        }
+        return serialEndpoint.canTickPerformanceQuietSpan(requested)
+                && serialEndpoint.performanceExternalClockWaitSpanLimit(requested) >= requested;
     }
 
     /** Naming alias for schedulers which use the GPU's advance-oriented bulk vocabulary. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/timer/Timer.java
@@ -171,13 +171,13 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
     }
 
     /**
-     * Fixed-x1 normal-speed epoch horizon shared by physical DMG and CGB compatibility.
-     * CGB compatibility retains the later-revision +2 DIV/APU frame-sequencer tap, so that
+     * Fixed-x1 normal-speed epoch horizon shared by physical DMG and CGB hardware.
+     * CGB retains the later-revision +2 DIV/APU frame-sequencer tap, so that
      * candidate is stopped before either possible frame-sequencer edge.
      */
-    public int performanceNormalSpeedEpochSpanLimit(int requested, boolean cgbCompat) {
-        boolean topologyMatches = cgbCompat
-                ? speedMode.isGbc() && speedMode.isDmgCompat()
+    public int performanceNormalSpeedEpochSpanLimit(int requested, boolean cgbHardware) {
+        boolean topologyMatches = cgbHardware
+                ? speedMode.isGbc()
                 : !speedMode.isGbc();
         if (requested <= 0 || speedMode.getSpeedMode() != 1 || !topologyMatches
                 || debugHooks != null || divReset || overflow || haltWakeDelay != 0
@@ -189,9 +189,9 @@ public class Timer implements AddressSpace, StatefulComponent<Timer> {
         span = capBeforeMasterTicks(span, clocksToOverflowFallingEdge(), 1);
         span = capBeforeMasterTicks(span, clocksToPendingDividerRipple(), 1);
         span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(0), 1);
-        if (cgbCompat) {
+        if (cgbHardware) {
             // The CGB PSG tap is two CPU clocks ahead of the divider until FF04 is reset.
-            // A compatibility epoch must retain that same edge exclusion as native CGB.
+            // Every normal-speed CGB epoch must retain that edge exclusion.
             span = capBeforeMasterTicks(span, clocksToFrameSequencerEdge(2), 1);
         }
         return Math.max(0, span);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -292,11 +292,214 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
-    public void unrelatedNormalSpeedTopologiesStayOutsideFixedEpochLane() throws Exception {
-        byte[] nonColor = dmgRomWramLoop();
-        byte[] nativeColor = dmgRomWramLoop();
-        nativeColor[0x143] = (byte) 0x80;
-        try (Gameboy cgb0 = new Gameboy.GameboyConfiguration(new Rom(nonColor))
+    public void nativeCgbNormalSpeedRomWramLoopMatchesFallbackWithEpochCoverage()
+            throws Exception {
+        byte[] image = nativeColor(dmgRomWramLoop());
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("native CGB x1 frame callbacks", scalarFrames, candidateFrames);
+            assertEquals("custom-source oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native CGB x1 ROM/WRAM loop had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000);
+            assertEquals("native CGB x1 used a non-raster epoch plan",
+                    candidate.getPerformanceEpochTicks(),
+                    candidate.getPerformanceEpochRasterFastTicks());
+            assertFalse(candidate.getSpeedMode().isDmgCompat());
+            assertEquals(1, candidate.getSpeedMode().getSpeedMode());
+            assertEquals(scalar.getAddressSpace().getByte(0xc000),
+                    candidate.getAddressSpace().getByte(0xc000));
+            assertDeepStateEquals("native CGB x1 ROM/WRAM loop",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbExternalClockWaitMatchesFallbackWithEpochCoverage()
+            throws Exception {
+        byte[] image = nativeCgbExternalClockWramLoop();
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("native CGB external-wait frame callbacks",
+                    scalarFrames, candidateFrames);
+            assertEquals("test ROM did not retain its active external-clock transfer",
+                    0x80, candidate.getAddressSpace().getByte(0xff02) & 0x81);
+            assertEquals("custom-source oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native CGB external-clock wait had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000);
+            assertEquals("native CGB external-clock wait used a non-raster epoch plan",
+                    candidate.getPerformanceEpochTicks(),
+                    candidate.getPerformanceEpochRasterFastTicks());
+            assertEquals(scalar.getAddressSpace().getByte(0xc000),
+                    candidate.getAddressSpace().getByte(0xc000));
+            assertDeepStateEquals("native CGB external-clock wait",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedUnsafeIoWriteMatchesFallbackAndStaysScalar()
+            throws Exception {
+        byte[] image = nativeColor(cgbCompatibilityIoWriteLoop());
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            for (int chunk = 0; chunk < 12; chunk++) {
+                assertEquals("native CGB x1 IO frame callback", scalar.runTicks(5_000),
+                        candidate.runTicks(5_000));
+            }
+            assertTrue("native CGB x1 IO loop had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertEquals("decoded IO write crossed a native CGB x1 epoch",
+                    0L, candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertDeepStateEquals("native CGB x1 IO loop",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedNr44TriggerStaysScalarAfterSafeEpochCoverage()
+            throws Exception {
+        byte[] image = nativeColor(dmgRomWramLoop());
+        image[0x200] = (byte) 0xe0; // LDH (FF23),A: trigger CH4
+        image[0x201] = 0x23;
+        image[0x202] = 0x18; // JR 0202
+        image[0x203] = (byte) 0xfe;
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 0
+                    && candidate.getCpu().performanceNativeCgbNormalSpeedEpochEntryEligible())
+                    && guard++ < 200_000) {
+                assertEquals("native CGB x1 NR44 setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not reach a trusted native CGB x1 NR44 entry",
+                    guard < 200_000);
+            assertDeepStateEquals("before native CGB x1 NR44 decode",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.getAddressSpace().setByte(0xff26, 0x80); // APU on
+            candidate.getAddressSpace().setByte(0xff26, 0x80);
+            scalar.getAddressSpace().setByte(0xff21, 0xf3); // CH4 DAC/envelope
+            candidate.getAddressSpace().setByte(0xff21, 0xf3);
+            scalar.getAddressSpace().setByte(0xff22, 0x30); // stable nonzero divisor
+            candidate.getAddressSpace().setByte(0xff22, 0x30);
+            scalar.getCpu().getRegisters().setA(0xc0);
+            candidate.getCpu().getRegisters().setA(0xc0);
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            int boundaryGuard = 0;
+            while (!(candidate.getCpu().getState() == Cpu.State.RUNNING
+                    && candidate.getCpu().getDebugOpcode() == 0xe0
+                    && candidate.getCpu().getRegisters().getPC() == 0x0202
+                    && candidate.getCpu().getDebugMachineCycle() == 3)
+                    && boundaryGuard++ < 64) {
+                assertEquals("native CGB x1 NR44 decode frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not stop immediately before the NR44 write", boundaryGuard < 64);
+            assertEquals("native CGB x1 scalar oracle entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("safe NR44 decode prefix had no native CGB x1 epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("before native CGB x1 NR44 trigger boundary",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("native CGB x1 NR44 trigger frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("decoded NR44 write crossed a native CGB x1 epoch",
+                    0L, candidate.getPerformanceEpochTicks());
+            assertEquals("decoded NR44 write reached the deferred epoch bus",
+                    0L, candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertTrue("NR44 trigger did not enable CH4",
+                    (candidate.getAddressSpace().getByte(0xff26) & 0x08) != 0);
+            assertDeepStateEquals("native CGB x1 NR44 trigger Sound state",
+                    scalar.getSound().captureState(), candidate.getSound().captureState());
+            assertDeepStateEquals("after native CGB x1 NR44 trigger boundary",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void fastForwardNativeCgbNormalSpeedMatchesScalarAfterCompletedBootGdma()
+            throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+             Gameboy scalar = fastForwardNativeCgbNormalSpeedSession(
+                     PlayerInputSnapshot::released);
+             Gameboy candidate = fastForwardNativeCgbNormalSpeedSession(candidateHub)) {
+            assertEquals("native CGB FAST_FORWARD handoff tail",
+                    scalar.runTicksUntilStop(32, scalar::isBootstrapReady),
+                    candidate.runTicksUntilStop(32, candidate::isBootstrapReady));
+            assertTrue(scalar.isBootstrapReady());
+            assertTrue(candidate.isBootstrapReady());
+            assertFalse(candidate.getSpeedMode().isDmgCompat());
+            assertEquals(1, candidate.getSpeedMode().getSpeedMode());
+            Hdma.HdmaState bootHdma = (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertEquals("authentic boot did not retain the completed-GDMA request clock",
+                    0, bootHdma.hblankRequestTicks());
+            assertDeepStateEquals("native CGB FAST_FORWARD handoff",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            for (int chunk = 0; chunk < 12; chunk++) {
+                assertEquals("native CGB FAST_FORWARD frame callback " + chunk,
+                        scalar.runTicks(5_000), candidate.runTicks(5_000));
+                assertDeepStateEquals("native CGB FAST_FORWARD chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+            assertEquals("FAST_FORWARD scalar oracle entered the epoch lane", 0L,
+                    scalar.getPerformanceEpochTicks());
+            assertTrue("FAST_FORWARD native CGB x1 had no coarse coverage",
+                    candidate.getPerformanceEpochTicks() > 0L);
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedEpochIsLimitedToOrdinaryPerformanceCgb() throws Exception {
+        byte[] nativeColor = nativeColor(dmgRomWramLoop());
+        try (Gameboy cgb0 = new Gameboy.GameboyConfiguration(new Rom(nativeColor))
                      .setHardwareProfile(HardwareProfileRegistry.CGB0)
                      .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                      .setExecutionMode(ExecutionMode.PERFORMANCE)
@@ -307,12 +510,21 @@ public final class GameboyPerformanceEpochTest {
                      .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                      .setExecutionMode(ExecutionMode.PERFORMANCE)
                      .setSupportBatterySave(false)
+                     .build();
+             Gameboy accuracy = new Gameboy.GameboyConfiguration(new Rom(nativeColor))
+                     .setHardwareProfile(HardwareProfileRegistry.CGB)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.ACCURACY)
+                     .setSupportBatterySave(false)
                      .build()) {
             cgb0.runTicks(100_000);
             nativeSpeed1.runTicks(100_000);
+            accuracy.runTicks(100_000);
             assertEquals(0L, cgb0.getPerformanceEpochTicks());
-            assertEquals(0L, nativeSpeed1.getPerformanceEpochTicks());
+            assertTrue(nativeSpeed1.getPerformanceEpochTicks() > 0L);
+            assertEquals(0L, accuracy.getPerformanceEpochTicks());
             assertFalse(nativeSpeed1.getSpeedMode().isDmgCompat());
+            assertEquals(1, nativeSpeed1.getSpeedMode().getSpeedMode());
         }
     }
 
@@ -436,6 +648,8 @@ public final class GameboyPerformanceEpochTest {
                 image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
              Gameboy candidate = cgbCompatibilitySession(
                      image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            completeOneBlockGdmaPair(scalar, candidate,
+                    "CGB compatibility completed-GDMA HALT setup");
             int guard = 0;
             while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
                     && candidate.getGpu().getTicksInLine() >= 100
@@ -463,6 +677,114 @@ public final class GameboyPerformanceEpochTest {
             assertTrue("HALT fetch did not retire inside a CGB compatibility epoch",
                     candidate.getPerformanceEpochTicks() > 0);
             assertDeepStateEquals("after CGB compatibility HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedEpochAndSettledHaltMatchScalarDeepState()
+            throws Exception {
+        byte[] image = nativeColor(dmgRomWramLoop());
+        image[0x200] = 0x76; // HALT, selected after reaching a trusted CGB raster span
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            completeOneBlockGdmaPair(scalar, candidate,
+                    "native CGB x1 completed-GDMA HALT setup");
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 0
+                    && candidate.getCpu().performanceNativeCgbNormalSpeedEpochEntryEligible())
+                    && guard++ < 200_000) {
+                assertEquals("native CGB x1 HALT setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not reach a trusted native CGB x1 HALT entry",
+                    guard < 200_000);
+            assertDeepStateEquals("before native CGB x1 HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("native CGB x1 HALT frame callback",
+                    scalar.runTicks(8), candidate.runTicks(8));
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertEquals("native CGB x1 scalar oracle entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("HALT fetch did not retire inside a native CGB x1 epoch",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("after native CGB x1 HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("native CGB x1 settled-HALT frame callback",
+                    scalar.runTicks(64), candidate.runTicks(64));
+            assertTrue("native CGB x1 settled HALT had no long packet",
+                    candidate.getPerformanceBulkMaxTicks() > 3);
+            assertDeepStateEquals("native CGB x1 settled HALT",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedEpochRetiringHaltAfterCompletedGdmaMatchesScalar()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        image[0x200] = 0x76;
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            int speedGuard = 0;
+            while (!(candidate.getSpeedMode().getSpeedMode() == 2
+                    && candidate.getCpu().getState() != Cpu.State.SPEED_SWITCH)
+                    && speedGuard++ < 300_000) {
+                assertEquals("native CGB x2 speed setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("native CGB x2 setup did not finish its speed switch",
+                    speedGuard < 300_000);
+            completeOneBlockGdmaPair(scalar, candidate,
+                    "native CGB x2 completed-GDMA HALT setup");
+
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 1
+                    && candidate.getCpu().performanceEpochEntryEligible())
+                    && guard++ < 200_000) {
+                assertEquals("native CGB x2 HALT setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not reach a trusted native CGB x2 HALT entry",
+                    guard < 200_000);
+            assertDeepStateEquals("before native CGB x2 HALT epoch",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("native CGB x2 HALT frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertTrue("HALT fetch did not retire inside a native CGB x2 epoch",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("after native CGB x2 completed-GDMA HALT epoch",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
@@ -555,9 +877,30 @@ public final class GameboyPerformanceEpochTest {
                 .build();
     }
 
+    private static Gameboy nativeDoubleSpeedSession(
+            byte[] image, PlayerInputSource inputSource) throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
     private static Gameboy fastForwardCgbCompatibilitySession(PlayerInputSource inputSource)
             throws Exception {
         return new Gameboy.GameboyConfiguration(new Rom(validNonColorRom()))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy fastForwardNativeCgbNormalSpeedSession(PlayerInputSource inputSource)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(validNativeColorRom()))
                 .setHardwareProfile(HardwareProfileRegistry.CGB)
                 .setBootstrapMode(Gameboy.BootstrapMode.FAST_FORWARD)
                 .setExecutionMode(ExecutionMode.PERFORMANCE)
@@ -582,6 +925,18 @@ public final class GameboyPerformanceEpochTest {
             byte[] image, PlayerInputSource inputSource, ExecutionMode executionMode)
             throws Exception {
         return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy nativeCgbNormalSpeedSession(
+            byte[] image, PlayerInputSource inputSource, ExecutionMode executionMode)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(nativeColor(image)))
                 .setHardwareProfile(HardwareProfileRegistry.CGB)
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(executionMode)
@@ -685,6 +1040,42 @@ public final class GameboyPerformanceEpochTest {
                 candidate.captureStateWithoutTimeSource());
     }
 
+    private static void completeOneBlockGdmaPair(
+            Gameboy scalar, Gameboy candidate, String label) {
+        startOneBlockGdma(scalar);
+        startOneBlockGdma(candidate);
+        int guard = 0;
+        while (candidate.getHdma().hasActiveOrPendingTransfer() && guard++ < 256) {
+            assertEquals(label + " frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue(label + " did not complete", guard < 256);
+        Hdma.HdmaState scalarHdma = (Hdma.HdmaState) scalar.getHdma().captureState();
+        Hdma.HdmaState candidateHdma = (Hdma.HdmaState) candidate.getHdma().captureState();
+        assertFalse(label + " scalar transfer remained active", scalarHdma.transferInProgress());
+        assertFalse(label + " candidate transfer remained active",
+                candidateHdma.transferInProgress());
+        assertFalse(label + " scalar HBlank transfer remained armed",
+                scalarHdma.hblankTransfer());
+        assertFalse(label + " candidate HBlank transfer remained armed",
+                candidateHdma.hblankTransfer());
+        assertEquals(label + " scalar request clock", 0, scalarHdma.hblankRequestTicks());
+        assertEquals(label + " candidate request clock", 0,
+                candidateHdma.hblankRequestTicks());
+        assertDeepStateEquals(label,
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static void startOneBlockGdma(Gameboy gameboy) {
+        var bus = gameboy.getAddressSpace();
+        bus.setByte(0xff51, 0);
+        bus.setByte(0xff52, 0);
+        bus.setByte(0xff53, 0);
+        bus.setByte(0xff54, 0);
+        bus.setByte(0xff55, 0);
+    }
+
     /** Record/array-aware equality for the private immutable component-state graph. */
     private static void assertDeepStateEquals(String path, Object expected, Object actual) {
         if (expected == null || actual == null) {
@@ -755,6 +1146,26 @@ public final class GameboyPerformanceEpochTest {
         return image;
     }
 
+    private static byte[] validNativeColorRom() {
+        byte[] image = validNonColorRom();
+        image[0x143] = (byte) 0x80;
+        updateHeaderChecksum(image);
+        return image;
+    }
+
+    private static byte[] nativeColor(byte[] image) {
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static void updateHeaderChecksum(byte[] image) {
+        int checksum = 0;
+        for (int address = 0x134; address <= 0x14c; address++) {
+            checksum = (checksum - (image[address] & 0xff) - 1) & 0xff;
+        }
+        image[0x14d] = (byte) checksum;
+    }
+
     private static byte[] doubleSpeedLoop() {
         byte[] image = new byte[0x8000];
         image[0x100] = 0x3e; // LD A,1
@@ -781,6 +1192,24 @@ public final class GameboyPerformanceEpochTest {
         image[0x106] = 0x18; // JR 0103
         image[0x107] = (byte) 0xfb;
         image[0x143] = 0x00;
+        return image;
+    }
+
+    private static byte[] nativeCgbExternalClockWramLoop() {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,80
+        image[0x101] = (byte) 0x80;
+        image[0x102] = (byte) 0xe0; // LDH (FF02),A: active external-clock wait
+        image[0x103] = 0x02;
+        image[0x104] = 0x21; // LD HL,C000
+        image[0x105] = 0x00;
+        image[0x106] = (byte) 0xc0;
+        image[0x107] = 0x7e; // LD A,(HL)
+        image[0x108] = 0x3c; // INC A
+        image[0x109] = 0x77; // LD (HL),A
+        image[0x10a] = 0x18; // JR 0107
+        image[0x10b] = (byte) 0xfb;
+        image[0x143] = (byte) 0x80;
         return image;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -164,7 +164,7 @@ public final class GameboyPerformanceEpochTest {
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
             assertTrue("FAST_FORWARD compatibility mode 2 rejected its phase transaction",
-                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
+                    candidate.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3) > 0);
             scalar.resetPerformanceBulkCounters();
             candidate.resetPerformanceBulkCounters();
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/** Differential coverage for the short DMG-clocked mode-2 phase packet. */
+/** Differential coverage for the short normal-speed mode-2 phase packet. */
 public final class GameboyPerformanceMode2PhaseTest {
 
     /** Deliberately non-identity source: PERFORMANCE's input horizon must reject this leg. */
@@ -49,8 +49,20 @@ public final class GameboyPerformanceMode2PhaseTest {
                 HardwareProfileRegistry.CGB});
     }
 
+    @Test
+    public void nativeCgbNormalSpeedMode2PacketsMatchScalarForBothSpriteHeights()
+            throws Exception {
+        assertMode2PacketsMatchScalarForBothSpriteHeights(new HardwareProfile[] {
+                HardwareProfileRegistry.CGB}, true);
+    }
+
     private static void assertMode2PacketsMatchScalarForBothSpriteHeights(
             HardwareProfile[] profiles) throws Exception {
+        assertMode2PacketsMatchScalarForBothSpriteHeights(profiles, false);
+    }
+
+    private static void assertMode2PacketsMatchScalarForBothSpriteHeights(
+            HardwareProfile[] profiles, boolean nativeColor) throws Exception {
         for (HardwareProfile profile : profiles) {
             for (boolean tallSprites : new boolean[] {false, true}) {
                 for (int start : new int[] {0, 1, 2, 3, 13, 20, 76, 77, 78}) {
@@ -61,8 +73,10 @@ public final class GameboyPerformanceMode2PhaseTest {
                         }
                         PlayerInputHub candidateHub = new PlayerInputHub();
                         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                                Gameboy scalar = session(profile, SCALAR_INPUT);
-                                Gameboy candidate = session(profile, candidateHub)) {
+                                Gameboy scalar = session(profile, SCALAR_INPUT,
+                                        ExecutionMode.PERFORMANCE, nativeColor);
+                                Gameboy candidate = session(profile, candidateHub,
+                                        ExecutionMode.PERFORMANCE, nativeColor)) {
                             reachMode2Start(scalar, candidate, start, tallSprites);
                             scalar.getGpu().setPerformanceScanlineEnabled(true);
                             candidate.getGpu().setPerformanceScanlineEnabled(true);
@@ -75,7 +89,8 @@ public final class GameboyPerformanceMode2PhaseTest {
                                             candidate, profile, requested) > 0);
                             int cpuPhaseLimit = candidate.getCpu().performancePhaseOnlySpanLimit();
                             String caseDetails = "profile=" + profile.id()
-                                    + " tall=" + tallSprites + " start=" + start
+                                    + " native=" + nativeColor + " tall=" + tallSprites
+                                    + " start=" + start
                                     + " requested=" + requested + " cpuPhaseLimit="
                                     + cpuPhaseLimit + " cpuState=" + candidate.getCpu().getState()
                                     + " gpuMode=" + candidate.getGpu().getMode()
@@ -98,7 +113,8 @@ public final class GameboyPerformanceMode2PhaseTest {
                                         candidate.getPerformanceBulkTicks());
                             }
                             assertDeepStateEquals("profile=" + profile.id()
-                                            + " tall=" + tallSprites + " start=" + start
+                                            + " native=" + nativeColor + " tall="
+                                            + tallSprites + " start=" + start
                                             + " span=" + requested,
                                     scalar.captureStateWithoutTimeSource(),
                                     candidate.captureStateWithoutTimeSource());
@@ -127,12 +143,24 @@ public final class GameboyPerformanceMode2PhaseTest {
         assertMode2LeavesDot79To80Scalar(HardwareProfileRegistry.CGB);
     }
 
+    @Test
+    public void nativeCgbNormalSpeedMode2LeavesDot79To80Scalar() throws Exception {
+        assertMode2LeavesDot79To80Scalar(HardwareProfileRegistry.CGB, true);
+    }
+
     private static void assertMode2LeavesDot79To80Scalar(HardwareProfile profile)
             throws Exception {
+        assertMode2LeavesDot79To80Scalar(profile, false);
+    }
+
+    private static void assertMode2LeavesDot79To80Scalar(
+            HardwareProfile profile, boolean nativeColor) throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(profile, SCALAR_INPUT);
-                Gameboy candidate = session(profile, candidateHub)) {
+                Gameboy scalar = session(profile, SCALAR_INPUT,
+                        ExecutionMode.PERFORMANCE, nativeColor);
+                Gameboy candidate = session(profile, candidateHub,
+                        ExecutionMode.PERFORMANCE, nativeColor)) {
             reachMode2Start(scalar, candidate, 76, false);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
@@ -154,12 +182,13 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals("mode-3 handoff entered the mode-2 packet", packetTicks,
                     candidate.getPerformanceBulkTicks());
             if (profile == HardwareProfileRegistry.CGB) {
-                assertTrue("CGB handoff left DMG compatibility mode",
+                assertEquals("CGB handoff compatibility identity", !nativeColor,
                         candidate.getGpu().isDmgCompatMode());
-                assertTrue("scalar CGB compatibility handoff did not arm the color renderer",
+                assertTrue("scalar CGB handoff did not arm the color renderer",
                         candidate.getGpu().isPerformanceScanlineCursorActive());
             }
-            assertDeepStateEquals(profile.id() + " dot-79 handoff",
+            assertDeepStateEquals(profile.id() + " native=" + nativeColor
+                            + " dot-79 handoff",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
@@ -183,12 +212,24 @@ public final class GameboyPerformanceMode2PhaseTest {
         assertMode2RejectsAnActiveDmaTransfer(HardwareProfileRegistry.CGB);
     }
 
+    @Test
+    public void nativeCgbNormalSpeedMode2RejectsActiveOamDma() throws Exception {
+        assertMode2RejectsAnActiveDmaTransfer(HardwareProfileRegistry.CGB, true);
+    }
+
     private static void assertMode2RejectsAnActiveDmaTransfer(HardwareProfile profile)
             throws Exception {
+        assertMode2RejectsAnActiveDmaTransfer(profile, false);
+    }
+
+    private static void assertMode2RejectsAnActiveDmaTransfer(
+            HardwareProfile profile, boolean nativeColor) throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(profile, SCALAR_INPUT);
-                Gameboy candidate = session(profile, candidateHub)) {
+                Gameboy scalar = session(profile, SCALAR_INPUT,
+                        ExecutionMode.PERFORMANCE, nativeColor);
+                Gameboy candidate = session(profile, candidateHub,
+                        ExecutionMode.PERFORMANCE, nativeColor)) {
             reachMode2Start(scalar, candidate, 20, false);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
@@ -203,7 +244,8 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(0, candidate.runTicks(3));
             assertEquals("active OAM DMA entered a mode-2 packet", 0,
                     candidate.getPerformanceBulkTicks());
-            assertDeepStateEquals(profile.id() + " active OAM DMA",
+            assertDeepStateEquals(profile.id() + " native=" + nativeColor
+                            + " active OAM DMA",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
@@ -219,12 +261,25 @@ public final class GameboyPerformanceMode2PhaseTest {
         assertMode2RestoreFailsClosedThenMatchesScalar(HardwareProfileRegistry.CGB);
     }
 
+    @Test
+    public void nativeCgbNormalSpeedMode2RestoreFailsClosedThenMatchesScalar()
+            throws Exception {
+        assertMode2RestoreFailsClosedThenMatchesScalar(HardwareProfileRegistry.CGB, true);
+    }
+
     private static void assertMode2RestoreFailsClosedThenMatchesScalar(
             HardwareProfile profile) throws Exception {
+        assertMode2RestoreFailsClosedThenMatchesScalar(profile, false);
+    }
+
+    private static void assertMode2RestoreFailsClosedThenMatchesScalar(
+            HardwareProfile profile, boolean nativeColor) throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(profile, SCALAR_INPUT);
-                Gameboy candidate = session(profile, candidateHub)) {
+                Gameboy scalar = session(profile, SCALAR_INPUT,
+                        ExecutionMode.PERFORMANCE, nativeColor);
+                Gameboy candidate = session(profile, candidateHub,
+                        ExecutionMode.PERFORMANCE, nativeColor)) {
             reachMode2Start(scalar, candidate, 20, true);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
@@ -242,7 +297,8 @@ public final class GameboyPerformanceMode2PhaseTest {
             }
             assertEquals("restore drain entered a mode-2 packet", 0,
                     candidate.getPerformanceBulkTicks());
-            assertDeepStateEquals(profile.id() + " restore mode-2 drain",
+            assertDeepStateEquals(profile.id() + " native=" + nativeColor
+                            + " restore mode-2 drain",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
@@ -250,17 +306,29 @@ public final class GameboyPerformanceMode2PhaseTest {
 
     @Test
     public void cgbCompatibilityMode2RejectsActiveHdma() throws Exception {
+        assertCgbNormalSpeedMode2RejectsActiveHdmaAndAdvancesCompletedGdma(false);
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedMode2RejectsActiveHdma() throws Exception {
+        assertCgbNormalSpeedMode2RejectsActiveHdmaAndAdvancesCompletedGdma(true);
+    }
+
+    private static void assertCgbNormalSpeedMode2RejectsActiveHdmaAndAdvancesCompletedGdma(
+            boolean nativeColor) throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
-                Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT);
-                Gameboy candidate = session(HardwareProfileRegistry.CGB, candidateHub)) {
+                Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT,
+                        ExecutionMode.PERFORMANCE, nativeColor);
+                Gameboy candidate = session(HardwareProfileRegistry.CGB, candidateHub,
+                        ExecutionMode.PERFORMANCE, nativeColor)) {
             reachMode2Start(scalar, candidate, 20, false);
             scalar.getGpu().setPerformanceScanlineEnabled(true);
             candidate.getGpu().setPerformanceScanlineEnabled(true);
             startOneBlockGdma(scalar);
             startOneBlockGdma(candidate);
             assertEquals(0,
-                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
+                    candidate.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3));
             candidate.resetPerformanceBulkCounters();
 
             for (int i = 0; i < 3; i++) {
@@ -269,7 +337,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(0, candidate.runTicks(3));
             assertEquals("active HDMA entered a mode-2 packet", 0,
                     candidate.getPerformanceBulkTicks());
-            assertDeepStateEquals("CGB compatibility active HDMA",
+            assertDeepStateEquals("CGB native=" + nativeColor + " active HDMA",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
 
@@ -288,7 +356,7 @@ public final class GameboyPerformanceMode2PhaseTest {
 
             candidate.getGpu().setPerformanceScanlineEnabled(true);
             assertTrue("post-GDMA request clock rejected an exact mode-2 packet",
-                    candidate.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
+                    candidate.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3) > 0);
             candidate.resetPerformanceBulkCounters();
             int tail = Math.min(8, 79 - candidate.getGpu().getTicksInLine());
             for (int i = 0; i < tail; i++) {
@@ -297,21 +365,24 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(0, candidate.runTicks(tail));
             assertTrue("completed GDMA tail did not enter a mode-2 packet",
                     candidate.getPerformanceBulkTicks() > 0);
-            assertDeepStateEquals("CGB compatibility completed-GDMA request clock",
+            assertDeepStateEquals("CGB native=" + nativeColor
+                            + " completed-GDMA request clock",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }
     }
 
     @Test
-    public void cgbCompatibilityMode2RejectsCgb0NativeAccuracyAndDebug() throws Exception {
+    public void cgbNormalSpeedMode2RejectsCgb0AccuracyAndDebug() throws Exception {
         Mode2ExclusionCase[] cases = {
                 new Mode2ExclusionCase("cgb0-compat", HardwareProfileRegistry.CGB0,
                         ExecutionMode.PERFORMANCE, false, true),
-                new Mode2ExclusionCase("cgb-native", HardwareProfileRegistry.CGB,
+                new Mode2ExclusionCase("cgb0-native", HardwareProfileRegistry.CGB0,
                         ExecutionMode.PERFORMANCE, true, true),
                 new Mode2ExclusionCase("accuracy-cgb-compat", HardwareProfileRegistry.CGB,
-                        ExecutionMode.ACCURACY, false, false)
+                        ExecutionMode.ACCURACY, false, false),
+                new Mode2ExclusionCase("accuracy-cgb-native", HardwareProfileRegistry.CGB,
+                        ExecutionMode.ACCURACY, true, false)
         };
         for (Mode2ExclusionCase exclusion : cases) {
             PlayerInputHub hub = new PlayerInputHub();
@@ -322,33 +393,41 @@ public final class GameboyPerformanceMode2PhaseTest {
                 if (exclusion.scanlineCapable()) {
                     gameboy.getGpu().setPerformanceScanlineEnabled(true);
                 }
-                assertEquals(exclusion.label() + " entered CGB compatibility mode 2", 0,
-                        gameboy.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
+                assertEquals(exclusion.label() + " entered CGB normal-speed mode 2", 0,
+                        gameboy.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3));
             }
         }
 
-        PlayerInputHub debugHub = new PlayerInputHub();
-        try (PlayerInputHub.SourceHandle ignored = debugHub.openSource(0);
-                Gameboy debug = session(HardwareProfileRegistry.CGB, debugHub)) {
-            reachMode2Start(debug, debug, 20, false);
-            debug.getGpu().setPerformanceScanlineEnabled(true);
-            assertTrue("ordinary CGB compatibility control was not eligible",
-                    debug.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3) > 0);
-            debug.getGpu().setDebugHooks(new TestDebugHooks());
-            assertEquals("debug hooks entered CGB compatibility mode 2", 0,
-                    debug.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(3));
+        for (boolean nativeColor : new boolean[] {false, true}) {
+            PlayerInputHub debugHub = new PlayerInputHub();
+            try (PlayerInputHub.SourceHandle ignored = debugHub.openSource(0);
+                    Gameboy debug = session(HardwareProfileRegistry.CGB, debugHub,
+                            ExecutionMode.PERFORMANCE, nativeColor)) {
+                reachMode2Start(debug, debug, 20, false);
+                debug.getGpu().setPerformanceScanlineEnabled(true);
+                assertTrue("ordinary CGB control was not eligible native=" + nativeColor,
+                        debug.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3) > 0);
+                debug.getGpu().setDebugHooks(new TestDebugHooks());
+                assertEquals("debug hooks entered CGB normal-speed mode 2 native="
+                                + nativeColor, 0,
+                        debug.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3));
+            }
         }
     }
 
     @Test
-    public void nativeCgbNormalSpeedMode2RemainsScalar() throws Exception {
+    public void nativeCgbNormalSpeedLineZeroMode2UsesOnlyThePhasePacket() throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
              Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT,
                      ExecutionMode.PERFORMANCE, true);
              Gameboy candidate = session(HardwareProfileRegistry.CGB, candidateHub,
                      ExecutionMode.PERFORMANCE, true)) {
-            reachMode2Start(scalar, candidate, 20, false);
+            reachMode2Start(scalar, candidate, 0, 13, false);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+            assertTrue("native CGB line-0 mode-2 preflight rejected dot 13",
+                    candidate.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3) > 0);
             scalar.resetPerformanceBulkCounters();
             candidate.resetPerformanceBulkCounters();
 
@@ -356,13 +435,30 @@ public final class GameboyPerformanceMode2PhaseTest {
                 scalar.tick();
             }
             assertEquals(0, candidate.runTicks(3));
-            assertEquals("native CGB x1 mode 2 entered a phase packet", 0L,
-                    candidate.getPerformanceBulkTicks());
+            assertTrue("native CGB x1 line-0 mode 2 did not enter a phase packet",
+                    candidate.getPerformanceBulkTicks() > 0);
             assertEquals("native CGB x1 mode 2 entered a CPU epoch", 0L,
                     candidate.getPerformanceEpochTicks());
-            assertDeepStateEquals("native CGB x1 scalar mode 2",
+            assertDeepStateEquals("native CGB x1 line-0 mode 2",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedIsExcludedFromNormalSpeedMode2Packet() throws Exception {
+        PlayerInputHub hub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = hub.openSource(0);
+                Gameboy gameboy = doubleSpeedSession(hub)) {
+            int guard = 0;
+            while (gameboy.getSpeedMode().getSpeedMode() != 2 && guard++ < 200_000) {
+                gameboy.tick();
+            }
+            assertTrue("test ROM did not enter CGB double speed", guard < 200_000);
+            reachMode2Start(gameboy, gameboy, 20, false);
+            gameboy.getGpu().setPerformanceScanlineEnabled(true);
+            assertEquals("native CGB x2 entered the x1 mode-2 packet", 0,
+                    gameboy.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(3));
         }
     }
 
@@ -439,7 +535,7 @@ public final class GameboyPerformanceMode2PhaseTest {
     private static int performanceMode2PhaseSpanLimit(
             Gameboy gameboy, HardwareProfile profile, int requested) {
         return profile == HardwareProfileRegistry.CGB
-                ? gameboy.getGpu().performanceCgbCompatibilityMode2PhaseSpanLimit(requested)
+                ? gameboy.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(requested)
                 : gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(requested);
     }
 
@@ -483,6 +579,12 @@ public final class GameboyPerformanceMode2PhaseTest {
 
     private static void reachMode2Start(Gameboy scalar, Gameboy candidate,
                                          int targetDot, boolean tallSprites) {
+        reachMode2Start(scalar, candidate, 1, targetDot, tallSprites);
+    }
+
+    private static void reachMode2Start(Gameboy scalar, Gameboy candidate,
+                                         int targetLine, int targetDot,
+                                         boolean tallSprites) {
         int guard = 0;
         while (scalar.getGpu().getMode() != Mode.VBlank && guard++ < 456 * 155) {
             scalar.tick();
@@ -499,28 +601,28 @@ public final class GameboyPerformanceMode2PhaseTest {
             candidate.getGpu().setByte(0xff40, requestedLcdc);
         }
         // Two selected sprites exercise the same Y/X commit path without relying on an OAM
-        // DMA burst.  Their Y covers line 1 for both 8- and 16-pixel modes.
+        // DMA burst. Their Y covers the target line for both 8- and 16-pixel modes.
         for (int index = 0; index < 2; index++) {
             int address = 0xfe00 + index * 4;
-            scalar.getGpu().setByte(address, 17);
+            scalar.getGpu().setByte(address, 16 + targetLine);
             scalar.getGpu().setByte(address + 1, 8 + index * 16);
             if (candidate != scalar) {
-                candidate.getGpu().setByte(address, 17);
+                candidate.getGpu().setByte(address, 16 + targetLine);
                 candidate.getGpu().setByte(address + 1, 8 + index * 16);
             }
         }
 
         guard = 0;
-        while ((scalar.getGpu().getLine() != 1
+        while ((scalar.getGpu().getLine() != targetLine
                         || scalar.getGpu().getTicksInLine() != targetDot)
-                && guard++ < 456 * 12) {
+                && guard++ < 456 * 13) {
             scalar.tick();
             if (candidate != scalar) {
                 candidate.tick();
             }
         }
-        assertTrue("mode-2 setup did not reach line 1 dot " + targetDot,
-                guard < 456 * 12);
+        assertTrue("mode-2 setup did not reach line " + targetLine + " dot " + targetDot,
+                guard < 456 * 13);
         assertEquals(Mode.OamSearch, scalar.getGpu().getMode());
         assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
     }
@@ -544,6 +646,27 @@ public final class GameboyPerformanceMode2PhaseTest {
                 .setHardwareProfile(profile)
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(executionMode)
+                .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy doubleSpeedSession(PlayerInputSource inputSource) throws Exception {
+        byte[] image = new byte[0x8000];
+        image[0x100] = 0x3e; // LD A,1
+        image[0x101] = 0x01;
+        image[0x102] = (byte) 0xe0; // LDH (FF4D),A
+        image[0x103] = 0x4d;
+        image[0x104] = 0x10; // STOP + padding
+        image[0x105] = 0x00;
+        image[0x106] = (byte) 0xc3; // JP 0106
+        image[0x107] = 0x06;
+        image[0x108] = 0x01;
+        image[0x143] = (byte) 0x80;
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
                 .setPlayerInputSource(inputSource)
                 .setSupportBatterySave(false)
                 .build();

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -341,6 +341,32 @@ public final class GameboyPerformanceMode2PhaseTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedMode2RemainsScalar() throws Exception {
+        PlayerInputHub candidateHub = new PlayerInputHub();
+        try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
+             Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT,
+                     ExecutionMode.PERFORMANCE, true);
+             Gameboy candidate = session(HardwareProfileRegistry.CGB, candidateHub,
+                     ExecutionMode.PERFORMANCE, true)) {
+            reachMode2Start(scalar, candidate, 20, false);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            for (int tick = 0; tick < 3; tick++) {
+                scalar.tick();
+            }
+            assertEquals(0, candidate.runTicks(3));
+            assertEquals("native CGB x1 mode 2 entered a phase packet", 0L,
+                    candidate.getPerformanceBulkTicks());
+            assertEquals("native CGB x1 mode 2 entered a CPU epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("native CGB x1 scalar mode 2",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
     public void physicalDmgMode2ExcludesOtherProfilesAtAnOtherwiseEligibleMode2Point()
             throws Exception {
         // The positive DMG control proves that this exact non-first-line mode-2 fixture has

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -99,21 +99,25 @@ public final class GameboyPlayerInputHubPerformanceTest {
                     PlayerInputSnapshot.released());
             try (Gameboy performance = session(true, ExecutionMode.PERFORMANCE, hub);
                     Gameboy scalar = session(true, ExecutionMode.PERFORMANCE, scalarInput::get)) {
-                // Find a synchronized endpoint where the immediately preceding call is exactly
-                // one all-subsystem packet of the requested 1–3 dots. The scalar oracle follows
-                // the same PERFORMANCE renderer lifecycle but has a custom source, so its
-                // all-subsystem packet horizon is zero.
-                boolean allBulk = false;
-                for (int attempt = 0; attempt < 4_000 && !allBulk; attempt++) {
-                    long before = performance.getPerformanceBulkTicks();
+                // Find a synchronized endpoint where the requested 1–3 dots are covered wholly
+                // by exact scheduler packets. Native CGB normal speed may use either the short
+                // all-subsystem packet or the fixed-x1 running-CPU epoch. The scalar oracle
+                // follows the same PERFORMANCE renderer lifecycle but has a custom source, so
+                // both horizons are zero.
+                boolean allFast = false;
+                for (int attempt = 0; attempt < 4_000 && !allFast; attempt++) {
+                    long bulkBefore = performance.getPerformanceBulkTicks();
+                    long epochBefore = performance.getPerformanceEpochTicks();
                     performance.runTicks(tail);
                     for (int i = 0; i < tail; i++) {
                         scalar.runTicks(1);
                     }
-                    allBulk = performance.getPerformanceBulkTicks() - before == tail;
+                    long fastTicks = performance.getPerformanceBulkTicks() - bulkBefore
+                            + performance.getPerformanceEpochTicks() - epochBefore;
+                    allFast = fastTicks == tail;
                 }
-                assertTrue("CGB setup did not exercise an all-bulk " + tail + "-dot tail",
-                        allBulk);
+                assertTrue("CGB setup did not exercise an all-fast " + tail + "-dot tail",
+                        allFast);
 
                 // Start GDMA immediately after the proven packet tail. The final GPU timing
                 // publication must make FF55 observe the same request state as scalar execution.
@@ -158,14 +162,10 @@ public final class GameboyPlayerInputHubPerformanceTest {
                 assertTrue("stable HALT had no substantial bulk coverage cgb=" + cgb
                                 + " ticks=" + performance.getPerformanceBulkTicks(),
                         performance.getPerformanceBulkTicks() > 1_000);
-                if (cgb) {
-                    assertEquals("CGB settled HALT must retain the ordinary three-dot cap",
-                            0, performance.getPerformanceBulkMaxTicks());
-                } else {
-                    assertTrue("DMG settled HALT never crossed a machine-cycle boundary"
-                                    + " maxSpan=" + performance.getPerformanceBulkMaxTicks(),
-                            performance.getPerformanceBulkMaxTicks() > 3);
-                }
+                assertTrue((cgb ? "CGB" : "DMG")
+                                + " settled HALT never crossed a machine-cycle boundary"
+                                + " maxSpan=" + performance.getPerformanceBulkMaxTicks(),
+                        performance.getPerformanceBulkMaxTicks() > 3);
             }
         }
     }
@@ -428,13 +428,9 @@ public final class GameboyPlayerInputHubPerformanceTest {
                     assertRasterEquivalent(scalar, performance,
                             "random HALT tail cgb=" + cgb + ", chunk=" + chunkIndex);
                 }
-                if (cgb) {
-                    assertEquals("CGB random HALT tails must retain the ordinary three-dot cap",
-                            0, performance.getPerformanceBulkMaxTicks());
-                } else {
-                    assertTrue("DMG random HALT tails never crossed a machine cycle",
-                            performance.getPerformanceBulkMaxTicks() > 3);
-                }
+                assertTrue((cgb ? "CGB" : "DMG")
+                                + " random HALT tails never crossed a machine cycle",
+                        performance.getPerformanceBulkMaxTicks() > 3);
             }
         }
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -190,6 +190,51 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedFourDotEpochMatchesScalarAtEveryBudget()
+            throws Exception {
+        for (int entryPhase = 0; entryPhase < 4; entryPhase++) {
+            for (int budget = 1; budget <= Cpu.PERFORMANCE_EPOCH_MAX_TICKS; budget++) {
+                ParityMemory directMemory = new ParityMemory();
+                directMemory.bytes[0x0000] = 0x21; // LD HL,C000
+                directMemory.bytes[0x0001] = 0x00;
+                directMemory.bytes[0x0002] = (byte) 0xc0;
+                directMemory.bytes[0x0003] = 0x7e; // LD A,(HL)
+                directMemory.bytes[0x0004] = 0x3c; // INC A
+                directMemory.bytes[0x0005] = 0x77; // LD (HL),A
+                directMemory.bytes[0x0006] = 0x18; // JR 0003
+                directMemory.bytes[0x0007] = (byte) 0xfb;
+                directMemory.bytes[0xc000] = 0x23;
+                ParityMemory scalarMemory = new ParityMemory();
+                System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                        directMemory.bytes.length);
+
+                InterruptManager directInterrupts = new InterruptManager(true);
+                InterruptManager scalarInterrupts = new InterruptManager(true);
+                SpeedMode directSpeed = new SpeedMode(true);
+                SpeedMode scalarSpeed = new SpeedMode(true);
+                Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                        directSpeed, new Display(false));
+                Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                        scalarSpeed, new Display(false));
+                CpuPair pair = new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                        directMemory, scalarMemory);
+
+                for (int tick = 0; tick < entryPhase; tick++) {
+                    direct.tick();
+                    scalar.tick();
+                }
+
+                assertEquals("native CGB x1 phase " + entryPhase + " budget " + budget,
+                        budget, direct.runNativeCgbNormalSpeedPerformanceEpoch(budget));
+                for (int tick = 0; tick < budget; tick++) {
+                    scalar.tick();
+                }
+                assertCpuPairEquals(pair);
+            }
+        }
+    }
+
+    @Test
     public void nativeCgbAndPhysicalDmgEntryPointsAreTopologyIsolated() {
         Cpu physicalDmg = new Cpu(new CountingMemory(), new InterruptManager(false), null,
                 new SpeedMode(false), new Display(false));
@@ -202,11 +247,22 @@ public final class CpuPerformanceEpochTest {
         assertTrue(nativeCgb.performanceEpochEntryEligible());
         assertFalse(nativeCgb.performancePhysicalDmgEpochEntryEligible());
         assertEquals(0, nativeCgb.runPhysicalDmgPerformanceEpoch(54));
+        assertFalse(nativeCgb.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        assertEquals(0, nativeCgb.runNativeCgbNormalSpeedPerformanceEpoch(54));
 
         Cpu nativeNormalSpeed = new Cpu(new CountingMemory(), new InterruptManager(true), null,
                 new SpeedMode(true), new Display(false));
         assertFalse(nativeNormalSpeed.performanceCgbCompatibilityEpochEntryEligible());
         assertEquals(0, nativeNormalSpeed.runCgbCompatibilityPerformanceEpoch(54));
+        assertTrue(nativeNormalSpeed.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        assertEquals(54, nativeNormalSpeed.runNativeCgbNormalSpeedPerformanceEpoch(54));
+
+        SpeedMode compatibilitySpeed = new SpeedMode(true);
+        compatibilitySpeed.setDmgCompat(true);
+        Cpu compatibility = new Cpu(new CountingMemory(), new InterruptManager(true), null,
+                compatibilitySpeed, new Display(false));
+        assertFalse(compatibility.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        assertEquals(0, compatibility.runNativeCgbNormalSpeedPerformanceEpoch(54));
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -31,6 +31,77 @@ public class HdmaTest {
     }
 
     @Test
+    public void inactiveCompletedGdmaRequestClockBulkMatchesScalarAcrossPpuModes() {
+        Fixture scalar = new Fixture();
+        Fixture bulk = new Fixture();
+        scalar.startTransfer(0x00);
+        bulk.startTransfer(0x00);
+        scalar.tick(38);
+        bulk.tick(38);
+        scalar.hdma.onGpuUpdate(Mode.PixelTransfer);
+        bulk.hdma.onGpuUpdate(Mode.PixelTransfer);
+
+        Hdma.HdmaState completed = hdmaState(bulk);
+        assertEquals(0, completed.hblankRequestTicks());
+        assertFalse(completed.transferInProgress());
+        assertTrue(bulk.hdma.isPerformanceInactiveRequestClockStable());
+        assertFalse("mode-specific wrapper crossed a PPU mode boundary",
+                bulk.hdma.isPerformanceOamSearchPhaseClockStable());
+
+        scalar.advanceHblankRequest(17);
+        bulk.hdma.advancePerformanceInactiveRequestClockTrusted(17);
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals(17, hdmaState(bulk).hblankRequestAge());
+
+        bulk.hdma.onGpuUpdate(Mode.OamSearch);
+        assertTrue(bulk.hdma.isPerformanceOamSearchPhaseClockStable());
+    }
+
+    @Test
+    public void inactiveRequestClockBulkPreservesScalarHaltAsymmetry() {
+        Fixture scalar = new Fixture();
+        Fixture bulk = new Fixture();
+        scalar.startTransfer(0x00);
+        bulk.startTransfer(0x00);
+        scalar.tick(38);
+        bulk.tick(38);
+        scalar.hdma.onCpuHaltState(true);
+        bulk.hdma.onCpuHaltState(true);
+
+        scalar.advanceHblankRequest(11);
+        bulk.hdma.advancePerformanceInactiveRequestClockTrusted(11);
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals("halted current request clock must not age", 0,
+                hdmaState(bulk).hblankRequestAge());
+    }
+
+    @Test
+    public void runningEpochHaltReconciliationExcludesOnlyTheTerminalCurrentAge() {
+        Fixture scalar = new Fixture();
+        Fixture bulk = new Fixture();
+        Hdma.HdmaState clocks = withRequestClockState(
+                hdmaState(scalar), 0, 40, 0, 70);
+        scalar.hdma.restoreState(clocks);
+        bulk.hdma.restoreState(clocks);
+
+        for (int tick = 0; tick < 4; tick++) {
+            scalar.advanceHblankRequest(1);
+        }
+        scalar.hdma.onCpuHaltState(true);
+        scalar.advanceHblankRequest(1);
+
+        bulk.hdma.advancePerformanceInactiveRequestClockTrusted(5);
+        bulk.hdma.reconcilePerformanceRunningEpochHaltEntryTrusted();
+        bulk.hdma.onCpuHaltState(true);
+
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals("terminal HALT dot must not age the current request", 44,
+                hdmaState(bulk).hblankRequestAge());
+        assertEquals("terminal HALT dot must still age the next request", 75,
+                hdmaState(bulk).nextHblankRequestAge());
+    }
+
+    @Test
     public void generalPurposeDmaPaysStartupCostOnlyOnce() {
         Fixture fixture = new Fixture();
         fixture.startTransfer(0x01);
@@ -447,6 +518,32 @@ public class HdmaTest {
                 values[i] = switch (components[i].getName()) {
                     case "interruptEntryWonArbitration" -> interruptOwner;
                     case "cpuRequestAllowsLateInterrupt" -> lateInterrupt;
+                    default -> components[i].getAccessor().invoke(state);
+                };
+            }
+            var constructor = Hdma.HdmaState.class.getDeclaredConstructor(parameterTypes);
+            constructor.setAccessible(true);
+            return (Hdma.HdmaState) constructor.newInstance(values);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private Hdma.HdmaState withRequestClockState(
+            Hdma.HdmaState state, int currentTicks, int currentAge,
+            int nextTicks, int nextAge) {
+        try {
+            RecordComponent[] components = Hdma.HdmaState.class.getRecordComponents();
+            Class<?>[] parameterTypes = Arrays.stream(components)
+                    .map(RecordComponent::getType)
+                    .toArray(Class<?>[]::new);
+            Object[] values = new Object[components.length];
+            for (int i = 0; i < components.length; i++) {
+                values[i] = switch (components[i].getName()) {
+                    case "hblankRequestTicks" -> currentTicks;
+                    case "hblankRequestAge" -> currentAge;
+                    case "nextHblankRequestTicks" -> nextTicks;
+                    case "nextHblankRequestAge" -> nextAge;
                     default -> components[i].getAccessor().invoke(state);
                 };
             }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortPerformanceSpanTest.java
@@ -46,12 +46,12 @@ public class SerialPortPerformanceSpanTest {
     }
 
     @Test
-    public void cgbNormalSpeedRemainsOutsideEpochIdleContract() {
+    public void nativeCgbNormalSpeedUsesOnlyTheFixedX1EpochIdleContract() {
         SerialPort cgbNormal = new SerialPort(
                 new InterruptManager(true), true, new SpeedMode(true));
         assertFalse(cgbNormal.performanceEpochIdle(54));
         assertFalse(cgbNormal.performancePhysicalDmgEpochIdle(54));
-        assertFalse(cgbNormal.performanceNormalSpeedEpochIdle(54, true));
+        assertTrue(cgbNormal.performanceNormalSpeedEpochIdle(54, true));
     }
 
     @Test
@@ -73,6 +73,100 @@ public class SerialPortPerformanceSpanTest {
             scalar.tick();
         }
         bulk.tickPerformanceNormalSpeedEpochIdle(54);
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
+    public void nativeCgbIdleEpochMatchesScalarNormalSpeedTicks() {
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        InterruptManager bulkInterrupts = new InterruptManager(true);
+        SerialPort scalar = new SerialPort(
+                scalarInterrupts, true, new SpeedMode(true));
+        SerialPort bulk = new SerialPort(
+                bulkInterrupts, true, new SpeedMode(true));
+        for (int tick = 0; tick < 37; tick++) {
+            scalar.tick();
+            bulk.tick();
+        }
+        assertTrue(bulk.performanceNormalSpeedEpochIdle(54, true));
+        for (int tick = 0; tick < 54; tick++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceNormalSpeedEpochIdle(54);
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
+    public void nativeCgbExternalClockTransferMatchesScalarNormalSpeedEpoch() {
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        InterruptManager bulkInterrupts = new InterruptManager(true);
+        SerialPort scalar = new SerialPort(
+                scalarInterrupts, true, new SpeedMode(true));
+        SerialPort bulk = new SerialPort(
+                bulkInterrupts, true, new SpeedMode(true));
+        for (int tick = 0; tick < 37; tick++) {
+            scalar.tick();
+            bulk.tick();
+        }
+        scalar.setByte(0xff02, 0x80);
+        bulk.setByte(0xff02, 0x80);
+
+        assertEquals(3, bulk.performanceQuietSpanLimit(3));
+        assertEquals(54, bulk.performanceSettledHaltSpanLimit(54));
+        assertTrue(bulk.performanceNormalSpeedEpochIdle(54, true));
+        assertFalse(bulk.performancePhysicalDmgEpochIdle(54));
+        for (int tick = 0; tick < 54; tick++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceNormalSpeedEpochIdle(54);
+
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
+    public void disconnectedPeerExternalClockTransferMatchesScalarNormalSpeedEpoch() {
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        InterruptManager bulkInterrupts = new InterruptManager(true);
+        SerialPort scalar = new SerialPort(
+                scalarInterrupts, true, new SpeedMode(true));
+        SerialPort bulk = new SerialPort(
+                bulkInterrupts, true, new SpeedMode(true));
+        scalar.init(new Peer2PeerSerialEndpoint());
+        bulk.init(new Peer2PeerSerialEndpoint());
+        scalar.setByte(0xff02, 0x80);
+        bulk.setByte(0xff02, 0x80);
+
+        assertTrue(bulk.performanceNormalSpeedEpochIdle(54, true));
+        for (int tick = 0; tick < 54; tick++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceNormalSpeedEpochIdle(54);
+
+        assertEquals(scalar.captureState(), bulk.captureState());
+        assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
+    }
+
+    @Test
+    public void nativeCgbExternalClockTransferMatchesScalarDoubleSpeedEpoch()
+            throws ReflectiveOperationException {
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        InterruptManager bulkInterrupts = new InterruptManager(true);
+        SerialPort scalar = new SerialPort(scalarInterrupts, true, doubleSpeed());
+        SerialPort bulk = new SerialPort(bulkInterrupts, true, doubleSpeed());
+        scalar.setByte(0xff02, 0x80);
+        bulk.setByte(0xff02, 0x80);
+
+        assertTrue(bulk.performanceEpochIdle(54));
+        assertEquals(0, bulk.performanceQuietSpanLimit(3));
+        assertEquals(0, bulk.performanceSettledHaltSpanLimit(54));
+        for (int tick = 0; tick < 54; tick++) {
+            scalar.tick();
+        }
+        bulk.tickPerformanceEpochIdle(54);
+
         assertEquals(scalar.captureState(), bulk.captureState());
         assertEquals(scalarInterrupts.captureState(), bulkInterrupts.captureState());
     }
@@ -154,18 +248,35 @@ public class SerialPortPerformanceSpanTest {
 
     @Test
     public void quietSpanFailsClosedForTransfersEndpointsAndDebugHooks() {
-        SerialPort transfer = new SerialPort(
-                new InterruptManager(false), false, new SpeedMode(false));
-        transfer.setByte(0xff02, 0x81);
-        var transferState = transfer.captureState();
-        assertFalse(transfer.canTickPerformanceQuietSpan(1));
-        assertFalse(transfer.tickPerformanceQuietSpan(1));
-        assertEquals(transferState, transfer.captureState());
+        SerialPort internalTransfer = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        internalTransfer.setByte(0xff02, 0x81);
+        var transferState = internalTransfer.captureState();
+        assertFalse(internalTransfer.canTickPerformanceQuietSpan(1));
+        assertFalse(internalTransfer.tickPerformanceQuietSpan(1));
+        assertEquals(0, internalTransfer.performanceSettledHaltSpanLimit(54));
+        assertFalse(internalTransfer.performanceNormalSpeedEpochIdle(54, true));
+        assertEquals(transferState, internalTransfer.captureState());
 
         SerialPort endpoint = new SerialPort(
-                new InterruptManager(false), false, new SpeedMode(false));
+                new InterruptManager(true), true, new SpeedMode(true));
         endpoint.init(new NoopEndpoint());
+        endpoint.setByte(0xff02, 0x80);
         assertEquals(0, endpoint.performanceQuietSpanLimit(1));
+        assertEquals(0, endpoint.performanceSettledHaltSpanLimit(54));
+        assertFalse(endpoint.performanceNormalSpeedEpochIdle(54, true));
+
+        LegacyQuietEndpoint legacyEndpoint = new LegacyQuietEndpoint();
+        SerialPort legacy = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        legacy.init(legacyEndpoint);
+        legacy.setByte(0xff02, 0x80);
+        assertEquals(0, legacy.performanceQuietSpanLimit(1));
+        assertEquals(0, legacy.performanceSettledHaltSpanLimit(54));
+        assertFalse(legacy.performanceNormalSpeedEpochIdle(54, true));
+        legacy.tick();
+        assertTrue("legacy quiet endpoint did not observe the active external wait",
+                legacyEndpoint.activeExternalWaitObserved);
 
         SerialPort debug = new SerialPort(
                 new InterruptManager(false), false, new SpeedMode(false));
@@ -221,6 +332,50 @@ public class SerialPortPerformanceSpanTest {
     }
 
     private static final class NoopEndpoint implements SerialEndpoint {
+        @Override
+        public void setSb(int sb) {
+        }
+
+        @Override
+        public int recvBit() {
+            return -1;
+        }
+
+        @Override
+        public void startSending() {
+        }
+
+        @Override
+        public int sendBit() {
+            return 1;
+        }
+
+        @Override
+        public eu.rekawek.coffeegb.core.state.ComponentState<SerialEndpoint> captureState() {
+            return null;
+        }
+
+        @Override
+        public void restoreState(
+                eu.rekawek.coffeegb.core.state.ComponentState<SerialEndpoint> state) {
+        }
+    }
+
+    /** Models an old quiet-capability implementer which observes active external waits. */
+    private static final class LegacyQuietEndpoint implements SerialEndpoint {
+
+        private boolean activeExternalWaitObserved;
+
+        @Override
+        public int performanceQuietSpanLimit(int requested) {
+            return requested > 0 ? requested : 0;
+        }
+
+        @Override
+        public void setExternalTransfer(boolean inProgress) {
+            activeExternalWaitObserved |= inProgress;
+        }
+
         @Override
         public void setSb(int sb) {
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/timer/TimerPerformanceEpochTest.java
@@ -95,7 +95,7 @@ public final class TimerPerformanceEpochTest {
     }
 
     @Test
-    public void cgbCompatibilityEpochIncludesThePlusTwoApuTap() {
+    public void normalSpeedCgbEpochIncludesThePlusTwoApuTapInBothColorModes() {
         SpeedMode speed = new SpeedMode(true);
         speed.setDmgCompat(true);
         Timer timer = new Timer(new InterruptManager(true), speed);
@@ -106,7 +106,7 @@ public final class TimerPerformanceEpochTest {
         SpeedMode nativeSpeed = new SpeedMode(true);
         Timer nativeTimer = new Timer(new InterruptManager(true), nativeSpeed);
         nativeTimer.presetDiv(0x1ff9);
-        assertEquals(0, nativeTimer.performanceNormalSpeedEpochSpanLimit(54, true));
+        assertEquals(4, nativeTimer.performanceNormalSpeedEpochSpanLimit(54, true));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- route ordinary CGB software that remains at 1x speed through the existing fixed-width PERFORMANCE CPU/raster and settled-HALT machinery
- admit proven-quiet external-clock serial waits used by Tetris DX without weakening endpoint contracts
- reuse the exact CGB 1x mode-2 phase packet for native-color games
- preserve scalar fallbacks at decoded I/O, DMA/HDMA transitions, dot 79 to 80, CGB0, ACCURACY, and double-speed boundaries

## Tetris DX results

Measured on the same Android phone with FAST_FORWARD bootstrap, native CGB 1x, PERFORMANCE mode, canonical audio, 600 frames:

| | Before | After |
|---|---:|---:|
| Ready FPS | 32.569718634 | 54.277411305 |
| Submission FPS | 32.566145700 | 54.299354100 |
| Wall time | 18,399 ms | 11,043 ms |
| Controller CPU | 18,324 ms | 10,668 ms |
| Fast-path coverage | 47.258534% | 83.579045% |

Ready FPS improves by 66.649924%. Both runs produced 600/600 frames; the candidate had zero dropped, duplicate, late, or corrupt frames and drained successfully.

An active Marathon checkpoint also matched a forced-scalar oracle exactly for full portable machine state, final pixels, frame count, audio event count, sample count, and audio hash. Host throughput more than doubled after the native 1x epoch slice; the mode-2 slice added a further 4-7% normalized throughput.

## Validation

- `mvn -pl core test`: 1,926 tests, 0 failures/errors
- Mooneye: 130/130
- DMG Acid2 and CGB Acid2
- Blargg aggregate: 8/8
- Blargg individual: 46/46
- focused native/compat CPU, timer, serial, HDMA, mode-2, restore, DMA, and topology differentials
- minified Android benchmark APK on physical device
