### PR TITLE
Optimize native CGB epochs for MBC3 RTC

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1736,6 +1736,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
+        if (nativeCgbNormalSpeed && cartridgeClocked) {
+            // Native x1 keeps every decoded mapper/RTC access on the scalar boundary.  A
+            // clocked primary cartridge may therefore join only through its independently
+            // proven arithmetic clock horizon; the conservative MemoryController default
+            // rejects unknown clocked hardware here.
+            span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
         span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbHardware));
         span = Math.min(span, nativeCgbNormalSpeed || sgb
                 ? sound.performanceFencedEpochSpanLimit(span)
@@ -1894,7 +1901,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && (lcdEnabled ? !lcdDisabled : nativeCgbNormalSpeed && lcdDisabled)
                 && !dma.isTransferInProgress()
                 && !dma.requiresClockTick(false)
-                && !cartridgeClocked
+                && (!cartridgeClocked || nativeCgbNormalSpeed)
                 && !slotCartridgeClocked
                 && (!cgbHardware || (!hdma.hasActiveOrPendingTransfer()
                         && !hdma.hasPendingHblankTransfer()
@@ -2003,6 +2010,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private void commitNormalSpeedPerformanceEpochPeripherals(int ticks, boolean cgbHardware) {
         if (ticks <= 0) {
             return;
+        }
+        if (cgbHardware && !speedMode.isDmgCompat() && cartridgeClocked) {
+            // Scalar Gameboy.tick() clocks the cartridge before Timer and every other
+            // subsystem.  Prefix flushes and the final suffix both pass through this method,
+            // preserving that ordering before a fenced mapper/RTC boundary returns scalar.
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
         timer.tickPerformanceNormalSpeedEpochTrusted(ticks);
         sound.tickFrameSequencer(false);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -363,6 +363,131 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedMbc3RtcMatchesScalarWithEpochCoverage()
+            throws Exception {
+        byte[] image = nativeMbc3(dmgRomWramLoop());
+        try (Gameboy scalar = nativeCgbNormalSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeCgbNormalSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(5_000);
+                candidateFrames += candidate.runTicks(5_000);
+            }
+
+            assertEquals("native CGB x1 MBC3 frame callbacks", scalarFrames, candidateFrames);
+            assertEquals("custom-source MBC3 oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native CGB x1 MBC3 loop had no coarse epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000L);
+            assertEquals("native CGB x1 MBC3 epoch plan accounting",
+                    candidate.getPerformanceEpochTicks(),
+                    candidate.getPerformanceEpochRasterFastTicks()
+                            + candidate.getPerformanceEpochMode2BulkTicks());
+            assertDeepStateEquals("native CGB x1 MBC3 RTC oscillator",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedMbc3RtcWritesStayScalarAfterExactClockPrefixes()
+            throws Exception {
+        byte[] image = nativeMbc3(nativeCgbMbc3RtcWriteLoop());
+        try (Gameboy scalar = nativeCgbNormalSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeCgbNormalSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            for (int chunk = 0; chunk < 20; chunk++) {
+                assertEquals("native CGB x1 MBC3 RTC-write frame callback " + chunk,
+                        scalar.runTicks(4_000), candidate.runTicks(4_000));
+                assertDeepStateEquals("native CGB x1 MBC3 RTC-write chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            assertTrue("safe MBC3 instruction prefixes had no native CGB x1 epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertEquals("decoded MBC3/RTC access crossed a native CGB x1 epoch",
+                    0L, candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertEquals("latched RTC seconds", 42,
+                    candidate.getAddressSpace().getByte(0xc000));
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedMbc3LcdOffVramAndLcdcHandoffMatchScalar()
+            throws Exception {
+        byte[] image = nativeMbc3(nativeCgbLcdOffVramThenEnable());
+        try (Gameboy scalar = nativeCgbNormalSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeCgbNormalSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairUntilLcdDisabled(scalar, candidate);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("MBC3 LCD-off blank/VRAM frame callback",
+                    scalar.runTicks(2_000), candidate.runTicks(2_000));
+            int guard = 0;
+            while (!(candidate.getCpu().getState() == Cpu.State.RUNNING
+                    && candidate.getCpu().getDebugOpcode() == 0xe0
+                    && candidate.getCpu().getRegisters().getPC() == 0x0112
+                    && candidate.getCpu().getDebugMachineCycle() == 3)
+                    && guard++ < 12_000) {
+                assertEquals("MBC3 LCDC-enable setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("MBC3 test did not stop before the LCDC-enable write", guard < 12_000);
+            assertFalse(candidate.getGpu().isLcdEnabled());
+            assertTrue("MBC3 VRAM clear had no LCD-off epoch coverage",
+                    candidate.getPerformanceEpochLcdOffTicks() > 0L);
+            assertEquals("MBC3 LCD-off VRAM access reached the terminal bus", 0L,
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            for (int offset = 0; offset < 0x100; offset++) {
+                assertEquals("MBC3 LCD-off VRAM read/write " + offset, 1,
+                        candidate.getAddressSpace().getByte(0x8000 + offset));
+            }
+            assertDeepStateEquals("MBC3 before LCDC enable",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("MBC3 LCDC-enable boundary frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("MBC3 decoded LCDC enable crossed the LCD-off epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertTrue(candidate.getGpu().isLcdEnabled());
+            assertDeepStateEquals("MBC3 after scalar LCDC enable",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void clockedMbc3CgbCompatibilityRemainsOutsideRunningEpoch()
+            throws Exception {
+        byte[] compatibility = mbc3(dmgRomWramLoop());
+        try (Gameboy cgbCompatibility = new Gameboy.GameboyConfiguration(new Rom(compatibility))
+                     .setHardwareProfile(HardwareProfileRegistry.CGB)
+                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                     .setExecutionMode(ExecutionMode.PERFORMANCE)
+                     .setPlayerInputSource(PlayerInputSource.RELEASED)
+                     .setRtcTimeSource(() -> 0L)
+                     .setSupportBatterySave(false)
+                     .build()) {
+            cgbCompatibility.runTicks(100_000);
+
+            assertTrue(cgbCompatibility.getSpeedMode().isDmgCompat());
+            assertEquals("clocked MBC3 entered CGB-compatibility running epoch",
+                    0L, cgbCompatibility.getPerformanceEpochTicks());
+        }
+    }
+
+    @Test
     public void nativeCgbExternalClockWaitMatchesFallbackWithEpochCoverage()
             throws Exception {
         byte[] image = nativeCgbExternalClockWramLoop();
@@ -1111,6 +1236,18 @@ public final class GameboyPerformanceEpochTest {
                 .build();
     }
 
+    private static Gameboy nativeCgbNormalSpeedMbc3Session(
+            byte[] image, PlayerInputSource inputSource) throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(nativeMbc3(image)))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setRtcTimeSource(() -> 0L)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
     private static Gameboy sgbSession(
             byte[] image, HardwareProfile profile, PlayerInputSource inputSource)
             throws Exception {
@@ -1339,6 +1476,16 @@ public final class GameboyPerformanceEpochTest {
         return image;
     }
 
+    private static byte[] mbc3(byte[] image) {
+        image[0x147] = 0x10; // MBC3 + timer + RAM + battery
+        image[0x149] = 0x03; // 32 KiB external RAM
+        return image;
+    }
+
+    private static byte[] nativeMbc3(byte[] image) {
+        return nativeColor(mbc3(image));
+    }
+
     private static void updateHeaderChecksum(byte[] image) {
         int checksum = 0;
         for (int address = 0x134; address <= 0x14c; address++) {
@@ -1440,6 +1587,42 @@ public final class GameboyPerformanceEpochTest {
         image[0x109] = 0x77; // LD (HL),A
         image[0x10a] = 0x18; // JR 0107
         image[0x10b] = (byte) 0xfb;
+        image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] nativeCgbMbc3RtcWriteLoop() {
+        byte[] image = new byte[0x8000];
+        int pc = 0x100;
+        image[pc++] = 0x3e; // LD A,0A
+        image[pc++] = 0x0a;
+        image[pc++] = (byte) 0xea; // LD (0000),A: enable MBC3 RAM/RTC
+        image[pc++] = 0x00;
+        image[pc++] = 0x00;
+        image[pc++] = 0x3e; // LD A,08
+        image[pc++] = 0x08;
+        image[pc++] = (byte) 0xea; // LD (4000),A: select RTC seconds
+        image[pc++] = 0x00;
+        image[pc++] = 0x40;
+        int loop = pc;
+        image[pc++] = 0x3e; // LD A,2A
+        image[pc++] = 0x2a;
+        image[pc++] = (byte) 0xea; // LD (A000),A: reset seconds and sub-second phase
+        image[pc++] = 0x00;
+        image[pc++] = (byte) 0xa0;
+        image[pc++] = (byte) 0xaf; // XOR A
+        image[pc++] = (byte) 0xea; // LD (6000),A: latch current RTC value
+        image[pc++] = 0x00;
+        image[pc++] = 0x60;
+        image[pc++] = (byte) 0xfa; // LD A,(A000): read latched seconds
+        image[pc++] = 0x00;
+        image[pc++] = (byte) 0xa0;
+        image[pc++] = (byte) 0xea; // LD (C000),A: expose the observed value
+        image[pc++] = 0x00;
+        image[pc++] = (byte) 0xc0;
+        image[pc++] = (byte) 0xc3; // JP loop
+        image[pc++] = (byte) (loop & 0xff);
+        image[pc] = (byte) (loop >>> 8);
         image[0x143] = (byte) 0x80;
         return image;
     }


### PR DESCRIPTION
## Summary

- allow clocked primary cartridges to join ordinary native-CGB x1 CPU epochs only through their explicit quiet-span capability
- advance the cartridge before Timer in every epoch prefix and suffix, preserving scalar subsystem order
- keep mapper/RTC accesses, slot cartridges, compatibility mode, x2, DMG/SGB, debug hooks, and unknown clocked controllers fail-closed

## Pokémon Crystal USA evidence

- native CGB, non-compatibility, normal speed
- running-CPU epoch coverage: `0` -> `1,848,668` ticks in the measured window
- scheduled coverage: `43.809%` -> `84.262%`
- median scheduler throughput: `13.531421` -> `27.020140` M ticks/s (`+99.684%`)
- 20,000,000-tick scalar/candidate comparison: full portable state equal; 284/284 frames and final pixels equal; 286/286 audio events with identical sample count and PCM hash

## Validation

- `GameboyPerformanceEpochTest`: 34/34
- MBC3 + RTC focused tests: 22/22
- full core unit suite: 1,941 tests, 0 failures/errors, 8 skipped
- Mooneye + dmg-acid2 + cgb-acid2: 132/132
- Blargg aggregate + individual: 54/54
- Android benchmark unit tests, minified benchmark assembly, and lint
- independent source review: GO, no P0/P1

The existing Android benchmark warmup rejects RTC cartridges before arming, so the device FPS cell was not used; the exact host comparison exercises the production scheduler directly.