### PR TITLE
Enlarge Android A+B touch zone

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsLayout.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/TouchControlsLayout.java
@@ -80,11 +80,20 @@ final class TouchControlsLayout {
             }
             return List.copyOf(pressed);
         }
+        float actionMiddleX = (geometry.aX + geometry.bX) / 2f;
+        float actionMiddleY = (geometry.aY + geometry.bY) / 2f;
+        if (inCircle(x, y, actionMiddleX, actionMiddleY, geometry.actionRadius)) {
+            return List.of(Button.A, Button.B);
+        }
         if (inCircle(x, y, geometry.bX, geometry.bY, geometry.actionRadius)) {
             return List.of(Button.B);
         }
         if (inCircle(x, y, geometry.aX, geometry.aY, geometry.actionRadius)) {
             return List.of(Button.A);
+        }
+        if (inCapsule(x, y, geometry.bX, geometry.bY, geometry.aX, geometry.aY,
+                geometry.actionRadius)) {
+            return List.of(Button.A, Button.B);
         }
         if (inRect(x, y, geometry.selectX, geometry.utilityY,
                 geometry.utilityWidth, geometry.utilityHeight)) {
@@ -149,6 +158,25 @@ final class TouchControlsLayout {
         float dx = x - centerX;
         float dy = y - centerY;
         return dx * dx + dy * dy <= radius * radius;
+    }
+
+    /**
+     * Covers the rest of the bridge between the two round action-button hit targets. The central
+     * A+B circle is checked first so its larger target can overlap the inner edges of both buttons.
+     */
+    private static boolean inCapsule(float x, float y, float startX, float startY,
+                                     float endX, float endY, float radius) {
+        float segmentX = endX - startX;
+        float segmentY = endY - startY;
+        float segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+        if (segmentLengthSquared == 0f) {
+            return inCircle(x, y, startX, startY, radius);
+        }
+        float projection = ((x - startX) * segmentX + (y - startY) * segmentY)
+                / segmentLengthSquared;
+        projection = clamp(projection, 0f, 1f);
+        return inCircle(x, y, startX + projection * segmentX,
+                startY + projection * segmentY, radius);
     }
 
     private static boolean inRect(float x, float y, float centerX, float centerY,

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/TouchControlsLayoutTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/TouchControlsLayoutTest.java
@@ -46,6 +46,14 @@ public class TouchControlsLayoutTest {
     }
 
     @Test
+    public void enlargedSpaceBetweenActionButtonsOverlapsBothButtonsInBothOrientations() {
+        TouchControlsLayout layout = new TouchControlsLayout(.5f, 1f, 0f, false, true);
+
+        assertActionButtonBridge(layout, 1_080, 1_920);
+        assertActionButtonBridge(layout, 1_920, 1_080);
+    }
+
+    @Test
     public void mappedViewTouchUsesNativeSkinGeometryAndLetterboxMoveReleasesIt() {
         TouchControlsLayout layout = new TouchControlsLayout(.5f, 1f, 0f, false, false);
         SkinTransform transform = SkinTransform.aspectFit(941, 1672, 920, 1884);
@@ -65,5 +73,30 @@ public class TouchControlsLayoutTest {
         } finally {
             router.close();
         }
+    }
+
+    private static void assertActionButtonBridge(TouchControlsLayout layout,
+                                                  int width, int height) {
+        float middleX = (layout.actionCenterX(width, height, false)
+                + layout.actionCenterX(width, height, true)) / 2f;
+        float middleY = (layout.actionCenterY(width, height, false)
+                + layout.actionCenterY(width, height, true)) / 2f;
+        float bOverlapX = (middleX + layout.actionCenterX(width, height, false)) / 2f;
+        float bOverlapY = (middleY + layout.actionCenterY(width, height, false)) / 2f;
+        float aOverlapX = (middleX + layout.actionCenterX(width, height, true)) / 2f;
+        float aOverlapY = (middleY + layout.actionCenterY(width, height, true)) / 2f;
+
+        assertEquals(List.of(Button.A, Button.B),
+                layout.buttonsAt(middleX, middleY, width, height));
+        assertEquals(List.of(Button.A, Button.B),
+                layout.buttonsAt(bOverlapX, bOverlapY, width, height));
+        assertEquals(List.of(Button.A, Button.B),
+                layout.buttonsAt(aOverlapX, aOverlapY, width, height));
+        assertEquals(List.of(Button.B), layout.buttonsAt(
+                layout.actionCenterX(width, height, false),
+                layout.actionCenterY(width, height, false), width, height));
+        assertEquals(List.of(Button.A), layout.buttonsAt(
+                layout.actionCenterX(width, height, true),
+                layout.actionCenterY(width, height, true), width, height));
     }
 }


### PR DESCRIPTION
## Summary

- add a dedicated A+B hit target centered between the Android action buttons
- extend the combined target through the full bridge between A and B while preserving each button's outer single-button area
- cover portrait and landscape geometry, including intentional overlap with both button circles

## Verification

- Android `:app:testDebugUnitTest` — successful
- same-checkout core, controller, and portable UI artifacts compiled successfully

