### PR TITLE
Bring native CGB normal-speed games to real time

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -197,6 +197,7 @@ dependencies {
   implementation("androidx.camera:camera-core:1.6.1")
   implementation("androidx.camera:camera-lifecycle:1.6.1")
   implementation("androidx.lifecycle:lifecycle-process:2.11.0")
+  implementation("androidx.profileinstaller:profileinstaller:1.4.1")
   testImplementation("junit:junit:4.13.2")
   androidTestImplementation("androidx.test:core:1.7.0")
   androidTestImplementation("androidx.test.ext:junit:1.3.0")

--- a/android/app/src/main/baseline-prof.txt
+++ b/android/app/src/main/baseline-prof.txt
@@ -1,0 +1,1 @@
+HPLeu/rekawek/coffeegb/core/Gameboy;->**(**)**

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -220,6 +220,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 && options.audioPolicy == DiagnosticsOptions.AudioPolicy.SILENT_PCM_V1) {
             return RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1;
         }
+        if (options.enabled
+                && options.runtimeWarmup
+                && options.executionMode == ExecutionMode.PERFORMANCE) {
+            return RuntimeWarmupFlavor.PERFORMANCE;
+        }
         return RuntimeWarmupFlavor.SCALAR;
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -101,6 +101,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final DiagnosticsOptions diagnosticsOptions;
     private final AndroidBenchmarkDiagnostics diagnostics;
     private final BenchmarkGameplayScenario benchmarkScenario;
+    /** Adaptive hint session; live mutations stay on synchronous controller callbacks. */
+    private final AndroidPerformanceBoost performanceBoost;
     private final NativeFrameStore frames;
     /** Session timing belongs to the service, not to a short-lived Activity attachment. */
     private final PlayTimeTracker playTime = new PlayTimeTracker();
