### PR TITLE
Fix Android lifecycle and platform defaults

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:exported="false" />
         <activity
             android:name=".MainActivity"
+            android:configChanges="keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:launchMode="singleTop"
             android:exported="true">
             <intent-filter>

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -1059,6 +1059,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     }
 
     private void resumeSession() {
+        resumeHostOutputs();
+        lifecycle.resumedByUser();
+        eventBus.post(new Controller.ResumeEmulationEvent());
+    }
+
+    /** Resumes Android-owned outputs without changing the portable controller playback state. */
+    private void resumeHostOutputs() {
         AndroidAudioSink activeAudio = audio;
         if (activeAudio != null) {
             activeAudio.resume();
@@ -1075,8 +1082,6 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (activeCamera != null) {
             activeCamera.resume();
         }
-        lifecycle.resumedByUser();
-        eventBus.post(new Controller.ResumeEmulationEvent());
     }
 
     /**
@@ -2170,6 +2175,13 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             @Override
             public void pause() {
                 eventBus.post(new Controller.PauseEmulationEvent());
+            }
+
+            @Override
+            public void resumeOutputs() {
+                if (!diagnostics.enabled()) {
+                    resumeHostOutputs();
+                }
             }
 
             @Override

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
@@ -48,7 +48,7 @@ final class AndroidMenuModel {
     }
 
     static MenuPageSpec settingsPage() {
-        return settingsPage("accuracy");
+        return settingsPage("performance");
     }
 
     static MenuPageSpec settingsPage(String executionMode) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -27,7 +27,7 @@ public final class EmulationService extends Service implements AudioManager.OnAu
 
     public static void start(Context context) {
         start(context, DiagnosticsOptions.executionModeValue(
-                ExecutionMode.ACCURACY));
+                ExecutionMode.PERFORMANCE));
     }
 
     /** Starts an ordinary session with the persisted frontend-selected core strategy. */

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -179,6 +179,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private static final String PREF_SYSTEM_CGB = "system.cgbGames";
     private static final String PREF_SYSTEM_BOOTSTRAP = "system.bootstrap";
     private static final String PREF_EXECUTION_MODE = "execution.mode";
+    private static final String DEFAULT_EXECUTION_MODE = "performance";
     private static final String PREF_DISPLAY_BORDER = "display.sgbBorder";
     private static final String PREF_DISPLAY_COLORS = "display.dmgColors";
     private static final String PREF_CAMERA_SELECTION = "devices.camera.selection";
@@ -2463,10 +2464,10 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         };
     }
 
