### PR TITLE
Keep Android audio smooth and restore full-speed CGB emulation

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioSink.java
@@ -8,6 +8,8 @@ import eu.rekawek.coffeegb.core.events.EventBus;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.sound.Sound;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -19,8 +21,21 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 final class AndroidAudioSink implements AutoCloseable {
 
+    /** Four real controller packets cover roughly 65-67 ms for every supported clock profile. */
+    static final int PRIMER_PACKETS = 4;
+
     interface OutputFactory {
         Output open();
+    }
+
+    /** Package-private deterministic seam for the queue-swap concurrency test. */
+    interface QueueSwapHook {
+        void beforeRateChangingSwap();
+    }
+
+    /** Package-private deterministic seam for boundary-publication concurrency tests. */
+    interface BoundaryClearHook {
+        void beforeQueuedPcmClear();
     }
 
     record AudioStats(int sampleRate, int minimumBufferBytes, int configuredBufferBytes,
@@ -32,6 +47,21 @@ final class AndroidAudioSink implements AutoCloseable {
 
         default AudioStats audioStats() {
             return new AudioStats(sampleRate(), 0, 0, 0);
+        }
+
+        /** Maximum application-write reservoir in stereo PCM sample frames. */
+        default int bufferCapacityFrames() {
+            return Math.max(0, audioStats().actualBufferBytes() / 4);
+        }
+
+        /** Current application-write reservoir in stereo PCM sample frames. */
+        default int effectiveBufferFrames() {
+            return bufferCapacityFrames();
+        }
+
+        /** Refill level at which a streaming output is expected to restart after underrun. */
+        default int startThresholdFrames() {
+            return effectiveBufferFrames();
         }
 
         /** Playback head in stereo PCM sample frames, or -1 when unavailable. */
@@ -110,6 +140,8 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     private static final long POLL_MILLIS = 20L;
+    /** Shorter than the six-slot source runway, so a dead output cannot force a queue overrun. */
+    private static final long UNDERRUN_STALL_MILLIS = 60L;
     private static final long CLOSE_TIMEOUT_MILLIS = 750L;
 
     private final OutputFactory outputFactory;
@@ -118,6 +150,10 @@ final class AndroidAudioSink implements AutoCloseable {
     private final AndroidBenchmarkDiagnostics diagnostics;
     private final AtomicBoolean running = new AtomicBoolean();
     private final AtomicBoolean reopenRequested = new AtomicBoolean();
+    /** Sticky flush command; unlike the paused level, every pause request is observed once. */
+    private final AtomicLong pauseFlushGeneration = new AtomicLong();
+    /** Monotonic fence for PCM rendered with an obsolete mute/volume policy. */
+    private final AtomicLong pcmPolicyGeneration = new AtomicLong();
     private final AtomicLong underruns = new AtomicLong();
     private final AtomicLong restarts = new AtomicLong();
     /** Monotonic identity fence for observational benchmark snapshots. */
@@ -126,15 +162,25 @@ final class AndroidAudioSink implements AutoCloseable {
     private final PcmAccounting pcmAccounting = BuildConfig.DIAGNOSTICS_ENABLED
             ? new DiagnosticPcmAccounting() : NoOpPcmAccounting.INSTANCE;
     private final Object wakeLock = new Object();
+    /** Linearizes play() with pause/policy/reopen boundaries. */
+    private final Object playbackControlLock = new Object();
+    /** Serializes producer offers with a sample-rate-changing queue replacement. */
+    private final Object queueLock = new Object();
+    private final QueueSwapHook queueSwapHook;
+    private final BoundaryClearHook boundaryClearHook;
     private final AudioDeviceCallback deviceCallback = new AudioDeviceCallback() {
         @Override
         public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
-            requestRouteReopen();
+            if (containsOutputSink(addedDevices)) {
+                requestRouteReopen();
+            }
         }
 
         @Override
         public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
-            requestRouteReopen();
+            if (containsOutputSink(removedDevices)) {
+                requestRouteReopen();
+            }
         }
     };
 
@@ -151,6 +197,8 @@ final class AndroidAudioSink implements AutoCloseable {
     private volatile int actualBufferBytes;
     private volatile boolean outputOpen;
     private volatile boolean outputPlaying;
+    /** Diagnostics-only exception for the legacy paused pre-ARM host-output proof. */
+    private final AtomicBoolean benchmarkEmptyPlayRequested = new AtomicBoolean();
     private volatile Output activeOutput;
     private volatile long playbackPositionFrames = -1L;
     private volatile long outputUnderruns = -1L;
@@ -162,26 +210,46 @@ final class AndroidAudioSink implements AutoCloseable {
     AndroidAudioSink(Context context, EventBus eventBus) {
         this(eventBus, new AndroidAudioTrackOutput.Factory(),
                 Objects.requireNonNull(context, "context").getSystemService(AudioManager.class),
-                true, null);
+                true, null, null, null);
     }
 
     AndroidAudioSink(Context context, EventBus eventBus,
             AndroidBenchmarkDiagnostics diagnostics) {
         this(eventBus, new AndroidAudioTrackOutput.Factory(),
                 Objects.requireNonNull(context, "context").getSystemService(AudioManager.class),
-                true, diagnostics);
+                true, diagnostics, null, null);
     }
 
     AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory) {
-        this(eventBus, outputFactory, null, true, null);
+        this(eventBus, outputFactory, null, true, null, null, null);
+    }
+
+    /** Benchmark JVM seam; ordinary construction cannot authorize empty AudioTrack playback. */
+    AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory,
+            AndroidBenchmarkDiagnostics diagnostics) {
+        this(eventBus, outputFactory, null, true, diagnostics, null, null);
+    }
+
+    AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory, QueueSwapHook queueSwapHook) {
+        this(eventBus, outputFactory, null, true, null,
+                Objects.requireNonNull(queueSwapHook, "queueSwapHook"), null);
+    }
+
+    AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory,
+            QueueSwapHook queueSwapHook, BoundaryClearHook boundaryClearHook) {
+        this(eventBus, outputFactory, null, true, null, queueSwapHook,
+                Objects.requireNonNull(boundaryClearHook, "boundaryClearHook"));
     }
 
     private AndroidAudioSink(EventBus eventBus, OutputFactory outputFactory, AudioManager audioManager,
-            boolean enabled, AndroidBenchmarkDiagnostics diagnostics) {
+            boolean enabled, AndroidBenchmarkDiagnostics diagnostics, QueueSwapHook queueSwapHook,
+            BoundaryClearHook boundaryClearHook) {
         this.outputFactory = Objects.requireNonNull(outputFactory, "outputFactory");
         this.audioManager = audioManager;
         this.enabled = enabled;
         this.diagnostics = diagnostics;
+        this.queueSwapHook = queueSwapHook;
+        this.boundaryClearHook = boundaryClearHook;
         EventBus bus = Objects.requireNonNull(eventBus, "eventBus");
         if (enabled) {
             bus.register(this::onSoundSample, Sound.SoundSampleEvent.class);
@@ -190,7 +258,7 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     static AndroidAudioSink disabled(EventBus eventBus) {
-        return new AndroidAudioSink(eventBus, () -> null, null, false, null);
+        return new AndroidAudioSink(eventBus, () -> null, null, false, null, null, null);
     }
 
     void start() {
@@ -210,13 +278,41 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     void pause() {
-        paused = true;
-        clearQueuedPcm();
+        synchronized (playbackControlLock) {
+            paused = true;
+            benchmarkEmptyPlayRequested.set(false);
+            pauseFlushGeneration.incrementAndGet();
+            clearQueuedPcmAtBoundary();
+        }
         wakeConsumer();
     }
 
     void resume() {
-        paused = false;
+        synchronized (playbackControlLock) {
+            if (benchmarkEmptyPlayRequested.getAndSet(false)) {
+                pauseFlushGeneration.incrementAndGet();
+            }
+            paused = false;
+        }
+        wakeConsumer();
+    }
+
+    /**
+     * Preserves the benchmark's existing stopped/empty-to-playing pre-ARM proof while the guest is
+     * paused and cannot produce primer packets.  This is intentionally unavailable to production
+     * playback; all ordinary resume paths wait for the full genuine-PCM primer.
+     */
+    void resumeEmptyForBenchmarkPreArm() {
+        if (diagnostics == null || !diagnostics.enabled()) {
+            throw new IllegalStateException("Empty audio playback is benchmark-only");
+        }
+        synchronized (playbackControlLock) {
+            if (!paused) {
+                throw new IllegalStateException("Benchmark empty playback requires a paused sink");
+            }
+            benchmarkEmptyPlayRequested.set(true);
+            paused = false;
+        }
         wakeConsumer();
     }
 
@@ -269,35 +365,38 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     void setMuted(boolean nextMuted) {
-        muted = nextMuted;
-        clearQueuedPcm();
+        synchronized (playbackControlLock) {
+            if (muted == nextMuted) {
+                return;
+            }
+            muted = nextMuted;
+            pcmPolicyGeneration.incrementAndGet();
+            clearQueuedPcmAtBoundary();
+        }
         wakeConsumer();
     }
 
-    /**
-     * Selects the fixed source-buffer size used by the next audio queue. Profile events arrive
-     * before the first sound event; if the worker already opened its default queue, rebuild it
-     * without ever allocating from the controller callback.
-     */
+    /** Updates source cadence without reopening AudioTrack or rebuilding fixed PCM storage. */
     void setClockSpec(ClockSpec nextClock) {
         ClockSpec checked = Objects.requireNonNull(nextClock, "nextClock");
         if (sourceClock.equals(checked)) {
             return;
         }
         sourceClock = checked;
-        if (running.get()) {
-            reopenRequested.set(true);
-            clearQueuedPcm();
-            wakeConsumer();
-        }
     }
 
     void setVolume(int nextVolume) {
         if (nextVolume < 0 || nextVolume > 100) {
             throw new IllegalArgumentException("Audio volume must be between 0 and 100");
         }
-        volume = nextVolume;
-        clearQueuedPcm();
+        synchronized (playbackControlLock) {
+            if (volume == nextVolume) {
+                return;
+            }
+            volume = nextVolume;
+            pcmPolicyGeneration.incrementAndGet();
+            clearQueuedPcmAtBoundary();
+        }
         wakeConsumer();
     }
 
@@ -337,8 +436,10 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     void requestRouteReopen() {
-        reopenRequested.set(true);
-        clearQueuedPcm();
+        synchronized (playbackControlLock) {
+            benchmarkEmptyPlayRequested.set(false);
+            reopenRequested.set(true);
+        }
         wakeConsumer();
     }
 
@@ -353,8 +454,11 @@ final class AndroidAudioSink implements AutoCloseable {
 
     @Override
     public void close() {
-        if (!running.getAndSet(false)) {
-            return;
+        synchronized (playbackControlLock) {
+            if (!running.getAndSet(false)) {
+                return;
+            }
+            benchmarkEmptyPlayRequested.set(false);
         }
         if (audioManager != null) {
             audioManager.unregisterAudioDeviceCallback(deviceCallback);
@@ -372,43 +476,106 @@ final class AndroidAudioSink implements AutoCloseable {
     }
 
     private void onSoundSample(Sound.SoundSampleEvent event) {
-        BoundedPcmQueue active = queue;
-        if (!running.get() || active == null || paused) {
-            return;
-        }
-        if (BuildConfig.DIAGNOSTICS_ENABLED) {
-            synchronized (pcmAccounting) {
-                pcmAccounting.input(event.buffer().length / 2L);
-                int bytes = active.offer(event, volume, muted);
-                accountQueueDiscards(active);
-                if (bytes > 0) {
-                    pcmAccounting.enqueued(bytes, bytes / 4L);
-                }
+        long eventPolicyGeneration;
+        long eventPauseFlushGeneration;
+        int eventVolume;
+        boolean eventMuted;
+        synchronized (playbackControlLock) {
+            if (!running.get() || paused) {
+                return;
             }
-        } else {
-            active.offer(event, volume, muted);
+            // The first real packet revokes the diagnostics-only empty-play exception.  Its
+            // sticky boundary makes the worker stop/flush even if it already called play().
+            if (benchmarkEmptyPlayRequested.getAndSet(false)) {
+                pauseFlushGeneration.incrementAndGet();
+            }
+            eventPolicyGeneration = pcmPolicyGeneration.get();
+            eventPauseFlushGeneration = pauseFlushGeneration.get();
+            eventVolume = volume;
+            eventMuted = muted;
         }
-        hasProducedPcm = true;
+        synchronized (queueLock) {
+            BoundedPcmQueue active = queue;
+            if (!running.get() || active == null || paused) {
+                return;
+            }
+            if (BuildConfig.DIAGNOSTICS_ENABLED) {
+                synchronized (pcmAccounting) {
+                    pcmAccounting.input(event.buffer().length / 2L);
+                    int bytes = active.offer(event, eventVolume, eventMuted,
+                            eventPolicyGeneration, eventPauseFlushGeneration);
+                    accountQueueDiscards(active);
+                    if (bytes > 0) {
+                        pcmAccounting.enqueued(bytes, bytes / 4L);
+                    }
+                }
+            } else {
+                active.offer(event, eventVolume, eventMuted, eventPolicyGeneration,
+                        eventPauseFlushGeneration);
+            }
+            hasProducedPcm = true;
+        }
         wakeConsumer();
     }
 
     private void runConsumer() {
+        preferAudioThreadPriority();
         Output output = null;
         BoundedPcmQueue activeQueue = null;
-        boolean outputPaused = false;
+        List<PendingFrame> primerFrames = new ArrayList<>(PRIMER_PACKETS + 1);
+        boolean outputStarted = false;
         boolean outputOpenedOnce = false;
+        UnderrunRecovery underrunRecovery = new UnderrunRecovery();
+        OutputBufferLimits outputBufferLimits = OutputBufferLimits.UNAVAILABLE;
+        long appliedPauseFlushGeneration = pauseFlushGeneration.get();
+        long appliedPcmPolicyGeneration = pcmPolicyGeneration.get();
+        long observedOutputUnderruns = -1L;
+        OutputProgress outputProgress = new OutputProgress();
+        int primerReplayIndex = 0;
+        int primerPackets = 0;
+        int primerBytes = 0;
         try {
             while (running.get()) {
-                if (output == null || reopenRequested.getAndSet(false)) {
+                long requestedPauseFlushGeneration = pauseFlushGeneration.get();
+                long requestedPcmPolicyGeneration = pcmPolicyGeneration.get();
+                if (requestedPauseFlushGeneration != appliedPauseFlushGeneration
+                        || requestedPcmPolicyGeneration != appliedPcmPolicyGeneration) {
+                    appliedPauseFlushGeneration = requestedPauseFlushGeneration;
+                    appliedPcmPolicyGeneration = requestedPcmPolicyGeneration;
+                    if (activeQueue != null) {
+                        discardPrimerFrames(activeQueue, primerFrames);
+                    } else {
+                        primerFrames.clear();
+                    }
+                    primerReplayIndex = 0;
+                    primerPackets = 0;
+                    primerBytes = 0;
+                    outputStarted = false;
+                    underrunRecovery.reset();
+                    if (resetOutputForPcmBoundary(output)) {
+                        outputProgress.resetAfterFlush(output);
+                        observedOutputUnderruns = sampleOutputUnderruns(output,
+                                observedOutputUnderruns);
+                    }
+                    continue;
+                }
+                boolean reopen = reopenRequested.getAndSet(false);
+                if (output == null || reopen) {
                     if (BuildConfig.DIAGNOSTICS_ENABLED && output != null) {
                         outputOpen = false;
                         outputPlaying = false;
                     }
+                    resetPendingFramesForReplacement(primerFrames);
                     release(output);
                     output = openOutput();
                     activeOutput = output;
                     routeGeneration.incrementAndGet();
-                    outputPaused = false;
+                    outputStarted = false;
+                    underrunRecovery.reset();
+                    outputBufferLimits = OutputBufferLimits.UNAVAILABLE;
+                    primerReplayIndex = 0;
+                    primerPackets = 0;
+                    primerBytes = 0;
                     if (output == null) {
                         if (BuildConfig.DIAGNOSTICS_ENABLED) {
                             outputOpen = false;
@@ -417,6 +584,39 @@ final class AndroidAudioSink implements AutoCloseable {
                         awaitWake(POLL_MILLIS);
                         continue;
                     }
+                    int openedSampleRate;
+                    AudioStats outputStats;
+                    try {
+                        openedSampleRate = output.sampleRate();
+                        outputStats = output.audioStats();
+                        outputBufferLimits = readOutputBufferLimits(output);
+                    } catch (RuntimeException unavailable) {
+                        accountRouteFailure();
+                        release(output);
+                        output = null;
+                        activeOutput = null;
+                        routeGeneration.incrementAndGet();
+                        awaitWake(POLL_MILLIS);
+                        continue;
+                    }
+                    if (activeQueue == null || sampleRate != openedSampleRate) {
+                        synchronized (queueLock) {
+                            if (activeQueue != null) {
+                                if (queueSwapHook != null) {
+                                    queueSwapHook.beforeRateChangingSwap();
+                                }
+                                discardPrimerFrames(activeQueue, primerFrames);
+                                clearQueue(activeQueue);
+                            }
+                            activeQueue = new BoundedPcmQueue(openedSampleRate, sourceClock);
+                            queue = activeQueue;
+                        }
+                        routeGeneration.incrementAndGet();
+                    }
+                    sampleRate = openedSampleRate;
+                    minimumBufferBytes = outputStats.minimumBufferBytes();
+                    configuredBufferBytes = outputStats.configuredBufferBytes();
+                    actualBufferBytes = outputStats.actualBufferBytes();
                     if (BuildConfig.DIAGNOSTICS_ENABLED) {
                         outputOpen = true;
                         outputPlaying = false;
@@ -426,62 +626,327 @@ final class AndroidAudioSink implements AutoCloseable {
                     } else {
                         outputOpenedOnce = true;
                     }
-                    ClockSpec queueClock = sourceClock;
-                    int expectedSourceSamples = Math.multiplyExact(
-                            queueClock.controllerTicksPerFrame(), 2);
-                    if (activeQueue == null || sampleRate != output.sampleRate()
-                            || activeQueue.maximumSourceSamples() != expectedSourceSamples) {
-                        if (BuildConfig.DIAGNOSTICS_ENABLED && activeQueue != null) {
-                            clearAndAccount(activeQueue);
-                        } else if (activeQueue != null) {
-                            activeQueue.clear();
-                        }
-                        activeQueue = new BoundedPcmQueue(output.sampleRate(), queueClock);
-                        queue = activeQueue;
-                        routeGeneration.incrementAndGet();
-                    } else {
-                        if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                            clearAndAccount(activeQueue);
-                        } else {
-                            activeQueue.clear();
-                        }
-                    }
-                    sampleRate = output.sampleRate();
-                    AudioStats outputStats = output.audioStats();
-                    minimumBufferBytes = outputStats.minimumBufferBytes();
-                    configuredBufferBytes = outputStats.configuredBufferBytes();
-                    actualBufferBytes = outputStats.actualBufferBytes();
                     if (diagnostics != null) {
                         diagnostics.audioStats(outputStats);
                     }
-                    hasProducedPcm = false;
-                    if (!paused) {
-                        output.play();
-                        if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                            outputPlaying = true;
-                        }
-                    }
+                    outputProgress.open(output);
+                    observedOutputUnderruns = sampleOutputUnderruns(output, -1L);
                     continue;
                 }
 
                 if (paused) {
-                    if (!outputPaused) {
-                        output.pause();
-                        output.flush();
-                        outputPaused = true;
-                        if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                            outputPlaying = false;
-                        }
-                    }
                     awaitWake(POLL_MILLIS);
                     continue;
                 }
-                if (outputPaused) {
-                    output.play();
-                    outputPaused = false;
-                    if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                        outputPlaying = true;
+
+                if (underrunRecovery.active()) {
+                    if (reopenRequested.get()) {
+                        continue;
                     }
+                    long playedFrames = outputProgress.readPlaybackPosition(output);
+                    if (playedFrames < 0L) {
+                        // Without a trustworthy head, bounded refill progress cannot be proven.
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                        underrunRecovery.reset();
+                        continue;
+                    }
+                    long latestOutputUnderruns = sampleOutputUnderruns(output,
+                            observedOutputUnderruns);
+                    if (hasOutputUnderrunIncreased(observedOutputUnderruns,
+                            latestOutputUnderruns)) {
+                        observedOutputUnderruns = latestOutputUnderruns;
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                            underrunRecovery.reset();
+                        }
+                        continue;
+                    }
+                    observedOutputUnderruns = latestOutputUnderruns;
+                    long bufferedFrames = outputProgress.bufferedFrames(playedFrames);
+                    if (bufferedFrames < 0L) {
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                        underrunRecovery.reset();
+                        continue;
+                    }
+                    underrunRecovery.observeRefillProgress(outputProgress.acceptedFrames(),
+                            bufferedFrames, outputBufferLimits.startThresholdFrames());
+                    if (underrunRecovery.hasRestarted(playedFrames)
+                            && primerFrames.isEmpty()) {
+                        // AudioTrack restarts itself after its data path reaches the threshold.
+                        // Keep every accepted byte in place and resume the ordinary write stream.
+                        underrunRecovery.reset();
+                        continue;
+                    }
+                    int effectiveFrames = outputBufferLimits.effectiveBufferFrames();
+                    if (bufferedFrames >= effectiveFrames) {
+                        if (underrunRecovery.capacityHasStalled(System.nanoTime())) {
+                            // A blocking write beyond known free capacity could deadlock forever.
+                            // Replace only after a full reservoir still produces no head progress.
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                            underrunRecovery.reset();
+                        } else {
+                            awaitWake(POLL_MILLIS);
+                        }
+                        continue;
+                    }
+
+                    underrunRecovery.clearCapacityStall();
+                    PendingFrame pending;
+                    if (!primerFrames.isEmpty()) {
+                        pending = primerFrames.get(0);
+                    } else {
+                        BoundedPcmQueue.Frame frame = activeQueue.poll(
+                                POLL_MILLIS, TimeUnit.MILLISECONDS);
+                        if (frame == null) {
+                            continue;
+                        }
+                        reconcileFrameAccounting(activeQueue, frame);
+                        long latestPauseFlushGeneration = pauseFlushGeneration.get();
+                        long latestPcmPolicyGeneration = pcmPolicyGeneration.get();
+                        if (latestPauseFlushGeneration != appliedPauseFlushGeneration
+                                || latestPcmPolicyGeneration != appliedPcmPolicyGeneration) {
+                            discardPrimerFrames(activeQueue, primerFrames);
+                            if (frameMatchesBoundary(frame, latestPauseFlushGeneration,
+                                    latestPcmPolicyGeneration)) {
+                                primerFrames.add(new PendingFrame(frame));
+                            } else {
+                                discardFrame(activeQueue, frame);
+                            }
+                            appliedPauseFlushGeneration = latestPauseFlushGeneration;
+                            appliedPcmPolicyGeneration = latestPcmPolicyGeneration;
+                            primerReplayIndex = 0;
+                            primerPackets = 0;
+                            primerBytes = 0;
+                            outputStarted = false;
+                            underrunRecovery.reset();
+                            if (resetOutputForPcmBoundary(output)) {
+                                outputProgress.resetAfterFlush(output);
+                                observedOutputUnderruns = sampleOutputUnderruns(output,
+                                        observedOutputUnderruns);
+                            }
+                            continue;
+                        }
+                        if (!frameMatchesBoundary(frame, appliedPauseFlushGeneration,
+                                appliedPcmPolicyGeneration)) {
+                            discardFrame(activeQueue, frame);
+                            continue;
+                        }
+                        pending = new PendingFrame(frame);
+                        primerFrames.add(pending);
+                    }
+                    long freeFrames = effectiveFrames - bufferedFrames;
+                    int writeBudget = (int) Math.min(Integer.MAX_VALUE & ~3L,
+                            Math.multiplyExact(freeFrames, 4L));
+                    WriteResult result = writeFrame(output, pending,
+                            appliedPauseFlushGeneration, appliedPcmPolicyGeneration,
+                            outputProgress, observedOutputUnderruns, false, writeBudget);
+                    latestOutputUnderruns = sampleOutputUnderruns(output,
+                            result.observedOutputUnderruns());
+                    boolean newerOutputUnderrun = hasOutputUnderrunIncreased(
+                            observedOutputUnderruns, latestOutputUnderruns);
+                    observedOutputUnderruns = latestOutputUnderruns;
+                    if (result.outcome() == WriteOutcome.COMPLETE) {
+                        primerFrames.remove(0);
+                        commitFrame(activeQueue, pending.frame());
+                    } else if (result.outcome() == WriteOutcome.OUTPUT_FAILURE) {
+                        accountWriteFailure();
+                        requestRecoveryReopen();
+                        underrunRecovery.reset();
+                    }
+                    if (newerOutputUnderrun
+                            && (result.outcome() == WriteOutcome.COMPLETE
+                                    || result.outcome() == WriteOutcome.CAPACITY_FILLED)
+                            && !rebaseUnderrunRecovery(output, outputProgress,
+                                    outputBufferLimits, underrunRecovery)) {
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                        underrunRecovery.reset();
+                    }
+                    continue;
+                }
+
+                if (!outputStarted && benchmarkEmptyPlayRequested.get()) {
+                    PlayOutcome playOutcome = playOutput(output, appliedPauseFlushGeneration,
+                            appliedPcmPolicyGeneration, true);
+                    if (playOutcome == PlayOutcome.STARTED) {
+                        outputStarted = true;
+                        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+                            outputPlaying = true;
+                        }
+                    } else if (playOutcome == PlayOutcome.OUTPUT_FAILURE) {
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                    }
+                    continue;
+                }
+
+                if (outputStarted && benchmarkEmptyPlayRequested.get()) {
+                    // The diagnostics pre-ARM proof intentionally runs an empty track. Rebaseline
+                    // its expected counter movement without entering production recovery.
+                    outputProgress.readPlaybackPosition(output);
+                    observedOutputUnderruns = sampleOutputUnderruns(output,
+                            observedOutputUnderruns);
+                } else if (outputStarted) {
+                    // Keep the unsigned playback head extended continuously so a long-running
+                    // output can cross 2^32 frames before an underrun needs refill tracking.
+                    outputProgress.readPlaybackPosition(output);
+                    long latestOutputUnderruns = sampleOutputUnderruns(output,
+                            observedOutputUnderruns);
+                    if (hasOutputUnderrunIncreased(observedOutputUnderruns,
+                            latestOutputUnderruns)) {
+                        observedOutputUnderruns = latestOutputUnderruns;
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                        }
+                        continue;
+                    }
+                    observedOutputUnderruns = latestOutputUnderruns;
+                }
+
+                if (!outputStarted) {
+                    int requiredPrimerFrames = outputBufferLimits.startThresholdFrames();
+                    PendingFrame pending;
+                    if (primerReplayIndex < primerFrames.size()) {
+                        pending = primerFrames.get(primerReplayIndex);
+                    } else {
+                        BoundedPcmQueue.Frame frame = activeQueue.poll(
+                                POLL_MILLIS, TimeUnit.MILLISECONDS);
+                        if (frame == null) {
+                            continue;
+                        }
+                        reconcileFrameAccounting(activeQueue, frame);
+                        long latestPauseFlushGeneration = pauseFlushGeneration.get();
+                        long latestPcmPolicyGeneration = pcmPolicyGeneration.get();
+                        if (latestPauseFlushGeneration != appliedPauseFlushGeneration
+                                || latestPcmPolicyGeneration != appliedPcmPolicyGeneration) {
+                            discardPrimerFrames(activeQueue, primerFrames);
+                            if (frameMatchesBoundary(frame, latestPauseFlushGeneration,
+                                    latestPcmPolicyGeneration)) {
+                                primerFrames.add(new PendingFrame(frame));
+                            } else {
+                                discardFrame(activeQueue, frame);
+                            }
+                            appliedPauseFlushGeneration = latestPauseFlushGeneration;
+                            appliedPcmPolicyGeneration = latestPcmPolicyGeneration;
+                            primerReplayIndex = 0;
+                            primerPackets = 0;
+                            primerBytes = 0;
+                            outputStarted = false;
+                            underrunRecovery.reset();
+                            if (resetOutputForPcmBoundary(output)) {
+                                outputProgress.resetAfterFlush(output);
+                                observedOutputUnderruns = sampleOutputUnderruns(output,
+                                        observedOutputUnderruns);
+                            }
+                            continue;
+                        }
+                        if (!frameMatchesBoundary(frame, appliedPauseFlushGeneration,
+                                appliedPcmPolicyGeneration)) {
+                            discardFrame(activeQueue, frame);
+                            continue;
+                        }
+                        pending = new PendingFrame(frame);
+                        primerFrames.add(pending);
+                    }
+                    BoundedPcmQueue.Frame frame = pending.frame();
+                    int writeStartOffset = pending.writeOffset();
+                    int effectiveBufferBytes = Math.multiplyExact(
+                            outputBufferLimits.effectiveBufferFrames(), 4);
+                    int availableBufferBytes = effectiveBufferBytes - primerBytes;
+                    if (availableBufferBytes <= 0) {
+                        // A stopped streaming track cannot consume more data. If its advertised
+                        // start threshold is still unmet, the output contract is inconsistent.
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                        continue;
+                    }
+                    WriteResult result = writeFrame(output, pending,
+                            appliedPauseFlushGeneration, appliedPcmPolicyGeneration,
+                            outputProgress, observedOutputUnderruns, false,
+                            Math.min(frame.length() - pending.writeOffset(),
+                                    availableBufferBytes));
+                    observedOutputUnderruns = result.observedOutputUnderruns();
+                    if (result.outcome() == WriteOutcome.OUTPUT_FAILURE) {
+                        accountWriteFailure();
+                        requestRecoveryReopen();
+                        continue;
+                    }
+                    if (result.outcome() == WriteOutcome.INTERRUPTED) {
+                        continue;
+                    }
+                    if (result.outcome() == WriteOutcome.OUTPUT_UNDERRUN) {
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                        }
+                        continue;
+                    }
+                    primerBytes += pending.writeOffset() - writeStartOffset;
+                    if (result.outcome() == WriteOutcome.COMPLETE && writeStartOffset == 0) {
+                        primerPackets++;
+                    }
+                    if (result.outcome() == WriteOutcome.COMPLETE) {
+                        primerReplayIndex++;
+                    }
+                    if (primerPackets < PRIMER_PACKETS
+                            || primerBytes / 4 < requiredPrimerFrames) {
+                        continue;
+                    }
+                    PlayOutcome playOutcome = playOutput(output, appliedPauseFlushGeneration,
+                            appliedPcmPolicyGeneration, false);
+                    if (playOutcome == PlayOutcome.STALE_BOUNDARY) {
+                        continue;
+                    }
+                    if (playOutcome == PlayOutcome.OUTPUT_FAILURE) {
+                        accountRouteFailure();
+                        requestRecoveryReopen();
+                        continue;
+                    }
+                    if (playOutcome == PlayOutcome.STARTED) {
+                        outputStarted = true;
+                        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+                            outputPlaying = true;
+                        }
+                    }
+                    commitCompletedPrimerFrames(activeQueue, primerFrames);
+                    primerReplayIndex = 0;
+                    primerPackets = 0;
+                    primerBytes = 0;
+                    continue;
+                }
+
+                if (!primerFrames.isEmpty()) {
+                    // A pre-S device can require its full effective buffer before the first play,
+                    // leaving an ordered suffix of the threshold-filling packet. Finish that
+                    // suffix after playback has started before polling any later packet.
+                    PendingFrame pending = primerFrames.get(0);
+                    WriteResult result = writeFrame(output, pending,
+                            appliedPauseFlushGeneration, appliedPcmPolicyGeneration,
+                            outputProgress, observedOutputUnderruns, true,
+                            pending.frame().length() - pending.writeOffset());
+                    observedOutputUnderruns = result.observedOutputUnderruns();
+                    if (result.outcome() == WriteOutcome.COMPLETE) {
+                        primerFrames.remove(0);
+                        commitFrame(activeQueue, pending.frame());
+                    } else if (result.outcome() == WriteOutcome.OUTPUT_UNDERRUN) {
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                        }
+                    } else if (result.outcome() == WriteOutcome.OUTPUT_FAILURE) {
+                        accountWriteFailure();
+                        requestRecoveryReopen();
+                    }
+                    continue;
                 }
 
                 BoundedPcmQueue.Frame frame = activeQueue.poll(POLL_MILLIS, TimeUnit.MILLISECONDS);
@@ -491,49 +956,107 @@ final class AndroidAudioSink implements AutoCloseable {
                     }
                     continue;
                 }
-                try {
-                    if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                        synchronized (pcmAccounting) {
-                            pcmAccounting.adjustEnqueued(
-                                    frame.length() - frame.accountingBytes(),
-                                    frame.length() / 4L - frame.accountingBytes() / 4L);
-                            accountQueueDiscards(activeQueue);
-                        }
+                reconcileFrameAccounting(activeQueue, frame);
+                long latestPauseFlushGeneration = pauseFlushGeneration.get();
+                long latestPcmPolicyGeneration = pcmPolicyGeneration.get();
+                if (latestPauseFlushGeneration != appliedPauseFlushGeneration
+                        || latestPcmPolicyGeneration != appliedPcmPolicyGeneration) {
+                    discardPrimerFrames(activeQueue, primerFrames);
+                    if (frameMatchesBoundary(frame, latestPauseFlushGeneration,
+                            latestPcmPolicyGeneration)) {
+                        primerFrames.add(new PendingFrame(frame));
+                    } else {
+                        discardFrame(activeQueue, frame);
                     }
-                    if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                        WriteResult result = writeFullyWithAccounting(output, frame);
-                        synchronized (pcmAccounting) {
-                            if (result.bytesWritten() > 0) {
-                                pcmAccounting.written(result.bytesWritten(),
-                                        result.complete() ? frame.length() / 4L : 0L);
-                            }
-                            if (!result.complete()) {
-                                int discarded = frame.length() - result.bytesWritten();
-                                if (discarded > 0) {
-                                    pcmAccounting.discarded(discarded);
-                                }
-                                pcmAccounting.writeFailure();
-                                reopenRequested.set(true);
-                            }
+                    appliedPauseFlushGeneration = latestPauseFlushGeneration;
+                    appliedPcmPolicyGeneration = latestPcmPolicyGeneration;
+                    primerReplayIndex = 0;
+                    primerPackets = 0;
+                    primerBytes = 0;
+                    outputStarted = false;
+                    underrunRecovery.reset();
+                    if (resetOutputForPcmBoundary(output)) {
+                        outputProgress.resetAfterFlush(output);
+                        observedOutputUnderruns = sampleOutputUnderruns(output,
+                                observedOutputUnderruns);
+                    }
+                    continue;
+                }
+                if (!frameMatchesBoundary(frame, appliedPauseFlushGeneration,
+                        appliedPcmPolicyGeneration)) {
+                    discardFrame(activeQueue, frame);
+                    continue;
+                }
+                PendingFrame pending = new PendingFrame(frame);
+                try {
+                    long latestOutputUnderruns = sampleOutputUnderruns(output,
+                            observedOutputUnderruns);
+                    if (hasOutputUnderrunIncreased(observedOutputUnderruns,
+                            latestOutputUnderruns)) {
+                        observedOutputUnderruns = latestOutputUnderruns;
+                        primerFrames.add(pending);
+                        frame = null;
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
+                        }
+                        continue;
+                    }
+                    observedOutputUnderruns = latestOutputUnderruns;
+                    WriteResult result = writeFrame(output, pending,
+                            appliedPauseFlushGeneration, appliedPcmPolicyGeneration,
+                            outputProgress, observedOutputUnderruns, true,
+                            frame.length() - pending.writeOffset());
+                    observedOutputUnderruns = result.observedOutputUnderruns();
+                    if (result.outcome() == WriteOutcome.COMPLETE) {
+                        commitFrame(activeQueue, frame);
+                        frame = null;
+                    } else if (result.outcome() == WriteOutcome.OUTPUT_UNDERRUN) {
+                        if (pending.writeOffset() < pending.frame().length()) {
+                            primerFrames.add(pending);
+                            frame = null;
+                        } else {
+                            commitFrame(activeQueue, frame);
+                            frame = null;
+                        }
+                        if (!rebaseUnderrunRecovery(output, outputProgress,
+                                outputBufferLimits, underrunRecovery)) {
+                            accountRouteFailure();
+                            requestRecoveryReopen();
                         }
                     } else {
-                        if (!writeFully(output, frame)) {
-                            reopenRequested.set(true);
+                        // Retain the exact converted packet.  A replacement stopped track will
+                        // replay it first, followed by three new ordered packets, before play().
+                        primerFrames.add(pending);
+                        frame = null;
+                        if (result.outcome() == WriteOutcome.OUTPUT_FAILURE) {
+                            accountWriteFailure();
+                            requestRecoveryReopen();
                         }
                     }
                 } finally {
-                    activeQueue.release(frame);
+                    if (frame != null) {
+                        discardFrame(activeQueue, frame);
+                    }
                 }
             }
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
         } finally {
-            if (BuildConfig.DIAGNOSTICS_ENABLED && activeQueue != null) {
-                clearAndAccount(activeQueue);
-            } else if (activeQueue != null) {
-                activeQueue.clear();
+            if (activeQueue != null) {
+                discardPrimerFrames(activeQueue, primerFrames);
+                synchronized (queueLock) {
+                    clearQueue(activeQueue);
+                    if (queue == activeQueue) {
+                        queue = null;
+                    }
+                }
+            } else {
+                synchronized (queueLock) {
+                    queue = null;
+                }
             }
-            queue = null;
             activeOutput = null;
             routeGeneration.incrementAndGet();
             sampleRate = 0;
@@ -601,40 +1124,284 @@ final class AndroidAudioSink implements AutoCloseable {
         }
     }
 
-    private boolean writeFully(Output output, BoundedPcmQueue.Frame frame) {
-        int offset = 0;
-        while (offset < frame.length() && running.get() && !paused) {
-            int written = output.write(frame.bytes(), offset, frame.length() - offset);
-            if (written <= 0) {
-                return false;
-            }
-            offset += written;
+    private static OutputBufferLimits readOutputBufferLimits(Output output) {
+        int capacityFrames = output.bufferCapacityFrames();
+        int effectiveFrames = output.effectiveBufferFrames();
+        int startThresholdFrames = output.startThresholdFrames();
+        if (capacityFrames <= 0 || effectiveFrames <= 0 || effectiveFrames > capacityFrames
+                || startThresholdFrames <= 0 || startThresholdFrames > effectiveFrames) {
+            throw new IllegalStateException("Invalid AudioTrack buffer limits");
         }
-        return offset == frame.length();
+        return new OutputBufferLimits(capacityFrames, effectiveFrames, startThresholdFrames);
     }
 
-    private WriteResult writeFullyWithAccounting(Output output, BoundedPcmQueue.Frame frame) {
-        int offset = 0;
-        while (offset < frame.length() && running.get() && !paused) {
-            int written = output.write(frame.bytes(), offset, frame.length() - offset);
-            if (written <= 0) {
-                return new WriteResult(false, offset);
-            }
-            offset += written;
+    private WriteResult writeFrame(Output output, PendingFrame pending,
+            long expectedPauseFlushGeneration, long expectedPcmPolicyGeneration,
+            OutputProgress outputProgress, long observedOutputUnderruns,
+            boolean monitorOutputUnderruns, int maximumBytes) {
+        BoundedPcmQueue.Frame frame = pending.frame();
+        long latestOutputUnderruns = observedOutputUnderruns;
+        if ((frame.length() & 3) != 0 || (pending.writeOffset() & 3) != 0
+                || maximumBytes < 0 || (maximumBytes & 3) != 0) {
+            return new WriteResult(WriteOutcome.OUTPUT_FAILURE, latestOutputUnderruns);
         }
-        return new WriteResult(offset == frame.length(), offset);
+        int writeBudget = maximumBytes;
+        while (pending.writeOffset() < frame.length()) {
+            if (writeBudget == 0) {
+                return new WriteResult(WriteOutcome.CAPACITY_FILLED, latestOutputUnderruns);
+            }
+            if (!isPlaybackBoundaryCurrent(expectedPauseFlushGeneration,
+                    expectedPcmPolicyGeneration)) {
+                return new WriteResult(WriteOutcome.INTERRUPTED, latestOutputUnderruns);
+            }
+            if (monitorOutputUnderruns) {
+                long sampled = sampleOutputUnderruns(output, latestOutputUnderruns);
+                if (hasOutputUnderrunIncreased(latestOutputUnderruns, sampled)) {
+                    return new WriteResult(WriteOutcome.OUTPUT_UNDERRUN, sampled);
+                }
+                latestOutputUnderruns = sampled;
+            }
+            int remaining = Math.min(frame.length() - pending.writeOffset(), writeBudget);
+            int written;
+            try {
+                written = output.write(frame.bytes(), pending.writeOffset(), remaining);
+            } catch (RuntimeException unavailable) {
+                return new WriteResult(WriteOutcome.OUTPUT_FAILURE, latestOutputUnderruns);
+            }
+            if (written <= 0 || written > remaining || (written & 3) != 0) {
+                return new WriteResult(WriteOutcome.OUTPUT_FAILURE, latestOutputUnderruns);
+            }
+            pending.advance(written);
+            writeBudget -= written;
+            outputProgress.accept(written);
+            if (monitorOutputUnderruns) {
+                long sampled = sampleOutputUnderruns(output, latestOutputUnderruns);
+                if (hasOutputUnderrunIncreased(latestOutputUnderruns, sampled)) {
+                    return new WriteResult(WriteOutcome.OUTPUT_UNDERRUN, sampled);
+                }
+                latestOutputUnderruns = sampled;
+            }
+        }
+        if (!isPlaybackBoundaryCurrent(expectedPauseFlushGeneration,
+                expectedPcmPolicyGeneration)) {
+            return new WriteResult(WriteOutcome.INTERRUPTED, latestOutputUnderruns);
+        }
+        return new WriteResult(WriteOutcome.COMPLETE, latestOutputUnderruns);
+    }
+
+    private boolean isPlaybackBoundaryCurrent(long expectedPauseFlushGeneration,
+            long expectedPcmPolicyGeneration) {
+        return running.get() && !paused && !reopenRequested.get()
+                && pauseFlushGeneration.get() == expectedPauseFlushGeneration
+                && pcmPolicyGeneration.get() == expectedPcmPolicyGeneration;
+    }
+
+    private PlayOutcome playOutput(Output output, long expectedPauseFlushGeneration,
+            long expectedPcmPolicyGeneration, boolean benchmarkEmptyPlay) {
+        synchronized (playbackControlLock) {
+            if (!isPlaybackBoundaryCurrent(expectedPauseFlushGeneration,
+                    expectedPcmPolicyGeneration)
+                    || benchmarkEmptyPlayRequested.get() != benchmarkEmptyPlay) {
+                return PlayOutcome.STALE_BOUNDARY;
+            }
+            try {
+                output.play();
+                return PlayOutcome.STARTED;
+            } catch (RuntimeException unavailable) {
+                return PlayOutcome.OUTPUT_FAILURE;
+            }
+        }
+    }
+
+    private long sampleOutputUnderruns(Output output, long previous) {
+        if (output == null) {
+            return previous;
+        }
+        try {
+            long sampled = output.outputUnderrunCount();
+            if (BuildConfig.DIAGNOSTICS_ENABLED) {
+                outputUnderruns = sampled;
+            }
+            return sampled >= 0L ? sampled : previous;
+        } catch (RuntimeException unavailable) {
+            if (BuildConfig.DIAGNOSTICS_ENABLED) {
+                outputUnderruns = -1L;
+            }
+            return previous;
+        }
+    }
+
+    private static boolean hasOutputUnderrunIncreased(long previous, long latest) {
+        return previous >= 0L && latest > previous;
+    }
+
+    /**
+     * Starts a fresh proof for the latest cumulative underrun observation. The playback head is
+     * deliberately sampled here, after the counter increase has been observed, so progress that
+     * preceded the latest underrun cannot satisfy the new recovery.
+     */
+    private static boolean rebaseUnderrunRecovery(Output output,
+            OutputProgress outputProgress, OutputBufferLimits outputBufferLimits,
+            UnderrunRecovery underrunRecovery) {
+        long playbackHeadFrames = outputProgress.readPlaybackPosition(output);
+        long bufferedFrames = outputProgress.bufferedFrames(playbackHeadFrames);
+        return underrunRecovery.rebase(playbackHeadFrames, outputProgress.acceptedFrames(),
+                bufferedFrames, outputBufferLimits.startThresholdFrames());
+    }
+
+    private void requestRecoveryReopen() {
+        synchronized (playbackControlLock) {
+            benchmarkEmptyPlayRequested.set(false);
+            reopenRequested.set(true);
+        }
+    }
+
+    private static boolean frameMatchesBoundary(BoundedPcmQueue.Frame frame,
+            long pauseGeneration, long policyGeneration) {
+        return frame.pauseFlushGeneration() == pauseGeneration
+                && frame.policyGeneration() == policyGeneration;
+    }
+
+    private void reconcileFrameAccounting(BoundedPcmQueue active,
+            BoundedPcmQueue.Frame frame) {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        synchronized (pcmAccounting) {
+            int delta = active.reconcileAccountingBytes(frame);
+            pcmAccounting.adjustEnqueued(delta, delta / 4L);
+            accountQueueDiscards(active);
+        }
+    }
+
+    private void commitCompletedPrimerFrames(BoundedPcmQueue active,
+            List<PendingFrame> frames) {
+        while (!frames.isEmpty()) {
+            PendingFrame pending = frames.get(0);
+            if (pending.writeOffset() < pending.frame().length()) {
+                return;
+            }
+            frames.remove(0);
+            commitFrame(active, pending.frame());
+        }
+    }
+
+    private void commitFrame(BoundedPcmQueue active, BoundedPcmQueue.Frame frame) {
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            synchronized (pcmAccounting) {
+                pcmAccounting.written(frame.length(), frame.length() / 4L);
+            }
+        }
+        active.release(frame);
+    }
+
+    private void discardPrimerFrames(BoundedPcmQueue active, List<PendingFrame> frames) {
+        for (PendingFrame pending : frames) {
+            discardFrame(active, pending.frame());
+        }
+        frames.clear();
+    }
+
+    private static void resetPendingFramesForReplacement(List<PendingFrame> frames) {
+        for (PendingFrame frame : frames) {
+            frame.resetForReplacement();
+        }
+    }
+
+    private void discardFrame(BoundedPcmQueue active, BoundedPcmQueue.Frame frame) {
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            synchronized (pcmAccounting) {
+                pcmAccounting.discarded(frame.accountingBytes());
+            }
+        }
+        active.release(frame);
+    }
+
+    private void accountWriteFailure() {
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            synchronized (pcmAccounting) {
+                pcmAccounting.writeFailure();
+            }
+        }
+    }
+
+    private void accountRouteFailure() {
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            synchronized (pcmAccounting) {
+                pcmAccounting.routeFailure();
+            }
+        }
+    }
+
+    private boolean resetOutputForPcmBoundary(Output output) {
+        boolean reset = true;
+        if (output != null) {
+            try {
+                output.pause();
+                output.flush();
+            } catch (RuntimeException unavailable) {
+                accountRouteFailure();
+                requestRecoveryReopen();
+                reset = false;
+            }
+        }
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            outputPlaying = false;
+        }
+        return reset;
+    }
+
+    private static void preferAudioThreadPriority() {
+        try {
+            android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_AUDIO);
+        } catch (RuntimeException unavailable) {
+            // Some OEM policies can reject priority changes. Audio remains functional.
+        }
+    }
+
+    private static boolean containsOutputSink(AudioDeviceInfo[] devices) {
+        if (devices == null) {
+            return false;
+        }
+        for (AudioDeviceInfo device : devices) {
+            if (device == null) {
+                continue;
+            }
+            try {
+                if (device.isSink()) {
+                    return true;
+                }
+            } catch (RuntimeException unavailable) {
+                // A stale framework descriptor must not force an unrelated route restart.
+            }
+        }
+        return false;
     }
 
     private void clearQueuedPcm() {
-        BoundedPcmQueue active = queue;
-        if (active != null) {
-            if (BuildConfig.DIAGNOSTICS_ENABLED) {
-                clearAndAccount(active);
-            } else {
-                active.clear();
+        synchronized (queueLock) {
+            BoundedPcmQueue active = queue;
+            if (active != null) {
+                clearQueue(active);
             }
+            hasProducedPcm = false;
         }
-        hasProducedPcm = false;
+    }
+
+    /** Called only while playbackControlLock publishes a new pause/policy boundary. */
+    private void clearQueuedPcmAtBoundary() {
+        if (boundaryClearHook != null) {
+            boundaryClearHook.beforeQueuedPcmClear();
+        }
+        clearQueuedPcm();
+    }
+
+    private void clearQueue(BoundedPcmQueue active) {
+        if (BuildConfig.DIAGNOSTICS_ENABLED) {
+            clearAndAccount(active);
+        } else {
+            active.clear();
+        }
     }
 
     private void clearAndAccount(BoundedPcmQueue active) {
@@ -815,6 +1582,219 @@ final class AndroidAudioSink implements AutoCloseable {
                 0L, 0L, 0L, 0L);
     }
 
-    private record WriteResult(boolean complete, int bytesWritten) {
+    /** One converted packet retained across a stopped-state replay or underrun refill. */
+    private static final class PendingFrame {
+        private final BoundedPcmQueue.Frame frame;
+        /** Prefix accepted by the current output (including positive short writes). */
+        private int writeOffset;
+
+        private PendingFrame(BoundedPcmQueue.Frame frame) {
+            this.frame = frame;
+        }
+
+        private BoundedPcmQueue.Frame frame() {
+            return frame;
+        }
+
+        private int writeOffset() {
+            return writeOffset;
+        }
+
+        private void advance(int bytes) {
+            writeOffset = Math.addExact(writeOffset, bytes);
+        }
+
+        private void resetForReplacement() {
+            writeOffset = 0;
+        }
+    }
+
+    private record OutputBufferLimits(int capacityFrames, int effectiveBufferFrames,
+            int startThresholdFrames) {
+        private static final OutputBufferLimits UNAVAILABLE = new OutputBufferLimits(0, 0, 0);
+    }
+
+    /** Worker-local state for one or more coalesced in-place AudioTrack threshold refills. */
+    static final class UnderrunRecovery {
+        private boolean active;
+        private long headAtDetectionFrames = -1L;
+        private long acceptedFramesAtDetection = -1L;
+        private long refillFramesRequired;
+        private long capacityFullSinceNanos = -1L;
+        private boolean refillThresholdReached;
+
+        boolean rebase(long playbackHeadFrames, long acceptedFrames, long bufferedFrames,
+                int startThresholdFrames) {
+            if (playbackHeadFrames < 0L || acceptedFrames < 0L || bufferedFrames < 0L
+                    || startThresholdFrames <= 0) {
+                return false;
+            }
+            active = true;
+            headAtDetectionFrames = playbackHeadFrames;
+            acceptedFramesAtDetection = acceptedFrames;
+            refillFramesRequired = Math.max(0L, startThresholdFrames - bufferedFrames);
+            capacityFullSinceNanos = -1L;
+            refillThresholdReached = false;
+            return true;
+        }
+
+        boolean active() {
+            return active;
+        }
+
+        boolean hasRestarted(long playbackHeadFrames) {
+            return active && refillThresholdReached
+                    && playbackHeadFrames > headAtDetectionFrames;
+        }
+
+        void observeRefillProgress(long acceptedFrames, long bufferedFrames,
+                int startThresholdFrames) {
+            if (active && acceptedFrames >= acceptedFramesAtDetection
+                    && acceptedFrames - acceptedFramesAtDetection >= refillFramesRequired
+                    && bufferedFrames >= startThresholdFrames) {
+                refillThresholdReached = true;
+            }
+        }
+
+        boolean capacityHasStalled(long nowNanos) {
+            if (!refillThresholdReached) {
+                return false;
+            }
+            if (capacityFullSinceNanos < 0L) {
+                capacityFullSinceNanos = nowNanos;
+                return false;
+            }
+            return nowNanos - capacityFullSinceNanos
+                    >= TimeUnit.MILLISECONDS.toNanos(UNDERRUN_STALL_MILLIS);
+        }
+
+        void clearCapacityStall() {
+            capacityFullSinceNanos = -1L;
+        }
+
+        void reset() {
+            active = false;
+            headAtDetectionFrames = -1L;
+            acceptedFramesAtDetection = -1L;
+            refillFramesRequired = 0L;
+            capacityFullSinceNanos = -1L;
+            refillThresholdReached = false;
+        }
+    }
+
+    private record WriteResult(WriteOutcome outcome, long observedOutputUnderruns) {
+    }
+
+    private enum PlayOutcome {
+        STARTED,
+        STALE_BOUNDARY,
+        OUTPUT_FAILURE
+    }
+
+    /**
+     * Per-output accepted-byte ledger and unsigned 32-bit playback-head extension.
+     * The epoch is reset after every flush/reopen, matching AudioTrack's head semantics.
+     */
+    static final class OutputProgress {
+        private static final long UNSIGNED_INT_RANGE = 1L << 32;
+        private static final long UNSIGNED_INT_MASK = UNSIGNED_INT_RANGE - 1L;
+        private static final long WRAP_THRESHOLD = 1L << 31;
+
+        private long previousExtendedPosition = -1L;
+        private long playbackBaseFrames = -1L;
+        private long acceptedBytes;
+
+        void open(Output output) {
+            previousExtendedPosition = -1L;
+            playbackBaseFrames = -1L;
+            acceptedBytes = 0L;
+            long initialPosition = readPlaybackPosition(output);
+            if (initialPosition >= 0L) {
+                playbackBaseFrames = initialPosition;
+            }
+        }
+
+        void resetAfterFlush(Output output) {
+            open(output);
+        }
+
+        void accept(int bytes) {
+            acceptedBytes = Math.addExact(acceptedBytes, bytes);
+        }
+
+        long acceptedFrames() {
+            return (acceptedBytes & 3L) == 0L ? acceptedBytes / 4L : -1L;
+        }
+
+        long readPlaybackPosition(Output output) {
+            if (output == null) {
+                return -1L;
+            }
+            long raw;
+            try {
+                raw = output.playbackPositionFrames();
+            } catch (RuntimeException unavailable) {
+                return -1L;
+            }
+            long extended = extendUnsignedPlaybackPosition(previousExtendedPosition, raw);
+            if (extended >= 0L) {
+                previousExtendedPosition = extended;
+                if (playbackBaseFrames < 0L) {
+                    // A new/just-flushed streaming AudioTrack starts at frame zero. Some routes
+                    // expose the head only after play(), so make that documented epoch explicit.
+                    playbackBaseFrames = 0L;
+                }
+            }
+            return extended;
+        }
+
+        long bufferedFrames(long playedFrames) {
+            if (playbackBaseFrames < 0L || playedFrames < 0L) {
+                return -1L;
+            }
+            if ((acceptedBytes & 3L) != 0L) {
+                return -1L;
+            }
+            long playedSinceOpen = playedFrames - playbackBaseFrames;
+            if (playedSinceOpen < 0L) {
+                return -1L;
+            }
+            long acceptedFrames = acceptedBytes / 4L;
+            return Math.max(0L, acceptedFrames - playedSinceOpen);
+        }
+
+        static long extendUnsignedPlaybackPosition(long previousExtended, long currentRaw) {
+            if (currentRaw < 0L) {
+                return -1L;
+            }
+            // Test outputs may already expose a wider monotonic head. Android's implementation
+            // supplies the documented unsigned 32-bit value.
+            if (currentRaw > UNSIGNED_INT_MASK) {
+                return previousExtended < 0L || currentRaw >= previousExtended
+                        ? currentRaw : -1L;
+            }
+            long normalized = currentRaw & UNSIGNED_INT_MASK;
+            if (previousExtended < 0L) {
+                return normalized;
+            }
+            long previousRaw = previousExtended & UNSIGNED_INT_MASK;
+            long epoch = previousExtended - previousRaw;
+            if (normalized < previousRaw) {
+                if (previousRaw - normalized <= WRAP_THRESHOLD) {
+                    // A small regression within one flush epoch is not a trustworthy drain head.
+                    return -1L;
+                }
+                epoch = Math.addExact(epoch, UNSIGNED_INT_RANGE);
+            }
+            return Math.addExact(epoch, normalized);
+        }
+    }
+
+    private enum WriteOutcome {
+        COMPLETE,
+        CAPACITY_FILLED,
+        INTERRUPTED,
+        OUTPUT_UNDERRUN,
+        OUTPUT_FAILURE
     }
 }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutput.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutput.java
@@ -4,11 +4,16 @@ import android.media.AudioAttributes;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
+import android.os.Build;
 
 /** Android framework bridge kept outside the portable DSP and fixed PCM queue. */
 final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
 
     static final class Factory implements AndroidAudioSink.OutputFactory {
+
+        /** Five maximum packets of physical capacity; the start threshold is configured below. */
+        static final int BUFFER_PACKETS = AndroidAudioSink.PRIMER_PACKETS + 1;
+
         @Override
         public AndroidAudioSink.Output open() {
             int nativeRate = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC);
@@ -31,9 +36,14 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
          * duplicate candidates before any framework call.</p>
          */
         static int[] candidateSampleRates(int nativeRate) {
+            if (nativeRate == 44_100) {
+                return new int[]{44_100, 48_000};
+            }
+            if (nativeRate == 48_000) {
+                return new int[]{48_000, 44_100};
+            }
             boolean hasDistinctPositiveNativeRate = nativeRate > 0
-                    && nativeRate != 48_000
-                    && nativeRate != 44_100;
+                    && nativeRate != 48_000 && nativeRate != 44_100;
             int[] candidates = new int[hasDistinctPositiveNativeRate ? 3 : 2];
             candidates[0] = 48_000;
             candidates[1] = 44_100;
@@ -41,6 +51,49 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
                 candidates[2] = nativeRate;
             }
             return candidates;
+        }
+
+        static int packetBufferBytes(int sampleRate) {
+            return Math.multiplyExact(BUFFER_PACKETS,
+                    BoundedPcmQueue.maximumFrameBytes(sampleRate));
+        }
+
+        static int configuredBufferBytes(int sampleRate, int minimumBufferBytes) {
+            if (minimumBufferBytes <= 0) {
+                throw new IllegalArgumentException("Minimum audio buffer must be positive");
+            }
+            return Math.max(minimumBufferBytes, packetBufferBytes(sampleRate));
+        }
+
+        static boolean hasPacketCapacity(int sampleRate, int configuredBytes, int actualBytes) {
+            int required = packetBufferBytes(sampleRate);
+            return configuredBytes >= required && actualBytes >= required;
+        }
+
+        static boolean hasEffectivePrimerWindow(int sampleRate, int effectiveFrames,
+                int startThresholdFrames) {
+            int minimumEffective = BoundedPcmQueue.maximumOutputFramesForPackets(sampleRate,
+                    AndroidAudioSink.PRIMER_PACKETS);
+            int maximumThreshold = BoundedPcmQueue.minimumOutputFramesForPackets(sampleRate,
+                    BoundedPcmQueue.DEFAULT_CAPACITY);
+            return effectiveFrames >= minimumEffective && startThresholdFrames > 0
+                    && startThresholdFrames <= effectiveFrames
+                    && startThresholdFrames <= maximumThreshold;
+        }
+
+        static int startThresholdFrames(int sdkInt, int reportedFrames, int effectiveFrames) {
+            if (effectiveFrames <= 0) {
+                throw new IllegalArgumentException("Effective audio buffer must be positive");
+            }
+            if (sdkInt < Build.VERSION_CODES.S) {
+                // Pre-S does not expose the device threshold. The documented portable refill is
+                // the entire effective application-write buffer.
+                return effectiveFrames;
+            }
+            if (reportedFrames <= 0 || reportedFrames > effectiveFrames) {
+                throw new IllegalArgumentException("Invalid AudioTrack start threshold");
+            }
+            return reportedFrames;
         }
 
         private static AndroidAudioTrackOutput tryOpen(int sampleRate) {
@@ -54,6 +107,7 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
             }
             AudioTrack track = null;
             try {
+                int configured = configuredBufferBytes(sampleRate, minimum);
                 track = new AudioTrack.Builder()
                         .setAudioAttributes(new AudioAttributes.Builder()
                                 .setUsage(AudioAttributes.USAGE_GAME)
@@ -64,7 +118,7 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
                                 .setSampleRate(sampleRate)
                                 .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
                                 .build())
-                        .setBufferSizeInBytes(Math.max(minimum, sampleRate * 4 / 100))
+                        .setBufferSizeInBytes(configured)
                         .setTransferMode(AudioTrack.MODE_STREAM)
                         .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
                         .build();
@@ -73,11 +127,31 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
                     return null;
                 }
                 int actualRate = track.getSampleRate();
-                int actualBuffer = Math.max(0, track.getBufferSizeInFrames()) * 4;
-                int configured = Math.max(minimum, sampleRate * 4 / 100);
+                int selectedRate = actualRate > 0 ? actualRate : sampleRate;
+                int capacityFrames = Math.max(0, track.getBufferCapacityInFrames());
+                int capacityBytes = Math.multiplyExact(capacityFrames, 4);
+                if (!hasPacketCapacity(selectedRate, configured, capacityBytes)) {
+                    track.release();
+                    return null;
+                }
+                int requestedEffectiveFrames = Math.max((minimum + 3) / 4,
+                        packetBufferBytes(selectedRate) / 4);
+                int effectiveFrames = track.setBufferSizeInFrames(requestedEffectiveFrames);
+                int desiredThresholdFrames = BoundedPcmQueue.minimumOutputFramesForPackets(
+                        selectedRate, AndroidAudioSink.PRIMER_PACKETS);
+                int reportedThreshold = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        ? track.setStartThresholdInFrames(desiredThresholdFrames) : effectiveFrames;
+                int selectedStartThresholdFrames = startThresholdFrames(Build.VERSION.SDK_INT,
+                        reportedThreshold, effectiveFrames);
+                if (!hasEffectivePrimerWindow(selectedRate, effectiveFrames,
+                        selectedStartThresholdFrames)) {
+                    track.release();
+                    return null;
+                }
                 return new AndroidAudioTrackOutput(track,
-                        actualRate > 0 ? actualRate : sampleRate,
-                        minimum, configured, actualBuffer);
+                        selectedRate,
+                        minimum, configured, capacityBytes, capacityFrames, effectiveFrames,
+                        selectedStartThresholdFrames);
             } catch (RuntimeException unavailable) {
                 if (track != null) {
                     track.release();
@@ -92,14 +166,21 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
     private final int minimumBufferBytes;
     private final int configuredBufferBytes;
     private final int actualBufferBytes;
+    private final int bufferCapacityFrames;
+    private final int effectiveBufferFrames;
+    private final int startThresholdFrames;
 
     private AndroidAudioTrackOutput(AudioTrack track, int sampleRate, int minimumBufferBytes,
-            int configuredBufferBytes, int actualBufferBytes) {
+            int configuredBufferBytes, int actualBufferBytes, int bufferCapacityFrames,
+            int effectiveBufferFrames, int startThresholdFrames) {
         this.track = track;
         this.sampleRate = sampleRate;
         this.minimumBufferBytes = minimumBufferBytes;
         this.configuredBufferBytes = configuredBufferBytes;
         this.actualBufferBytes = actualBufferBytes;
+        this.bufferCapacityFrames = bufferCapacityFrames;
+        this.effectiveBufferFrames = effectiveBufferFrames;
+        this.startThresholdFrames = startThresholdFrames;
     }
 
     @Override
@@ -111,6 +192,21 @@ final class AndroidAudioTrackOutput implements AndroidAudioSink.Output {
     public AndroidAudioSink.AudioStats audioStats() {
         return new AndroidAudioSink.AudioStats(sampleRate, minimumBufferBytes,
                 configuredBufferBytes, actualBufferBytes);
+    }
+
+    @Override
+    public int bufferCapacityFrames() {
+        return bufferCapacityFrames;
+    }
+
+    @Override
+    public int effectiveBufferFrames() {
+        return effectiveBufferFrames;
+    }
+
+    @Override
+    public int startThresholdFrames() {
+        return startThresholdFrames;
     }
 
     @Override

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -1179,7 +1179,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             audioReady = false;
             boolean flushObserved = activeAudio != null && emptyAudio && !baseline.outputPlaying();
             if (flushObserved) {
-                activeAudio.resume();
+                // The guest intentionally remains paused until ARM, so it cannot produce the
+                // four genuine packets required by ordinary AudioTrack startup. Preserve this
+                // diagnostics-only empty-playing proof through the sink's explicit narrow bypass.
+                activeAudio.resumeEmptyForBenchmarkPreArm();
                 deadlines.schedule(
                         () -> submit(() -> finishBenchmarkScenarioCompletion(
                                 event, completionEpoch, 0, true)),

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/BoundedPcmQueue.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/BoundedPcmQueue.java
@@ -17,6 +17,9 @@ import java.util.concurrent.atomic.AtomicLong;
 final class BoundedPcmQueue {
 
     static final int DEFAULT_CAPACITY = 6;
+    private static final ClockSpec[] SUPPORTED_CLOCKS = {
+            ClockSpec.LEGACY, ClockSpec.SGB, ClockSpec.SGB2
+    };
 
     private final StereoPcmConverter converter;
     private final ArrayBlockingQueue<Frame> available;
@@ -54,7 +57,10 @@ final class BoundedPcmQueue {
         converter = new StereoPcmConverter(sampleRate);
         this.capacity = capacity;
         this.frameBytes = frameBytes;
-        sourceSamples = Math.multiplyExact(sourceClock.controllerTicksPerFrame(), 2);
+        // HardwareProfile can arrive immediately before its first PCM event.  Every reserved
+        // source slot therefore covers the largest supported controller packet; changing the
+        // source cadence never has to rebuild the queue or race that first SGB-family packet.
+        sourceSamples = maximumSourceSamplesAcrossProfiles();
         available = new ArrayBlockingQueue<>(capacity);
         queued = new ArrayBlockingQueue<>(capacity);
         for (int index = 0; index < capacity; index++) {
@@ -68,6 +74,15 @@ final class BoundedPcmQueue {
      * ordering without retaining the core's reusable event buffer.
      */
     int offer(Sound.SoundSampleEvent event, int volume, boolean muted) {
+        return offer(event, volume, muted, 0L, 0L);
+    }
+
+    int offer(Sound.SoundSampleEvent event, int volume, boolean muted, long policyGeneration) {
+        return offer(event, volume, muted, policyGeneration, 0L);
+    }
+
+    int offer(Sound.SoundSampleEvent event, int volume, boolean muted, long policyGeneration,
+            long pauseFlushGeneration) {
         Frame frame = available.poll();
         if (frame == null) {
             frame = queued.poll();
@@ -84,11 +99,12 @@ final class BoundedPcmQueue {
         }
         try {
             if (event.buffer().length > frame.source.length) {
-                // A profile change races queue construction only during startup. Drop this
-                // source frame rather than allocate on the controller thread; the runtime's
-                // profile callback requests a bounded queue rebuild before the next event.
+                // Fixed storage covers every supported production profile. Keep a fail-closed
+                // guard for malformed/custom events rather than allocate on the controller.
                 frame.clearSource();
                 frame.accountingBytes = 0;
+                frame.policyGeneration = 0L;
+                frame.pauseFlushGeneration = 0L;
                 available.offer(frame);
                 overruns.incrementAndGet();
                 return 0;
@@ -98,6 +114,8 @@ final class BoundedPcmQueue {
             frame.clockSpec = event.clockSpec();
             frame.volume = volume;
             frame.muted = muted;
+            frame.policyGeneration = policyGeneration;
+            frame.pauseFlushGeneration = pauseFlushGeneration;
             frame.accountingBytes = converter.maximumPcmBytes(
                     event.buffer().length / 2, event.clockSpec());
             frame.length = 0;
@@ -110,6 +128,8 @@ final class BoundedPcmQueue {
         } catch (RuntimeException failure) {
             frame.clearSource();
             frame.accountingBytes = 0;
+            frame.policyGeneration = 0L;
+            frame.pauseFlushGeneration = 0L;
             available.offer(frame);
             throw failure;
         }
@@ -132,6 +152,8 @@ final class BoundedPcmQueue {
             frame.clearSource();
             frame.length = 0;
             frame.accountingBytes = 0;
+            frame.policyGeneration = 0L;
+            frame.pauseFlushGeneration = 0L;
             available.offer(frame);
             throw failure;
         }
@@ -144,6 +166,8 @@ final class BoundedPcmQueue {
         frame.length = 0;
         frame.clearSource();
         frame.accountingBytes = 0;
+        frame.policyGeneration = 0L;
+        frame.pauseFlushGeneration = 0L;
         if (!available.offer(frame)) {
             throw new IllegalStateException("PCM queue released a frame twice");
         }
@@ -195,13 +219,56 @@ final class BoundedPcmQueue {
         return converter.samplePhase();
     }
 
-    private static int maximumFrameBytes(int sampleRate) {
+    static int maximumFrameBytes(int sampleRate) {
         long maximum = 0;
-        for (ClockSpec clock : new ClockSpec[]{ClockSpec.LEGACY, ClockSpec.SGB, ClockSpec.SGB2}) {
+        for (ClockSpec clock : SUPPORTED_CLOCKS) {
             maximum = Math.max(maximum, clock.maximumOutputUnits(
                     clock.controllerTicksPerFrame(), sampleRate));
         }
         return Math.toIntExact(Math.multiplyExact(maximum, 4));
+    }
+
+    /** Lowest PCM-frame total for this many packets, including a profile reset per packet. */
+    static int minimumOutputFramesForPackets(int sampleRate, int packets) {
+        if (sampleRate <= 0 || packets <= 0) {
+            throw new IllegalArgumentException("Sample rate and packet count must be positive");
+        }
+        long minimumPacket = Long.MAX_VALUE;
+        for (ClockSpec clock : SUPPORTED_CLOCKS) {
+            long frames = clock.newTickRateAccumulator(sampleRate)
+                    .advance(clock.controllerTicksPerFrame());
+            minimumPacket = Math.min(minimumPacket, frames);
+        }
+        return Math.toIntExact(Math.multiplyExact(minimumPacket, packets));
+    }
+
+    /** Highest PCM-frame total for this many packets, including arbitrary profile/phase changes. */
+    static int maximumOutputFramesForPackets(int sampleRate, int packets) {
+        if (sampleRate <= 0 || packets <= 0) {
+            throw new IllegalArgumentException("Sample rate and packet count must be positive");
+        }
+        long maximumPacket = 0L;
+        for (ClockSpec clock : SUPPORTED_CLOCKS) {
+            maximumPacket = Math.max(maximumPacket, clock.maximumOutputUnits(
+                    clock.controllerTicksPerFrame(), sampleRate));
+        }
+        return Math.toIntExact(Math.multiplyExact(maximumPacket, packets));
+    }
+
+    private static int maximumSourceSamplesAcrossProfiles() {
+        int maximum = 0;
+        for (ClockSpec clock : SUPPORTED_CLOCKS) {
+            maximum = Math.max(maximum,
+                    Math.multiplyExact(clock.controllerTicksPerFrame(), 2));
+        }
+        return maximum;
+    }
+
+    /** Reconciles the producer's maximum estimate with the converter's exact packet length. */
+    int reconcileAccountingBytes(Frame frame) {
+        int previous = frame.accountingBytes;
+        frame.accountingBytes = frame.length;
+        return frame.length - previous;
     }
 
     static final class Frame {
@@ -212,6 +279,8 @@ final class BoundedPcmQueue {
         private ClockSpec clockSpec;
         private int volume;
         private boolean muted;
+        private long policyGeneration;
+        private long pauseFlushGeneration;
         private int accountingBytes;
 
         private Frame(byte[] bytes, int[] source) {
@@ -229,6 +298,14 @@ final class BoundedPcmQueue {
 
         int accountingBytes() {
             return accountingBytes;
+        }
+
+        long policyGeneration() {
+            return policyGeneration;
+        }
+
+        long pauseFlushGeneration() {
+            return pauseFlushGeneration;
         }
 
         private void clearSource() {

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
@@ -5,44 +5,60 @@ import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.sound.Sound;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AndroidAudioSinkTest {
 
+    private static final int SAMPLE_RATE = 44_100;
+
     @Test
-    public void writesOnlyOnDedicatedConsumerAndRecoversAfterUnderrunAndRouteChange() throws Exception {
+    public void primesFourGenuineOrderedPacketsBeforePlayWithMoreThanFiftyMilliseconds()
+            throws Exception {
         EventBusImpl events = new EventBusImpl(null, null, false);
         FakeFactory factory = new FakeFactory();
         AndroidAudioSink sink = new AndroidAudioSink(events, factory);
         sink.start();
         try {
-            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput output = factory.current();
             Thread owner = sink.workerThreadForTesting();
             assertNotNull(owner);
             assertTrue(owner.getName().contains("android-audio"));
 
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            await("first PCM write", () -> factory.current().writes.size() == 1);
-            assertTrue(factory.current().writeThreads.stream().allMatch(name -> name.equals(owner.getName())));
+            List<Sound.SoundSampleEvent> packets = packets(ClockSpec.LEGACY, 4, 120);
+            byte[] expected = render(packets);
+            byte[] firstThree = render(packets.subList(0, 3));
+            post(events, packets.subList(0, 3));
+            await("three stopped writes", () -> output.acceptedLength() == firstThree.length);
+            assertEquals(0, output.playCalls);
 
-            await("underrun", () -> sink.stats().underruns() > 0);
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            await("underrun recovery", () -> factory.current().writes.size() == 2);
+            events.post(packets.get(3));
+            await("primed playback", () -> output.playCalls == 1);
+            assertArrayEquals(expected, output.acceptedBytes());
+            assertEquals(expected.length, output.bytesAtFirstPlay);
+            assertTrue(output.writeThreads.stream().allMatch(owner.getName()::equals));
 
-            FakeOutput first = factory.current();
-            sink.requestRouteReopen();
-            await("route reopen", () -> factory.opens.get() == 2 && first.released);
-            assertEquals(1, sink.stats().restarts());
+            double primerMillis = expected.length / 4.0 / SAMPLE_RATE * 1_000.0;
+            assertTrue("primer must absorb more than 50 ms ticker debt: " + primerMillis,
+                    primerMillis > 50.0);
+            assertTrue("four frame packets should remain below 70 ms: " + primerMillis,
+                    primerMillis < 70.0);
         } finally {
             sink.close();
         }
@@ -52,71 +68,657 @@ public class AndroidAudioSinkTest {
     }
 
     @Test
-    public void pauseClearsQueuedFramesUntilExplicitResume() throws Exception {
+    public void pauseResumeAndLegitimateReopenEachRequireANewPrimer() throws Exception {
         EventBusImpl events = new EventBusImpl(null, null, false);
         FakeFactory factory = new FakeFactory();
         AndroidAudioSink sink = new AndroidAudioSink(events, factory);
         sink.start();
         try {
-            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput first = factory.current();
+            List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+            post(events, initial);
+            await("initial play", () -> first.playCalls == 1);
+
             sink.pause();
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            Thread.sleep(60);
-            assertEquals(0, factory.current().writes.size());
+            await("pause flush", () -> first.flushCalls > 0 && !first.playing);
+            events.post(packet(ClockSpec.LEGACY, 900));
+            Thread.sleep(40L);
+            int playsBeforeResume = first.playCalls;
 
             sink.resume();
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            await("resumed PCM write", () -> factory.current().writes.size() == 1);
+            List<Sound.SoundSampleEvent> resumed = packets(ClockSpec.LEGACY, 4, 200);
+            byte[] resumedFirstThree = renderFollowing(initial, resumed.subList(0, 3));
+            int resumeOffset = first.acceptedLength();
+            post(events, resumed.subList(0, 3));
+            await("three resume writes",
+                    () -> first.acceptedLength() == resumeOffset + resumedFirstThree.length);
+            assertEquals(playsBeforeResume, first.playCalls);
+            events.post(resumed.get(3));
+            await("resume play", () -> first.playCalls == playsBeforeResume + 1);
+
+            sink.requestRouteReopen();
+            await("route reopen", () -> factory.opens.get() == 2 && first.released);
+            FakeOutput second = factory.current();
+            List<Sound.SoundSampleEvent> reopened = packets(ClockSpec.LEGACY, 4, 500);
+            List<Sound.SoundSampleEvent> beforeReopen = new ArrayList<>(initial);
+            beforeReopen.addAll(resumed);
+            byte[] reopenedFirstThree = renderFollowing(
+                    beforeReopen, reopened.subList(0, 3));
+            post(events, reopened.subList(0, 3));
+            await("three reopen writes",
+                    () -> second.acceptedLength() == reopenedFirstThree.length);
+            assertEquals(0, second.playCalls);
+            events.post(reopened.get(3));
+            await("reopened play", () -> second.playCalls == 1);
+            assertArrayEquals(renderFollowing(beforeReopen, reopened), second.acceptedBytes());
+            assertEquals(1L, sink.stats().restarts());
         } finally {
             sink.close();
         }
     }
 
     @Test
-    public void profileFrameBudgetRebuildsSourceQueueBeforeSgbAudio() throws Exception {
+    public void clockSpecChangeDoesNotReopenAndImmediateSgbPacketIsAccepted() throws Exception {
         EventBusImpl events = new EventBusImpl(null, null, false);
         FakeFactory factory = new FakeFactory();
         AndroidAudioSink sink = new AndroidAudioSink(events, factory);
         sink.start();
         try {
-            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput output = factory.current();
 
-            // SGB2's 70,224-tick frame is larger than the legacy 69,905-tick source slot. The
-            // profile callback must rebuild the queue before this event arrives; otherwise the
-            // fixed-storage producer drops it instead of allocating on the emulation thread.
-            sink.setClockSpec(ClockSpec.SGB2);
-            await("SGB2 source queue rebuild", () -> factory.opens.get() >= 2
-                    && sink.stats().restarts() >= 1
-                    && sink.sourceSamplesForTesting() == ClockSpec.SGB2.controllerTicksPerFrame() * 2);
+            sink.setClockSpec(ClockSpec.SGB);
+            Sound.SoundSampleEvent firstSgbPacket = packet(ClockSpec.SGB, 240);
+            events.post(firstSgbPacket);
+            int firstPacketBytes = render(List.of(firstSgbPacket)).length;
+            await("first SGB PCM packet", () -> output.acceptedLength() == firstPacketBytes);
 
-            FakeOutput sgbOutput = factory.current();
-            events.post(new Sound.SoundSampleEvent(audibleSamples(ClockSpec.SGB2), ClockSpec.SGB2));
-            await("SGB2 PCM write", () -> sgbOutput.writes.size() == 1);
-            assertTrue(sgbOutput.writes.get(0).length > 0);
+            assertEquals(1, factory.opens.get());
+            assertEquals(0L, sink.stats().restarts());
+            assertEquals(maximumSourceSamples(), sink.sourceSamplesForTesting());
+            assertEquals(0, output.playCalls);
+            post(events, packets(ClockSpec.SGB, 3, 300));
+            await("SGB primer", () -> output.playCalls == 1);
         } finally {
             sink.close();
         }
     }
 
     @Test
-    public void benchmarkBaselineAndConcurrentSnapshotsRemainCoherentAcrossPartialWrites()
+    public void producerDuringRateChangingSwapOffersOnlyToReplacementQueue() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        CountDownLatch swapEntered = new CountDownLatch(1);
+        CountDownLatch allowSwap = new CountDownLatch(1);
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory, () -> {
+            swapEntered.countDown();
+            try {
+                allowSwap.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        sink.start();
+        try {
+            await("initial audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            post(events, packets(ClockSpec.LEGACY, 4, 100));
+            await("initial playback", () -> factory.current().playCalls == 1);
+
+            int replacementRate = 48_000;
+            factory.nextSampleRate = replacementRate;
+            sink.requestRouteReopen();
+            assertTrue(swapEntered.await(2, TimeUnit.SECONDS));
+
+            List<Sound.SoundSampleEvent> replacement = packets(ClockSpec.SGB, 4, 500);
+            Thread producer = new Thread(() -> post(events, replacement), "rate-swap-producer");
+            producer.start();
+            Thread.sleep(40L);
+            assertTrue("producer must wait for the linearized queue handoff", producer.isAlive());
+
+            allowSwap.countDown();
+            producer.join(2_000L);
+            assertFalse(producer.isAlive());
+            await("replacement rate", () -> sink.stats().sampleRate() == replacementRate);
+            FakeOutput second = factory.current();
+            await("replacement primer", () -> second.playCalls == 1);
+            assertEquals(replacementRate, second.sampleRate());
+            assertArrayEquals(renderAtRate(replacementRate, List.of(), replacement, 100, false),
+                    second.acceptedBytes());
+        } finally {
+            allowSwap.countDown();
+            sink.close();
+        }
+    }
+
+    @Test
+    public void shortStoppedWritesRemainExactAndNeverExceedReportedCapacity() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        factory.writeLimit = 36;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> packets = packets(ClockSpec.SGB2, 4, 140);
+            byte[] expected = render(packets);
+            post(events, packets);
+
+            FakeOutput output = factory.current();
+            await("short-write primer", () -> output.playCalls == 1);
+            assertArrayEquals(expected, output.acceptedBytes());
+            assertTrue(output.writeCalls > AndroidAudioSink.PRIMER_PACKETS);
+            assertTrue(output.writeSizes.stream().allMatch(size -> size % 4 == 0));
+            assertEquals(expected.length, output.bytesAtFirstPlay);
+            assertTrue(output.bytesAtFirstPlay <= output.audioStats().actualBufferBytes());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void prePrimeMuteAndVolumeChangesFlushStaleHeldPcmAndReprimeExactly()
+            throws Exception {
+        assertPrePrimePolicyReset(true);
+        assertPrePrimePolicyReset(false);
+    }
+
+    @Test
+    public void newPolicyProducerCannotOvertakeItsBoundaryClear() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        CountDownLatch boundaryPublished = new CountDownLatch(1);
+        CountDownLatch allowBoundaryClear = new CountDownLatch(1);
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory, null, () -> {
+            boundaryPublished.countDown();
+            try {
+                allowBoundaryClear.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+            post(events, initial);
+            FakeOutput output = factory.current();
+            await("initial play", () -> output.playCalls == 1);
+            int initialBytes = output.acceptedLength();
+
+            Thread policy = new Thread(() -> sink.setVolume(50), "policy-boundary");
+            policy.start();
+            assertTrue(boundaryPublished.await(2, TimeUnit.SECONDS));
+
+            List<Sound.SoundSampleEvent> fresh = packets(ClockSpec.LEGACY, 4, 700);
+            Thread producer = new Thread(() -> post(events, fresh), "new-policy-producer");
+            producer.start();
+            Thread.sleep(40L);
+            assertTrue("new-policy producer must wait until the old queue is cleared",
+                    producer.isAlive());
+            assertEquals(initialBytes, output.acceptedLength());
+
+            allowBoundaryClear.countDown();
+            policy.join(2_000L);
+            producer.join(2_000L);
+            assertFalse(policy.isAlive());
+            assertFalse(producer.isAlive());
+            await("new-policy primer", () -> output.playCalls == 2);
+            byte[] expected = renderFollowing(initial, fresh, 50, false);
+            assertArrayEquals(expected, Arrays.copyOfRange(output.acceptedBytes(),
+                    output.lastFlushAcceptedOffset, output.acceptedLength()));
+        } finally {
+            allowBoundaryClear.countDown();
+            sink.close();
+        }
+    }
+
+    @Test
+    public void partialWriteInterruptedByReopenReplaysFromZeroAfterOldTrackRelease()
+            throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        factory.blockFirstWrite = true;
+        factory.writeLimit = 36;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> packets = packets(ClockSpec.LEGACY, 4, 180);
+            byte[] expected = render(packets);
+            post(events, packets);
+
+            FakeOutput first = factory.current();
+            assertTrue(first.firstWriteEntered.await(2, TimeUnit.SECONDS));
+            sink.requestRouteReopen();
+            first.continueFirstWrite.countDown();
+
+            await("replacement output", () -> factory.opens.get() == 2 && first.released);
+            FakeOutput second = factory.current();
+            await("replayed primer", () -> second.playCalls == 1);
+            assertEquals(36, first.acceptedLength());
+            assertArrayEquals(Arrays.copyOf(expected, 36), first.acceptedBytes());
+            assertTrue(first.flushCalls > 0);
+            assertArrayEquals(expected, second.acceptedBytes());
+            assertTrue(factory.eventIndex("release-1")
+                    < factory.eventIndex("write-2"));
+        } finally {
+            factory.releaseBlockedWrites();
+            sink.close();
+        }
+    }
+
+    @Test
+    public void rapidPauseResumeDuringPartialWriteStillFlushesAndReprimes() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+            post(events, initial);
+            FakeOutput output = factory.current();
+            await("initial play", () -> output.playCalls == 1);
+
+            output.writeLimit = 36;
+            output.armBlockedWrite();
+            Sound.SoundSampleEvent interrupted = packet(ClockSpec.LEGACY, 400);
+            events.post(interrupted);
+            assertTrue(output.blockedWriteEntered.await(2, TimeUnit.SECONDS));
+
+            int flushesBefore = output.flushCalls;
+            sink.pause();
+            sink.resume();
+            output.continueBlockedWrite.countDown();
+            await("sticky rapid-pause flush", () -> output.flushCalls > flushesBefore);
+            assertEquals(1, output.playCalls);
+
+            List<Sound.SoundSampleEvent> fresh = packets(ClockSpec.LEGACY, 4, 700);
+            int flushOffset = output.lastFlushAcceptedOffset;
+            post(events, fresh.subList(0, 3));
+            int firstThreeBytes = renderFollowing(
+                    concat(initial, List.of(interrupted)), fresh.subList(0, 3)).length;
+            await("three post-pause packets", () -> output.acceptedLength()
+                    == flushOffset + firstThreeBytes);
+            assertEquals(1, output.playCalls);
+            events.post(fresh.get(3));
+            await("post-pause primer", () -> output.playCalls == 2);
+            byte[] expectedFresh = renderFollowing(
+                    concat(initial, List.of(interrupted)), fresh);
+            assertArrayEquals(expectedFresh, Arrays.copyOfRange(output.acceptedBytes(),
+                    flushOffset, output.acceptedLength()));
+        } finally {
+            factory.releaseBlockedWrites();
+            sink.close();
+        }
+    }
+
+    @Test
+    public void closeLinearizesAfterAnInFlightPlayAndThenStopsTheWorker() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        Thread closer = null;
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput output = factory.current();
+            List<Sound.SoundSampleEvent> primer = packets(ClockSpec.LEGACY, 4, 200);
+            post(events, primer.subList(0, 3));
+            int firstThreeBytes = render(primer.subList(0, 3)).length;
+            await("three stopped packets", () -> output.acceptedLength() == firstThreeBytes);
+            output.blockNextPlay = true;
+            events.post(primer.get(3));
+            assertTrue(output.blockedPlayEntered.await(2, TimeUnit.SECONDS));
+
+            closer = new Thread(sink::close, "audio-close");
+            closer.start();
+            Thread.sleep(40L);
+            assertTrue("close must wait for the already-linearized play call", closer.isAlive());
+            output.continueBlockedPlay.countDown();
+            closer.join(2_000L);
+            assertFalse(closer.isAlive());
+            assertEquals(1, output.playCalls);
+            assertTrue(output.released);
+            assertFalse(sink.workerThreadForTesting().isAlive());
+        } finally {
+            factory.releaseBlockedWrites();
+            if (closer != null && closer.isAlive()) {
+                closer.join(2_000L);
+            }
+            sink.close();
+        }
+    }
+
+    @Test
+    public void reportedStartThresholdBeyondFourPacketsDelaysPlayAndPreservesPartialSuffix()
+            throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        List<Sound.SoundSampleEvent> packets = packets(ClockSpec.LEGACY, 5, 100);
+        int fourPacketBytes = render(packets.subList(0, 4)).length;
+        byte[] expected = render(packets);
+        int thresholdFrames = (fourPacketBytes + (expected.length - fourPacketBytes) / 2) / 4;
+        factory.nextEffectiveBufferFrames = thresholdFrames;
+        factory.nextStartThresholdFrames = thresholdFrames;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput output = factory.current();
+            post(events, packets.subList(0, 4));
+            await("four complete stopped packets",
+                    () -> output.acceptedLength() == fourPacketBytes);
+            assertEquals("packet count alone must not bypass the device threshold",
+                    0, output.playCalls);
+
+            events.post(packets.get(4));
+            await("reported threshold play", () -> output.playCalls == 1);
+            assertEquals(thresholdFrames * 4, output.bytesAtFirstPlay);
+            assertEquals("threshold-aware primer must not start in underrun", 0L,
+                    output.outputUnderrunCount);
+            await("ordered threshold packet suffix", () -> output.acceptedLength() == expected.length);
+            assertArrayEquals(expected, output.acceptedBytes());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void advancingHeadCannotEndRecoveryBeforeLatestRefillThresholdIsRebuilt() {
+        AndroidAudioSink.UnderrunRecovery recovery = new AndroidAudioSink.UnderrunRecovery();
+        assertTrue(recovery.rebase(100L, 1_000L, 100L, 400));
+
+        recovery.observeRefillProgress(1_299L, 399L, 400);
+        assertFalse("head progress alone must not prove the latest refill",
+                recovery.hasRestarted(110L));
+        recovery.observeRefillProgress(1_300L, 399L, 400);
+        assertFalse("accepted refill debt does not replace the buffered-runway proof",
+                recovery.hasRestarted(110L));
+        recovery.observeRefillProgress(1_301L, 400L, 400);
+        assertTrue(recovery.hasRestarted(110L));
+
+        assertTrue(recovery.rebase(110L, 1_300L, 200L, 400));
+        recovery.observeRefillProgress(1_499L, 399L, 400);
+        assertFalse("a newer underrun must revoke the preceding refill proof",
+                recovery.hasRestarted(111L));
+        recovery.observeRefillProgress(1_500L, 400L, 400);
+        assertTrue(recovery.hasRestarted(111L));
+    }
+
+    @Test
+    public void actualUnderrunRefillsThresholdInPlaceWithoutFlushDropOrDuplicate()
+            throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+        Sound.SoundSampleEvent interrupted = packet(ClockSpec.LEGACY, 500);
+        Sound.SoundSampleEvent refill = packet(ClockSpec.LEGACY, 700);
+        Sound.SoundSampleEvent sentinel = packet(ClockSpec.LEGACY, 900);
+        int initialBytes = render(initial).length;
+        int interruptedBytes = renderFollowing(initial, List.of(interrupted)).length;
+        int refillThresholdFrames = renderFollowing(initial,
+                List.of(interrupted, refill)).length / 4;
+        factory.nextEffectiveBufferFrames = AndroidAudioTrackOutput.Factory
+                .packetBufferBytes(SAMPLE_RATE) / 4;
+        factory.nextStartThresholdFrames = refillThresholdFrames;
+        factory.nextInitialPlaybackHeadFrames = 0L;
+        factory.nextUnavailablePlaybackHeadReads = 1;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            post(events, initial);
+            FakeOutput output = factory.current();
+            await("initial play", () -> output.playCalls == 1);
+
+            output.writeLimit = 36;
+            output.armThresholdUnderrun(false, initialBytes / 4);
+            events.post(interrupted);
+            await("complete first refill packet", () -> output.acceptedLength()
+                    == initialBytes + interruptedBytes);
+            assertEquals("the post-detection head advance is the refill baseline",
+                    1L, output.thresholdRestarted.getCount());
+            assertEquals(0, output.flushCalls);
+
+            // A second cumulative rise while refilling must coalesce into the same recovery.
+            output.outputUnderrunCount++;
+            events.post(refill);
+            assertTrue(output.thresholdRestarted.await(2, TimeUnit.SECONDS));
+            output.writeLimit = 0;
+            events.post(sentinel);
+
+            List<Sound.SoundSampleEvent> all = concat(initial,
+                    List.of(interrupted, refill, sentinel));
+            byte[] expected = render(all);
+            await("post-restart sentinel", () -> output.acceptedLength() == expected.length);
+            assertArrayEquals(expected, output.acceptedBytes());
+            assertEquals("ordinary threshold refill does not call play again", 1, output.playCalls);
+            assertEquals("ordinary threshold refill does not pause", 0, output.pauseCalls);
+            assertEquals("ordinary threshold refill does not flush", 0, output.flushCalls);
+            assertEquals("ordinary threshold refill keeps the same output", 1,
+                    factory.opens.get());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void repeatedUnderrunDuringRetainedShortWriteRebasesAndFallsBackBoundedly()
+            throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+        Sound.SoundSampleEvent interrupted = packet(ClockSpec.LEGACY, 500);
+        int initialBytes = render(initial).length;
+        int effectiveFrames = BoundedPcmQueue.maximumOutputFramesForPackets(
+                SAMPLE_RATE, AndroidAudioSink.PRIMER_PACKETS + 1);
+        factory.nextEffectiveBufferFrames = effectiveFrames;
+        factory.nextStartThresholdFrames = BoundedPcmQueue.minimumOutputFramesForPackets(
+                SAMPLE_RATE, AndroidAudioSink.PRIMER_PACKETS);
+        factory.nextInitialPlaybackHeadFrames = 0L;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            post(events, initial);
+            FakeOutput first = factory.current();
+            await("initial play", () -> first.playCalls == 1);
+
+            first.writeLimit = 36;
+            first.blockWriteAfterThresholdUnderrun = true;
+            first.armThresholdUnderrun(true, initialBytes / 4);
+            events.post(interrupted);
+            assertTrue("the retained suffix write must block deterministically",
+                    first.blockedWriteEntered.await(2, TimeUnit.SECONDS));
+            assertEquals(1L, first.outputUnderrunCount);
+            long firstUnderrunHead = first.recoveryHeadFrames;
+
+            first.manualPlaybackHeadFrames = firstUnderrunHead + 1L;
+            first.armThresholdUnderrun(true, 0);
+            // One of the six fixed queue slots is the retained interrupted packet.
+            List<Sound.SoundSampleEvent> stalled = packets(ClockSpec.LEGACY, 5, 700);
+            post(events, stalled);
+            first.continueBlockedWrite.countDown();
+            await("second underrun during retained suffix",
+                    () -> first.outputUnderrunCount == 2L);
+            assertEquals(firstUnderrunHead + 1L, first.recoveryHeadFrames);
+
+            Thread.sleep(30L);
+            assertEquals("the latest underrun receives a fresh stall grace", 1,
+                    factory.opens.get());
+            await("bounded repeated-underrun reopen", () -> factory.opens.get() == 2);
+            assertTrue(first.released);
+            long unplayedFrames = first.acceptedLength() / 4L - first.recoveryHeadFrames;
+            assertTrue("recovery writes must remain within effective capacity: "
+                    + unplayedFrames, unplayedFrames <= effectiveFrames);
+
+            List<Sound.SoundSampleEvent> ordered = concat(initial,
+                    concat(List.of(interrupted), stalled));
+            byte[] expected = render(ordered);
+            byte[] accepted = first.acceptedBytes();
+            assertArrayEquals("the replaced output must contain one exact ordered prefix",
+                    Arrays.copyOf(expected, accepted.length), accepted);
+        } finally {
+            factory.releaseBlockedWrites();
+            sink.close();
+        }
+    }
+
+    @Test
+    public void capacityFullUnderrunWithNoHeadProgressFallsBackToReopenAndPrimer()
+            throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+        int initialBytes = render(initial).length;
+        int effectiveFrames = BoundedPcmQueue.maximumOutputFramesForPackets(
+                SAMPLE_RATE, AndroidAudioSink.PRIMER_PACKETS + 1);
+        factory.nextEffectiveBufferFrames = effectiveFrames;
+        factory.nextStartThresholdFrames = BoundedPcmQueue.minimumOutputFramesForPackets(
+                SAMPLE_RATE, AndroidAudioSink.PRIMER_PACKETS);
+        factory.nextInitialPlaybackHeadFrames = 0L;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            post(events, initial);
+            FakeOutput first = factory.current();
+            await("initial play", () -> first.playCalls == 1);
+
+            first.armThresholdUnderrun(true, initialBytes / 4);
+            List<Sound.SoundSampleEvent> stalled = packets(ClockSpec.LEGACY, 6, 500);
+            post(events, stalled);
+            await("bounded stalled-output reopen", () -> factory.opens.get() == 2);
+            assertTrue(first.released);
+            long unplayedFrames = first.acceptedLength() / 4L - first.recoveryHeadFrames;
+            assertTrue("writes must stop at effective capacity: " + unplayedFrames,
+                    unplayedFrames <= effectiveFrames);
+
+            FakeOutput replacement = factory.current();
+            List<Sound.SoundSampleEvent> tail = packets(ClockSpec.LEGACY, 6, 900);
+            post(events, tail);
+            await("replacement genuine primer", () -> replacement.playCalls == 1);
+            assertTrue(replacement.bytesAtFirstPlay / 4
+                    >= replacement.startThresholdFrames());
+            assertTrue(replacement.bytesAtFirstPlay > 0);
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void playbackHeadExtensionHandlesUnsignedWrapAndRejectsRegression() {
+        long beforeWrap = 0xfffffff0L;
+        assertEquals(beforeWrap,
+                AndroidAudioSink.OutputProgress.extendUnsignedPlaybackPosition(-1L, beforeWrap));
+        assertEquals(0x1_00000010L,
+                AndroidAudioSink.OutputProgress.extendUnsignedPlaybackPosition(beforeWrap, 0x10L));
+        assertEquals(-1L,
+                AndroidAudioSink.OutputProgress.extendUnsignedPlaybackPosition(100L, 99L));
+    }
+
+    @Test
+    public void transientWriteAndPlayExceptionsReopenAndReplayExactPrimer() throws Exception {
+        assertPrimerFailureRecovers(FailurePoint.WRITE);
+        assertPrimerFailureRecovers(FailurePoint.PLAY);
+    }
+
+    @Test
+    public void transientPauseAndFlushExceptionsReopenAndResumeThroughPrimer() throws Exception {
+        assertPauseFailureRecovers(FailurePoint.PAUSE);
+        assertPauseFailureRecovers(FailurePoint.FLUSH);
+    }
+
+    @Test
+    public void emptyPlayBypassIsRejectedForOrdinaryPlayback() throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            try {
+                sink.resumeEmptyForBenchmarkPreArm();
+                fail("ordinary playback must not authorize empty AudioTrack play");
+            } catch (IllegalStateException expected) {
+                // Expected production gate.
+            }
+            sink.resume();
+            Thread.sleep(40L);
+            assertEquals(0, factory.current().playCalls);
+            assertEquals(0, factory.current().acceptedLength());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void benchmarkOnlyPreArmBypassCanPlayEmptyWhileGuestRemainsPaused() throws Exception {
+        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
+            return;
+        }
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        DiagnosticsOptions options = DiagnosticsOptions.parseValues(
+                true, "dmg", true, "presentation", true, true, false);
+        AndroidBenchmarkDiagnostics diagnostics = new AndroidBenchmarkDiagnostics(
+                null, options, message -> { });
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory, diagnostics);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            sink.pause();
+            await("benchmark stopped output", () -> factory.current().flushCalls > 0);
+            sink.resumeEmptyForBenchmarkPreArm();
+            FakeOutput output = factory.current();
+            await("benchmark empty play", () -> output.playCalls == 1);
+            assertEquals(0, output.acceptedLength());
+
+            int flushesAfterEmptyPlay = output.flushCalls;
+            output.outputUnderrunCount = 1L;
+            Thread.sleep(60L);
+            assertEquals("intentional empty-play underruns must not start recovery",
+                    flushesAfterEmptyPlay, output.flushCalls);
+            assertEquals(1, output.playCalls);
+
+            List<Sound.SoundSampleEvent> packets = packets(ClockSpec.LEGACY, 4, 300);
+            byte[] firstThree = render(packets.subList(0, 3));
+            post(events, packets.subList(0, 3));
+            await("empty-play exit flush and three genuine packets", () -> output.flushCalls
+                    > flushesAfterEmptyPlay && output.acceptedLength() == firstThree.length);
+            assertEquals("N-1 packets must not restart playback", 1, output.playCalls);
+            events.post(packets.get(3));
+            await("production primer after benchmark bypass", () -> output.playCalls == 2);
+            assertArrayEquals(render(packets), output.acceptedBytes());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    public void benchmarkBaselineAndConcurrentSnapshotsRemainCoherentAcrossShortWrites()
             throws Exception {
         if (!BuildConfig.DIAGNOSTICS_ENABLED) {
             return;
         }
         EventBusImpl events = new EventBusImpl(null, null, false);
         FakeFactory factory = new FakeFactory();
-        factory.writeLimit = 37;
+        factory.writeLimit = 36;
         AndroidAudioSink sink = new AndroidAudioSink(events, factory);
         sink.start();
         try {
-            await("audio output", () -> sink.stats().sampleRate() == 44_100);
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+            post(events, initial);
+            await("primed output", () -> factory.current().playCalls == 1);
             AndroidAudioSink.AudioBaseline baseline = sink.benchmarkBaseline();
             assertTrue(baseline.outputOpen());
             assertTrue(baseline.outputPlaying());
             assertTrue(baseline.outputIdentity() > 0L);
             assertTrue(baseline.queueIdentity() > 0L);
-            int flushesBefore = factory.current().flushes;
+            int flushesBefore = factory.current().flushCalls;
 
             AtomicInteger snapshots = new AtomicInteger();
             Thread sampler = new Thread(() -> {
@@ -127,130 +729,495 @@ public class AndroidAudioSinkTest {
                 }
             });
             sampler.start();
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            await("partial PCM writes", () -> sink.stats().pcmWrittenBytes() > 0L);
+            events.post(packet(ClockSpec.LEGACY, 700));
+            await("short PCM writes", () -> sink.stats().pcmWrittenBytes() > baseline.writtenBytes());
             sampler.join(2_000L);
             assertEquals(100, snapshots.get());
             AndroidAudioSink.Stats stats = sink.stats();
             assertEquals(0L, stats.writeFailures());
             assertEquals(stats.pcmEnqueuedBytes(), stats.pcmWrittenBytes()
                     + stats.pcmPendingBytes() + stats.pcmDiscardedBytes());
-            assertEquals(flushesBefore, factory.current().flushes);
+            assertEquals(flushesBefore, factory.current().flushCalls);
         } finally {
             sink.close();
         }
     }
 
-    @Test
-    public void benchmarkMuteClearsQueuedPcmAndReopenKeepsAccountingMonotonic() throws Exception {
-        if (!BuildConfig.DIAGNOSTICS_ENABLED) {
-            return;
+    private static void assertPrimerFailureRecovers(FailurePoint failure) throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        factory.firstOutputFailure = failure;
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> packets = packets(ClockSpec.LEGACY, 4, 260);
+            byte[] expected = render(packets);
+            post(events, packets);
+
+            await(failure + " recovery", () -> factory.opens.get() == 2
+                    && factory.current().playCalls == 1);
+            assertTrue(factory.outputs.get(0).released);
+            assertArrayEquals(expected, factory.current().acceptedBytes());
+            assertTrue(sink.workerThreadForTesting().isAlive());
+        } finally {
+            sink.close();
         }
+    }
+
+    private static void assertPrePrimePolicyReset(boolean muteChange) throws Exception {
         EventBusImpl events = new EventBusImpl(null, null, false);
         FakeFactory factory = new FakeFactory();
         AndroidAudioSink sink = new AndroidAudioSink(events, factory);
         sink.start();
         try {
-            await("audio output", () -> sink.stats().sampleRate() == 44_100);
-            events.post(new Sound.SoundSampleEvent(audibleSamples(), ClockSpec.LEGACY));
-            await("initial PCM accounting", () -> sink.stats().pcmInputEvents() > 0L);
-            long beforeMute = sink.stats().pcmDiscardedBytes();
-            sink.setMuted(true);
-            long afterMute = sink.stats().pcmDiscardedBytes();
-            assertTrue(afterMute >= beforeMute);
-            sink.requestRouteReopen();
-            await("route reopen", () -> factory.opens.get() >= 2);
-            AndroidAudioSink.Stats reopened = sink.stats();
-            assertTrue(reopened.restarts() >= 1L);
-            assertTrue(reopened.pcmDiscardedBytes() >= afterMute);
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            FakeOutput output = factory.current();
+            List<Sound.SoundSampleEvent> stale = packets(ClockSpec.LEGACY, 2, 120);
+            post(events, stale);
+            int staleBytes = render(stale).length;
+            await("held stale primer", () -> output.acceptedLength() == staleBytes);
+            assertEquals(0, output.playCalls);
+
+            int volume = muteChange ? 100 : 37;
+            boolean muted = muteChange;
+            if (muteChange) {
+                sink.setMuted(true);
+            } else {
+                sink.setVolume(volume);
+            }
+            List<Sound.SoundSampleEvent> fresh = packets(ClockSpec.LEGACY, 4, 500);
+            byte[] expected = renderFollowing(stale, fresh, volume, muted);
+            // Post immediately: the first new-policy packet may wake a poll that began before the
+            // generation changed. It must be preserved across the worker's reset, not dropped.
+            post(events, fresh);
+            await("policy flush", () -> output.flushCalls > 0
+                    && output.lastFlushAcceptedOffset == staleBytes);
+            await("policy re-prime", () -> output.playCalls == 1);
+            byte[] accepted = output.acceptedBytes();
+            assertArrayEquals(expected,
+                    Arrays.copyOfRange(accepted, staleBytes, accepted.length));
+            assertEquals(expected.length, output.bytesSinceLastFlushAtFirstPlay);
         } finally {
             sink.close();
         }
     }
 
-    private static int[] audibleSamples() {
-        return audibleSamples(ClockSpec.LEGACY);
+    private static void assertPauseFailureRecovers(FailurePoint failure) throws Exception {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        FakeFactory factory = new FakeFactory();
+        AndroidAudioSink sink = new AndroidAudioSink(events, factory);
+        sink.start();
+        try {
+            await("audio output", () -> sink.stats().sampleRate() == SAMPLE_RATE);
+            List<Sound.SoundSampleEvent> initial = packets(ClockSpec.LEGACY, 4, 100);
+            post(events, initial);
+            FakeOutput first = factory.current();
+            await("initial play", () -> first.playCalls == 1);
+            first.armFailure(failure);
+
+            sink.pause();
+            await(failure + " reopen", () -> factory.opens.get() == 2 && first.released);
+            sink.resume();
+            List<Sound.SoundSampleEvent> resumed = packets(ClockSpec.LEGACY, 4, 600);
+            post(events, resumed);
+            await(failure + " resumed primer", () -> factory.current().playCalls == 1);
+            assertArrayEquals(renderFollowing(initial, resumed),
+                    factory.current().acceptedBytes());
+            assertTrue(sink.workerThreadForTesting().isAlive());
+        } finally {
+            sink.close();
+        }
     }
 
-    private static int[] audibleSamples(ClockSpec clockSpec) {
-        int ticks = clockSpec.controllerTicksPerFrame();
+    private static int maximumSourceSamples() {
+        return Math.max(ClockSpec.LEGACY.controllerTicksPerFrame(),
+                Math.max(ClockSpec.SGB.controllerTicksPerFrame(),
+                        ClockSpec.SGB2.controllerTicksPerFrame())) * 2;
+    }
+
+    private static List<Sound.SoundSampleEvent> packets(
+            ClockSpec clock, int count, int firstAmplitude) {
+        List<Sound.SoundSampleEvent> result = new ArrayList<>();
+        for (int index = 0; index < count; index++) {
+            result.add(packet(clock, firstAmplitude + index * 37));
+        }
+        return result;
+    }
+
+    private static Sound.SoundSampleEvent packet(ClockSpec clock, int amplitude) {
+        int ticks = clock.controllerTicksPerFrame();
         int[] samples = new int[ticks * 2];
         for (int tick = 0; tick < ticks; tick++) {
-            samples[tick * 2] = 480;
-            samples[tick * 2 + 1] = -480;
+            samples[tick * 2] = amplitude;
+            samples[tick * 2 + 1] = -amplitude;
         }
-        return samples;
+        return new Sound.SoundSampleEvent(samples, clock);
+    }
+
+    private static byte[] render(List<Sound.SoundSampleEvent> packets) throws Exception {
+        return renderFollowing(List.of(), packets);
+    }
+
+    private static byte[] renderFollowing(List<Sound.SoundSampleEvent> preceding,
+            List<Sound.SoundSampleEvent> packets) throws Exception {
+        return renderFollowing(preceding, packets, 100, false);
+    }
+
+    private static byte[] renderFollowing(List<Sound.SoundSampleEvent> preceding,
+            List<Sound.SoundSampleEvent> packets, int volume, boolean muted) throws Exception {
+        return renderAtRate(SAMPLE_RATE, preceding, packets, volume, muted);
+    }
+
+    private static byte[] renderAtRate(int sampleRate,
+            List<Sound.SoundSampleEvent> preceding, List<Sound.SoundSampleEvent> packets,
+            int volume, boolean muted) throws Exception {
+        BoundedPcmQueue queue = new BoundedPcmQueue(sampleRate);
+        for (Sound.SoundSampleEvent packet : preceding) {
+            queue.offer(packet, 100, false);
+            BoundedPcmQueue.Frame frame = queue.poll(1, TimeUnit.SECONDS);
+            assertNotNull(frame);
+            queue.release(frame);
+        }
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        for (Sound.SoundSampleEvent packet : packets) {
+            queue.offer(packet, volume, muted);
+            BoundedPcmQueue.Frame frame = queue.poll(1, TimeUnit.SECONDS);
+            assertNotNull(frame);
+            bytes.write(frame.bytes(), 0, frame.length());
+            queue.release(frame);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static <T> List<T> concat(List<T> first, List<T> second) {
+        List<T> combined = new ArrayList<>(first.size() + second.size());
+        combined.addAll(first);
+        combined.addAll(second);
+        return combined;
+    }
+
+    private static void post(EventBusImpl events, List<Sound.SoundSampleEvent> packets) {
+        for (Sound.SoundSampleEvent packet : packets) {
+            events.post(packet);
+        }
     }
 
     private static void await(String description, BooleanSupplier condition) throws Exception {
-        long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
+        long deadline = System.nanoTime() + Duration.ofSeconds(4).toNanos();
         while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
-            Thread.sleep(5);
+            Thread.sleep(5L);
         }
         assertTrue("Timed out waiting for " + description, condition.getAsBoolean());
+    }
+
+    private enum FailurePoint {
+        NONE,
+        WRITE,
+        PLAY,
+        PAUSE,
+        FLUSH
     }
 
     private static final class FakeFactory implements AndroidAudioSink.OutputFactory {
         private final AtomicInteger opens = new AtomicInteger();
         private final List<FakeOutput> outputs = new CopyOnWriteArrayList<>();
+        private final List<String> lifecycleEvents = new CopyOnWriteArrayList<>();
         private volatile int writeLimit;
+        private volatile boolean blockFirstWrite;
+        private volatile int nextSampleRate = SAMPLE_RATE;
+        private volatile int nextEffectiveBufferFrames;
+        private volatile int nextStartThresholdFrames;
+        private volatile long nextInitialPlaybackHeadFrames = -1L;
+        private volatile int nextUnavailablePlaybackHeadReads;
+        private volatile FailurePoint firstOutputFailure = FailurePoint.NONE;
 
         @Override
         public AndroidAudioSink.Output open() {
-            FakeOutput output = new FakeOutput();
+            int identity = opens.incrementAndGet();
+            FakeOutput output = new FakeOutput(this, identity, nextSampleRate,
+                    nextEffectiveBufferFrames, nextStartThresholdFrames,
+                    nextInitialPlaybackHeadFrames, nextUnavailablePlaybackHeadReads);
             output.writeLimit = writeLimit;
+            output.blockFirstWrite = blockFirstWrite && identity == 1;
+            if (identity == 1) {
+                output.armFailure(firstOutputFailure);
+            }
             outputs.add(output);
-            opens.incrementAndGet();
+            lifecycleEvents.add("open-" + identity);
             return output;
         }
 
         private FakeOutput current() {
             return outputs.get(outputs.size() - 1);
         }
+
+        private int eventIndex(String event) {
+            return lifecycleEvents.indexOf(event);
+        }
+
+        private void releaseBlockedWrites() {
+            for (FakeOutput output : outputs) {
+                output.continueFirstWrite.countDown();
+                output.continueBlockedWrite.countDown();
+                output.continueBlockedPlay.countDown();
+            }
+        }
     }
 
     private static final class FakeOutput implements AndroidAudioSink.Output {
-        private final List<byte[]> writes = new CopyOnWriteArrayList<>();
+        private final FakeFactory owner;
+        private final int identity;
+        private final int sampleRate;
+        private final ByteArrayOutputStream accepted = new ByteArrayOutputStream();
         private final List<String> writeThreads = new CopyOnWriteArrayList<>();
+        private final List<Integer> writeSizes = new CopyOnWriteArrayList<>();
+        private final CountDownLatch firstWriteEntered = new CountDownLatch(1);
+        private final CountDownLatch continueFirstWrite = new CountDownLatch(1);
+        private final CountDownLatch blockedWriteEntered = new CountDownLatch(1);
+        private final CountDownLatch continueBlockedWrite = new CountDownLatch(1);
+        private final CountDownLatch blockedPlayEntered = new CountDownLatch(1);
+        private final CountDownLatch continueBlockedPlay = new CountDownLatch(1);
+        private final CountDownLatch thresholdRestarted = new CountDownLatch(1);
         private volatile boolean released;
+        private volatile boolean playing;
+        private volatile boolean blockFirstWrite;
         private volatile int writeLimit;
-        private volatile int flushes;
-        private volatile long outputUnderruns;
+        private volatile int writeCalls;
+        private volatile int playCalls;
+        private volatile int pauseCalls;
+        private volatile int flushCalls;
+        private volatile int bytesAtFirstPlay = -1;
+        private volatile int lastFlushAcceptedOffset;
+        private volatile int bytesSinceLastFlushAtFirstPlay = -1;
+        private volatile int blockedWriteCall = -1;
+        private volatile boolean blockNextPlay;
+        private volatile long outputUnderrunCount;
+        private volatile long manualPlaybackHeadFrames = -1L;
+        private final int bufferCapacityFrames;
+        private final int effectiveBufferFrames;
+        private final int startThresholdFrames;
+        private volatile boolean armThresholdUnderrunOnNextWrite;
+        private volatile boolean blockWriteAfterThresholdUnderrun;
+        private volatile boolean thresholdRecoveryArmed;
+        private volatile boolean thresholdRecoveryStalled;
+        private volatile int advanceHeadBeforeUnderrunFrames;
+        private volatile long recoveryAcceptedBaseFrames;
+        private volatile long recoveryHeadFrames;
+        private int unavailablePlaybackHeadReads;
+        private volatile FailurePoint armedFailure = FailurePoint.NONE;
+
+        private FakeOutput(FakeFactory owner, int identity, int sampleRate,
+                int configuredEffectiveFrames, int configuredStartThresholdFrames,
+                long initialPlaybackHeadFrames, int unavailablePlaybackHeadReads) {
+            this.owner = owner;
+            this.identity = identity;
+            this.sampleRate = sampleRate;
+            bufferCapacityFrames = AndroidAudioTrackOutput.Factory.packetBufferBytes(sampleRate)
+                    / 4;
+            effectiveBufferFrames = configuredEffectiveFrames > 0
+                    ? configuredEffectiveFrames
+                    : BoundedPcmQueue.maximumOutputFramesForPackets(sampleRate,
+                            AndroidAudioSink.PRIMER_PACKETS);
+            startThresholdFrames = configuredStartThresholdFrames > 0
+                    ? configuredStartThresholdFrames
+                    : BoundedPcmQueue.minimumOutputFramesForPackets(sampleRate,
+                            AndroidAudioSink.PRIMER_PACKETS);
+            if (startThresholdFrames > effectiveBufferFrames
+                    || effectiveBufferFrames > bufferCapacityFrames) {
+                throw new IllegalArgumentException("Invalid fake output buffer limits");
+            }
+            manualPlaybackHeadFrames = initialPlaybackHeadFrames;
+            this.unavailablePlaybackHeadReads = unavailablePlaybackHeadReads;
+        }
+
+        private void armBlockedWrite() {
+            blockedWriteCall = writeCalls + 1;
+        }
+
+        private void armFailure(FailurePoint failure) {
+            armedFailure = failure;
+        }
+
+        private void armThresholdUnderrun(boolean stalled, int headAdvanceFrames) {
+            thresholdRecoveryStalled = stalled;
+            advanceHeadBeforeUnderrunFrames = headAdvanceFrames;
+            armThresholdUnderrunOnNextWrite = true;
+        }
+
+        private boolean takeFailure(FailurePoint point) {
+            if (armedFailure != point) {
+                return false;
+            }
+            armedFailure = FailurePoint.NONE;
+            return true;
+        }
 
         @Override
         public int sampleRate() {
-            return 44_100;
+            return sampleRate;
+        }
+
+        @Override
+        public AndroidAudioSink.AudioStats audioStats() {
+            int capacityBytes = bufferCapacityFrames * 4;
+            return new AndroidAudioSink.AudioStats(sampleRate, 1_024,
+                    capacityBytes, capacityBytes);
+        }
+
+        @Override
+        public int bufferCapacityFrames() {
+            return bufferCapacityFrames;
+        }
+
+        @Override
+        public int effectiveBufferFrames() {
+            return effectiveBufferFrames;
+        }
+
+        @Override
+        public int startThresholdFrames() {
+            return startThresholdFrames;
+        }
+
+        @Override
+        public synchronized long playbackPositionFrames() {
+            if (unavailablePlaybackHeadReads > 0) {
+                unavailablePlaybackHeadReads--;
+                return -1L;
+            }
+            if (thresholdRecoveryArmed && !thresholdRecoveryStalled
+                    && accepted.size() / 4L - recoveryAcceptedBaseFrames
+                    >= startThresholdFrames) {
+                manualPlaybackHeadFrames = recoveryHeadFrames + 1L;
+                thresholdRecoveryArmed = false;
+                thresholdRestarted.countDown();
+            }
+            long manual = manualPlaybackHeadFrames;
+            return manual >= 0L ? manual : acceptedLength() / 4L;
         }
 
         @Override
         public long outputUnderrunCount() {
-            return outputUnderruns;
+            return outputUnderrunCount;
         }
 
         @Override
-        public void play() {
+        public boolean isPlaying() {
+            return playing;
         }
 
         @Override
-        public void pause() {
+        public synchronized void play() {
+            if (takeFailure(FailurePoint.PLAY)) {
+                throw new IllegalStateException("transient play failure");
+            }
+            if (blockNextPlay) {
+                blockNextPlay = false;
+                blockedPlayEntered.countDown();
+                try {
+                    continueBlockedPlay.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            playCalls++;
+            playing = true;
+            if ((accepted.size() - lastFlushAcceptedOffset) / 4 < startThresholdFrames) {
+                outputUnderrunCount++;
+            }
+            if (bytesAtFirstPlay < 0) {
+                bytesAtFirstPlay = accepted.size();
+                bytesSinceLastFlushAtFirstPlay = accepted.size() - lastFlushAcceptedOffset;
+            }
         }
 
         @Override
-        public void flush() {
-            flushes++;
+        public synchronized void pause() {
+            pauseCalls++;
+            if (takeFailure(FailurePoint.PAUSE)) {
+                throw new IllegalStateException("transient pause failure");
+            }
+            playing = false;
+        }
+
+        @Override
+        public synchronized void flush() {
+            if (takeFailure(FailurePoint.FLUSH)) {
+                throw new IllegalStateException("transient flush failure");
+            }
+            flushCalls++;
+            lastFlushAcceptedOffset = accepted.size();
+            long head = manualPlaybackHeadFrames;
+            if (head >= 0L) {
+                manualPlaybackHeadFrames = 0L;
+            }
         }
 
         @Override
         public int write(byte[] bytes, int offset, int length) {
+            int call = ++writeCalls;
+            if (takeFailure(FailurePoint.WRITE)) {
+                throw new IllegalStateException("transient write failure");
+            }
             int actual = writeLimit > 0 ? Math.min(writeLimit, length) : length;
-            writes.add(Arrays.copyOfRange(bytes, offset, offset + actual));
+            long acceptedBeforeFrames;
+            synchronized (this) {
+                acceptedBeforeFrames = accepted.size() / 4L;
+                accepted.write(bytes, offset, actual);
+            }
+            if (armThresholdUnderrunOnNextWrite) {
+                armThresholdUnderrunOnNextWrite = false;
+                long currentHead = manualPlaybackHeadFrames >= 0L
+                        ? manualPlaybackHeadFrames : acceptedBeforeFrames;
+                recoveryHeadFrames = currentHead + advanceHeadBeforeUnderrunFrames;
+                manualPlaybackHeadFrames = recoveryHeadFrames;
+                recoveryAcceptedBaseFrames = acceptedBeforeFrames;
+                thresholdRecoveryArmed = true;
+                outputUnderrunCount++;
+                if (blockWriteAfterThresholdUnderrun) {
+                    blockWriteAfterThresholdUnderrun = false;
+                    blockedWriteCall = call + 1;
+                }
+            }
+            writeSizes.add(actual);
             writeThreads.add(Thread.currentThread().getName());
+            owner.lifecycleEvents.add("write-" + identity);
+            if (blockFirstWrite && call == 1) {
+                firstWriteEntered.countDown();
+                try {
+                    continueFirstWrite.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (call == blockedWriteCall) {
+                blockedWriteEntered.countDown();
+                try {
+                    continueBlockedWrite.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
             return actual;
         }
 
         @Override
-        public void release() {
+        public synchronized void release() {
+            playing = false;
             released = true;
+            owner.lifecycleEvents.add("release-" + identity);
+            continueFirstWrite.countDown();
+            continueBlockedWrite.countDown();
+            continueBlockedPlay.countDown();
+        }
+
+        private synchronized int acceptedLength() {
+            return accepted.size();
+        }
+
+        private synchronized byte[] acceptedBytes() {
+            return accepted.toByteArray();
         }
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutputTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioTrackOutputTest.java
@@ -6,13 +6,16 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AndroidAudioTrackOutputTest {
 
     @Test
-    public void standardNativeRateIsTriedOnlyOnceAfterPreferredRates() {
+    public void standardNativeRateIsPreferredWithoutDuplicateAttempts() {
         assertCandidates(new int[]{48_000, 44_100}, 48_000);
-        assertCandidates(new int[]{48_000, 44_100}, 44_100);
+        assertCandidates(new int[]{44_100, 48_000}, 44_100);
     }
 
     @Test
@@ -34,6 +37,68 @@ public class AndroidAudioTrackOutputTest {
             long distinct = Arrays.stream(candidates).distinct().count();
             assertEquals("duplicate candidate for native rate " + nativeRate,
                     candidates.length, distinct);
+        }
+    }
+
+    @Test
+    public void configuredCapacityHoldsFiveMaximumPacketsAtEveryCandidateRate() {
+        for (int sampleRate : new int[]{44_100, 48_000, 96_000, 192_000}) {
+            int maximumPacket = BoundedPcmQueue.maximumFrameBytes(sampleRate);
+            int packetCapacity = AndroidAudioTrackOutput.Factory.packetBufferBytes(sampleRate);
+
+            assertEquals(AndroidAudioTrackOutput.Factory.BUFFER_PACKETS * maximumPacket,
+                    packetCapacity);
+            assertTrue(packetCapacity >= 5 * maximumPacket);
+            assertEquals(packetCapacity,
+                    AndroidAudioTrackOutput.Factory.configuredBufferBytes(sampleRate, 1_024));
+            assertEquals(packetCapacity + 4,
+                    AndroidAudioTrackOutput.Factory.configuredBufferBytes(
+                            sampleRate, packetCapacity + 4));
+        }
+    }
+
+    @Test
+    public void actualRateCapacityGateRejectsEitherUndersizedCapacityReport() {
+        int required = AndroidAudioTrackOutput.Factory.packetBufferBytes(96_000);
+
+        assertTrue(AndroidAudioTrackOutput.Factory.hasPacketCapacity(
+                96_000, required, required));
+        assertFalse(AndroidAudioTrackOutput.Factory.hasPacketCapacity(
+                96_000, required - 4, required));
+        assertFalse(AndroidAudioTrackOutput.Factory.hasPacketCapacity(
+                96_000, required, required - 4));
+    }
+
+    @Test
+    public void effectivePrimerWindowAcceptsMeasuredFivePacketBufferAndBoundsSixSlots() {
+        int measuredEffectiveFrames = 4_100;
+        assertTrue(AndroidAudioTrackOutput.Factory.hasEffectivePrimerWindow(
+                48_000, measuredEffectiveFrames, measuredEffectiveFrames));
+
+        int fourPacketMaximum = BoundedPcmQueue.maximumOutputFramesForPackets(
+                48_000, AndroidAudioSink.PRIMER_PACKETS);
+        int sixPacketMinimum = BoundedPcmQueue.minimumOutputFramesForPackets(
+                48_000, BoundedPcmQueue.DEFAULT_CAPACITY);
+        assertFalse(AndroidAudioTrackOutput.Factory.hasEffectivePrimerWindow(
+                48_000, fourPacketMaximum - 1, fourPacketMaximum - 1));
+        assertFalse(AndroidAudioTrackOutput.Factory.hasEffectivePrimerWindow(
+                48_000, sixPacketMinimum + 1, sixPacketMinimum + 1));
+        assertTrue("API31 can retain a larger effective reservoir with a bounded threshold",
+                AndroidAudioTrackOutput.Factory.hasEffectivePrimerWindow(
+                        48_000, sixPacketMinimum + 1, fourPacketMaximum));
+    }
+
+    @Test
+    public void preSUsesConservativeEffectiveThresholdAndSUsesReportedThreshold() {
+        assertEquals(4_100,
+                AndroidAudioTrackOutput.Factory.startThresholdFrames(30, 2_000, 4_100));
+        assertEquals(3_200,
+                AndroidAudioTrackOutput.Factory.startThresholdFrames(31, 3_200, 4_100));
+        try {
+            AndroidAudioTrackOutput.Factory.startThresholdFrames(31, 4_101, 4_100);
+            fail("threshold beyond effective buffer must fail closed");
+        } catch (IllegalArgumentException expected) {
+            // Expected.
         }
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/BoundedPcmQueueTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/BoundedPcmQueueTest.java
@@ -109,15 +109,63 @@ public class BoundedPcmQueueTest {
     }
 
     @Test
-    public void sourceStorageTracksHardwareProfileFrameBudget() {
+    public void everyQueueSourceSlotFitsTheLargestSupportedHardwarePacket() {
         BoundedPcmQueue legacy = new BoundedPcmQueue(44_100, ClockSpec.LEGACY);
+        BoundedPcmQueue sgb = new BoundedPcmQueue(44_100, ClockSpec.SGB);
         BoundedPcmQueue sgb2 = new BoundedPcmQueue(44_100, ClockSpec.SGB2);
 
-        assertEquals(ClockSpec.LEGACY.controllerTicksPerFrame() * 2,
-                legacy.maximumSourceSamples());
-        assertEquals(ClockSpec.SGB2.controllerTicksPerFrame() * 2,
-                sgb2.maximumSourceSamples());
-        assertTrue(sgb2.maximumSourceSamples() > legacy.maximumSourceSamples());
+        int maximum = Math.max(ClockSpec.LEGACY.controllerTicksPerFrame(),
+                Math.max(ClockSpec.SGB.controllerTicksPerFrame(),
+                        ClockSpec.SGB2.controllerTicksPerFrame())) * 2;
+        assertEquals(maximum, legacy.maximumSourceSamples());
+        assertEquals(maximum, sgb.maximumSourceSamples());
+        assertEquals(maximum, sgb2.maximumSourceSamples());
+    }
+
+    @Test
+    public void primerFrameBoundsCoverAllProfilesAndSixSlotsReachConservativeThreshold() {
+        for (int sampleRate : new int[]{44_100, 48_000, 96_000, 192_000}) {
+            int minimumFour = BoundedPcmQueue.minimumOutputFramesForPackets(
+                    sampleRate, AndroidAudioSink.PRIMER_PACKETS);
+            int maximumFour = BoundedPcmQueue.maximumOutputFramesForPackets(
+                    sampleRate, AndroidAudioSink.PRIMER_PACKETS);
+            int minimumSix = BoundedPcmQueue.minimumOutputFramesForPackets(
+                    sampleRate, BoundedPcmQueue.DEFAULT_CAPACITY);
+
+            assertTrue(minimumFour <= maximumFour);
+            assertTrue(maximumFour < minimumSix);
+            assertTrue(minimumFour * 1_000L / sampleRate > 50L);
+        }
+    }
+
+    @Test
+    public void firstSgbPacketFitsAQueueConstructedBeforeItsProfileEvent() throws Exception {
+        BoundedPcmQueue queue = new BoundedPcmQueue(44_100, ClockSpec.LEGACY);
+
+        int accepted = queue.offer(new Sound.SoundSampleEvent(
+                samples(ClockSpec.SGB.controllerTicksPerFrame()), ClockSpec.SGB), 100, false);
+        BoundedPcmQueue.Frame frame = queue.poll(1, TimeUnit.SECONDS);
+
+        assertTrue(accepted > 0);
+        assertNotNull(frame);
+        assertTrue(frame.length() > 0);
+        assertEquals(0L, queue.overruns());
+        queue.release(frame);
+    }
+
+    @Test
+    public void frameCarriesPolicyAndStickyPauseFlushGenerations() throws Exception {
+        BoundedPcmQueue queue = new BoundedPcmQueue(44_100);
+        Sound.SoundSampleEvent event = new Sound.SoundSampleEvent(
+                samples(ClockSpec.LEGACY.controllerTicksPerFrame()), ClockSpec.LEGACY);
+
+        queue.offer(event, 100, false, 7L, 11L);
+        BoundedPcmQueue.Frame frame = queue.poll(1, TimeUnit.SECONDS);
+
+        assertNotNull(frame);
+        assertEquals(7L, frame.policyGeneration());
+        assertEquals(11L, frame.pauseFlushGeneration());
+        queue.release(frame);
     }
 
     @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerTest.kt
@@ -2077,14 +2077,14 @@ class BasicControllerTest {
       // normal lifecycle command must still release that pause.
       eventBus.post(Controller.ResumeEmulationEvent())
       val resumed =
-          generateSequence { playback.poll(100, TimeUnit.MILLISECONDS) }
+          generateSequence { playback.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS) }
               .first { !it.paused }
       assertFalse(resumed.paused)
       // Pause at the next safe point so the just-released ordinary batch has a deterministic
       // terminal edge: every full PERFORMANCE start must complete, never abort.
       eventBus.post(Controller.PauseEmulationEvent())
       val pausedAgain =
-          generateSequence { playback.poll(100, TimeUnit.MILLISECONDS) }
+          generateSequence { playback.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS) }
               .first { it.paused }
       assertTrue(pausedAgain.paused)
       assertTrue(workStarts.get() > 0)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -255,6 +255,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     /** Native-CGB x1 epoch ticks committed while the LCD was stably disabled. */
     private transient long performanceEpochLcdOffTicks;
 
+    /** CPU/STAT phase frozen at the entrance of the current fixed-x1 CPU epoch. */
+    private transient int performanceEpochEntryStatReadPhaseFlags;
+
+    /** Whether the first positive peripheral prefix captured the frozen CPU/STAT phase. */
+    private transient boolean performanceEpochEntryStatReadPhaseCaptured;
+
     /** Raster transaction selected before the CPU observes its frozen peripheral view. */
     private transient PerformanceEpochPpuPlan performanceEpochPpuPlan =
             PerformanceEpochPpuPlan.NONE;
@@ -1294,6 +1300,17 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      * materialization and the PERFORMANCE scanline-enable lifecycle.
      */
     private int tryPerformancePhaseOnlySpan(long remaining, int cpuSpanLimit) {
+        boolean nativeCgbNormalSpeed = isNativeCgbNormalSpeedPerformanceEpochTopology();
+        // Most rejected Crystal dots are CPU-state/STAT-phase misses. Keep those allocation-free
+        // predicates ahead of the timer/audio/raster horizon walks; the identical checks remain
+        // adjacent to commit below so a future volatile input cannot turn this into a lease.
+        if (cpuSpanLimit <= 0
+                || !cpu.performancePhaseOnlySpanEligible()
+                || !(nativeCgbNormalSpeed
+                        ? cpu.performanceNativeCgbNormalSpeedNoPendingPpuReadPhase()
+                        : cpu.performanceNoPendingPpuReadPhase())) {
+            return 0;
+        }
         // SGB's JOYP packet receiver has no tick-driven state. When its cached input
         // eligibility is false, the span cannot commit anyway; reject before walking the
         // relatively expensive timer/PPU/STAT horizons. Stable SGB sessions remain eligible
@@ -1382,11 +1399,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (remaining < span) {
             span = (int) remaining;
         }
+        int entryStatReadPhaseFlags = cpu.getStatReadPhaseFlags();
         if (span <= 0
                 || warmResetRequested
                 || speedSwitchTailTicks != 0
                 || !cpu.performancePhaseOnlySpanEligible()
-                || !cpu.performanceNoPendingPpuReadPhase()
+                || !(nativeCgbNormalSpeed
+                        ? cpu.performanceNativeCgbNormalSpeedNoPendingPpuReadPhase()
+                        : cpu.performanceNoPendingPpuReadPhase())
                 || dma.isTransferInProgress()
                 || dma.requiresClockTick(cpu.getState() == Cpu.State.HALTED)
                 || gbc && (hdma.hasActiveOrPendingTransfer()
@@ -1395,7 +1415,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || !joypad.isPerformanceQuietSpanStillEligible()) {
             return 0;
         }
-        tickPerformanceQuietSpan(span, ppuPlan, directRasterSpan, steadyRasterSpan);
+        tickPerformanceQuietSpan(span, ppuPlan, directRasterSpan, steadyRasterSpan,
+                entryStatReadPhaseFlags);
         performanceBulkSpanCount++;
         performanceBulkTicks += span;
         return span;
@@ -1751,7 +1772,10 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         boolean nativeCgbNormalSpeed = isNativeCgbNormalSpeedPerformanceEpochTopology();
         boolean sgb = isSgbPerformanceTopology();
         boolean lcdOffEpoch = nativeCgbNormalSpeed && !gpu.isLcdEnabled();
-        if (remaining <= 0 || !cpu.performanceNormalSpeedEpochEntryEligible(cgbHardware)
+        boolean cpuEntryEligible = nativeCgbNormalSpeed
+                ? cpu.performanceNativeCgbNormalSpeedEpochEntryEligible()
+                : cpu.performanceNormalSpeedEpochEntryEligible(cgbHardware);
+        if (remaining <= 0 || !cpuEntryEligible
                 || !canStartNormalSpeedPerformanceEpoch(
                         cgbHardware, nativeCgbNormalSpeed)) {
             return 0;
@@ -1824,6 +1848,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && gpu.isPerformanceSteadyCursorActive();
         performanceEpochPpuPlan = ppuPlan;
         performanceEpochPrefixCommitted = 0;
+        performanceEpochEntryStatReadPhaseFlags = cpu.getStatReadPhaseFlags();
+        performanceEpochEntryStatReadPhaseCaptured = false;
         IntConsumer prefixCommitter;
         if (cgbHardware) {
             if (performanceCgbNormalSpeedEpochPrefixCommitter == null) {
@@ -2032,6 +2058,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (ticks <= 0) {
             return;
         }
+        capturePerformanceEpochEntryStatReadPhase();
         if (cgbHardware && !speedMode.isDmgCompat() && cartridgeClocked) {
             // Scalar Gameboy.tick() clocks the cartridge before Timer and every other
             // subsystem.  Prefix flushes and the final suffix both pass through this method,
@@ -2299,13 +2326,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private void tickPerformanceQuietSpan(int ticks, boolean directRasterSpan,
                                           boolean steadyRasterSpan) {
         tickPerformanceQuietSpan(
-                ticks, PerformancePhasePpuPlan.QUIET, directRasterSpan, steadyRasterSpan);
+                ticks, PerformancePhasePpuPlan.QUIET, directRasterSpan, steadyRasterSpan,
+                cpu.getStatReadPhaseFlags());
     }
 
     /** Advances the non-CPU-bus peripherals for one explicit phase-only PPU plan. */
     private void tickPerformanceQuietSpan(
             int ticks, PerformancePhasePpuPlan ppuPlan,
-            boolean directRasterSpan, boolean steadyRasterSpan) {
+            boolean directRasterSpan, boolean steadyRasterSpan,
+            int entryStatReadPhaseFlags) {
+        statRegister.capturePerformanceNoCpuReadPhaseTrusted(entryStatReadPhaseFlags);
         if (cartridgeClocked) {
             cartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
@@ -2351,6 +2381,16 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                     gpu.isStatModeLatchRephasedBySpeedSwitch());
             cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
         }
+    }
+
+    /** Captures the epoch's old-state CPU/STAT input at its first positive commit only. */
+    private void capturePerformanceEpochEntryStatReadPhase() {
+        if (performanceEpochEntryStatReadPhaseCaptured) {
+            return;
+        }
+        statRegister.capturePerformanceNoCpuReadPhaseTrusted(
+                performanceEpochEntryStatReadPhaseFlags);
+        performanceEpochEntryStatReadPhaseCaptured = true;
     }
 
     /** Resets the session-only PERFORMANCE bulk counters at benchmark arm. */
@@ -3016,12 +3056,19 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      * Requests that a future visible frame omit host presentation work.
      *
      * <p>This is a host-only pacing control. The request is latched only when the PPU reaches
-     * VBlank, is ignored for Super Game Boy profiles (their DMG pixels feed emulated SGB
-     * transfers), and never becomes serialized machine state.</p>
+     * VBlank and never becomes serialized machine state. Super Game Boy profiles always retain
+     * the complete DMG frame for emulated transfers; only their derived final host composite may
+     * be omitted.</p>
      */
     public void requestFrameRenderSuppression(boolean suppress) {
-        requestedFrameRenderSuppression = suppress
-                && !hardwareProfile.capabilities().superGameboyCommands();
+        if (hardwareProfile.capabilities().superGameboyCommands()) {
+            // SGB commands and VRAM transfers consume the complete DMG frame. Keep that emulated
+            // input live and shed only SgbDisplay's derived host composite when pacing is behind.
+            requestedFrameRenderSuppression = false;
+            sgbDisplay.requestFrameRenderSuppression(suppress);
+        } else {
+            requestedFrameRenderSuppression = suppress;
+        }
     }
 
     /**
@@ -3031,7 +3078,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      * not part of serialized machine state.</p>
      */
     public boolean isCurrentVisibleFrameFullyRendering() {
-        return !frameRenderSuppressed;
+        return !frameRenderSuppressed && sgbDisplay.isCurrentFrameRendering();
     }
 
     /**
@@ -3045,6 +3092,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         requestedFrameRenderSuppression = false;
         frameRenderSuppressed = false;
         gpu.setRenderOutput(true);
+        sgbDisplay.resetFrameRenderSuppression();
     }
 
     public Sound getSound() {
@@ -3526,6 +3574,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (hardwareProfile.capabilities().superGameboyCommands()) {
             frameRenderSuppressed = false;
             gpu.setRenderOutput(true);
+            sgbDisplay.resetFrameRenderSuppression();
             return;
         }
         frameRenderSuppressed = true;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -312,7 +312,8 @@ public class Cpu implements StatefulComponent<Cpu> {
      * @return master ticks consumed by the CPU epoch
      */
     public int runPhysicalDmgPerformanceEpoch(int maxMasterTicks) {
-        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false, false);
+        return runPerformanceNormalSpeedEpoch(
+                maxMasterTicks, false, false, false, false, false);
     }
 
     /**
@@ -322,7 +323,8 @@ public class Cpu implements StatefulComponent<Cpu> {
      * may remain inside the epoch.
      */
     public int runSgbPerformanceEpoch(int maxMasterTicks) {
-        return runPerformanceNormalSpeedEpoch(maxMasterTicks, false, true);
+        return runPerformanceNormalSpeedEpoch(
+                maxMasterTicks, false, true, false, false, false);
     }
 
     /**
@@ -332,17 +334,20 @@ public class Cpu implements StatefulComponent<Cpu> {
      */
     public int runCgbCompatibilityPerformanceEpoch(int maxMasterTicks) {
         return speedMode.isDmgCompat()
-                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, false) : 0;
+                ? runPerformanceNormalSpeedEpoch(
+                        maxMasterTicks, true, false, false, false, false) : 0;
     }
 
     /**
      * Fixed four-master-dot epoch for native CGB software which remains at normal speed.
-     * Decoded memory boundaries stay scalar so CPU-visible peripheral writes retain their
-     * position before the owner ticks Sound and the remaining peripherals.
+     * Address-known ROM reads and work/high-RAM accesses may remain inside the epoch.
+     * CPU-visible peripheral, mapper, cartridge-RAM, and RTC accesses stay scalar so they
+     * retain their position before the owner ticks Sound and the remaining peripherals.
      */
     public int runNativeCgbNormalSpeedPerformanceEpoch(int maxMasterTicks) {
         return !speedMode.isDmgCompat()
-                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, true) : 0;
+                ? runPerformanceNormalSpeedEpoch(
+                        maxMasterTicks, true, true, true, false, true) : 0;
     }
 
     /**
@@ -352,20 +357,17 @@ public class Cpu implements StatefulComponent<Cpu> {
      */
     public int runNativeCgbNormalSpeedLcdOffPerformanceEpoch(int maxMasterTicks) {
         return !speedMode.isDmgCompat()
-                ? runPerformanceNormalSpeedEpoch(maxMasterTicks, true, true, true) : 0;
+                ? runPerformanceNormalSpeedEpoch(
+                        maxMasterTicks, true, true, true, true, true) : 0;
     }
 
     /** Shared fixed-width normal-speed epoch; topology flags are explicit and allocation-free. */
     private int runPerformanceNormalSpeedEpoch(
-            int maxMasterTicks, boolean cgbHardware, boolean fenceDecodedMemoryCycles) {
-        return runPerformanceNormalSpeedEpoch(
-                maxMasterTicks, cgbHardware, fenceDecodedMemoryCycles, false);
-    }
-
-    private int runPerformanceNormalSpeedEpoch(
             int maxMasterTicks, boolean cgbHardware, boolean fenceDecodedMemoryCycles,
-            boolean allowLcdOffVramAccess) {
-        if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(cgbHardware)) {
+            boolean allowResolvedSafeDecodedAccess, boolean allowLcdOffVramAccess,
+            boolean allowImeDisabledRawPendingInterrupt) {
+        if (maxMasterTicks <= 0 || !performanceNormalSpeedEpochEntryEligible(
+                cgbHardware, allowImeDisabledRawPendingInterrupt)) {
             return 0;
         }
         int requested = Math.min(maxMasterTicks, PERFORMANCE_EPOCH_MAX_TICKS);
@@ -399,8 +401,12 @@ public class Cpu implements StatefulComponent<Cpu> {
                 }
 
                 if (!performanceEpochPrefetchSafe()
+                        || allowImeDisabledRawPendingInterrupt
+                        && hasImeDisabledRawPendingInterrupt()
+                        && performanceNextBoundaryFetchesHalt()
                         || fenceDecodedMemoryCycles
-                        && !performanceDecodedMemoryBoundarySafe(allowLcdOffVramAccess)) {
+                        && !performanceDecodedMemoryBoundarySafe(
+                        allowResolvedSafeDecodedAccess, allowLcdOffVramAccess)) {
                     performanceEpochTerminal = true;
                     break;
                 }
@@ -436,22 +442,33 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     /**
-     * Rejects an SGB epoch before a CPU boundary which can reach a data-memory operation.
-     * Operations before the next force-finish marker execute in the same machine-cycle tick;
-     * scanning the complete group here prevents a partial CPU tick before scalar fallback.
+     * Rejects a fenced epoch before a CPU boundary which can reach an unsafe data-memory
+     * operation. Operations before the next force-finish marker execute in the same
+     * machine-cycle tick, so the complete group is classified before any part may run.
      */
-    private boolean performanceDecodedMemoryBoundarySafe(boolean allowLcdOffVramAccess) {
+    private boolean performanceDecodedMemoryBoundarySafe(
+            boolean allowResolvedSafeDecodedAccess, boolean allowLcdOffVramAccess) {
         if (state != State.RUNNING || currentExecutionOps == null) {
             return true;
         }
         for (int i = opIndex; i < currentOpCount; i++) {
+            Op op = currentExecutionOps[i];
+            if (allowResolvedSafeDecodedAccess
+                    && op.causesOemBug(registers, opContext) != null) {
+                return false;
+            }
             if (currentOpAccessesMemory[i]) {
-                if (!allowLcdOffVramAccess) {
+                if (!allowResolvedSafeDecodedAccess) {
                     return false;
                 }
-                Integer address = currentExecutionOps[i].resolveMemoryAddress(
-                        registers, operand, opContext);
-                if (address == null || !PerformanceEpochBus.isVideoRam(address)) {
+                Integer address = op.resolveMemoryAddress(registers, operand, opContext);
+                if (address == null) {
+                    if (!op.isInternalMemoryCycle()) {
+                        return false;
+                    }
+                } else if (currentOpWritesMemory[i]
+                        ? !isPerformanceEpochSafeWrite(address, allowLcdOffVramAccess)
+                        : !isPerformanceEpochSafeRead(address, allowLcdOffVramAccess)) {
                     return false;
                 }
             }
@@ -462,16 +479,24 @@ public class Cpu implements StatefulComponent<Cpu> {
         return true;
     }
 
-    private boolean isPerformanceEpochSafeRead(int address) {
+    private static boolean isPerformanceEpochSafeRead(
+            int address, boolean allowLcdOffVramAccess) {
         return PerformanceEpochBus.isSafeRead(address)
-                || performanceEpochLcdOffVramAccess
-                && PerformanceEpochBus.isVideoRam(address);
+                || allowLcdOffVramAccess && PerformanceEpochBus.isVideoRam(address);
+    }
+
+    private static boolean isPerformanceEpochSafeWrite(
+            int address, boolean allowLcdOffVramAccess) {
+        return PerformanceEpochBus.isSafeWrite(address)
+                || allowLcdOffVramAccess && PerformanceEpochBus.isVideoRam(address);
+    }
+
+    private boolean isPerformanceEpochSafeRead(int address) {
+        return isPerformanceEpochSafeRead(address, performanceEpochLcdOffVramAccess);
     }
 
     private boolean isPerformanceEpochSafeWrite(int address) {
-        return PerformanceEpochBus.isSafeWrite(address)
-                || performanceEpochLcdOffVramAccess
-                && PerformanceEpochBus.isVideoRam(address);
+        return isPerformanceEpochSafeWrite(address, performanceEpochLcdOffVramAccess);
     }
 
     private boolean performanceEpochPrefetchSafe() {
@@ -492,6 +517,20 @@ public class Cpu implements StatefulComponent<Cpu> {
                     || PerformanceEpochBus.isSafeRead(registers.getPC());
             default -> true;
         };
+    }
+
+    /**
+     * HALT with IME clear and an enabled stored request owns the HALT-bug latch race. The
+     * native-CGB x1 epoch may run ordinary code under that masked request, but it leaves the
+     * fetch boundary itself untouched when the next opcode is HALT.
+     */
+    private boolean performanceNextBoundaryFetchesHalt() {
+        return state == State.OPCODE && readInstructionByte(registers.getPC()) == 0x76;
+    }
+
+    private boolean hasImeDisabledRawPendingInterrupt() {
+        return !interruptManager.isIme()
+                && interruptManager.hasRawPendingEnabledInterrupt();
     }
 
     /** Cheap state-only entrance check used before the owner walks peripheral horizons. */
@@ -532,11 +571,17 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     /** Cheap state-only entrance check for native CGB software at the normal clock. */
     public boolean performanceNativeCgbNormalSpeedEpochEntryEligible() {
-        return performanceNormalSpeedEpochEntryEligible(true) && !speedMode.isDmgCompat();
+        return !speedMode.isDmgCompat()
+                && performanceNormalSpeedEpochEntryEligible(true, true);
     }
 
     /** Shared state-only entrance check for the fixed-width normal-speed epoch. */
     public boolean performanceNormalSpeedEpochEntryEligible(boolean cgbHardware) {
+        return performanceNormalSpeedEpochEntryEligible(cgbHardware, false);
+    }
+
+    private boolean performanceNormalSpeedEpochEntryEligible(
+            boolean cgbHardware, boolean allowImeDisabledRawPendingInterrupt) {
         boolean topologyMatches = cgbHardware
                 ? speedMode.isGbc()
                 : !speedMode.isGbc();
@@ -547,7 +592,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                 || state == State.IRQ_PUSH_1 || state == State.IRQ_PUSH_2
                 || state == State.IRQ_JUMP
                 || state == State.EXT_OPCODE && opcode1 == 0x10
-                || state != State.OPCODE && opcode1 == 0xd9
+                || performanceInterruptTransitionInFlight()
                 || clockCycle < 0 || clockCycle > 3
                 || haltBugMode || haltEntrySampleTicks != 0
                 || phasedPpuInputHigh || fastPhasedPpuDispatch
@@ -556,10 +601,21 @@ public class Cpu implements StatefulComponent<Cpu> {
                 || interruptManager.hasPendingCpuReadPhase()
                 || interruptManager.hasPpuTickSignals()
                 || interruptManager.isInterruptEnablePending()
-                || interruptManager.hasRawPendingEnabledInterrupt()) {
+                || interruptManager.hasRawPendingEnabledInterrupt()
+                        && (!allowImeDisabledRawPendingInterrupt
+                        || interruptManager.isIme())) {
             return false;
         }
         return speedMode.getSpeedMode() == 1 && topologyMatches;
+    }
+
+    /** Keeps delayed-enable and low-power control instructions on their scalar seams. */
+    private boolean performanceInterruptTransitionInFlight() {
+        if (state == State.OPCODE) {
+            return false;
+        }
+        return opcode1 == 0xfb || opcode1 == 0xd9
+                || opcode1 == 0x76 || opcode1 == 0x10;
     }
 
     private boolean isPerformanceEpochLifecycleState() {
@@ -759,6 +815,26 @@ public class Cpu implements StatefulComponent<Cpu> {
      */
     public boolean performanceNoPendingPpuReadPhase() {
         return getStatReadPhaseFlags() == 0
+                && !interruptManager.hasPendingCpuReadPhase();
+    }
+
+    /**
+     * Native-CGB x1 phase packets may carry only the durable ordinary HALT-wake marker. Its
+     * optional one-cycle qualifier is meaningful only together with the ordinary marker;
+     * synchronous/asynchronous entry phases and every pending IF/STAT read aperture stay scalar.
+     */
+    public boolean performanceNativeCgbNormalSpeedNoPendingPpuReadPhase() {
+        if (!speedMode.isGbc() || speedMode.isDmgCompat()
+                || speedMode.getSpeedMode() != 1) {
+            return false;
+        }
+        int flags = getStatReadPhaseFlags();
+        int allowed = STAT_READ_PHASE_ORDINARY_HALT_WAKE
+                | STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE;
+        boolean flagsValid = (flags & ~allowed) == 0
+                && ((flags & STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE) == 0
+                || (flags & STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0);
+        return flagsValid
                 && !interruptManager.hasPendingCpuReadPhase();
     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/op/Op.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/op/Op.java
@@ -31,6 +31,15 @@ public interface Op  {
     }
 
     /**
+     * Whether a memory-timed operation is an internal CPU cycle rather than an
+     * access to the external address space. Internal cycles deliberately have no
+     * address for {@link #resolveMemoryAddress(Registers, int[], int)} to return.
+     */
+    default boolean isInternalMemoryCycle() {
+        return false;
+    }
+
+    /**
      * Previews a side-effect-free context-producing operation. This is kept
      * deliberately opt-in so speculative CPU timing checks never execute ALU,
      * register-write, interrupt, or memory operations.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/opcode/OpcodeBuilder.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/opcode/OpcodeBuilder.java
@@ -274,6 +274,12 @@ public class OpcodeBuilder  {
                     }
 
                     @Override
+                    public Integer resolveMemoryAddress(
+                            Registers registers, int[] args, int context) {
+                        return (registers.getSP() - 1) & 0xffff;
+                    }
+
+                    @Override
                     public int execute(
                             Registers registers, AddressSpace addressSpace, int[] args, int context) {
                         registers.setSP(dec.apply(registers.getFlags(), registers.getSP()));
@@ -296,6 +302,12 @@ public class OpcodeBuilder  {
                     @Override
                     public boolean writesMemory() {
                         return true;
+                    }
+
+                    @Override
+                    public Integer resolveMemoryAddress(
+                            Registers registers, int[] args, int context) {
+                        return (registers.getSP() - 1) & 0xffff;
                     }
 
                     @Override
@@ -592,6 +604,11 @@ public class OpcodeBuilder  {
                     }
 
                     @Override
+                    public boolean isInternalMemoryCycle() {
+                        return true;
+                    }
+
+                    @Override
                     public String toString() {
                         return "wait cycle";
                     }
@@ -608,6 +625,11 @@ public class OpcodeBuilder  {
                 new Op() {
                     @Override
                     public boolean readsMemory() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isInternalMemoryCycle() {
                         return true;
                     }
 

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -1117,20 +1117,7 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
 
     /** Native owner-side copy of the packed CPU phase bookkeeping. */
     private void captureNativeCgbPerformanceReadPhasePrepared(int statReadPhaseFlags) {
-        boolean ordinaryHaltWakePhase = (statReadPhaseFlags
-                & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0;
-        if (ordinaryHaltWakePhase && !previousOrdinaryHaltWakePhase) {
-            ordinaryHaltWakeStatClock = lycIrqClock;
-        }
-        previousOrdinaryHaltWakePhase = ordinaryHaltWakePhase;
-        boolean recentOrdinaryHaltWakePhase = ordinaryHaltWakePhase
-                && ordinaryHaltWakeStatClock != NO_LYC_IRQ_EVENT
-                && lycIrqClock - ordinaryHaltWakeStatClock
-                <= ORDINARY_HALT_WAKE_STAT_HOLD_TICKS;
-        statReadPhaseFlags &= ~STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
-        if (recentOrdinaryHaltWakePhase) {
-            statReadPhaseFlags |= STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
-        }
+        statReadPhaseFlags = captureDurableCpuStatReadPhase(statReadPhaseFlags);
         cpuStatReadPhaseFlags = statReadPhaseFlags;
         cpuStatModeOverride = CPU_STAT_MODE_UNRESOLVED;
     }
@@ -1213,6 +1200,28 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     private void captureCpuStatReadPhasePrepared(int statReadPhaseFlags) {
         boolean ordinaryHaltWakePhase = (statReadPhaseFlags
                 & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0;
+        gpu.captureCpuLyReadPhase(ordinaryHaltWakePhase
+                && isMode1InterruptSourceOnly());
+        statReadPhaseFlags = captureDurableCpuStatReadPhase(statReadPhaseFlags);
+        cpuStatReadPhaseFlags = statReadPhaseFlags;
+        cpuStatModeOverride = CPU_STAT_MODE_UNRESOLVED;
+    }
+
+    /**
+     * Captures the persistent ordinary-HALT-wake edge for a proven no-CPU-read packet. The
+     * packet has no FF41/FF44 callback, so it deliberately does not publish a transient STAT
+     * mode override or LY read latch. Callers invoke this exactly once before advancing the
+     * first positive peripheral prefix.
+     */
+    public void capturePerformanceNoCpuReadPhaseTrusted(int statReadPhaseFlags) {
+        captureDurableCpuStatReadPhase(statReadPhaseFlags);
+        clearCpuStatReadPhase();
+    }
+
+    /** Updates the memento-backed ordinary/recent window and returns its packed read view. */
+    private int captureDurableCpuStatReadPhase(int statReadPhaseFlags) {
+        boolean ordinaryHaltWakePhase = (statReadPhaseFlags
+                & Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE) != 0;
         if (ordinaryHaltWakePhase && !previousOrdinaryHaltWakePhase) {
             ordinaryHaltWakeStatClock = lycIrqClock;
         }
@@ -1221,14 +1230,11 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
                 && ordinaryHaltWakeStatClock != NO_LYC_IRQ_EVENT
                 && lycIrqClock - ordinaryHaltWakeStatClock
                 <= ORDINARY_HALT_WAKE_STAT_HOLD_TICKS;
-        gpu.captureCpuLyReadPhase(ordinaryHaltWakePhase
-                && isMode1InterruptSourceOnly());
         statReadPhaseFlags &= ~STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
         if (recentOrdinaryHaltWakePhase) {
             statReadPhaseFlags |= STAT_READ_PHASE_RECENT_ORDINARY_HALT_WAKE;
         }
-        cpuStatReadPhaseFlags = statReadPhaseFlags;
-        cpuStatModeOverride = CPU_STAT_MODE_UNRESOLVED;
+        return statReadPhaseFlags;
     }
 
     /** Captures PPU edges visible to this tick's CPU IF read before IF itself settles. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/sgb/SgbDisplay.java
@@ -86,6 +86,15 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
     private final transient ThreadLocal<RenderLeasePool> renderLeasePool;
 
     /**
+     * Host-only pacing gate for the expensive final SGB composite. The DMG frame event still
+     * reaches every emulated SGB transfer/background consumer; only the derived presentation
+     * event may be omitted while the controller repays pacing debt.
+     */
+    private transient volatile boolean requestedFrameRenderSuppression;
+
+    private transient boolean frameRenderSuppressed;
+
+    /**
      * PAL_PRI controls whether later game palette commands reclaim a palette selected in the
      * SNES firmware UI. Coffee GB has no SNES palette-selection UI, so game palettes are always
      * active; retaining this bit is still required for deterministic state and future adapters.
@@ -293,24 +302,55 @@ public class SgbDisplay implements StatefulComponent<SgbDisplay> {
     }
 
     private void onDmgFrame(DmgFrameReadyEvent dmgFrameReadyEvent) {
-        if (screenMask == GameboyScreenMask.FREEZE) {
-            return;
-        }
-        boolean includeBorder = sgbBorder;
-        RenderLeasePool pool = renderLeasePool.get();
-        RenderLease lease = pool.acquire(includeBorder);
         try {
-            int[] result = lease.frame;
-            int[] base = canonicalBase(includeBorder);
-            if (includeBorder) {
-                System.arraycopy(base, 0, result, 0, base.length);
+            if (screenMask == GameboyScreenMask.FREEZE || frameRenderSuppressed) {
+                return;
             }
-            renderCenter(result, base, dmgFrameReadyEvent.pixels(), includeBorder);
-            // The leased array remains valid through every synchronous subscriber callback. It is
-            // returned to this depth-specific pool only after the complete post has unwound.
-            eventBus.post(new SgbFrameReadyEvent(result, includeBorder));
+            boolean includeBorder = sgbBorder;
+            RenderLeasePool pool = renderLeasePool.get();
+            RenderLease lease = pool.acquire(includeBorder);
+            try {
+                int[] result = lease.frame;
+                int[] base = canonicalBase(includeBorder);
+                if (includeBorder) {
+                    System.arraycopy(base, 0, result, 0, base.length);
+                }
+                renderCenter(result, base, dmgFrameReadyEvent.pixels(), includeBorder);
+                // The leased array remains valid through every synchronous subscriber callback.
+                // It is returned to this depth-specific pool only after the complete post unwinds.
+                eventBus.post(new SgbFrameReadyEvent(result, includeBorder));
+            } finally {
+                pool.release(lease);
+            }
         } finally {
-            pool.release(lease);
+            latchFrameRenderSuppression();
+        }
+    }
+
+    /** Requests host presentation shedding without suppressing emulated DMG/SGB transfer input. */
+    public void requestFrameRenderSuppression(boolean suppress) {
+        if (sgb) {
+            requestedFrameRenderSuppression = suppress;
+        }
+    }
+
+    /** Whether the current physical SGB frame is eligible for host presentation/rewind capture. */
+    public boolean isCurrentFrameRendering() {
+        return !frameRenderSuppressed;
+    }
+
+    /** A visible restore starts from the existing complete SGB transfer path with no host debt. */
+    public void resetFrameRenderSuppression() {
+        requestedFrameRenderSuppression = false;
+        frameRenderSuppressed = false;
+    }
+
+    /** Applies the latest host request at the physical DMG frame edge, capped at one skipped frame. */
+    private void latchFrameRenderSuppression() {
+        if (!requestedFrameRenderSuppression) {
+            frameRenderSuppressed = false;
+        } else {
+            frameRenderSuppressed = !frameRenderSuppressed;
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyAdaptiveFrameRenderingTest.java
@@ -7,9 +7,12 @@ import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
+import eu.rekawek.coffeegb.core.sound.Sound;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -132,18 +135,121 @@ public class GameboyAdaptiveFrameRenderingTest {
     }
 
     @Test
-    public void superGameBoyOutputIsNeverSuppressed() throws Exception {
-        try (EventBus eventBus = new EventBusImpl(); Gameboy gameboy = newSgbGameboy()) {
-            AtomicInteger published = new AtomicInteger();
-            eventBus.register(e -> published.incrementAndGet(), SgbDisplay.SgbFrameReadyEvent.class);
-            gameboy.init(eventBus, SerialEndpoint.NULL_ENDPOINT, null);
+    public void superGameBoyKeepsEveryTransferFrameButMayShedFinalHostPresentation()
+            throws Exception {
+        try (EventBus referenceBus = new EventBusImpl();
+             EventBus pacedBus = new EventBusImpl();
+             Gameboy reference = newSgbGameboy();
+             Gameboy paced = newSgbGameboy()) {
+            AtomicInteger dmgTransfers = new AtomicInteger();
+            AtomicInteger sgbPresentations = new AtomicInteger();
+            List<int[]> referenceAudio = new ArrayList<>();
+            List<int[]> pacedAudio = new ArrayList<>();
+            pacedBus.register(e -> dmgTransfers.incrementAndGet(), Display.DmgFrameReadyEvent.class);
+            pacedBus.register(
+                    e -> sgbPresentations.incrementAndGet(), SgbDisplay.SgbFrameReadyEvent.class);
+            referenceBus.register(e -> referenceAudio.add(e.buffer().clone()),
+                    Sound.SoundSampleEvent.class);
+            pacedBus.register(e -> pacedAudio.add(e.buffer().clone()),
+                    Sound.SoundSampleEvent.class);
+            reference.init(referenceBus, SerialEndpoint.NULL_ENDPOINT, null);
+            paced.init(pacedBus, SerialEndpoint.NULL_ENDPOINT, null);
 
-            gameboy.requestFrameRenderSuppression(true);
-            runToNextFrame(gameboy);
-            runToNextFrame(gameboy);
-            runToNextFrame(gameboy);
+            paced.requestFrameRenderSuppression(true);
+            for (int frame = 0; frame < 4; frame++) {
+                runToNextFrame(reference, paced);
+            }
 
-            assertEquals("SGB DMG pixels remain emulated transfer input", 3, published.get());
+            assertEquals("SGB DMG pixels remain emulated transfer input", 4, dmgTransfers.get());
+            assertEquals("sustained debt still presents every other final SGB frame",
+                    2, sgbPresentations.get());
+            assertAudioEquals(referenceAudio, pacedAudio);
+            assertDeepStateEquals("suppressed SGB host output", reference.captureStateWithoutTimeSource(),
+                    paced.captureStateWithoutTimeSource());
+
+            paced.requestFrameRenderSuppression(false);
+            runToNextFrame(reference, paced);
+            runToNextFrame(reference, paced);
+            assertEquals(6, dmgTransfers.get());
+            assertEquals("presentation resumes after the physical handoff", 4,
+                    sgbPresentations.get());
+            assertAudioEquals(referenceAudio, pacedAudio);
+            assertDeepStateEquals("resumed SGB host output", reference.captureStateWithoutTimeSource(),
+                    paced.captureStateWithoutTimeSource());
+
+            var visibleState = paced.captureState();
+            paced.requestFrameRenderSuppression(true);
+            runToNextFrame(paced);
+            assertFalse(paced.isCurrentVisibleFrameFullyRendering());
+            paced.restoreStateSilently(visibleState);
+            assertFalse("silent rollback preserves the derived SGB pacing gate",
+                    paced.isCurrentVisibleFrameFullyRendering());
+            paced.restoreState(visibleState);
+            assertTrue("manual restore clears the derived SGB pacing gate",
+                    paced.isCurrentVisibleFrameFullyRendering());
+
+            paced.requestFrameRenderSuppression(true);
+            runToNextFrame(paced);
+            assertFalse(paced.isCurrentVisibleFrameFullyRendering());
+            paced.resumeFullFrameRenderingAfterRewindRestore();
+            assertTrue("rewind restore immediately clears the derived SGB host gate",
+                    paced.isCurrentVisibleFrameFullyRendering());
+        }
+    }
+
+    private static void assertAudioEquals(List<int[]> expected, List<int[]> actual) {
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertArrayEquals("audio event " + i, expected.get(i), actual.get(i));
+        }
+    }
+
+    private static void assertDeepStateEquals(String path, Object expected, Object actual)
+            throws Exception {
+        if (expected == null || actual == null) {
+            if (expected != actual) {
+                throw new AssertionError(path + " expected=" + expected + " actual=" + actual);
+            }
+            return;
+        }
+        if (!expected.getClass().equals(actual.getClass())) {
+            throw new AssertionError(path + " type expected=" + expected.getClass()
+                    + " actual=" + actual.getClass());
+        }
+        Class<?> type = expected.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(expected);
+            if (length != Array.getLength(actual)) {
+                throw new AssertionError(path + " array length");
+            }
+            for (int i = 0; i < length; i++) {
+                assertDeepStateEquals(path + '[' + i + ']', Array.get(expected, i),
+                        Array.get(actual, i));
+            }
+            return;
+        }
+        if (expected instanceof List<?> expectedList) {
+            List<?> actualList = (List<?>) actual;
+            if (expectedList.size() != actualList.size()) {
+                throw new AssertionError(path + " list size");
+            }
+            for (int i = 0; i < expectedList.size(); i++) {
+                assertDeepStateEquals(path + '[' + i + ']', expectedList.get(i),
+                        actualList.get(i));
+            }
+            return;
+        }
+        if (!type.isRecord()) {
+            if (!expected.equals(actual)) {
+                throw new AssertionError(path + " expected=" + expected + " actual=" + actual);
+            }
+            return;
+        }
+        for (RecordComponent component : type.getRecordComponents()) {
+            component.getAccessor().setAccessible(true);
+            assertDeepStateEquals(path + '.' + component.getName(),
+                    component.getAccessor().invoke(expected),
+                    component.getAccessor().invoke(actual));
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -393,6 +393,45 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedMbc3RtcMatchesScalarUnderImeDisabledRawPendingInterrupt()
+            throws Exception {
+        byte[] image = nativeMbc3(dmgRomWramLoop());
+        try (Gameboy scalar = nativeCgbNormalSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeCgbNormalSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            for (Gameboy gameboy : new Gameboy[] {scalar, candidate}) {
+                gameboy.getAddressSpace().setByte(0xffff, 0x01);
+                gameboy.getAddressSpace().setByte(0xff0f,
+                        gameboy.getAddressSpace().getByte(0xff0f) | 0x01);
+            }
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk = 0; chunk < 20; chunk++) {
+                scalarFrames += scalar.runTicks(4_000);
+                candidateFrames += candidate.runTicks(4_000);
+                assertDeepStateEquals("native CGB x1 masked MBC3 chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            assertEquals("native CGB x1 masked MBC3 frame callbacks",
+                    scalarFrames, candidateFrames);
+            assertEquals("custom-source masked oracle unexpectedly entered the epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("masked MBC3 loop had no native CGB x1 epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000L);
+            assertEquals("raw pending IF/IE was not retained", 0x01,
+                    candidate.getAddressSpace().getByte(0xffff) & 0x01);
+            assertEquals("raw pending IF was not retained", 0x01,
+                    candidate.getAddressSpace().getByte(0xff0f) & 0x01);
+        }
+    }
+
+    @Test
     public void nativeCgbNormalSpeedMbc3RtcWritesStayScalarAfterExactClockPrefixes()
             throws Exception {
         byte[] image = nativeMbc3(nativeCgbMbc3RtcWriteLoop());
@@ -1023,6 +1062,70 @@ public final class GameboyPerformanceEpochTest {
                     scalar.runTicks(1), candidate.runTicks(1));
             assertEquals(Mode.PixelTransfer, candidate.getGpu().getMode());
             assertDeepStateEquals("native CGB x1 scalar dot-80 handoff",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedOrdinaryHaltWakeUsesMaskedEpochAndPhasePackets()
+            throws Exception {
+        byte[] image = nativeColor(dmgRomWramLoop());
+        image[0x200] = 0x76; // HALT
+        image[0x201] = 0x00; // NOP stream after the ordinary IME=0 wake
+        try (Gameboy scalar = nativeCgbNormalSpeedSession(
+                image, PlayerInputSnapshot::released, ExecutionMode.PERFORMANCE);
+             Gameboy candidate = nativeCgbNormalSpeedSession(
+                     image, PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
+            int guard = 0;
+            while (!(candidate.getGpu().isPerformanceScanlineCursorActive()
+                    && candidate.getGpu().getTicksInLine() >= 100
+                    && candidate.getGpu().getTicksInLine() <= 180
+                    && candidate.getCpu().getState() == Cpu.State.OPCODE
+                    && candidate.getCpu().getDebugMachineCycle() == 0)
+                    && guard++ < 200_000) {
+                assertEquals("ordinary-wake setup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("ordinary-wake setup did not reach a stable epoch point",
+                    guard < 200_000);
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+
+            assertEquals("HALT entry frame callback",
+                    scalar.runTicks(8), candidate.runTicks(8));
+            assertEquals(Cpu.State.HALTED, scalar.getCpu().getState());
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertDeepStateEquals("settled HALT before ordinary wake",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            for (Gameboy gameboy : new Gameboy[] {scalar, candidate}) {
+                gameboy.getAddressSpace().setByte(0xffff, 0x01);
+                gameboy.getAddressSpace().setByte(0xff0f,
+                        gameboy.getAddressSpace().getByte(0xff0f) | 0x01);
+                gameboy.resetPerformanceBulkCounters();
+            }
+
+            assertEquals("ordinary-wake frame callback",
+                    scalar.runTicks(2_000), candidate.runTicks(2_000));
+            assertTrue("fixture did not retain the ordinary HALT-wake phase",
+                    candidate.getCpu().isOrdinaryHaltWakeStatPhase());
+            assertTrue("IME=0 raw pending code had no epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertTrue("ordinary HALT-wake phase had no short packet coverage",
+                    candidate.getPerformanceBulkTicks() > 0L);
+            assertDeepStateEquals("ordinary wake before restore",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            scalar.restoreState(scalarCheckpoint);
+            candidate.restoreState(candidateCheckpoint);
+            assertEquals("ordinary-wake restored frame callback",
+                    scalar.runTicks(2_000), candidate.runTicks(2_000));
+            assertDeepStateEquals("ordinary wake after restore",
                     scalar.captureStateWithoutTimeSource(),
                     candidate.captureStateWithoutTimeSource());
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -488,6 +488,261 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbNormalSpeedRunsOrdinaryCodeUnderImeDisabledRawPendingInterrupt()
+            throws Exception {
+        ParityMemory directMemory = new ParityMemory();
+        ParityMemory scalarMemory = new ParityMemory();
+        InterruptManager directInterrupts = new InterruptManager(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        directInterrupts.setByte(0xffff, 1);
+        scalarInterrupts.setByte(0xffff, 1);
+        directInterrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        scalarInterrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                new SpeedMode(true), new Display(false));
+        Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                new SpeedMode(true), new Display(false));
+
+        assertTrue(direct.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        int elapsed = direct.runNativeCgbNormalSpeedPerformanceEpoch(54);
+        assertEquals(54, elapsed);
+        for (int tick = 0; tick < elapsed; tick++) {
+            scalar.tick();
+        }
+
+        assertDeepEquals("cpu", scalar.captureState(), direct.captureState());
+        assertDeepEquals("interrupts", scalarInterrupts.captureState(),
+                directInterrupts.captureState());
+        assertArrayEquals(scalarMemory.bytes, directMemory.bytes);
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedMaskedInterruptKeepsImeAndControlSeamsScalar() {
+        CountingMemory imeMemory = new CountingMemory();
+        imeMemory.bytes[0] = 0x00;
+        InterruptManager imeInterrupts = pendingVBlank();
+        imeInterrupts.enableInterrupts(false);
+        Cpu ime = normalSpeedNativeCpu(imeMemory, imeInterrupts);
+        assertFalse("IME=1 must retain interrupt dispatch",
+                ime.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        assertEquals(0, ime.runNativeCgbNormalSpeedPerformanceEpoch(54));
+
+        CountingMemory eiMemory = new CountingMemory();
+        eiMemory.bytes[0] = (byte) 0xfb; // EI
+        InterruptManager eiInterrupts = new InterruptManager(true);
+        Cpu ei = normalSpeedNativeCpu(eiMemory, eiInterrupts);
+        for (int tick = 0; tick < 4; tick++) {
+            ei.tick();
+        }
+        eiInterrupts.setByte(0xffff, 1);
+        eiInterrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        assertFalse("delayed EI must remain scalar",
+                ei.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        assertEquals(0, ei.runNativeCgbNormalSpeedPerformanceEpoch(54));
+
+        CountingMemory retiMemory = new CountingMemory();
+        retiMemory.bytes[0] = (byte) 0xd9; // RETI
+        Cpu reti = normalSpeedNativeCpu(retiMemory, pendingVBlank());
+        assertEquals(4, reti.runNativeCgbNormalSpeedPerformanceEpoch(4));
+        assertTrue(reti.getState() != Cpu.State.OPCODE);
+        assertEquals("in-flight RETI must remain scalar", 0,
+                reti.runNativeCgbNormalSpeedPerformanceEpoch(54));
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedFencesHaltAndIoUnderImeDisabledRawPendingInterrupt()
+            throws Exception {
+        CountingMemory haltMemory = new CountingMemory();
+        haltMemory.bytes[0] = 0x76; // HALT
+        InterruptManager haltInterrupts = new InterruptManager(true);
+        Cpu halt = normalSpeedNativeCpu(haltMemory, haltInterrupts);
+        for (int tick = 0; tick < 3; tick++) {
+            halt.tick();
+        }
+        haltInterrupts.setByte(0xffff, 1);
+        haltInterrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        assertTrue(halt.performanceNativeCgbNormalSpeedEpochEntryEligible());
+        var haltState = halt.captureState();
+        var haltInterruptState = haltInterrupts.captureState();
+        assertEquals("HALT-bug decode must stay on the zero-dot scalar boundary", 0,
+                halt.runNativeCgbNormalSpeedPerformanceEpoch(54));
+        assertDeepEquals("zero-dot HALT CPU", haltState, halt.captureState());
+        assertDeepEquals("zero-dot HALT interrupts", haltInterruptState,
+                haltInterrupts.captureState());
+        assertEquals(0, halt.getRegisters().getPC());
+
+        CountingMemory ioMemory = new CountingMemory();
+        ioMemory.bytes[0] = (byte) 0xf0; // LDH A,(FF44)
+        ioMemory.bytes[1] = 0x44;
+        ioMemory.bytes[0xff44] = 0x66;
+        Cpu io = normalSpeedNativeCpu(ioMemory, pendingVBlank());
+        int elapsed = io.runNativeCgbNormalSpeedPerformanceEpoch(54);
+        assertTrue("safe prefix made no progress", elapsed > 0);
+        assertEquals("epoch crossed the FF44 read", 0, ioMemory.reads[0xff44]);
+        assertEquals(0, io.getRegisters().getA());
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedSafeDecodedStackAndIndirectOpsMatchScalar()
+            throws Exception {
+        String[] labels = {"CALL WRAM", "RET WRAM", "PUSH WRAM", "POP HRAM",
+                "RST WRAM", "CB (HL) HRAM"};
+        int[][] programs = {
+                {0xcd, 0x00, 0x02}, {0xc9}, {0xc5}, {0xc1}, {0xc7}, {0xcb, 0x46}
+        };
+        int[] expectedSp = {0xc0fe, 0xc102, 0xc0fe, 0xff82, 0xc0fe, 0xc100};
+
+        for (int index = 0; index < labels.length; index++) {
+            CpuPair pair = newNativeNormalSpeedPair(programs[index]);
+            pair.direct.getRegisters().setSP(index == 3 ? 0xff80 : 0xc100);
+            pair.scalar.getRegisters().setSP(index == 3 ? 0xff80 : 0xc100);
+            pair.direct.getRegisters().setBC(0x1234);
+            pair.scalar.getRegisters().setBC(0x1234);
+            if (index == 1) {
+                setPairByte(pair, 0xc100, 0x00);
+                setPairByte(pair, 0xc101, 0x02);
+            } else if (index == 3) {
+                setPairByte(pair, 0xff80, 0x34);
+                setPairByte(pair, 0xff81, 0x12);
+            } else if (index == 5) {
+                pair.direct.getRegisters().setHL(0xff80);
+                pair.scalar.getRegisters().setHL(0xff80);
+                setPairByte(pair, 0xff80, 0x01);
+            }
+
+            int elapsed = runNativeNormalSpeedPair(pair, 54);
+
+            assertTrue(labels[index] + " made no epoch progress", elapsed > 0);
+            assertEquals(labels[index] + " SP", expectedSp[index],
+                    pair.direct.getRegisters().getSP());
+            assertEquals(labels[index] + " reached a terminal access", 0L,
+                    pair.direct.getPerformanceEpochTerminalAccesses());
+        }
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedStopsBetweenSafeAndUnsafeStackBytes()
+            throws Exception {
+        CpuPair pair = newNativeNormalSpeedPair(0xc1); // POP BC
+        pair.direct.getRegisters().setSP(0xfffd);
+        pair.scalar.getRegisters().setSP(0xfffd);
+        setPairByte(pair, 0xfffd, 0x34);
+        setPairByte(pair, 0xfffe, 0x12);
+
+        int elapsed = runNativeNormalSpeedPair(pair, 54);
+
+        assertTrue(elapsed > 0);
+        assertEquals("safe low byte was not consumed", 0xfffe,
+                pair.direct.getRegisters().getSP());
+        assertEquals("unsafe FFFE byte was read", 0xfffd,
+                pair.directMemory.lastReadAddress);
+        assertEquals("preview fence delegated an unsafe access", 0L,
+                pair.direct.getPerformanceEpochTerminalAccesses());
+        assertEquals(Cpu.State.RUNNING, pair.direct.getState());
+    }
+
+    @Test
+    public void nativeCgbNormalSpeedLcdOnUnsafePlanesStayBeforeTheBusBoundary()
+            throws Exception {
+        String[] labels = {"VRAM", "OAM", "cartridge RAM", "RTC window", "IO", "IE"};
+        int[] addresses = {0x8000, 0xfe00, 0xa000, 0xa001, 0xff44, 0xffff};
+        for (int index = 0; index < addresses.length; index++) {
+            CpuPair pair = newNativeNormalSpeedPair(0x7e); // LD A,(HL)
+            pair.direct.getRegisters().setHL(addresses[index]);
+            pair.scalar.getRegisters().setHL(addresses[index]);
+            setPairByte(pair, addresses[index], 0x66);
+
+            int elapsed = runNativeNormalSpeedPair(pair, 54);
+
+            assertTrue(labels[index] + " prefix made no progress", elapsed > 0);
+            assertTrue(labels[index] + " crossed the decoded read",
+                    pair.directMemory.lastReadAddress != addresses[index]);
+            assertEquals(labels[index] + " changed A", 0,
+                    pair.direct.getRegisters().getA());
+            assertEquals(labels[index] + " delegated a terminal read", 0L,
+                    pair.direct.getPerformanceEpochTerminalAccesses());
+        }
+
+        CpuPair mapper = newNativeNormalSpeedPair(0xea, 0x00, 0x20); // LD (2000),A
+        mapper.direct.getRegisters().setA(0x02);
+        mapper.scalar.getRegisters().setA(0x02);
+        int elapsed = runNativeNormalSpeedPair(mapper, 54);
+        assertTrue("mapper-control prefix made no progress", elapsed > 0);
+        assertEquals("mapper-control write crossed the decoded fence", 0,
+                mapper.directMemory.writes);
+        assertEquals("mapper-control fence delegated a terminal write", 0L,
+                mapper.direct.getPerformanceEpochTerminalAccesses());
+    }
+
+    @Test
+    public void nativeCgbPhasePacketRejectsAnInterruptMicrostateWithoutAdvancing() {
+        CountingMemory memory = new CountingMemory();
+        InterruptManager interrupts = pendingVBlank();
+        interrupts.enableInterrupts(false);
+        Cpu cpu = normalSpeedNativeCpu(memory, interrupts);
+        for (int tick = 0; tick < 4; tick++) {
+            cpu.tick();
+        }
+        Cpu.State irqState = cpu.getState();
+
+        assertTrue(irqState == Cpu.State.IRQ_WAIT_1 || irqState == Cpu.State.IRQ_WAIT_2
+                || irqState == Cpu.State.IRQ_PUSH_1);
+        assertEquals(3, cpu.performancePhaseOnlySpanLimit());
+        assertFalse(cpu.performancePhaseOnlySpanEligible());
+        assertFalse(cpu.advancePerformancePhaseOnly(3));
+        assertEquals("rejected phase packet changed the IRQ microstate",
+                irqState, cpu.getState());
+        assertEquals("rejected phase packet changed the CPU clock", 0,
+                cpu.getDebugMachineCycle());
+    }
+
+    private static InterruptManager pendingVBlank() {
+        InterruptManager interrupts = new InterruptManager(true);
+        interrupts.setByte(0xffff, 1);
+        interrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
+        return interrupts;
+    }
+
+    private static Cpu normalSpeedNativeCpu(
+            AddressSpace memory, InterruptManager interrupts) {
+        return new Cpu(memory, interrupts, null,
+                new SpeedMode(true), new Display(false));
+    }
+
+    private static CpuPair newNativeNormalSpeedPair(int... program) {
+        ParityMemory directMemory = new ParityMemory();
+        for (int offset = 0; offset < program.length; offset++) {
+            directMemory.bytes[0x0100 + offset] = (byte) program[offset];
+        }
+        ParityMemory scalarMemory = new ParityMemory();
+        System.arraycopy(directMemory.bytes, 0, scalarMemory.bytes, 0,
+                directMemory.bytes.length);
+        InterruptManager directInterrupts = new InterruptManager(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        Cpu direct = normalSpeedNativeCpu(directMemory, directInterrupts);
+        Cpu scalar = normalSpeedNativeCpu(scalarMemory, scalarInterrupts);
+        direct.getRegisters().setPC(0x0100);
+        scalar.restoreState(direct.captureState());
+        scalarInterrupts.restoreState(directInterrupts.captureState());
+        return new CpuPair(direct, scalar, directInterrupts, scalarInterrupts,
+                directMemory, scalarMemory);
+    }
+
+    private static void setPairByte(CpuPair pair, int address, int value) {
+        pair.directMemory.bytes[address & 0xffff] = (byte) value;
+        pair.scalarMemory.bytes[address & 0xffff] = (byte) value;
+    }
+
+    private static int runNativeNormalSpeedPair(CpuPair pair, int budget) throws Exception {
+        int elapsed = pair.direct.runNativeCgbNormalSpeedPerformanceEpoch(budget);
+        for (int tick = 0; tick < elapsed; tick++) {
+            pair.scalar.tick();
+        }
+        assertCpuPairEquals(pair);
+        return elapsed;
+    }
+
+    @Test
     public void directBaseOpcodesMatchScalarPipelineForRandomizedState() throws Exception {
         Random random = new Random(0x5a17a9e1L);
         for (int opcode = 0; opcode < 0x100; opcode++) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -967,6 +967,65 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void trustedNoReadCaptureTracksOrdinaryWakeEdgeExpiryAndRearm()
+            throws Exception {
+        Fixture fixture = new Fixture(true);
+        fixture.advanceTo(1, 3);
+        int ordinary = Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE;
+
+        long firstClock = longField(fixture.stat, "lycIrqClock");
+        fixture.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals(firstClock, longField(fixture.stat, "ordinaryHaltWakeStatClock"));
+
+        for (int tick = 0; tick < 456; tick++) {
+            fixture.tick();
+        }
+        fixture.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("continuous ordinary wake must not rearm at the 456-dot limit",
+                firstClock, longField(fixture.stat, "ordinaryHaltWakeStatClock"));
+        fixture.tick();
+        fixture.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("expired continuous wake must remain anchored to its first edge",
+                firstClock, longField(fixture.stat, "ordinaryHaltWakeStatClock"));
+
+        fixture.stat.capturePerformanceNoCpuReadPhaseTrusted(0);
+        fixture.tick();
+        long rearmClock = longField(fixture.stat, "lycIrqClock");
+        fixture.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("false-to-true ordinary wake must rearm",
+                rearmClock, longField(fixture.stat, "ordinaryHaltWakeStatClock"));
+
+        Fixture restored = new Fixture(true);
+        restored.stat.restoreState(fixture.stat.captureState());
+        assertEquals(fixture.stat.captureState(), restored.stat.captureState());
+    }
+
+    @Test
+    public void trustedNoReadCaptureDoesNotPublishFf41OrFf44ReadApertures() {
+        int ordinary = Cpu.STAT_READ_PHASE_ORDINARY_HALT_WAKE;
+
+        Fixture dot78 = new Fixture(true);
+        dot78.advanceTo(1, 78);
+        dot78.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("no-read dot-78 packet published the old mode-2 mux",
+                Mode.PixelTransfer.ordinal(), dot78.readStatMode());
+
+        Fixture dot454 = new Fixture(true);
+        dot454.stat.setByte(StatRegister.ADDRESS, 0x20);
+        dot454.advanceTo(1, 454);
+        dot454.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("no-read dot-454 packet published the old HBlank mux",
+                Mode.OamSearch.ordinal(), dot454.readStatMode());
+
+        Fixture vblankLy = new Fixture(true);
+        vblankLy.advanceTo(144, 450);
+        assertEquals(144, vblankLy.readLy());
+        vblankLy.stat.capturePerformanceNoCpuReadPhaseTrusted(ordinary);
+        assertEquals("no-read VBlank packet published an FF44 line-edge sample",
+                144, vblankLy.readLy());
+    }
+
+    @Test
     public void cgbFrameStartCpuBusRetainsOamSearchModeAtDot78() {
         Fixture fixture = new Fixture(true);
         fixture.advanceTo(1, 0);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayPerformanceTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/sgb/SgbDisplayPerformanceTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static eu.rekawek.coffeegb.core.sgb.SuperGameboy.SGB_DISPLAY_HEIGHT;
@@ -138,6 +139,62 @@ public class SgbDisplayPerformanceTest {
             assertArrayEquals(first.get(), next.get());
             assertTrue(first.get()[borderIndex] != 0x13572468);
             assertTrue(first.get()[centerIndex] != 0x24681357);
+        } finally {
+            eventBus.close();
+            sgbBus.close();
+        }
+    }
+
+    @Test
+    public void hostSuppressionRetainsBorderUpdatesAndMaskTransitions() throws IOException {
+        EventBusImpl eventBus = new EventBusImpl(null, "sgb-suppression", false);
+        EventBusImpl sgbBus = new EventBusImpl(null, "sgb-suppression-commands", false);
+        SgbDisplay display = new SgbDisplay(testRom(), sgbBus, true, true);
+        display.init(eventBus);
+        AtomicReference<int[]> rendered = new AtomicReference<>();
+        AtomicInteger presentations = new AtomicInteger();
+        eventBus.register(event -> {
+            rendered.set(event.buffer().clone());
+            presentations.incrementAndGet();
+        }, SgbDisplay.SgbFrameReadyEvent.class);
+        int[] dmg = new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT];
+        int[] mask = new int[SGB_DISPLAY_WIDTH * SGB_DISPLAY_HEIGHT];
+        Arrays.fill(mask, 1);
+        try {
+            int[] firstBorder = new int[mask.length];
+            Arrays.fill(firstBorder, 0x001f);
+            eventBus.post(new Background.SgbBackgroundReadyEvent(firstBorder, mask));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals(1, presentations.get());
+            int firstPixel = rendered.get()[0];
+
+            display.requestFrameRenderSuppression(true);
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals(2, presentations.get());
+
+            int[] secondBorder = new int[mask.length];
+            Arrays.fill(secondBorder, 0x7c00);
+            eventBus.post(new Background.SgbBackgroundReadyEvent(secondBorder, mask));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals("derived presentation is omitted, not the committed border update",
+                    2, presentations.get());
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals(3, presentations.get());
+            assertTrue(firstPixel != rendered.get()[0]);
+
+            int[] freezePacket = commandPacket(0x17);
+            freezePacket[1] = 1;
+            sgbBus.post(Commands.toCommand(freezePacket));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals("MASK_EN freeze remains authoritative", 3,
+                    presentations.get());
+
+            int[] cancelPacket = commandPacket(0x17);
+            cancelPacket[1] = 0;
+            sgbBus.post(Commands.toCommand(cancelPacket));
+            eventBus.post(new Display.DmgFrameReadyEvent(dmg));
+            assertEquals("cancel resumes at the next presentation-eligible physical edge", 4,
+                    presentations.get());
         } finally {
             eventBus.close();
             sgbBus.close();

--- a/docs/android-audio.md
+++ b/docs/android-audio.md
@@ -3,31 +3,99 @@
 The Android frontend consumes the portable `StereoPcmConverter` used by the Swing adapter. It
 performs fractional resampling, a two-period box filter, DC blocking, volume, muting, clipping,
 and interleaved little-endian signed 16-bit stereo PCM conversion without Android dependencies.
-The Android adapter constructs that converter with the initialized `AudioTrack` rate.
+The Android adapter constructs that converter with the initialized `AudioTrack` rate. A standard
+native 44.1 or 48 kHz rate is tried first; unusual high native rates remain compatibility
+fallbacks. The converter's fractional phase, PCM sequence, and selected sample rate are not
+stretched, duplicated, or otherwise altered to hide host timing debt.
 
 `AndroidAudioSink` is one producer/one consumer hand-off. Controller audio events run only the
 producer path, which fills one of six preallocated PCM slots. If all available slots are busy, it
 discards the oldest queued slot and increments the overrun counter. The only code that opens,
 plays, pauses, flushes, writes, or releases an `AudioTrack` is the named
-`coffee-gb-android-audio` consumer thread. This keeps UI and emulation ownership separate and
-prevents a slow route from increasing host-audio latency indefinitely.
+`coffee-gb-android-audio` consumer thread, which requests Android's audio thread priority on a
+fail-soft basis. This keeps UI and emulation ownership separate and prevents a slow route from
+increasing host-audio latency indefinitely.
+
+Each fixed source slot is large enough for the maximum LEGACY, SGB, or SGB2 controller packet.
+Hardware-profile cadence changes therefore update the event cadence without rebuilding the queue
+or reopening `AudioTrack`, including when the first SGB packet immediately follows its profile
+event. Each `AudioTrack` has capacity for at least five maximum converted packets at its actual
+sample rate. The frontend asks Android to reduce the effective write reservoir toward that
+five-packet target, although an OEM may retain a larger effective buffer. On Android 12 and newer,
+the streaming start threshold is set to the universal minimum produced by four supported-profile
+packets. Older releases conservatively use the effective reservoir reported by the platform and
+accept an output only when that threshold is reachable with the six fixed source slots.
+
+Initial open, explicit resume after pause/flush, and a legitimate output-route reopen all write at
+least four complete, genuine, ordered PCM packets while stopped and never call `play()` before the
+reported/conservative streaming start threshold is also present. Four packets provide roughly
+65-67 ms, larger than the controller ticker's 50 ms debt ceiling. A pre-Android-12 threshold can
+require part of packet five or six; that exact retained suffix is the first write after playback
+starts, before any newer packet. Short writes are completed in order; a failed stopped output is
+released and retained packets are replayed from their beginning into its replacement before
+playback starts. Positive writes must remain aligned to one 4-byte PCM16 stereo frame, as required
+by `AudioTrack`; a misaligned platform result fails closed into output recovery. No silence packet,
+sample duplication, packet drop, rate change, or time stretch is used to manufacture the
+reservoir.
 
 On visibility or focus loss, the runtime pauses at its controller safe point, clears queued PCM,
 and asks the existing battery-save lifecycle to flush. It never resumes automatically on focus
-gain. A user Resume deliberately resumes the session and audio output. An audio-device callback releases
-and reopens the track on the consumer thread; PCM queued for the old route is cleared. Statistics
+gain. A user Resume deliberately resumes the session and begins a fresh primer. An audio-device
+callback releases and reopens the track on the consumer thread only when its change set contains
+an output sink; queued same-rate PCM is retained in order for the replacement track's primer.
+The producer offer is serialized with a sample-rate-changing queue handoff, so an event racing the
+swap can only enter the replacement queue, never the already-cleared queue. Unrelated
+microphone/input-device callbacks do not disturb playback. Transient play, pause, flush, and write
+exceptions release the unusable track and recover through the same reopen and re-prime path
+instead of terminating the audio worker. Pause/flush requests use a sticky monotonic fence, so even
+an immediate pause then resume during a blocked short write cannot lose the flush or leave a packet
+parked behind an already-playing output. A mute or volume change has its own generation fence: it
+flushes PCM already held under the old policy, rejects any raced stale packet, and primes again
+using only the new policy.
+
+The consumer also treats a rise in `AudioTrack`'s cumulative underrun count as a recovery signal,
+not merely a statistic. Android pauses a starved streaming data path until its start threshold is
+refilled, so the worker keeps writing genuine ordered PCM into the same playing track. It tracks
+every accepted aligned byte, including positive short writes, and extends the unsigned 32-bit
+playback head across wrap within each output epoch. Repeated counter rises coalesce into the same
+refill, but every newer rise establishes a fresh post-counter playback-head baseline and revokes
+the preceding refill and stall proof. Ordinary streaming resumes only after genuine writes rebuild
+the latest missing start-threshold reservoir and the head then advances beyond that latest
+baseline, without another `play()`, or any pause, flush, duplication, drop, or manufactured
+silence.
+
+Refill writes never exceed the track's reported effective capacity, avoiding a blocking write that
+could deadlock behind a frozen output. A capacity-full head that remains frozen for a bounded grace
+period is released and reopened through the normal genuine-primer path. Completed refill packets
+are committed as they enter the playing output, so even an OEM-large effective reservoir does not
+tie up the fixed source slots. A missing, invalid, or
+persistently non-progressing playback head uses the same fail-safe. As with a physical route loss,
+that exceptional replacement can have a discontinuity because the failed output cannot prove what
+reached the speaker. Statistics
 include producer overruns, consumer underruns, and successful output restarts for diagnostics and
 test probes. Closing the session unregisters the route callback and releases the output on that
 same consumer thread.
+
+The benchmark APK has one deliberately narrow exception: its established pre-ARM proof must move
+an empty `AudioTrack` from stopped to playing while the emulated guest remains paused and cannot
+produce PCM. Only that diagnostics-only runtime barrier may request empty playback. Ordinary app
+startup, lifecycle resume, and route recovery cannot use the exception and always require the
+four-packet genuine-PCM primer. Expected underrun-counter movement is ignored only while this empty
+diagnostics play is authorized. The first genuine guest packet revokes the exception through the
+same sticky stop/flush boundary, and playback cannot restart until all four real primer packets are
+present.
 
 No audio permission is needed for playback. The frontend requests neither microphone access nor
 Internet, and no audio payload, ROM path, URI, or persistent game content is logged or exported.
 
 ## Device validation procedure
 
-Automated JVM and Android unit tests prove converter parity, bounded slots, consumer-thread-only
-writes, underrun recovery, route reopen, pause/resume, and release. They do not claim physical
-latency measurements. Before a release, run the following on the current Android emulator and at
+Automated JVM and Android unit tests prove converter parity, maximum-profile bounded slots,
+capacity, threshold-aware primer duration, exact ordered PCM under short and threshold-splitting
+writes, consumer-thread-only writes, exception recovery, route and sample-rate handoff, rapid
+pause/resume/re-prime, playback-head wrap, in-place actual-underrun refill, frozen-output fallback,
+and release. They do not claim physical latency measurements. Before
+a release, run the following on the current Android emulator and at
 least one physical mid-range device, then record the model, Android version, active route/rate,
 and observed overrun/underrun/restart counts in the release or issue evidence:
 


### PR DESCRIPTION
## Summary

- prime and refill Android `AudioTrack` with genuine ordered PCM, preserving sample order across short writes, lifecycle changes, route changes, and real underruns without silence insertion, duplication, resampling, or time stretching
- skip only the derived SGB host composite when presentation falls behind, while retaining every DMG frame used by emulated SGB transfers
- expand conservative native-CGB normal-speed epochs across masked interrupt/ordinary STAT phases and safe ROM/WRAM/HRAM operations, retaining scalar seams for HALT/EI/RETI, mapper/RTC, MMIO, PPU-sensitive accesses, and DMA
- stabilize the benchmark pre-arm pause assertion around an indivisible cold frame

## Device evidence

- Pokémon Crystal, native CGB/PERFORMANCE: **47.861 → 59.7257 FPS** (**+24.8%**), effectively the 59.7275006 Hz hardware cadence and 59.73 FPS rounded
- 48 kHz audio: **0 AudioTrack/AudioFlinger underruns**, stable non-empty reservoir, no route/focus/reopen failures, and no emulation overspeed
- controller CPU: **99.1% → 93.1%** while sustaining real time
- acceptance ran with system media volume fixed at zero/muted; PCM production and playback continuity remained active and measurable

## Validation

- core unit: **1,962 tests**, 0 failures/errors, 8 skipped on the final base
- controller unit: **947 tests**, 0 failures/errors, 2 skipped
- Mooneye + DMG/CGB Acid2 + Blargg: **186/186**
- Android debug and benchmark unit suites: **244/244 each**
- Android debug/benchmark/release lint, debug/release assembly, APK-content verification, and release state-reflection verification
- controlled fixed-RTC host benchmark: **+53.20% CPU throughput**, with exact frame, PCM-event, PCM-sample, and deep-state oracle parity

## Notes

- PERFORMANCE-mode additions remain fail-closed at externally observable timing boundaries.
- New pacing/scheduler bookkeeping is transient; released save-state and memento schemas are unchanged.
