### PR TITLE
Add separate desktop autofire controls

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -218,8 +218,12 @@ data class ApplicationSettings(
       keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey>,
       gamepads: Map<Int, GamepadSelection>,
       gamepadTunings: Map<String, GamepadTuning> = emptyMap(),
+      autofireKeyboard: Map<ControllerProperties.PlayerAutofireButton, KeyboardKey> = emptyMap(),
   ) {
     val keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey> = immutableMapCopy(keyboard)
+
+    val autofireKeyboard: Map<ControllerProperties.PlayerAutofireButton, KeyboardKey> =
+        immutableMapCopy(autofireKeyboard)
 
     val gamepads: Map<Int, GamepadSelection> = immutableMapCopy(gamepads)
 
@@ -237,6 +241,12 @@ data class ApplicationSettings(
             "Disabled P2 through P4 gamepad selections must be omitted"
           }
       keyboard.keys.forEach { require(it.player in 0..3) }
+      autofireKeyboard.keys.forEach {
+        require(it.player in 0..3)
+        require(it.button == Button.A || it.button == Button.B) {
+          "Autofire keyboard bindings are supported only for A and B"
+        }
+      }
       require(this.gamepadTunings.size <= MAX_GAMEPAD_TUNINGS) {
         "At most $MAX_GAMEPAD_TUNINGS gamepad tuning profiles may be stored"
       }
@@ -261,6 +271,27 @@ data class ApplicationSettings(
             }
           }
 
+      val autofireByKey =
+          linkedMapOf<KeyboardKey, ControllerProperties.PlayerAutofireButton>()
+      autofireKeyboard.entries
+          .sortedWith(
+              compareBy<Map.Entry<ControllerProperties.PlayerAutofireButton, KeyboardKey>>(
+                  { it.key.player }, { it.key.button.ordinal }))
+          .forEach { (binding, key) ->
+            val regular = byKey[key]
+            require(regular == null) {
+              "Key ${key.propertyName} is assigned to both " +
+                  "P${regular!!.player + 1} ${regular.button} and " +
+                  "P${binding.player + 1} ${binding.button} autofire"
+            }
+            val previous = autofireByKey.put(key, binding)
+            require(previous == null) {
+              "Key ${key.propertyName} is assigned to both " +
+                  "P${previous!!.player + 1} ${previous.button} autofire and " +
+                  "P${binding.player + 1} ${binding.button} autofire"
+            }
+          }
+
       val assignments =
           gamepads.entries
               .mapNotNull { (player, selection) ->
@@ -278,27 +309,34 @@ data class ApplicationSettings(
       require(duplicate == null) {
         "Gamepad selector ${duplicate!!.key} is assigned to multiple logical players"
       }
-      return ControllerProperties.PlayerMapping(byKey.toMap(), assignments)
+      return ControllerProperties.PlayerMapping(
+          byKey.toMap(), assignments, autofireByKey.toMap())
     }
 
     fun copy(
         keyboard: Map<ControllerProperties.PlayerButton, KeyboardKey> = this.keyboard,
         gamepads: Map<Int, GamepadSelection> = this.gamepads,
         gamepadTunings: Map<String, GamepadTuning> = this.gamepadTunings,
-    ): Input = Input(keyboard, gamepads, gamepadTunings)
+        autofireKeyboard: Map<ControllerProperties.PlayerAutofireButton, KeyboardKey> =
+            this.autofireKeyboard,
+    ): Input = Input(keyboard, gamepads, gamepadTunings, autofireKeyboard)
 
     override fun equals(other: Any?): Boolean =
         this === other ||
             (other is Input &&
                 keyboard == other.keyboard &&
+                autofireKeyboard == other.autofireKeyboard &&
                 gamepads == other.gamepads &&
                 gamepadTunings == other.gamepadTunings)
 
     override fun hashCode(): Int =
-        31 * (31 * keyboard.hashCode() + gamepads.hashCode()) + gamepadTunings.hashCode()
+        31 *
+            (31 * (31 * keyboard.hashCode() + autofireKeyboard.hashCode()) +
+                gamepads.hashCode()) + gamepadTunings.hashCode()
 
     override fun toString(): String =
