### PR TITLE
Fix Revenge of the Gator link negotiation

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -168,6 +168,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final boolean jantakuBoyFourPlayerPatch;
 
+    private final boolean revengeGatorLinkRolePatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -320,6 +322,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.CLEAR_CGB_BOOT_OAM_SHADOW);
         jantakuBoyFourPlayerPatch = cartridgeProperties.has(
                 CartridgeProperties.Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH);
+        revengeGatorLinkRolePatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.REVENGE_GATOR_LINK_ROLE_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -645,6 +649,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         joypad.init(eventBus);
         display.init(eventBus);
         sound.init(eventBus);
+        if (revengeGatorLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
+            cartridge.enableRevengeGatorSecondaryLinkRole();
+        }
         if (jantakuBoyFourPlayerPatch) {
             serialEndpoint.enableCompatibilityProfile(
                     SerialCompatibilityProfile.JANTAKU_BOY_FOUR_PLAYER_CONTROL_PACKET);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -34,6 +34,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private final boolean clocked;
 
+    private boolean revengeGatorSecondaryLinkRole;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -179,11 +181,28 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     @Override
     public int getByte(int address) {
+        if (revengeGatorSecondaryLinkRole) {
+            if (address == 0x0214) {
+                return 0x18;
+            }
+            if (address == 0x0215) {
+                return 0x17;
+            }
+        }
         return addressSpace.getByte(address);
+    }
+
+    public void enableRevengeGatorSecondaryLinkRole() {
+        revengeGatorSecondaryLinkRole = true;
     }
 
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
+        // The role-selecting branch is a CPU-view overlay, not a mutation of the loaded image.
+        // Keep execution on the ordinary cartridge read path while that overlay is active.
+        if (revengeGatorSecondaryLinkRole) {
+            return null;
+        }
         if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {
             return null;
         }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -73,7 +73,8 @@ public final class CartridgeProperties {
         PRESERVE_INVALID_HEADER_CHECKSUM,
         SUPER_FIGHTERS_S_LIVE_PATCH,
         // Append new features: Feature ordinals are part of the StateFile v1 identity.
-        JANTAKU_BOY_FOUR_PLAYER_PATCH
+        JANTAKU_BOY_FOUR_PLAYER_PATCH,
+        REVENGE_GATOR_LINK_ROLE_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -206,6 +207,9 @@ public final class CartridgeProperties {
             features("Jantaku Boy four-player transition workaround",
                     CartridgeProperties::isJantakuBoyFourPlayer,
                     Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH),
+            features("Revenge of the Gator deterministic link roles",
+                    CartridgeProperties::isRevengeGatorLinkRole,
+                    Feature.REVENGE_GATOR_LINK_ROLE_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -830,6 +834,28 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x02
                 && info.byteAt(0x0149) == 0x00
                 && matches(info.data, 0x0395, fourPlayerWait);
+    }
+
+    private static boolean isRevengeGatorLinkRole(RomInfo info) {
+        int[] linkRoleNegotiation = {
+                0x3e, 0x81, 0xe0, 0xc9, 0xcd, 0x7a, 0x02, 0x21,
+                0x88, 0x77, 0x3e, 0x0a, 0xcd, 0xac, 0x02, 0x30,
+                0x30, 0x21, 0x88, 0x77, 0x11, 0x5a, 0xa5, 0x18,
+                0x17, 0x3e, 0x41, 0xe0, 0xc9, 0xcd, 0x7a, 0x02,
+                0x21, 0x77, 0x88, 0x3e, 0x0a, 0xcd, 0xac, 0x02
+        };
+        return info.data.length == 0x10000
+                && "PINBALL".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x01
+                && info.byteAt(0x0149) == 0x00
+                && matches(info.data, 0x0214, linkRoleNegotiation);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
@@ -18,10 +18,19 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
 
     private int bitIndex = 7;
 
+    private int linkPlayerIndex = -1;
+
     /** Pairs two endpoints before session installation; this is not a concurrent hot-plug API. */
     public void init(Peer2PeerSerialEndpoint peer) {
         this.peer = peer;
         peer.peer = this;
+        this.linkPlayerIndex = 0;
+        peer.linkPlayerIndex = 1;
+    }
+
+    @Override
+    public int linkPlayerIndex() {
+        return linkPlayerIndex;
     }
 
     /** True only while this endpoint has a live peer whose traffic must be replayed jointly. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -5,6 +5,11 @@ import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
 public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
 
+    /** Stable zero-based player index for an in-process link, or {@code -1}. */
+    default int linkPlayerIndex() {
+        return -1;
+    }
+
     /** Enables a narrowly detected cartridge compatibility profile for this endpoint. */
     default void enableCompatibilityProfile(SerialCompatibilityProfile profile) {
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RevengeGatorLinkRolePatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/RevengeGatorLinkRolePatchTest.java
@@ -1,0 +1,95 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RevengeGatorLinkRolePatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownLinkNegotiationRoutine() throws IOException {
+        Rom rom = new Rom(revengeGatorRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.REVENGE_GATOR_LINK_ROLE_PATCH));
+
+        byte[] changed = revengeGatorRom();
+        changed[0x0216] = 0;
+        assertFalse(new Rom(changed).getCartridgeProperties().has(
+                CartridgeProperties.Feature.REVENGE_GATOR_LINK_ROLE_PATCH));
+    }
+
+    @Test
+    public void assignsOppositeNegotiationBranchesToPairedPlayers() throws IOException {
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy primary = gameboy(revengeGatorRom());
+             Gameboy secondary = gameboy(revengeGatorRom())) {
+            primary.init(EventBus.NULL_EVENT_BUS, first, null);
+            secondary.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x3e, primary.getAddressSpace().getByte(0x0214));
+            assertEquals(0x81, primary.getAddressSpace().getByte(0x0215));
+            assertEquals(0x18, secondary.getAddressSpace().getByte(0x0214));
+            assertEquals(0x17, secondary.getAddressSpace().getByte(0x0215));
+        }
+    }
+
+    @Test
+    public void doesNotPatchAnotherCartridgeOnTheSecondaryEndpoint() throws IOException {
+        byte[] data = revengeGatorRom();
+        data[0x0134] = 'X';
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy gameboy = gameboy(data)) {
+            gameboy.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x3e, gameboy.getAddressSpace().getByte(0x0214));
+            assertEquals(0x81, gameboy.getAddressSpace().getByte(0x0215));
+        }
+    }
+
+    private static Gameboy gameboy(byte[] data) throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] revengeGatorRom() {
+        byte[] data = new byte[0x10000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "PINBALL".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x00;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x01;
+        data[0x0149] = 0x00;
+        int[] linkRoleNegotiation = {
+                0x3e, 0x81, 0xe0, 0xc9, 0xcd, 0x7a, 0x02, 0x21,
+                0x88, 0x77, 0x3e, 0x0a, 0xcd, 0xac, 0x02, 0x30,
+                0x30, 0x21, 0x88, 0x77, 0x11, 0x5a, 0xa5, 0x18,
+                0x17, 0x3e, 0x41, 0xe0, 0xc9, 0xcd, 0x7a, 0x02,
+                0x21, 0x77, 0x88, 0x3e, 0x0a, 0xcd, 0xac, 0x02
+        };
+        for (int i = 0; i < linkRoleNegotiation.length; i++) {
+            data[0x0214 + i] = (byte) linkRoleNegotiation[i];
+        }
+        return data;
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpointTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpointTest.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.core.serial;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -19,5 +20,7 @@ public class Peer2PeerSerialEndpointTest {
 
         assertTrue(first.isConnected());
         assertTrue(second.isConnected());
+        assertEquals(0, first.linkPlayerIndex());
+        assertEquals(1, second.linkPlayerIndex());
     }
 }


### PR DESCRIPTION
Fixes #588

## Summary
- identify the exact Revenge of the Gator link-negotiation routine
- assign stable player indices to paired local serial endpoints
- route player 2 through the cartridge’s existing secondary negotiation branch without mutating the loaded ROM image
- leave other cartridges and unpaired serial peripherals unchanged

## Validation
- /opt/maven/bin/mvn -pl core test
- two-instance authentic-boot reproduction: both players enter Match Play A and remain synchronized

## Visual evidence

Before: both players eventually fall back to the menu with the cable idle.

![Before](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f140_p1-7160dc86.png)

After: both players enter the linked Match Play table.

![After](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f140_p1-fb40b1e2.png)