### PR TITLE
Fix Android bootstrap and startup presentation

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FastForwardBootstrapAndroidTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FastForwardBootstrapAndroidTest.java
@@ -1,0 +1,143 @@
+package eu.rekawek.coffeegb.android;
+
+import android.net.Uri;
+import android.os.SystemClock;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import eu.rekawek.coffeegb.controller.Controller;
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfile;
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/** Device-level coverage for the release UI's fast-forward bootstrap path. */
+@RunWith(AndroidJUnit4.class)
+public class FastForwardBootstrapAndroidTest {
+
+    private static final long TIMEOUT_MILLIS = 180_000L;
+
+    @Test
+    public void fastForwardReachesCartridgeForDmgCgbAndSgbGames() throws Exception {
+        assertFastForwardStarts("dmg", null, FixtureRomProvider.URI,
+                HardwareProfileRegistry.DMG);
+        assertFastForwardStarts(null, "cgb", FixtureRomProvider.SECOND_URI,
+                HardwareProfileRegistry.CGB);
+        assertFastForwardStarts("sgb", null, FixtureRomProvider.SGB_URI,
+                HardwareProfileRegistry.SGB);
+    }
+
+    private static void assertFastForwardStarts(
+            String dmgProfile,
+            String cgbProfile,
+            Uri uri,
+            HardwareProfile expectedProfile) throws Exception {
+        try (AndroidEmulationRuntime runtime = new AndroidEmulationRuntime(
+                InstrumentationRegistry.getInstrumentation().getTargetContext())) {
+            awaitStopped(runtime);
+            if (dmgProfile != null) {
+                runtime.setSystemSelection("dmg-games", dmgProfile);
+            }
+            if (cgbProfile != null) {
+                runtime.setSystemSelection("cgb-games", cgbProfile);
+            }
+            runtime.setSystemSelection("bootstrap", "fast-forward");
+
+            EventBus events = runtimeEvents(runtime);
+            LinkedBlockingQueue<Controller.HardwareProfileEvent> profiles =
+                    new LinkedBlockingQueue<>();
+            AtomicReference<Boolean> bootstrapReadyAtProfile = new AtomicReference<>();
+            AtomicReference<Controller.LoadRomFailedEvent> failure = new AtomicReference<>();
+            events.register(event -> {
+                bootstrapReadyAtProfile.set(runtimeGameboy(runtime).isBootstrapReady());
+                profiles.add(event);
+            }, Controller.HardwareProfileEvent.class);
+            events.register(failure::set, Controller.LoadRomFailedEvent.class);
+
+            runtime.openRom(uri, 0);
+            long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+            while (SystemClock.elapsedRealtime() < deadline) {
+                if (runtime.state().phase() == RuntimeState.Phase.RUNNING) {
+                    Controller.HardwareProfileEvent profile = profiles.poll(
+                            5, TimeUnit.SECONDS);
+                    assertNotNull("hardware profile event", profile);
+                    assertEquals(expectedProfile, profile.getProfile());
+                    assertEquals("bootstrap readiness at hardware profile event", Boolean.TRUE,
+                            bootstrapReadyAtProfile.get());
+                    assertEquals(BootstrapMode.FAST_FORWARD,
+                            runtimeProperties(runtime).getSystem().getBootstrapMode());
+                    return;
+                }
+                if (runtime.state().phase() == RuntimeState.Phase.FAILED) {
+                    Controller.LoadRomFailedEvent loadFailure = failure.get();
+                    fail(loadFailure == null ? runtime.state().message()
+                            : loadFailure.getKind() + ": " + loadFailure.getTechnicalDetails());
+                }
+                Thread.sleep(50L);
+            }
+            fail("timed out waiting for fast-forward bootstrap: " + runtime.state().message());
+        }
+    }
+
+    private static void awaitStopped(AndroidEmulationRuntime runtime) throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (runtime.state().phase() != RuntimeState.Phase.STOPPED
+                && SystemClock.elapsedRealtime() < deadline) {
+            Thread.sleep(50L);
+        }
+        assertEquals(RuntimeState.Phase.STOPPED, runtime.state().phase());
+    }
+
+    private static EventBus runtimeEvents(AndroidEmulationRuntime runtime) throws Exception {
+        Field field = AndroidEmulationRuntime.class.getDeclaredField("eventBus");
+        field.setAccessible(true);
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            EventBus events = (EventBus) field.get(runtime);
+            if (events != null) {
+                return events;
+            }
+            Thread.sleep(50L);
+        }
+        fail("timed out waiting for the Android controller event bus");
+        return null;
+    }
+
+    private static Gameboy runtimeGameboy(AndroidEmulationRuntime runtime) {
+        try {
+            Field controllerField = AndroidEmulationRuntime.class.getDeclaredField("controller");
+            controllerField.setAccessible(true);
+            Object controller = controllerField.get(runtime);
+            assertNotNull("Android controller", controller);
+
+            Field sessionField = controller.getClass().getDeclaredField("session");
+            sessionField.setAccessible(true);
+            Object session = sessionField.get(controller);
+            assertNotNull("controller session", session);
+
+            Field gameboyField = session.getClass().getDeclaredField("gameboy");
+            gameboyField.setAccessible(true);
+            return (Gameboy) gameboyField.get(session);
+        } catch (ReflectiveOperationException failure) {
+            throw new AssertionError("could not inspect Android bootstrap readiness", failure);
+        }
+    }
+
+    private static eu.rekawek.coffeegb.controller.properties.EmulatorProperties runtimeProperties(
+            AndroidEmulationRuntime runtime) throws Exception {
+        Field field = AndroidEmulationRuntime.class.getDeclaredField("properties");
+        field.setAccessible(true);
+        return (eu.rekawek.coffeegb.controller.properties.EmulatorProperties) field.get(runtime);
+    }
+}

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -27,9 +27,21 @@ public final class FixtureRomProvider extends ContentProvider {
     static final Uri URI = Uri.parse("content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke.gb");
     static final Uri SECOND_URI = Uri.parse(
             "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-cgb.gbc");
+    static final Uri SGB_URI = Uri.parse(
+            "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-sgb.gb");
     private static final String DISPLAY_NAME = "coffee-gb-ci-smoke.gb";
     private static final String SECOND_DISPLAY_NAME = "coffee-gb-ci-smoke-cgb.gbc";
+    private static final String SGB_DISPLAY_NAME = "coffee-gb-ci-smoke-sgb.gb";
     private static final int ROM_SIZE = 0x8000;
+    private static final byte[] NINTENDO_LOGO = {
+            (byte) 0xce, (byte) 0xed, 0x66, 0x66, (byte) 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, (byte) 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, (byte) 0x88, (byte) 0x89, 0x00, 0x0e,
+            (byte) 0xdc, (byte) 0xcc, 0x6e, (byte) 0xe6, (byte) 0xdd, (byte) 0xdd,
+            (byte) 0xd9, (byte) 0x99, (byte) 0xbb, (byte) 0xbb, 0x67, 0x63,
+            0x6e, 0x0e, (byte) 0xec, (byte) 0xcc, (byte) 0xdd, (byte) 0xdc,
+            (byte) 0x99, (byte) 0x9f, (byte) 0xbb, (byte) 0xb9, 0x33, 0x3e,
+    };
 
     @Override
     public boolean onCreate() {
@@ -64,12 +76,11 @@ public final class FixtureRomProvider extends ContentProvider {
                 throw new FileNotFoundException("The CI fixture provider is not initialized");
             }
             File fixture = new File(context.getCacheDir(), displayName(uri));
-            if (!fixture.isFile() || fixture.length() != ROM_SIZE) {
-                try (FileOutputStream output = new FileOutputStream(fixture)) {
-                    output.write(fixtureBytes(
-                            uri.equals(SECOND_URI) ? "CI SMOKE CGB" : "CI SMOKE",
-                            uri.equals(SECOND_URI)));
-                }
+            try (FileOutputStream output = new FileOutputStream(fixture)) {
+                output.write(fixtureBytes(
+                        uri.equals(SECOND_URI) ? "CI SMOKE CGB"
+                                : uri.equals(SGB_URI) ? "CI SMOKE SGB" : "CI SMOKE",
+                        uri.equals(SECOND_URI), uri.equals(SGB_URI)));
             }
             return ParcelFileDescriptor.open(fixture, ParcelFileDescriptor.MODE_READ_ONLY);
         } catch (IOException failure) {
@@ -93,24 +104,27 @@ public final class FixtureRomProvider extends ContentProvider {
     }
 
     private static void assertFixture(Uri uri) {
-        if (!URI.equals(uri) && !SECOND_URI.equals(uri)) {
+        if (!URI.equals(uri) && !SECOND_URI.equals(uri) && !SGB_URI.equals(uri)) {
             throw new IllegalArgumentException("Unknown CI fixture");
         }
     }
 
     private static String displayName(Uri uri) {
         assertFixture(uri);
-        return uri.equals(SECOND_URI) ? SECOND_DISPLAY_NAME : DISPLAY_NAME;
+        return uri.equals(SECOND_URI) ? SECOND_DISPLAY_NAME
+                : uri.equals(SGB_URI) ? SGB_DISPLAY_NAME : DISPLAY_NAME;
     }
 
-    private static byte[] fixtureBytes(String fixtureTitle, boolean cgb) {
+    private static byte[] fixtureBytes(String fixtureTitle, boolean cgb, boolean sgb) {
         byte[] rom = new byte[ROM_SIZE];
         rom[0x0100] = (byte) 0xc3; // JP 0x0150
         rom[0x0101] = 0x50;
         rom[0x0102] = 0x01;
+        System.arraycopy(NINTENDO_LOGO, 0, rom, 0x0104, NINTENDO_LOGO.length);
         byte[] title = fixtureTitle.getBytes(StandardCharsets.US_ASCII);
         System.arraycopy(title, 0, rom, 0x0134, title.length);
         rom[0x0143] = cgb ? (byte) 0x80 : 0x00;
+        rom[0x0146] = sgb ? (byte) 0x03 : 0x00;
         rom[0x0147] = 0x00; // ROM only
         rom[0x0148] = 0x00; // 32 KiB
         rom[0x0149] = 0x00; // no RAM

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -39,17 +39,24 @@ import static org.junit.Assert.assertTrue;
 public class MainActivitySmokeTest {
 
     @Test
-    public void launchesRecreatesAndBackgroundsWithoutStartingACameraOrGame() {
+    public void freshLaunchShowsLibraryAndRestoresItAfterRecreation() throws Exception {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            awaitRoute(scenario, MenuRoute.LIBRARY);
+            scenario.onActivity(activity -> assertEquals("Close Coffee GB menu",
+                    menuButton(activity).getContentDescription().toString()));
             scenario.moveToState(Lifecycle.State.CREATED);
             scenario.moveToState(Lifecycle.State.RESUMED);
+            awaitRoute(scenario, MenuRoute.LIBRARY);
             scenario.recreate();
+            awaitRoute(scenario, MenuRoute.LIBRARY);
         }
     }
 
     @Test
-    public void transparentMenuHitTargetHasNoFrameworkVisualsButRemainsAccessibleAndClickable() {
+    public void transparentMenuHitTargetHasNoFrameworkVisualsButRemainsAccessibleAndClickable()
+            throws Exception {
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            awaitRoute(scenario, MenuRoute.LIBRARY);
             scenario.onActivity(activity -> {
                 View menu = menuButton(activity);
                 assertTrue(menu.isClickable());
@@ -65,9 +72,46 @@ public class MainActivitySmokeTest {
                 assertFalse(menu.getDefaultFocusHighlightEnabled());
 
                 assertTrue(menu.performClick());
-                assertEquals("Close Coffee GB menu", menu.getContentDescription().toString());
+                assertEquals("Open Coffee GB menu", menu.getContentDescription().toString());
                 assertTrue(menu.performClick());
+                assertEquals("Close Coffee GB menu", menu.getContentDescription().toString());
             });
+        }
+    }
+
+    @Test
+    public void startingAndRecreatingAnActiveGameShowsTheGameInsteadOfLibrary()
+            throws Exception {
+        AtomicReference<AndroidEmulationRuntime> runtime = new AtomicReference<>();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            awaitRoute(scenario, MenuRoute.LIBRARY);
+            await("runtime binding", () -> {
+                scenario.onActivity(activity -> runtime.set(runtime(activity)));
+                return runtime.get() != null;
+            });
+            runtime.get().openRom(FixtureRomProvider.URI, 0);
+            await("fixture game presentation", () -> {
+                AtomicBoolean gameVisible = new AtomicBoolean();
+                scenario.onActivity(activity -> gameVisible.set(
+                        observedState(activity).phase() == RuntimeState.Phase.RUNNING
+                                && !menuController(activity).visible()));
+                return gameVisible.get();
+            });
+
+            scenario.recreate();
+            await("recreated fixture game presentation", () -> {
+                AtomicBoolean gameVisible = new AtomicBoolean();
+                scenario.onActivity(activity -> gameVisible.set(runtime(activity) != null
+                        && observedState(activity).transferReady()
+                        && !menuController(activity).visible()));
+                return gameVisible.get();
+            });
+        } finally {
+            if (runtime.get() != null) {
+                runtime.get().stop();
+                await("runtime cleanup", () -> runtime.get().state().phase()
+                        == RuntimeState.Phase.STOPPED);
+            }
         }
     }
 
@@ -165,13 +209,12 @@ public class MainActivitySmokeTest {
     }
 
     @Test
-    public void systemBackClosesRootMenuBeforeFinishingActivity() throws IOException {
+    public void systemBackClosesRootMenuBeforeFinishingActivity() throws Exception {
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
         try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            awaitRoute(scenario, MenuRoute.LIBRARY);
             scenario.onActivity(activity -> {
                 View menu = menuButton(activity);
-                assertEquals("Open Coffee GB menu", menu.getContentDescription().toString());
-                menu.performClick();
                 assertEquals("Close Coffee GB menu", menu.getContentDescription().toString());
             });
             assertEquals(Lifecycle.State.RESUMED, scenario.getState());

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/SgbBorderAndroidTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/SgbBorderAndroidTest.java
@@ -1,0 +1,95 @@
+package eu.rekawek.coffeegb.android;
+
+import android.os.SystemClock;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.core.sgb.SuperGameboy;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Device-level coverage for live SGB border presentation on Android. */
+@RunWith(AndroidJUnit4.class)
+public class SgbBorderAndroidTest {
+
+    private static final long TIMEOUT_MILLIS = 10_000L;
+
+    @Test
+    public void borderSettingChangesThePublishedSgbFrameGeometry() throws Exception {
+        try (AndroidEmulationRuntime runtime = new AndroidEmulationRuntime(
+                InstrumentationRegistry.getInstrumentation().getTargetContext())) {
+            runtime.setSystemSelection("dmg-games", "sgb");
+            runtime.setSystemSelection("bootstrap", "skip");
+            runtime.setSgbBorder(true);
+            runtime.openRom(FixtureRomProvider.SGB_URI, 0);
+
+            awaitPhase(runtime, RuntimeState.Phase.RUNNING);
+            awaitFrameSize(runtime, SuperGameboy.SGB_DISPLAY_WIDTH,
+                    SuperGameboy.SGB_DISPLAY_HEIGHT);
+
+            // Recreate the state that used to strand Android with an ON preference and an
+            // effectively disabled live display. Reapplying the same UI value must still reach
+            // the session rather than being mistaken for a no-op.
+            runtimeEvents(runtime).post(new SgbDisplay.SetSgbBorder(false));
+            awaitFrameSize(runtime, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+            runtime.setSgbBorder(true);
+            awaitFrameSize(runtime, SuperGameboy.SGB_DISPLAY_WIDTH,
+                    SuperGameboy.SGB_DISPLAY_HEIGHT);
+
+            runtime.setSgbBorder(false);
+            awaitFrameSize(runtime, Display.DISPLAY_WIDTH, Display.DISPLAY_HEIGHT);
+
+            runtime.setSgbBorder(true);
+            awaitFrameSize(runtime, SuperGameboy.SGB_DISPLAY_WIDTH,
+                    SuperGameboy.SGB_DISPLAY_HEIGHT);
+        }
+    }
+
+    private static EventBus runtimeEvents(AndroidEmulationRuntime runtime) throws Exception {
+        Field field = AndroidEmulationRuntime.class.getDeclaredField("eventBus");
+        field.setAccessible(true);
+        EventBus events = (EventBus) field.get(runtime);
+        if (events == null) {
+            fail("Android controller event bus is unavailable");
+        }
+        return events;
+    }
+
+    private static void awaitPhase(AndroidEmulationRuntime runtime, RuntimeState.Phase phase)
+            throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (runtime.state().phase() == phase) {
+                return;
+            }
+            if (runtime.state().phase() == RuntimeState.Phase.FAILED) {
+                fail(runtime.state().message());
+            }
+            Thread.sleep(25L);
+        }
+        fail("timed out waiting for Android runtime phase " + phase);
+    }
+
+    private static void awaitFrameSize(AndroidEmulationRuntime runtime, int width, int height)
+            throws Exception {
+        long deadline = SystemClock.elapsedRealtime() + TIMEOUT_MILLIS;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            NativeFrameStore.Snapshot frame = runtime.frames().snapshot();
+            if (frame != null && frame.width() == width && frame.height() == height) {
+                assertEquals(width * height, frame.pixels().length);
+                return;
+            }
+            Thread.sleep(25L);
+        }
+        NativeFrameStore.Snapshot frame = runtime.frames().snapshot();
+        fail("timed out waiting for " + width + "x" + height + " SGB frame; latest="
+                + (frame == null ? "none" : frame.width() + "x" + frame.height()));
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -515,11 +515,14 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
         submit(() -> {
             String value = Boolean.toString(enabled);
-            if (Objects.equals(properties.getProperty(EmulatorProperties.Key.ShowSgbBorder, null),
-                    value)) {
-                return;
+            if (!Objects.equals(
+                    properties.getProperty(EmulatorProperties.Key.ShowSgbBorder, null), value)) {
+                properties.setProperty(EmulatorProperties.Key.ShowSgbBorder, value);
             }
-            properties.setProperty(EmulatorProperties.Key.ShowSgbBorder, value);
+            // The stored preference and the live machine can legitimately differ after a
+            // profile-constrained session or host reattachment. Reassert the requested value
+            // even when persistence already agrees, otherwise an ON checkbox can leave the
+            // active SGB display producing borderless 160x144 frames indefinitely.
             if (eventBus != null) {
                 eventBus.post(new SgbDisplay.SetSgbBorder(enabled));
             }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -654,14 +654,20 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         if (menuController == null || externalSurface.active()) {
             return;
         }
-        if (menuController.visible()) {
-            menuController.hide();
-            return;
-        }
+        boolean wasVisible = menuController.visible();
         AndroidEmulationRuntime active = runtime;
         RuntimeState current = active == null ? observedState : active.state();
+        // Resolve a retained-service transition before interpreting a tap on the automatic
+        // Library root. This turns a just-started session into its pause menu instead of treating
+        // the stale idle menu as something the user merely wants to close.
         applyState(current);
         current = observedState;
+        if (menuController.visible()) {
+            if (wasVisible) {
+                menuController.hide();
+            }
+            return;
+        }
         if (active != null) {
             active.input().releaseAll();
         }
@@ -2598,7 +2604,20 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         if (runtime == null || menuController == null || externalSurface.active()) {
             return;
         }
-        if (state.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION
+        if (isGamePresentationState(state) && menuController.visible()
+                && menuController.route() == MenuRoute.LIBRARY && !menuPauseOwned) {
+            // A cold Activity starts on Library while the retained service is idle. If a game is
+            // then opened without going through the document-picker callback (for example from an
+            // intent or a recent-game launch), replace that automatic root with the game surface.
+            menuController.hide();
+        }
+        if (!diagnosticsOptions.enabled && isIdlePresentationState(state)
+                && !menuController.visible() && !suspendedMenu.visible()) {
+            // A stopped service has no frame to present. Keep the first user-visible Activity
+            // state useful instead of leaving the LCD aperture empty.
+            menuPauseOwned = false;
+            menuController.show(MenuRoute.LIBRARY);
+        } else if (state.phase() == RuntimeState.Phase.AWAITING_ARCHIVE_SELECTION
                 && !menuController.visible()) {
             menuPauseOwned = false;
             menuController.show(MenuRoute.CHOOSE_ROM);
@@ -2607,6 +2626,18 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             menuPauseOwned = false;
             menuController.show(MenuRoute.LIBRARY);
         }
+    }
+
+    private static boolean isIdlePresentationState(RuntimeState state) {
+        return state.phase() == RuntimeState.Phase.STOPPED
+                || state.phase() == RuntimeState.Phase.FAILED;
+    }
+
+    private static boolean isGamePresentationState(RuntimeState state) {
+        return state.phase() == RuntimeState.Phase.OPENING
+                || state.phase() == RuntimeState.Phase.LOADING
+                || state.phase() == RuntimeState.Phase.RUNNING
+                || state.phase() == RuntimeState.Phase.PAUSED;
     }
 
     /** Defers a singleTop arm token until the real anchor has completed on the renderer. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4517,8 +4517,9 @@ class BasicController private constructor(
           null
         }
 
-    if (properties.overrides.benchmarkPolicyEnabled &&
-        !completeBenchmarkBootstrap(session)) {
+    if ((properties.overrides.benchmarkPolicyEnabled ||
+            session.config.bootstrapMode == Gameboy.BootstrapMode.FAST_FORWARD) &&
+        !completePresentationBootstrap(session)) {
       return
     }
 
@@ -4593,18 +4594,18 @@ class BasicController private constructor(
     postInitialMobileAdapterNetworkStatus()
   }
 
-  /** Completes a requested authentic BIOS handoff while the benchmark anchor remains paused. */
-  private fun completeBenchmarkBootstrap(currentSession: Session): Boolean {
+  /** Completes a requested authentic BIOS handoff before the session becomes presentable. */
+  private fun completePresentationBootstrap(currentSession: Session): Boolean {
     val gameboy = currentSession.gameboy
-    var remaining = BENCHMARK_BOOTSTRAP_MAX_TICKS
+    var remaining = PRESENTATION_BOOTSTRAP_MAX_TICKS
     while (!gameboy.isBootstrapReady()) {
       if (doStop || session !== currentSession) {
         return false
       }
       if (remaining <= 0L) {
-        throw IllegalStateException("Benchmark bootstrap did not reach the cartridge handoff")
+        throw IllegalStateException("Bootstrap did not reach the cartridge handoff")
       }
-      val chunk = minOf(remaining, BENCHMARK_BOOTSTRAP_CHUNK_TICKS.toLong()).toInt()
+      val chunk = minOf(remaining, PRESENTATION_BOOTSTRAP_CHUNK_TICKS.toLong()).toInt()
       val executed = gameboy.runTicksUntilStop(chunk) {
         doStop || session !== currentSession || gameboy.isBootstrapReady()
       }
@@ -4613,7 +4614,7 @@ class BasicController private constructor(
         if (doStop || session !== currentSession) {
           return false
         }
-        throw IllegalStateException("Benchmark bootstrap made no progress")
+        throw IllegalStateException("Bootstrap made no progress")
       }
     }
     return !doStop && session === currentSession
@@ -5462,9 +5463,9 @@ class BasicController private constructor(
 
     const val MAX_DEBUG_COMMANDS_PER_SAFE_POINT = 64
 
-    const val BENCHMARK_BOOTSTRAP_CHUNK_TICKS = 16_384
+    const val PRESENTATION_BOOTSTRAP_CHUNK_TICKS = 16_384
 
-    const val BENCHMARK_BOOTSTRAP_MAX_TICKS = 40_000_000L
+    const val PRESENTATION_BOOTSTRAP_MAX_TICKS = 40_000_000L
 
     const val MAX_DEBUG_CONTROL_EVENTS_PER_SAFE_POINT = 64
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -1896,6 +1896,63 @@ class BasicControllerTest {
   }
 
   @Test
+  fun fastForwardBootstrapCompletesBeforeProfileAndStartedEvents() {
+    val eventBus = EventBusImpl()
+    val started = LinkedBlockingQueue<EmulationStartedEvent>()
+    val profile = LinkedBlockingQueue<HardwareProfileEvent>()
+    val bootstrapCalls = AtomicInteger()
+    val bootstrapReadyAtProfile = AtomicBoolean()
+    eventBus.register<EmulationStartedEvent> {
+      assertTrue(bootstrapReadyAtProfile.get())
+      started.add(it)
+    }
+    eventBus.register<HardwareProfileEvent> {
+      assertTrue(bootstrapCalls.get() > 0)
+      bootstrapReadyAtProfile.set(true)
+      profile.add(it)
+    }
+    val rom = namedRom("FAST_FORWARD_BOOTSTRAP")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(bootstrapMode = BootstrapMode.FAST_FORWARD),
+        )
+    val preparer =
+        SessionPreparer { currentProperties, event ->
+          val config =
+              Controller.createGameboyConfig(currentProperties, Rom(event.rom))
+                  .setBootstrapMode(BootstrapMode.SKIP)
+          val gameboy =
+              object : Gameboy(config) {
+                private var ready = false
+
+                override fun isBootstrapReady(): Boolean = ready
+
+                override fun runTicksUntilStop(ticks: Int, stop: BooleanSupplier): Int {
+                  bootstrapCalls.incrementAndGet()
+                  ready = true
+                  return 1
+                }
+              }
+          config.setBootstrapMode(BootstrapMode.FAST_FORWARD)
+          PreparedSession.Ready(config, gameboy)
+        }
+    val controller = BasicController(eventBus, properties, null, preparer)
+
+    controller.startController()
+    try {
+      eventBus.post(LoadRomEvent(rom = rom, allowAutosaveResume = false))
+      assertNotNull(profile.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertNotNull(started.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      assertEquals(1, bootstrapCalls.get())
+    } finally {
+      controller.close()
+      properties.close()
+      eventBus.close()
+      rom.delete()
+    }
+  }
+
+  @Test
   fun benchmarkBoundaryCarriesPerformanceEpochTelemetry() {
     val eventBus = EventBusImpl()
     val started = LinkedBlockingQueue<EmulationStartedEvent>()


### PR DESCRIPTION
## Summary

- complete `FAST_FORWARD` boot-ROM execution before publishing the hardware profile or emulation-started events, so Android DMG, CGB, and SGB sessions reach cartridge code
- reassert the live SGB border event even when the persisted setting already has the requested value
- show the Library menu when Android attaches to a stopped or failed runtime, dismiss that automatic menu when a game starts, and keep an active game visible across Activity recreation

## Root cause

Android configured fast-forward bootstrap mode but the normal controller presentation path did not perform the authentic boot-ROM handoff that was previously limited to benchmark startup. The session could therefore be announced before bootstrap completion.

The Android SGB border setter returned early when persistence already matched the UI value. The stored preference and live SGB display can diverge after profile constraints or host reattachment, leaving an enabled setting with a borderless 160x144 frame.

Finally, a newly attached Activity left the portable menu hidden while an idle runtime had no game frame to display. That produced an empty LCD aperture on cold launch.

## Changes

- share the bounded bootstrap-completion path between benchmark and `FAST_FORWARD` presentation startup
- cover controller event ordering and Android DMG/CGB/SGB bootstrap readiness with generated fixture ROMs
- always deliver `SetSgbBorder` to the live event bus and verify 256x224 / 160x144 frame transitions
- make idle startup, active-game recreation, menu toggling, and Back behavior explicit in `MainActivitySmokeTest`

## Testing

- `/opt/maven/bin/mvn -pl controller -Dtest=BasicControllerTest#fastForwardBootstrapCompletesBeforeProfileAndStartedEvents test` — 1 passed
- `ANDROID_HOME=/opt/android-sdk ANDROID_SDK_ROOT=/opt/android-sdk ./gradlew --no-daemon -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:testDebugUnitTest :app:assembleDebug :app:assembleDebugAndroidTest` — passed
- API 26 Android instrumentation:
  - `FastForwardBootstrapAndroidTest#fastForwardReachesCartridgeForDmgCgbAndSgbGames` — passed for DMG, CGB, and SGB profiles
  - `SgbBorderAndroidTest#borderSettingChangesThePublishedSgbFrameGeometry` — passed
  - focused `MainActivitySmokeTest` cold-launch, menu-toggle, active-game recreation, stale-state, and Back tests — 5 passed
- Redmi / Android 15 (API 35): final debug APK installed; cold start displayed the Library menu and exposed the menu as open to accessibility inspection

## Visual verification

![Coffee GB Library menu shown on Android cold start](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/coffee-gb-android-startup-menu-safe-a7a6ee17.png)
