### PR TITLE
Move execution mode picker into System

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
@@ -48,17 +48,11 @@ final class AndroidMenuModel {
     }
 
     static MenuPageSpec settingsPage() {
-        return settingsPage("performance");
-    }
-
-    static MenuPageSpec settingsPage(String executionMode) {
         return page(MenuRoute.SETTINGS, "COFFEE GB", "SETTINGS", "", "", List.of(), List.of(
                         item("system", "SYSTEM", "", true),
                         item("display", "DISPLAY", "", true),
                         item("audio", "AUDIO", "", true),
-                        item("peripherals", "PERIPHERALS", "", true),
-                        item("execution-mode", "EXECUTION MODE", executionModeLabel(executionMode),
-                                true)),
+                        item("peripherals", "PERIPHERALS", "", true)),
                 "system",
                 MenuPreview.empty());
     }
@@ -79,11 +73,12 @@ final class AndroidMenuModel {
     }
 
     static MenuPageSpec systemPage(String dmgGames, String cgbGames, String bootstrap,
-            String preferredFocusId) {
+            String executionMode, String preferredFocusId) {
         return page(MenuRoute.SYSTEM, "COFFEE GB", "SYSTEM", "", "", List.of(), List.of(
                 item("dmg-games", "DMG GAMES", systemChoiceLabel(dmgGames), true),
                 item("cgb-games", "CGB GAMES", systemChoiceLabel(cgbGames), true),
-                item("bootstrap", "BOOTSTRAP", systemChoiceLabel(bootstrap), true)),
+                item("bootstrap", "BOOTSTRAP", systemChoiceLabel(bootstrap), true),
+                item("execution-mode", "EXECUTION MODE", executionModeLabel(executionMode), true)),
                 preferredFocusId, MenuPreview.empty());
     }
 
@@ -246,7 +241,7 @@ final class AndroidMenuModel {
     }
 
     static MenuPageSpec systemPage(String preferredFocusId) {
-        return systemPage("AUTO", "AUTO", "SKIP", preferredFocusId);
+        return systemPage("AUTO", "AUTO", "SKIP", "performance", preferredFocusId);
     }
 
     static MenuPageSpec dataMediaPage(TransferAvailability availability) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1051,11 +1051,6 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                 refreshMenuPages();
                 menuController.push(MenuRoute.OPTIONAL_DEVICES);
             }
-            case "execution-mode" -> openOptionPicker(MenuRoute.SETTINGS, id,
-                    "EXECUTION MODE",
-                    List.of(new AndroidMenuModel.ChoiceValue("accuracy", "ACCURACY"),
-                            new AndroidMenuModel.ChoiceValue("performance", "PERFORMANCE")),
-                    executionMode(getPreferences(MODE_PRIVATE)));
             case "touch-controls" -> {
                 touchDraft = AndroidMenuModel.touchDraft(video.touchLayout());
                 refreshMenuPages();
@@ -1099,6 +1094,11 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                             new AndroidMenuModel.ChoiceValue("fast-forward", "FAST-FORWARD"),
                             new AndroidMenuModel.ChoiceValue("full", "FULL")),
                     systemBootstrap(preferences));
+            case "execution-mode" -> openOptionPicker(MenuRoute.SYSTEM, id,
+                    "EXECUTION MODE",
+                    List.of(new AndroidMenuModel.ChoiceValue("accuracy", "ACCURACY"),
+                            new AndroidMenuModel.ChoiceValue("performance", "PERFORMANCE")),
+                    executionMode(preferences));
             default -> { }
         }
     }
