### PR TITLE
Label local netplay host and clients in the footer

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -7,6 +7,7 @@ import eu.rekawek.coffeegb.controller.Controller.LoadRomFailedEvent
 import eu.rekawek.coffeegb.controller.Controller.RomLoadingCancelledEvent
 import eu.rekawek.coffeegb.controller.Controller.RomLoadingEvent
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
 import eu.rekawek.coffeegb.controller.mobile.config.MobileAdapterConfigurationStore
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -1376,7 +1376,15 @@ internal fun netplaySummary(presentation: NetplayUiPresentation): String {
   val role =
       when (presentation.state.role) {
         NetplayRole.HOST -> "Host"
-        NetplayRole.CLIENT -> "Client"
+        NetplayRole.CLIENT ->
+            if (
+                presentation.state.mode == LinkMode.FOUR_PLAYER_ADAPTER &&
+                    presentation.state.localPlayer != null
+            ) {
+              "Client ${presentation.state.localPlayer + 1}"
+            } else {
+              "Client"
+            }
         null -> null
       }
   return if (role == null) "Netplay: $phase" else "Netplay: $role — $phase"

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -843,18 +843,6 @@ class SwingGui private constructor(
     desktopUiCoordinator.commandBarVisible(visible)
   }
 
-  private fun netplaySummary(presentation: NetplayUiPresentation): String =
-      when (presentation.state.phase) {
-        NetplayPhase.DISCONNECTED -> "Netplay: Off"
-        NetplayPhase.STARTING_HOST -> "Netplay: Starting"
-        NetplayPhase.WAITING_FOR_PEERS -> "Netplay: Hosting"
-        NetplayPhase.CONNECTING -> "Netplay: Connecting"
-        NetplayPhase.NEGOTIATING -> "Netplay: Synchronizing"
-        NetplayPhase.ACTIVE -> "Netplay: Active"
-        NetplayPhase.STOPPING -> "Netplay: Stopping"
-        NetplayPhase.FAILED -> "Netplay: Failed"
-      }
-
   private fun confirmNetplayPeripheralHandoff(
       selection: Controller.SerialPeripheralSelection,
   ): Boolean =
@@ -1372,6 +1360,27 @@ internal fun ApplicationSettings.Appearance.toDesktopAppearance(): DesktopAppear
       ApplicationSettings.Appearance.DARK -> DesktopAppearance.DARK
       ApplicationSettings.Appearance.SYSTEM -> DesktopAppearance.SYSTEM
     }
+
+internal fun netplaySummary(presentation: NetplayUiPresentation): String {
+  val phase =
+      when (presentation.state.phase) {
+        NetplayPhase.DISCONNECTED -> "Off"
+        NetplayPhase.STARTING_HOST -> "Starting"
+        NetplayPhase.WAITING_FOR_PEERS -> "Hosting"
+        NetplayPhase.CONNECTING -> "Connecting"
+        NetplayPhase.NEGOTIATING -> "Synchronizing"
+        NetplayPhase.ACTIVE -> "Active"
+        NetplayPhase.STOPPING -> "Stopping"
+        NetplayPhase.FAILED -> "Failed"
+      }
+  val role =
+      when (presentation.state.role) {
+        NetplayRole.HOST -> "Host"
+        NetplayRole.CLIENT -> "Client"
+        null -> null
+      }
+  return if (role == null) "Netplay: $phase" else "Netplay: $role — $phase"
+}
 
 internal fun DesktopPreferencesCategory.toPreferencesCategory(): PreferencesCategory =
     when (this) {

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayFooterSummaryTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayFooterSummaryTest.kt
@@ -1,0 +1,46 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.link.LinkMode
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class NetplayFooterSummaryTest {
+
+  @Test
+  fun `footer identifies the host and each client while retaining the connection phase`() {
+    assertEquals("Netplay: Off", netplaySummary(presentNetplay(NetplayUiState())))
+
+    assertEquals(
+        "Netplay: Host — Hosting",
+        netplaySummary(
+            presentNetplay(
+                NetplayUiState(
+                    phase = NetplayPhase.WAITING_FOR_PEERS,
+                    role = NetplayRole.HOST,
+                    mode = LinkMode.FOUR_PLAYER_ADAPTER,
+                    localPlayer = 0,
+                ))),
+    )
+    assertEquals(
+        "Netplay: Client — Connecting",
+        netplaySummary(
+            presentNetplay(
+                NetplayUiState(
+                    phase = NetplayPhase.CONNECTING,
+                    role = NetplayRole.CLIENT,
+                    endpoint = NetplayV8Endpoint.create("localhost", NETPLAY_V8_PORT, "localhost"),
+                ))),
+    )
+    assertEquals(
+        "Netplay: Client — Active",
+        netplaySummary(
+            presentNetplay(
+                NetplayUiState(
+                    phase = NetplayPhase.ACTIVE,
+                    role = NetplayRole.CLIENT,
+                    mode = LinkMode.FOUR_PLAYER_ADAPTER,
+                    localPlayer = 3,
+                ))),
+    )
+  }
+}

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayFooterSummaryTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/NetplayFooterSummaryTest.kt
@@ -32,7 +32,7 @@ class NetplayFooterSummaryTest {
                 ))),
     )
     assertEquals(
-        "Netplay: Client — Active",
+        "Netplay: Client 4 — Active",
         netplaySummary(
             presentNetplay(
                 NetplayUiState(


### PR DESCRIPTION
## Summary
- identify the host window and every client window in the persistent netplay footer
- retain the existing connection phase, for example: `Netplay: Host — Hosting` and `Netplay: Client — Active`

## Root cause and fix
The footer summarized only the netplay phase even though the UI already tracks whether the process is the host or a client. During local two- or four-player setup every window therefore looked the same. The formatter now combines that existing role with the phase while preserving `Netplay: Off` for disconnected instances.

## Regression coverage
- added `NetplayFooterSummaryTest` for disconnected, host, connecting-client, and active-client summaries

## Verification
- `/opt/maven/bin/mvn -pl swing -am test -Dtest=NetplayFooterSummaryTest -Dsurefire.failIfNoSpecifiedTests=false` — pass
- `/opt/maven/bin/mvn -pl swing -am test` — core (1,960 tests) and controller (958 tests) passed; Swing ran 806 tests with one unrelated controller-chord test failure in `SwingProposal3MenuTest`
- `/opt/maven/bin/mvn -pl swing -am test -Dtest=SwingProposal3MenuTest -Dsurefire.failIfNoSpecifiedTests=false` — rerun passed (33 tests)

Fixes #612