### PR TITLE
Fix Harvest Moon GB local link setup

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -174,6 +174,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final boolean volleyFireLinkRolePatch;
 
+    private final boolean harvestMoonLinkRolePatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -338,6 +340,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.SHIKINJOU_LINK_ROLE_PATCH);
         volleyFireLinkRolePatch = cartridgeProperties.has(
                 CartridgeProperties.Feature.VOLLEY_FIRE_LINK_ROLE_PATCH);
+        harvestMoonLinkRolePatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.HARVEST_MOON_LINK_ROLE_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -671,6 +675,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         if (volleyFireLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
             cartridge.enableVolleyFireSecondaryLinkRole();
+        }
+        if (harvestMoonLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
+            cartridge.enableHarvestMoonSecondaryLinkRole();
         }
         if (jantakuBoyFourPlayerPatch) {
             serialEndpoint.enableCompatibilityProfile(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -40,6 +40,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private boolean volleyFireSecondaryLinkRole;
 
+    private boolean harvestMoonSecondaryLinkRole;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -218,7 +220,21 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
                 return 0x21;
             }
         }
+        if (harvestMoonSecondaryLinkRole && address == 0x6768
+                && isHarvestMoonLinkTimeoutMapped()) {
+            return 0xc9;
+        }
         return addressSpace.getByte(address);