-        "Input(keyboard=$keyboard, gamepads=$gamepads, gamepadTunings=$gamepadTunings)"
+        "Input(keyboard=$keyboard, autofireKeyboard=$autofireKeyboard, " +
+            "gamepads=$gamepads, gamepadTunings=$gamepadTunings)"
 
     companion object {
       fun defaults(): Input {
@@ -583,7 +621,7 @@ data class ApplicationSettings(
   }
 
   companion object {
-    const val CURRENT_SCHEMA_VERSION = 10
+    const val CURRENT_SCHEMA_VERSION = 11
     const val MIN_RECENT_FILE_CAPACITY = 0
     const val DEFAULT_RECENT_FILE_CAPACITY = 10
     const val MAX_RECENT_FILE_CAPACITY = 50

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsCodec.kt
@@ -72,6 +72,7 @@ object ApplicationSettingsCodec {
       versionSevenFixedKeys + setOf(DESKTOP_APPEARANCE_KEY, DESKTOP_COMMAND_BAR_VISIBLE_KEY)
   private val versionNineFixedKeys = versionEightFixedKeys + EXECUTION_MODE_KEY
   private val versionTenFixedKeys = versionNineFixedKeys
+  private val versionElevenFixedKeys = versionTenFixedKeys
 
   fun decode(raw: Map<String, String>): ApplicationSettingsDocument {
     validateStringEntries(raw)
@@ -95,6 +96,7 @@ object ApplicationSettingsCodec {
             version == "7" ||
             version == "8" ||
             version == "9" ||
+            version == "10" ||
             version == SUPPORTED_SCHEMA_VERSION) {
       "Unsupported settings schema $version"
     }
@@ -493,6 +495,7 @@ object ApplicationSettingsCodec {
         if (sourceVersion >= 2) decodeUnknownCollisions(raw) else emptyMap()
     val knownFixedKeys =
         when {
+          sourceVersion >= 11 -> versionElevenFixedKeys
           sourceVersion >= 10 -> versionTenFixedKeys
           sourceVersion >= 9 -> versionNineFixedKeys
           sourceVersion >= 8 -> versionEightFixedKeys
@@ -922,6 +925,13 @@ object ApplicationSettingsCodec {
               "input.p${binding.player + 1}.btn_${binding.button.name.lowercase(Locale.ROOT)}"] =
               key.propertyName
         }
+    input.autofireKeyboard.entries
+        .sortedWith(compareBy({ it.key.player }, { it.key.button.ordinal }))
+        .forEach { (binding, key) ->
+          target[
+              "input.p${binding.player + 1}.autofire_${binding.button.name.lowercase(Locale.ROOT)}"] =
+              key.propertyName
+        }
     input.gamepads.toSortedMap().forEach { (player, selection) ->
       val value =
           when (selection) {
@@ -976,7 +986,7 @@ object ApplicationSettingsCodec {
   }
 
   private fun isReservedCurrentKey(key: String): Boolean =
-      key in versionTenFixedKeys ||
+      key in versionElevenFixedKeys ||
           key.startsWith(PRESERVED_UNKNOWN_COLLISIONS_PREFIX) ||
           isKnownRecentKey(key, supportsCanonicalRecentKeys = true) ||
           isKnownPreviousSaveDirectoryKey(key, supportsPreviousDirectories = true) ||

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ControllerProperties.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ControllerProperties.kt
@@ -8,6 +8,7 @@ import java.util.Properties
 /** Strict, backward-compatible desktop input property parser. */
 object ControllerProperties {
   private val playerButton = Regex("input\\.p(\\d+)\\.btn_([a-zA-Z_]+)")
+  private val playerAutofireButton = Regex("input\\.p(\\d+)\\.autofire_([a-zA-Z_]+)")
   private val playerGamepad = Regex("input\\.p(\\d+)\\.gamepad")
   private val stableGamepadId = Regex("sdl-[0-9a-f]{64}")
 
@@ -16,6 +17,15 @@ object ControllerProperties {
   data class PlayerButton(val player: Int, val button: Button) {
     init {
       require(player in 0..3) { "Logical player index must be in 0..3" }
+    }
+  }
+
+  data class PlayerAutofireButton(val player: Int, val button: Button) {
+    init {
+      require(player in 0..3) { "Logical player index must be in 0..3" }
+      require(button == Button.A || button == Button.B) {
+        "Autofire is supported only for A and B"
+      }
     }
   }
 
@@ -35,7 +45,13 @@ object ControllerProperties {
   data class PlayerMapping(
       val keyboard: Map<ApplicationSettings.KeyboardKey, PlayerButton>,
       val gamepads: List<GamepadAssignment>,
+      val autofireKeyboard: Map<ApplicationSettings.KeyboardKey, PlayerAutofireButton> = emptyMap(),
   ) {
+    constructor(
+        keyboard: Map<ApplicationSettings.KeyboardKey, PlayerButton>,
+        gamepads: List<GamepadAssignment>,
+    ) : this(keyboard, gamepads, emptyMap())
+
     /** Historical P1 view retained for source compatibility with existing callers. */
     fun legacyPrimaryKeyboard(): Map<ApplicationSettings.KeyboardKey, Button> =
         keyboard.filterValues { it.player == 0 }.mapValues { it.value.button }
@@ -48,6 +64,8 @@ object ControllerProperties {
       legacyDefaults: Boolean = true,
   ): ApplicationSettings.Input {
     val perPlayer =
+        List(4) { EnumMap<Button, ApplicationSettings.KeyboardKey>(Button::class.java) }
+    val perPlayerAutofire =
         List(4) { EnumMap<Button, ApplicationSettings.KeyboardKey>(Button::class.java) }
     if (legacyDefaults) {
       ApplicationSettings.Input.defaultPrimaryKeyboard().forEach { (button, key) ->
@@ -82,6 +100,15 @@ object ControllerProperties {
           }
           require(explicitPlayer.add(player to button)) { "Duplicate mapping property $key" }
           perPlayer[player][button] = parseKey(value, key)
+        }
+        playerAutofireButton.matches(key) -> {
+          val match = checkNotNull(playerAutofireButton.matchEntire(key))
+          val player = parsePlayer(match.groupValues[1], key)
+          val button = parseButton(match.groupValues[2], key)
+          require(button == Button.A || button == Button.B) {
+            "$key autofire button must be A or B"
+          }
+          perPlayerAutofire[player][button] = parseKey(value, key)
         }
         playerGamepad.matches(key) -> {
           val match = checkNotNull(playerGamepad.matchEntire(key))
@@ -120,7 +147,25 @@ object ControllerProperties {
       }
     }
 
-    return ApplicationSettings.Input(keyboard.toMap(), gamepads.toMap()).also { it.toPlayerMapping() }
+    val autofireKeyboard = linkedMapOf<PlayerAutofireButton, ApplicationSettings.KeyboardKey>()
+    perPlayerAutofire.forEachIndexed { player, bindings ->
+      bindings.forEach { (button, key) ->
+        val binding = PlayerAutofireButton(player, button)
+        val previous = usedKeys.put(key, PlayerButton(player, button))
+        require(previous == null) {
+          "Key ${key.propertyName} is assigned to both P${previous!!.player + 1} " +
+              "${previous.button} and P${player + 1} $button autofire"
+        }
+        autofireKeyboard[binding] = key
+      }
+    }
+
+    return ApplicationSettings.Input(
+            keyboard.toMap(),
+            gamepads.toMap(),
+            autofireKeyboard = autofireKeyboard.toMap(),
+        )
+        .also { it.toPlayerMapping() }
   }
 
   fun getControllerMapping(properties: Properties): Map<ApplicationSettings.KeyboardKey, Button> =

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsDevicesTest.kt
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.controller.properties
 
+import eu.rekawek.coffeegb.core.joypad.Button
 import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -8,6 +9,55 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 class ApplicationSettingsDevicesTest {
+
+  @Test
+  fun `schema ten migrates with no autofire bindings`() {
+    val decoded =
+        ApplicationSettingsCodec.decode(
+            mapOf(ApplicationSettingsCodec.SCHEMA_VERSION_KEY to "10"))
+
+    assertTrue(decoded.settings.input.autofireKeyboard.isEmpty())
+    assertEquals(
+        ApplicationSettings.CURRENT_SCHEMA_VERSION.toString(),
+        ApplicationSettingsCodec.encode(decoded)[ApplicationSettingsCodec.SCHEMA_VERSION_KEY],
+    )
+  }
+
+  @Test
+  fun `separate keyboard autofire bindings round trip and remain immutable`() {
+    val autofire =
+        linkedMapOf(
+            ControllerProperties.PlayerAutofireButton(0, Button.A) to
+                ApplicationSettings.KeyboardKey.parse("VK_C", "test"),
+            ControllerProperties.PlayerAutofireButton(3, Button.B) to
+                ApplicationSettings.KeyboardKey.parse("VK_V", "test"),
+        )
+    val input = ApplicationSettings.Input.defaults().copy(autofireKeyboard = autofire)
+    autofire.clear()
+    val document = ApplicationSettingsDocument(ApplicationSettings(input = input))
+
+    val encoded = ApplicationSettingsCodec.encode(document)
+    assertEquals("VK_C", encoded["input.p1.autofire_a"])
+    assertEquals("VK_V", encoded["input.p4.autofire_b"])
+    val decoded = ApplicationSettingsCodec.decode(encoded)
+    assertEquals(document, decoded)
+    assertEquals(encoded, ApplicationSettingsCodec.encode(decoded))
+    assertFailsWith<UnsupportedOperationException> {
+      @Suppress("UNCHECKED_CAST")
+      (decoded.settings.input.autofireKeyboard as MutableMap<Any?, Any?>).clear()
+    }
+
+    assertFailsWith<IllegalArgumentException> {
+      ApplicationSettingsCodec.decode(
+          mapOf(
+              ApplicationSettingsCodec.SCHEMA_VERSION_KEY to
+                  ApplicationSettings.CURRENT_SCHEMA_VERSION.toString(),
+              "input.p1.btn_a" to "VK_C",
+              "input.p1.autofire_a" to "VK_C",
+              "input.p1.gamepad" to "auto",
+          ))
+    }
+  }
 
   @Test
   fun `audio and gamepad tuning models enforce explicit defaults and bounds`() {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ControllerPropertiesTest.kt
@@ -21,6 +21,25 @@ import org.junit.Test
 class ControllerPropertiesTest {
 
   @Test
+  fun `separate A and B autofire keyboard bindings are accepted`() {
+    val input =
+        ControllerProperties.getInputSettings(
+            Properties().apply {
+              setProperty("input.p1.autofire_a", "VK_C")
+              setProperty("input.p2.autofire_b", "VK_V")
+            })
+
+    assertEquals(
+        key("VK_C"),
+        input.autofireKeyboard[ControllerProperties.PlayerAutofireButton(0, Button.A)],
+    )
+    assertEquals(
+        ControllerProperties.PlayerAutofireButton(1, Button.B),
+        input.toPlayerMapping().autofireKeyboard[key("VK_V")],
+    )
+  }
+
+  @Test
   fun defaultsPreserveLegacyPrimaryKeyboardAndOneAutomaticGamepad() {
     val mapping = ControllerProperties.getPlayerMapping(Properties())
 
@@ -33,6 +52,7 @@ class ControllerPropertiesTest {
         listOf(ControllerProperties.GamepadAssignment(0, "auto")),
         mapping.gamepads,
     )
+    assertTrue(mapping.autofireKeyboard.isEmpty())
     assertEquals(Button.B, mapping.legacyPrimaryKeyboard()[key("VK_X")])
   }
 
@@ -66,6 +86,8 @@ class ControllerPropertiesTest {
             "input.p5.btn_a" to "VK_Q",
             "input.p2.btn_fire" to "VK_Q",
             "input.p2.btn_a" to "NOT_A_KEY",
+            "input.p1.autofire_start" to "VK_C",
+            "input.p5.autofire_a" to "VK_C",
             "input.p2.unknown" to "VK_Q",
             "input.p2.gamepad" to "controller-zero",
         )
@@ -84,6 +106,17 @@ class ControllerPropertiesTest {
           Properties().apply {
             setProperty("input.p1.btn_a", "VK_SEPARATOR")
             setProperty("input.p2.btn_a", "VK_SEPARATER")
+          })
+    }
+    assertFailsWith<IllegalArgumentException>("regular/autofire duplicate") {
+      ControllerProperties.getPlayerMapping(
+          Properties().apply { setProperty("input.p2.autofire_a", "VK_Z") })
+    }
+    assertFailsWith<IllegalArgumentException>("autofire duplicate") {
+      ControllerProperties.getPlayerMapping(
+          Properties().apply {
+            setProperty("input.p2.autofire_a", "VK_C")
+            setProperty("input.p3.autofire_b", "VK_C")
           })
     }
     assertFailsWith<IllegalArgumentException>("legacy/new duplicate") {

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -50,7 +50,7 @@ so the portable JAR remains compatible during the migration window.
 
 | Key | Typed value | Built-in default |
 | --- | --- | --- |
-| `settings.schemaVersion` | exact supported schema version | `10` |
+| `settings.schemaVersion` | exact supported schema version | `11` |
 | `system.dmgGames` | explicit stable profile or absent/Auto | Auto (`sgb`) |
 | `system.cgbGames` | explicit stable profile or absent/Auto | Auto (`cgb`) |
 | `system.bootstrapMode` | `SKIP`, `FAST_FORWARD`, or `NORMAL` | `SKIP` |
@@ -87,6 +87,7 @@ so the portable JAR remains compatible during the migration window.
 | `datel.slot.rom` | optional local path | absent |
 | `fullchanger.character` | optional stable menu value | absent |
 | `btn_*`, `input.pN.btn_*` | validated keyboard binding | documented P1 defaults |
+| `input.pN.autofire_a`, `input.pN.autofire_b` | separate validated A/B autofire keyboard binding | unbound |
 | `input.pN.gamepad` | disabled, automatic, or stable SDL device ID | P1 automatic |
 | `input.gamepad.<stable-id>.movementDeadZone` | raw SDL threshold in `0..32766` | `16384` |
 | `input.gamepad.<stable-id>.tiltDeadZone` | raw SDL threshold in `0..32766` | `4096` |
@@ -125,9 +126,11 @@ bootstrap choices; General owns ROM-opening policy, appearance, and command-bar 
 owns sizing, letterboxing, fullscreen, rotation, color, blending, and the Super Game Boy border.
 
 Controls combines keyboard and gamepad subpages for a selected player. Keyboard presents all eight
-buttons like a Game Boy pad; choose **Capture** and press a key, including Enter or Escape. Tab
-remains reserved for focus navigation and Backspace for Rewind. Assigning an occupied key swaps the
-two bindings, or moves it when the destination was unassigned. Gamepad lists up to four logical
+buttons like a Game Boy pad plus separate A and B Autofire controls; choose **Capture** and press a
+key, including Enter or Escape. Tab remains reserved for focus navigation and Backspace for Rewind.
+Assigning an occupied key swaps the two bindings, or moves it when the destination was unassigned.
+Held autofire inputs pulse for two frames down and two frames up, approximately 15 presses per
+second. Gamepad L1 drives A Autofire and R1 drives B Autofire. Gamepad lists up to four logical
 assignments without calling SDL on the EDT, keeps an unavailable configured controller visible,
 prevents duplicate explicit or automatic assignments, and exposes independent movement/tilt dead
 zones and X/Y inversion for each stable device. A mapping change releases held input and waits for

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyAdapter.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopKeyboardKeyAdapter.java
@@ -81,6 +81,23 @@ public final class DesktopKeyboardKeyAdapter {
         return resolved;
     }
 
+    /** Converts portable A/B autofire bindings just before Swing receives host key events. */
+    public static Map<Integer, ControllerProperties.PlayerAutofireButton> resolveAutofireMapping(
+            Map<ApplicationSettings.KeyboardKey,
+                    ControllerProperties.PlayerAutofireButton> mapping) {
+        Map<Integer, ControllerProperties.PlayerAutofireButton> resolved = new LinkedHashMap<>();
+        mapping.forEach((key, binding) -> {
+            int keyCode = keyCode(key);
+            ControllerProperties.PlayerAutofireButton previous = resolved.put(keyCode, binding);
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "Desktop key " + KeyEvent.getKeyText(keyCode)
+                                + " has multiple autofire assignments");
+            }
+        });
+        return resolved;
+    }
+
     private static int getInt(Field field) {
         try {
             return field.getInt(null);

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditor.kt
@@ -40,13 +40,22 @@ class KeyboardMappingEditor private constructor(
       defaultInput: ApplicationSettings.Input = ApplicationSettings.Input.defaults(),
   ) : this(initialInput, defaultInput, requireEventDispatchThread())
 
-  data class Binding(val player: Int, val button: Button) {
+  data class Binding(
+      val player: Int,
+      val button: Button,
+      val autofire: Boolean = false,
+  ) {
     init {
       require(player in 0..3) { "Logical player index must be in 0..3" }
+      require(!autofire || button == Button.A || button == Button.B) {
+        "Autofire is supported only for A and B"
+      }
     }
 
     val displayName: String
-      get() = "Player ${player + 1} ${button.keyboardEditorDisplayName()}"
+      get() =
+          "Player ${player + 1} ${button.keyboardEditorDisplayName()}" +
+              if (autofire) " Autofire" else ""
   }
 
   sealed interface EditResult {
@@ -74,15 +83,22 @@ class KeyboardMappingEditor private constructor(
       val card: JPanel,
   )
 
+  private data class Control(val button: Button, val autofire: Boolean = false) {
+    val displayName: String
+      get() = button.keyboardEditorDisplayName() + if (autofire) " Autofire" else ""
+  }
+
   internal data class PadPosition(val column: Int, val row: Int)
 
   private val keyboard =
       initialInput.keyboard.toMutableMap().also { initialInput.toPlayerMapping() }
+  private val autofireKeyboard = initialInput.autofireKeyboard.toMutableMap()
   private val gamepads = initialInput.gamepads.toMap()
   private val gamepadTunings = initialInput.gamepadTunings.toMap()
   private val defaultKeyboard =
       defaultInput.keyboard.toMap().also { defaultInput.toPlayerMapping() }
-  private val rows = linkedMapOf<Button, Row>()
+  private val defaultAutofireKeyboard = defaultInput.autofireKeyboard.toMap()
+  private val rows = linkedMapOf<Control, Row>()
   private val status = JLabel("Choose Capture, then press one key.")
   private var selectedPlayerIndex = 0
 
@@ -157,9 +173,13 @@ class KeyboardMappingEditor private constructor(
    */
   fun validatedDraft(): ApplicationSettings.Input {
     requireEventDispatchThread()
-    return ApplicationSettings.Input(keyboard.toMap(), gamepads, gamepadTunings).also {
-      it.toPlayerMapping()
-    }
+    return ApplicationSettings.Input(
+            keyboard.toMap(),
+            gamepads,
+            gamepadTunings,
+            autofireKeyboard.toMap(),
+        )
+        .also { it.toPlayerMapping() }
   }
 
   fun currentBinding(
@@ -168,6 +188,14 @@ class KeyboardMappingEditor private constructor(
   ): ApplicationSettings.KeyboardKey? {
     requireEventDispatchThread()
     return keyboard[ControllerProperties.PlayerButton(player, button)]
+  }
+
+  fun currentAutofireBinding(
+      player: Int,
+      button: Button,
+  ): ApplicationSettings.KeyboardKey? {
+    requireEventDispatchThread()
+    return autofireKeyboard[ControllerProperties.PlayerAutofireButton(player, button)]
   }
 
   /** Selects the player represented by the reusable pad controls. */
@@ -196,9 +224,19 @@ class KeyboardMappingEditor private constructor(
       player: Int,
       button: Button,
       keyCode: Int,
+  ): EditResult = editBinding(Binding(player, button), keyCode)
+
+  fun editAutofireBinding(
+      player: Int,
+      button: Button,
+      keyCode: Int,
+  ): EditResult = editBinding(Binding(player, button, autofire = true), keyCode)
+
+  private fun editBinding(
+      binding: Binding,
+      keyCode: Int,
   ): EditResult {
     requireEventDispatchThread()
-    val binding = Binding(player, button)
     if (keyCode in UNAVAILABLE_GAMEPLAY_KEYS) {
       return EditResult.Reserved(binding, keyCode).also {
         showStatus(
@@ -217,19 +255,18 @@ class KeyboardMappingEditor private constructor(
             showStatus("That key cannot be stored as a keyboard binding.")
           }
         }
-    val target = binding.toPlayerButton()
-    val previousTargetKey = keyboard[target]
+    val previousTargetKey = keyFor(binding)
     val conflict =
-        keyboard.entries.firstOrNull { (candidate, candidateKey) ->
-          candidate != target && candidateKey == key
+        bindingEntries().firstOrNull { (candidate, candidateKey) ->
+          candidate != binding && candidateKey == key
         }
     if (conflict != null) {
-      val existing = conflict.key.toBinding()
-      keyboard.remove(conflict.key)
+      val existing = conflict.first
+      removeBinding(existing)
       if (previousTargetKey != null) {
-        keyboard[conflict.key] = previousTargetKey
+        putBinding(existing, previousTargetKey)
       }
-      keyboard[target] = key
+      putBinding(binding, key)
       refreshRows()
       showStatus(
           buildString {
@@ -241,7 +278,7 @@ class KeyboardMappingEditor private constructor(
       return EditResult.Applied(binding, key)
     }
 
-    keyboard[target] = key
+    putBinding(binding, key)
     refreshRows()
     showStatus("${binding.displayName} is now ${key.displayName()}.")
     return EditResult.Applied(binding, key)
@@ -252,6 +289,8 @@ class KeyboardMappingEditor private constructor(
     cancelCapture()
     keyboard.clear()
     keyboard.putAll(defaultKeyboard)
+    autofireKeyboard.clear()
+    autofireKeyboard.putAll(defaultAutofireKeyboard)
     refreshRows()
     showStatus("Keyboard mappings restored to defaults.")
   }
@@ -286,7 +325,20 @@ class KeyboardMappingEditor private constructor(
   ): PadPosition {
     requireEventDispatchThread()
     require(player in 0 until PLAYER_COUNT) { "Logical player index must be in 0..3" }
-    val card = checkNotNull(rows[button]).card
+    val card = checkNotNull(rows[Control(button)]).card
+    val layout = card.parent.layout as GridBagLayout
+    val constraints = layout.getConstraints(card)
+    return PadPosition(constraints.gridx, constraints.gridy)
+  }
+
+  internal fun autofirePadPosition(
+      player: Int,
+      button: Button,
+  ): PadPosition {
+    requireEventDispatchThread()
+    require(player in 0 until PLAYER_COUNT) { "Logical player index must be in 0..3" }
+    require(button == Button.A || button == Button.B) { "Autofire is supported only for A and B" }
+    val card = checkNotNull(rows[Control(button, autofire = true)]).card
     val layout = card.parent.layout as GridBagLayout
     val constraints = layout.getConstraints(card)
     return PadPosition(constraints.gridx, constraints.gridy)
@@ -334,22 +386,14 @@ class KeyboardMappingEditor private constructor(
           pendingModifier = event.keyCode
           true
         } else {
-          editBinding(
-              capture.binding.player,
-              capture.binding.button,
-              event.keyCode,
-          )
+          editBinding(capture.binding, event.keyCode)
           finishCapture(event.keyCode)
           true
         }
       }
       KeyEvent.KEY_RELEASED -> {
         if (pendingModifier == event.keyCode) {
-          editBinding(
-              capture.binding.player,
-              capture.binding.button,
-              event.keyCode,
-          )
+          editBinding(capture.binding, event.keyCode)
           finishCapture()
           true
         } else {
@@ -364,22 +408,22 @@ class KeyboardMappingEditor private constructor(
     val panel = JPanel(GridBagLayout())
     panel.accessibleContext.accessibleName = "Selected player keyboard mappings"
     panel.accessibleContext.accessibleDescription =
-        "A Game Boy-shaped arrangement of the eight keyboard bindings for the selected player."
+        "A Game Boy-shaped arrangement of keyboard and A/B autofire bindings for the selected player."
     panel.border = BorderFactory.createEmptyBorder(12, 12, 12, 12)
 
-    PAD_FOCUS_ORDER.forEach { button ->
+    CONTROL_FOCUS_ORDER.forEach { control ->
       val bindingLabel =
           JLabel("", SwingConstants.CENTER).apply {
             getAccessibleContext().accessibleName = "Current binding"
           }
       val capture =
           actionButton("Capture", "Capture keyboard binding") {
-            startCapture(Binding(selectedPlayerIndex, button))
+            startCapture(Binding(selectedPlayerIndex, control.button, control.autofire))
           }
       val card =
           JPanel(BorderLayout(4, 4)).apply {
             getAccessibleContext().accessibleName = "Keyboard mapping controls"
-            border = BorderFactory.createTitledBorder(button.keyboardEditorDisplayName())
+            border = BorderFactory.createTitledBorder(control.displayName)
             add(
                 JLabel("Current key", SwingConstants.CENTER).apply {
                   labelFor = capture
@@ -390,9 +434,9 @@ class KeyboardMappingEditor private constructor(
             add(bindingLabel, BorderLayout.CENTER)
             add(capture, BorderLayout.SOUTH)
           }
-      rows[button] = Row(bindingLabel, capture, card)
+      rows[control] = Row(bindingLabel, capture, card)
 
-      val position = PAD_POSITIONS.getValue(button)
+      val position = PAD_POSITIONS.getValue(control)
       panel.add(
           card,
           GridBagConstraints().apply {
@@ -454,9 +498,9 @@ class KeyboardMappingEditor private constructor(
   }
 
   private fun refreshRows() {
-    rows.forEach { (button, row) ->
-      val binding = Binding(selectedPlayerIndex, button)
-      val key = keyboard[binding.toPlayerButton()]
+    rows.forEach { (control, row) ->
+      val binding = Binding(selectedPlayerIndex, control.button, control.autofire)
+      val key = keyFor(binding)
       row.currentBinding.text = key?.displayName() ?: "Unassigned"
       row.currentBinding.accessibleContext.accessibleName =
           "Current binding for ${binding.displayName}"
@@ -496,9 +540,36 @@ class KeyboardMappingEditor private constructor(
     }
   }
 
-  private fun Binding.toPlayerButton() = ControllerProperties.PlayerButton(player, button)
+  private fun keyFor(binding: Binding): ApplicationSettings.KeyboardKey? =
+      if (binding.autofire) {
+        autofireKeyboard[ControllerProperties.PlayerAutofireButton(binding.player, binding.button)]
+      } else {
+        keyboard[ControllerProperties.PlayerButton(binding.player, binding.button)]
+      }
 
-  private fun ControllerProperties.PlayerButton.toBinding() = Binding(player, button)
+  private fun putBinding(binding: Binding, key: ApplicationSettings.KeyboardKey) {
+    if (binding.autofire) {
+      autofireKeyboard[
+          ControllerProperties.PlayerAutofireButton(binding.player, binding.button)] = key
+    } else {
+      keyboard[ControllerProperties.PlayerButton(binding.player, binding.button)] = key
+    }
+  }
+
+  private fun removeBinding(binding: Binding) {
+    if (binding.autofire) {
+      autofireKeyboard.remove(
+          ControllerProperties.PlayerAutofireButton(binding.player, binding.button))
+    } else {
+      keyboard.remove(ControllerProperties.PlayerButton(binding.player, binding.button))
+    }
+  }
+
+  private fun bindingEntries(): List<Pair<Binding, ApplicationSettings.KeyboardKey>> =
+      keyboard.map { (binding, key) -> Binding(binding.player, binding.button) to key } +
+          autofireKeyboard.map { (binding, key) ->
+            Binding(binding.player, binding.button, autofire = true) to key
+          }
 
   private fun ApplicationSettings.KeyboardKey.displayName(): String =
       KeyEvent.getKeyText(DesktopKeyboardKeyAdapter.keyCode(this))
@@ -508,28 +579,32 @@ class KeyboardMappingEditor private constructor(
     const val PAD_COLUMN_COUNT = 7
     const val PAD_ROW_COUNT = 4
 
-    val PAD_FOCUS_ORDER =
+    val CONTROL_FOCUS_ORDER =
         listOf(
-            Button.UP,
-            Button.LEFT,
-            Button.RIGHT,
-            Button.DOWN,
-            Button.SELECT,
-            Button.START,
-            Button.B,
-            Button.A,
+            Control(Button.UP),
+            Control(Button.LEFT),
+            Control(Button.RIGHT),
+            Control(Button.DOWN),
+            Control(Button.SELECT),
+            Control(Button.START),
+            Control(Button.B),
+            Control(Button.A),
+            Control(Button.B, autofire = true),
+            Control(Button.A, autofire = true),
         )
 
     val PAD_POSITIONS =
         mapOf(
-            Button.UP to PadPosition(1, 0),
-            Button.LEFT to PadPosition(0, 1),
-            Button.RIGHT to PadPosition(2, 1),
-            Button.DOWN to PadPosition(1, 2),
-            Button.SELECT to PadPosition(3, 3),
-            Button.START to PadPosition(4, 3),
-            Button.B to PadPosition(5, 2),
-            Button.A to PadPosition(6, 1),
+            Control(Button.UP) to PadPosition(1, 0),
+            Control(Button.LEFT) to PadPosition(0, 1),
+            Control(Button.RIGHT) to PadPosition(2, 1),
+            Control(Button.DOWN) to PadPosition(1, 2),
+            Control(Button.SELECT) to PadPosition(3, 3),
+            Control(Button.START) to PadPosition(4, 3),
+            Control(Button.B) to PadPosition(5, 2),
+            Control(Button.A) to PadPosition(6, 1),
+            Control(Button.B, autofire = true) to PadPosition(5, 3),
+            Control(Button.A, autofire = true) to PadPosition(6, 3),
         )
 
     val UNAVAILABLE_GAMEPLAY_KEYS =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PreferencesDialog.kt
@@ -79,6 +79,11 @@ internal data class PreferencesEdit(
             ControllerProperties.PlayerButton,
             ApplicationSettings.KeyboardKey,
         >,
+    val autofireKeyboard:
+        Map<
+            ControllerProperties.PlayerAutofireButton,
+            ApplicationSettings.KeyboardKey,
+        > = emptyMap(),
     val gamepads: Map<Int, ApplicationSettings.GamepadSelection>,
     val gamepadTunings: Map<String, ApplicationSettings.GamepadTuning>,
     val cameraDeviceIndex: Int,
@@ -93,7 +98,13 @@ internal data class PreferencesEdit(
         recentFileCapacity in
             ApplicationSettings.MIN_RECENT_FILE_CAPACITY..
                 ApplicationSettings.MAX_RECENT_FILE_CAPACITY)
-    ApplicationSettings.Input(keyboard, gamepads, gamepadTunings).toPlayerMapping()
+    ApplicationSettings.Input(
+            keyboard,
+            gamepads,
+            gamepadTunings,
+            autofireKeyboard,
+        )
+        .toPlayerMapping()
   }
 
   fun applyTo(current: ApplicationSettings): ApplicationSettings =
@@ -120,6 +131,7 @@ internal data class PreferencesEdit(
           input =
               current.input.copy(
                   keyboard = keyboard,
+                  autofireKeyboard = autofireKeyboard,
                   gamepads = gamepads,
                   gamepadTunings = gamepadTunings,
               ),
@@ -341,7 +353,8 @@ internal class PreferencesPanel private constructor(
       }
   internal val controlsRuntimeGuidance =
       JTextArea(
-              "Fixed runtime controls: Backspace rewinds; I/J/K/L tilt supported cartridges. " +
+              "Autofire uses separate A/B keyboard bindings or gamepad L1/R1. " +
+                  "Fixed runtime controls: Backspace rewinds; I/J/K/L tilt supported cartridges. " +
                   "Application shortcuts are listed in Help > Keyboard Shortcuts and withdraw " +
                   "when an unmodified key is assigned to gameplay.")
           .apply {
@@ -555,6 +568,7 @@ internal class PreferencesPanel private constructor(
         confirmationPolicy = (confirmationPolicy.selectedItem as ConfirmationOption).policy,
         display = display,
         keyboard = input.keyboard,
+        autofireKeyboard = input.autofireKeyboard,
         gamepads = gamepad.selections,
         gamepadTunings = gamepad.tunings,
         cameraDeviceIndex = peripheralsEditor.validatedPeripherals().cameraDeviceIndex,
@@ -873,6 +887,21 @@ internal class PreferencesPanel private constructor(
             }
           }
         }
+    val autofireKeyboard =
+        buildMap {
+          repeat(4) { player ->
+            listOf(
+                    eu.rekawek.coffeegb.core.joypad.Button.A,
+                    eu.rekawek.coffeegb.core.joypad.Button.B,
+                )
+                .forEach { button ->
+                  put(
+                      ControllerProperties.PlayerAutofireButton(player, button),
+                      keyboardEditor.currentAutofireBinding(player, button),
+                  )
+                }
+          }
+        }
     return PreferencesDraftFingerprint(
         listOf(
             directoryField.text,
@@ -894,6 +923,7 @@ internal class PreferencesPanel private constructor(
             audioEditor.volume.value,
             audioEditor.latency.selectedItem,
             keyboard,
+            autofireKeyboard,
             (0 until CONTROL_PLAYER_COUNT).map(gamepadEditor::selectionForPlayer),
             trackedGamepadTunings.toMap(),
             spinnerText(gamepadEditor.movementDeadZone),

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -19,6 +19,7 @@ import eu.rekawek.coffeegb.swing.io.AudioDeviceSnapshot
 import eu.rekawek.coffeegb.swing.io.AudioOutputStatus
 import eu.rekawek.coffeegb.swing.io.AudioRuntimeConfiguration
 import eu.rekawek.coffeegb.swing.io.AudioSystemSound
+import eu.rekawek.coffeegb.swing.io.DesktopAutofireInput
 import eu.rekawek.coffeegb.swing.io.DesktopPlayerInput
 import eu.rekawek.coffeegb.swing.io.DesktopTiltInput
 import eu.rekawek.coffeegb.swing.io.DisplayScaleMode
@@ -86,6 +87,7 @@ class SwingEmulator(
 
   private val display: SwingDisplay
   private val joypad: SwingJoypad
+  private val autofireInput: DesktopAutofireInput
   private val gamepad: SwingGamepad
   private val gamepadThread: Thread
   private val sound: AudioSystemSound
@@ -127,10 +129,17 @@ class SwingEmulator(
             "main",
         )
     playerInput = DesktopPlayerInput(properties.playerInputSource, eventBus)
+    autofireInput = DesktopAutofireInput(playerInput, eventBus, "main")
     tiltInput = DesktopTiltInput(eventBus)
-    joypad = SwingJoypad(properties.playerInputMapping, eventBus, playerInput)
-    gamepad = SwingGamepad(properties.playerInputMapping, playerInput, tiltInput, eventBus)
-    gamepad.updateConfiguration(properties.applicationSettings.toGamepadConfiguration())
+    joypad = SwingJoypad(properties.playerInputMapping, eventBus, playerInput, autofireInput)
+    gamepad =
+        SwingGamepad(
+            properties.applicationSettings.toGamepadConfiguration(),
+            playerInput,
+            tiltInput,
+            eventBus,
+            autofireInput,
+        )
     accelerometer = SwingAccelerometer(eventBus, tiltInput, display.preferredSize)
     tiltKeys = SwingTiltKeys(tiltInput)
     printer = SwingPrinter(eventBus)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopAutofireInput.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopAutofireInput.java
@@ -1,0 +1,108 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.joypad.Button;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** Converts held desktop turbo controls into frame-paced A/B presses. */
+public final class DesktopAutofireInput {
+
+    /** Two frames down and two frames up produces roughly 15 presses per second. */
+    private static final int FRAMES_PER_PHASE = 2;
+
+    private final DesktopPlayerInput input;
+    private final Map<Object, Registration> sources = new IdentityHashMap<>();
+
+    public DesktopAutofireInput(DesktopPlayerInput input, EventBus eventBus) {
+        this(input, eventBus, null);
+    }
+
+    public DesktopAutofireInput(DesktopPlayerInput input, EventBus eventBus, String callerFilter) {
+        this.input = input;
+        if (callerFilter == null) {
+            eventBus.register(ignored -> advanceFrame(), Display.DmgFrameReadyEvent.class);
+            eventBus.register(ignored -> advanceFrame(), Display.GbcFrameReadyEvent.class);
+        } else {
+            eventBus.register(
+                    ignored -> advanceFrame(), Display.DmgFrameReadyEvent.class, callerFilter);
+            eventBus.register(
+                    ignored -> advanceFrame(), Display.GbcFrameReadyEvent.class, callerFilter);
+        }
+    }
+
+    public synchronized void update(Object identity, int player, Collection<Button> buttons) {
+        EnumSet<Button> held = EnumSet.noneOf(Button.class);
+        for (Button button : buttons) {
+            if (button != Button.A && button != Button.B) {
+                throw new IllegalArgumentException("Autofire supports only A and B");
+            }
+            held.add(button);
+        }
+        if (held.isEmpty()) {
+            disconnect(identity);
+            return;
+        }
+
+        Registration registration = sources.get(identity);
+        if (registration != null && registration.player != player) {
+            input.disconnect(identity);
+            registration = null;
+        }
+        if (registration == null) {
+            registration = new Registration(player);
+            sources.put(identity, registration);
+        }
+        registration.buttons.clear();
+        registration.buttons.addAll(held);
+        publish(identity, registration);
+    }
+
+    public synchronized void disconnect(Object identity) {
+        if (sources.remove(identity) != null) {
+            input.disconnect(identity);
+        }
+    }
+
+    public synchronized void releaseAll() {
+        for (Object identity : Set.copyOf(sources.keySet())) {
+            input.disconnect(identity);
+        }
+        sources.clear();
+    }
+
+    synchronized void advanceFrame() {
+        sources.forEach((identity, registration) -> {
+            registration.framesInPhase++;
+            if (registration.framesInPhase == FRAMES_PER_PHASE) {
+                registration.framesInPhase = 0;
+                registration.downPhase = !registration.downPhase;
+                publish(identity, registration);
+            }
+        });
+    }
+
+    private void publish(Object identity, Registration registration) {
+        input.update(identity, registration.player,
+                registration.downPhase ? registration.buttons : Set.of());
+    }
+
+    private static final class Registration {
+        private final int player;
+        private final EnumSet<Button> buttons = EnumSet.noneOf(Button.class);
+        private boolean downPhase = true;
+        private int framesInPhase;
+
+        private Registration(int player) {
+            if (player < 0 || player > 3) {
+                throw new IllegalArgumentException("Logical player index must be in 0..3");
+            }
+            this.player = player;
+        }
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/GamepadBackend.java
@@ -21,7 +21,8 @@ interface GamepadBackend extends AutoCloseable {
 
     enum Axis { LEFT_X, LEFT_Y, RIGHT_X, RIGHT_Y }
 
-    enum PadButton { UP, DOWN, LEFT, RIGHT, A, B, X, START, BACK }
+    enum PadButton { UP, DOWN, LEFT, RIGHT, A, B, X, START, BACK,
+        LEFT_SHOULDER, RIGHT_SHOULDER }
 
     interface GamepadDevice extends AutoCloseable {
         String stableId();

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SdlGamepadBackend.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SdlGamepadBackend.java
@@ -190,6 +190,8 @@ final class SdlGamepadBackend implements GamepadBackend {
                 case X -> SDL_CONTROLLER_BUTTON_X;
                 case START -> SDL_CONTROLLER_BUTTON_START;
                 case BACK -> SDL_CONTROLLER_BUTTON_BACK;
+                case LEFT_SHOULDER -> SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+                case RIGHT_SHOULDER -> SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
             };
             return SDL_GameControllerGetButton(controller, value) != 0;
         }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingGamepad.java
@@ -37,6 +37,7 @@ public class SwingGamepad implements Runnable {
 
     private final EventBus eventBus;
     private final DesktopPlayerInput input;
+    private final DesktopAutofireInput autofireInput;
     private final DesktopTiltInput tiltInput;
     private final GamepadBackend backend;
     private final Consumer<GamepadBackend.DeviceInfo> discoveryObserver;
@@ -58,26 +59,33 @@ public class SwingGamepad implements Runnable {
     public SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                         DesktopTiltInput tiltInput, EventBus eventBus) {
         this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
-                new SdlGamepadBackend(), ignored -> {});
+                new SdlGamepadBackend(), new DesktopAutofireInput(input, eventBus), ignored -> {});
     }
 
     public SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
                         DesktopTiltInput tiltInput, EventBus eventBus) {
         this(configuration, input, tiltInput, eventBus,
-                new SdlGamepadBackend(), ignored -> {});
+                new SdlGamepadBackend(), new DesktopAutofireInput(input, eventBus), ignored -> {});
+    }
+
+    public SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                        DesktopTiltInput tiltInput, EventBus eventBus,
+                        DesktopAutofireInput autofireInput) {
+        this(configuration, input, tiltInput, eventBus,
+                new SdlGamepadBackend(), autofireInput, ignored -> {});
     }
 
     SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                  DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend) {
         this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
-                backend, ignored -> {});
+                backend, new DesktopAutofireInput(input, eventBus), ignored -> {});
     }
 
     SwingGamepad(ControllerProperties.PlayerMapping mapping, DesktopPlayerInput input,
                  DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
                  Consumer<GamepadBackend.DeviceInfo> discoveryObserver) {
         this(GamepadConfiguration.from(mapping), input, tiltInput, eventBus,
-                backend, discoveryObserver);
+                backend, new DesktopAutofireInput(input, eventBus), discoveryObserver);
     }
 
     SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
@@ -87,10 +95,25 @@ public class SwingGamepad implements Runnable {
 
     SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
                  DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
+                 DesktopAutofireInput autofireInput) {
+        this(configuration, input, tiltInput, eventBus, backend, autofireInput, ignored -> {});
+    }
+
+    SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                 DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
+                 Consumer<GamepadBackend.DeviceInfo> discoveryObserver) {
+        this(configuration, input, tiltInput, eventBus, backend,
+                new DesktopAutofireInput(input, eventBus), discoveryObserver);
+    }
+
+    SwingGamepad(GamepadConfiguration configuration, DesktopPlayerInput input,
+                 DesktopTiltInput tiltInput, EventBus eventBus, GamepadBackend backend,
+                 DesktopAutofireInput autofireInput,
                  Consumer<GamepadBackend.DeviceInfo> discoveryObserver) {
         this.requestedConfiguration = Objects.requireNonNull(configuration, "configuration");
         this.appliedConfiguration = configuration;
         this.input = Objects.requireNonNull(input, "input");
+        this.autofireInput = Objects.requireNonNull(autofireInput, "autofireInput");
         this.tiltInput = Objects.requireNonNull(tiltInput, "tiltInput");
         this.eventBus = Objects.requireNonNull(eventBus, "eventBus");
         this.backend = Objects.requireNonNull(backend, "backend");
@@ -120,6 +143,7 @@ public class SwingGamepad implements Runnable {
         rearmRequested = true;
         rumbleRequested = false;
         input.releaseAll();
+        autofireInput.releaseAll();
         tiltInput.clear(tiltSourceIdentity);
     }
 
@@ -132,6 +156,7 @@ public class SwingGamepad implements Runnable {
         rearmRequested = true;
         rumbleRequested = false;
         input.releaseAll();
+        autofireInput.releaseAll();
         tiltInput.clear(tiltSourceIdentity);
     }
 
@@ -282,6 +307,7 @@ public class SwingGamepad implements Runnable {
                 appliedConfiguration.tuningFor(device.stableId());
         PhysicalState state = PhysicalState.read(device);
         EnumSet<Button> buttons = EnumSet.noneOf(Button.class);
+        EnumSet<Button> autofireButtons = EnumSet.noneOf(Button.class);
         if (activeDevice.waitingForNeutral) {
             if (state.isNeutral(tuning)) {
                 activeDevice.waitingForNeutral = false;
@@ -298,8 +324,11 @@ public class SwingGamepad implements Runnable {
             add(buttons, Button.B, state.buttons.contains(B) || state.buttons.contains(X));
             add(buttons, Button.START, state.buttons.contains(START));
             add(buttons, Button.SELECT, state.buttons.contains(BACK));
+            add(autofireButtons, Button.A, state.buttons.contains(LEFT_SHOULDER));
+            add(autofireButtons, Button.B, state.buttons.contains(RIGHT_SHOULDER));
         }
         input.update(activeDevice.sourceIdentity, player, buttons);
+        autofireInput.update(activeDevice.autofireSourceIdentity, player, autofireButtons);
 
         if (player == 0) {
             if (input.isFocused() && !activeDevice.waitingForNeutral) {
@@ -334,6 +363,7 @@ public class SwingGamepad implements Runnable {
         ActiveDevice removed = active.remove(player);
         if (removed == null) return;
         input.disconnect(removed.sourceIdentity);
+        autofireInput.disconnect(removed.autofireSourceIdentity);
         if (player == 0) {
             if (rumbleActive) removed.device.rumble(false);
             rumbleActive = false;
@@ -433,6 +463,7 @@ public class SwingGamepad implements Runnable {
     private static final class ActiveDevice {
         private final GamepadBackend.GamepadDevice device;
         private final Object sourceIdentity = new Object();
+        private final Object autofireSourceIdentity = new Object();
         private boolean waitingForNeutral;
 
         private ActiveDevice(GamepadBackend.GamepadDevice device, boolean waitingForNeutral) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingJoypad.java
@@ -20,23 +20,39 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
     private static final int REWIND_KEY = KeyEvent.VK_BACK_SPACE;
 
     private Map<Integer, ControllerProperties.PlayerButton> mapping;
+    private Map<Integer, ControllerProperties.PlayerAutofireButton> autofireMapping;
     private final EventBus eventBus;
     private final DesktopPlayerInput input;
+    private final DesktopAutofireInput autofireInput;
     private final Object[] sourceIdentities = new Object[4];
+    private final Object[] autofireSourceIdentities = new Object[4];
     private final EnumSet<Button>[] pressed;
+    private final EnumSet<Button>[] autofirePressed;
 
     private boolean rewindActive;
 
     @SuppressWarnings("unchecked")
     public SwingJoypad(ControllerProperties.PlayerMapping mapping, EventBus eventBus,
                        DesktopPlayerInput input) {
+        this(mapping, eventBus, input, new DesktopAutofireInput(input, eventBus));
+    }
+
+    @SuppressWarnings("unchecked")
+    public SwingJoypad(ControllerProperties.PlayerMapping mapping, EventBus eventBus,
+                       DesktopPlayerInput input, DesktopAutofireInput autofireInput) {
         this.mapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveMapping(mapping.getKeyboard()));
+        this.autofireMapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveAutofireMapping(
+                mapping.getAutofireKeyboard()));
         this.eventBus = eventBus;
         this.input = input;
+        this.autofireInput = autofireInput;
         this.pressed = new EnumSet[4];
+        this.autofirePressed = new EnumSet[4];
         for (int player = 0; player < 4; player++) {
             sourceIdentities[player] = new Object();
+            autofireSourceIdentities[player] = new Object();
             pressed[player] = EnumSet.noneOf(Button.class);
+            autofirePressed[player] = EnumSet.noneOf(Button.class);
         }
     }
 
@@ -50,6 +66,14 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
         if (binding != null) {
             if (pressed[binding.getPlayer()].add(binding.getButton())) {
                 update(binding.getPlayer());
+            }
+            return;
+        }
+        ControllerProperties.PlayerAutofireButton autofireBinding =
+                autofireMapping.get(e.getKeyCode());
+        if (autofireBinding != null) {
+            if (autofirePressed[autofireBinding.getPlayer()].add(autofireBinding.getButton())) {
+                updateAutofire(autofireBinding.getPlayer());
             }
             return;
         }
@@ -69,6 +93,14 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
             update(binding.getPlayer());
             return;
         }
+        ControllerProperties.PlayerAutofireButton autofireBinding =
+                autofireMapping.get(e.getKeyCode());
+        if (autofireBinding != null
+                && autofirePressed[autofireBinding.getPlayer()].remove(
+                        autofireBinding.getButton())) {
+            updateAutofire(autofireBinding.getPlayer());
+            return;
+        }
         if (e.getKeyCode() == REWIND_KEY) {
             releaseRewind();
         }
@@ -76,7 +108,8 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
 
     /** True when an unmodified key belongs to a configured button or the fallback rewind key. */
     public synchronized boolean handlesKeyCode(int keyCode) {
-        return mapping.containsKey(keyCode) || keyCode == REWIND_KEY;
+        return mapping.containsKey(keyCode) || autofireMapping.containsKey(keyCode)
+                || keyCode == REWIND_KEY;
     }
 
     /** Returns the configured player-one logical key for portable-menu capture, if any. */
@@ -134,16 +167,25 @@ public class SwingJoypad implements KeyListener, WindowFocusListener {
         releaseRewind();
         input.releaseAll();
         this.mapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveMapping(mapping.getKeyboard()));
+        this.autofireMapping = Map.copyOf(DesktopKeyboardKeyAdapter.resolveAutofireMapping(
+                mapping.getAutofireKeyboard()));
     }
 
     private void update(int player) {
         input.update(sourceIdentities[player], player, pressed[player]);
     }
 
+    private void updateAutofire(int player) {
+        autofireInput.update(
+                autofireSourceIdentities[player], player, autofirePressed[player]);
+    }
+
     private void releaseKeyboard() {
         for (int player = 0; player < pressed.length; player++) {
             pressed[player].clear();
             input.disconnect(sourceIdentities[player]);
+            autofirePressed[player].clear();
+            autofireInput.disconnect(autofireSourceIdentities[player]);
         }
     }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditorTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/KeyboardMappingEditorTest.kt
@@ -28,7 +28,7 @@ class KeyboardMappingEditorTest {
         val actions = descendants(editor).filterIsInstance<AbstractButton>()
         assertTrue(actions.all { !it.accessibleContext.accessibleName.isNullOrBlank() })
         assertTrue(actions.all(Component::isFocusable))
-        assertEquals(8, actions.count { it.text == "Capture" })
+        assertEquals(10, actions.count { it.text == "Capture" })
         assertEquals(1, actions.count { it.text == "Reset keyboard defaults" })
         assertTrue(actions.none { it.text in setOf("Dialog key…", "Clear", "Reset") })
         assertEquals(
@@ -36,7 +36,7 @@ class KeyboardMappingEditorTest {
             button(editor, "Restore all keyboard defaults").text,
         )
         assertEquals(
-            8,
+            10,
             descendants(editor)
                 .mapNotNull { it.accessibleContext.accessibleName }
                 .count { it.startsWith("Current binding for Player ") },
@@ -52,6 +52,8 @@ class KeyboardMappingEditorTest {
                 "Capture Player 1 Start keyboard binding",
                 "Capture Player 1 B keyboard binding",
                 "Capture Player 1 A keyboard binding",
+                "Capture Player 1 B Autofire keyboard binding",
+                "Capture Player 1 A Autofire keyboard binding",
             ),
             descendants(editor)
                 .filterIsInstance<AbstractButton>()
@@ -80,7 +82,46 @@ class KeyboardMappingEditorTest {
           expected.forEach { (button, position) ->
             assertEquals(position, editor.padPosition(player, button))
           }
+          assertEquals(
+              KeyboardMappingEditor.PadPosition(5, 3),
+              editor.autofirePadPosition(player, Button.B),
+          )
+          assertEquals(
+              KeyboardMappingEditor.PadPosition(6, 3),
+              editor.autofirePadPosition(player, Button.A),
+          )
         }
+      }
+
+  @Test
+  fun autofireBindingsCaptureSeparatelyAndSwapConflictsWithRegularBindings() =
+      onEventThread {
+        val editor = KeyboardMappingEditor(ApplicationSettings.Input.defaults())
+
+        assertIs<KeyboardMappingEditor.EditResult.Applied>(
+            editor.editAutofireBinding(0, Button.A, KeyEvent.VK_C))
+        assertEquals(KeyEvent.VK_C, editor.currentAutofireBinding(0, Button.A)?.code)
+
+        assertIs<KeyboardMappingEditor.EditResult.Applied>(
+            editor.editAutofireBinding(1, Button.B, KeyEvent.VK_Q))
+        assertIs<KeyboardMappingEditor.EditResult.Applied>(
+            editor.editAutofireBinding(1, Button.B, KeyEvent.VK_Z))
+        assertEquals(KeyEvent.VK_Z, editor.currentAutofireBinding(1, Button.B)?.code)
+        assertEquals(KeyEvent.VK_Q, editor.currentBinding(0, Button.A)?.code)
+        assertEquals(KeyEvent.VK_C, editor.currentAutofireBinding(0, Button.A)?.code)
+
+        editor.selectPlayer(1)
+        val capture = button(editor, "Capture Player 2 A Autofire keyboard binding")
+        capture.doClick()
+        assertTrue(editor.handleCaptureKey(key(capture, KeyEvent.KEY_PRESSED, KeyEvent.VK_Q)))
+        assertTrue(editor.handleCaptureKey(key(capture, KeyEvent.KEY_RELEASED, KeyEvent.VK_Q)))
+        assertEquals(KeyEvent.VK_Q, editor.currentAutofireBinding(1, Button.A)?.code)
+        assertEquals(
+            KeyEvent.VK_Q,
+            editor.validatedDraft()
+                .autofireKeyboard[ControllerProperties.PlayerAutofireButton(1, Button.A)]
+                ?.code,
+        )
       }
 
   @Test
@@ -138,6 +179,9 @@ class KeyboardMappingEditorTest {
                 ApplicationSettings.Input.defaults().keyboard,
                 gamepads,
                 tunings,
+                mapOf(
+                    ControllerProperties.PlayerAutofireButton(0, Button.A) to
+                        DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_C)),
             )
         val editor = KeyboardMappingEditor(initial)
 
@@ -150,12 +194,14 @@ class KeyboardMappingEditorTest {
         assertNull(initial.keyboard[playerButton(1, Button.A)], "the initial value is immutable")
 
         editor.editBinding(1, Button.B, KeyEvent.VK_W)
+        editor.editAutofireBinding(2, Button.B, KeyEvent.VK_R)
         editor.resetToDefaults()
         assertEquals(
             ApplicationSettings.Input(
                 ApplicationSettings.Input.defaults().keyboard,
                 gamepads,
                 tunings,
+                ApplicationSettings.Input.defaults().autofireKeyboard,
             ),
             editor.validatedDraft(),
         )

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PreferencesDialogTest.kt
@@ -137,6 +137,10 @@ class PreferencesDialogTest {
                     fullscreen = true,
                 ),
             keyboard = emptyMap(),
+            autofireKeyboard =
+                mapOf(
+                    ControllerProperties.PlayerAutofireButton(2, Button.B) to
+                        DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_V)),
             gamepads = mapOf(0 to GamepadSelection.Disabled),
             gamepadTunings =
                 mapOf(
@@ -168,6 +172,7 @@ class PreferencesDialogTest {
     assertEquals(2, updated.general.recentFileCapacity)
     assertEquals(RomChangeConfirmationPolicy.NEVER, updated.general.romChangeConfirmationPolicy)
     assertTrue(updated.input.keyboard.isEmpty())
+    assertEquals(edit.autofireKeyboard, updated.input.autofireKeyboard)
     assertEquals(edit.gamepads, updated.input.gamepads)
     assertEquals(edit.gamepadTunings, updated.input.gamepadTunings)
     assertEquals(6, updated.peripherals.cameraDeviceIndex)
@@ -246,6 +251,10 @@ class PreferencesDialogTest {
         assertEquals(listOf("apply", "close"), events)
         assertEquals(ApplicationSettings.DEFAULT_RECENT_FILE_CAPACITY, received?.recentFileCapacity)
         assertEquals(ApplicationSettings.Input.defaults().keyboard, received?.keyboard)
+        assertEquals(
+            ApplicationSettings.Input.defaults().autofireKeyboard,
+            received?.autofireKeyboard,
+        )
         assertEquals(ApplicationSettings.Input.defaults().gamepads, received?.gamepads)
         assertEquals(
             ApplicationSettings.DEFAULT_CAMERA_DEVICE_INDEX,
@@ -308,6 +317,10 @@ class PreferencesDialogTest {
             defaults.input.keyboard +
                 (ControllerProperties.PlayerButton(0, Button.A) to
                     DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_A))
+        val changedAutofireKeyboard =
+            mapOf(
+                ControllerProperties.PlayerAutofireButton(0, Button.A) to
+                    DesktopKeyboardKeyAdapter.fromKeyCode(KeyEvent.VK_C))
         val initial =
             defaults.copy(
                 general =
@@ -332,6 +345,7 @@ class PreferencesDialogTest {
                 input =
                     defaults.input.copy(
                         keyboard = changedKeyboard,
+                        autofireKeyboard = changedAutofireKeyboard,
                         gamepads = mapOf(0 to GamepadSelection.Disabled),
                         gamepadTunings =
                             mapOf(
@@ -365,6 +379,7 @@ class PreferencesDialogTest {
             restored.confirmationPolicy,
         )
         assertEquals(defaults.input.keyboard, restored.keyboard)
+        assertEquals(defaults.input.autofireKeyboard, restored.autofireKeyboard)
         assertEquals(defaults.input.gamepads, restored.gamepads)
         assertEquals(defaults.input.gamepadTunings, restored.gamepadTunings)
         assertEquals(defaults.display, restored.display)
@@ -1022,6 +1037,7 @@ class PreferencesDialogTest {
         )
         assertTrue(panel.controlsRuntimeGuidance.text.contains("Backspace rewinds"))
         assertTrue(panel.controlsRuntimeGuidance.text.contains("I/J/K/L"))
+        assertTrue(panel.controlsRuntimeGuidance.text.contains("L1/R1"))
         assertEquals(true, panel.controlsRuntimeGuidance.getClientProperty("html.disable"))
         panel.controlsPlayerSelector.selectedIndex = 1
         assertEquals(1, panel.keyboardEditor.selectedPlayer)

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DesktopAutofireInputTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/DesktopAutofireInputTest.java
@@ -1,0 +1,77 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.gpu.Display;
+import eu.rekawek.coffeegb.core.joypad.Button;
+import eu.rekawek.coffeegb.core.joypad.PlayerInputHub;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class DesktopAutofireInputTest {
+
+    @Test
+    public void heldButtonsPulseForTwoFramesOnAndTwoFramesOff() {
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        PlayerInputHub hub = new PlayerInputHub();
+        DesktopPlayerInput input = new DesktopPlayerInput(hub, bus);
+        DesktopAutofireInput autofire = new DesktopAutofireInput(input, bus);
+        Object source = new Object();
+
+        autofire.update(source, 0, Set.of(Button.A));
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+
+        postFrame(bus);
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        postFrame(bus);
+        assertTrue(hub.sample().buttons(0).isEmpty());
+
+        Object secondSource = new Object();
+        autofire.update(secondSource, 1, Set.of(Button.B));
+        assertEquals(Set.of(Button.B), hub.sample().buttons(1));
+        postFrame(bus);
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        assertEquals(Set.of(Button.B), hub.sample().buttons(1));
+        postFrame(bus);
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        assertTrue(hub.sample().buttons(1).isEmpty());
+
+        autofire.disconnect(source);
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        autofire.disconnect(secondSource);
+        bus.close();
+    }
+
+    @Test
+    public void normalAndAutofireSourcesComposeAndLifecycleReleaseIsFinal() {
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        PlayerInputHub hub = new PlayerInputHub();
+        DesktopPlayerInput input = new DesktopPlayerInput(hub, bus);
+        DesktopAutofireInput autofire = new DesktopAutofireInput(input, bus);
+        Object normal = new Object();
+
+        input.update(normal, 0, Set.of(Button.A));
+        autofire.update(new Object(), 0, Set.of(Button.A, Button.B));
+        postFrame(bus);
+        postFrame(bus);
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+
+        autofire.releaseAll();
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        input.disconnect(normal);
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> autofire.update(new Object(), 0, Set.of(Button.START)));
+        bus.close();
+    }
+
+    private static void postFrame(EventBusImpl bus) {
+        bus.post(new Display.DmgFrameReadyEvent(
+                new int[Display.DISPLAY_WIDTH * Display.DISPLAY_HEIGHT]));
+    }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingGamepadTest.java
@@ -128,6 +128,27 @@ public class SwingGamepadTest {
     }
 
     @Test
+    public void shoulderButtonsDriveSeparateAAndBAutofireChannels() {
+        Rig rig = new Rig(mapping(new ControllerProperties.GamepadAssignment(0, ID_A)));
+        FakeDevice device = rig.backend.add(ID_A, "primary");
+        device.buttons.add(GamepadBackend.PadButton.LEFT_SHOULDER);
+        device.buttons.add(GamepadBackend.PadButton.RIGHT_SHOULDER);
+
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.A, Button.B), rig.hub.sample().buttons(0));
+        rig.autofire.advanceFrame();
+        rig.autofire.advanceFrame();
+        assertTrue(rig.hub.sample().buttons(0).isEmpty());
+
+        device.buttons.add(GamepadBackend.PadButton.A);
+        rig.gamepad.pollOnce();
+        assertEquals(Set.of(Button.A), rig.hub.sample().buttons(0));
+        rig.autofire.advanceFrame();
+        rig.autofire.advanceFrame();
+        assertEquals(Set.of(Button.A, Button.B), rig.hub.sample().buttons(0));
+    }
+
+    @Test
     public void everyControllerIsDiscoveredOncePerConnectionEvenWhenUnassigned() {
         List<GamepadBackend.DeviceInfo> discovered = new ArrayList<>();
         Rig rig = new Rig(
@@ -446,6 +467,7 @@ public class SwingGamepadTest {
         final EventBusImpl bus = new EventBusImpl(null, null, false);
         final PlayerInputHub hub = new PlayerInputHub();
         final DesktopPlayerInput input = new DesktopPlayerInput(hub, bus);
+        final DesktopAutofireInput autofire = new DesktopAutofireInput(input, bus);
         final DesktopTiltInput tiltInput = new DesktopTiltInput(bus);
         final FakeBackend backend = new FakeBackend();
         final SwingGamepad gamepad;
@@ -456,11 +478,13 @@ public class SwingGamepadTest {
 
         Rig(ControllerProperties.PlayerMapping mapping,
             List<GamepadBackend.DeviceInfo> discovered) {
-            gamepad = new SwingGamepad(mapping, input, tiltInput, bus, backend, discovered::add);
+            gamepad = new SwingGamepad(
+                    GamepadConfiguration.from(mapping), input, tiltInput, bus, backend,
+                    autofire, discovered::add);
         }
 
         Rig(GamepadConfiguration configuration) {
-            gamepad = new SwingGamepad(configuration, input, tiltInput, bus, backend);
+            gamepad = new SwingGamepad(configuration, input, tiltInput, bus, backend, autofire);
         }
     }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingJoypadTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingJoypadTest.java
@@ -115,6 +115,40 @@ public class SwingJoypadTest {
         assertFalse(joypad.handlesKeyCode(KeyEvent.VK_F12));
     }
 
+    @Test
+    public void configuredAutofireKeyPulsesAndComposesWithTheNormalButton() {
+        Properties properties = new Properties();
+        properties.setProperty("input.p1.autofire_a", "VK_C");
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        PlayerInputHub hub = new PlayerInputHub();
+        DesktopPlayerInput input = new DesktopPlayerInput(hub, bus);
+        DesktopAutofireInput autofire = new DesktopAutofireInput(input, bus);
+        SwingJoypad joypad = new SwingJoypad(
+                ControllerProperties.INSTANCE.getPlayerMapping(properties), bus, input, autofire);
+
+        joypad.keyPressed(key(KeyEvent.VK_C, KeyEvent.KEY_PRESSED));
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        autofire.advanceFrame();
+        autofire.advanceFrame();
+        assertTrue(hub.sample().buttons(0).isEmpty());
+
+        joypad.keyPressed(key(KeyEvent.VK_Z, KeyEvent.KEY_PRESSED));
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        joypad.keyReleased(key(KeyEvent.VK_Z, KeyEvent.KEY_RELEASED));
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        autofire.advanceFrame();
+        autofire.advanceFrame();
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+
+        joypad.keyReleased(key(KeyEvent.VK_C, KeyEvent.KEY_RELEASED));
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        joypad.keyPressed(key(KeyEvent.VK_C, KeyEvent.KEY_PRESSED));
+        assertEquals(Set.of(Button.A), hub.sample().buttons(0));
+        joypad.windowLostFocus(null);
+        assertTrue(hub.sample().buttons(0).isEmpty());
+        bus.close();
+    }
+
     private static KeyEvent key(int code, int id) {
         return new KeyEvent(new Canvas(), id, 0, 0, code, KeyEvent.CHAR_UNDEFINED);
     }


### PR DESCRIPTION
Fixes #582

## Summary

- add independent configurable A Autofire and B Autofire keyboard bindings for every logical player
- map gamepad L1 to A Autofire and R1 to B Autofire while composing correctly with ordinary held buttons
- pulse each held autofire source for two frames down and two frames up, with lifecycle/focus/configuration cleanup
- persist the new bindings in settings schema 11 and expose them in the accessible keyboard-mapping editor

## Verification

- `/opt/maven/bin/mvn -pl controller,swing -am -Dtest=ControllerPropertiesTest,ApplicationSettingsDevicesTest,DesktopAutofireInputTest,SwingJoypadTest,SwingGamepadTest,KeyboardMappingEditorTest,PreferencesDialogTest -Dsurefire.failIfNoSpecifiedTests=false test` — 68 tests, 0 failures
- `/opt/maven/bin/mvn -pl controller,swing -am test` — core 1,970; portable UI 106; controller 951; Swing 805 tests, 0 failures

## Visual evidence

![Separate A and B Autofire controls](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/autofire-preferences-4ef74cf7.png)
