### PR TITLE
Normalize CGB WRAM bank state

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -301,8 +301,9 @@ internal object StateSemantics {
             it.nonNegative("ticksSinceDivReset")
           })
       put("eu.rekawek.coffeegb.core.memory.GbcRam\$GbcRamState",
-          constrained("The CGB work-RAM bank selector is a three-bit register.") {
-            it.range("svbk", 0, 7)
+          constrained(
+              "Legacy snapshots may retain unused bits of the byte-sized CGB work-RAM bank register.") {
+            it.range("svbk", 0, 0xff)
           })
       put("eu.rekawek.coffeegb.core.memory.UndocumentedGbcRegisters\$UndocumentedGbcRegistersState",
           constrained("The FF6C compatibility register is byte-sized.") { it.range("xff6c", 0, 0xff) })

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/GbcRamStateSemanticsTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/GbcRamStateSemanticsTest.kt
@@ -1,0 +1,27 @@
+package eu.rekawek.coffeegb.controller.state
+
+import eu.rekawek.coffeegb.core.memory.GbcRam
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.Test
+
+class GbcRamStateSemanticsTest {
+
+  @Test
+  fun `legacy full-byte bank state validates and restores canonically`() {
+    val legacy = GbcRam.GbcRamState(IntArray(7 * 0x1000), 0xf8)
+
+    StateSemantics.validate(legacy)
+    val ram = GbcRam()
+    ram.restoreState(legacy)
+
+    assertEquals(0, (ram.captureState() as GbcRam.GbcRamState).svbk())
+  }
+
+  @Test
+  fun `bank state outside a byte remains invalid`() {
+    val invalid = GbcRam.GbcRamState(IntArray(7 * 0x1000), 0x100)
+
+    assertFailsWith<StateApplyException> { StateSemantics.validate(invalid) }
+  }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/GbcRam.java
@@ -41,7 +41,7 @@ public class GbcRam implements AddressSpace, StatefulComponent<GbcRam> {
     public void setByte(int address, int value) {
         if (address == SVBK) {
             if (!isDmgCompat()) {
-                this.svbk = value;
+                this.svbk = value & 0x07;
             }
         } else {
             ram[translate(address)] = value;
@@ -94,7 +94,9 @@ public class GbcRam implements AddressSpace, StatefulComponent<GbcRam> {
             throw new IllegalArgumentException("ComponentState ram length doesn't match");
         }
         System.arraycopy(mem.ram, 0, this.ram, 0, this.ram.length);
-        this.svbk = mem.svbk;
+        // Released portable states may contain the full byte previously retained from FF70.
+        // Only the low three bits are a hardware latch, so canonicalize while restoring them.
+        this.svbk = mem.svbk & 0x07;
     }
 
     public record GbcRamState(int[] ram, int svbk) implements ComponentState<GbcRam> {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/GbcRamTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/GbcRamTest.java
@@ -28,4 +28,26 @@ public class GbcRamTest {
 
         assertEquals(0xff, ram.getByte(GbcRam.SVBK));
     }
+
+    @Test
+    public void unusedSvbkWriteBitsDoNotEnterPortableState() {
+        GbcRam ram = new GbcRam();
+        ram.setSpeedMode(new SpeedMode(true));
+
+        ram.setByte(GbcRam.SVBK, 0xf8);
+
+        assertEquals(0xf8, ram.getByte(GbcRam.SVBK));
+        assertEquals(0, ((GbcRam.GbcRamState) ram.captureState()).svbk());
+    }
+
+    @Test
+    public void legacyFullByteSvbkStateIsNormalizedOnRestore() {
+        GbcRam ram = new GbcRam();
+        ram.setSpeedMode(new SpeedMode(true));
+
+        ram.restoreState(new GbcRam.GbcRamState(new int[7 * 0x1000], 0xfe));
+
+        assertEquals(0xfe, ram.getByte(GbcRam.SVBK));
+        assertEquals(6, ((GbcRam.GbcRamState) ram.captureState()).svbk());
+    }
 }


### PR DESCRIPTION
Fixes #585

## Summary
- retain only the hardware-defined low three bits when software writes the CGB SVBK register
- normalize legacy snapshots that retained unused high bits when restoring them
- admit those previously emitted byte-sized legacy values during portable-state validation while continuing to reject values outside a byte
- add core register/state and controller semantic-validation regressions

## Tests
- `/opt/maven/bin/mvn -q -pl core -Dtest=GbcRamTest test`
- `/opt/maven/bin/mvn -q -pl controller -am -Dtest=GbcRamStateSemanticsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `/opt/maven/bin/mvn -q -pl controller -am test` — core passed and controller completed 948 tests before one unrelated close-deadline timing test expired under load
- `/opt/maven/bin/mvn -q -pl controller -am -Dtest=GbcRamStateSemanticsTest,BasicControllerTest#closeDeadlineBoundsBlockedTimingThreadAndAllowsRetry -Dsurefire.failIfNoSpecifiedTests=false test` — both the new regression and isolated timeout rerun passed