@@ -176,6 +178,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     AndroidEmulationRuntime(Context context, DiagnosticsOptions options) {
         this.context = Objects.requireNonNull(context, "context").getApplicationContext();
+        performanceBoost = new AndroidPerformanceBoost(this.context);
         diagnosticsOptions = options == null ? DiagnosticsOptions.disabled() : options;
         benchmarkScenario = new BenchmarkGameplayScenario(
                 diagnosticsOptions.benchmarkScenario,
@@ -1465,6 +1468,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(
                 event -> {
                     frames.setHardwareProfile(event.getProfile());
+                    performanceBoost.onHardwareProfile(event.getProfile().clockSpec());
                     AndroidAudioSink activeAudio = audio;
                     if (activeAudio != null) {
                         activeAudio.setClockSpec(event.getProfile().clockSpec());
@@ -1543,6 +1547,17 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     });
                 },
                 Controller.BenchmarkArmAcknowledgedEvent.class);
+        // BasicController brackets each live PERFORMANCE controller batch. These synchronous
+        // events report its work while excluding TimingTicker pacing.
+        eventBus.register(
+                event -> performanceBoost.onWorkStarted(),
+                Controller.PerformanceWorkStartedEvent.class);
+        eventBus.register(
+                event -> performanceBoost.onWorkCompleted(),
+                Controller.PerformanceWorkCompletedEvent.class);
+        eventBus.register(
+                event -> performanceBoost.onWorkAborted(),
+                Controller.PerformanceWorkAbortedEvent.class);
         // Display events run synchronously on the controller thread. The bounded store must copy
         // their producer-owned arrays before this callback returns; it never touches Android UI.
         // A configured scenario observes only its matching native event, so an SGB transfer DMG
@@ -1594,8 +1609,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         eventBus.register(
                 (Controller.EmulationStartedEvent event) -> {
                     // This callback runs synchronously on the controller thread. Keep the CPU
-                    // sample on that thread instead of the runtime owner executor.
-                    AndroidPerformanceBoost.apply(executionModeForSession());
+                    // sample and adaptive session ownership on that thread instead of the runtime
+                    // owner executor.
+                    ExecutionMode executionMode = executionModeForSession();
+                    performanceBoost.onSessionStarted(executionMode);
+                    AndroidPerformanceBoost.apply(executionMode);
                     submit(() -> {
                     boolean requestedOpen = event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId;
@@ -1685,6 +1703,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 (Controller.EmulationStoppedEvent event) -> {
                     // The BasicController thread survives between sessions; do not let a prior
                     // PERFORMANCE session leave its scheduler hint on an idle/Accuracy session.
+                    performanceBoost.onSessionStopped();
                     AndroidPerformanceBoost.apply(ExecutionMode.ACCURACY);
                     submit(() -> {
                         if (!closed.get()) {
@@ -1726,7 +1745,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 },
                 StateResumeAvailableEvent.class);
         eventBus.register(
-                (Controller.SessionPlaybackStateEvent event) -> submit(() -> {
+                (Controller.SessionPlaybackStateEvent event) -> {
+                    // This authoritative edge is synchronous on the controller thread. Resetting
+                    // here prevents a paused interval from becoming the next reported duration.
+                    performanceBoost.onPlaybackStateChanged(event.getPaused());
+                    submit(() -> {
                     if (activeLayout == null || state.phase() == RuntimeState.Phase.LOADING) {
                         return;
                     }
@@ -1743,7 +1766,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                         publish(RuntimeState.Phase.RUNNING, "Game running.", List.of(),
                                 true, false, state.flushPending());
                     }
-                }),
+                    });
+                },
                 Controller.SessionPlaybackStateEvent.class);
         eventBus.register(
                 (Controller.BatteryFlushCompletedEvent event) -> submit(() -> {
@@ -2228,6 +2252,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         camera = null;
         printer = null;
         if (active == null) {
+            performanceBoost.onSessionStopped();
             if (activeAudio != null) {
                 activeAudio.close();
             }
@@ -2247,7 +2272,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             return true;
         }
         try {
+            // BasicController.close() joins its timing thread and intentionally suppresses the
+            // ordinary EmulationStoppedEvent. Close the mutable platform session only after that
+            // join, when no work callback can still race this runtime-owner fallback.
             active.close();
+            performanceBoost.onSessionStopped();
             if (activeAudio != null) {
                 activeAudio.close();
             }
@@ -2267,6 +2296,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             stateSaveCompletions.clear();
             return true;
         } catch (RuntimeException failure) {
+            // The synchronized boost owner can be disarmed safely even if controller shutdown
+            // timed out; subsequent synchronous work callbacks observe the cleared session.
+            performanceBoost.onSessionStopped();
             // Retain the controller for an explicit retry; it may still own an unflushed battery.
             controller = active;
             eventBus = activeBus;

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoost.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoost.java
@@ -1,22 +1,176 @@
 package eu.rekawek.coffeegb.android;
 
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.PerformanceHintManager;
 import android.os.Process;
+import android.os.SystemClock;
 import eu.rekawek.coffeegb.core.ExecutionMode;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
+
+import java.util.Objects;
 
 /**
- * Small, deliberately scoped Android scheduler hint for the emulation/controller thread.
- * Accuracy sessions never call into {@link Process#setThreadPriority(int)}.
+ * Small, deliberately scoped Android scheduler hints for the emulation/controller thread.
+ * Accuracy sessions never open an adaptive performance session or call into
+ * {@link Process#setThreadPriority(int)}.
+ *
+ * <p>The adaptive session is created, reset, and sampled only from synchronous controller event
+ * callbacks. One reported work cycle is one near-60-Hz controller PERFORMANCE batch; presentation
+ * callbacks are deliberately not its clock because catch-up may suppress them. Terminal runtime
+ * teardown calls {@link #onSessionStopped()} only after the controller thread has joined. The
+ * methods are synchronized as a final guard around the platform session, whose mutable API must
+ * never be raced by teardown.
  */
-final class AndroidPerformanceBoost {
+final class AndroidPerformanceBoost implements AutoCloseable {
 
     /** Urgent-display is high enough for a 60-Hz producer without using the audio RT class. */
     static final int PERFORMANCE_THREAD_PRIORITY = Process.THREAD_PRIORITY_URGENT_DISPLAY;
     static final int DEFAULT_THREAD_PRIORITY = Process.THREAD_PRIORITY_DEFAULT;
+    /** Controller work-cycle deadline, rounded to the nearest nanosecond at 60 Hz. */
+    static final long TARGET_WORK_DURATION_NANOS = 16_666_667L;
 
     /** The controller thread survives a ROM replacement; only undo a boost installed by us. */
     private static final ThreadLocal<Integer> ORIGINAL_PRIORITY = new ThreadLocal<>();
 
-    private AndroidPerformanceBoost() {
+    private final HintPlatform hintPlatform;
+    private long targetWorkDurationNanos = TARGET_WORK_DURATION_NANOS;
+    private HintSession hintSession;
+    private boolean running;
+    private boolean workCycleActive;
+    private long activeWorkStartedNanos;
+
+    AndroidPerformanceBoost(Context context) {
+        this(new AndroidHintPlatform(Objects.requireNonNull(context, "context")));
+    }
+
+    AndroidPerformanceBoost(HintPlatform hintPlatform) {
+        this.hintPlatform = Objects.requireNonNull(hintPlatform, "hintPlatform");
+    }
+
+    /** Latches the controller cadence synchronously before the matching session starts. */
+    synchronized void onHardwareProfile(ClockSpec clockSpec) {
+        Objects.requireNonNull(clockSpec, "clockSpec");
+        targetWorkDurationNanos = Math.round(
+                1_000_000_000d * clockSpec.controllerFramesPerSecondDenominator()
+                        / clockSpec.controllerFramesPerSecondNumerator());
+    }
+
+    /** Replaces any previous adaptive session at the controller's ownership-commit boundary. */
+    synchronized void onSessionStarted(ExecutionMode mode) {
+        closeHintSession();
+        if (mode != ExecutionMode.PERFORMANCE
+                || hintPlatform.sdkInt() < Build.VERSION_CODES.S) {
+            return;
+        }
+        try {
+            int tid = hintPlatform.currentThreadId();
+            HintSession created = hintPlatform.createHintSession(
+                    new int[]{tid}, targetWorkDurationNanos);
+            if (created != null) {
+                hintSession = created;
+            }
+        } catch (RuntimeException | LinkageError unavailable) {
+            // Some API-31+ vendor builds expose the service but reject or fail session creation.
+            // PERFORMANCE remains fully functional without the optional adaptive hint.
+            closeHintSession();
+        }
+    }
+
+    /** Resets the work interval across every authoritative pause/resume transition. */
+    synchronized void onPlaybackStateChanged(boolean paused) {
+        if (hintSession == null) {
+            return;
+        }
+        if (paused) {
+            running = false;
+            resetWorkAccounting();
+            return;
+        }
+        if (running) {
+            return;
+        }
+        resetWorkAccounting();
+        running = true;
+    }
+
+    /** Begins one controller-owned PERFORMANCE span after lifecycle work and before guest work. */
+    synchronized void onWorkStarted() {
+        if (hintSession == null || !running || workCycleActive) {
+            return;
+        }
+        try {
+            activeWorkStartedNanos = hintPlatform.uptimeNanos();
+            workCycleActive = true;
+        } catch (RuntimeException | LinkageError unavailable) {
+            disableHintSession();
+        }
+    }
+
+    /** Ends and reports one controller work cycle immediately before pacing. */
+    synchronized void onWorkCompleted() {
+        if (hintSession == null || !running || !workCycleActive) {
+            return;
+        }
+        long actualDurationNanos;
+        try {
+            actualDurationNanos = hintPlatform.uptimeNanos() - activeWorkStartedNanos;
+            workCycleActive = false;
+            activeWorkStartedNanos = 0L;
+        } catch (RuntimeException | LinkageError unavailable) {
+            disableHintSession();
+            return;
+        }
+        if (actualDurationNanos <= 0L) {
+            return;
+        }
+        try {
+            hintSession.reportActualWorkDuration(actualDurationNanos);
+        } catch (RuntimeException | LinkageError unavailable) {
+            // Do not repeatedly enter a broken vendor session on the frame hot path. A later ROM
+            // ownership commit may create a fresh one if the service recovers.
+            disableHintSession();
+        }
+    }
+
+    /** Drops a controller batch which stopped before consuming its complete tick budget. */
+    synchronized void onWorkAborted() {
+        resetWorkAccounting();
+    }
+
+    /** Ends the active adaptive session at replacement, stop, or terminal close. */
+    synchronized void onSessionStopped() {
+        closeHintSession();
+    }
+
+    @Override
+    public void close() {
+        onSessionStopped();
+    }
+
+    private void disableHintSession() {
+        closeHintSession();
+    }
+
+    private void closeHintSession() {
+        HintSession closing = hintSession;
+        hintSession = null;
+        running = false;
+        resetWorkAccounting();
+        if (closing == null) {
+            return;
+        }
+        try {
+            closing.close();
+        } catch (RuntimeException | LinkageError unavailable) {
+            // Closing is terminal from our perspective even if a vendor service has disappeared.
+        }
+    }
+
+    private void resetWorkAccounting() {
+        workCycleActive = false;
+        activeWorkStartedNanos = 0L;
     }
 
     static boolean apply(ExecutionMode mode) {
@@ -63,5 +217,91 @@ final class AndroidPerformanceBoost {
     @FunctionalInterface
     interface ThreadPriorityGetter {
         int get();
+    }
+
+    /** Test seam which keeps JVM tests independent of Android framework method stubs. */
+    interface HintPlatform {
+        int sdkInt();
+
+        int currentThreadId();
+
+        long uptimeNanos();
+
+        HintSession createHintSession(int[] threadIds, long targetWorkDurationNanos);
+    }
+
+    interface HintSession {
+        void reportActualWorkDuration(long actualDurationNanos);
+
+        void close();
+    }
+
+    private static final class AndroidHintPlatform implements HintPlatform {
+        private final Context context;
+
+        private AndroidHintPlatform(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public int sdkInt() {
+            return Build.VERSION.SDK_INT;
+        }
+
+        @Override
+        public int currentThreadId() {
+            return Process.myTid();
+        }
+
+        @Override
+        public long uptimeNanos() {
+            if (Build.VERSION.SDK_INT >= 35) {
+                return Api35.uptimeNanos();
+            }
+            // uptimeNanos() itself was added after PerformanceHintManager. Android's monotonic
+            // System.nanoTime() uses the same uptime (no deep sleep) basis without quantizing
+            // API 31-34 workload samples to whole milliseconds.
+            return System.nanoTime();
+        }
+
+        @Override
+        public HintSession createHintSession(int[] threadIds, long targetWorkDurationNanos) {
+            // Kept behind the SDK check in onSessionStarted so pre-31 devices are exact no-ops.
+            return Api31.createHintSession(context, threadIds, targetWorkDurationNanos);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.S)
+    private static final class Api31 {
+        private static HintSession createHintSession(
+                Context context, int[] threadIds, long targetWorkDurationNanos) {
+            PerformanceHintManager manager = context.getSystemService(PerformanceHintManager.class);
+            if (manager == null) {
+                return null;
+            }
+            PerformanceHintManager.Session session =
+                    manager.createHintSession(threadIds, targetWorkDurationNanos);
+            if (session == null) {
+                return null;
+            }
+            return new HintSession() {
+                @Override
+                public void reportActualWorkDuration(long actualDurationNanos) {
+                    session.reportActualWorkDuration(actualDurationNanos);
+                }
+
+                @Override
+                public void close() {
+                    session.close();
+                }
+            };
+        }
+    }
+
+    @TargetApi(35)
+    private static final class Api35 {
+        private static long uptimeNanos() {
+            return SystemClock.uptimeNanos();
+        }
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoost.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoost.java
@@ -9,6 +9,7 @@ import android.os.SystemClock;
 import eu.rekawek.coffeegb.core.ExecutionMode;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 /**
@@ -28,8 +29,14 @@ final class AndroidPerformanceBoost implements AutoCloseable {
     /** Urgent-display is high enough for a 60-Hz producer without using the audio RT class. */
     static final int PERFORMANCE_THREAD_PRIORITY = Process.THREAD_PRIORITY_URGENT_DISPLAY;
     static final int DEFAULT_THREAD_PRIORITY = Process.THREAD_PRIORITY_DEFAULT;
-    /** Controller work-cycle deadline, rounded to the nearest nanosecond at 60 Hz. */
-    static final long TARGET_WORK_DURATION_NANOS = 16_666_667L;
+    /**
+     * The controller owns only the emulation portion of a host frame. Reserve the remaining third
+     * for audio and presentation instead of inviting ADPF to stretch controller work across the
+     * complete frame deadline.
+     */
+    static final int WORK_BUDGET_NUMERATOR = 2;
+    static final int WORK_BUDGET_DENOMINATOR = 3;
+    static final long TARGET_WORK_DURATION_NANOS = 11_111_111L;
 
     /** The controller thread survives a ROM replacement; only undo a boost installed by us. */
     private static final ThreadLocal<Integer> ORIGINAL_PRIORITY = new ThreadLocal<>();
@@ -52,9 +59,14 @@ final class AndroidPerformanceBoost implements AutoCloseable {
     /** Latches the controller cadence synchronously before the matching session starts. */
     synchronized void onHardwareProfile(ClockSpec clockSpec) {
         Objects.requireNonNull(clockSpec, "clockSpec");
-        targetWorkDurationNanos = Math.round(
-                1_000_000_000d * clockSpec.controllerFramesPerSecondDenominator()
-                        / clockSpec.controllerFramesPerSecondNumerator());
+        BigInteger numerator = BigInteger.valueOf(1_000_000_000L)
+                .multiply(BigInteger.valueOf(clockSpec.controllerFramesPerSecondDenominator()))
+                .multiply(BigInteger.valueOf(WORK_BUDGET_NUMERATOR));
+        BigInteger denominator = BigInteger.valueOf(clockSpec.controllerFramesPerSecondNumerator())
+                .multiply(BigInteger.valueOf(WORK_BUDGET_DENOMINATOR));
+        BigInteger rounded = numerator.add(denominator.shiftRight(1)).divide(denominator);
+        targetWorkDurationNanos = rounded.max(BigInteger.ONE)
+                .min(BigInteger.valueOf(Long.MAX_VALUE)).longValue();
     }
 
     /** Replaces any previous adaptive session at the controller's ownership-commit boundary. */

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -131,14 +131,29 @@ public final class CoffeeGbSurfaceView extends SurfaceView
      * new snapshot. Passing {@code null} is equivalent to {@link #clearMenuPresentation()}.
      */
     public void setMenuPresentation(MenuPresentation presentation) {
+        if (presentation == null) {
+            clearMenuPresentation();
+            return;
+        }
         menuPresentation = presentation;
         onFrameAvailable();
     }
 
-    /** Clears the in-screen menu and schedules one redraw without changing frame ownership. */
+    /**
+     * Clears the UI-thread-owned menu snapshot. A present snapshot schedules exactly one redraw;
+     * an already-cleared snapshot leaves the retained game frame and renderer asleep.
+     */
     public void clearMenuPresentation() {
+        if (!requiresMenuInvalidationOnClear(menuPresentation)) {
+            return;
+        }
         menuPresentation = null;
         onFrameAvailable();
+    }
+
+    /** Pure seam for keeping an already-hidden menu from resubmitting the retained game frame. */
+    static boolean requiresMenuInvalidationOnClear(MenuPresentation presentation) {
+        return presentation != null;
     }
 
     /**

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
@@ -250,7 +250,7 @@ public class AndroidEmulationRuntimeTest {
     }
 
     @Test
-    public void shadowMeasuredWarmupSelectorIsOnlyNativeCgbPerformanceSilentScenario() {
+    public void warmupSelectorUsesExactSilentShapeThenMatchingPerformanceScheduler() {
         DiagnosticsOptions eligible = DiagnosticsOptions.parseValues(
                 true, "cgb", true, "presentation", true, true, false,
                 null, null, null, -1, null, null, null, null, false, null, -1, -1,
@@ -269,9 +269,19 @@ public class AndroidEmulationRuntimeTest {
                     "performance", "cgb-action-v1", "silent-pcm-v1");
             try (EmulatorProperties properties = new EmulatorProperties(
                     AndroidEmulationRuntime.androidSettingsOverrides(rejected))) {
-                assertEquals(RuntimeWarmupFlavor.SCALAR,
+                assertEquals(RuntimeWarmupFlavor.PERFORMANCE,
                         properties.getOverrides().getRuntimeWarmupFlavor());
             }
+        }
+
+        DiagnosticsOptions canonical = DiagnosticsOptions.parseValues(
+                true, "cgb", true, "presentation", true, true, false,
+                null, null, null, -1, null, null, null, null, false, null, -1, -1,
+                "performance", null, null);
+        try (EmulatorProperties properties = new EmulatorProperties(
+                AndroidEmulationRuntime.androidSettingsOverrides(canonical))) {
+            assertEquals(RuntimeWarmupFlavor.PERFORMANCE,
+                    properties.getOverrides().getRuntimeWarmupFlavor());
         }
 
         DiagnosticsOptions accuracy = DiagnosticsOptions.parseValues(

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoostTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoostTest.java
@@ -1,11 +1,16 @@
 package eu.rekawek.coffeegb.android;
 
 import eu.rekawek.coffeegb.core.ExecutionMode;
+import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -68,5 +73,286 @@ public class AndroidPerformanceBoostTest {
         assertTrue(AndroidPerformanceBoost.apply(ExecutionMode.ACCURACY, () -> 11,
                 calls::set));
         assertEquals(11, calls.get());
+    }
+
+    @Test
+    public void accuracyAndPreApi31HintSessionsAreExactNoOps() {
+        FakeHintPlatform accuracyPlatform = new FakeHintPlatform(36, 41);
+        AndroidPerformanceBoost accuracy = new AndroidPerformanceBoost(accuracyPlatform);
+        accuracy.onSessionStarted(ExecutionMode.ACCURACY);
+        accuracy.onPlaybackStateChanged(false);
+        accuracy.onWorkStarted();
+        accuracy.onWorkAborted();
+        accuracy.onWorkCompleted();
+        accuracy.onSessionStopped();
+        assertEquals(0, accuracyPlatform.threadIdCalls);
+        assertEquals(0, accuracyPlatform.clockCalls);
+        assertEquals(0, accuracyPlatform.createCalls);
+
+        FakeHintPlatform legacyPlatform = new FakeHintPlatform(30, 42);
+        AndroidPerformanceBoost legacy = new AndroidPerformanceBoost(legacyPlatform);
+        legacy.onSessionStarted(ExecutionMode.PERFORMANCE);
+        legacy.onPlaybackStateChanged(false);
+        legacy.onWorkStarted();
+        legacy.onWorkAborted();
+        legacy.onWorkCompleted();
+        legacy.close();
+        assertEquals(0, legacyPlatform.threadIdCalls);
+        assertEquals(0, legacyPlatform.clockCalls);
+        assertEquals(0, legacyPlatform.createCalls);
+    }
+
+    @Test
+    public void performanceCreatesSessionForControllerTidAndReportsControllerCycles() {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 73);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        assertEquals(1, platform.createCalls);
+        assertEquals(1, platform.threadIdCalls);
+        assertArrayEquals(new int[]{73}, platform.lastThreadIds);
+        assertEquals(16_666_667L, AndroidPerformanceBoost.TARGET_WORK_DURATION_NANOS);
+        assertEquals(AndroidPerformanceBoost.TARGET_WORK_DURATION_NANOS,
+                platform.lastTargetWorkDurationNanos);
+
+        platform.nowNanos = 10_000L;
+        // A newly committed session waits for the controller's authoritative playback event.
+        boost.onWorkStarted();
+        boost.onWorkCompleted();
+        assertTrue(platform.sessions.get(0).durations.isEmpty());
+
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 14_250L;
+        boost.onWorkCompleted();
+        // The pacing gap between controller batches is excluded.
+        platform.nowNanos = 100_000L;
+        boost.onWorkStarted();
+        platform.nowNanos = 104_000L;
+        boost.onWorkCompleted();
+
+        assertEquals(List.of(4_250L, 4_000L), platform.sessions.get(0).durations);
+    }
+
+    @Test
+    public void hardwareProfileSelectsTheMatchingControllerCadenceTarget() {
+        assertTargetDuration(ClockSpec.LEGACY, 16_666_667L);
+        assertTargetDuration(ClockSpec.SGB, 16_348_444L);
+        assertTargetDuration(ClockSpec.SGB2, 16_742_706L);
+    }
+
+    @Test
+    public void idleAndResumeDiscardThePausedInterval() {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 91);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+
+        platform.nowNanos = 1_000L;
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 2_000L;
+        boost.onWorkCompleted();
+        boost.onPlaybackStateChanged(true);
+        platform.nowNanos = 1_000_000L;
+        boost.onWorkStarted();
+        boost.onWorkCompleted();
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 1_000_900L;
+        boost.onWorkCompleted();
+
+        assertEquals(List.of(1_000L, 900L), platform.sessions.get(0).durations);
+    }
+
+    @Test
+    public void pauseDuringActiveCycleDropsItBeforeOrdinaryWorkResumes() {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 96);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        boost.onPlaybackStateChanged(false);
+
+        platform.nowNanos = 100L;
+        boost.onWorkStarted();
+        platform.nowNanos = 150L;
+        boost.onPlaybackStateChanged(true);
+        boost.onWorkCompleted();
+        platform.nowNanos = 1_000L;
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 1_030L;
+        boost.onWorkCompleted();
+
+        assertEquals(List.of(30L), platform.sessions.get(0).durations);
+    }
+
+    @Test
+    public void abortedCycleCannotLeakIntoTheNextCompletedCycle() {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 97);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        boost.onPlaybackStateChanged(false);
+
+        platform.nowNanos = 100L;
+        boost.onWorkStarted();
+        platform.nowNanos = 150L;
+        boost.onWorkAborted();
+        platform.nowNanos = 1_000L;
+        boost.onWorkStarted();
+        platform.nowNanos = 1_030L;
+        boost.onWorkCompleted();
+
+        assertEquals(List.of(30L), platform.sessions.get(0).durations);
+    }
+
+    @Test
+    public void replacementAndDowngradeCannotLeakSamplesAcrossSessions() {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 101);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        FakeHintSession first = platform.sessions.get(0);
+        platform.nowNanos = 100L;
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 150L;
+        boost.onWorkCompleted();
+        platform.nowNanos = 200L;
+        boost.onWorkStarted();
+        platform.nowNanos = 225L;
+
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        FakeHintSession second = platform.sessions.get(1);
+        assertEquals(1, first.closeCalls);
+        boost.onWorkCompleted();
+        assertTrue(second.durations.isEmpty());
+        platform.nowNanos = 1_000L;
+        boost.onPlaybackStateChanged(false);
+        boost.onWorkStarted();
+        platform.nowNanos = 1_070L;
+        boost.onWorkCompleted();
+
+        boost.onSessionStarted(ExecutionMode.ACCURACY);
+        boost.onWorkStarted();
+        boost.onWorkCompleted();
+        boost.close();
+        assertEquals(List.of(50L), first.durations);
+        assertEquals(List.of(70L), second.durations);
+        assertEquals(1, second.closeCalls);
+        assertEquals(2, platform.createCalls);
+    }
+
+    @Test
+    public void vendorCreationAndReportingFailuresAreNonFatalAndDisarmTheSession() {
+        FakeHintPlatform unavailable = new FakeHintPlatform(31, 111);
+        unavailable.createFailure = new UnsupportedOperationException("unsupported");
+        AndroidPerformanceBoost failedCreate = new AndroidPerformanceBoost(unavailable);
+        failedCreate.onSessionStarted(ExecutionMode.PERFORMANCE);
+        failedCreate.onPlaybackStateChanged(false);
+        failedCreate.onWorkStarted();
+        failedCreate.onWorkCompleted();
+        assertEquals(1, unavailable.createCalls);
+        assertEquals(0, unavailable.clockCalls);
+
+        FakeHintPlatform platform = new FakeHintPlatform(31, 112);
+        AndroidPerformanceBoost failedReport = new AndroidPerformanceBoost(platform);
+        failedReport.onSessionStarted(ExecutionMode.PERFORMANCE);
+        FakeHintSession session = platform.sessions.get(0);
+        session.reportFailure = new IllegalStateException("service died");
+        session.closeFailure = new IllegalStateException("already gone");
+        platform.nowNanos = 10L;
+        failedReport.onPlaybackStateChanged(false);
+        failedReport.onWorkStarted();
+        platform.nowNanos = 20L;
+        failedReport.onWorkCompleted();
+        failedReport.onWorkStarted();
+        platform.nowNanos = 40L;
+        failedReport.onWorkCompleted();
+        platform.nowNanos = 50L;
+        failedReport.onWorkStarted();
+        failedReport.onWorkCompleted();
+        assertEquals(1, session.reportCalls);
+        assertEquals(1, session.closeCalls);
+    }
+
+    private static void assertTargetDuration(ClockSpec clockSpec, long expectedNanos) {
+        FakeHintPlatform platform = new FakeHintPlatform(31, 120);
+        AndroidPerformanceBoost boost = new AndroidPerformanceBoost(platform);
+        boost.onHardwareProfile(clockSpec);
+        boost.onSessionStarted(ExecutionMode.PERFORMANCE);
+        assertEquals(expectedNanos, platform.lastTargetWorkDurationNanos);
+        boost.close();
+    }
+
+    private static final class FakeHintPlatform implements AndroidPerformanceBoost.HintPlatform {
+        private final int sdkInt;
+        private final int tid;
+        private final List<FakeHintSession> sessions = new ArrayList<>();
+        private int threadIdCalls;
+        private int clockCalls;
+        private int createCalls;
+        private int[] lastThreadIds;
+        private long lastTargetWorkDurationNanos;
+        private long nowNanos;
+        private RuntimeException createFailure;
+
+        private FakeHintPlatform(int sdkInt, int tid) {
+            this.sdkInt = sdkInt;
+            this.tid = tid;
+        }
+
+        @Override
+        public int sdkInt() {
+            return sdkInt;
+        }
+
+        @Override
+        public int currentThreadId() {
+            threadIdCalls++;
+            return tid;
+        }
+
+        @Override
+        public long uptimeNanos() {
+            clockCalls++;
+            return nowNanos;
+        }
+
+        @Override
+        public AndroidPerformanceBoost.HintSession createHintSession(
+                int[] threadIds, long targetWorkDurationNanos) {
+            createCalls++;
+            if (createFailure != null) {
+                throw createFailure;
+            }
+            lastThreadIds = Arrays.copyOf(threadIds, threadIds.length);
+            lastTargetWorkDurationNanos = targetWorkDurationNanos;
+            FakeHintSession session = new FakeHintSession();
+            sessions.add(session);
+            return session;
+        }
+    }
+
+    private static final class FakeHintSession implements AndroidPerformanceBoost.HintSession {
+        private final List<Long> durations = new ArrayList<>();
+        private int reportCalls;
+        private int closeCalls;
+        private RuntimeException reportFailure;
+        private RuntimeException closeFailure;
+
+        @Override
+        public void reportActualWorkDuration(long actualDurationNanos) {
+            reportCalls++;
+            if (reportFailure != null) {
+                throw reportFailure;
+            }
+            durations.add(actualDurationNanos);
+        }
+
+        @Override
+        public void close() {
+            closeCalls++;
+            if (closeFailure != null) {
+                throw closeFailure;
+            }
+        }
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoostTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidPerformanceBoostTest.java
@@ -111,7 +111,7 @@ public class AndroidPerformanceBoostTest {
         assertEquals(1, platform.createCalls);
         assertEquals(1, platform.threadIdCalls);
         assertArrayEquals(new int[]{73}, platform.lastThreadIds);
-        assertEquals(16_666_667L, AndroidPerformanceBoost.TARGET_WORK_DURATION_NANOS);
+        assertEquals(11_111_111L, AndroidPerformanceBoost.TARGET_WORK_DURATION_NANOS);
         assertEquals(AndroidPerformanceBoost.TARGET_WORK_DURATION_NANOS,
                 platform.lastTargetWorkDurationNanos);
 
@@ -136,9 +136,23 @@ public class AndroidPerformanceBoostTest {
 
     @Test
     public void hardwareProfileSelectsTheMatchingControllerCadenceTarget() {
-        assertTargetDuration(ClockSpec.LEGACY, 16_666_667L);
-        assertTargetDuration(ClockSpec.SGB, 16_348_444L);
-        assertTargetDuration(ClockSpec.SGB2, 16_742_706L);
+        assertTargetDuration(ClockSpec.LEGACY, 11_111_111L);
+        assertTargetDuration(ClockSpec.SGB, 10_898_963L);
+        assertTargetDuration(ClockSpec.SGB2, 11_161_804L);
+
+        long largeNumerator = Long.MAX_VALUE / 3L + 1L;
+        assertTargetDuration(
+                new ClockSpec(1L, largeNumerator, largeNumerator + 1L),
+                666_666_667L);
+        assertTargetDuration(
+                new ClockSpec(
+                        1_000L,
+                        1_537_228_672_809_129_301L,
+                        23_058_431_245_058_444L),
+                10_000_000L);
+        assertTargetDuration(
+                new ClockSpec(Integer.MAX_VALUE, Integer.MAX_VALUE, 1L),
+                1L);
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceViewTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceViewTest.java
@@ -1,0 +1,36 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
+import eu.rekawek.coffeegb.ui.menu.MenuRoute;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CoffeeGbSurfaceViewTest {
+
+    @Test
+    public void menuClearInvalidatesOnlyAnExistingPresentation() {
+        assertFalse(CoffeeGbSurfaceView.requiresMenuInvalidationOnClear(null));
+
+        MenuPresentation existingPresentation =
+                new MenuController(new NoopMenuListener()).presentation();
+        assertTrue(CoffeeGbSurfaceView.requiresMenuInvalidationOnClear(existingPresentation));
+    }
+
+    private static final class NoopMenuListener implements MenuController.Listener {
+
+        @Override
+        public void onPresentation(MenuPresentation presentation) {
+        }
+
+        @Override
+        public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+        }
+
+        @Override
+        public void onHeaderSelected(MenuRoute route) {
+        }
+    }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -968,34 +968,53 @@ class BasicController private constructor(
     if (gameboy != null && !benchmarkExecutionFrozen
         && (rewound || (!isEffectivelyPaused() && !isRewinding))) {
       relinquishDebugBreakpointPauseOwnership()
-      val exactBenchmarkScenarioFrame = benchmarkGameplayScenarioActive
-      if (exactBenchmarkScenarioFrame) {
-        // Native Display events are emitted synchronously from Gameboy.tick(). The endpoint event
-        // above sets the pause before that call returns, so this loop executes no post-endpoint
-        // tail even when the ordinary PERFORMANCE path would own a frame-sized runTicks batch.
-        emulatedTicks =
-            gameboy.runTicksUntilStop(frameTicks) { benchmarkGameplayScenarioStopRequested }
-      } else if (properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
-          && !benchmarkCoreFrozenGate.getAsBoolean() && !trackDebugHistory && !rewound) {
-        // The physical frame-600 callback is synchronous on this owner thread. Keep the normal
-        // PERFORMANCE epoch/scanline scheduler for the measured window, but stop at the callback
-        // before another scalar hand-off or bulk packet can advance the frozen core.
-        emulatedTicks = gameboy.runMeasuredTicksUntilStop(frameTicks, benchmarkCoreFrozenGate)
-      } else if (!trackDebugHistory && !rewound
-          && gameboy.executionMode == ExecutionMode.PERFORMANCE) {
-        // The core owns the frame-sized loop in ordinary PERFORMANCE mode. Debug/history
-        // paths remain on their per-tick hooks so every observation and checkpoint boundary is
-        // still materialized before the next callback.
-        gameboy.runTicks(frameTicks)
-        emulatedTicks = frameTicks
-      } else {
-        repeat(frameTicks) {
-          if (trackDebugHistory) {
-            tickWithDebugHistory(gameboy, frameTicks)
-          } else {
-            gameboy.tick()
+      val performanceWorkSession =
+          session?.takeIf { gameboy.executionMode == ExecutionMode.PERFORMANCE }
+      performanceWorkSession?.let {
+        postSessionEventSafely(it, Controller.PerformanceWorkStartedEvent)
+      }
+      try {
+        val exactBenchmarkScenarioFrame = benchmarkGameplayScenarioActive
+        if (exactBenchmarkScenarioFrame) {
+          // Native Display events are emitted synchronously from Gameboy.tick(). The endpoint
+          // event above sets the pause before that call returns, so this loop executes no
+          // post-endpoint tail even when the ordinary PERFORMANCE path would own a frame-sized
+          // runTicks batch.
+          emulatedTicks =
+              gameboy.runTicksUntilStop(frameTicks) { benchmarkGameplayScenarioStopRequested }
+        } else if (properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
+            && !benchmarkCoreFrozenGate.getAsBoolean() && !trackDebugHistory && !rewound) {
+          // The physical frame-600 callback is synchronous on this owner thread. Keep the normal
+          // PERFORMANCE epoch/scanline scheduler for the measured window, but stop at the callback
+          // before another scalar hand-off or bulk packet can advance the frozen core.
+          emulatedTicks = gameboy.runMeasuredTicksUntilStop(frameTicks, benchmarkCoreFrozenGate)
+        } else if (!trackDebugHistory && !rewound
+            && gameboy.executionMode == ExecutionMode.PERFORMANCE) {
+          // The core owns the frame-sized loop in ordinary PERFORMANCE mode. Debug/history
+          // paths remain on their per-tick hooks so every observation and checkpoint boundary is
+          // still materialized before the next callback.
+          gameboy.runTicks(frameTicks)
+          emulatedTicks = frameTicks
+        } else {
+          repeat(frameTicks) {
+            if (trackDebugHistory) {
+              tickWithDebugHistory(gameboy, frameTicks)
+            } else {
+              gameboy.tick()
+            }
+            emulatedTicks++
           }
-          emulatedTicks++
+        }
+      } finally {
+        performanceWorkSession?.let {
+          postSessionEventSafely(
+              it,
+              if (emulatedTicks == frameTicks) {
+                Controller.PerformanceWorkCompletedEvent
+              } else {
+                Controller.PerformanceWorkAbortedEvent
+              },
+          )
         }
       }
       emulated = emulatedTicks == frameTicks

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -58,6 +58,17 @@ interface Controller : AutoCloseable {
 
   class EmulationStoppedEvent : Event
 
+  /**
+   * Synchronous boundary around one near-60-Hz PERFORMANCE controller work cycle. Host
+   * integrations use these singleton events to exclude controller pacing and idle time.
+   */
+  object PerformanceWorkStartedEvent : Event
+
+  object PerformanceWorkCompletedEvent : Event
+
+  /** Cancels a started work cycle which stopped before its complete controller tick budget. */
+  object PerformanceWorkAbortedEvent : Event
+
   data class LoadRomEvent
   @JvmOverloads
   constructor(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -256,6 +256,10 @@ internal class RuntimeWarmupCache(
                 || rom.gameboyColorFlag == Rom.GameboyColorFlag.NON_CGB)) {
           return null
         }
+        if (flavor == RuntimeWarmupFlavor.PERFORMANCE
+            && config.executionMode != eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE) {
+          return null
+        }
         val cartridgeFeatures = Feature.values().filter(rom.cartridgeProperties::has)
         return RuntimeWarmupKey(
             config.executionMode,
@@ -349,6 +353,27 @@ internal class RuntimeWarmupCache(
               && gameboy.getPerformanceEpochTicks() > 0L
               && gameboy.getPerformanceEpochMaxTicks() <= MAX_NATIVE_EPOCH_TICKS) {
             "Shadow measured warmup did not exercise bounded native epochs"
+          }
+        } else if (flavor == RuntimeWarmupFlavor.PERFORMANCE) {
+          require(config.executionMode == eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE) {
+            "PERFORMANCE runtime warmup requires PERFORMANCE execution mode"
+          }
+          val frameTicks = config.clockSpec.controllerTicksPerFrame()
+          require(frameTicks > 0) { "Runtime warmup frame must contain positive controller ticks" }
+          val totalTicks = Math.multiplyExact(WARMUP_FRAMES.toLong(), frameTicks.toLong())
+          require(ticks.toLong() == totalTicks) {
+            "PERFORMANCE runtime warmup received an unexpected tick budget"
+          }
+          gameboy.resetPerformanceBulkCounters()
+          repeat(WARMUP_FRAMES) { frame ->
+            if (frame % CANCELLATION_CHECK_FRAMES == 0) {
+              ensureActive()
+            }
+            gameboy.runTicks(frameTicks)
+          }
+          ensureActive()
+          require(gameboy.performanceBulkTicks + gameboy.performanceEpochTicks > 0L) {
+            "PERFORMANCE runtime warmup did not exercise the frame-batched scheduler"
           }
         } else {
           repeat(ticks) { tick ->

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -12,6 +12,7 @@ import java.util.EnumMap
 /** Process-local shape selector for the disposable runtime warmup; never persisted. */
 enum class RuntimeWarmupFlavor {
   SCALAR,
+  PERFORMANCE,
   SHADOW_MEASURED_EXACT_V1,
 }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerDebugPortTest.kt
@@ -15,6 +15,7 @@ import eu.rekawek.coffeegb.controller.state.StateLoadRefRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateOperationCompletedEvent
 import eu.rekawek.coffeegb.controller.state.StateSaveRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
+import eu.rekawek.coffeegb.core.ExecutionMode
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.debug.DebugAddressSpace
@@ -66,6 +67,31 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class BasicControllerDebugPortTest {
+
+  @Test
+  fun debuggerOwnedPerformanceStepDoesNotPublishOrdinaryWorkSpans() {
+    withController(
+        namedRom("DEBUG_PERFORMANCE_WORK"),
+        null,
+        null,
+        { config -> config.setExecutionMode(ExecutionMode.PERFORMANCE) },
+    ) { eventBus, port, _, _, _ ->
+      assertTrue(await(port.pause()).isSuccess)
+      val workStarts = AtomicInteger()
+      val workCompletions = AtomicInteger()
+      val workAborts = AtomicInteger()
+      eventBus.register<Controller.PerformanceWorkStartedEvent> { workStarts.incrementAndGet() }
+      eventBus.register<Controller.PerformanceWorkCompletedEvent> {
+        workCompletions.incrementAndGet()
+      }
+      eventBus.register<Controller.PerformanceWorkAbortedEvent> { workAborts.incrementAndGet() }
+
+      assertTrue(await(port.step(DebugStepKind.FRAME)).isSuccess)
+      assertEquals(0, workStarts.get())
+      assertEquals(0, workCompletions.get())
+      assertEquals(0, workAborts.get())
+    }
+  }
 
   @Test
   fun reverseFrameRestoresThePrecedingBoundaryWithoutGuestOrHostSideEffects() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1980,8 +1980,14 @@ class BasicControllerTest {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()
     val playback = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
+    val workStarts = AtomicInteger()
+    val workCompletions = AtomicInteger()
+    val workAborts = AtomicInteger()
     eventBus.register<EmulationStartedEvent>(started::add)
     eventBus.register<Controller.SessionPlaybackStateEvent>(playback::add)
+    eventBus.register<Controller.PerformanceWorkStartedEvent> { workStarts.incrementAndGet() }
+    eventBus.register<Controller.PerformanceWorkCompletedEvent> { workCompletions.incrementAndGet() }
+    eventBus.register<Controller.PerformanceWorkAbortedEvent> { workAborts.incrementAndGet() }
     val rom = namedRom("BENCHMARK_PRE_ARM_RESUME")
     val properties =
         EmulatorProperties(
@@ -2006,6 +2012,10 @@ class BasicControllerTest {
     try {
       eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
       assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      Thread.sleep(50)
+      assertEquals(0, workStarts.get(), "paused PERFORMANCE session published a work start")
+      assertEquals(0, workCompletions.get(), "paused PERFORMANCE session published a work end")
+      assertEquals(0, workAborts.get(), "paused PERFORMANCE session published a work abort")
       // The benchmark session starts paused so the host can capture its anchor. Before ARM the
       // normal lifecycle command must still release that pause.
       eventBus.post(Controller.ResumeEmulationEvent())
@@ -2013,6 +2023,16 @@ class BasicControllerTest {
           generateSequence { playback.poll(100, TimeUnit.MILLISECONDS) }
               .first { !it.paused }
       assertFalse(resumed.paused)
+      // Pause at the next safe point so the just-released ordinary batch has a deterministic
+      // terminal edge: every full PERFORMANCE start must complete, never abort.
+      eventBus.post(Controller.PauseEmulationEvent())
+      val pausedAgain =
+          generateSequence { playback.poll(100, TimeUnit.MILLISECONDS) }
+              .first { it.paused }
+      assertTrue(pausedAgain.paused)
+      assertTrue(workStarts.get() > 0)
+      assertEquals(workStarts.get(), workCompletions.get())
+      assertEquals(0, workAborts.get())
     } finally {
       controller.close()
       properties.close()
@@ -2027,9 +2047,13 @@ class BasicControllerTest {
     val started = LinkedBlockingQueue<EmulationStartedEvent>()
     val acknowledged = LinkedBlockingQueue<Controller.BenchmarkArmAcknowledgedEvent>()
     val boundary = LinkedBlockingQueue<Controller.BenchmarkFrameBoundaryEvent>()
+    val workEvents = LinkedBlockingQueue<String>()
     eventBus.register<EmulationStartedEvent>(started::add)
     eventBus.register<Controller.BenchmarkArmAcknowledgedEvent>(acknowledged::add)
     eventBus.register<Controller.BenchmarkFrameBoundaryEvent>(boundary::add)
+    eventBus.register<Controller.PerformanceWorkStartedEvent> { workEvents.add("start") }
+    eventBus.register<Controller.PerformanceWorkCompletedEvent> { workEvents.add("complete") }
+    eventBus.register<Controller.PerformanceWorkAbortedEvent> { workEvents.add("abort") }
     val executedTicks = AtomicInteger()
     val boundaryPosted = AtomicInteger()
     val generation = AtomicLong()
@@ -2100,10 +2124,68 @@ class BasicControllerTest {
           boundary.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS),
           "measured batch did not reach the synchronous frame boundary",
       )
+      assertEquals("start", workEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals("abort", workEvents.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
       assertEquals(5, executedTicks.get())
       Thread.sleep(100)
       assertEquals(5, executedTicks.get(), "a post-boundary measured tick was executed")
+      assertNull(workEvents.poll(), "frozen measured gate published another work span")
     } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
+  fun accuracyExecutionDoesNotPublishPerformanceWorkSpans() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val workStarts = AtomicInteger()
+    val workCompletions = AtomicInteger()
+    val workAborts = AtomicInteger()
+    val tickEntered = CountDownLatch(1)
+    val releaseTick = CountDownLatch(1)
+    eventBus.register<EmulationStartedEvent>(started::add)
+    eventBus.register<Controller.PerformanceWorkStartedEvent> { workStarts.incrementAndGet() }
+    eventBus.register<Controller.PerformanceWorkCompletedEvent> { workCompletions.incrementAndGet() }
+    eventBus.register<Controller.PerformanceWorkAbortedEvent> { workAborts.incrementAndGet() }
+    val rom = namedRom("ACCURACY_NO_PERFORMANCE_WORK")
+    val properties = testProperties()
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+                  .setExecutionMode(ExecutionMode.ACCURACY)
+          val gameboy =
+              object : Gameboy(config) {
+                private var blocked = false
+
+                override fun tick(): Boolean {
+                  if (!blocked) {
+                    blocked = true
+                    tickEntered.countDown()
+                    releaseTick.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                  }
+                  return false
+                }
+              }
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertTrue(tickEntered.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(0, workStarts.get())
+      assertEquals(0, workCompletions.get())
+      assertEquals(0, workAborts.get())
+    } finally {
+      releaseTick.countDown()
       controller.close()
       properties.close()
       eventBus.close()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -245,7 +245,7 @@ class RomSessionPreparerTest {
   }
 
   @Test
-  fun shadowMeasuredWarmupIsCgbPerformanceOnlyAndHasAnIsolatedCacheKey() {
+  fun performanceWarmupsRequirePerformanceModeAndHaveIsolatedCacheKeys() {
     val executor = RecordingWarmupExecutor()
     val cache = RuntimeWarmupCache(8, executor)
     val cgbPerformance =
@@ -282,9 +282,17 @@ class RomSessionPreparerTest {
             RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
         ) {})
     assertTrue(cache.warm(cgbPerformance, RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1) {})
+    assertFalse(
+        cache.warm(
+            skipConfig(cgbNativeImage())
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.ACCURACY),
+            RuntimeWarmupFlavor.PERFORMANCE,
+        ) {})
+    assertTrue(cache.warm(cgbPerformance, RuntimeWarmupFlavor.PERFORMANCE) {})
     assertTrue(cache.warm(cgbPerformance, RuntimeWarmupFlavor.SCALAR) {})
-    assertEquals(2, executor.calls.size)
-    assertEquals(2, cache.size)
+    assertEquals(3, executor.calls.size)
+    assertEquals(3, cache.size)
   }
 
   @Test
@@ -308,6 +316,21 @@ class RomSessionPreparerTest {
         config.forRuntimeWarmup(),
         120 * config.clockSpec.controllerTicksPerFrame(),
         RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1,
+    ) {}
+    assertContentEquals(originalConfigRom, config.rom.rom)
+  }
+
+  @Test
+  fun productionPerformanceExecutorRunsItsFrameBatchedSchedulerPath() {
+    val config =
+        skipConfig(cgbNativeImage())
+            .setHardwareProfile(HardwareProfileRegistry.CGB)
+            .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)
+    val originalConfigRom = config.rom.rom.copyOf()
+    RuntimeWarmupCache.GameboyRuntimeWarmupExecutor.warm(
+        config.forRuntimeWarmup(),
+        120 * config.clockSpec.controllerTicksPerFrame(),
+        RuntimeWarmupFlavor.PERFORMANCE,
     ) {}
     assertContentEquals(originalConfigRom, config.rom.rom)
   }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -2038,11 +2038,26 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (slotCartridgeClocked) {
             span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
         }
+        PerformancePhasePpuPlan ppuPlan = PerformancePhasePpuPlan.QUIET;
         int gpuSpanLimit = gpu.performanceQuietSpanLimit();
-        span = Math.min(span, gpuSpanLimit);
-        boolean directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
-        boolean steadyRasterSpan = span > 0 && !directRasterSpan
-                && gpu.isPerformanceSteadyCursorActive();
+        boolean directRasterSpan = false;
+        boolean steadyRasterSpan = false;
+        if (gpuSpanLimit > 0) {
+            span = Math.min(span, gpuSpanLimit);
+            directRasterSpan = span > 0 && gpu.isPerformanceScanlineCursorActive();
+            steadyRasterSpan = span > 0 && !directRasterSpan
+                    && gpu.isPerformanceSteadyCursorActive();
+        } else if (isNativeCgbNormalSpeedPerformanceEpochTopology()) {
+            int mode2SpanLimit = gpu.performanceCgbNormalSpeedMode2PhaseSpanLimit(span);
+            if (mode2SpanLimit > 0) {
+                span = Math.min(span, mode2SpanLimit);
+                ppuPlan = PerformancePhasePpuPlan.CGB_NORMAL_SPEED_MODE2;
+            } else {
+                span = 0;
+            }
+        } else {
+            span = 0;
+        }
         span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
         if (span <= 3
                 || warmResetRequested
@@ -2060,7 +2075,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || !canStartCgbNormalSpeedSettledHaltSpan()) {
             return 0;
         }
-        tickPerformanceSettledCgbHaltSpan(span, directRasterSpan, steadyRasterSpan);
+        tickPerformanceSettledCgbHaltSpan(
+                span, ppuPlan, directRasterSpan, steadyRasterSpan);
         performanceBulkSpanCount++;
         performanceBulkTicks += span;
         if (span > performanceBulkMaxTicks) {
@@ -2089,9 +2105,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && hdma.isPerformanceInactiveRequestClockStable();
     }
 
-    /** Commits a normal-speed CGB settled-HALT packet with the complete CGB idle plane. */
+    /**
+     * Commits a normal-speed CGB settled-HALT packet through either the quiet raster plane or
+     * the exact native-x1 mode-2 OAM transaction selected during preflight.
+     */
     private void tickPerformanceSettledCgbHaltSpan(
-            int ticks, boolean directRasterSpan, boolean steadyRasterSpan) {
+            int ticks, PerformancePhasePpuPlan ppuPlan,
+            boolean directRasterSpan, boolean steadyRasterSpan) {
         if (cartridgeClocked) {
             cartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
@@ -2109,7 +2129,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.tickPerformanceQuietSpanTrusted(ticks);
         cpu.advancePerformanceSettledHaltSpanTrusted(ticks);
         hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
-        gpu.advancePerformanceQuietSpanTrusted(ticks, directRasterSpan, steadyRasterSpan);
+        switch (ppuPlan) {
+            case QUIET -> gpu.advancePerformanceQuietSpanTrusted(
+                    ticks, directRasterSpan, steadyRasterSpan);
+            case CGB_NORMAL_SPEED_MODE2 ->
+                    gpu.advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(ticks);
+            default -> throw new IllegalStateException(
+                    "normal-speed CGB settled HALT has no PPU plan");
+        }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
         hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
                 gpu.isStatModeLatchRephasedBySpeedSwitch());

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -121,8 +121,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     static final int OAM_DMA_HBLANK_SPEED_SWITCH_DELAY_TICKS = 2;
 
-    /** Maximum packet horizon for the settled normal-speed HALT path. */
-    private static final int SETTLED_HALT_PERFORMANCE_MAX_SPAN = 54;
+    /** Maximum settled-HALT packet horizon; Android's next input poll trims this to at most 63. */
+    private static final int SETTLED_HALT_PERFORMANCE_MAX_SPAN = 64;
 
     // A granted HBlank burst can finish while the CPU speed-switch countdown is still
     // running. Its completed bus hand-off removes five ticks from the retained tail.
@@ -1587,7 +1587,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         int span = (int) Math.min((long) SETTLED_HALT_PERFORMANCE_MAX_SPAN, remaining);
         span = Math.min(span, timer.performanceEpochSpanLimit(span));
-        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        // This is a settled no-bus HALT transaction, so ordinary compact samples cannot race a
+        // deferred CPU sound-register write. Only the synchronous host callback stays scalar.
+        span = Math.min(span, sound.performanceQuietSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
         if (span <= 0 || !serialPort.performanceEpochIdle(span)
                 || !infraredPort.performanceEpochIdle(span)) {
@@ -1729,7 +1731,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
         span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbHardware));
-        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        span = Math.min(span, nativeCgbNormalSpeed || sgb
+                ? sound.performanceFencedEpochSpanLimit(span)
+                : sound.performanceEpochSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
         if (cgbHardware) {
             span = Math.min(span, serialPort.performanceNormalSpeedEpochIdle(span, true)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -246,6 +246,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Subset of mode-2 epoch ticks committed by the allocation-free OAM transaction. */
     private transient long performanceEpochMode2BulkTicks;
 
+    /** Native-CGB x1 epoch ticks committed while the LCD was stably disabled. */
+    private transient long performanceEpochLcdOffTicks;
+
     /** Raster transaction selected before the CPU observes its frozen peripheral view. */
     private transient PerformanceEpochPpuPlan performanceEpochPpuPlan =
             PerformanceEpochPpuPlan.NONE;
@@ -266,7 +269,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         NONE,
         TRUSTED_RASTER,
         MODE2_BULK,
-        MODE2_REPLAY
+        MODE2_REPLAY,
+        LCD_OFF
     }
 
     /** PPU commit selected for a normal-speed, phase-only PERFORMANCE packet. */
@@ -1725,8 +1729,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         boolean cgbHardware = isCgbNormalSpeedPerformanceEpochTopology();
         boolean nativeCgbNormalSpeed = isNativeCgbNormalSpeedPerformanceEpochTopology();
         boolean sgb = isSgbPerformanceTopology();
+        boolean lcdOffEpoch = nativeCgbNormalSpeed && !gpu.isLcdEnabled();
         if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbHardware)
-                || !canStartNormalSpeedPerformanceEpoch(cgbHardware)) {
+                || !canStartNormalSpeedPerformanceEpoch(
+                        cgbHardware, nativeCgbNormalSpeed)) {
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
@@ -1745,21 +1751,36 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
 
         PerformanceEpochPpuPlan ppuPlan;
-        int rasterSpan = cgbHardware
-                ? gpu.performanceEpochSpanLimit(span)
-                : gpu.performancePhysicalDmgEpochSpanLimit(span);
-        if (rasterSpan > 0) {
-            span = Math.min(span, rasterSpan);
-            ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
-        } else if (nativeCgbNormalSpeed) {
-            int mode2Span = gpu.performanceCgbNormalSpeedMode2PhaseSpanLimit(span);
-            if (mode2Span <= 0) {
+        if (lcdOffEpoch) {
+            span = Math.min(span, performanceLcdOffEpochSpanLimit(span));
+            span = Math.min(span,
+                    gpu.performanceNativeCgbNormalSpeedLcdOffSpanLimit(span));
+            if (span <= 0) {
                 return 0;
             }
-            span = Math.min(span, mode2Span);
-            ppuPlan = PerformanceEpochPpuPlan.MODE2_BULK;
+            ppuPlan = PerformanceEpochPpuPlan.LCD_OFF;
+        } else if (nativeCgbNormalSpeed) {
+            int rasterSpan = gpu.performanceEpochSpanLimit(span);
+            if (rasterSpan > 0) {
+                span = Math.min(span, rasterSpan);
+                ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+            } else {
+                int mode2Span = gpu.performanceCgbNormalSpeedMode2PhaseSpanLimit(span);
+                if (mode2Span <= 0) {
+                    return 0;
+                }
+                span = Math.min(span, mode2Span);
+                ppuPlan = PerformanceEpochPpuPlan.MODE2_BULK;
+            }
         } else {
-            return 0;
+            int rasterSpan = cgbHardware
+                    ? gpu.performanceEpochSpanLimit(span)
+                    : gpu.performancePhysicalDmgEpochSpanLimit(span);
+            if (rasterSpan <= 0) {
+                return 0;
+            }
+            span = Math.min(span, rasterSpan);
+            ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
         }
         span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
         if (span <= 0) {
@@ -1794,7 +1815,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         try {
             elapsed = cgbHardware
                     ? nativeCgbNormalSpeed
-                            ? cpu.runNativeCgbNormalSpeedPerformanceEpoch(span)
+                            ? lcdOffEpoch
+                                    ? cpu.runNativeCgbNormalSpeedLcdOffPerformanceEpoch(span)
+                                    : cpu.runNativeCgbNormalSpeedPerformanceEpoch(span)
                             : cpu.runCgbCompatibilityPerformanceEpoch(span)
                     : sgb
                             ? cpu.runSgbPerformanceEpoch(span)
@@ -1860,13 +1883,15 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /** Stable normal-speed epoch topology; transient guards are evaluated by the caller. */
-    private boolean canStartNormalSpeedPerformanceEpoch(boolean cgbHardware) {
+    private boolean canStartNormalSpeedPerformanceEpoch(
+            boolean cgbHardware, boolean nativeCgbNormalSpeed) {
+        boolean lcdEnabled = gpu.isLcdEnabled();
         return !warmResetRequested
                 && speedSwitchTailTicks == 0
                 && !debugHistoryReplay
                 && debugInstrumentation == null
                 && !debugRetirementTrackingActive
-                && gpu.isLcdEnabled()
+                && (lcdEnabled ? !lcdDisabled : nativeCgbNormalSpeed && lcdDisabled)
                 && !dma.isTransferInProgress()
                 && !dma.requiresClockTick(false)
                 && !cartridgeClocked
@@ -1878,6 +1903,18 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                         && !hdma.pausesOamDmaForSpeedSwitchBurst()
                         && !hdma.requiresCpuHdmaPhaseFlags()
                         && hdma.isPerformanceInactiveRequestClockStable()));
+    }
+
+    /** Leaves the exact host blank publication/reset tick on the scalar owner. */
+    private int performanceLcdOffEpochSpanLimit(int requested) {
+        if (requested <= 0 || !lcdDisabled || gpu.isLcdEnabled()) {
+            return 0;
+        }
+        int target = lcdOffTicks < LCD_OFF_BLANK_DELAY
+                ? LCD_OFF_BLANK_DELAY
+                : LCD_OFF_BLANK_DELAY + clockSpec.controllerTicksPerFrame();
+        int distance = target - lcdOffTicks;
+        return Math.min(requested, Math.max(0, distance - 1));
     }
 
     private void commitPerformanceEpochPrefix(int ticks) {
@@ -1994,6 +2031,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     performanceEpochMode2ReplayTicks += ticks;
                     performanceEpochMode2BulkTicks += ticks;
                 }
+                case LCD_OFF -> {
+                    gpu.advancePerformanceNativeCgbNormalSpeedLcdOffSpanTrusted(ticks);
+                    performanceEpochLcdOffTicks += ticks;
+                }
                 default -> throw new IllegalStateException(
                         "normal-speed CGB epoch has no PPU plan");
             }
@@ -2006,6 +2047,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (cgbHardware) {
             hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
                     gpu.isStatModeLatchRephasedBySpeedSwitch());
+        }
+        if (performanceEpochPpuPlan == PerformanceEpochPpuPlan.LCD_OFF) {
+            lcdOffTicks += ticks;
         }
     }
 
@@ -2286,6 +2330,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochRasterFastTicks = 0L;
         performanceEpochMode2ReplayTicks = 0L;
         performanceEpochMode2BulkTicks = 0L;
+        performanceEpochLcdOffTicks = 0L;
         performanceEpochPpuPlan = PerformanceEpochPpuPlan.NONE;
         cpu.resetPerformanceEpochTelemetry();
     }
@@ -2327,6 +2372,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     public long getPerformanceEpochMode2BulkTicks() {
         return performanceEpochMode2BulkTicks;
+    }
+
+    public long getPerformanceEpochLcdOffTicks() {
+        return performanceEpochLcdOffTicks;
     }
 
     private Mode tickSubsystems() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1213,9 +1213,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     }
 
     /**
-     * Fixed-x1 normal-speed coarse scheduler. Only the trusted rendered raster may join a CPU
-     * epoch; mode 2, STAT/line edges, DMA, IRQ/HALT, and every rejected topology retain the
-     * established normal-speed PERFORMANCE scheduler.
+     * Fixed-x1 normal-speed coarse scheduler. Trusted rendered raster spans may join every
+     * supported CPU epoch; native CGB x1 may also use the exact mode-2 OAM transaction. STAT
+     * and line edges, DMA, IRQ boundaries, and every rejected topology retain the established
+     * normal-speed PERFORMANCE scheduler.
      */
     private long runNormalSpeedPerformanceTicks(long ticks) {
         gpu.setPerformanceScanlineEnabled(true);
@@ -1739,13 +1740,23 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     ? span : 0);
         }
 
+        PerformanceEpochPpuPlan ppuPlan;
         int rasterSpan = cgbHardware
                 ? gpu.performanceEpochSpanLimit(span)
                 : gpu.performancePhysicalDmgEpochSpanLimit(span);
-        if (rasterSpan <= 0) {
+        if (rasterSpan > 0) {
+            span = Math.min(span, rasterSpan);
+            ppuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+        } else if (nativeCgbNormalSpeed) {
+            int mode2Span = gpu.performanceCgbNormalSpeedMode2PhaseSpanLimit(span);
+            if (mode2Span <= 0) {
+                return 0;
+            }
+            span = Math.min(span, mode2Span);
+            ppuPlan = PerformanceEpochPpuPlan.MODE2_BULK;
+        } else {
             return 0;
         }
-        span = Math.min(span, rasterSpan);
         span = Math.min(span, statRegister.performanceSettledHaltSpanLimit(span));
         if (span <= 0) {
             return 0;
@@ -1758,7 +1769,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochDirectRaster = gpu.isPerformanceScanlineCursorActive();
         performanceEpochSteadyRaster = !performanceEpochDirectRaster
                 && gpu.isPerformanceSteadyCursorActive();
-        performanceEpochPpuPlan = PerformanceEpochPpuPlan.TRUSTED_RASTER;
+        performanceEpochPpuPlan = ppuPlan;
         performanceEpochPrefixCommitted = 0;
         IntConsumer prefixCommitter;
         if (cgbHardware) {
@@ -1942,7 +1953,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         commitNormalSpeedPerformanceEpochPeripherals(ticks, false);
     }
 
-    /** Normal-speed CGB prefix commit through the existing CGB quiet epoch plane. */
+    /** Normal-speed CGB prefix commit through the selected raster or mode-2 PPU plane. */
     private void commitCgbNormalSpeedPerformanceEpochPeripherals(int ticks) {
         commitNormalSpeedPerformanceEpochPeripherals(ticks, true);
     }
@@ -1968,14 +1979,26 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             // The preflight admits only inactive countdowns, so their zero-clock ages are the
             // complete arithmetic transaction skipped by this fixed-x1 packet.
             hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
-            gpu.advancePerformanceEpochQuietSpanTrusted(
-                    ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+            switch (performanceEpochPpuPlan) {
+                case TRUSTED_RASTER -> {
+                    gpu.advancePerformanceEpochQuietSpanTrusted(
+                            ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+                    performanceEpochRasterFastTicks += ticks;
+                }
+                case MODE2_BULK -> {
+                    gpu.advancePerformanceCgbNormalSpeedMode2PhaseSpanTrusted(ticks);
+                    performanceEpochMode2ReplayTicks += ticks;
+                    performanceEpochMode2BulkTicks += ticks;
+                }
+                default -> throw new IllegalStateException(
+                        "normal-speed CGB epoch has no PPU plan");
+            }
         } else {
             gpu.advancePhysicalDmgPerformanceEpochQuietSpanTrusted(
                     ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
+            performanceEpochRasterFastTicks += ticks;
         }
         statRegister.tickPerformanceQuietSpanTrusted(ticks);
-        performanceEpochRasterFastTicks += ticks;
         if (cgbHardware) {
             hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
                     gpu.isStatModeLatchRephasedBySpeedSwitch());

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -100,6 +100,9 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private transient int performanceEpochPrefixTicks;
 
+    /** Epoch-local proof that LCD-off CGB VRAM is an unobserved direct memory plane. */
+    private transient boolean performanceEpochLcdOffVramAccess;
+
     private transient DebugCpuAddressSpace debugAddressSpace;
 
     private transient DebugHooks debugHooks;
@@ -342,9 +345,26 @@ public class Cpu implements StatefulComponent<Cpu> {
                 ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, true) : 0;
     }
 
+    /**
+     * Native-CGB x1 epoch while the owner has proven that LCD output and both DMA planes are
+     * inactive. Decoded memory cycles remain fenced except for direct VRAM reads/writes; LCDC,
+     * other IO, OAM, cartridge control, and executable VRAM all retain the scalar boundary.
+     */
+    public int runNativeCgbNormalSpeedLcdOffPerformanceEpoch(int maxMasterTicks) {
+        return !speedMode.isDmgCompat()
+                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, true, true) : 0;
+    }
+
     /** Shared fixed-width normal-speed epoch; topology flags are explicit and allocation-free. */
     private int runPerformanceNormalSpeedEpoch(
             int maxMasterTicks, boolean cgbHardware, boolean fenceDecodedMemoryCycles) {
+        return runPerformanceNormalSpeedEpoch(
+                maxMasterTicks, cgbHardware, fenceDecodedMemoryCycles, false);
+    }
+
+    private int runPerformanceNormalSpeedEpoch(
+            int maxMasterTicks, boolean cgbHardware, boolean fenceDecodedMemoryCycles,
+            boolean allowLcdOffVramAccess) {
         if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbHardware)) {
             return 0;
         }
@@ -362,6 +382,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         performanceEpochElapsed = 0;
         performanceEpochPrefixTicks = 0;
         performanceEpochActive = true;
+        performanceEpochLcdOffVramAccess = allowLcdOffVramAccess;
         bus.resetForEpoch(target);
         addressSpace = bus;
         int elapsed = 0;
@@ -378,7 +399,8 @@ public class Cpu implements StatefulComponent<Cpu> {
                 }
 
                 if (!performanceEpochPrefetchSafe()
-                        || fenceDecodedMemoryCycles && !performanceSgbBoundarySafe()) {
+                        || fenceDecodedMemoryCycles
+                        && !performanceDecodedMemoryBoundarySafe(allowLcdOffVramAccess)) {
                     performanceEpochTerminal = true;
                     break;
                 }
@@ -401,6 +423,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         } finally {
             addressSpace = target;
             performanceEpochActive = false;
+            performanceEpochLcdOffVramAccess = false;
             performanceEpochAccesses += bus.accesses();
             performanceEpochTerminalAccesses += bus.terminalAccesses();
             performanceEpochTicks += elapsed;
@@ -417,19 +440,38 @@ public class Cpu implements StatefulComponent<Cpu> {
      * Operations before the next force-finish marker execute in the same machine-cycle tick;
      * scanning the complete group here prevents a partial CPU tick before scalar fallback.
      */
-    private boolean performanceSgbBoundarySafe() {
+    private boolean performanceDecodedMemoryBoundarySafe(boolean allowLcdOffVramAccess) {
         if (state != State.RUNNING || currentExecutionOps == null) {
             return true;
         }
         for (int i = opIndex; i < currentOpCount; i++) {
             if (currentOpAccessesMemory[i]) {
-                return false;
+                if (!allowLcdOffVramAccess) {
+                    return false;
+                }
+                Integer address = currentExecutionOps[i].resolveMemoryAddress(
+                        registers, operand, opContext);
+                if (address == null || !PerformanceEpochBus.isVideoRam(address)) {
+                    return false;
+                }
             }
             if (currentExecutionOps[i].forceFinishCycle()) {
                 break;
             }
         }
         return true;
+    }
+
+    private boolean isPerformanceEpochSafeRead(int address) {
+        return PerformanceEpochBus.isSafeRead(address)
+                || performanceEpochLcdOffVramAccess
+                && PerformanceEpochBus.isVideoRam(address);
+    }
+
+    private boolean isPerformanceEpochSafeWrite(int address) {
+        return PerformanceEpochBus.isSafeWrite(address)
+                || performanceEpochLcdOffVramAccess
+                && PerformanceEpochBus.isVideoRam(address);
     }
 
     private boolean performanceEpochPrefetchSafe() {
@@ -3625,7 +3667,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         @Override
         public int getByte(int address) {
             accesses++;
-            if (!isSafeRead(address)) {
+            if (!owner.isPerformanceEpochSafeRead(address)) {
                 terminalAccesses++;
                 owner.markPerformanceEpochTerminal();
                 owner.flushPerformanceEpochPrefix();
@@ -3636,7 +3678,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         @Override
         public void setByte(int address, int value) {
             accesses++;
-            if (!isSafeWrite(address)) {
+            if (!owner.isPerformanceEpochSafeWrite(address)) {
                 int a = address & 0xffff;
                 if (!owner.speedMode.isGbc() && a >= 0xfe00 && a <= 0xfeff) {
                     // DMG OAM writes must observe the corruption-suppression latch and access
@@ -3672,6 +3714,11 @@ public class Cpu implements StatefulComponent<Cpu> {
             int a = address & 0xffff;
             return a >= 0xc000 && a <= 0xfdff
                     || a >= 0xff80 && a <= 0xfffd;
+        }
+
+        private static boolean isVideoRam(int address) {
+            int a = address & 0xffff;
+            return a >= 0x8000 && a <= 0x9fff;
         }
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1202,6 +1202,39 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
     }
 
     /**
+     * Stable native-CGB x1 LCD-off plane. Scalar {@link #tick()} changes only the timing
+     * generation in this state; raster, LY, mode, output-delay, and frozen conflict histories
+     * do not advance. The owner separately fences LCDC/IO writes and the host blank cadence.
+     */
+    public int performanceNativeCgbNormalSpeedLcdOffSpanLimit(int requested) {
+        if (requested <= 0 || !gbc || dmgCompatValue || speedModeValue != 1
+                || lcdEnabled || lcdc.isLcdEnabled() || displayEnabledDelay != 0
+                || firstLine || line != 0 || ticksInLine != 0 || mode != Mode.HBlank
+                || performanceScanlineCursor || steadyTimingCursor
+                || !performanceScanlineEnabled || !performanceScanlineCapable
+                || !bootCompatibilityResolved
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || dma == null || dma.isTransferInProgress() || dma.ownsOamForPpu()
+                || dma.hasPpuOamOwnershipTransitionThisTick()
+                || hdma == null || hdma.hasActiveOrPendingTransfer()) {
+            return 0;
+        }
+        return requested;
+    }
+
+    /** Advances the inert GPU clock after the owner has preflighted the complete packet. */
+    public void advancePerformanceNativeCgbNormalSpeedLcdOffSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        assert performanceNativeCgbNormalSpeedLcdOffSpanLimit(ticks) >= ticks
+                : "trusted native-CGB x1 LCD-off proof changed before commit";
+        timingGeneration += ticks;
+        cpuLyReadAcrossLineEdge = false;
+    }
+
+    /**
      * Physical-DMG counterpart of {@link #performanceEpochSpanLimit(int)}. The empty output
      * clocks are part of the proof in HBlank/VBlank; IR, HDMA, mode 2 and scalar mode 3 are not.
      */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1322,9 +1322,10 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     /**
      * Horizon for a short ordinary-CGB normal-speed mode-2 phase packet. The CGB OAM reader
-     * uses the same Y/X height latch at x1 in native and compatibility modes. Only non-CPU dots
-     * before the dot-79-to-80 handoff are admitted; every fixed-point, observation, DMA, and
-     * HDMA miss leaves the complete phase to the scalar scheduler.
+     * uses the same Y/X height latch at x1 in native and compatibility modes. Only dots before
+     * the dot-79-to-80 handoff are admitted; callers may use the proof for the short phase-only
+     * packet or the fenced native-x1 CPU epoch. Every fixed-point, observation, DMA, and HDMA
+     * miss leaves the complete span to the scalar scheduler.
      */
     public int performanceCgbNormalSpeedMode2PhaseSpanLimit(int requested) {
         if (!performanceDmgCompatTiming || requested <= 0 || !gbc || speedModeValue != 1

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransfer.java
@@ -82,6 +82,11 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     // instance is ticked from the GPU every T-cycle since it outlives the skeleton's mode 3
     private boolean machineActive;
 
+    // Successful idle-output proofs are stable across empty output-clock advances. Cache only
+    // that TRUE result: a failed proof may recover as soon as a delay line drains or a deferred
+    // write settles. This is session-transient PERFORMANCE metadata, not portable machine state.
+    private boolean performanceIdleOutputKnownTrue;
+
     private int position;
 
     private boolean window;
@@ -391,6 +396,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     private void bindTimingFifo() {
+        invalidatePerformanceIdleOutputCache();
         if (!timingSkeleton || timingFifo == null) {
             throw new IllegalStateException("Scalar timing FIFO is not allowed for this machine");
         }
@@ -401,6 +407,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     private void bindFullFifo() {
+        invalidatePerformanceIdleOutputCache();
         if (fullFifo instanceof ColorPixelFifo colorPixelFifo) {
             colorPixelFifo.setRenderOutput(renderOutput);
         } else if (fullFifo instanceof DmgPixelFifo dmgPixelFifo) {
@@ -413,11 +420,13 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     private void deoptToFullFifo() {
+        invalidatePerformanceIdleOutputCache();
         bindFullFifo();
         fullFifo.resetForMissingState();
     }
 
     public PixelTransfer start(int extraEntryDelay, boolean lcdEnableFirstLine) {
+        invalidatePerformanceIdleOutputCache();
         this.lcdEnableFirstLine = lcdEnableFirstLine;
         entryTicks = entryDelay + extraEntryDelay;
         machineActive = true;
@@ -492,6 +501,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
      * its exact CGB map-attribute, bank, and tile-flip reads.
      */
     public void advanceSteadyBackgroundSpan(int ticks) {
+        invalidatePerformanceIdleOutputCache();
         if (!timingSkeleton
                 || !(fifo instanceof ScalarTimingDmgPixelFifo
                 || fifo instanceof ScalarTimingColorPixelFifo)
@@ -514,6 +524,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
      * skeleton, and materializes it before any observable boundary.</p>
      */
     public void advanceSteadyBackgroundOutputSpan(int ticks) {
+        invalidatePerformanceIdleOutputCache();
         if (timingSkeleton
                 || !(fifo instanceof DmgPixelFifo || fifo instanceof ColorPixelFifo)
                 || ticks < 0) {
@@ -618,6 +629,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     public void restoreDmgFifoRuntimeState(DmgPixelFifo.RuntimeState state) {
+        invalidatePerformanceIdleOutputCache();
         validateDmgFifoRuntimeState(state);
         if (fifo instanceof DmgPixelFifo dmgFifo) {
             dmgFifo.restoreRuntimeState(state);
@@ -679,6 +691,19 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     private boolean isPerformanceIdleOutput() {
+        if (performanceIdleOutputKnownTrue) {
+            assert isPerformanceIdleOutputSlow()
+                    : "cached PERFORMANCE idle-output proof became stale";
+            return true;
+        }
+        if (isPerformanceIdleOutputSlow()) {
+            performanceIdleOutputKnownTrue = true;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isPerformanceIdleOutputSlow() {
         return
                 // The timing skeleton is driven directly through Gpu.phase.tick(); its
                 // historical machineActive marker remains set after a scalar mode-3 end, but
@@ -689,6 +714,12 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
                 && pendingWindowXWrites.isEmpty()
                 && windowWyDelay < 0
                 && windowWyOldOnWriteTick < 0;
+    }
+
+    private void invalidatePerformanceIdleOutputCache() {
+        if (performanceIdleOutputKnownTrue) {
+            performanceIdleOutputKnownTrue = false;
+        }
     }
 
     /**
@@ -782,6 +813,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     public void scheduleWindowDisplayWrite(boolean windowDisplay, int delayDots) {
+        invalidatePerformanceIdleOutputCache();
         if (pendingWindowDisplayWrites.isEmpty()) {
             windowDisplayOverride = isWindowDisplay() ? 1 : 0;
         }
@@ -790,6 +822,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
     }
 
     public void scheduleWindowXWrite(int windowX, int delayDots) {
+        invalidatePerformanceIdleOutputCache();
         if (pendingWindowXWrites.isEmpty()) {
             windowXOverride = getWindowX();
         }
@@ -957,6 +990,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     /** Schedules the secondary WY comparator latch after a WY write. */
     public void scheduleWindowYWrite(int value, int delayDots) {
+        invalidatePerformanceIdleOutputCache();
         pendingWindowWy = value & 0xff;
         if (gbc && delayDots > 0) {
             windowWyOldOnWriteTick = r.get(WY);
@@ -1036,6 +1070,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     @Override
     public boolean tick() {
+        invalidatePerformanceIdleOutputCache();
         boolean windowDisplay = isWindowDisplay();
         tickWindowDisplay = windowDisplay;
         tickWindowX = getWindowX();
@@ -1582,6 +1617,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
 
     @Override
     public void restoreState(ComponentState<PixelTransfer> state) {
+        invalidatePerformanceIdleOutputCache();
         if (!(state instanceof PixelTransferState mem)) {
             throw new IllegalArgumentException("Invalid state type");
         }
@@ -1715,6 +1751,7 @@ public class PixelTransfer implements GpuPhase, StatefulComponent<PixelTransfer>
      */
     @SuppressWarnings("unchecked")
     private void restoreFifoState(ComponentState<?> state) {
+        invalidatePerformanceIdleOutputCache();
         validateFifoState(state);
         if (state instanceof ScalarTimingDmgPixelFifo.State scalarDmg) {
             if (timingSkeleton && !renderOutput && !gbc) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sound/Sound.java
@@ -37,7 +37,8 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     /**
      * PERFORMANCE audio is intentionally represented at a decimated master-tick rate. The normal
      * source is sampled at approximately 76.26 kHz, which is still comfortably above the host
-     * audio band and gives the emulator a 54-master-tick quiet window in which to batch the PSG.
+     * audio band. Quiet spans may cross ordinary compact samples: each sample boundary
+     * materializes at most 54 deferred PSG clocks before recording the exact mixed value.
      * SGB-family clocks use a 56-tick decimation, yielding exactly 1,254 samples in their
      * 70,224-tick frame while retaining a 55-master-tick quiet window. The pending span is
      * transient: CPU-visible operations and state boundaries materialize it before observing or
@@ -267,8 +268,9 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
     /**
      * Defers a PERFORMANCE-only quiet span without visiting the four channel dispatches for
      * every master tick. The caller must split the span at CPU-visible sound writes,
-     * frame-sequencer commits, DIV resets, and compact-output boundaries. The channel clocks are
-     * materialized arithmetically at the next such boundary.
+     * frame-sequencer commits, DIV resets, and host output callbacks. Ordinary compact samples
+     * are handled inside the span: the channel clocks are materialized arithmetically at each
+     * sample boundary before its exact mixed value is recorded.
      */
     public void tickPerformanceQuietSpan(int ticks) {
         if (ticks <= 0) {
@@ -278,20 +280,37 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
             accumulateSilentPcmTicks(ticks);
             return;
         }
-        if (!performanceAudio || debugHooks != null || outputObserver != null
-                || performanceSamplePhase + ticks >= performanceAudioDecimation) {
+        if (!performanceAudio || debugHooks != null || outputObserver != null) {
             materializePendingPerformanceTicks();
             for (int j = 0; j < ticks; j++) {
                 tick(false);
             }
             return;
         }
-        // The PERFORMANCE horizon stops before the next decimated sample, where the pending span
-        // is materialized. Consequently this accumulator is bounded by
-        // performanceAudioDecimation - 1, so an overflow-checked add in the hot path cannot
-        // provide any additional protection.
-        pendingPerformanceTicks += ticks;
-        performanceSamplePhase += ticks;
+        int quietTicks = performanceAudioDecimation - performanceSamplePhase - 1;
+        if (ticks <= quietTicks) {
+            // Preserve the original sub-sample hot path: most CPU packets do not contain a
+            // compact-output boundary and need only the two lazy counters below.
+            pendingPerformanceTicks += ticks;
+            performanceSamplePhase += ticks;
+            return;
+        }
+        int remaining = ticks;
+        while (remaining > 0) {
+            // Keep each arithmetic channel transaction inside the already-proven sub-sample
+            // bound. The sample tick itself uses the scalar Sound clock after publishing the
+            // deferred prefix, so frequency expiries and the mixed PCM value retain their exact
+            // order without returning through the whole-machine scheduler.
+            quietTicks = Math.min(remaining,
+                    performanceAudioDecimation - performanceSamplePhase - 1);
+            pendingPerformanceTicks += quietTicks;
+            performanceSamplePhase += quietTicks;
+            remaining -= quietTicks;
+            if (remaining > 0) {
+                tick(false);
+                remaining--;
+            }
+        }
     }
 
     /**
@@ -440,7 +459,7 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         return pendingFrameSequencerStep >= 0;
     }
 
-    /** Returns the largest compact-output-safe quiet span not crossing the next sample slot. */
+    /** Returns the largest compact-output-safe quiet span before the next host callback. */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0 || !performanceAudio || debugHooks != null || outputObserver != null
                 || pendingFrameSequencerStep >= 0) {
@@ -449,14 +468,14 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
             return requested;
         }
-        return Math.min(requested,
-                performanceAudioDecimation - performanceSamplePhase - 1);
+        return performanceHostCallbackSafeSpanLimit(requested);
     }
 
     /**
-     * Horizon used by the native-CGB coarse epoch.  With lazy PERFORMANCE audio enabled,
-     * stop immediately before the next compact sample; with audio disabled there is no host
-     * sample boundary to cross and the regular per-tick state update remains exact.
+     * Horizon used by an unfenced coarse CPU epoch. With lazy PERFORMANCE audio enabled, stop
+     * immediately before the next compact sample so a deferred NRxx journal write is replayed
+     * first. With audio disabled there is no host sample boundary to cross and the regular
+     * per-tick state update remains exact.
      */
     public int performanceEpochSpanLimit(int requested) {
         if (requested <= 0 || debugHooks != null || outputObserver != null
@@ -469,8 +488,41 @@ public class Sound implements AddressSpace, StatefulComponent<Sound> {
         if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
             return requested;
         }
+        // An unfenced CPU epoch may defer an NRxx write until its old-state peripheral prefix
+        // has committed. Keep the next compact sample scalar so that replayed write remains
+        // ordered before a sample on the same tick.
         return Math.min(requested,
                 performanceAudioDecimation - performanceSamplePhase - 1);
+    }
+
+    /**
+     * Callback-only horizon for a CPU epoch whose decoder fences every data-memory boundary.
+     * Such an epoch cannot defer an NRxx write, so ordinary compact samples are exact inside it.
+     */
+    public int performanceFencedEpochSpanLimit(int requested) {
+        if (requested <= 0 || debugHooks != null || outputObserver != null
+                || pendingFrameSequencerStep >= 0) {
+            return 0;
+        }
+        if (!performanceAudio) {
+            return requested;
+        }
+        if (performanceSystemMutedAudioMode != PerformanceSystemMutedAudioMode.OFF) {
+            return requested;
+        }
+        return performanceHostCallbackSafeSpanLimit(requested);
+    }
+
+    /**
+     * Excludes the compact sample which fills the host buffer. SoundSampleEvent is synchronous,
+     * so its tick must retain scalar whole-machine ordering; earlier samples have no observer and
+     * can be recorded inside a preflighted packet.
+     */
+    private int performanceHostCallbackSafeSpanLimit(int requested) {
+        long sampleSlotsRemaining = (buffer.length - i) / 2L;
+        long ticksUntilCallback = sampleSlotsRemaining * performanceAudioDecimation
+                - performanceSamplePhase;
+        return (int) Math.min((long) requested, Math.max(0L, ticksUntilCallback - 1L));
     }
 
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -422,6 +422,104 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedLcdOffBlankBoundariesMatchScalarDeepState()
+            throws Exception {
+        byte[] image = nativeCgbLcdOffVramLoop();
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            advancePairUntilLcdDisabled(scalar, candidate);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            int beforeInitialBlank = Gameboy.LCD_OFF_BLANK_DELAY - 2;
+            assertEquals("LCD-off pre-blank frame callback", 0,
+                    scalar.runTicks(beforeInitialBlank));
+            assertEquals("LCD-off epoch crossed initial blank boundary", 0,
+                    candidate.runTicks(beforeInitialBlank));
+            assertDeepStateEquals("before initial LCD-off blank",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("scalar initial LCD-off blank", 1, scalar.runTicks(1));
+            assertEquals("candidate initial LCD-off blank", 1, candidate.runTicks(1));
+            assertDeepStateEquals("after initial LCD-off blank",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            int beforeRefreshBlank = candidate.getClockSpec().controllerTicksPerFrame() - 1;
+            assertEquals("LCD-off pre-refresh frame callback", 0,
+                    scalar.runTicks(beforeRefreshBlank));
+            assertEquals("LCD-off epoch crossed refresh blank boundary", 0,
+                    candidate.runTicks(beforeRefreshBlank));
+            assertDeepStateEquals("before recurring LCD-off blank",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("scalar recurring LCD-off blank", 1, scalar.runTicks(1));
+            assertEquals("candidate recurring LCD-off blank", 1, candidate.runTicks(1));
+            assertTrue("stable LCD-off loop had no epoch coverage",
+                    candidate.getPerformanceEpochLcdOffTicks() > 50_000L);
+            assertEquals("LCD-off VRAM accesses reached the terminal bus", 0L,
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertDeepStateEquals("after recurring LCD-off blank",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedLcdOffVramReadWriteAndLcdcEnableMatchScalar()
+            throws Exception {
+        byte[] image = nativeCgbLcdOffVramThenEnable();
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            advancePairUntilLcdDisabled(scalar, candidate);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("LCD-off VRAM bulk setup frame callback",
+                    scalar.runTicks(2_000), candidate.runTicks(2_000));
+            int guard = 0;
+            while (!(candidate.getCpu().getState() == Cpu.State.RUNNING
+                    && candidate.getCpu().getDebugOpcode() == 0xe0
+                    && candidate.getCpu().getRegisters().getPC() == 0x0112
+                    && candidate.getCpu().getDebugMachineCycle() == 3)
+                    && guard++ < 12_000) {
+                assertEquals("LCD-off LCDC-enable setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not stop before the LCDC-enable write", guard < 12_000);
+            assertFalse(candidate.getGpu().isLcdEnabled());
+            assertTrue("VRAM clear loop had no LCD-off epoch coverage",
+                    candidate.getPerformanceEpochLcdOffTicks() > 0L);
+            assertEquals("LCD-off VRAM accesses reached the terminal bus", 0L,
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            for (int offset = 0; offset < 0x100; offset++) {
+                assertEquals("LCD-off VRAM read/write " + offset, 1,
+                        candidate.getAddressSpace().getByte(0x8000 + offset));
+            }
+            assertDeepStateEquals("before LCDC enable",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("LCDC-enable boundary frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("decoded LCDC enable crossed the LCD-off epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertTrue(candidate.getGpu().isLcdEnabled());
+            assertDeepStateEquals("after scalar LCDC enable",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
     public void nativeCgbNormalSpeedNr44TriggerStaysScalarAfterSafeEpochCoverage()
             throws Exception {
         byte[] image = nativeColor(dmgRomWramLoop());
@@ -1135,6 +1233,21 @@ public final class GameboyPerformanceEpochTest {
                 candidate.captureStateWithoutTimeSource());
     }
 
+    private static void advancePairUntilLcdDisabled(Gameboy scalar, Gameboy candidate) {
+        int guard = 0;
+        while ((scalar.getGpu().isLcdEnabled() || candidate.getGpu().isLcdEnabled())
+                && guard++ < 256) {
+            assertEquals("LCD-disable setup frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue("test ROM did not disable the LCD", guard < 256);
+        assertFalse(scalar.getGpu().isLcdEnabled());
+        assertFalse(candidate.getGpu().isLcdEnabled());
+        assertDeepStateEquals("after scalar LCD-disable boundary",
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
     private static void startOneBlockGdma(Gameboy gameboy) {
         var bus = gameboy.getAddressSpace();
         bus.setByte(0xff51, 0);
@@ -1327,6 +1440,54 @@ public final class GameboyPerformanceEpochTest {
         image[0x109] = 0x77; // LD (HL),A
         image[0x10a] = 0x18; // JR 0107
         image[0x10b] = (byte) 0xfb;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] nativeCgbLcdOffVramLoop() {
+        byte[] image = new byte[0x8000];
+        int pc = 0x100;
+        image[pc++] = (byte) 0xaf; // XOR A
+        image[pc++] = (byte) 0xe0; // LDH (FF40),A: LCD off
+        image[pc++] = 0x40;
+        image[pc++] = 0x21; // LD HL,8000
+        image[pc++] = 0x00;
+        image[pc++] = (byte) 0x80;
+        int loop = pc;
+        image[pc++] = 0x7e; // LD A,(HL)
+        image[pc++] = 0x3c; // INC A
+        image[pc++] = 0x77; // LD (HL),A
+        image[pc++] = 0x18; // JR loop
+        image[pc++] = (byte) (loop - pc);
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] nativeCgbLcdOffVramThenEnable() {
+        byte[] image = new byte[0x8000];
+        int pc = 0x100;
+        image[pc++] = (byte) 0xaf; // XOR A
+        image[pc++] = (byte) 0xe0; // LDH (FF40),A: LCD off
+        image[pc++] = 0x40;
+        image[pc++] = 0x21; // LD HL,8000
+        image[pc++] = 0x00;
+        image[pc++] = (byte) 0x80;
+        image[pc++] = 0x06; // LD B,00: 256 iterations
+        image[pc++] = 0x00;
+        int loop = pc;
+        image[pc++] = 0x7e; // LD A,(HL)
+        image[pc++] = 0x3c; // INC A
+        image[pc++] = 0x22; // LD (HL+),A
+        image[pc++] = 0x05; // DEC B
+        image[pc++] = 0x20; // JR NZ,loop
+        image[pc++] = (byte) (loop - pc);
+        image[pc++] = 0x3e; // LD A,91
+        image[pc++] = (byte) 0x91;
+        image[pc++] = (byte) 0xe0; // LDH (FF40),A: LCD on, must stay scalar
+        image[pc++] = 0x40;
+        image[pc++] = (byte) 0xc3; // JP 0112
+        image[pc++] = 0x12;
+        image[pc] = 0x01;
         image[0x143] = (byte) 0x80;
         return image;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -311,9 +311,12 @@ public final class GameboyPerformanceEpochTest {
                     0L, scalar.getPerformanceEpochTicks());
             assertTrue("native CGB x1 ROM/WRAM loop had no coarse coverage",
                     candidate.getPerformanceEpochTicks() > 10_000);
-            assertEquals("native CGB x1 used a non-raster epoch plan",
+            assertTrue("native CGB x1 ROM/WRAM loop had no mode-2 epoch coverage",
+                    candidate.getPerformanceEpochMode2BulkTicks() > 0);
+            assertEquals("native CGB x1 epoch plan accounting",
                     candidate.getPerformanceEpochTicks(),
-                    candidate.getPerformanceEpochRasterFastTicks());
+                    candidate.getPerformanceEpochRasterFastTicks()
+                            + candidate.getPerformanceEpochMode2BulkTicks());
             assertFalse(candidate.getSpeedMode().isDmgCompat());
             assertEquals(1, candidate.getSpeedMode().getSpeedMode());
             assertEquals(scalar.getAddressSpace().getByte(0xc000),
@@ -347,9 +350,12 @@ public final class GameboyPerformanceEpochTest {
                     0L, scalar.getPerformanceEpochTicks());
             assertTrue("native CGB external-clock wait had no coarse coverage",
                     candidate.getPerformanceEpochTicks() > 10_000);
-            assertEquals("native CGB external-clock wait used a non-raster epoch plan",
+            assertTrue("native CGB external-clock wait had no mode-2 epoch coverage",
+                    candidate.getPerformanceEpochMode2BulkTicks() > 0);
+            assertEquals("native CGB external-clock wait epoch plan accounting",
                     candidate.getPerformanceEpochTicks(),
-                    candidate.getPerformanceEpochRasterFastTicks());
+                    candidate.getPerformanceEpochRasterFastTicks()
+                            + candidate.getPerformanceEpochMode2BulkTicks());
             assertEquals(scalar.getAddressSpace().getByte(0xc000),
                     candidate.getAddressSpace().getByte(0xc000));
             assertDeepStateEquals("native CGB external-clock wait",

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -740,6 +740,33 @@ public final class GameboyPerformanceEpochTest {
             assertDeepStateEquals("native CGB x1 settled HALT",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
+
+            // A quiet-raster settled-HALT packet does not prove the native-x1 mode-2 lane.
+            // Place both machines at a visible OAM-search fixed point, then run exactly to the
+            // scalar dot-79 handoff.  Before this optimization, the scheduler could cover this
+            // interval only with one-to-three-dot phase packets, so bulkMaxTicks stayed <= 3.
+            advanceScalarPairToVisibleMode2Dot(scalar, candidate, 20);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("native CGB x1 mode-2 settled-HALT frame callback",
+                    scalar.runTicks(59), candidate.runTicks(59));
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
+            assertEquals(79, candidate.getGpu().getTicksInLine());
+            assertEquals("mode-2 settled HALT unexpectedly used a running-CPU epoch",
+                    0L, candidate.getPerformanceEpochTicks());
+            assertTrue("native CGB x1 mode-2 settled HALT had no long packet",
+                    candidate.getPerformanceBulkMaxTicks() > 3);
+            assertDeepStateEquals("native CGB x1 mode-2 settled HALT at dot 79",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("native CGB x1 scalar dot-80 handoff frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
+            assertDeepStateEquals("native CGB x1 scalar dot-80 handoff",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -49,6 +49,41 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void nativeDoubleSpeedNr50WritesAcrossSamplesMatchScalarHostAudio()
+            throws Exception {
+        byte[] image = nativeDoubleSpeedNr50Loop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            // The speed-switch preamble is about 130k master ticks. The alternating NR50
+            // loop then writes every 20 double-speed master ticks, walking every phase of the
+            // 55-dot compact-output cadence and repeatedly terminating unfenced epochs.
+            for (int chunk = 0; chunk < 60; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("native CGB x2 NR50 frame callbacks", scalarFrames, candidateFrames);
+            assertEquals(2, scalar.getSpeedMode().getSpeedMode());
+            assertEquals(2, candidate.getSpeedMode().getSpeedMode());
+            assertEquals("custom-source oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native CGB x2 NR50 loop had no coarse epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertTrue("NR50 writes did not terminate an unfenced native CGB x2 epoch",
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses() > 0);
+            // This includes SoundState.buffer/i/performanceSamplePhase, so a sample captured
+            // before replaying its preceding NR50 write is observable even when CPU/PPU agree.
+            assertDeepStateEquals("native CGB x2 NR50/sample ordering",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
     public void stopAwarePreconditioningNeverUsesEpochLane() throws Exception {
         try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(doubleSpeedLoop()))
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
@@ -1210,6 +1245,56 @@ public final class GameboyPerformanceEpochTest {
         image[0x106] = (byte) 0xc3; // JP 0106
         image[0x107] = 0x06;
         image[0x108] = 0x01;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] nativeDoubleSpeedNr50Loop() {
+        byte[] image = new byte[0x8000];
+        int pc = 0x100;
+        image[pc++] = 0x3e; // LD A,1
+        image[pc++] = 0x01;
+        image[pc++] = (byte) 0xe0; // LDH (FF4D),A
+        image[pc++] = 0x4d;
+        image[pc++] = 0x10; // STOP + padding: enter native CGB double speed
+        image[pc++] = 0x00;
+
+        image[pc++] = 0x3e; // LD A,80
+        image[pc++] = (byte) 0x80;
+        image[pc++] = (byte) 0xe0; // LDH (FF26),A: APU on
+        image[pc++] = 0x26;
+        image[pc++] = 0x3e; // LD A,11
+        image[pc++] = 0x11;
+        image[pc++] = (byte) 0xe0; // LDH (FF25),A: route CH1 to both outputs
+        image[pc++] = 0x25;
+        image[pc++] = 0x3e; // LD A,80
+        image[pc++] = (byte) 0x80;
+        image[pc++] = (byte) 0xe0; // LDH (FF11),A: 50% duty
+        image[pc++] = 0x11;
+        image[pc++] = 0x3e; // LD A,F0
+        image[pc++] = (byte) 0xf0;
+        image[pc++] = (byte) 0xe0; // LDH (FF12),A: CH1 DAC/envelope
+        image[pc++] = 0x12;
+        image[pc++] = 0x3e; // LD A,FF
+        image[pc++] = (byte) 0xff;
+        image[pc++] = (byte) 0xe0; // LDH (FF13),A
+        image[pc++] = 0x13;
+        image[pc++] = 0x3e; // LD A,87
+        image[pc++] = (byte) 0x87;
+        image[pc++] = (byte) 0xe0; // LDH (FF14),A: trigger CH1
+        image[pc++] = 0x14;
+
+        int loop = pc;
+        image[pc++] = 0x3e; // LD A,77
+        image[pc++] = 0x77;
+        image[pc++] = (byte) 0xe0; // LDH (FF24),A: maximum output volume
+        image[pc++] = 0x24;
+        image[pc++] = (byte) 0xee; // XOR 77 => 00
+        image[pc++] = 0x77;
+        image[pc++] = (byte) 0xe0; // LDH (FF24),A: minimum output volume
+        image[pc++] = 0x24;
+        image[pc++] = 0x18; // JR loop
+        image[pc++] = (byte) (loop - pc);
         image[0x143] = (byte) 0x80;
         return image;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceMode2PhaseTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/** Differential coverage for the short normal-speed mode-2 phase packet. */
+/** Differential coverage for the normal-speed mode-2 PERFORMANCE packets. */
 public final class GameboyPerformanceMode2PhaseTest {
 
     /** Deliberately non-identity source: PERFORMANCE's input horizon must reject this leg. */
@@ -65,6 +65,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             HardwareProfile[] profiles, boolean nativeColor) throws Exception {
         for (HardwareProfile profile : profiles) {
             for (boolean tallSprites : new boolean[] {false, true}) {
+                boolean sawNativeMode2Epoch = false;
                 for (int start : new int[] {0, 1, 2, 3, 13, 20, 76, 77, 78}) {
                     int[] spans = {1, 2, 3};
                     for (int requested : spans) {
@@ -102,15 +103,17 @@ public final class GameboyPerformanceMode2PhaseTest {
                             }
                             assertEquals("candidate frame callback",
                                     0, candidate.runTicks(requested));
+                            long committedMode2Ticks = performanceMode2CommittedTicks(candidate);
+                            sawNativeMode2Epoch |= candidate.getPerformanceEpochMode2BulkTicks() > 0;
                             if (start >= 13 && requested <= cpuPhaseLimit) {
                                 assertTrue("mode-2 packet was not selected (" + caseDetails
-                                                + ", bulkTicks="
-                                                + candidate.getPerformanceBulkTicks() + ")",
-                                        candidate.getPerformanceBulkTicks() > 0);
+                                                + ", committedTicks="
+                                                + committedMode2Ticks + ")",
+                                        committedMode2Ticks > 0);
                             } else if (start <= 3) {
                                 assertEquals("early mode-2 STAT checkpoint took a bulk packet ("
                                                 + caseDetails + ")", 0,
-                                        candidate.getPerformanceBulkTicks());
+                                        committedMode2Ticks);
                             }
                             assertDeepStateEquals("profile=" + profile.id()
                                             + " native=" + nativeColor + " tall="
@@ -120,6 +123,11 @@ public final class GameboyPerformanceMode2PhaseTest {
                                     candidate.captureStateWithoutTimeSource());
                         }
                     }
+                }
+                if (nativeColor) {
+                    assertTrue("native CGB x1 did not enter a mode-2 CPU epoch tall="
+                                    + tallSprites,
+                            sawNativeMode2Epoch);
                 }
             }
         }
@@ -172,7 +180,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(0, candidate.runTicks(3));
             assertEquals(79, candidate.getGpu().getTicksInLine());
             assertEquals(Mode.OamSearch, candidate.getGpu().getMode());
-            long packetTicks = candidate.getPerformanceBulkTicks();
+            long packetTicks = performanceMode2CommittedTicks(candidate);
             assertTrue("mode-2 prefix was not bulk committed", packetTicks > 0);
 
             scalar.tick();
@@ -180,7 +188,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             assertEquals(80, candidate.getGpu().getTicksInLine());
             assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
             assertEquals("mode-3 handoff entered the mode-2 packet", packetTicks,
-                    candidate.getPerformanceBulkTicks());
+                    performanceMode2CommittedTicks(candidate));
             if (profile == HardwareProfileRegistry.CGB) {
                 assertEquals("CGB handoff compatibility identity", !nativeColor,
                         candidate.getGpu().isDmgCompatMode());
@@ -243,7 +251,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             }
             assertEquals(0, candidate.runTicks(3));
             assertEquals("active OAM DMA entered a mode-2 packet", 0,
-                    candidate.getPerformanceBulkTicks());
+                    performanceMode2CommittedTicks(candidate));
             assertDeepStateEquals(profile.id() + " native=" + nativeColor
                             + " active OAM DMA",
                     scalar.captureStateWithoutTimeSource(),
@@ -296,7 +304,7 @@ public final class GameboyPerformanceMode2PhaseTest {
                 candidate.runTicks(1);
             }
             assertEquals("restore drain entered a mode-2 packet", 0,
-                    candidate.getPerformanceBulkTicks());
+                    performanceMode2CommittedTicks(candidate));
             assertDeepStateEquals(profile.id() + " native=" + nativeColor
                             + " restore mode-2 drain",
                     scalar.captureStateWithoutTimeSource(),
@@ -336,7 +344,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             }
             assertEquals(0, candidate.runTicks(3));
             assertEquals("active HDMA entered a mode-2 packet", 0,
-                    candidate.getPerformanceBulkTicks());
+                    performanceMode2CommittedTicks(candidate));
             assertDeepStateEquals("CGB native=" + nativeColor + " active HDMA",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
@@ -364,7 +372,7 @@ public final class GameboyPerformanceMode2PhaseTest {
             }
             assertEquals(0, candidate.runTicks(tail));
             assertTrue("completed GDMA tail did not enter a mode-2 packet",
-                    candidate.getPerformanceBulkTicks() > 0);
+                    performanceMode2CommittedTicks(candidate) > 0);
             assertDeepStateEquals("CGB native=" + nativeColor
                             + " completed-GDMA request clock",
                     scalar.captureStateWithoutTimeSource(),
@@ -416,7 +424,7 @@ public final class GameboyPerformanceMode2PhaseTest {
     }
 
     @Test
-    public void nativeCgbNormalSpeedLineZeroMode2UsesOnlyThePhasePacket() throws Exception {
+    public void nativeCgbNormalSpeedLineZeroMode2UsesTheFencedCpuEpoch() throws Exception {
         PlayerInputHub candidateHub = new PlayerInputHub();
         try (PlayerInputHub.SourceHandle ignored = candidateHub.openSource(0);
              Gameboy scalar = session(HardwareProfileRegistry.CGB, SCALAR_INPUT,
@@ -435,10 +443,12 @@ public final class GameboyPerformanceMode2PhaseTest {
                 scalar.tick();
             }
             assertEquals(0, candidate.runTicks(3));
-            assertTrue("native CGB x1 line-0 mode 2 did not enter a phase packet",
-                    candidate.getPerformanceBulkTicks() > 0);
-            assertEquals("native CGB x1 mode 2 entered a CPU epoch", 0L,
-                    candidate.getPerformanceEpochTicks());
+            assertEquals("native CGB x1 line-0 mode 2 used the phase-only packet", 0L,
+                    candidate.getPerformanceBulkTicks());
+            assertTrue("native CGB x1 line-0 mode 2 did not enter a CPU epoch",
+                    candidate.getPerformanceEpochMode2BulkTicks() > 0);
+            assertEquals("native CGB x1 line-0 mode 2 used the raster epoch plan", 0L,
+                    candidate.getPerformanceEpochRasterFastTicks());
             assertDeepStateEquals("native CGB x1 line-0 mode 2",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
@@ -537,6 +547,11 @@ public final class GameboyPerformanceMode2PhaseTest {
         return profile == HardwareProfileRegistry.CGB
                 ? gameboy.getGpu().performanceCgbNormalSpeedMode2PhaseSpanLimit(requested)
                 : gameboy.getGpu().performancePhysicalDmgMode2PhaseSpanLimit(requested);
+    }
+
+    private static long performanceMode2CommittedTicks(Gameboy gameboy) {
+        return gameboy.getPerformanceBulkTicks()
+                + gameboy.getPerformanceEpochMode2BulkTicks();
     }
 
     @Test

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPlayerInputHubPerformanceTest.java
@@ -61,6 +61,10 @@ public final class GameboyPlayerInputHubPerformanceTest {
                                         + ", chunk=" + chunkIndex + " "
                                         + componentHashes(scalarState, performanceState),
                                 stateHash(scalarState), stateHash(performanceState));
+                        assertEquals("host audio cgb=" + cgb + ", held=" + held
+                                        + ", chunk=" + chunkIndex,
+                                soundHostOutputHash(scalarState),
+                                soundHostOutputHash(performanceState));
                         assertRasterEquivalent(scalar, performance,
                                 "cgb=" + cgb + ", held=" + held + ", chunk=" + chunkIndex);
                     }
@@ -158,6 +162,9 @@ public final class GameboyPlayerInputHubPerformanceTest {
                 assertEquals("HALT differential cgb=" + cgb + " "
                                 + componentHashes(scalar.captureState(), performance.captureState()),
                         stateHash(scalar.captureState()), stateHash(performance.captureState()));
+                assertEquals("HALT host audio cgb=" + cgb,
+                        soundHostOutputHash(scalar.captureState()),
+                        soundHostOutputHash(performance.captureState()));
                 assertRasterEquivalent(scalar, performance, "HALT cgb=" + cgb);
                 assertTrue("stable HALT had no substantial bulk coverage cgb=" + cgb
                                 + " ticks=" + performance.getPerformanceBulkTicks(),
@@ -166,6 +173,10 @@ public final class GameboyPlayerInputHubPerformanceTest {
                                 + " settled HALT never crossed a machine-cycle boundary"
                                 + " maxSpan=" + performance.getPerformanceBulkMaxTicks(),
                         performance.getPerformanceBulkMaxTicks() > 3);
+                if (cgb) {
+                    assertTrue("CGB settled HALT never crossed a compact sample boundary",
+                            performance.getPerformanceBulkMaxTicks() > 54);
+                }
             }
         }
     }
@@ -867,6 +878,17 @@ public final class GameboyPlayerInputHubPerformanceTest {
     private static long joypadTick(Gameboy gameboy) {
         Object memento = recordComponentValue(gameboy.captureState(), "joypadMemento");
         return ((Number) recordComponentValue(memento, "tick")).longValue();
+    }
+
+    /** Exact host-audio prefix omitted from the canonical machine-state differential above. */
+    private static int soundHostOutputHash(ComponentState<Gameboy> gameboyState) {
+        Object soundState = recordComponentValue(gameboyState, "soundMemento");
+        int hash = stateHash(recordComponentValue(soundState, "buffer"));
+        hash = 31 * hash + stateHash(recordComponentValue(soundState, "i"));
+        hash = 31 * hash + stateHash(recordComponentValue(
+                soundState, "performanceSamplePhase"));
+        hash = 31 * hash + stateHash(recordComponentValue(soundState, "audioDecimation"));
+        return hash;
     }
 
     private enum WakeSource {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferIdleOutputCacheTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/phase/PixelTransferIdleOutputCacheTest.java
@@ -1,0 +1,232 @@
+package eu.rekawek.coffeegb.core.gpu.phase;
+
+import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.gpu.ColorPalette;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.gpu.DmgPixelFifo;
+import eu.rekawek.coffeegb.core.gpu.GpuRegister;
+import eu.rekawek.coffeegb.core.gpu.GpuRegisterValues;
+import eu.rekawek.coffeegb.core.gpu.Lcdc;
+import eu.rekawek.coffeegb.core.gpu.phase.OamSearch.SpritePosition;
+import eu.rekawek.coffeegb.core.memory.Ram;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Focused lifetime tests for PixelTransfer's transient successful idle-output proof. */
+public class PixelTransferIdleOutputCacheTest {
+
+    private static final Field IDLE_CACHE = field("performanceIdleOutputKnownTrue");
+
+    @Test
+    public void startTickAndSpecializedEnqueuePathsInvalidateTheProof() {
+        PixelTransfer visible = create(true, false);
+        assertIdleAndCached(visible);
+
+        visible.start();
+        assertCache(false, visible);
+        assertFalse(visible.isPerformanceNativeCgbMode2IdleOutput());
+
+        PixelTransfer timing = create(true, true);
+        assertIdleAndCached(timing);
+        timing.start();
+        assertCache(false, timing);
+        // machineActive is intentionally ignored by the timing skeleton's mode-2 proof.
+        assertIdleAndCached(timing);
+
+        timing.tick();
+        assertCache(false, timing);
+        assertIdleAndCached(timing);
+
+        timing.advanceSteadyBackgroundSpan(12);
+        assertCache(false, timing);
+        assertFalse("the specialized path enqueued an output-delay entry",
+                timing.isPerformanceNativeCgbMode2IdleOutput());
+
+        PixelTransfer output = create(true, false);
+        output.start();
+        output.finishPerformanceLine();
+        assertIdleAndCached(output);
+        output.advanceSteadyBackgroundOutputSpan(12);
+        assertCache(false, output);
+        assertFalse("the specialized output path enqueued an output-delay entry",
+                output.isPerformanceNativeCgbMode2IdleOutput());
+    }
+
+    @Test
+    public void everyDelayedWindowWriteInvalidatesAndRecovers() {
+        PixelTransfer transfer = create(true, false);
+        assertIdleAndCached(transfer);
+
+        transfer.scheduleWindowDisplayWrite(false, 2);
+        assertCache(false, transfer);
+        assertFalse(transfer.isPerformanceNativeCgbMode2IdleOutput());
+        transfer.cancelDelayedWindowDisplayWrite();
+        assertIdleAndCached(transfer);
+
+        transfer.scheduleWindowXWrite(17, 2);
+        assertCache(false, transfer);
+        assertFalse(transfer.isPerformanceNativeCgbMode2IdleOutput());
+        transfer.cancelDelayedWindowXWrite();
+        assertIdleAndCached(transfer);
+
+        transfer.scheduleWindowYWrite(23, 2);
+        assertCache(false, transfer);
+        assertFalse(transfer.isPerformanceNativeCgbMode2IdleOutput());
+        for (int i = 0; i < 3; i++) {
+            transfer.advanceWindowYDelay();
+        }
+        assertIdleAndCached(transfer);
+    }
+
+    @Test
+    public void fifoRuntimeRestoreAndRepresentationRebindInvalidateTheProof() {
+        PixelTransfer idleFull = create(false, false);
+        DmgPixelFifo.RuntimeState idleFifo = idleFull.captureDmgFifoRuntimeState();
+
+        PixelTransfer queuedFull = create(false, false);
+        queuedFull.start();
+        queuedFull.finishPerformanceLine();
+        queuedFull.advanceSteadyBackgroundOutputSpan(12);
+        assertFalse(queuedFull.isPerformanceDmgIdleOutput());
+        DmgPixelFifo.RuntimeState queuedFifo = queuedFull.captureDmgFifoRuntimeState();
+
+        PixelTransfer target = create(false, false);
+        assertIdleAndCached(target);
+        target.restoreDmgFifoRuntimeState(queuedFifo);
+        assertCache(false, target);
+        assertFalse(target.isPerformanceDmgIdleOutput());
+        target.restoreDmgFifoRuntimeState(idleFifo);
+        assertCache(false, target);
+        assertIdleAndCached(target);
+
+        ComponentState<PixelTransfer> fullState = create(false, false).captureState();
+        ComponentState<PixelTransfer> scalarState = create(false, true).captureState();
+        PixelTransfer skeleton = create(false, true);
+        assertIdleAndCached(skeleton);
+
+        skeleton.restoreState(fullState);
+        assertCache(false, skeleton);
+        assertFalse(skeleton.usesScalarTimingFifo());
+        assertIdleAndCached(skeleton);
+
+        skeleton.restoreState(scalarState);
+        assertCache(false, skeleton);
+        assertTrue(skeleton.usesScalarTimingFifo());
+        assertIdleAndCached(skeleton);
+    }
+
+    @Test
+    public void portableRestoreDropsRatherThanSerializesTheTransientProof() {
+        PixelTransfer source = create(true, false);
+        assertIdleAndCached(source);
+        ComponentState<PixelTransfer> portable = source.captureState();
+        for (RecordComponent component : portable.getClass().getRecordComponents()) {
+            assertFalse("cache must not enter portable state",
+                    component.getName().equals("performanceIdleOutputKnownTrue"));
+        }
+
+        PixelTransfer target = create(true, false);
+        assertIdleAndCached(target);
+        target.restoreState(portable);
+        assertCache(false, target);
+        assertIdleAndCached(target);
+    }
+
+    @Test
+    public void emptyOutputTicksAndTrustedIdleSpansRetainTheProof() {
+        PixelTransfer cgb = create(true, false);
+        assertIdleAndCached(cgb);
+        cgb.outputTick();
+        assertCache(true, cgb);
+        cgb.advancePerformanceNativeCgbMode2IdleOutputSpanTrusted(37);
+        assertCache(true, cgb);
+        assertTrue(cgb.isPerformanceNativeCgbMode2IdleOutput());
+        assertEquals(38, outputTicks(cgb));
+
+        PixelTransfer dmg = create(false, false);
+        assertIdleAndCached(dmg);
+        dmg.outputTick();
+        assertCache(true, dmg);
+        dmg.advancePerformanceDmgIdleOutputSpanTrusted(41);
+        assertCache(true, dmg);
+        assertTrue(dmg.isPerformanceDmgIdleOutput());
+        assertEquals(42, outputTicks(dmg));
+    }
+
+    private static PixelTransfer create(boolean gbc, boolean timingSkeleton) {
+        SpeedMode speedMode = new SpeedMode(gbc);
+        GpuRegisterValues registers = new GpuRegisterValues();
+        registers.setGbc(gbc);
+        registers.setSpeedMode(speedMode);
+        registers.put(GpuRegister.LY, 0);
+        Lcdc lcdc = new Lcdc();
+        lcdc.setGbc(gbc);
+        lcdc.set(0x91);
+        SpritePosition[] sprites = new SpritePosition[10];
+        for (int i = 0; i < sprites.length; i++) {
+            sprites[i] = new SpritePosition();
+        }
+        AddressSpace oam = new Ram(0xfe00, 0xa0);
+        return new PixelTransfer(
+                new Display(gbc),
+                new Ram(0x8000, 0x2000),
+                gbc ? new Ram(0x8000, 0x2000) : null,
+                oam,
+                lcdc,
+                registers,
+                gbc,
+                new ColorPalette(0xff68),
+                new ColorPalette(0xff6a),
+                sprites,
+                null,
+                speedMode,
+                0,
+                timingSkeleton);
+    }
+
+    private static void assertIdleAndCached(PixelTransfer transfer) {
+        boolean idle = transfer.isPerformanceDmgIdleOutput();
+        if (!idle) {
+            idle = transfer.isPerformanceNativeCgbMode2IdleOutput();
+        }
+        assertTrue(idle);
+        assertCache(true, transfer);
+    }
+
+    private static void assertCache(boolean expected, PixelTransfer transfer) {
+        try {
+            assertEquals(expected, IDLE_CACHE.getBoolean(transfer));
+        } catch (IllegalAccessException failure) {
+            throw new AssertionError("Could not inspect idle-output cache", failure);
+        }
+    }
+
+    private static long outputTicks(PixelTransfer transfer) {
+        try {
+            Object fifo = field("fifo").get(transfer);
+            Field outputTicks = fifo.getClass().getDeclaredField("outputTicks");
+            outputTicks.setAccessible(true);
+            return outputTicks.getLong(fifo);
+        } catch (ReflectiveOperationException failure) {
+            throw new AssertionError("Could not inspect FIFO output clock", failure);
+        }
+    }
+
+    private static Field field(String name) {
+        try {
+            Field field = PixelTransfer.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException failure) {
+            throw new ExceptionInInitializerError(failure);
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceAudioTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceAudioTest.java
@@ -68,6 +68,26 @@ public class SoundPerformanceAudioTest {
     }
 
     @Test
+    public void canonicalSpanStopsBeforeSynchronousHostCallback() {
+        ClockSpec sourceClock = new ClockSpec(550, 1, 1);
+        Sound sound = newSound(sourceClock);
+        EventBusImpl eventBus = new EventBusImpl(null, null, false);
+        List<Sound.SoundSampleEvent> events = new ArrayList<>();
+        eventBus.register(events::add, Sound.SoundSampleEvent.class);
+        sound.init(eventBus);
+
+        // Ten compact samples fill this host buffer. The first 549 ticks may be one exact span,
+        // while the callback-producing 550th tick remains owned by the scalar scheduler.
+        assertEquals(549, sound.performanceQuietSpanLimit(1_000));
+        sound.tickPerformanceQuietSpan(549);
+        assertEquals(0, events.size());
+        assertEquals(0, sound.performanceQuietSpanLimit(1));
+        sound.tick(false);
+        assertEquals(1, events.size());
+        assertEquals(20, events.get(0).buffer().length);
+    }
+
+    @Test
     public void sgbPerformanceSourcesEmit1254SamplesPerExactFrame() {
         for (ClockSpec sourceClock : new ClockSpec[]{ClockSpec.SGB, ClockSpec.SGB2}) {
             Sound sound = newSound(sourceClock);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceSpanTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sound/SoundPerformanceSpanTest.java
@@ -62,6 +62,61 @@ public final class SoundPerformanceSpanTest {
     }
 
     @Test
+    public void multiSampleSpansMatchScalarChannelStateAndCompactPcm() throws Exception {
+        int[] warmups = {0, 1, 17, 54};
+        int[] spans = {55, 56, 109, 110, 111, 257, 456};
+        for (boolean gbc : new boolean[]{false, true}) {
+            for (int warmup : warmups) {
+                for (int span : spans) {
+                    Sound scalar = configured(gbc);
+                    Sound bulk = configured(gbc);
+                    for (int tick = 0; tick < warmup; tick++) {
+                        scalar.tick(false);
+                        bulk.tick(false);
+                    }
+                    assertEquals("admission gbc=" + gbc + " warmup=" + warmup
+                                    + " span=" + span,
+                            span, bulk.performanceQuietSpanLimit(span));
+                    for (int tick = 0; tick < span; tick++) {
+                        scalar.tick(false);
+                    }
+                    bulk.tickPerformanceQuietSpan(span);
+                    // Unlike canonicalSoundDigest(), this includes the compact PCM prefix,
+                    // buffer index, and sample phase as well as every emulated APU field.
+                    assertEquals("gbc=" + gbc + " warmup=" + warmup + " span=" + span,
+                            digest(scalar.captureState()), digest(bulk.captureState()));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void sgb56TickCadenceMultiSampleSpansMatchScalarStateAndPcm() throws Exception {
+        int[] warmups = {0, 1, 18, 55};
+        int[] spans = {56, 57, 111, 112, 257, 456};
+        for (int warmup : warmups) {
+            for (int span : spans) {
+                Sound scalar = configured(false, ClockSpec.SGB);
+                Sound bulk = configured(false, ClockSpec.SGB);
+                for (int tick = 0; tick < warmup; tick++) {
+                    scalar.tick(false);
+                    bulk.tick(false);
+                }
+                assertEquals("SGB admission warmup=" + warmup + " span=" + span,
+                        span, bulk.performanceQuietSpanLimit(span));
+                for (int tick = 0; tick < span; tick++) {
+                    scalar.tick(false);
+                }
+                bulk.tickPerformanceQuietSpan(span);
+                // Full SoundState digest includes the compact stereo prefix, write index,
+                // 56-dot phase, and all channel state.
+                assertEquals("SGB warmup=" + warmup + " span=" + span,
+                        digest(scalar.captureState()), digest(bulk.captureState()));
+            }
+        }
+    }
+
+    @Test
     public void unsupportedBoundaryFallsBackToScalarOutputCadence() throws Exception {
         Sound scalar = configured(true);
         Sound bulk = configured(true);
@@ -419,10 +474,13 @@ public final class SoundPerformanceSpanTest {
     }
 
     private static Sound configured(boolean gbc) {
+        return configured(gbc, new ClockSpec(1_100_000, 1, 100, 1));
+    }
+
+    private static Sound configured(boolean gbc, ClockSpec clockSpec) {
         SpeedMode speedMode = new SpeedMode(gbc);
         Timer timer = new Timer(new InterruptManager(gbc), speedMode);
-        Sound sound = new Sound(timer, speedMode, gbc,
-                new ClockSpec(1_100_000, 1, 100, 1), ExecutionMode.PERFORMANCE);
+        Sound sound = new Sound(timer, speedMode, gbc, clockSpec, ExecutionMode.PERFORMANCE);
         sound.setByte(0xff26, 0x80);
         sound.setByte(0xff24, 0x77);
         sound.setByte(0xff25, 0xff);


### PR DESCRIPTION
## Summary

- batch native CGB x1 CPU, raster, mode-2, halted, audio, and LCD-off work using the existing exact performance machinery
- warm and baseline-profile the production scheduler, and cache the derived idle pixel-output proof
- add Android performance-hint integration with profile-specific budgets
- avoid redundant hidden-menu redraws that could resubmit a retained frame

## Device result

On the same Android device and native-CGB x1 workload, ready throughput improved from 32.57 FPS to 59.64 FPS (+83.13%). Controller CPU time fell from 18,324 ms to 7,167 ms (-60.89%). The final 600-frame run had zero dropped, duplicate, late, or corrupt frames, with canonical audio active.

Exact CGB cadence is 59.72750057 FPS; the final result is 99.86% of that cadence. The remaining finite-window variation is pacing-bound rather than core-throughput-bound.

## Correctness and validation

- exact 20M-tick scalar/performance deep-state, frame, pixel, and PCM parity
- core unit suite: 2,123 tests, 0 failures/errors, 8 skipped
- controller suite: 946 tests, 0 failures/errors, 2 skipped
- Mooneye: 130/130
- dmg-acid2 and cgb-acid2: 1/1 each
- Blargg aggregate and individual: 54/54
- Android benchmark unit suite: 220/220
- Android benchmark assembly and lint passed

No benchmark harness or ROM-specific production behavior is added.