### PR TITLE
Fix Ikari no Yousai 2 local link setup

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -176,6 +176,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private final boolean harvestMoonLinkRolePatch;
 
+    private final boolean ikariYousai2LinkRolePatch;
+
     private transient EventBus hostEventBus = EventBus.NULL_EVENT_BUS;
 
     private final Joypad joypad;
@@ -342,6 +344,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 CartridgeProperties.Feature.VOLLEY_FIRE_LINK_ROLE_PATCH);
         harvestMoonLinkRolePatch = cartridgeProperties.has(
                 CartridgeProperties.Feature.HARVEST_MOON_LINK_ROLE_PATCH);
+        ikariYousai2LinkRolePatch = cartridgeProperties.has(
+                CartridgeProperties.Feature.IKARI_YOUSAI_2_LINK_ROLE_PATCH);
 
         boolean legacySpeedSwitchRequired = cartridgeProperties.has(
                 CartridgeProperties.Feature.LEGACY_SPEED_SWITCH);
@@ -678,6 +682,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         }
         if (harvestMoonLinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
             cartridge.enableHarvestMoonSecondaryLinkRole();
+        }
+        if (ikariYousai2LinkRolePatch && serialEndpoint.linkPlayerIndex() == 1) {
+            cartridge.enableIkariYousai2SecondaryLinkRole();
         }
         if (jantakuBoyFourPlayerPatch) {
             serialEndpoint.enableCompatibilityProfile(

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -42,6 +42,8 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private boolean harvestMoonSecondaryLinkRole;
 
+    private boolean ikariYousai2SecondaryLinkRole;
+
     public Cartridge(Rom rom, boolean supportBatterySaves) {
         this(rom, supportBatterySaves && canPersist(rom, null)
                         ? createBattery(rom, null) : Battery.NULL_BATTERY,
@@ -224,6 +226,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
                 && isHarvestMoonLinkTimeoutMapped()) {
             return 0xc9;
         }
+        if (ikariYousai2SecondaryLinkRole && (address == 0x08fd || address == 0x08fe)) {
+            return 0x00;
+        }
         return addressSpace.getByte(address);
     }
 
@@ -253,12 +258,17 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
         harvestMoonSecondaryLinkRole = true;
     }
 
+    public void enableIkariYousai2SecondaryLinkRole() {
+        ikariYousai2SecondaryLinkRole = true;
+    }
+
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
         // The role-selecting branch is a CPU-view overlay, not a mutation of the loaded image.
         // Keep execution on the ordinary cartridge read path while that overlay is active.
         if (revengeGatorSecondaryLinkRole || shikinjouSecondaryLinkRole
-                || volleyFireSecondaryLinkRole || harvestMoonSecondaryLinkRole) {
+                || volleyFireSecondaryLinkRole || harvestMoonSecondaryLinkRole
+                || ikariYousai2SecondaryLinkRole) {
             return null;
         }
         if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -77,7 +77,8 @@ public final class CartridgeProperties {
         REVENGE_GATOR_LINK_ROLE_PATCH,
         SHIKINJOU_LINK_ROLE_PATCH,
         VOLLEY_FIRE_LINK_ROLE_PATCH,
-        HARVEST_MOON_LINK_ROLE_PATCH
+        HARVEST_MOON_LINK_ROLE_PATCH,
+        IKARI_YOUSAI_2_LINK_ROLE_PATCH
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -222,6 +223,9 @@ public final class CartridgeProperties {
             features("Harvest Moon GB deterministic link roles",
                     CartridgeProperties::isHarvestMoonLinkRole,
                     Feature.HARVEST_MOON_LINK_ROLE_PATCH),
+            features("Ikari no Yousai 2 deterministic link roles",
+                    CartridgeProperties::isIkariYousai2LinkRole,
+                    Feature.IKARI_YOUSAI_2_LINK_ROLE_PATCH),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -936,6 +940,32 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x04
                 && info.byteAt(0x0149) == 0x02
                 && matches(info.data, 0x7e750, linkRoleNegotiation);
+    }
+
+    private static boolean isIkariYousai2LinkRole(RomInfo info) {
+        int[] linkRoleNegotiation = {
+                0x7e, 0xcb, 0x47, 0x28, 0x08, 0xf0, 0x01, 0xfe,
+                0x25, 0x28, 0x0c, 0x18, 0x13, 0xcb, 0x7f, 0x20,
+                0x0f, 0xf0, 0x01, 0xfe, 0x4a, 0x20, 0x09, 0x7e,
+                0xe6, 0x01, 0xe0, 0xd2, 0xaf, 0xe0, 0x01, 0xc9,
+                0x3e, 0xff, 0xe0, 0xd2, 0xcb, 0xbe, 0xf0, 0xd4,
+                0x3c, 0xe0, 0xd4, 0xe6, 0x03, 0x20, 0x0c, 0xf0,
+                0x04, 0xcb, 0x47, 0x20, 0x06, 0x36, 0x00, 0x3e,
+                0x25, 0x18, 0x04, 0x36, 0x01, 0x3e, 0x4a, 0xe0,
+                0x01, 0xcb, 0xfe, 0xc9
+        };
+        return info.data.length == 0x20000
+                && "FORTIFIED ZONE2".equals(info.title())
+                && info.byteAt(0x0100) == 0x00
+                && info.byteAt(0x0101) == 0xc3
+                && info.byteAt(0x0102) == 0x50
+                && info.byteAt(0x0103) == 0x01
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0146) == 0x00
+                && info.rawType() == 0x01
+                && info.byteAt(0x0148) == 0x02
+                && info.byteAt(0x0149) == 0x00
+                && matches(info.data, 0x08ca, linkRoleNegotiation);
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/IkariYousai2LinkRolePatchTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/IkariYousai2LinkRolePatchTest.java
@@ -1,0 +1,100 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IkariYousai2LinkRolePatchTest {
+
+    @Test
+    public void detectsOnlyTheKnownLinkNegotiationRoutine() throws IOException {
+        Rom rom = new Rom(ikariYousai2Rom());
+
+        assertTrue(rom.getCartridgeProperties().has(
+                CartridgeProperties.Feature.IKARI_YOUSAI_2_LINK_ROLE_PATCH));
+
+        byte[] changed = ikariYousai2Rom();
+        changed[0x08ca] = 0;
+        assertFalse(new Rom(changed).getCartridgeProperties().has(
+                CartridgeProperties.Feature.IKARI_YOUSAI_2_LINK_ROLE_PATCH));
+    }
+
+    @Test
+    public void makesOnlyTheSecondLinkedPlayerUseTheExternalClockRole() throws IOException {
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy primary = gameboy(ikariYousai2Rom());
+             Gameboy secondary = gameboy(ikariYousai2Rom())) {
+            primary.init(EventBus.NULL_EVENT_BUS, first, null);
+            secondary.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x20, primary.getAddressSpace().getByte(0x08fd));
+            assertEquals(0x06, primary.getAddressSpace().getByte(0x08fe));
+            assertEquals(0x00, secondary.getAddressSpace().getByte(0x08fd));
+            assertEquals(0x00, secondary.getAddressSpace().getByte(0x08fe));
+            assertEquals(0xf0, secondary.getAddressSpace().getByte(0x08f9));
+        }
+    }
+
+    @Test
+    public void leavesAnotherCartridgeUnchangedOnTheSecondEndpoint() throws IOException {
+        byte[] data = ikariYousai2Rom();
+        data[0x0134] = 'X';
+        Peer2PeerSerialEndpoint first = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint second = new Peer2PeerSerialEndpoint();
+        first.init(second);
+
+        try (Gameboy gameboy = gameboy(data)) {
+            gameboy.init(EventBus.NULL_EVENT_BUS, second, null);
+
+            assertEquals(0x20, gameboy.getAddressSpace().getByte(0x08fd));
+            assertEquals(0x06, gameboy.getAddressSpace().getByte(0x08fe));
+        }
+    }
+
+    private static Gameboy gameboy(byte[] data) throws IOException {
+        return new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static byte[] ikariYousai2Rom() {
+        byte[] data = new byte[0x20000];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        byte[] title = "FORTIFIED ZONE2".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0146] = 0x00;
+        data[0x0147] = 0x01;
+        data[0x0148] = 0x02;
+        data[0x0149] = 0x00;
+        int[] linkRoleNegotiation = {
+                0x7e, 0xcb, 0x47, 0x28, 0x08, 0xf0, 0x01, 0xfe,
+                0x25, 0x28, 0x0c, 0x18, 0x13, 0xcb, 0x7f, 0x20,
+                0x0f, 0xf0, 0x01, 0xfe, 0x4a, 0x20, 0x09, 0x7e,
+                0xe6, 0x01, 0xe0, 0xd2, 0xaf, 0xe0, 0x01, 0xc9,
+                0x3e, 0xff, 0xe0, 0xd2, 0xcb, 0xbe, 0xf0, 0xd4,
+                0x3c, 0xe0, 0xd4, 0xe6, 0x03, 0x20, 0x0c, 0xf0,
+                0x04, 0xcb, 0x47, 0x20, 0x06, 0x36, 0x00, 0x3e,
+                0x25, 0x18, 0x04, 0x36, 0x01, 0x3e, 0x4a, 0xe0,
+                0x01, 0xcb, 0xfe, 0xc9
+        };
+        for (int i = 0; i < linkRoleNegotiation.length; i++) {
+            data[0x08ca + i] = (byte) linkRoleNegotiation[i];
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #580

## Summary

- detect the exact Ikari no Yousai 2 link routine and apply the secondary-console role only to that cartridge
- leave the primary console on its original internal-clock path while the secondary follows the game's external-clock path
- disable the performance ROM shortcut while the tiny cartridge overlay is active
- cover exact detection, role scoping, and byte-level overlay behavior with regression tests

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=IkariYousai2LinkRolePatchTest test`
- `/opt/maven/bin/mvn -pl core test` — 1,970 tests, 0 failures, 8 skipped
- authentic two-console linked run reaches synchronized gameplay at frame 1700 without modifying either ROM image

## Visual evidence

| Before: setup stalls | After: primary | After: secondary |
| --- | --- | --- |
| ![Before](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f750_p1-e3244308.png) | ![Primary](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f1700_p1-a711912c.png) | ![Secondary](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/link_f1700_p2-07c34c99.png) |