@@ -2205,7 +2205,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         }
         menuController.setPages(List.of(
                 pausePage(), statePage(), recentGamesPage(), libraryPage(), chooseRomPage(),
-                AndroidMenuModel.settingsPage(executionMode(preferences)),
+                AndroidMenuModel.settingsPage(),
                 AndroidMenuModel.audioPage(audio),
                 AndroidMenuModel.displayPage(
                         preferences.getBoolean(PREF_DISPLAY_BORDER, false),
@@ -2219,7 +2219,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                         optionSession == null ? null : optionSession.selectedToken()),
                 AndroidMenuModel.printerPaperPage(printerPreview, printerStatus),
                 AndroidMenuModel.systemPage(systemDmg(preferences), systemCgb(preferences),
-                        systemBootstrap(preferences), systemPreferredFocus),
+                        systemBootstrap(preferences), executionMode(preferences),
+                        systemPreferredFocus),
                 AndroidMenuModel.dataMediaPage(AndroidMenuModel.transferAvailability(
                         runtime != null, observedState)),
                 AndroidMenuModel.aboutPage(BuildConfig.VERSION_NAME, aboutStatus),

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
@@ -18,7 +18,7 @@ public class AndroidMenuModelTest {
 
     @Test
     public void settingsExposesOnlyInlineEditableRoutes() {
-        assertEquals(List.of("system", "display", "audio", "peripherals", "execution-mode"),
+        assertEquals(List.of("system", "display", "audio", "peripherals"),
                 AndroidMenuModel.settingsPage().items().stream()
                         .map(MenuPageSpec.Item::id).toList());
         assertEquals("system", AndroidMenuModel.settingsPage().preferredFocusId());
@@ -67,7 +67,7 @@ public class AndroidMenuModelTest {
         assertIds(AndroidMenuModel.printerPaperPage(MenuPreview.empty(), "READY"),
                 "paper-status");
         assertIds(AndroidMenuModel.systemPage("dmg-games"),
-                "dmg-games", "cgb-games", "bootstrap");
+                "dmg-games", "cgb-games", "bootstrap", "execution-mode");
         assertIds(AndroidMenuModel.dataMediaPage(new AndroidMenuModel.TransferAvailability(
                         true, true, "READY / NATIVE PICKER")),
                 "import-battery", "export-battery", "import-state-0", "export-state-0",
@@ -191,7 +191,7 @@ public class AndroidMenuModelTest {
 
         MenuPageSpec system = AndroidMenuModel.systemPage("bootstrap");
         assertEquals("bootstrap", system.preferredFocusId());
-        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap"),
+        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap", "execution-mode"),
                 system.items().stream().map(MenuPageSpec.Item::id).toList());
 
         MenuPageSpec about = AndroidMenuModel.aboutPage("1.2.3", "OPEN");
@@ -222,11 +222,13 @@ public class AndroidMenuModelTest {
                         .map(MenuPageSpec.Item::id).toList());
         assertEquals("ON", AndroidMenuModel.displayPage(true, false).items().get(0).detail());
         assertEquals("GREEN", AndroidMenuModel.displayPage(true, false).items().get(1).detail());
-        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap"),
-                AndroidMenuModel.systemPage("DMG", "CGB", "FULL", "dmg-games")
+        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap", "execution-mode"),
+                AndroidMenuModel.systemPage("DMG", "CGB", "FULL", "accuracy", "dmg-games")
                         .items().stream().map(MenuPageSpec.Item::id).toList());
-        assertEquals("DMG", AndroidMenuModel.systemPage("DMG", "CGB", "FULL", "dmg-games")
-                .items().get(0).detail());
+        MenuPageSpec system = AndroidMenuModel.systemPage(
+                "DMG", "CGB", "FULL", "accuracy", "dmg-games");
+        assertEquals("DMG", system.items().get(0).detail());
+        assertEquals("ACCURACY", system.items().get(3).detail());
     }
 
     @Test

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
@@ -14,16 +14,16 @@ import static org.junit.Assert.assertTrue;
 public class SettingsSelectionTest {
 
     @Test
-    public void settingsGraphIncludesTheCoreExecutionModeSelector() {
-        assertEquals(List.of("system", "display", "audio", "peripherals", "execution-mode"),
-                AndroidMenuModel.settingsPage("performance").items().stream()
+    public void settingsGraphGroupsTheExecutionModeSelectorUnderSystem() {
+        assertEquals(List.of("system", "display", "audio", "peripherals"),
+                AndroidMenuModel.settingsPage().items().stream()
                         .map(MenuPageSpec.Item::id).toList());
-        assertEquals("PERFORMANCE", AndroidMenuModel.settingsPage("performance").items().get(4)
-                .detail());
-        assertEquals("PERFORMANCE", AndroidMenuModel.settingsPage().items().get(4).detail());
-        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap"),
-                AndroidMenuModel.systemPage("AUTO", "AUTO", "SKIP", "dmg-games")
+        MenuPageSpec system = AndroidMenuModel.systemPage(
+                "AUTO", "AUTO", "SKIP", "performance", "dmg-games");
+        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap", "execution-mode"),
+                system
                         .items().stream().map(MenuPageSpec.Item::id).toList());
+        assertEquals("PERFORMANCE", system.items().get(3).detail());
         assertEquals(List.of("sgb-border", "dmg-colors"),
                 AndroidMenuModel.displayPage(false, false).items().stream()
                         .map(MenuPageSpec.Item::id).toList());
@@ -31,7 +31,8 @@ public class SettingsSelectionTest {
                 AndroidMenuModel.optionalDevicesPage("off", "auto", false, List.of())
                         .items().stream().map(MenuPageSpec.Item::id).toList());
         assertEquals("FAST-FORWARD",
-                AndroidMenuModel.systemPage("auto", "auto", "fast-forward", "dmg-games")
+                AndroidMenuModel.systemPage(
+                        "auto", "auto", "fast-forward", "accuracy", "dmg-games")
                         .items().get(2).detail());
     }
 

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPages.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPages.java
@@ -96,7 +96,8 @@ final class MenuPages {
             case SYSTEM -> page(route, "COFFEE GB", "SYSTEM", "", "", List.of(),
                     items(item("dmg-games", "DMG GAMES", "AUTO"),
                             item("cgb-games", "CGB GAMES", "AUTO"),
-                            item("bootstrap", "BOOTSTRAP", "SKIP")));
+                            item("bootstrap", "BOOTSTRAP", "SKIP"),
+                            item("execution-mode", "EXECUTION MODE", "PERFORMANCE")));
             case ABOUT -> page(route, "COFFEE GB", "ABOUT", "", "COFFEE GB",
                     List.of("MIT LICENSE", "OPEN SOURCE"),
                     items(

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositor.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositor.java
@@ -717,7 +717,7 @@ public final class Proposal3MenuCompositor {
     private static boolean isChoiceRow(MenuRoute route, Entry entry) {
         return switch (route) {
             case SYSTEM -> entry.id.equals("dmg-games") || entry.id.equals("cgb-games")
-                    || entry.id.equals("bootstrap");
+                    || entry.id.equals("bootstrap") || entry.id.equals("execution-mode");
             case DISPLAY -> entry.id.equals("dmg-colors");
             case OPTIONAL_DEVICES -> entry.id.equals("camera") || entry.id.equals("gamepad");
             default -> false;
@@ -1071,7 +1071,7 @@ public final class Proposal3MenuCompositor {
 
     static MenuRoute optionPickerIllustrationRoute(String context) {
         return switch (display(context)) {
-            case "DMG GAMES", "CGB GAMES", "BOOTSTRAP" -> MenuRoute.SYSTEM;
+            case "DMG GAMES", "CGB GAMES", "BOOTSTRAP", "EXECUTION MODE" -> MenuRoute.SYSTEM;
             case "DMG COLORS" -> MenuRoute.DISPLAY;
             case "CAMERA", "GAMEPAD" -> MenuRoute.OPTIONAL_DEVICES;
             default -> null;
@@ -1447,6 +1447,7 @@ public final class Proposal3MenuCompositor {
             case SYSTEM -> switch (e.id) {
                 case "dmg-games", "cgb-games" -> "AUTO";
                 case "bootstrap" -> "SKIP";
+                case "execution-mode" -> "PERFORMANCE";
                 case "video-status" -> "NEAREST NEIGHBOR / ASPECT FIT";
                 case "profile-status" -> "SELECTED ON OPEN";
                 case "rewind-save-status" -> "PORTABLE DEFAULTS";

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3OverlayCatalog.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3OverlayCatalog.java
@@ -86,6 +86,10 @@ final class Proposal3OverlayCatalog {
     static final List<MenuRect> LIBRARY_DIVIDERS = SAVE_DIVIDERS;
     private static final List<MenuRect> CHOOSE_ROM_ROW_BOUNDS = equalRows(387, 179, 524, 333, 7, 3);
     static final List<MenuRect> CHOOSE_ROM_DIVIDERS = dividers(CHOOSE_ROM_ROW_BOUNDS);
+    private static final int[][] SYSTEM_ROW_BOUNDS = {
+            {378, 124, 530, 95}, {378, 223, 530, 103},
+            {378, 329, 530, 103}, {378, 435, 530, 103}
+    };
 
     /** Kept entirely inside the left inset so changing a percentage cannot erase its frame. */
     static final MenuRect AUDIO_VOLUME_LABEL = new MenuRect(62, 405, 275, 45);
@@ -268,11 +272,9 @@ final class Proposal3OverlayCatalog {
                 new Marker(407), false));
 
         layouts.put(MenuRoute.SYSTEM, layout(MenuRoute.SYSTEM,
-                rows(new int[][]{{378, 124, 530, 95}, {378, 223, 530, 103},
-                        {378, 329, 530, 103}}, Surface.DARK), List.of(),
+                rows(SYSTEM_ROW_BOUNDS, Surface.DARK), List.of(),
                 masks(SYSTEM_LEFT_META, SYSTEM_LEFT_STATUS, SYSTEM_RIGHT_COPY,
-                        rowsMasks(new int[][]{{378, 124, 530, 95}, {378, 223, 530, 103},
-                                {378, 329, 530, 103}})), false, "dmg-games", null, false));
+                        rowsMasks(SYSTEM_ROW_BOUNDS)), false, "dmg-games", null, false));
 
         layouts.put(MenuRoute.ABOUT, layout(MenuRoute.ABOUT,
                 rows(new int[][]{{352, 115, 558, 89}, {352, 207, 558, 83},

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/PortableSettingsContractTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/PortableSettingsContractTest.java
@@ -47,7 +47,7 @@ public class PortableSettingsContractTest {
         assertEquals("PERIPHERALS", MenuRoute.OPTIONAL_DEVICES.label());
         assertEquals("DISPLAY", MenuRoute.DISPLAY.label());
         assertEquals("OPTION PICKER", MenuRoute.OPTION_PICKER.label());
-        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap"),
+        assertEquals(List.of("dmg-games", "cgb-games", "bootstrap", "execution-mode"),
                 show(MenuRoute.SYSTEM).items().stream().map(MenuPresentation.Item::id).toList());
         assertEquals(List.of("sgb-border", "dmg-colors"),
                 show(MenuRoute.DISPLAY).items().stream().map(MenuPresentation.Item::id).toList());
@@ -56,6 +56,7 @@ public class PortableSettingsContractTest {
                         .map(MenuPresentation.Item::id).toList());
         assertEquals("GREEN", show(MenuRoute.DISPLAY).items().get(1).detail());
         assertEquals("SKIP", show(MenuRoute.SYSTEM).items().get(2).detail());
+        assertEquals("PERFORMANCE", show(MenuRoute.SYSTEM).items().get(3).detail());
     }
 
     @Test
@@ -75,6 +76,21 @@ public class PortableSettingsContractTest {
             assertEquals(924, frame.width());
             assertEquals(736, frame.height());
         }
+    }
+
+    @Test
+    public void systemExecutionModeUsesTheFourthVisibleChoiceRow() {
+        MenuController controller = new MenuController(new NoopListener());
+        controller.show(MenuRoute.SYSTEM);
+        Proposal3OverlayCatalog.RouteLayout layout =
+                Proposal3OverlayCatalog.layout(MenuRoute.SYSTEM);
+
+        assertEquals(4, layout.rows().size());
+        MenuRect fourthRow = layout.rows().get(3).bounds();
+        int[] frame = new Proposal3MenuCompositor().compose(controller.presentation())
+                .orElseThrow().copyPixels();
+        assertTrue(lightPixels(frame, fourthRow.x(), fourthRow.y(),
+                fourthRow.width(), fourthRow.height()) > 20);
     }
 
     @Test
@@ -110,6 +126,8 @@ public class PortableSettingsContractTest {
                 Proposal3MenuCompositor.optionPickerIllustrationRoute("DMG GAMES"));
         assertEquals(MenuRoute.SYSTEM,
                 Proposal3MenuCompositor.optionPickerIllustrationRoute("BOOTSTRAP"));
+        assertEquals(MenuRoute.SYSTEM,
+                Proposal3MenuCompositor.optionPickerIllustrationRoute("EXECUTION MODE"));
         assertEquals(MenuRoute.DISPLAY,
                 Proposal3MenuCompositor.optionPickerIllustrationRoute("DMG COLORS"));
         assertEquals(MenuRoute.OPTIONAL_DEVICES,


### PR DESCRIPTION
## Summary

- move the execution-mode picker from the top-level Settings page into System
- route selection and focus through the System page while preserving the current preference value
- expand the portable System artwork and contracts with a fourth visible choice row

## Verification

- Android `:app:testDebugUnitTest` — successful
- `ui-portable` tests — 107 passed, 0 failures
- same-checkout core, controller, and portable UI artifacts compiled successfully
