### PR TITLE
Fix browsable ROM filtering on Android

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.android;
 
 import android.app.Instrumentation;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +39,36 @@ import static org.junit.Assert.assertTrue;
 /** Exercises the bound runtime through Activity recreation and a visibility transition. */
 @RunWith(AndroidJUnit4.class)
 public class MainActivitySmokeTest {
+
+    @Test
+    public void romPickerUsesTrustedExtensionFilterWhenTheDeviceProvidesOne() {
+        Intent intent = RomPickerIntents.create(
+                InstrumentationRegistry.getInstrumentation().getTargetContext());
+        if (RomPickerIntents.MIUI_FILTERED_PICKER.equals(intent.getComponent())) {
+            assertEquals(Intent.ACTION_PICK, intent.getAction());
+            assertEquals("all/*", intent.getType());
+            assertArrayEquals(RomPickerIntents.SUPPORTED_EXTENSIONS,
+                    intent.getStringArrayExtra(RomPickerIntents.MIUI_EXTENSION_FILTER));
+        } else {
+            assertEquals(Intent.ACTION_OPEN_DOCUMENT, intent.getAction());
+            assertEquals("application/octet-stream", intent.getType());
+            assertNotNull(intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES));
+        }
+    }
+
+    @Test
+    public void transientPickerRomBecomesAReadablePrivateImport() throws Exception {
+        AndroidRomImportStore store = new AndroidRomImportStore(
+                InstrumentationRegistry.getInstrumentation().getTargetContext());
+        Uri imported = store.importDocument(FixtureRomProvider.URI);
+        try {
+            assertEquals("file", imported.getScheme());
+            assertTrue(store.ownsReadable(imported));
+            assertTrue(RomDocumentFilter.accepts(imported.getLastPathSegment()));
+        } finally {
+            store.deleteIfOwned(imported);
+        }
+    }
 
     @Test
     public void freshLaunchShowsLibraryAndRestoresItAfterRecreation() throws Exception {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="com.mi.android.globalFileexplorer" />
+    </queries>
+
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -794,10 +794,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     /** Opens a document selected from a menu that may own the current session's pause. */
     void openRom(Uri uri, int resultFlags, boolean releaseMenuPause) {
         Uri checked = Objects.requireNonNull(uri, "uri");
-        submit(() -> {
-            retainReadPermission(checked, resultFlags);
-            openRom(checked, releaseMenuPause);
-        });
+        submit(() -> openSelectedRom(checked, resultFlags, releaseMenuPause));
     }
 
     /** Selects an opaque archive token published through {@link RuntimeState#selections()}. */
@@ -923,7 +920,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             }
             Uri uri = pendingRecents.get((int) token);
             pendingRecents = List.of();
-            openRom(uri, false);
+            openSelectedRom(uri, 0, false);
         });
     }
 
@@ -1802,24 +1799,30 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         controller.startController();
     }
 
-    private void openRom(Uri uri, boolean releaseMenuPause) {
+    private void openSelectedRom(Uri uri, int resultFlags, boolean releaseMenuPause) {
         persistCurrentRecentGame();
         clearPendingSource();
         frames.clear();
         publish(RuntimeState.Phase.OPENING, "Opening selected ROM…", List.of(), false, true, false);
+        Uri durableSource = uri;
+        boolean imported = false;
         try {
-            AndroidRomInput input = new AndroidRomInput(context.getContentResolver(), uri);
+            if (!retainReadPermission(uri, resultFlags)) {
+                durableSource = new AndroidRomImportStore(context).importDocument(uri);
+                imported = true;
+            }
+            AndroidRomInput input = new AndroidRomInput(context.getContentResolver(), durableSource);
             RomSourceSnapshot snapshot = RomSourceSnapshot.open(input);
             if (!snapshot.isArchive() || snapshot.candidates().size() == 1) {
                 activateSnapshot(snapshot,
                         snapshot.isArchive()
                                 ? snapshot.candidates().get(0).token()
                                 : RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN,
-                        uri, releaseMenuPause);
+                        durableSource, releaseMenuPause);
                 return;
             }
             pendingSnapshot = snapshot;
-            pendingSource = uri;
+            pendingSource = durableSource;
             pendingSnapshotReleasesMenuPause = releaseMenuPause;
             List<RuntimeState.Selection> choices = snapshot.candidates().stream()
                     .map(candidate -> new RuntimeState.Selection(candidate.token(), candidate.displayName()))
@@ -1828,7 +1831,15 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     "Choose ROM from archive.", choices, false, true, false);
         } catch (Exception failure) {
             if (!diagnostics.enabled()) {
-                forgetRevokedPermission(uri);
+                if (imported) {
+                    try {
+                        new AndroidRomImportStore(context).deleteIfOwned(durableSource);
+                    } catch (IOException ignored) {
+                        // The import directory being unavailable already explains this failure.
+                    }
+                } else {
+                    forgetRevokedPermission(uri);
+                }
             }
             publish(RuntimeState.Phase.FAILED,
                     "Coffee GB could not open this document. Check its permission and format.",
@@ -2314,16 +2325,30 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         }
     }
 