-    /** Reads the persisted core strategy; malformed/legacy values safely select Accuracy. */
+    /** Reads the persisted core strategy; a new Android install starts in Performance mode. */
     private static String executionMode(SharedPreferences preferences) {
         return DiagnosticsOptions.executionModeValue(DiagnosticsOptions.parseExecutionMode(
-                preferences.getString(PREF_EXECUTION_MODE, "accuracy")));
+                preferences.getString(PREF_EXECUTION_MODE, DEFAULT_EXECUTION_MODE)));
     }
 
     private static void applySystemSettings(AndroidEmulationRuntime runtime,

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGate.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGate.java
@@ -12,6 +12,8 @@ final class RuntimeLifecycleGate {
     interface SessionCommands {
         void pause();
 
+        void resumeOutputs();
+
         void requestBatteryFlush();
     }
 
@@ -19,19 +21,29 @@ final class RuntimeLifecycleGate {
     private boolean background;
     private boolean hostPauseRequested;
     private boolean flushRequested;
+    /** Host outputs were paused before there was a session for the controller to pause. */
+    private boolean resumeOutputsOnActivation;
 
     void activated(SessionCommands commands) {
         active = true;
         hostPauseRequested = false;
         flushRequested = false;
         if (background) {
+            resumeOutputsOnActivation = false;
             background(commands);
+        } else if (resumeOutputsOnActivation) {
+            // A document picker can pause host outputs before the first session exists. Starting
+            // that session in the foreground must reactivate those outputs without manufacturing
+            // a controller resume edge for a machine that is already running.
+            resumeOutputsOnActivation = false;
+            commands.resumeOutputs();
         }
     }
 
     void background(SessionCommands commands) {
         background = true;
         if (!active) {
+            resumeOutputsOnActivation = true;
             return;
         }
         if (!hostPauseRequested) {
@@ -46,6 +58,7 @@ final class RuntimeLifecycleGate {
 
     void resumedByUser() {
         background = false;
+        resumeOutputsOnActivation = false;
         if (active) {
             hostPauseRequested = false;
         }
@@ -65,6 +78,7 @@ final class RuntimeLifecycleGate {
         background = false;
         hostPauseRequested = false;
         flushRequested = false;
+        resumeOutputsOnActivation = false;
     }
 
     boolean active() {

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGateTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/RuntimeLifecycleGateTest.java
@@ -22,6 +22,10 @@ public class RuntimeLifecycleGateTest {
             }
 
             @Override
+            public void resumeOutputs() {
+            }
+
+            @Override
             public void requestBatteryFlush() {
                 flushes.incrementAndGet();
             }
@@ -55,6 +59,10 @@ public class RuntimeLifecycleGateTest {
             }
 
             @Override
+            public void resumeOutputs() {
+            }
+
+            @Override
             public void requestBatteryFlush() {
                 calls.incrementAndGet();
             }
@@ -80,6 +88,10 @@ public class RuntimeLifecycleGateTest {
             }
 
             @Override
+            public void resumeOutputs() {
+            }
+
+            @Override
             public void requestBatteryFlush() {
                 flushes.incrementAndGet();
             }
@@ -97,5 +109,94 @@ public class RuntimeLifecycleGateTest {
         assertFalse(gate.active());
         assertEquals(10, pauses.get());
         assertEquals(10, flushes.get());
+    }
+
+    @Test
+    public void foregroundActivationResumesOutputsAfterAFirstRomPickerRoundTrip() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger pauses = new AtomicInteger();
+        AtomicInteger resumes = new AtomicInteger();
+        AtomicInteger flushes = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                pauses.incrementAndGet();
+            }
+
+            @Override
+            public void resumeOutputs() {
+                resumes.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                flushes.incrementAndGet();
+            }
+        };
+
+        gate.background(session);
+        gate.foregrounded();
+        gate.activated(session);
+
+        assertEquals(0, pauses.get());
+        assertEquals(1, resumes.get());
+        assertEquals(0, flushes.get());
+    }
+
+    @Test
+    public void ordinaryForegroundActivationLeavesAlreadyRunningOutputsAlone() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger calls = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                calls.incrementAndGet();
+            }
+
+            @Override
+            public void resumeOutputs() {
+                calls.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                calls.incrementAndGet();
+            }
+        };
+
+        gate.activated(session);
+
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    public void backgroundActivationKeepsNewSessionOutputsPaused() {
+        RuntimeLifecycleGate gate = new RuntimeLifecycleGate();
+        AtomicInteger pauses = new AtomicInteger();
+        AtomicInteger resumes = new AtomicInteger();
+        AtomicInteger flushes = new AtomicInteger();
+        RuntimeLifecycleGate.SessionCommands session = new RuntimeLifecycleGate.SessionCommands() {
+            @Override
+            public void pause() {
+                pauses.incrementAndGet();
+            }
+
+            @Override
+            public void resumeOutputs() {
+                resumes.incrementAndGet();
+            }
+
+            @Override
+            public void requestBatteryFlush() {
+                flushes.incrementAndGet();
+            }
+        };
+
+        gate.background(session);
+        gate.activated(session);
+
+        assertEquals(1, pauses.get());
+        assertEquals(0, resumes.get());
+        assertEquals(1, flushes.get());
     }
 }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
@@ -20,7 +20,7 @@ public class SettingsSelectionTest {
                         .map(MenuPageSpec.Item::id).toList());
         assertEquals("PERFORMANCE", AndroidMenuModel.settingsPage("performance").items().get(4)
                 .detail());
-        assertEquals("ACCURACY", AndroidMenuModel.settingsPage().items().get(4).detail());
+        assertEquals("PERFORMANCE", AndroidMenuModel.settingsPage().items().get(4).detail());
         assertEquals(List.of("dmg-games", "cgb-games", "bootstrap"),
                 AndroidMenuModel.systemPage("AUTO", "AUTO", "SKIP", "dmg-games")
                         .items().stream().map(MenuPageSpec.Item::id).toList());

--- a/doc/android-real-time-fast-path-design.md
+++ b/doc/android-real-time-fast-path-design.md
@@ -204,7 +204,9 @@ and replay/netplay mismatch tests. Compare controller overhead with the setting 
 effective mode, including a visible deoptimization-to-Accuracy indication when applicable.
 
 **Acceptance:** UI selection affects the next session only; benchmark logs identify the effective
-mode and all seven hardware rows independently; no Android/Swing class is referenced by core.
+mode and all seven hardware rows independently; a missing Android frontend preference selects
+Performance while desktop retains the controller's Accuracy default; no Android/Swing class is
+referenced by core.
 
 **Tests/measurement:** Swing preference/session test, Android option/diagnostic unit test, headless
 smoke test, and one visible phone run in each mode with audio on.


### PR DESCRIPTION
## Summary

- resume Android-owned outputs when the first foreground ROM session follows a picker round trip
- handle orientation and screen-size changes without recreating and pausing the emulation Activity
- default Android to Performance mode while retaining the desktop Accuracy default

## Validation

- Full Android debug unit suite
- Android lintDebug
- Android assembleDebug
- Controller SystemPropertiesTest (8 tests)