### PR TITLE
Publish interruption-test PID marker atomically

### DIFF
--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifierTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifierTest.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -798,10 +799,17 @@ public class NativePackageVerifierTest {
         }
 
         public static void main(String[] args) throws Exception {
+            Path marker = Path.of(args[0]);
+            Path pendingMarker = marker.resolveSibling(marker.getFileName() + ".pending");
             Files.writeString(
-                    Path.of(args[0]),
+                    pendingMarker,
                     Long.toString(ProcessHandle.current().pid()),
                     StandardOpenOption.CREATE_NEW);
+            try {
+                Files.move(pendingMarker, marker, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(pendingMarker, marker);
+            }
             Thread.sleep(TimeUnit.MINUTES.toMillis(1));
         }
     }


### PR DESCRIPTION
## Summary

- publish the interruption-test child PID marker only after its contents are complete
- use an atomic same-directory rename when supported, with a normal rename fallback
- prevent the parent test from observing the marker between creation and the PID write

## Root cause

The 2.0.7 release workflow failed because `NativePackageVerifierTest` waited for the PID marker to exist and then immediately parsed it. `Files.writeString` creates the file before writing its contents, so CI could observe a regular but still-empty file and throw `NumberFormatException`.

Failed release run: https://github.com/trekawek/coffee-gb/actions/runs/33246054049

## Validation

- focused interrupted-process test: pass
- complete `NativePackageVerifierTest`: 20 tests, 0 failures/errors
- `git diff --check`: clean