-    private void retainReadPermission(Uri uri, int resultFlags) {
+    private boolean retainReadPermission(Uri uri, int resultFlags) {
+        try {
+            if (new AndroidRomImportStore(context).ownsReadable(uri)) {
+                return true;
+            }
+        } catch (IOException ignored) {
+            // A transient document can still be opened or reported as unavailable below.
+        }
+        for (UriPermission permission : context.getContentResolver().getPersistedUriPermissions()) {
+            if (permission.isReadPermission() && permission.getUri().equals(uri)) {
+                return true;
+            }
+        }
         int read = resultFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION;
         int persistable = resultFlags & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION;
         if (read == 0 || persistable == 0) {
-            return;
+            return false;
         }
         try {
             context.getContentResolver().takePersistableUriPermission(uri, read);
+            return true;
         } catch (SecurityException ignored) {
             // A one-shot provider grant remains usable for this open but is not retained in Recents.
+            return false;
         }
     }
 
@@ -2332,6 +2357,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             return;
         }
         new RecentSafDocuments(context).remove(uri);
+        try {
+            new AndroidRomImportStore(context).deleteIfOwned(uri);
+        } catch (IOException ignored) {
+            // There is no app-private import to remove.
+        }
         for (UriPermission permission : context.getContentResolver().getPersistedUriPermissions()) {
             if (permission.getUri().equals(uri) && permission.isReadPermission()) {
                 try {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomImportStore.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRomImportStore.java
@@ -1,0 +1,148 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+
+import eu.rekawek.coffeegb.core.memory.cart.RomImage;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Durable app-private copies of documents returned by non-persistable Android pickers. */
+final class AndroidRomImportStore {
+
+    private static final String DIRECTORY = "rom-imports";
+    private static final int COPY_BUFFER_BYTES = 64 * 1024;
+    private static final long MAX_ZIP_BYTES = 128L * 1024 * 1024;
+    private static final int MAX_IMPORTS = 16;
+
+    private final ContentResolver resolver;
+    private final File directory;
+
+    AndroidRomImportStore(Context context) throws IOException {
+        Context application = context.getApplicationContext();
+        resolver = application.getContentResolver();
+        directory = new File(application.getFilesDir(), DIRECTORY);
+        if ((!directory.isDirectory() && !directory.mkdirs()) || !directory.isDirectory()) {
+            throw new IOException("Could not create the private ROM import directory");
+        }
+    }
+
+    Uri importDocument(Uri source) throws IOException {
+        AndroidRomInput input = new AndroidRomInput(resolver, source);
+        String extension = RomDocumentFilter.extension(input.displayName());
+        if (!RomDocumentFilter.accepts(input.displayName())) {
+            throw new IOException("Unsupported ROM document type");
+        }
+        long limit = extension.equals("zip") ? MAX_ZIP_BYTES : RomImage.MAX_ROM_BYTES;
+        if (input.declaredSize() > limit) {
+            throw new IOException("ROM document exceeds its size limit");
+        }
+
+        File temporary = File.createTempFile("pending-", ".tmp", directory);
+        MessageDigest digest = sha256();
+        long total = 0L;
+        try (InputStream stream = input.openStream();
+                FileOutputStream output = new FileOutputStream(temporary)) {
+            byte[] buffer = new byte[COPY_BUFFER_BYTES];
+            int read;
+            while ((read = stream.read(buffer)) != -1) {
+                if (read > limit - total) {
+                    throw new IOException("ROM document exceeds its size limit");
+                }
+                output.write(buffer, 0, read);
+                digest.update(buffer, 0, read);
+                total += read;
+            }
+            output.getFD().sync();
+        } catch (IOException | RuntimeException failure) {
+            temporary.delete();
+            throw failure;
+        }
+
+        File imported = new File(directory, hex(digest.digest()) + "." + extension);
+        if (imported.isFile()) {
+            temporary.delete();
+            imported.setLastModified(System.currentTimeMillis());
+        } else if (!temporary.renameTo(imported)) {
+            temporary.delete();
+            throw new IOException("Could not retain the selected ROM document");
+        }
+        pruneOldImports(imported);
+        return Uri.fromFile(imported);
+    }
+
+    boolean ownsReadable(Uri uri) {
+        File file = ownedFile(uri);
+        return file != null && file.isFile() && file.canRead();
+    }
+
+    void deleteIfOwned(Uri uri) {
+        File file = ownedFile(uri);
+        if (file != null) {
+            file.delete();
+        }
+    }
+
+    private File ownedFile(Uri uri) {
+        if (uri == null || !ContentResolver.SCHEME_FILE.equals(uri.getScheme())
+                || uri.getPath() == null) {
+            return null;
+        }
+        try {
+            File file = new File(uri.getPath()).getCanonicalFile();
+            File parent = file.getParentFile();
+            if (parent == null || !parent.equals(directory.getCanonicalFile())
+                    || !file.getName().matches("[0-9a-f]{64}\\.(gb|gbc|rom|zip)")) {
+                return null;
+            }
+            return file;
+        } catch (IOException failure) {
+            return null;
+        }
+    }
+
+    private void pruneOldImports(File keep) {
+        File[] files = directory.listFiles(file -> file.isFile()
+                && file.getName().matches("[0-9a-f]{64}\\.(gb|gbc|rom|zip)"));
+        if (files == null || files.length <= MAX_IMPORTS) {
+            return;
+        }
+        ArrayList<File> ordered = new ArrayList<>(List.of(files));
+        ordered.sort(Comparator.comparingLong(File::lastModified));
+        int remaining = ordered.size();
+        for (File candidate : ordered) {
+            if (remaining <= MAX_IMPORTS) {
+                break;
+            }
+            if (!candidate.equals(keep) && candidate.delete()) {
+                remaining--;
+            }
+        }
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException failure) {
+            throw new IllegalStateException("SHA-256 is unavailable", failure);
+        }
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder result = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            result.append(String.format(Locale.ROOT, "%02x", value));
+        }
+        return result.toString();
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1724,15 +1724,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
     }
 
-    private static Intent openRomIntent() {
-        return new Intent(Intent.ACTION_OPEN_DOCUMENT)
-                .addCategory(Intent.CATEGORY_OPENABLE)
-                .setType("application/octet-stream")
-                .putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
-                        "application/octet-stream", "application/x-gameboy-rom",
-                        "application/zip", "application/x-zip-compressed"})
-                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+    private Intent openRomIntent() {
+        return RomPickerIntents.create(this);
     }
 
     private static Intent importIntent() {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RecentSafDocuments.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RecentSafDocuments.java
@@ -42,12 +42,14 @@ final class RecentSafDocuments {
     private static final int CAPACITY = 10;
     private static final SecureRandom BENCHMARK_NONCE_RANDOM = new SecureRandom();
 
+    private final Context context;
     private final ContentResolver resolver;
     private final SharedPreferences preferences;
     private final File previewDirectory;
 
     RecentSafDocuments(Context context) {
         Context application = context.getApplicationContext();
+        this.context = application;
         resolver = application.getContentResolver();
         preferences = application.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
         previewDirectory = new File(application.getFilesDir(), "recent-game-previews");
@@ -564,6 +566,13 @@ final class RecentSafDocuments {
     }
 
     private boolean hasPersistedReadPermission(Uri uri) {
+        try {
+            if (new AndroidRomImportStore(context).ownsReadable(uri)) {
+                return true;
+            }
+        } catch (java.io.IOException ignored) {
+            // Continue with Android's persisted document grants.
+        }
         for (android.content.UriPermission permission : resolver.getPersistedUriPermissions()) {
             if (permission.getUri().equals(uri) && permission.isReadPermission()) {
                 return true;

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RomDocumentFilter.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RomDocumentFilter.java
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.android;
+
+import java.util.Locale;
+
+/** Filename filter shared by Android's ROM picker/import path and its regression tests. */
+final class RomDocumentFilter {
+
+    private RomDocumentFilter() {
+    }
+
+    static boolean accepts(String displayName) {
+        String extension = extension(displayName);
+        return extension.equals("gb") || extension.equals("gbc")
+                || extension.equals("rom") || extension.equals("zip");
+    }
+
+    static String extension(String displayName) {
+        if (displayName == null) {
+            return "";
+        }
+        int separator = displayName.lastIndexOf('.');
+        if (separator < 0 || separator == displayName.length() - 1) {
+            return "";
+        }
+        return displayName.substring(separator + 1).toLowerCase(Locale.ROOT);
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RomPickerIntents.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RomPickerIntents.java
@@ -1,0 +1,63 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+/** Creates the best ROM-picker request available without broad storage permissions. */
+final class RomPickerIntents {
+
+    static final ComponentName MIUI_FILTERED_PICKER = new ComponentName(
+            "com.mi.android.globalFileexplorer",
+            "com.android.fileexplorer.activity.FileActivity");
+    static final String MIUI_EXTENSION_FILTER = "ext_filter";
+    static final String[] SUPPORTED_EXTENSIONS = {"gb", "gbc", "rom", "zip"};
+
+    private RomPickerIntents() {
+    }
+
+    static Intent create(Context context) {
+        if (hasTrustedMiuiPicker(context.getPackageManager())) {
+            return miuiFiltered();
+        }
+        return standardSaf();
+    }
+
+    static Intent miuiFiltered() {
+        return new Intent(Intent.ACTION_PICK)
+                .setComponent(MIUI_FILTERED_PICKER)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("all/*")
+                // MIUI's category-picker filter is flat. FileActivity's extension filter keeps
+                // directories visible while hiding non-ROM files, so normal browsing survives.
+                .putExtra(MIUI_EXTENSION_FILTER, SUPPORTED_EXTENSIONS.clone())
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    }
+
+    static Intent standardSaf() {
+        return new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                // Some providers, including Redmi's, label valid GB/GBC files as generic binary
+                // data. Keep them selectable when no trusted extension-aware picker is present;
+                // RomSourceSnapshot still rejects unsupported selections before loading.
+                .setType("application/octet-stream")
+                .putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
+                        "application/octet-stream", "application/x-gameboy-rom",
+                        "application/zip", "application/x-zip-compressed"})
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+    }
+
+    private static boolean hasTrustedMiuiPicker(PackageManager packages) {
+        try {
+            ActivityInfo info = packages.getActivityInfo(MIUI_FILTERED_PICKER, 0);
+            return info.exported && info.enabled && info.applicationInfo != null
+                    && (info.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0;
+        } catch (PackageManager.NameNotFoundException failure) {
+            return false;
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/RomDocumentFilterTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/RomDocumentFilterTest.java
@@ -1,0 +1,24 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RomDocumentFilterTest {
+
+    @Test
+    public void acceptsExactlyAndroidSupportedRomAndArchiveExtensions() {
+        assertTrue(RomDocumentFilter.accepts("game.gb"));
+        assertTrue(RomDocumentFilter.accepts("game.GBC"));
+        assertTrue(RomDocumentFilter.accepts("multi.part.rom"));
+        assertTrue(RomDocumentFilter.accepts("games.ZIP"));
+
+        assertFalse(RomDocumentFilter.accepts("game.sav"));
+        assertFalse(RomDocumentFilter.accepts("game.sn0"));
+        assertFalse(RomDocumentFilter.accepts("game.cgbstate"));
+        assertFalse(RomDocumentFilter.accepts("game.7z"));
+        assertFalse(RomDocumentFilter.accepts("gbc"));
+        assertFalse(RomDocumentFilter.accepts(null));
+    }
+}


### PR DESCRIPTION
## Summary

- use the trusted MIUI hierarchical file browser with its extension filter, keeping directories visible while hiding unsupported files
- retain one-shot picker results in a bounded app-private ROM store so Recent Games remains usable
- keep the standard Storage Access Framework fallback and validate supported ROM/archive extensions before import

## Testing

- `ANDROID_SDK_ROOT=/opt/android-sdk ANDROID_HOME=/opt/android-sdk ./gradlew -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease :app:verifyDebugApkContents`
- Redmi 15C / Android 15: browsed three directory levels in the ROM picker
- verified mixed directories stay visible and APK, video, save, and state files are hidden
- launched a nested ROM, restarted Coffee GB, and reopened the private import from Recent Games
