### PR TITLE
Fix Shikinjou link negotiation

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -170,6 +170,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final boolean revengeGatorLinkRolePatch;
 
+    private final boolean shikinjouLinkRolePatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -324,6 +326,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH);
         revengeGatorLinkRolePatch = cartridgeProperties.has(
                 CartridgeProperties.Feature.REVENGE_GATOR_LINK_ROLE_PATCH);
+        shikinjouLinkRolePatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.SHIKINJOU_LINK_ROLE_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -651,6 +655,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         sound.init(eventBus);
         if (revengeGatorLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
             cartridge.enableRevengeGatorSecondaryLinkRole();
+        }
+        if (shikinjouLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
+            cartridge.enableShikinjouSecondaryLinkRole();
         }
         if (jantakuBoyFourPlayerPatch) {
             serialEndpoint.enableCompatibilityProfile(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -36,6 +36,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private boolean revengeGatorSecondaryLinkRole;
 
+    private boolean shikinjouSecondaryLinkRole;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -189,6 +191,17 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
                 return 0x17;
             }
         }
+        if (shikinjouSecondaryLinkRole) {
+            if (address == 0x22cb) {
+                return 0xc3;
+            }
+            if (address == 0x22cc) {
+                return 0xf3;
+            }
+            if (address == 0x22cd) {
+                return 0x22;
+            }
+        }
         return addressSpace.getByte(address);
     }
 
@@ -196,11 +209,15 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
         revengeGatorSecondaryLinkRole = true;
     }
 
+    public void enableShikinjouSecondaryLinkRole() {
+        shikinjouSecondaryLinkRole = true;
+    }
+
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
         // The role-selecting branch is a CPU-view overlay, not a mutation of the loaded image.
         // Keep execution on the ordinary cartridge read path while that overlay is active.
