### PR TITLE
Expose every desktop display scale

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -583,7 +583,7 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 9
+    const val CURRENT_SCHEMA_VERSION = 10
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50
@@ -600,7 +600,7 @@ data class ApplicationSettings(
     const val MAX_CAMERA_DEVICE_INDEX = 15
     const val MIN_EXPLICIT_DISPLAY_SCALE = 1
     const val DEFAULT_EXPLICIT_DISPLAY_SCALE = 2
-    const val MAX_EXPLICIT_DISPLAY_SCALE = 4
+    const val MAX_EXPLICIT_DISPLAY_SCALE = 5
     const val MIN_LETTERBOX_COLOR = 0x000000
     const val DEFAULT_LETTERBOX_COLOR = 0x000000
     const val MAX_LETTERBOX_COLOR = 0xFFFFFF

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -71,6 +71,7 @@ object ApplicationSettingsCodec {
   private val versionEightFixedKeys =
       versionSevenFixedKeys + setOf(DESKTOP_APPEARANCE_KEY, DESKTOP_COMMAND_BAR_VISIBLE_KEY)
   private val versionNineFixedKeys = versionEightFixedKeys + EXECUTION_MODE_KEY
+  private val versionTenFixedKeys = versionNineFixedKeys
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -93,6 +94,7 @@ object ApplicationSettingsCodec {
             version == "6" ||
             version == "7" ||
             version == "8" ||
+            version == "9" ||
             version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
@@ -491,6 +493,7 @@ object ApplicationSettingsCodec {
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
         when {
+          sourceVersion >= 10 -> versionTenFixedKeys
           sourceVersion >= 9 -> versionNineFixedKeys
           sourceVersion >= 8 -> versionEightFixedKeys
           sourceVersion >= 7 -> versionSevenFixedKeys
@@ -973,7 +976,7 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionNineFixedKeys ||
+      key in versionTenFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           isKnownPreviousSaveDirectoryKey(key, supportsPreviousDirectories = true) ||

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDisplayTest.kt
@@ -19,12 +19,12 @@ class ApplicationSettingsDisplayTest {
     assertFalse(defaults.fullscreen)
 
     ApplicationSettings.Display(explicitScale = 1, letterboxColor = 0x000000)
-    ApplicationSettings.Display(explicitScale = 4, letterboxColor = 0xFFFFFF)
+    ApplicationSettings.Display(explicitScale = 5, letterboxColor = 0xFFFFFF)
     ApplicationSettings.DisplayScalingMode.entries.forEach { mode ->
       ApplicationSettings.Display(scalingMode = mode)
     }
 
-    listOf(0, 5).forEach { invalidScale ->
+    listOf(0, 6).forEach { invalidScale ->
       assertFailsWith<IllegalArgumentException> {
         ApplicationSettings.Display(explicitScale = invalidScale)
       }
@@ -165,14 +165,14 @@ class ApplicationSettingsDisplayTest {
   }
 
   @Test
-  fun `schema four rejects noncanonical display values and accepts explicit three times`() {
+  fun `schema four rejects noncanonical display values and accepts every added explicit scale`() {
     val validSchema = mapOf(ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "4")
     val invalid =
         listOf(
             mapOf(ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "aspect_fit"),
             mapOf(ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "FIXED"),
             mapOf("display.scale" to "0"),
-            mapOf("display.scale" to "5"),
+            mapOf("display.scale" to "6"),
             mapOf("display.scale" to "3.0"),
             mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "#123456"),
             mapOf(ApplicationSettingsCodec.DISPLAY_LETTERBOX_COLOR_KEY to "abcdef"),
@@ -187,14 +187,16 @@ class ApplicationSettingsDisplayTest {
       }
     }
 
-    val explicitThree =
-        ApplicationSettingsCodec.decode(
-            validSchema +
-                mapOf(
-                    ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "EXPLICIT",
-                    "display.scale" to "3",
-                ))
-    assertEquals(3, explicitThree.settings.display.explicitScale)
+    listOf(3, 5).forEach { scale ->
+      val decoded =
+          ApplicationSettingsCodec.decode(
+              validSchema +
+                  mapOf(
+                      ApplicationSettingsCodec.DISPLAY_SCALING_MODE_KEY to "EXPLICIT",
+                      "display.scale" to scale.toString(),
+                  ))
+      assertEquals(scale, decoded.settings.display.explicitScale)
+    }
   }
 
   private fun serializeCollisions(values: Map<String, String>): String =

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -50,12 +50,12 @@ so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `8` |
+| `settings.schemaVersion` | exact supported schema version | `10` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
 | `display.scalingMode` | `INTEGER_FIT`, `ASPECT_FIT`, or `EXPLICIT` | `EXPLICIT` |
-| `display.scale` | explicit integer scale in `1..4` | `2` |
+| `display.scale` | explicit integer scale in `1..5` | `2` |
 | `display.letterboxColor` | six uppercase RGB hexadecimal digits | `000000` |
 | `display.fullscreen` | boolean | `false` |
 | `display.rotation` | `0`, `90`, `180`, or `270` degrees | `0` |
@@ -167,11 +167,11 @@ geometry; an enabled SGB border uses its native 256×224 geometry. Rotation is i
 viewport fitting, and both axes always use the same scale.
 
 The renderer always uses the largest uniform scale that fits the available component, so resizing
-never crops the image or distorts its aspect ratio. The 1×, 2×, and 4× commands are convenient
+never crops the image or distorts its aspect ratio. The 1× through 5× commands are convenient
 window-size commands: choosing one repacks the window to that native-size multiple while windowed.
 Afterward the window remains freely resizable and the renderer continues to fit its complete frame.
-Persisted 3×, integer-fit, and aspect-fit settings remain readable for compatibility, use the same
-always-fit renderer immediately, and normalize to the nearest exposed window size when edited.
+Persisted integer-fit and aspect-fit settings remain readable for compatibility and use the same
+always-fit renderer immediately.
 
 Unused space is letterboxed or pillarboxed with the configured RGB color. The viewport uses
 half-open geometry and conservative paint bounds, so odd device-pixel margins put the extra pixel

--- a/docs/native-release-checklist.md
+++ b/docs/native-release-checklist.md
@@ -56,7 +56,7 @@ has a named tester, target/architecture, date, and result. A tag push alone must
   hot-plug, and neutral release; on macOS also record whether compatible system SDL2 is installed.
 - [ ] Confirm audio starts, mute/volume/device selection work, and quit releases the audio device.
 - [ ] Enter and leave fullscreen with both F11 and Escape, resize the window, and verify complete
-  aspect-preserving fit plus the 1×/2×/4× window-size commands on the attached display.
+  aspect-preserving fit plus the 1× through 5× window-size commands on the attached display.
 - [ ] Create battery-backed progress, quit, relaunch, and confirm it persisted. Repeat package
   upgrade/reinstall without losing it.
 - [ ] Save and load a state, verify the thumbnail/metadata where available, and confirm a wrong-ROM

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDisplayController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopDisplayController.kt
@@ -183,4 +183,4 @@ internal fun ApplicationSettings.Display.toRuntimeScaleMode(): DisplayScaleMode 
           DisplayScaleMode.explicit(explicitScale)
     }
 
-private val EXPOSED_WINDOW_SCALES = setOf(1, 2, 4)
+private val EXPOSED_WINDOW_SCALES = (1..5).toSet()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditor.kt
@@ -51,7 +51,7 @@ internal class DisplayPreferencesEditor private constructor(
         selectedItem = scaleOption(initial.explicitScale)
         getAccessibleContext().accessibleName = "Window scale"
         getAccessibleContext().accessibleDescription =
-            "Resize the window to one, two, or four times. The picture still fits the window when resized."
+            "Resize the window from one to five times. The picture still fits the window when resized."
       }
   internal var windowScaleCommandRequested = false
     private set
@@ -262,7 +262,7 @@ internal class DisplayPreferencesEditor private constructor(
 
   private companion object {
     const val COLOR_ERROR = "Enter a color in #RRGGBB form."
-    val SCALES = listOf(1, 2, 4).map(::ScaleOption)
+    val SCALES = (1..5).map(::ScaleOption)
     val ROTATIONS = ApplicationSettings.Rotation.entries.map(::RotationOption)
 
     fun scaleOption(scale: Int): ScaleOption =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -864,7 +864,7 @@ internal fun createScreenMenu(
   val scale = JMenu("Scale")
   screenMenu.add(scale)
   val scaleGroup = ButtonGroup()
-  val supportedScales = listOf(1, 2, 4)
+  val supportedScales = (1..5).toList()
   val initialScale = supportedScales.minBy { kotlin.math.abs(it - initial.explicitScale) }
   val scaleItems = mutableMapOf<Int, JRadioButtonMenuItem>()
 

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayScaleMode.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DisplayScaleMode.java
@@ -17,7 +17,9 @@ public enum DisplayScaleMode {
 
     EXPLICIT_3X(3),
 
-    EXPLICIT_4X(4);
+    EXPLICIT_4X(4),
+
+    EXPLICIT_5X(5);
 
     private final int explicitScale;
 
@@ -42,8 +44,9 @@ public enum DisplayScaleMode {
             case 2 -> EXPLICIT_2X;
             case 3 -> EXPLICIT_3X;
             case 4 -> EXPLICIT_4X;
+            case 5 -> EXPLICIT_5X;
             default -> throw new IllegalArgumentException(
-                    "Explicit display scale must be between 1 and 4");
+                    "Explicit display scale must be between 1 and 5");
         };
     }
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DisplayPreferencesEditorTest.kt
@@ -59,26 +59,24 @@ class DisplayPreferencesEditorTest {
         assertTrue(editor.explicitScale.isEnabled)
         assertFalse(editor.windowScaleCommandRequested)
         assertEquals(
-            listOf(1, 2, 4),
+            (1..5).toList(),
             (0 until editor.explicitScale.itemCount)
                 .map(editor.explicitScale::getItemAt)
                 .map { it.scale },
         )
-        // A legacy 3x value is presented as the nearest available command but remains untouched
-        // until that command is actually selected.
         assertEquals(
-            2,
+            3,
             (editor.explicitScale.selectedItem as DisplayPreferencesEditor.ScaleOption).scale,
         )
         assertEquals(initial, editor.validatedDisplay())
 
-        selectScale(editor, 4)
+        selectScale(editor, 5)
         assertTrue(editor.windowScaleCommandRequested)
         assertEquals(
             ApplicationSettings.DisplayScalingMode.EXPLICIT,
             editor.validatedDisplay().scalingMode,
         )
-        assertEquals(4, editor.validatedDisplay().explicitScale)
+        assertEquals(5, editor.validatedDisplay().explicitScale)
       }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -263,11 +263,11 @@ class PreferencesDialogTest {
   fun `choosing a display scale propagates one window-size command through the edit`() =
       onEdt {
         val panel = PreferencesPanel(ApplicationSettings())
-        panel.displayEditor.explicitScale.selectedIndex = 2
+        panel.displayEditor.explicitScale.selectedIndex = 4
 
         val edit = panel.validatedEdit()
 
-        assertEquals(4, edit.display.explicitScale)
+        assertEquals(5, edit.display.explicitScale)
         assertTrue(edit.forceWindowSize)
       }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/ScreenMenuTest.kt
@@ -85,7 +85,7 @@ class ScreenMenuTest {
             val scaleItems = scale.items()
             val rotateItems = rotate.items()
             assertEquals(
-                listOf("1x", "2x", "4x"),
+                listOf("1x", "2x", "3x", "4x", "5x"),
                 scaleItems.map { it.text },
             )
             assertTrue(scaleItems.all { it is JRadioButtonMenuItem })

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DisplayViewportTest.java
@@ -126,7 +126,8 @@ public class DisplayViewportTest {
                 DisplayScaleMode.EXPLICIT_1X,
                 DisplayScaleMode.EXPLICIT_2X,
                 DisplayScaleMode.EXPLICIT_3X,
-                DisplayScaleMode.EXPLICIT_4X
+                DisplayScaleMode.EXPLICIT_4X,
+                DisplayScaleMode.EXPLICIT_5X
         };
         for (DisplayScaleMode mode : modes) {
             DisplayViewport viewport = DisplayViewport.calculate(
@@ -199,8 +200,9 @@ public class DisplayViewportTest {
         assertEquals(DisplayScaleMode.EXPLICIT_2X, DisplayScaleMode.explicit(2));
         assertEquals(DisplayScaleMode.EXPLICIT_3X, DisplayScaleMode.explicit(3));
         assertEquals(DisplayScaleMode.EXPLICIT_4X, DisplayScaleMode.explicit(4));
+        assertEquals(DisplayScaleMode.EXPLICIT_5X, DisplayScaleMode.explicit(5));
         assertThrows(IllegalArgumentException.class, () -> DisplayScaleMode.explicit(0));
-        assertThrows(IllegalArgumentException.class, () -> DisplayScaleMode.explicit(5));
+        assertThrows(IllegalArgumentException.class, () -> DisplayScaleMode.explicit(6));
     }
 
     private static void assertUniformTransform(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingDisplayTest.java
@@ -503,6 +503,26 @@ public class SwingDisplayTest {
     }
 
     @Test
+    public void explicitWindowSizeCommandPublishesASmallerPreferredSize() throws Exception {
+        EventBusImpl eventBus = new EventBusImpl(null, "test", false);
+        SwingDisplay display = newDisplay(eventBus);
+        AtomicReference<Dimension> latestSize = new AtomicReference<>();
+        eventBus.register(event -> latestSize.set(event.preferredSize()),
+                SwingDisplay.DisplaySizeUpdatedEvent.class);
+
+        eventBus.post(new SwingDisplay.SetScaleModeEvent(DisplayScaleMode.EXPLICIT_4X, true));
+        flushEdt();
+        assertEquals(new Dimension(640, 576), latestSize.get());
+        assertEquals(new Dimension(640, 576), onEdt(display::getPreferredSize));
+
+        eventBus.post(new SwingDisplay.SetScaleModeEvent(DisplayScaleMode.EXPLICIT_2X, true));
+        flushEdt();
+        assertEquals(new Dimension(320, 288), latestSize.get());
+        assertEquals(new Dimension(320, 288), onEdt(display::getPreferredSize));
+        eventBus.close();
+    }
+
+    @Test
     public void displaySizeEventDefensivelyCopiesItsDimension() {
         Dimension original = new Dimension(320, 288);
         SwingDisplay.DisplaySizeUpdatedEvent event =


### PR DESCRIPTION
Fixes #583

## Summary

- expose every integer desktop window-size command from 1× through 5× in both the Screen menu and Preferences
- add the 5× runtime scale mode and extend validated/persisted display settings to the same range
- keep smaller scale commands effective after a larger choice, with a regression test covering the 4× → 2× preferred-size transition
- advance the desktop settings schema and update the settings and native-release documentation

## Verification

- `/opt/maven/bin/mvn -pl controller,swing -am -Dtest=ApplicationSettingsDisplayTest,DisplayPreferencesEditorTest,SwingDisplayTest,PreferencesDialogTest -Dsurefire.failIfNoSpecifiedTests=false test` — 62 tests, 0 failures
- `/opt/maven/bin/mvn -pl controller,swing -am test` — core 1,970; portable UI 106; controller 949; Swing 800 tests, 0 failures

## Visual evidence

![Display preferences expose 1× through 5×](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/display-scales-81300293.png)
