### PR TITLE
Fix Volley Fire 2-player link negotiation

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -172,6 +172,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final boolean shikinjouLinkRolePatch;
 
+    private final boolean volleyFireLinkRolePatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -328,6 +330,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.REVENGE_GATOR_LINK_ROLE_PATCH);
         shikinjouLinkRolePatch = cartridgeProperties.has(
                 CartridgeProperties.Feature.SHIKINJOU_LINK_ROLE_PATCH);
+        volleyFireLinkRolePatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.VOLLEY_FIRE_LINK_ROLE_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -658,6 +662,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         if (shikinjouLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
             cartridge.enableShikinjouSecondaryLinkRole();
+        }
+        if (volleyFireLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
+            cartridge.enableVolleyFireSecondaryLinkRole();
         }
         if (jantakuBoyFourPlayerPatch) {
             serialEndpoint.enableCompatibilityProfile(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -38,6 +38,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private boolean shikinjouSecondaryLinkRole;
 
+    private boolean volleyFireSecondaryLinkRole;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -202,6 +204,20 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
                 return 0x22;
             }
         }
+        if (volleyFireSecondaryLinkRole) {
+            if (address == 0x2289) {
+                return 0xf1;
+            }
+            if (address == 0x228a) {
+                return 0xc3;
+            }
+            if (address == 0x228b) {
+                return 0x43;
+            }
+            if (address == 0x228c) {
+                return 0x21;
+            }
+        }
         return addressSpace.getByte(address);
     }
 
@@ -213,11 +229,16 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
         shikinjouSecondaryLinkRole = true;
     }
 
+    public void enableVolleyFireSecondaryLinkRole() {
+        volleyFireSecondaryLinkRole = true;
+    }
+
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
         // The role-selecting branch is a CPU-view overlay, not a mutation of the loaded image.
         // Keep execution on the ordinary cartridge read path while that overlay is active.
