### PR TITLE
Fix Windows local netplay relaunch and mute child clients

### DIFF
--- a/packaging/verify-native-package.ps1
+++ b/packaging/verify-native-package.ps1
@@ -18,9 +18,10 @@ $BuildRoot = if ([System.IO.Path]::IsPathRooted($BuildRoot)) {
 $Dist = Join-Path $BuildRoot "dist"
 $Extracted = Join-Path $BuildRoot "extracted-installer"
 $InstalledRoot = Join-Path $BuildRoot "installed-msi"
-$SmokeHome = Join-Path $BuildRoot "unpacked-smoke-home"
+$ExtractedSmokeHome = Join-Path $BuildRoot "extracted-smoke-home"
+$InstalledSmokeHome = Join-Path $BuildRoot "installed-smoke-home"
 
-foreach ($Path in @($Extracted, $InstalledRoot)) {
+foreach ($Path in @($Extracted, $InstalledRoot, $ExtractedSmokeHome, $InstalledSmokeHome)) {
     if (Test-Path -LiteralPath $Path) {
         throw "MSI verification output already exists: $Path"
     }
@@ -170,7 +171,7 @@ $Arguments = @(
     "--source-legal", (Join-Path $RepositoryRoot "packaging/resources/legal"),
     "--dist", $Dist,
     "--run-smoke",
-    "--smoke-home", $SmokeHome
+    "--smoke-home", $ExtractedSmokeHome
 )
 & java @Arguments
 if ($LASTEXITCODE -ne 0) {
@@ -197,6 +198,25 @@ try {
     }
     Assert-NoRomAssociations $InstalledRoot
     Assert-OnlyCoffeeGbShortcuts $InstalledRoot
+
+    $InstalledArguments = @(
+        "-cp", $AppJars[0].FullName,
+        "eu.rekawek.coffeegb.swing.packaging.NativePackageVerifier",
+        "verify",
+        "--target", $Target,
+        "--type", "msi",
+        "--root", $InstalledRoot,
+        "--source-app-jar", $AppJars[0].FullName,
+        "--source-sbom", $Sboms[0].FullName,
+        "--source-legal", (Join-Path $RepositoryRoot "packaging/resources/legal"),
+        "--dist", $Dist,
+        "--run-smoke",
+        "--smoke-home", $InstalledSmokeHome
+    )
+    & java @InstalledArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Installed MSI verification failed with exit code $LASTEXITCODE"
+    }
 } finally {
     if ($Installed) {
         Invoke-Msi -Operation "MSI uninstall" -Arguments @(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
@@ -66,6 +66,7 @@ internal class CurrentProcessLocalNetplayInstanceLauncher(
             listOf(
                 "--profile=${profile.id()}",
                 "--disable-battery-saves",
+                "--start-muted",
                 "--join-netplay",
                 endpoint.startClientValue,
                 rom.toAbsolutePath().normalize().toString(),

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
@@ -3,6 +3,9 @@ package eu.rekawek.coffeegb.swing
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile
 import java.nio.file.Path
 
+private const val DESKTOP_MAIN_CLASS = "eu.rekawek.coffeegb.swing.MainKt"
+private const val JPACKAGE_APP_PATH_PROPERTY = "jpackage.app-path"
+
 /** Launches sibling desktop processes that use the current executable or Java launcher. */
 internal fun interface LocalNetplayInstanceLauncher {
   fun launch(
@@ -46,7 +49,7 @@ internal data class LocalNetplayInstanceLaunchResult(
  */
 internal class CurrentProcessLocalNetplayInstanceLauncher(
     private val currentCommand: List<String> = currentProcessCommand(),
-    private val startProcess: (List<String>) -> Unit = ::startProcessWithInheritedError,
+    private val startProcess: (List<String>) -> Unit = ::startLocalNetplayProcess,
 ) : LocalNetplayInstanceLauncher {
 
   override fun launch(
@@ -81,16 +84,18 @@ internal class CurrentProcessLocalNetplayInstanceLauncher(
 }
 
 /**
- * A child desktop process has no terminal of its own when launched from the netplay window.
- * Keep its diagnostic stream attached to the host process so a rejected checkpoint can be
- * diagnosed without a separate client console.
+ * A packaged GUI process may have no valid console handles, especially when started from the
+ * Windows Start menu. Route child output to the platform null device so relaunch never depends on
+ * inheritable standard streams and an unobserved pipe cannot fill up and stall emulation.
  */
-private fun startProcessWithInheritedError(command: List<String>) {
+private fun startLocalNetplayProcess(command: List<String>) {
   localNetplayProcessBuilder(command).start()
 }
 
 internal fun localNetplayProcessBuilder(command: List<String>): ProcessBuilder =
-    ProcessBuilder(command).redirectError(ProcessBuilder.Redirect.INHERIT)
+    ProcessBuilder(command)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
 
 /** Builds a fresh Coffee GB command without replaying this process's app arguments. */
 internal fun localNetplayLauncherPrefix(command: List<String>): List<String>? {
@@ -101,19 +106,66 @@ internal fun localNetplayLauncherPrefix(command: List<String>): List<String>? {
   val module = command.indexOfFirst { it == "-m" || it == "--module" }
   if (module >= 0 && module + 1 < command.size) return command.take(module + 2)
 
-  val mainClass = command.indexOf("eu.rekawek.coffeegb.swing.MainKt")
+  val mainClass = command.indexOf(DESKTOP_MAIN_CLASS)
   if (mainClass >= 0) return command.take(mainClass + 1)
 
   val executable = command.first()
-  val executableName = executable.substringAfterLast('/').substringAfterLast('\\').substringBeforeLast('.')
-  if (executableName.equals("java", ignoreCase = true)) {
+  if (isJavaLauncher(executable)) {
     return null
   }
   return listOf(executable)
 }
 
-private fun currentProcessCommand(): List<String> {
+internal fun currentProcessCommand(): List<String> {
   val info = ProcessHandle.current().info()
-  val executable = info.command().orElse(null) ?: return emptyList()
-  return listOf(executable) + info.arguments().orElse(emptyArray()).toList()
+  return currentProcessCommand(
+      packagedLauncher = System.getProperty(JPACKAGE_APP_PATH_PROPERTY),
+      executable = info.command().orElse(null),
+      arguments = info.arguments().orElse(emptyArray()).toList(),
+      classPath = System.getProperty("java.class.path"),
+      desktopMainOnSystemClassPath = desktopMainOnSystemClassPath(),
+  )
+}
+
+/**
+ * Reconstructs a fresh desktop invocation without relying on application arguments being exposed
+ * by [ProcessHandle]. Windows JVMs may report `java.exe`/`javaw.exe` while omitting every argument,
+ * whereas jpackage publishes the exact native launcher through `jpackage.app-path`.
+ */
+internal fun currentProcessCommand(
+    packagedLauncher: String?,
+    executable: String?,
+    arguments: List<String>,
+    classPath: String?,
+    desktopMainOnSystemClassPath: Boolean = true,
+): List<String> {
+  packagedLauncher?.takeIf(String::isNotBlank)?.let { return listOf(it) }
+  val currentExecutable = executable?.takeIf(String::isNotBlank) ?: return emptyList()
+  if (!isJavaLauncher(currentExecutable)) return listOf(currentExecutable)
+
+  if (!desktopMainOnSystemClassPath) return emptyList()
+  localNetplayLauncherPrefix(listOf(currentExecutable) + arguments)?.let { return it }
+  val currentClassPath = classPath?.takeIf(String::isNotBlank) ?: return emptyList()
+  return listOf(currentExecutable, "-cp", currentClassPath, DESKTOP_MAIN_CLASS)
+}
+
+/**
+ * A custom Java host (for example Maven's plugin realm) can load Coffee GB without putting it on
+ * the system class path inherited by a fresh JVM. Only reconstruct a class-path command when the
+ * same system loader that a child JVM will use can resolve the desktop entry point.
+ */
+private fun desktopMainOnSystemClassPath(): Boolean =
+    runCatching {
+          Class.forName(
+              DESKTOP_MAIN_CLASS,
+              false,
+              ClassLoader.getSystemClassLoader(),
+          )
+        }
+        .isSuccess
+
+private fun isJavaLauncher(executable: String): Boolean {
+  val name =
+      executable.substringAfterLast('/').substringAfterLast('\\').substringBeforeLast('.')
+  return name.equals("java", ignoreCase = true) || name.equals("javaw", ignoreCase = true)
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -5,7 +5,7 @@ import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
 import eu.rekawek.coffeegb.core.memory.Bios
-import eu.rekawek.coffeegb.swing.SwingGui.Companion.run
+import eu.rekawek.coffeegb.swing.SwingGui.Companion.runWithStartupAudio
 import eu.rekawek.coffeegb.swing.packaging.NativeRuntimeBootstrap
 import java.io.File
 import java.io.PrintStream
@@ -21,6 +21,8 @@ internal data class CliLaunchRequest(
     val initialRom: File?,
     /** Validated direct-host endpoint text to join after [initialRom] has opened. */
     val joinNetplayHost: String?,
+    /** Process-local startup policy used by automatically launched netplay clients. */
+    val startMuted: Boolean,
     /** A netplay child receives its authoritative state from the host, never from a local resume. */
     val suppressInitialAutosaveResume: Boolean,
     val settingsOverrides: ApplicationSettingsOverrides,
@@ -59,12 +61,13 @@ fun main(args: Array<String>) {
       ) { request ->
         // SwingGui installs the macOS open-file handler before resolving package natives so an
         // early Finder event cannot be lost during bootstrap.
-        run(
+        runWithStartupAudio(
             request.debug,
             request.initialRom,
             request.settingsOverrides,
             request.joinNetplayHost,
             request.suppressInitialAutosaveResume,
+            request.startMuted,
         )
       }
   if (exitCode != SUCCESS) {
@@ -129,6 +132,7 @@ private fun parseCli(args: Array<String>): CliCommand {
   var forceCgb = false
   var useBootstrap = false
   var disableBatterySaves = false
+  var startMuted = false
   var profileId: String? = null
   var profileOccurrences = 0
   var joinNetplayEndpoint: NetplayV8Endpoint? = null
@@ -205,6 +209,10 @@ private fun parseCli(args: Array<String>): CliCommand {
         if (disableBatterySaves) repeatedOption("--disable-battery-saves")
         disableBatterySaves = true
       }
+      "--start-muted" -> {
+        if (startMuted) repeatedOption("--start-muted")
+        startMuted = true
+      }
       "--profile" -> cliError("--profile requires =<id>")
       "--join-netplay" -> {
         if (joinNetplayEndpoint != null) repeatedOption("--join-netplay")
@@ -241,6 +249,7 @@ private fun parseCli(args: Array<String>): CliCommand {
           forceCgb ||
           useBootstrap ||
           disableBatterySaves ||
+          startMuted ||
           profileId != null ||
           joinNetplayEndpoint != null ||
           positional.isNotEmpty())) {
@@ -271,6 +280,7 @@ private fun parseCli(args: Array<String>): CliCommand {
           debug = debug,
           initialRom = positional.singleOrNull()?.let(::File),
           joinNetplayHost = joinNetplayEndpoint?.startClientValue,
+          startMuted = startMuted,
           suppressInitialAutosaveResume = joinNetplayEndpoint != null,
           settingsOverrides =
               ApplicationSettingsOverrides(
@@ -315,6 +325,7 @@ internal fun printUsage(stream: PrintStream) {
   stream.println("  -b  --use-bootstrap            Run the bundled boot ROM normally")
   stream.println("  -db --disable-battery-saves    Disable battery save reads and writes")
   stream.println("      --join-netplay HOST        Join a netplay host after opening ROM_FILE")
+  stream.println("      --start-muted              Start muted without changing saved audio settings")
   stream.println("      --debug                    Enable debug console")
   stream.println("  -h  --help                     Display this help and exit")
   stream.println("      --version                  Display version and exit")

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -37,6 +37,7 @@ private sealed class CliCommand {
 }
 
 fun main(args: Array<String>) {
+  validatePackagedLocalNetplayRelaunchChildIfRequested(args)
   val exitCode =
       runCli(
           args,
@@ -44,8 +45,9 @@ fun main(args: Array<String>) {
           System.err,
           applicationVersion(),
           packageSmoke = {
+            launchPackagedLocalNetplayRelaunchChildIfRequested()
             // Exercise the package-native handoff before constructing the synthetic archive and
-            // machine. The smoke is intentionally headless and never reads an external/user ROM.
+            // machine. This in-process leg is headless and never reads an external/user ROM.
             val selection = NativeRuntimeBootstrap.bootstrapFromSystem()
             val nativeTarget =
                 NativeRuntimeBootstrap.requirePackageSmokeSelection(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
@@ -127,6 +127,9 @@ internal fun validatePackagedLocalNetplayRelaunchChildIfRequested(
   check(request.settingsOverrides.suppressCloseAutosave) {
     "Packaged local netplay child did not suppress close autosave"
   }
+  check(request.startMuted) {
+    "Packaged local netplay child did not retain its process-local mute request"
+  }
   val expectedEndpoint =
       environment[LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV]?.takeIf(String::isNotBlank) ?: "localhost"
   check(request.joinNetplayHost == expectedEndpoint && request.suppressInitialAutosaveResume) {
@@ -135,7 +138,7 @@ internal fun validatePackagedLocalNetplayRelaunchChildIfRequested(
 
   val evidence =
       "$RELAUNCH_EVIDENCE_PREFIX pid=$processId, launcher=$actualLauncher, " +
-          "profile=dmg, battery-saves=false, join=$expectedEndpoint\n"
+          "profile=dmg, battery-saves=false, audio=muted, join=$expectedEndpoint\n"
   writeExclusiveText(marker, evidence)
   return true
 }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
@@ -1,0 +1,253 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import java.io.OutputStream
+import java.io.PrintStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.TimeUnit
+
+internal const val LOCAL_NETPLAY_RELAUNCH_MARKER_ENV =
+    "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_MARKER"
+internal const val LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER_ENV =
+    "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER"
+internal const val LOCAL_NETPLAY_RELAUNCH_PID_MARKER_ENV =
+    "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_PID_MARKER"
+internal const val LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV =
+    "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_ENDPOINT"
+private const val RELAUNCH_ROM_NAME = "local-netplay-relaunch-smoke.gb"
+private const val RELAUNCH_EVIDENCE_PREFIX = "Coffee GB local netplay relaunch OK:"
+
+/**
+ * The native-package verifier sets the marker only for a primary-launcher `--package-smoke` run.
+ * The parent uses the production netplay launcher. Its child validates the exact typed request,
+ * then continues through normal Swing, ROM, and automatic-connect startup.
+ */
+internal fun launchPackagedLocalNetplayRelaunchChildIfRequested(
+    environment: Map<String, String> = System.getenv(),
+    launcher: LocalNetplayInstanceLauncher? = null,
+) {
+  val marker = relaunchMarker(environment) ?: return
+  val parent = requireNotNull(marker.parent) { "Local netplay relaunch marker must have a parent" }
+  check(Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+    "Local netplay relaunch marker parent is not a directory"
+  }
+  check(!Files.exists(marker, LinkOption.NOFOLLOW_LINKS)) {
+    "Local netplay relaunch marker already exists"
+  }
+  val rom = parent.resolve(RELAUNCH_ROM_NAME)
+  Files.newByteChannel(
+          rom,
+          setOf(
+              StandardOpenOption.CREATE_NEW,
+              StandardOpenOption.WRITE,
+              LinkOption.NOFOLLOW_LINKS,
+          ),
+      )
+      .use { channel ->
+        val generated = ByteBuffer.wrap(syntheticPackageRom())
+        while (generated.hasRemaining()) channel.write(generated)
+      }
+  val endpointText =
+      environment[LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV]?.takeIf(String::isNotBlank) ?: "localhost"
+  val endpoint =
+      (validateNetplayV8Address(endpointText) as? NetplayAddressValidation.Valid)?.endpoint
+          ?: error("Packaged local netplay relaunch endpoint is invalid")
+  val activeLauncher = launcher ?: observedPackagedLocalNetplayLauncher(environment)
+  val result = activeLauncher.launch(rom, HardwareProfileRegistry.DMG, endpoint, 1)
+  check(result.launcherAvailable && result.started == 1) {
+    "Packaged local netplay relaunch did not start its child"
+  }
+}
+
+/**
+ * Validates the packaged child before normal CLI/Swing startup and writes exclusive request
+ * evidence. Returning true identifies the child but deliberately does not intercept it: package
+ * verification continues through ROM activation and the automatic netplay connection.
+ */
+internal fun validatePackagedLocalNetplayRelaunchChildIfRequested(
+    args: Array<String>,
+    environment: Map<String, String> = System.getenv(),
+    packagedLauncher: String? = System.getProperty("jpackage.app-path"),
+    processId: Long = ProcessHandle.current().pid(),
+): Boolean {
+  val marker = relaunchMarker(environment) ?: return false
+  if (args.contentEquals(arrayOf("--package-smoke"))) return false
+
+  val expectedLauncher =
+      environment[LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER_ENV]
+          ?.takeIf(String::isNotBlank)
+          ?.let(Path::of)
+          ?.toAbsolutePath()
+          ?.normalize()
+          ?: error("Packaged local netplay relaunch expected launcher is missing")
+  val actualLauncher =
+      packagedLauncher
+          ?.takeIf(String::isNotBlank)
+          ?.let(Path::of)
+          ?.toAbsolutePath()
+          ?.normalize()
+          ?: error("Packaged local netplay child did not report jpackage.app-path")
+  check(Files.isSameFile(expectedLauncher, actualLauncher)) {
+    "Packaged local netplay child used an unexpected launcher"
+  }
+
+  var launchRequest: CliLaunchRequest? = null
+  val nullStream = PrintStream(OutputStream.nullOutputStream(), true, StandardCharsets.UTF_8)
+  nullStream.use {
+    val exitCode =
+        runCli(
+            args,
+            it,
+            it,
+            "package-relaunch-smoke",
+            packageSmoke = { error("Relaunch child unexpectedly selected package smoke") },
+        ) { request -> launchRequest = request }
+    check(exitCode == 0) { "Packaged local netplay child request did not parse" }
+  }
+  val request = checkNotNull(launchRequest) { "Packaged local netplay child did not request launch" }
+  val expectedRom = marker.resolveSibling(RELAUNCH_ROM_NAME).toAbsolutePath().normalize()
+  check(request.initialRom?.toPath()?.toAbsolutePath()?.normalize() == expectedRom) {
+    "Packaged local netplay child received an unexpected ROM"
+  }
+  check(request.settingsOverrides.hardwareProfile == HardwareProfileRegistry.DMG) {
+    "Packaged local netplay child did not retain the DMG profile"
+  }
+  check(request.settingsOverrides.batterySavesEnabled == false) {
+    "Packaged local netplay child did not disable battery saves"
+  }
+  check(request.settingsOverrides.forceInMemoryBattery) {
+    "Packaged local netplay child did not select an in-memory battery"
+  }
+  check(request.settingsOverrides.suppressCloseAutosave) {
+    "Packaged local netplay child did not suppress close autosave"
+  }
+  val expectedEndpoint =
+      environment[LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV]?.takeIf(String::isNotBlank) ?: "localhost"
+  check(request.joinNetplayHost == expectedEndpoint && request.suppressInitialAutosaveResume) {
+    "Packaged local netplay child did not retain its localhost join request"
+  }
+
+  val evidence =
+      "$RELAUNCH_EVIDENCE_PREFIX pid=$processId, launcher=$actualLauncher, " +
+          "profile=dmg, battery-saves=false, join=$expectedEndpoint\n"
+  writeExclusiveText(marker, evidence)
+  return true
+}
+
+private fun observedPackagedLocalNetplayLauncher(
+    environment: Map<String, String>
+): LocalNetplayInstanceLauncher {
+  val pidMarker =
+      environment[LOCAL_NETPLAY_RELAUNCH_PID_MARKER_ENV]
+          ?.takeIf(String::isNotBlank)
+          ?.let(Path::of)
+          ?.toAbsolutePath()
+          ?.normalize()
+          ?: error("Packaged local netplay relaunch PID marker is missing")
+  val parent = requireNotNull(pidMarker.parent) { "Local netplay PID marker must have a parent" }
+  check(Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+    "Local netplay PID marker parent is not a directory"
+  }
+  check(!Files.exists(pidMarker, LinkOption.NOFOLLOW_LINKS)) {
+    "Local netplay PID marker already exists"
+  }
+  return CurrentProcessLocalNetplayInstanceLauncher(
+      currentProcessCommand(),
+  ) { command ->
+    val child = localNetplayProcessBuilder(command).start()
+    try {
+      writeExclusivePidMarker(pidMarker, child.pid())
+    } catch (failure: Exception) {
+      val terminated = terminateStartedChild(child, timeoutMillis = 5_000)
+      if (!terminated) {
+        throw IllegalStateException(
+            "Packaged local netplay child survived failed PID publication",
+            failure,
+        )
+      }
+      throw failure
+    }
+  }
+}
+
+/** Publishes a complete PID or no marker at all, so verifier cleanup never parses partial data. */
+private fun writeExclusivePidMarker(marker: Path, processId: Long) {
+  require(processId > 0) { "Packaged local netplay child PID must be positive" }
+  val parent = requireNotNull(marker.parent) { "Local netplay PID marker must have a parent" }
+  val temporary = Files.createTempFile(parent, ".local-netplay-pid-", ".tmp")
+  try {
+    Files.newByteChannel(
+            temporary,
+            setOf(
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                LinkOption.NOFOLLOW_LINKS,
+            ),
+        )
+        .use { channel ->
+          val bytes = StandardCharsets.UTF_8.encode("$processId\n")
+          while (bytes.hasRemaining()) channel.write(bytes)
+        }
+    try {
+      Files.move(temporary, marker, StandardCopyOption.ATOMIC_MOVE)
+    } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+      Files.move(temporary, marker)
+    }
+  } finally {
+    Files.deleteIfExists(temporary)
+  }
+}
+
+/** Bounded, interruption-preserving cleanup used when PID publication itself fails. */
+internal fun terminateStartedChild(child: Process, timeoutMillis: Long): Boolean {
+  require(timeoutMillis > 0) { "Child cleanup timeout must be positive" }
+  var interrupted = Thread.interrupted()
+  val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+  try {
+    child.destroyForcibly()
+    while (child.isAlive && System.nanoTime() < deadline) {
+      val remaining = deadline - System.nanoTime()
+      if (remaining <= 0) break
+      try {
+        child.waitFor(
+            TimeUnit.NANOSECONDS.toMillis(remaining).coerceIn(1, 100),
+            TimeUnit.MILLISECONDS,
+        )
+      } catch (_: InterruptedException) {
+        interrupted = true
+      }
+      if (child.isAlive) child.destroyForcibly()
+    }
+    return !child.isAlive
+  } finally {
+    if (interrupted) Thread.currentThread().interrupt()
+  }
+}
+
+private fun writeExclusiveText(path: Path, text: String) {
+  Files.newByteChannel(
+          path,
+          setOf(
+              StandardOpenOption.CREATE_NEW,
+              StandardOpenOption.WRITE,
+              LinkOption.NOFOLLOW_LINKS,
+          ),
+      )
+      .use { channel ->
+        val bytes = StandardCharsets.UTF_8.encode(text)
+        while (bytes.hasRemaining()) channel.write(bytes)
+      }
+}
+
+private fun relaunchMarker(environment: Map<String, String>): Path? =
+    environment[LOCAL_NETPLAY_RELAUNCH_MARKER_ENV]
+        ?.takeIf(String::isNotBlank)
+        ?.let(Path::of)
+        ?.toAbsolutePath()
+        ?.normalize()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -67,6 +67,23 @@ class SwingEmulator(
           AudioSystemSound(configuration, bus, callerId) {}
         },
 ) {
+  /** Adds transient startup policy without changing the published primary constructor ABI. */
+  internal constructor(
+      eventBus: EventBus,
+      console: Console?,
+      properties: EmulatorProperties,
+      mobileAdapterConfigurationProvider: Controller.MobileAdapterConfigurationProvider,
+      mobileAdapterGuestConfigurationSink: MobileAdapterGuestConfigurationSink,
+      startMuted: Boolean,
+  ) : this(
+      eventBus,
+      console,
+      properties,
+      mobileAdapterConfigurationProvider,
+      mobileAdapterGuestConfigurationSink,
+      startupAudioOutputFactory(startMuted),
+  )
+
   private val display: SwingDisplay
   private val joypad: SwingJoypad
   private val gamepad: SwingGamepad
@@ -297,6 +314,13 @@ class SwingEmulator(
   fun applyDeviceSettings(settings: ApplicationSettings) {
     gamepad.updateConfiguration(settings.toGamepadConfiguration())
     sound.applyConfiguration(settings.audio.toRuntimeConfiguration())
+  }
+
+  /** Reconfigures devices/volume while retaining an explicit transient mute or unmute. */
+  internal fun applyDeviceSettingsPreservingMute(settings: ApplicationSettings) {
+    gamepad.updateConfiguration(settings.toGamepadConfiguration())
+    sound.applyConfiguration(
+        settings.audio.toRuntimeConfigurationPreservingMute(sound.currentConfiguration()))
   }
 
   fun gamepadCatalog(): GamepadCatalog = gamepad.catalog()
@@ -589,3 +613,25 @@ internal fun ApplicationSettings.Audio.toRuntimeConfiguration(): AudioRuntimeCon
         !enabled,
         AudioRuntimeConfiguration.LatencyPreset.valueOf(latency.name),
     )
+
+internal fun startupAudioMuted(audio: ApplicationSettings.Audio, startMuted: Boolean): Boolean =
+    startMuted || !audio.enabled
+
+private fun startupAudioOutputFactory(startMuted: Boolean): SwingAudioOutputFactory =
+    SwingAudioOutputFactory { configuration, eventBus, callerId ->
+      AudioSystemSound(
+          startupAudioRuntimeConfiguration(configuration, startMuted),
+          eventBus,
+          callerId,
+      ) {}
+    }
+
+internal fun startupAudioRuntimeConfiguration(
+    configured: AudioRuntimeConfiguration,
+    startMuted: Boolean,
+): AudioRuntimeConfiguration = configured.withMuted(startMuted || configured.muted())
+
+/** Device, volume, and latency edits must not silently undo a process-local mute. */
+internal fun ApplicationSettings.Audio.toRuntimeConfigurationPreservingMute(
+    current: AudioRuntimeConfiguration,
+): AudioRuntimeConfiguration = toRuntimeConfiguration().withMuted(current.muted())

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -1088,6 +1088,7 @@ class SwingGui private constructor(
    */
   private fun requestDesktopStartupSmokeIfConfigured() {
     val markerText = System.getenv(DESKTOP_SMOKE_MARKER_ENV)?.takeIf(String::isNotBlank) ?: return
+    val closeAfterEvidence = desktopStartupSmokeShouldAutoClose(System.getenv())
     check(SwingUtilities.isEventDispatchThread()) {
       "Desktop startup smoke readiness must be observed on the Event Dispatch Thread"
     }
@@ -1115,7 +1116,9 @@ class SwingGui private constructor(
         LOG.error("Unable to write desktop startup smoke evidence", failure)
         exitProcess(1)
       }
-      SwingUtilities.invokeLater(::requestAutomatedClose)
+      if (closeAfterEvidence) {
+        SwingUtilities.invokeLater(::requestAutomatedClose)
+      }
     }
   }
 
@@ -1380,6 +1383,10 @@ internal fun shouldApplyRomLifecycleEvent(
     } else {
       ownsVisibleRequest(openRequestId)
     }
+
+/** The relaunch verifier retains the packaged child until its automatic TCP join is observed. */
+internal fun desktopStartupSmokeShouldAutoClose(environment: Map<String, String>): Boolean =
+    environment[LOCAL_NETPLAY_RELAUNCH_MARKER_ENV].isNullOrBlank()
 
 internal data class DesktopLoadingUiState(
     val title: String,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -82,6 +82,7 @@ class SwingGui private constructor(
     private val initialRom: File?,
     private val initialJoinNetplayHost: String?,
     private val suppressInitialAutosaveResume: Boolean,
+    private val startMuted: Boolean,
     private val properties: EmulatorProperties,
     private val mobileAdapterConfiguration: MobileAdapterConfigurationCoordinator,
     private val mobileAdapterConfigurationUiState: MobileAdapterConfigurationUiState,
@@ -196,6 +197,7 @@ class SwingGui private constructor(
             properties,
             mobileAdapterConfiguration.provider,
             mobileAdapterConfiguration,
+            startMuted = startMuted,
         )
   }
 
@@ -442,7 +444,7 @@ class SwingGui private constructor(
                     properties.updateApplicationSettings { settings ->
                       settings.copy(audio = settings.audio.copy(volume = volume))
                     }
-                    emulator.applyDeviceSettings(properties.applicationSettings)
+                    emulator.applyDeviceSettingsPreservingMute(properties.applicationSettings)
                   }
                   desktopUiCoordinator.audioVolume(volume)
                 },
@@ -461,7 +463,7 @@ class SwingGui private constructor(
                         eventBus = eventBus,
                         displayController = displayController,
                         gamepadCatalog = { emulator.gamepadCatalog().snapshot() },
-                        applyDeviceSettings = emulator::applyDeviceSettings,
+                        applyDeviceSettings = emulator::applyDeviceSettingsPreservingMute,
                         isCameraEnabled = { ::menu.isInitialized && menu.isCameraEnabled() },
                         setCameraEnabled = { enabled ->
                           if (::menu.isInitialized) menu.setCameraEnabled(enabled)
@@ -530,7 +532,10 @@ class SwingGui private constructor(
             DesktopPresentation(
                 commands =
                     DesktopCommandPresentation(
-                        muted = !properties.applicationSettings.audio.enabled,
+                        muted = startupAudioMuted(
+                            properties.applicationSettings.audio,
+                            startMuted,
+                        ),
                         audioVolume = properties.applicationSettings.audio.volume,
                         commandBarVisible =
                             properties.applicationSettings.desktop.commandBarVisible,
@@ -1110,7 +1115,7 @@ class SwingGui private constructor(
         }
     val evidence =
         "Coffee GB desktop ready OK: edt=true, visible=true, displayable=true, menu=true, " +
-            "mobile-adapter=true\n"
+            "mobile-adapter=true, muted=${desktopUiCoordinator.current().commands.muted}\n"
     writeDesktopStartupEvidence(marker, evidence) { failure ->
       if (failure != null) {
         LOG.error("Unable to write desktop startup smoke evidence", failure)
@@ -1159,11 +1164,16 @@ class SwingGui private constructor(
           )
         },
     ) { edit ->
-      val previousAdvanced = properties.applicationSettings.advanced
-      val previousDesktop = properties.applicationSettings.desktop
+      val previous = properties.applicationSettings
       properties.updateApplicationSettings(edit::applyTo)
       val applied = properties.applicationSettings
-      applyPreferencesRuntime(previousAdvanced, previousDesktop, applied, edit)
+      applyPreferencesRuntime(
+          previous.advanced,
+          previous.desktop,
+          previous.audio.enabled,
+          applied,
+          edit,
+      )
     }
     updateRecentRoms()
   }
@@ -1171,6 +1181,7 @@ class SwingGui private constructor(
   private fun applyPreferencesRuntime(
       previousAdvanced: ApplicationSettings.Advanced,
       previousDesktop: ApplicationSettings.Desktop,
+      previousAudioEnabled: Boolean,
       applied: ApplicationSettings,
       edit: PreferencesEdit,
   ) {
@@ -1189,7 +1200,13 @@ class SwingGui private constructor(
       desktopActions.applyShortcuts(
           DesktopShortcutRegistry(DesktopKeyboardKeyAdapter.keyCodes(applied.input.keyboard.values)))
     }
-    applyEffect("audio and game controllers") { emulator.applyDeviceSettings(applied) }
+    applyEffect("audio and game controllers") {
+      if (applied.audio.enabled == previousAudioEnabled) {
+        emulator.applyDeviceSettingsPreservingMute(applied)
+      } else {
+        emulator.applyDeviceSettings(applied)
+      }
+    }
     // Preferences can change the volume outside the portable overlay. Republish the applied
     // value so the overlay's cached command presentation (and its next +/- adjustment) starts
     // from the setting the user just applied.
@@ -1213,8 +1230,10 @@ class SwingGui private constructor(
       }
     }
     desktopUiCoordinator.commandBarVisible(applied.desktop.commandBarVisible)
-    applyEffect("audio mute") {
-      eventBus.post(Sound.SoundEnabledEvent(applied.audio.enabled))
+    if (applied.audio.enabled != previousAudioEnabled) {
+      applyEffect("audio mute") {
+        eventBus.post(Sound.SoundEnabledEvent(applied.audio.enabled))
+      }
     }
     applyEffect("save and rewind settings") {
       eventBus.post(Controller.UpdatedSavesSettingsEvent(applied.saves))
@@ -1259,6 +1278,24 @@ class SwingGui private constructor(
         settingsOverrides: ApplicationSettingsOverrides = ApplicationSettingsOverrides(),
         initialJoinNetplayHost: String? = null,
         suppressInitialAutosaveResume: Boolean = false,
+    ) =
+        runWithStartupAudio(
+            debug,
+            initialRom,
+            settingsOverrides,
+            initialJoinNetplayHost,
+            suppressInitialAutosaveResume,
+            startMuted = false,
+        )
+
+    /** Internal launch path for child-only transient policy; keeps [run]'s published ABI intact. */
+    internal fun runWithStartupAudio(
+        debug: Boolean,
+        initialRom: File?,
+        settingsOverrides: ApplicationSettingsOverrides,
+        initialJoinNetplayHost: String?,
+        suppressInitialAutosaveResume: Boolean,
+        startMuted: Boolean,
     ) {
       val desktopOpenFiles = DesktopOpenFilesBridge()
       prepareDesktopLaunch(
@@ -1304,6 +1341,7 @@ class SwingGui private constructor(
                 initialRom,
                 initialJoinNetplayHost,
                 suppressInitialAutosaveResume,
+                startMuted,
                 properties,
                 mobileAdapterConfiguration,
                 mobileAdapterConfigurationUiState,

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
@@ -7,6 +7,10 @@ import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -54,6 +58,18 @@ public final class NativePackageVerifier {
     private static final int MAX_PROCESS_OUTPUT = 4 * 1024 * 1024;
     private static final int MAX_JSON_DEPTH = 64;
     private static final Duration SMOKE_TIMEOUT = Duration.ofSeconds(45);
+    private static final String LOCAL_NETPLAY_RELAUNCH_MARKER_ENV =
+            "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_MARKER";
+    private static final String LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER_ENV =
+            "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER";
+    private static final String LOCAL_NETPLAY_RELAUNCH_PID_MARKER_ENV =
+            "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_PID_MARKER";
+    private static final String LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV =
+            "COFFEE_GB_LOCAL_NETPLAY_RELAUNCH_SMOKE_ENDPOINT";
+    private static final String DESKTOP_SMOKE_MARKER_ENV =
+            "COFFEE_GB_DESKTOP_SMOKE_MARKER";
+    private static final Pattern LOCAL_NETPLAY_RELAUNCH_PID =
+            Pattern.compile("(?:^|[ ,])pid=([0-9]+)(?:[, ]|$)");
     private static final Set<String> ROM_SUFFIXES = Set.of(".gb", ".gbc", ".rom", ".sgb");
     private static final Set<String> SIGNING_SUFFIXES = Set.of(
             ".p12", ".pfx", ".pem", ".key", ".keystore", ".jks", ".mobileprovision");
@@ -319,6 +335,10 @@ public final class NativePackageVerifier {
                 launcherSmoke,
                 "native-target=" + result.target().id(),
                 "packaged launcher package smoke native target");
+        if (result.target() == NativeTarget.WINDOWS_X86_64) {
+            runPackagedLocalNetplayRelaunchSmoke(
+                    result, home, smokeCaches.localNetplayRelaunch());
+        }
         if (desktopSmokeEnabled(System.getenv())) {
             runDesktopSmoke(result, home, smokeCaches.desktopNormal(), false);
             runDesktopSmoke(result, home, smokeCaches.desktopDebug(), true);
@@ -330,6 +350,7 @@ public final class NativePackageVerifier {
         return new SmokeCacheLayout(
                 Files.createDirectory(home.resolve("direct-runtime-native-cache")),
                 Files.createDirectory(home.resolve("packaged-launcher-native-cache")),
+                Files.createDirectory(home.resolve("local-netplay-relaunch-native-cache")),
                 Files.createDirectory(home.resolve("desktop-normal-native-cache")),
                 Files.createDirectory(home.resolve("desktop-debug-native-cache")));
     }
@@ -337,8 +358,136 @@ public final class NativePackageVerifier {
     record SmokeCacheLayout(
             Path directRuntime,
             Path packagedLauncher,
+            Path localNetplayRelaunch,
             Path desktopNormal,
             Path desktopDebug) {
+    }
+
+    private static void runPackagedLocalNetplayRelaunchSmoke(
+            VerificationResult result, Path home, Path nativeCache)
+            throws IOException, InterruptedException {
+        Path relaunchHome = Files.createDirectory(home.resolve("local-netplay-relaunch-home"));
+        Path requestMarker = home.resolve("local-netplay-relaunch-request.marker");
+        Path pidMarker = home.resolve("local-netplay-relaunch-pid.marker");
+        Path desktopMarker = home.resolve("local-netplay-relaunch-desktop.marker");
+        Path expectedLauncher = result.launcher().toAbsolutePath().normalize();
+        String javaOptions = "-Djava.awt.headless=false -Duser.home=" + relaunchHome
+                + " -Dcoffee-gb.native.cache=" + nativeCache;
+        try (ServerSocket joinProbe = new ServerSocket()) {
+            joinProbe.bind(new InetSocketAddress("127.0.0.1", 0), 1);
+            joinProbe.setSoTimeout((int) SMOKE_TIMEOUT.toMillis());
+            String endpoint = "127.0.0.1:" + joinProbe.getLocalPort();
+            try {
+                run(
+                        List.of(expectedLauncher.toString(), "--package-smoke"),
+                        Map.of(
+                                "_JAVA_OPTIONS", javaOptions,
+                                LOCAL_NETPLAY_RELAUNCH_MARKER_ENV, requestMarker.toString(),
+                                LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER_ENV,
+                                        expectedLauncher.toString(),
+                                LOCAL_NETPLAY_RELAUNCH_PID_MARKER_ENV, pidMarker.toString(),
+                                LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV, endpoint,
+                                DESKTOP_SMOKE_MARKER_ENV, desktopMarker.toString()));
+
+                awaitRegularFile(pidMarker, "packaged local netplay relaunch PID marker");
+                awaitRegularFile(requestMarker, "packaged local netplay relaunch request marker");
+                awaitRegularFile(desktopMarker, "packaged local netplay relaunch desktop marker");
+                try (Socket connection = acceptLocalNetplayConnection(joinProbe)) {
+                    if (!connection.getInetAddress().isLoopbackAddress()) {
+                        throw new IOException(
+                                "Packaged local netplay child connected from a non-loopback address");
+                    }
+                }
+
+                String evidence = Files.readString(requestMarker, StandardCharsets.UTF_8);
+                requireOutput(
+                        evidence,
+                        "Coffee GB local netplay relaunch OK:",
+                        "packaged local netplay relaunch");
+                requireOutput(evidence, "profile=dmg", "packaged local netplay relaunch profile");
+                requireOutput(
+                        evidence,
+                        "battery-saves=false",
+                        "packaged local netplay relaunch battery policy");
+                requireOutput(
+                        evidence,
+                        "join=" + endpoint,
+                        "packaged local netplay relaunch endpoint");
+                long observedPid = parseEvidencePid(evidence);
+                long startedPid = readPidMarker(pidMarker);
+                if (observedPid != startedPid) {
+                    throw new IOException("Packaged local netplay child PID evidence changed");
+                }
+                String desktopEvidence = Files.readString(desktopMarker, StandardCharsets.UTF_8);
+                requireOutput(
+                        desktopEvidence,
+                        "Coffee GB desktop ready OK:",
+                        "packaged local netplay desktop startup");
+            } finally {
+                terminateTrackedProcess(pidMarker);
+            }
+        }
+    }
+
+    private static Socket acceptLocalNetplayConnection(ServerSocket server) throws IOException {
+        try {
+            return server.accept();
+        } catch (SocketTimeoutException failure) {
+            throw new IOException(
+                    "Packaged local netplay child did not attempt its automatic connection",
+                    failure);
+        }
+    }
+
+    private static void awaitRegularFile(Path marker, String description)
+            throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + SMOKE_TIMEOUT.toNanos();
+        while (!Files.isRegularFile(marker, LinkOption.NOFOLLOW_LINKS)
+                && System.nanoTime() < deadline) {
+            Thread.sleep(25);
+        }
+        requireRegularFile(marker, description);
+    }
+
+    private static long parseEvidencePid(String evidence) throws IOException {
+        var matcher = LOCAL_NETPLAY_RELAUNCH_PID.matcher(evidence);
+        if (!matcher.find()) {
+            throw new IOException("Packaged local netplay relaunch evidence has no child PID");
+        }
+        try {
+            return Long.parseLong(matcher.group(1));
+        } catch (NumberFormatException failure) {
+            throw new IOException(
+                    "Packaged local netplay relaunch evidence has an invalid PID",
+                    failure);
+        }
+    }
+
+    private static long readPidMarker(Path marker) throws IOException {
+        String text = Files.readString(marker, StandardCharsets.UTF_8).strip();
+        try {
+            long pid = Long.parseLong(text);
+            if (pid <= 0) {
+                throw new NumberFormatException("PID must be positive");
+            }
+            return pid;
+        } catch (NumberFormatException failure) {
+            throw new IOException("Packaged local netplay PID marker is invalid", failure);
+        }
+    }
+
+    private static void terminateTrackedProcess(Path pidMarker)
+            throws IOException {
+        if (!Files.isRegularFile(pidMarker, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        ProcessHandle process = ProcessHandle.of(readPidMarker(pidMarker)).orElse(null);
+        if (process == null || !process.isAlive()) {
+            return;
+        }
+        if (!terminateProcessTree(process, Duration.ofSeconds(8))) {
+            throw new IOException("Packaged local netplay child could not be terminated");
+        }
     }
 
     static boolean desktopSmokeEnabled(Map<String, String> environment) {
@@ -1480,7 +1629,7 @@ public final class NativePackageVerifier {
         }
     }
 
-    private static String run(List<String> command, Map<String, String> environment)
+    static String run(List<String> command, Map<String, String> environment)
             throws IOException, InterruptedException {
         ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
         builder.environment().putAll(environment);
@@ -1506,23 +1655,143 @@ public final class NativePackageVerifier {
         }, "coffee-gb-package-smoke-output");
         reader.setDaemon(true);
         reader.start();
-        if (!process.waitFor(SMOKE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
-            process.destroyForcibly();
+        Throwable pendingFailure = null;
+        boolean restoreInterrupt = false;
+        try {
+            if (!process.waitFor(SMOKE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IOException(command.get(0) + " exceeded "
+                        + SMOKE_TIMEOUT.toSeconds() + " second smoke deadline");
+            }
             reader.join(5_000);
-            throw new IOException(command.get(0) + " exceeded "
-                    + SMOKE_TIMEOUT.toSeconds() + " second smoke deadline");
-        }
-        reader.join(5_000);
-        IOException failure = readFailure.get();
-        if (failure != null) {
+            if (reader.isAlive()) {
+                throw new IOException(command.get(0) + " output reader did not stop");
+            }
+            IOException failure = readFailure.get();
+            if (failure != null) {
+                throw failure;
+            }
+            String captured = output.toString(StandardCharsets.UTF_8);
+            if (process.exitValue() != 0) {
+                throw new IOException(command.get(0) + " exited " + process.exitValue()
+                        + ": " + captured.strip());
+            }
+            return captured;
+        } catch (InterruptedException failure) {
+            pendingFailure = failure;
+            restoreInterrupt = true;
             throw failure;
+        } catch (IOException | RuntimeException | Error failure) {
+            pendingFailure = failure;
+            throw failure;
+        } finally {
+            IOException cleanupFailure = null;
+            if ((process.isAlive() || pendingFailure != null)
+                    && !terminateProcessTree(process.toHandle(), Duration.ofSeconds(8))) {
+                cleanupFailure = new IOException(
+                        "Unable to terminate package smoke process " + process.pid());
+            }
+            if (reader.isAlive()
+                    && !joinThreadUninterruptibly(reader, Duration.ofSeconds(5))) {
+                IOException readerFailure = new IOException(
+                        "Unable to stop package smoke output reader for " + command.get(0));
+                if (cleanupFailure == null) {
+                    cleanupFailure = readerFailure;
+                } else {
+                    cleanupFailure.addSuppressed(readerFailure);
+                }
+            }
+            if (restoreInterrupt) {
+                Thread.currentThread().interrupt();
+            }
+            if (cleanupFailure != null) {
+                if (pendingFailure != null) {
+                    pendingFailure.addSuppressed(cleanupFailure);
+                } else {
+                    throw cleanupFailure;
+                }
+            }
         }
-        String captured = output.toString(StandardCharsets.UTF_8);
-        if (process.exitValue() != 0) {
-            throw new IOException(command.get(0) + " exited " + process.exitValue()
-                    + ": " + captured.strip());
+    }
+
+    /** Bounded process-tree cleanup that completes even if the caller was interrupted. */
+    private static boolean terminateProcessTree(ProcessHandle root, Duration timeout) {
+        boolean interrupted = Thread.interrupted();
+        long deadline = System.nanoTime() + timeout.toNanos();
+        List<ProcessHandle> descendants = new ArrayList<>(root.descendants().toList());
+        try {
+            for (int index = descendants.size() - 1; index >= 0; index--) {
+                descendants.get(index).destroy();
+            }
+            root.destroy();
+            long gracefulDeadline = Math.min(
+                    deadline,
+                    System.nanoTime() + TimeUnit.SECONDS.toNanos(2));
+            while (processTreeAlive(root, descendants)
+                    && System.nanoTime() < gracefulDeadline) {
+                try {
+                    Thread.sleep(25);
+                } catch (InterruptedException failure) {
+                    interrupted = true;
+                }
+            }
+            root.descendants().forEach(candidate -> {
+                if (!descendants.contains(candidate)) {
+                    descendants.add(candidate);
+                }
+            });
+            if (processTreeAlive(root, descendants)) {
+                for (int index = descendants.size() - 1; index >= 0; index--) {
+                    if (descendants.get(index).isAlive()) {
+                        descendants.get(index).destroyForcibly();
+                    }
+                }
+                if (root.isAlive()) {
+                    root.destroyForcibly();
+                }
+            }
+            while (processTreeAlive(root, descendants) && System.nanoTime() < deadline) {
+                try {
+                    Thread.sleep(25);
+                } catch (InterruptedException failure) {
+                    interrupted = true;
+                }
+            }
+            return !processTreeAlive(root, descendants);
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
-        return captured;
+    }
+
+    private static boolean processTreeAlive(
+            ProcessHandle root, List<ProcessHandle> descendants) {
+        return root.isAlive() || descendants.stream().anyMatch(ProcessHandle::isAlive);
+    }
+
+    private static boolean joinThreadUninterruptibly(Thread thread, Duration timeout) {
+        boolean interrupted = Thread.interrupted();
+        long deadline = System.nanoTime() + timeout.toNanos();
+        try {
+            while (thread.isAlive() && System.nanoTime() < deadline) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    break;
+                }
+                try {
+                    thread.join(Math.max(1, Math.min(
+                            TimeUnit.NANOSECONDS.toMillis(remaining),
+                            100)));
+                } catch (InterruptedException failure) {
+                    interrupted = true;
+                }
+            }
+            return !thread.isAlive();
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private static void requireOutput(String output, String expected, String description)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
@@ -411,6 +411,10 @@ public final class NativePackageVerifier {
                         "packaged local netplay relaunch battery policy");
                 requireOutput(
                         evidence,
+                        "audio=muted",
+                        "packaged local netplay relaunch startup audio policy");
+                requireOutput(
+                        evidence,
                         "join=" + endpoint,
                         "packaged local netplay relaunch endpoint");
                 long observedPid = parseEvidencePid(evidence);
@@ -423,6 +427,10 @@ public final class NativePackageVerifier {
                         desktopEvidence,
                         "Coffee GB desktop ready OK:",
                         "packaged local netplay desktop startup");
+                requireOutput(
+                        desktopEvidence,
+                        "muted=true",
+                        "packaged local netplay desktop mute presentation");
             } finally {
                 terminateTrackedProcess(pidMarker);
             }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
@@ -47,6 +47,7 @@ class LocalNetplayInstanceLauncherTest {
             "/apps/coffee-gb.jar",
             "--profile=cgb",
             "--disable-battery-saves",
+            "--start-muted",
             "--join-netplay",
             "localhost",
             rom.toString(),

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
@@ -10,11 +10,18 @@ import org.junit.Test
 class LocalNetplayInstanceLauncherTest {
 
   @Test
-  fun `child processes inherit the host error stream`() {
+  fun `the running desktop test JVM has a reusable launcher`() {
+    assertTrue(localNetplayLauncherPrefix(currentProcessCommand()).orEmpty().isNotEmpty())
+  }
+
+  @Test
+  fun `child processes do not require host console handles or retain unread pipes`() {
+    val builder = localNetplayProcessBuilder(listOf("coffee-gb"))
     assertEquals(
-        ProcessBuilder.Redirect.INHERIT,
-        localNetplayProcessBuilder(listOf("coffee-gb")).redirectError(),
+        ProcessBuilder.Redirect.DISCARD,
+        builder.redirectOutput(),
     )
+    assertEquals(ProcessBuilder.Redirect.DISCARD, builder.redirectError())
   }
 
   @Test
@@ -58,6 +65,53 @@ class LocalNetplayInstanceLauncherTest {
         ),
     )
     assertNull(localNetplayLauncherPrefix(listOf("/usr/bin/java", "old.gb")))
+    assertNull(localNetplayLauncherPrefix(listOf("C:\\Java\\bin\\javaw.exe", "old.gb")))
+  }
+
+  @Test
+  fun `Windows JVM without process arguments is reconstructed from its classpath`() {
+    assertEquals(
+        listOf(
+            "C:\\Java\\bin\\java.exe",
+            "-cp",
+            "swing\\target\\classes;controller\\target\\classes",
+            "eu.rekawek.coffeegb.swing.MainKt",
+        ),
+        currentProcessCommand(
+            packagedLauncher = null,
+            executable = "C:\\Java\\bin\\java.exe",
+            arguments = emptyList(),
+            classPath = "swing\\target\\classes;controller\\target\\classes",
+        ),
+    )
+  }
+
+  @Test
+  fun `installed jpackage launcher takes precedence over its embedded JVM details`() {
+    assertEquals(
+        listOf("C:\\Program Files\\Coffee GB\\Coffee GB.exe"),
+        currentProcessCommand(
+            packagedLauncher = "C:\\Program Files\\Coffee GB\\Coffee GB.exe",
+            executable = "C:\\Program Files\\Coffee GB\\runtime\\bin\\javaw.exe",
+            arguments = emptyList(),
+            classPath = "app\\coffee-gb.jar",
+        ),
+    )
+  }
+
+  @Test
+  fun `custom Java host without desktop main on its system classpath is unavailable`() {
+    for (arguments in listOf(emptyList(), listOf("-jar", "custom-host.jar"))) {
+      assertTrue(
+          currentProcessCommand(
+                  packagedLauncher = null,
+                  executable = "C:\\Java\\bin\\java.exe",
+                  arguments = arguments,
+                  classPath = "maven-embedder.jar",
+                  desktopMainOnSystemClassPath = false,
+              )
+              .isEmpty())
+    }
   }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -40,6 +40,7 @@ class MainTest {
     assertFalse(request.debug)
     assertNull(request.initialRom)
     assertNull(request.joinNetplayHost)
+    assertFalse(request.startMuted)
     assertFalse(request.suppressInitialAutosaveResume)
     assertNull(request.settingsOverrides.hardwareProfile)
     assertNull(request.settingsOverrides.bootstrapMode)
@@ -48,7 +49,7 @@ class MainTest {
 
   @Test
   fun `all launch flags produce one typed process-local request`() {
-    val execution = execute("--debug", "-d", "-b", "-db", "game.gb")
+    val execution = execute("--debug", "-d", "-b", "-db", "--start-muted", "game.gb")
 
     val request = execution.singleLaunch()
     assertEquals(0, execution.exitCode)
@@ -57,6 +58,7 @@ class MainTest {
     assertEquals(HardwareProfileRegistry.DMG, request.settingsOverrides.hardwareProfile)
     assertEquals(BootstrapMode.NORMAL, request.settingsOverrides.bootstrapMode)
     assertEquals(false, request.settingsOverrides.batterySavesEnabled)
+    assertTrue(request.startMuted)
   }
 
   @Test
@@ -150,6 +152,7 @@ class MainTest {
               "-b  --use-bootstrap",
               "-db --disable-battery-saves",
               "--join-netplay HOST",
+              "--start-muted",
               "--debug",
               "-h  --help",
               "--version",
@@ -222,11 +225,19 @@ class MainTest {
                 "Option '--join-netplay' may be specified only once",
             ),
             Failure(
+                arrayOf("--start-muted", "--start-muted"),
+                "Option '--start-muted' may be specified only once",
+            ),
+            Failure(
                 arrayOf("--package-smoke", "game.gb"),
                 "--package-smoke cannot be combined with launch options or a ROM file",
             ),
             Failure(
                 arrayOf("--package-smoke", "--debug"),
+                "--package-smoke cannot be combined with launch options or a ROM file",
+            ),
+            Failure(
+                arrayOf("--package-smoke", "--start-muted"),
                 "--package-smoke cannot be combined with launch options or a ROM file",
             ),
             Failure(arrayOf("one.gb", "two.gb"), "Expected at most one ROM file, received 2"),

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
@@ -71,6 +71,7 @@ class PackagedLocalNetplayRelaunchSmokeTest {
             arrayOf(
                 "--profile=dmg",
                 "--disable-battery-saves",
+                "--start-muted",
                 "--join-netplay",
                 "127.0.0.1:4567",
                 rom.toString(),
@@ -83,6 +84,7 @@ class PackagedLocalNetplayRelaunchSmokeTest {
     assertTrue(evidence.startsWith("Coffee GB local netplay relaunch OK:"))
     assertTrue(evidence.contains("pid=1234"))
     assertTrue(evidence.contains("profile=dmg"))
+    assertTrue(evidence.contains("audio=muted"))
     assertTrue(evidence.contains("join=127.0.0.1:4567"))
 
     assertFalse(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
@@ -1,0 +1,129 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class PackagedLocalNetplayRelaunchSmokeTest {
+
+  @Test
+  fun `failed PID publication cleanup forcibly terminates and preserves interruption`() {
+    val process = FakeProcess()
+    Thread.currentThread().interrupt()
+    try {
+      assertTrue(terminateStartedChild(process, timeoutMillis = 100))
+      assertFalse(process.isAlive)
+      assertEquals(1, process.forcedDestroyCount)
+      assertTrue(Thread.currentThread().isInterrupted)
+    } finally {
+      Thread.interrupted()
+    }
+  }
+
+  @Test
+  fun `parent uses the production local client request`() {
+    val directory = Files.createTempDirectory("local-netplay-relaunch-parent")
+    val marker = directory.resolve("child.marker")
+    val launches = mutableListOf<List<String>>()
+
+    launchPackagedLocalNetplayRelaunchChildIfRequested(
+        environment = mapOf(LOCAL_NETPLAY_RELAUNCH_MARKER_ENV to marker.toString()),
+        launcher = LocalNetplayInstanceLauncher { rom, profile, endpoint, count ->
+          launches += listOf(rom.toString(), profile.id(), endpoint.startClientValue, "$count")
+          LocalNetplayInstanceLaunchResult(1, 1, launcherAvailable = true)
+        },
+    )
+
+    assertEquals(
+        listOf(
+            listOf(
+                directory.resolve("local-netplay-relaunch-smoke.gb").toString(),
+                HardwareProfileRegistry.DMG.id(),
+                "localhost",
+                "1",
+            )),
+        launches,
+    )
+    assertEquals(0x8000, Files.size(directory.resolve("local-netplay-relaunch-smoke.gb")))
+  }
+
+  @Test
+  fun `child validates parsed request and writes PID evidence`() {
+    val directory = Files.createTempDirectory("local-netplay-relaunch-child")
+    val marker = directory.resolve("child.marker")
+    val rom = Files.createFile(directory.resolve("local-netplay-relaunch-smoke.gb"))
+    val packagedLauncher = Files.createFile(directory.resolve("Coffee GB.exe"))
+    val environment =
+        mapOf(
+            LOCAL_NETPLAY_RELAUNCH_MARKER_ENV to marker.toString(),
+            LOCAL_NETPLAY_RELAUNCH_EXPECTED_LAUNCHER_ENV to packagedLauncher.toString(),
+            LOCAL_NETPLAY_RELAUNCH_ENDPOINT_ENV to "127.0.0.1:4567",
+        )
+
+    assertTrue(
+        validatePackagedLocalNetplayRelaunchChildIfRequested(
+            arrayOf(
+                "--profile=dmg",
+                "--disable-battery-saves",
+                "--join-netplay",
+                "127.0.0.1:4567",
+                rom.toString(),
+            ),
+            environment,
+            packagedLauncher.toString(),
+            processId = 1234,
+        ))
+    val evidence = Files.readString(marker)
+    assertTrue(evidence.startsWith("Coffee GB local netplay relaunch OK:"))
+    assertTrue(evidence.contains("pid=1234"))
+    assertTrue(evidence.contains("profile=dmg"))
+    assertTrue(evidence.contains("join=127.0.0.1:4567"))
+
+    assertFalse(
+        validatePackagedLocalNetplayRelaunchChildIfRequested(
+            arrayOf("--package-smoke"),
+            environment,
+            packagedLauncher.toString(),
+        ))
+  }
+
+  private class FakeProcess : Process() {
+    private var alive = true
+    var forcedDestroyCount = 0
+      private set
+
+    override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+    override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+    override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+    override fun waitFor(): Int {
+      alive = false
+      return 0
+    }
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = !alive
+
+    override fun exitValue(): Int =
+        if (alive) throw IllegalThreadStateException("still running") else 0
+
+    override fun destroy() {
+      alive = false
+    }
+
+    override fun destroyForcibly(): Process {
+      forcedDestroyCount++
+      alive = false
+      return this
+    }
+
+    override fun isAlive(): Boolean = alive
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingEmulatorSettingsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingEmulatorSettingsTest.kt
@@ -36,6 +36,44 @@ class SwingEmulatorSettingsTest {
   }
 
   @Test
+  fun `process-local startup mute leaves the persisted audio setting enabled`() {
+    val persisted = ApplicationSettings.Audio(enabled = true)
+
+    val runtime = startupAudioRuntimeConfiguration(
+        persisted.toRuntimeConfiguration(),
+        startMuted = true,
+    )
+
+    assertTrue(runtime.muted())
+    assertTrue(persisted.enabled)
+    assertFalse(persisted.toRuntimeConfiguration().muted())
+  }
+
+  @Test
+  fun `device reconfiguration preserves a process-local mute`() {
+    val current = startupAudioRuntimeConfiguration(
+        ApplicationSettings.Audio(enabled = true, volume = 100).toRuntimeConfiguration(),
+        startMuted = true,
+    )
+    val edited = ApplicationSettings.Audio(enabled = true, volume = 37)
+
+    val runtime = edited.toRuntimeConfigurationPreservingMute(current)
+
+    assertTrue(runtime.muted())
+    assertEquals(37, runtime.masterVolume())
+    assertTrue(edited.enabled)
+  }
+
+  @Test
+  fun `explicit audio enable setting remains authoritative outside preserving reconfiguration`() {
+    val unmuted = ApplicationSettings.Audio(enabled = true).toRuntimeConfiguration()
+    val disabled = ApplicationSettings.Audio(enabled = false)
+
+    assertTrue(disabled.toRuntimeConfiguration().muted())
+    assertFalse(disabled.toRuntimeConfigurationPreservingMute(unmuted).muted())
+  }
+
+  @Test
   fun `gamepad assignments and per-device tuning cross the runtime boundary`() {
     val stableId = "sdl-" + "b".repeat(64)
     val input =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingGuiShutdownTest.kt
@@ -20,6 +20,13 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class SwingGuiShutdownTest {
+  @Test
+  fun `ordinary desktop smoke closes but packaged relaunch remains for connection proof`() {
+    assertTrue(desktopStartupSmokeShouldAutoClose(emptyMap()))
+    assertFalse(
+        desktopStartupSmokeShouldAutoClose(
+            mapOf(LOCAL_NETPLAY_RELAUNCH_MARKER_ENV to "request.marker")))
+  }
 
   @Test
   fun `successful settings close finishes suspended window size persistence`() {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifierTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifierTest.java
@@ -19,6 +19,9 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -58,6 +61,7 @@ public class NativePackageVerifierTest {
         List<Path> paths = List.of(
                 caches.directRuntime(),
                 caches.packagedLauncher(),
+                caches.localNetplayRelaunch(),
                 caches.desktopNormal(),
                 caches.desktopDebug());
         assertEquals(paths.size(), new HashSet<>(paths).size());
@@ -71,6 +75,56 @@ public class NativePackageVerifierTest {
         try (Stream<Path> launcherContents = Files.list(caches.packagedLauncher())) {
             assertEquals(0, launcherContents.count());
         }
+    }
+
+    @Test
+    public void interruptedPackageRunTerminatesItsDirectProcessAndPreservesInterruption()
+            throws Exception {
+        Path childMarker = temporaryFolder.newFile("interrupted-child.pid").toPath();
+        Files.delete(childMarker);
+        String javaName = System.getProperty("os.name").startsWith("Windows")
+                ? "java.exe"
+                : "java";
+        String java = Path.of(System.getProperty("java.home"), "bin", javaName).toString();
+        String testClasses = Path.of(
+                        InterruptedRunChild.class.getProtectionDomain()
+                                .getCodeSource()
+                                .getLocation()
+                                .toURI())
+                .toString();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interruptedAtExit = new AtomicBoolean();
+        Thread verifier = new Thread(() -> {
+            try {
+                NativePackageVerifier.run(
+                        List.of(
+                                java,
+                                "-cp",
+                                testClasses,
+                                InterruptedRunChild.class.getName(),
+                                childMarker.toString()),
+                        Map.of());
+            } catch (Throwable problem) {
+                failure.set(problem);
+                interruptedAtExit.set(Thread.currentThread().isInterrupted());
+            }
+        }, "interrupted-native-package-verifier-test");
+        verifier.start();
+
+        long markerDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (!Files.isRegularFile(childMarker) && System.nanoTime() < markerDeadline) {
+            Thread.sleep(10);
+        }
+        assertTrue("Child PID marker was not written", Files.isRegularFile(childMarker));
+        long childPid = Long.parseLong(Files.readString(childMarker));
+
+        verifier.interrupt();
+        verifier.join(TimeUnit.SECONDS.toMillis(15));
+
+        assertFalse("Interrupted verifier thread survived cleanup", verifier.isAlive());
+        assertTrue(failure.get() instanceof InterruptedException);
+        assertTrue("Interrupted status was not restored", interruptedAtExit.get());
+        assertFalse(ProcessHandle.of(childPid).map(ProcessHandle::isAlive).orElse(false));
     }
 
     @Test
@@ -737,6 +791,19 @@ public class NativePackageVerifierTest {
     }
 
     private record PayloadLayout(Path payload, Path appDirectory, Path runtime) {
+    }
+
+    public static final class InterruptedRunChild {
+        private InterruptedRunChild() {
+        }
+
+        public static void main(String[] args) throws Exception {
+            Files.writeString(
+                    Path.of(args[0]),
+                    Long.toString(ProcessHandle.current().pid()),
+                    StandardOpenOption.CREATE_NEW);
+            Thread.sleep(TimeUnit.MINUTES.toMillis(1));
+        }
     }
 
     private static void writeChecksums(Path dist) throws Exception {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackagingScriptTest.java
@@ -85,6 +85,8 @@ public class NativePackagingScriptTest {
         assertTrue(verifyPs.contains("INSTALLDIR="));
         assertTrue(verifyPs.contains("\"--type\", \"msi\""));
         assertTrue(verifyPs.contains("\"--root\", $Extracted"));
+        assertTrue(verifyPs.contains("\"--root\", $InstalledRoot"));
+        assertTrue(verifyPs.contains("\"--smoke-home\", $InstalledSmokeHome"));
         assertTrue(verifyPs.contains("Assert-OnlyCoffeeGbShortcuts"));
         assertTrue(verifyPs.contains("Coffee GB Console.exe"));
         assertFalse(verifyPs.contains("Get-Command \"7z.exe\""));


### PR DESCRIPTION
## Summary

- fix local-netplay relaunch on Windows by preferring the jpackage launcher path and reconstructing Java launches when `ProcessHandle` omits arguments
- recognize `javaw.exe`, reject unsupported custom Java hosts, and detach child standard streams for GUI launches
- strengthen Windows package verification with a real child process, Swing desktop, ROM-load, loopback-connection, and cleanup smoke; MSI verification now also exercises the installed launcher
- start automatically opened netplay clients muted while leaving the host audio unchanged
- keep startup mute transient so persisted audio settings are not modified and explicit later mute/unmute choices remain authoritative

This is a Windows follow-up to #549.

Closes #589

## Verification

- Windows app-image build plus the full Maven reactor: 3,796 tests, 0 failures
- packaged app-image relaunch smoke: child PID, desktop window, ROM load, loopback connection, and `muted=true`
- Windows MSI build and packaged-payload smoke
- exact MSI administrative-install payload smoke using its installed `Coffee GB.exe`: child PID, desktop window, ROM load, loopback connection, and `muted=true`
- focused post-rebase suite: 81 tests, 0 failures
- `git diff --check`