### PR TITLE
Fix Donkey Kong Country fast link negotiation

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
@@ -21,9 +21,13 @@ internal object LinkedFrameStepper {
   // a slow mirrored master-selection loop about 217 ms of independent machine time.
   private const val INTERNAL_COLLISION_ESCAPE_FRAMES = 13
 
-  // External listeners need a shorter election window: P1 either reaches its internal-clock
-  // fallback within this interval or resumes lockstep with enough phase separation to do so first.
+  // DMG-speed listeners need enough independent execution to reach their timeout fallback.
   private const val EXTERNAL_ELECTION_ESCAPE_FRAMES = 2
+
+  // A native-CGB fast byte is far shorter than a controller frame. A single T-cycle gives later
+  // role election a deterministic order without running a valid passive listener thousands of
+  // byte periods ahead of an input-driven peer.
+  private const val FAST_EXTERNAL_ELECTION_PHASE_TICKS = 1L
 
   fun advanceFrame(
       mode: LinkMode,
@@ -77,10 +81,14 @@ internal object LinkedFrameStepper {
       }
       bothExternal -> {
         val limit =
-            Math.multiplyExact(
-                clockSpec.controllerTicksPerFrame().toLong(),
-                EXTERNAL_ELECTION_ESCAPE_FRAMES.toLong(),
-            )
+            if (first.gameboy.isFastSerialClockSelectedForActiveTransfer) {
+              FAST_EXTERNAL_ELECTION_PHASE_TICKS
+            } else {
+              Math.multiplyExact(
+                  clockSpec.controllerTicksPerFrame().toLong(),
+                  EXTERNAL_ELECTION_ESCAPE_FRAMES.toLong(),
+              )
+            }
         val ticks =
             advanceUnilaterally(first, limit) {
               first.gameboy.isInternalClockTransferActive

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.controller.link
 
 import eu.rekawek.coffeegb.controller.Session
 import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
+import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
@@ -38,7 +39,7 @@ class LinkedFrameStepperTest {
   }
 
   @Test
-  fun mirroredExternalListenersReceiveABoundedP1ElectionLead() {
+  fun mirroredDmgExternalListenersReceiveABoundedP1ElectionLead() {
     PairFixture().use { fixture ->
       fixture.armBoth(0x80)
 
@@ -52,6 +53,46 @@ class LinkedFrameStepperTest {
           expectedLead.toInt() and 0xffff,
           dividerDelta(fixture.first, fixture.second),
       )
+      assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+    }
+  }
+
+  @Test
+  fun mirroredCgbNormalExternalListenersKeepTheBoundedP1ElectionLead() {
+    PairFixture(GameboyType.CGB).use { fixture ->
+      fixture.armBoth(0x80)
+
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.EXTERNAL_CLOCK_DEADLOCK,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+
+      val expectedLead = 2L * fixture.clockSpec.controllerTicksPerFrame()
+      assertEquals(
+          expectedLead.toInt() and 0xffff,
+          dividerDelta(fixture.first, fixture.second),
+      )
+      assertFalse(fixture.first.gameboy.isFastSerialClockSelectedForActiveTransfer)
+      assertFalse(fixture.second.gameboy.isFastSerialClockSelectedForActiveTransfer)
+      assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+    }
+  }
+
+  @Test
+  fun mirroredCgbFastExternalListenersReceiveOnlyASingleTickP1PhaseLead() {
+    PairFixture(GameboyType.CGB).use { fixture ->
+      fixture.armBoth(0x82)
+
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.EXTERNAL_CLOCK_DEADLOCK,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+
+      assertEquals(1, dividerDelta(fixture.first, fixture.second))
+      assertTrue(fixture.first.gameboy.isExternalClockTransferActive)
+      assertTrue(fixture.second.gameboy.isExternalClockTransferActive)
+      assertTrue(fixture.first.gameboy.isFastSerialClockSelectedForActiveTransfer)
+      assertTrue(fixture.second.gameboy.isFastSerialClockSelectedForActiveTransfer)
       assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
     }
   }
@@ -82,7 +123,7 @@ class LinkedFrameStepperTest {
     return (aheadDivider - behindDivider) and 0xffff
   }
 
-  private class PairFixture : AutoCloseable {
+  private class PairFixture(hardware: GameboyType = GameboyType.DMG) : AutoCloseable {
     val firstEndpoint = Peer2PeerSerialEndpoint()
     val secondEndpoint = Peer2PeerSerialEndpoint()
     val first: Session
@@ -92,8 +133,16 @@ class LinkedFrameStepperTest {
 
     init {
       firstEndpoint.init(secondEndpoint)
-      val firstConfig = StateCodecTestSupport.configuration()
-      val secondConfig = StateCodecTestSupport.configuration()
+      val firstConfig =
+          StateCodecTestSupport.configuration(
+              bytes = StateCodecTestSupport.rom(cgb = hardware == GameboyType.CGB),
+              hardware = hardware,
+          )
+      val secondConfig =
+          StateCodecTestSupport.configuration(
+              bytes = StateCodecTestSupport.rom(cgb = hardware == GameboyType.CGB),
+              hardware = hardware,
+          )
       first = Session(firstConfig, EventBusImpl(null, null, false), null, firstEndpoint)
       second = Session(secondConfig, EventBusImpl(null, null, false), null, secondEndpoint)
       sessions = listOf(first, second)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -698,6 +698,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return serialPort.isExternalClockTransferActive();
     }
 
+    /** True when an active native-CGB serial transfer has the fast-clock selector bit set. */
+    public boolean isFastSerialClockSelectedForActiveTransfer() {
+        return serialPort.isFastClockSelectedForActiveTransfer();
+    }
+
     /**
      * Conservatively identifies machines whose independent clocks and current execution cursors
      * are indistinguishable for link-role arbitration. The comparison is observational only and

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -72,6 +72,11 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         return (sc & 0x81) == 0x80;
     }
 
+    /** True when an active native-CGB transfer has the fast-clock selector bit set. */
+    public boolean isFastClockSelectedForActiveTransfer() {
+        return (sc & 0x80) != 0 && isColorMode() && (sc & 0x02) != 0;
+    }
+
     /** Allocation-free scalar comparison for the owning Gameboy's link timing check. */
     public boolean hasSameTimingState(SerialPort other) {
         return other != null

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortTest.java
@@ -53,6 +53,27 @@ public class SerialPortTest {
     }
 
     @Test
+    public void fastClockSelectorQueryRequiresAnActiveNativeCgbTransfer() {
+        SpeedMode speedMode = new SpeedMode(true);
+        SerialPort cgb = new SerialPort(new InterruptManager(true), true, speedMode);
+
+        cgb.setByte(0xff02, 0x02);
+        assertFalse(cgb.isFastClockSelectedForActiveTransfer());
+        cgb.setByte(0xff02, 0x80);
+        assertFalse(cgb.isFastClockSelectedForActiveTransfer());
+        cgb.setByte(0xff02, 0x82);
+        assertTrue(cgb.isFastClockSelectedForActiveTransfer());
+
+        speedMode.setDmgCompat(true);
+        assertFalse(cgb.isFastClockSelectedForActiveTransfer());
+
+        SerialPort dmg = new SerialPort(
+                new InterruptManager(false), false, new SpeedMode(false));
+        dmg.setByte(0xff02, 0x82);
+        assertFalse(dmg.isFastClockSelectedForActiveTransfer());
+    }
+
+    @Test
     public void switchingFromExternalClockDoesNotReplayAnOldDividerEdge() {
         SpeedMode speedMode = new SpeedMode(false);
         InterruptManager interruptManager = new InterruptManager(false);


### PR DESCRIPTION
Fixes #624

## Compatibility symptom

With the reported USA/Europe multilingual GBC release, both consoles can enter Link-Up and start Funky Fishing, but the connection then collapses and both return to Adventure. The deterministic reproduction used two linked CGB sessions, an in-memory-only progression unlock, and the documented staggered role election: P1 presses START first, P2 presses START later, then P1 selects the minigame.

## Root cause

Both games legitimately arm external fast serial transfers while passively waiting at the dual START prompt. Because the two emulated machines are otherwise identical, the generic mirrored-role arbiter treated that state as an external-clock deadlock and ran P1 two controller frames (139,810 T-cycles) ahead before either player pressed START.

That window is appropriate for the older normal-speed timeout elections it was calibrated against, but it is thousands of native-CGB fast-byte periods. The permanent phase displacement survives the initially clean handshake and later breaks the minigame link loop.

## Fix

- Detect an active native-CGB transfer with the fast-clock selector bit set.
- Give that mirrored external-listener state only a deterministic one-T-cycle phase lead.
- Preserve the existing two-frame fallback for DMG and CGB normal-clock transfers, and preserve the internal-clock collision path.

This keeps the correction in the generic scheduler and does not add game-specific logic or change serial bit delivery.

## Validation

- `/opt/maven/bin/mvn -q -pl controller -am -Dtest=SerialPortTest,LinkedFrameStepperTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 18 focused tests passed.
- `/opt/maven/bin/mvn -q -pl controller -am test`
  - 3,146 tests passed; 0 failures, 0 errors, 10 skipped.
- Replayed the reported two-console Link-Up flow. Both players remain in complementary Funky Fishing gameplay beyond the point where the old scheduler returns them to Adventure.
- Replayed the five link-title scenarios covered by the earlier role-arbitration change: Gator, Shikinjou, Volley Fire, Harvest Moon, and Ikari. All ten final frames are byte-identical to their known-good references.
- Compared the staggered Donkey Kong Country handshake with SameBoy at two timing gaps; both reference runs remain connected.

Visual verification was performed locally. The captures contain copyrighted commercial-game imagery, so they were not uploaded without authorization to redistribute them publicly.