-        if (revengeGatorSecondaryLinkRole) {
+        if (revengeGatorSecondaryLinkRole || shikinjouSecondaryLinkRole) {
             return null;
         }
         if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -74,7 +74,8 @@ public final class CartridgeProperties {
         SUPER_FIGHTERS_S_LIVE_PATCH,
         // Append new features: Feature ordinals are part of the StateFile v1 identity.
         JANTAKU_BOY_FOUR_PLAYER_PATCH,
-        REVENGE_GATOR_LINK_ROLE_PATCH
+        REVENGE_GATOR_LINK_ROLE_PATCH,
+        SHIKINJOU_LINK_ROLE_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -210,6 +211,9 @@ public final class CartridgeProperties {
             features("Revenge of the Gator deterministic link roles",
                     CartridgeProperties::isRevengeGatorLinkRole,
                     Feature.REVENGE_GATOR_LINK_ROLE_PATCH),
+            features("Shikinjou deterministic link roles",
+                    CartridgeProperties::isShikinjouLinkRole,
+                    Feature.SHIKINJOU_LINK_ROLE_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -856,6 +860,31 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x01
                 && info.byteAt(0x0149) == 0x00
                 && matches(info.data, 0x0214, linkRoleNegotiation);
+    }
+
+    private static boolean isShikinjouLinkRole(RomInfo info) {
+        int[] linkRoleNegotiation = {
+                0xc5, 0x3e, 0x01, 0xe0, 0x90, 0x3e, 0x54, 0xea,
+                0xa1, 0xc0, 0xe0, 0x95, 0x3e, 0x01, 0xe0, 0x91,
+                0xcd, 0x2e, 0x23, 0xcd, 0x4e, 0x23, 0xf0, 0x92,
+                0xa7, 0x20, 0xfb, 0xfa, 0xa4, 0xc0, 0xfe, 0xff,
+                0x28, 0x44, 0xfe, 0xaa, 0x20, 0x07, 0x3e, 0x01,
+                0xcd, 0xed, 0x23, 0x18, 0x2e, 0x3e, 0xaa, 0xea,
+                0xa1, 0xc0, 0xe0, 0x95, 0xaf, 0xe0, 0x91, 0xea,
+                0xa4, 0xc0
+        };
+        return info.data.length == 0x10000
+                && "SHIKINJYO".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x01
+                && info.byteAt(0x0149) == 0x00
+                && matches(info.data, 0x22c6, linkRoleNegotiation);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/ShikinjouLinkRolePatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/ShikinjouLinkRolePatchTest.java
@@ -1,0 +1,101 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShikinjouLinkRolePatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownLinkNegotiationRoutine() throws IOException {
+        Rom rom = new Rom(shikinjouRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.SHIKINJOU_LINK_ROLE_PATCH));
+
+        byte[] changed = shikinjouRom();
+        changed[0x22ca] = 0;
+        assertFalse(new Rom(changed).getCartridgeProperties().has(
+                CartridgeProperties.Feature.SHIKINJOU_LINK_ROLE_PATCH));
+    }
+
+    @Test
+    public void assignsTheExistingSlaveBranchToTheSecondLinkedPlayer() throws IOException {
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy primary = gameboy(shikinjouRom());
+             Gameboy secondary = gameboy(shikinjouRom())) {
+            primary.init(EventBus.NULL_EVENT_BUS, first, null);
+            secondary.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x3e, primary.getAddressSpace().getByte(0x22cb));
+            assertEquals(0x54, primary.getAddressSpace().getByte(0x22cc));
+            assertEquals(0xea, primary.getAddressSpace().getByte(0x22cd));
+            assertEquals(0xc3, secondary.getAddressSpace().getByte(0x22cb));
+            assertEquals(0xf3, secondary.getAddressSpace().getByte(0x22cc));
+            assertEquals(0x22, secondary.getAddressSpace().getByte(0x22cd));
+        }
+    }
+
+    @Test
+    public void leavesAnotherCartridgeUnchangedOnTheSecondEndpoint() throws IOException {
+        byte[] data = shikinjouRom();
+        data[0x0134] = 'X';
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy gameboy = gameboy(data)) {
+            gameboy.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x3e, gameboy.getAddressSpace().getByte(0x22cb));
+            assertEquals(0x54, gameboy.getAddressSpace().getByte(0x22cc));
+            assertEquals(0xea, gameboy.getAddressSpace().getByte(0x22cd));
+        }
+    }
+
+    private static Gameboy gameboy(byte[] data) throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] shikinjouRom() {
+        byte[] data = new byte[0x10000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "SHIKINJYO".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x00;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x01;
+        data[0x0149] = 0x00;
+        int[] linkRoleNegotiation = {
+                0xc5, 0x3e, 0x01, 0xe0, 0x90, 0x3e, 0x54, 0xea,
+                0xa1, 0xc0, 0xe0, 0x95, 0x3e, 0x01, 0xe0, 0x91,
+                0xcd, 0x2e, 0x23, 0xcd, 0x4e, 0x23, 0xf0, 0x92,
+                0xa7, 0x20, 0xfb, 0xfa, 0xa4, 0xc0, 0xfe, 0xff,
+                0x28, 0x44, 0xfe, 0xaa, 0x20, 0x07, 0x3e, 0x01,
+                0xcd, 0xed, 0x23, 0x18, 0x2e, 0x3e, 0xaa, 0xea,
+                0xa1, 0xc0, 0xe0, 0x95, 0xaf, 0xe0, 0x91, 0xea,
+                0xa4, 0xc0
+        };
+        for (int i = 0; i < linkRoleNegotiation.length; i++) {
+            data[0x22c6 + i] = (byte) linkRoleNegotiation[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #587

## Summary
- assign paired Shikinjou instances to the ROM's existing master and slave startup paths
- preserve the loaded ROM/debug image by applying a three-byte CPU-view overlay only to linked player 2
- require an exact title, header, and negotiation-routine signature before enabling the compatibility path

## Testing
- /opt/maven/bin/mvn -pl core -Dtest=ShikinjouLinkRolePatchTest,RevengeGatorLinkRolePatchTest test
- /opt/maven/bin/mvn -q -pl core test
- authentic-boot paired local run: both players reached the 2P board with YOU/ENEMY scores and synchronized opponent positions

## Visual evidence

| Before: both instances wait for an external clock | After: linked 2P board |
| --- | --- |
| ![](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f900_p1-9c0a3a18.png) | ![](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f900_p1-441f5e2a.png) |