-        if (revengeGatorSecondaryLinkRole || shikinjouSecondaryLinkRole) {
+        if (revengeGatorSecondaryLinkRole || shikinjouSecondaryLinkRole
+                || volleyFireSecondaryLinkRole) {
             return null;
         }
         if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -75,7 +75,8 @@ public final class CartridgeProperties {
         // Append new features: Feature ordinals are part of the StateFile v1 identity.
         JANTAKU_BOY_FOUR_PLAYER_PATCH,
         REVENGE_GATOR_LINK_ROLE_PATCH,
-        SHIKINJOU_LINK_ROLE_PATCH
+        SHIKINJOU_LINK_ROLE_PATCH,
+        VOLLEY_FIRE_LINK_ROLE_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -214,6 +215,9 @@ public final class CartridgeProperties {
             features("Shikinjou deterministic link roles",
                     CartridgeProperties::isShikinjouLinkRole,
                     Feature.SHIKINJOU_LINK_ROLE_PATCH),
+            features("Volley Fire deterministic link roles",
+                    CartridgeProperties::isVolleyFireLinkRole,
+                    Feature.VOLLEY_FIRE_LINK_ROLE_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -885,6 +889,27 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x01
                 && info.byteAt(0x0149) == 0x00
                 && matches(info.data, 0x22c6, linkRoleNegotiation);
+    }
+
+    private static boolean isVolleyFireLinkRole(RomInfo info) {
+        int[] linkRoleNegotiation = {
+                0xf0, 0x9c, 0xfe, 0x01, 0x20, 0x17, 0xf0, 0x9d,
+                0xb7, 0x28, 0x0e, 0xcd, 0x96, 0x0e, 0x28, 0x09,
+                0xf1, 0x3e, 0x80, 0x1e, 0x00, 0xc7, 0xc3, 0x43,
+                0x21, 0x3e, 0x01, 0xe0, 0x9d
+        };
+        return info.data.length == 0x8000
+                && "VOLLEY FIRE".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x00
+                && info.byteAt(0x0148) == 0x00
+                && info.byteAt(0x0149) == 0x00
+                && matches(info.data, 0x227e, linkRoleNegotiation);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/VolleyFireLinkRolePatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/VolleyFireLinkRolePatchTest.java
@@ -1,0 +1,100 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VolleyFireLinkRolePatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownLinkNegotiationRoutine() throws IOException {
+        Rom rom = new Rom(volleyFireRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.VOLLEY_FIRE_LINK_ROLE_PATCH));
+
+        byte[] changed = volleyFireRom();
+        changed[0x2288] = 0;
+        assertFalse(new Rom(changed).getCartridgeProperties().has(
+                CartridgeProperties.Feature.VOLLEY_FIRE_LINK_ROLE_PATCH));
+    }
+
+    @Test
+    public void returnsTheSecondLinkedPlayerToTheExistingListenerLoop() throws IOException {
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy primary = gameboy(volleyFireRom());
+             Gameboy secondary = gameboy(volleyFireRom())) {
+            primary.init(EventBus.NULL_EVENT_BUS, first, null);
+            secondary.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0xcd, primary.getAddressSpace().getByte(0x2289));
+            assertEquals(0x96, primary.getAddressSpace().getByte(0x228a));
+            assertEquals(0x0e, primary.getAddressSpace().getByte(0x228b));
+            assertEquals(0x28, primary.getAddressSpace().getByte(0x228c));
+            assertEquals(0xf1, secondary.getAddressSpace().getByte(0x2289));
+            assertEquals(0xc3, secondary.getAddressSpace().getByte(0x228a));
+            assertEquals(0x43, secondary.getAddressSpace().getByte(0x228b));
+            assertEquals(0x21, secondary.getAddressSpace().getByte(0x228c));
+        }
+    }
+
+    @Test
+    public void leavesAnotherCartridgeUnchangedOnTheSecondEndpoint() throws IOException {
+        byte[] data = volleyFireRom();
+        data[0x0134] = 'X';
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy gameboy = gameboy(data)) {
+            gameboy.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0xcd, gameboy.getAddressSpace().getByte(0x2289));
+            assertEquals(0x96, gameboy.getAddressSpace().getByte(0x228a));
+            assertEquals(0x0e, gameboy.getAddressSpace().getByte(0x228b));
+            assertEquals(0x28, gameboy.getAddressSpace().getByte(0x228c));
+        }
+    }
+
+    private static Gameboy gameboy(byte[] data) throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] volleyFireRom() {
+        byte[] data = new byte[0x8000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "VOLLEY FIRE".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x00;
+        data[0x0147] = 0x00;
+        data[0x0148] = 0x00;
+        data[0x0149] = 0x00;
+        int[] linkRoleNegotiation = {
+                0xf0, 0x9c, 0xfe, 0x01, 0x20, 0x17, 0xf0, 0x9d,
+                0xb7, 0x28, 0x0e, 0xcd, 0x96, 0x0e, 0x28, 0x09,
+                0xf1, 0x3e, 0x80, 0x1e, 0x00, 0xc7, 0xc3, 0x43,
+                0x21, 0x3e, 0x01, 0xe0, 0x9d
+        };
+        for (int i = 0; i < linkRoleNegotiation.length; i++) {
+            data[0x227e + i] = (byte) linkRoleNegotiation[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #586

## Summary
- detect the affected Volley Fire release narrowly from its cartridge metadata and negotiation routine
- assign the existing listener/retry path to linked player 2 while player 1 keeps the original master path
- expose the role adjustment only through the CPU cartridge view, leaving the loaded ROM image unchanged
- add exact-detection, linked-role, and cross-cartridge regression coverage

## Tests
- `/opt/maven/bin/mvn -q -pl core -Dtest=VolleyFireLinkRolePatchTest,RevengeGatorLinkRolePatchTest,ShikinjouLinkRolePatchTest test`
- `/opt/maven/bin/mvn -q -pl core test`
- authentic-boot two-console linked gameplay trace through title, negotiation, stage selection, and a live synchronized match

## Visual evidence

| Before: both consoles remain at the 2-player title | After: player 1 | After: player 2 |
|---|---|---|
| ![Volley Fire frozen link title](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f500_p1-10ca296b.png) | ![Volley Fire linked gameplay player 1](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f1600_p1-fb297f8b.png) | ![Volley Fire linked gameplay player 2](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f1600_p2-b3802119.png) |