+    }
+
+    private boolean isHarvestMoonLinkTimeoutMapped() {
+        int[] timeoutRoutine = {0x3e, 0xfe, 0xe0, 0x01, 0x3e, 0x81, 0xe0, 0x02, 0xc9};
+        for (int i = 0; i < timeoutRoutine.length; i++) {
+            if (addressSpace.getByte(0x6768 + i) != timeoutRoutine[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public void enableRevengeGatorSecondaryLinkRole() {
@@ -233,12 +249,16 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
         volleyFireSecondaryLinkRole = true;
     }
 
+    public void enableHarvestMoonSecondaryLinkRole() {
+        harvestMoonSecondaryLinkRole = true;
+    }
+
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
         // The role-selecting branch is a CPU-view overlay, not a mutation of the loaded image.
         // Keep execution on the ordinary cartridge read path while that overlay is active.
         if (revengeGatorSecondaryLinkRole || shikinjouSecondaryLinkRole
-                || volleyFireSecondaryLinkRole) {
+                || volleyFireSecondaryLinkRole || harvestMoonSecondaryLinkRole) {
             return null;
         }
         if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -76,7 +76,8 @@ public final class CartridgeProperties {
         JANTAKU_BOY_FOUR_PLAYER_PATCH,
         REVENGE_GATOR_LINK_ROLE_PATCH,
         SHIKINJOU_LINK_ROLE_PATCH,
-        VOLLEY_FIRE_LINK_ROLE_PATCH
+        VOLLEY_FIRE_LINK_ROLE_PATCH,
+        HARVEST_MOON_LINK_ROLE_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -218,6 +219,9 @@ public final class CartridgeProperties {
             features("Volley Fire deterministic link roles",
                     CartridgeProperties::isVolleyFireLinkRole,
                     Feature.VOLLEY_FIRE_LINK_ROLE_PATCH),
+            features("Harvest Moon GB deterministic link roles",
+                    CartridgeProperties::isHarvestMoonLinkRole,
+                    Feature.HARVEST_MOON_LINK_ROLE_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -910,6 +914,28 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x00
                 && info.byteAt(0x0149) == 0x00
                 && matches(info.data, 0x227e, linkRoleNegotiation);
+    }
+
+    private static boolean isHarvestMoonLinkRole(RomInfo info) {
+        int[] linkRoleNegotiation = {
+                0x06, 0x80, 0x21, 0x06, 0xd6, 0x3e, 0x5e, 0xe0,
+                0x01, 0x77, 0x78, 0xe0, 0x02, 0xc9, 0xaf, 0xe0,
+                0x01, 0xea, 0x06, 0xd6, 0xea, 0x01, 0xd6, 0xc9,
+                0x3e, 0xfe, 0xe0, 0x01, 0x3e, 0x81, 0xe0, 0x02,
+                0xc9
+        };
+        return info.data.length == 0x80000
+                && "HARVEST-MOON GB".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x03
+                && info.rawType() == 0x03
+                && info.byteAt(0x0148) == 0x04
+                && info.byteAt(0x0149) == 0x02
+                && matches(info.data, 0x7e750, linkRoleNegotiation);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/HarvestMoonLinkRolePatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/HarvestMoonLinkRolePatchTest.java
@@ -1,0 +1,102 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HarvestMoonLinkRolePatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownLinkNegotiationRoutine() throws IOException {
+        Rom rom = new Rom(harvestMoonRom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.HARVEST_MOON_LINK_ROLE_PATCH));
+
+        byte[] changed = harvestMoonRom();
+        changed[0x7e767] = 0;
+        assertFalse(new Rom(changed).getCartridgeProperties().has(
+                CartridgeProperties.Feature.HARVEST_MOON_LINK_ROLE_PATCH));
+    }
+
+    @Test
+    public void keepsTheSecondLinkedPlayerListeningDuringTheFirstPlayersTimeout()
+            throws IOException {
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy primary = gameboy(harvestMoonRom());
+             Gameboy secondary = gameboy(harvestMoonRom())) {
+            primary.init(EventBus.NULL_EVENT_BUS, first, null);
+            secondary.init(EventBus.NULL_EVENT_BUS, second, null);
+            primary.getAddressSpace().setByte(0x2000, 0x1f);
+            secondary.getAddressSpace().setByte(0x2000, 0x1f);
+
+            assertEquals(0x3e, primary.getAddressSpace().getByte(0x6768));
+            assertEquals(0xc9, secondary.getAddressSpace().getByte(0x6768));
+            assertEquals(0xfe, secondary.getAddressSpace().getByte(0x6769));
+            assertEquals(0xe0, secondary.getAddressSpace().getByte(0x676a));
+
+            secondary.getAddressSpace().setByte(0x2000, 0x02);
+            assertEquals(0x42, secondary.getAddressSpace().getByte(0x6768));
+        }
+    }
+
+    @Test
+    public void leavesAnotherCartridgeUnchangedOnTheSecondEndpoint() throws IOException {
+        byte[] data = harvestMoonRom();
+        data[0x0134] = 'X';
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy gameboy = gameboy(data)) {
+            gameboy.init(EventBus.NULL_EVENT_BUS, second, null);
+            gameboy.getAddressSpace().setByte(0x2000, 0x1f);
+
+            assertEquals(0x3e, gameboy.getAddressSpace().getByte(0x6768));
+        }
+    }
+
+    private static Gameboy gameboy(byte[] data) throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] harvestMoonRom() {
+        byte[] data = new byte[0x80000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "HARVEST-MOON GB".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x03;
+        data[0x0147] = 0x03;
+        data[0x0148] = 0x04;
+        data[0x0149] = 0x02;
+        int[] linkRoleNegotiation = {
+                0x06, 0x80, 0x21, 0x06, 0xd6, 0x3e, 0x5e, 0xe0,
+                0x01, 0x77, 0x78, 0xe0, 0x02, 0xc9, 0xaf, 0xe0,
+                0x01, 0xea, 0x06, 0xd6, 0xea, 0x01, 0xd6, 0xc9,
+                0x3e, 0xfe, 0xe0, 0x01, 0x3e, 0x81, 0xe0, 0x02,
+                0xc9
+        };
+        for (int i = 0; i < linkRoleNegotiation.length; i++) {
+            data[0x7e750 + i] = (byte) linkRoleNegotiation[i];
+        }
+        data[2 * 0x4000 + 0x2768] = 0x42;
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #581

## Summary
- identify the exact Harvest Moon GB link-negotiation routine
- keep the secondary local-link console listening while the primary timeout selects the clocked role
- apply the CPU-view overlay only when the expected banked routine is mapped
- cover exact detection, both link roles, bank scoping, and unrelated cartridges

## Tests
- `/opt/maven/bin/mvn -q -pl core -Dtest=HarvestMoonLinkRolePatchTest test`
- `/opt/maven/bin/mvn -pl core test` (1,967 tests, 0 failures)
- authentic two-console linked replay with the reporter-provided save; both consoles reached the connection screen

## Visual evidence

| Before: identical peers time out | After: player 1 connected | After: player 2 connected |
| --- | --- | --- |
| ![](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f2200_p1-38fcdbd8.png) | ![](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f2050_p1-2d78fa84.png) | ![](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f2050_p2-a1257add.png) |