### PR TITLE
Give local netplay clients persistent battery saves

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -210,7 +210,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         // Release/non-diagnostic callers retain the ordinary settings path unchanged.
         BootstrapMode bootstrapMode = checked.enabled ? checked.bootstrapMode : null;
         return new ApplicationSettingsOverrides(profile, bootstrapMode,
-                checked.enabled ? false : null, false, false, false,
+                checked.enabled ? false : null, null, false, false, false,
                 checked.enabled && checked.runtimeWarmup, runtimeWarmupFlavor(checked), checked.enabled,
                 checked.enabled ? checked.executionMode : null);
     }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -4742,18 +4742,23 @@ class BasicController private constructor(
           "Active session has no precomputed ROM identity"
         }
     val batteryStorage =
-        try {
-          liveBatteryStorageResolver.resolve(
-              saves,
-              currentSession.config,
-              romHashes,
-          )
-        } catch (failure: RuntimeException) {
-          LOG.warn(
-              "Unable to reconfigure battery storage; retaining the active destination",
-              failure,
-          )
+        if (properties.overrides.batterySavePath != null) {
+          // An explicit launch path remains authoritative for the lifetime of this process.
           null
+        } else {
+          try {
+            liveBatteryStorageResolver.resolve(
+                saves,
+                currentSession.config,
+                romHashes,
+            )
+          } catch (failure: RuntimeException) {
+            LOG.warn(
+                "Unable to reconfigure battery storage; retaining the active destination",
+                failure,
+            )
+            null
+          }
         }
     if (batteryStorage != null) {
       // Resolution is pure. Commit both views only after both primary and slot paths passed, so a

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/Controller.kt
@@ -992,7 +992,8 @@ interface Controller : AutoCloseable {
       config.setHardwareProfile(hardwareProfile)
       config.setBootstrapMode(bootstrapMode)
       config.setExecutionMode(properties.system.executionMode)
-      config.setSupportBatterySave(properties.saves.batterySavesEnabled)
+      config.setSupportBatterySave(
+          properties.overrides.batterySavePath != null || properties.saves.batterySavesEnabled)
       if (properties.overrides.forceInMemoryBattery && rom.type.isBattery) {
         // A local netplay child must never touch the host's sidecar, but its detached checkpoint
         // still needs the same battery-state presence as the service-free network peer target.

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -50,7 +50,11 @@ internal class RomSessionPreparer(
     ensureActive()
     val hostPersistenceStore = event.persistenceStore
     val persistence =
-        (hostPersistenceStore ?: DesktopRomPersistenceStore(properties.applicationSettings.saves))
+        (hostPersistenceStore
+                ?: DesktopRomPersistenceStore(
+                    properties.applicationSettings.saves,
+                    properties.overrides.batterySavePath,
+                ))
             .resolve(config, romHashes)
     persistence.applyTo(config)
     // The desktop controller retains its configurable workspace (and its bounded fallbacks).

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettings.kt
@@ -662,6 +662,8 @@ data class ApplicationSettingsOverrides(
     val hardwareProfile: HardwareProfile? = null,
     val bootstrapMode: BootstrapMode? = null,
     val batterySavesEnabled: Boolean? = null,
+    /** Exact process-local primary battery destination selected by the launcher. */
+    val batterySavePath: Path? = null,
     /**
      * Supplies a blank in-memory cartridge battery without reading or writing a local sidecar.
      * Netplay children use this to retain the same portable-state graph as a transferred peer.
@@ -679,6 +681,9 @@ data class ApplicationSettingsOverrides(
 ) {
   init {
     hardwareProfile?.let(HardwareProfileRegistry::requireRegistered)
+    require(batterySavePath == null || !forceInMemoryBattery) {
+      "An explicit battery save cannot be combined with an in-memory battery"
+    }
   }
 }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/RomPersistenceStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/RomPersistenceStore.kt
@@ -3,6 +3,7 @@ package eu.rekawek.coffeegb.controller.state
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryStorage
+import java.nio.file.Path
 
 /**
  * Host-owned persistence for one emulation session.
@@ -55,6 +56,7 @@ class FileStateStore(
 /** Existing desktop save policy retained as the default controller adapter. */
 class DesktopRomPersistenceStore(
     private val saves: ApplicationSettings.Saves,
+    private val primaryBatteryPath: Path? = null,
 ) : RomPersistenceStore {
   override fun resolve(
       configuration: Gameboy.GameboyConfiguration,
@@ -63,9 +65,10 @@ class DesktopRomPersistenceStore(
     val stateStore =
         configuration.rom.file?.let { FileStateStore(StateStorageResolver.resolve(saves, configuration).layout) }
     val batteries = BatteryStorageResolver.resolve(saves, configuration, hashes)
+    val primaryBattery = primaryBatteryPath?.let(BatteryStorage::direct) ?: batteries.primary
     return SessionPersistence(
         stateStore,
-        batteries.primary?.let { battery -> BatteryStore { battery } },
+        primaryBattery?.let { battery -> BatteryStore { battery } },
         batteries.slot?.let { battery -> BatteryStore { battery } },
     )
   }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -146,6 +146,29 @@ class RomSessionPreparerTest {
   }
 
   @Test
+  fun explicitBatterySaveOverrideOwnsThePreparedSessionStorage() {
+    val directory = Files.createTempDirectory("coffee-gb-explicit-battery")
+    val batterySave = directory.resolve("client1.sav")
+    val properties =
+        EmulatorProperties(
+            ApplicationSettingsOverrides(
+                batterySavePath = batterySave,
+                runtimeWarmupEnabled = false,
+            ))
+    try {
+      val prepared =
+          RomSessionPreparer(BootStateCache(2), runtimeWarmupCache = noopWarmupCache())
+              .prepare(properties, LoadRomEvent(ROM))
+
+      assertEquals(batterySave, prepared.config.batteryStorage.targetPath())
+      assertTrue(prepared.config.isSupportBatterySave)
+    } finally {
+      properties.close()
+      Files.deleteIfExists(directory)
+    }
+  }
+
+  @Test
   fun skipLoadWarmsExactlyOneHundredTwentyControllerFramesBeforeDeferring() {
     val executor = RecordingWarmupExecutor()
     val cache = RuntimeWarmupCache(2, executor)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncher.kt
@@ -1,6 +1,9 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.core.hardware.HardwareProfile
+import eu.rekawek.coffeegb.core.memory.cart.RomOrigin
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 private const val DESKTOP_MAIN_CLASS = "eu.rekawek.coffeegb.swing.MainKt"
@@ -44,8 +47,8 @@ internal data class LocalNetplayInstanceLaunchResult(
 
 /**
  * Reuses the current package launcher (or `java -jar`/module invocation) rather than depending on
- * a platform-specific installation path. Child clients deliberately disable battery saves so they
- * cannot race the host process over the same sidecar files.
+ * a platform-specific installation path. Every child receives an isolated persistent battery so
+ * it cannot race the host process over the original sidecar.
  */
 internal class CurrentProcessLocalNetplayInstanceLauncher(
     private val currentCommand: List<String> = currentProcessCommand(),
@@ -61,19 +64,25 @@ internal class CurrentProcessLocalNetplayInstanceLauncher(
     require(count in 1..3) { "Local netplay client count must be in 1..3" }
     val launcher = localNetplayLauncherPrefix(currentCommand)
         ?: return LocalNetplayInstanceLaunchResult(0, count, launcherAvailable = false)
-    val command =
-        launcher +
-            listOf(
-                "--profile=${profile.id()}",
-                "--disable-battery-saves",
-                "--start-muted",
-                "--join-netplay",
-                endpoint.startClientValue,
-                rom.toAbsolutePath().normalize().toString(),
-            )
+    val normalizedRom = rom.toAbsolutePath().normalize()
+    val hostBattery =
+        RomOrigin.directFile(normalizedRom).persistencePath(".sav").orElseThrow()
     var started = 0
-    repeat(count) {
+    repeat(count) { index ->
       try {
+        val clientBattery = localNetplayClientBatteryPath(hostBattery, index + 1)
+        copyHostBatteryIfClientIsNew(hostBattery, clientBattery)
+        val command =
+            launcher +
+                listOf(
+                    "--profile=${profile.id()}",
+                    "--battery-save",
+                    clientBattery.toString(),
+                    "--start-muted",
+                    "--join-netplay",
+                    endpoint.startClientValue,
+                    normalizedRom.toString(),
+                )
         startProcess(command)
         started++
       } catch (_: Exception) {
@@ -82,6 +91,21 @@ internal class CurrentProcessLocalNetplayInstanceLauncher(
     }
     return LocalNetplayInstanceLaunchResult(started, count, launcherAvailable = true)
   }
+}
+
+private fun localNetplayClientBatteryPath(hostBattery: Path, clientNumber: Int): Path {
+  require(clientNumber in 1..3) { "Local netplay client number must be in 1..3" }
+  val hostName = hostBattery.fileName.toString()
+  val stem = hostName.removeSuffix(".sav")
+  return hostBattery.resolveSibling("$stem-client$clientNumber.sav")
+}
+
+private fun copyHostBatteryIfClientIsNew(hostBattery: Path, clientBattery: Path) {
+  if (Files.exists(clientBattery, LinkOption.NOFOLLOW_LINKS) ||
+      !Files.isRegularFile(hostBattery, LinkOption.NOFOLLOW_LINKS)) {
+    return
+  }
+  Files.copy(hostBattery, clientBattery)
 }
 
 /**

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/Main.kt
@@ -9,6 +9,7 @@ import eu.rekawek.coffeegb.swing.SwingGui.Companion.runWithStartupAudio
 import eu.rekawek.coffeegb.swing.packaging.NativeRuntimeBootstrap
 import java.io.File
 import java.io.PrintStream
+import java.nio.file.Path
 import kotlin.system.exitProcess
 
 private const val SUCCESS = 0
@@ -132,6 +133,7 @@ private fun parseCli(args: Array<String>): CliCommand {
   var forceCgb = false
   var useBootstrap = false
   var disableBatterySaves = false
+  var batterySavePath: Path? = null
   var startMuted = false
   var profileId: String? = null
   var profileOccurrences = 0
@@ -175,6 +177,12 @@ private fun parseCli(args: Array<String>): CliCommand {
       index++
       continue
     }
+    if (argument.startsWith("--battery-save=")) {
+      if (batterySavePath != null) repeatedOption("--battery-save")
+      batterySavePath = parseBatterySavePath(argument.substringAfter("--battery-save="))
+      index++
+      continue
+    }
 
     when (argument) {
       "-h", "--help" -> {
@@ -208,6 +216,14 @@ private fun parseCli(args: Array<String>): CliCommand {
       "-db", "--disable-battery-saves" -> {
         if (disableBatterySaves) repeatedOption("--disable-battery-saves")
         disableBatterySaves = true
+      }
+      "--battery-save" -> {
+        if (batterySavePath != null) repeatedOption("--battery-save")
+        val value = args.getOrNull(++index) ?: cliError("--battery-save requires a path")
+        if (value.startsWith("-")) {
+          cliError("--battery-save requires a path")
+        }
+        batterySavePath = parseBatterySavePath(value)
       }
       "--start-muted" -> {
         if (startMuted) repeatedOption("--start-muted")
@@ -243,12 +259,19 @@ private fun parseCli(args: Array<String>): CliCommand {
   if (joinNetplayEndpoint != null && positional.isEmpty()) {
     cliError("--join-netplay requires a ROM file")
   }
+  if (batterySavePath != null && positional.isEmpty()) {
+    cliError("--battery-save requires a ROM file")
+  }
+  if (batterySavePath != null && disableBatterySaves) {
+    cliError("--battery-save conflicts with --disable-battery-saves")
+  }
   if (packageSmoke &&
       (debug ||
           forceDmg ||
           forceCgb ||
           useBootstrap ||
           disableBatterySaves ||
+          batterySavePath != null ||
           startMuted ||
           profileId != null ||
           joinNetplayEndpoint != null ||
@@ -286,11 +309,22 @@ private fun parseCli(args: Array<String>): CliCommand {
               ApplicationSettingsOverrides(
                   hardwareProfile = profileOverride,
                   bootstrapMode = if (useBootstrap) BootstrapMode.NORMAL else null,
-                  batterySavesEnabled = if (disableBatterySaves) false else null,
-                  forceInMemoryBattery = joinNetplayEndpoint != null,
+                  batterySavesEnabled =
+                      when {
+                        disableBatterySaves -> false
+                        batterySavePath != null -> true
+                        else -> null
+                      },
+                  batterySavePath = batterySavePath,
+                  forceInMemoryBattery = joinNetplayEndpoint != null && batterySavePath == null,
                   suppressCloseAutosave = joinNetplayEndpoint != null,
               ),
       ))
+}
+
+private fun parseBatterySavePath(value: String): Path {
+  if (value.isBlank()) cliError("--battery-save requires a path")
+  return Path.of(value)
 }
 
 private fun parseJoinNetplayEndpoint(value: String): NetplayV8Endpoint =
@@ -324,6 +358,7 @@ internal fun printUsage(stream: PrintStream) {
           HardwareProfileRegistry.supportedIds().joinToString(", "))
   stream.println("  -b  --use-bootstrap            Run the bundled boot ROM normally")
   stream.println("  -db --disable-battery-saves    Disable battery save reads and writes")
+  stream.println("      --battery-save PATH        Use an exact process-local battery save file")
   stream.println("      --join-netplay HOST        Join a netplay host after opening ROM_FILE")
   stream.println("      --start-muted              Start muted without changing saved audio settings")
   stream.println("      --debug                    Enable debug console")

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmoke.kt
@@ -118,11 +118,17 @@ internal fun validatePackagedLocalNetplayRelaunchChildIfRequested(
   check(request.settingsOverrides.hardwareProfile == HardwareProfileRegistry.DMG) {
     "Packaged local netplay child did not retain the DMG profile"
   }
-  check(request.settingsOverrides.batterySavesEnabled == false) {
-    "Packaged local netplay child did not disable battery saves"
+  val expectedBatterySave =
+      expectedRom.resolveSibling(
+          "${expectedRom.fileName.toString().removeSuffix(".gb")}-client1.sav")
+  check(
+      request.settingsOverrides.batterySavesEnabled == true &&
+          request.settingsOverrides.batterySavePath?.toAbsolutePath()?.normalize() ==
+              expectedBatterySave) {
+    "Packaged local netplay child did not retain its isolated battery save"
   }
-  check(request.settingsOverrides.forceInMemoryBattery) {
-    "Packaged local netplay child did not select an in-memory battery"
+  check(!request.settingsOverrides.forceInMemoryBattery) {
+    "Packaged local netplay child unexpectedly selected an in-memory battery"
   }
   check(request.settingsOverrides.suppressCloseAutosave) {
     "Packaged local netplay child did not suppress close autosave"
@@ -138,7 +144,7 @@ internal fun validatePackagedLocalNetplayRelaunchChildIfRequested(
 
   val evidence =
       "$RELAUNCH_EVIDENCE_PREFIX pid=$processId, launcher=$actualLauncher, " +
-          "profile=dmg, battery-saves=false, audio=muted, join=$expectedEndpoint\n"
+          "profile=dmg, battery-save=isolated, audio=muted, join=$expectedEndpoint\n"
   writeExclusiveText(marker, evidence)
   return true
 }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/LocalNetplayInstanceLauncherTest.kt
@@ -1,13 +1,19 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class LocalNetplayInstanceLauncherTest {
+
+  @get:Rule val temporaryFolder = TemporaryFolder()
 
   @Test
   fun `the running desktop test JVM has a reusable launcher`() {
@@ -25,9 +31,13 @@ class LocalNetplayInstanceLauncherTest {
   }
 
   @Test
-  fun `jar launcher starts each client with the ROM profile and localhost join command`() {
+  fun `jar launcher gives every client a persistent copy of the host battery save`() {
     val started = mutableListOf<List<String>>()
-    val rom = Path.of("test data", "Tetris.gb").toAbsolutePath().normalize()
+    val directory = temporaryFolder.newFolder("test data").toPath()
+    val rom = Files.createFile(directory.resolve("Tetris.gb"))
+    val hostSave = Files.write(directory.resolve("Tetris.sav"), byteArrayOf(1, 2, 3))
+    val retainedClientSave =
+        Files.write(directory.resolve("Tetris-client2.sav"), byteArrayOf(9, 8, 7))
     val launcher =
         CurrentProcessLocalNetplayInstanceLauncher(
             listOf("/usr/bin/java", "-Dcoffee-gb.theme=dark", "-jar", "/apps/coffee-gb.jar", "old.gb"),
@@ -38,23 +48,29 @@ class LocalNetplayInstanceLauncherTest {
 
     assertEquals(3, result.started)
     assertEquals(3, started.size)
-    val command = started.first()
-    assertEquals(
-        listOf(
-            "/usr/bin/java",
-            "-Dcoffee-gb.theme=dark",
-            "-jar",
-            "/apps/coffee-gb.jar",
-            "--profile=cgb",
-            "--disable-battery-saves",
-            "--start-muted",
-            "--join-netplay",
-            "localhost",
-            rom.toString(),
-        ),
-        command,
-    )
-    assertTrue(started.all { it == command })
+    started.forEachIndexed { index, command ->
+      val clientSave = directory.resolve("Tetris-client${index + 1}.sav")
+      assertEquals(
+          listOf(
+              "/usr/bin/java",
+              "-Dcoffee-gb.theme=dark",
+              "-jar",
+              "/apps/coffee-gb.jar",
+              "--profile=cgb",
+              "--battery-save",
+              clientSave.toString(),
+              "--start-muted",
+              "--join-netplay",
+              "localhost",
+              rom.toString(),
+          ),
+          command,
+      )
+      assertContentEquals(
+          if (index == 1) Files.readAllBytes(retainedClientSave) else Files.readAllBytes(hostSave),
+          Files.readAllBytes(clientSave),
+      )
+    }
   }
 
   @Test

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/MainTest.kt
@@ -88,6 +88,33 @@ class MainTest {
   }
 
   @Test
+  fun `explicit battery save is process local and replaces the blank netplay battery`() {
+    val path = File("client saves/game-client1.sav").toPath()
+    val request =
+        execute(
+                "--battery-save",
+                path.toString(),
+                "--join-netplay=localhost",
+                "game.gb",
+            )
+            .singleLaunch()
+
+    assertEquals(path, request.settingsOverrides.batterySavePath)
+    assertEquals(true, request.settingsOverrides.batterySavesEnabled)
+    assertFalse(request.settingsOverrides.forceInMemoryBattery)
+    assertTrue(request.settingsOverrides.suppressCloseAutosave)
+
+    assertUsageFailure(
+        execute("--battery-save", path.toString()),
+        "--battery-save requires a ROM file",
+    )
+    assertUsageFailure(
+        execute("--battery-save", path.toString(), "--disable-battery-saves", "game.gb"),
+        "--battery-save conflicts with --disable-battery-saves",
+    )
+  }
+
+  @Test
   fun `legacy aliases and their long forms have identical typed effects`() {
     for (alias in listOf("-d", "--force-dmg")) {
       assertEquals(
@@ -151,6 +178,7 @@ class MainTest {
               "--profile=<id>",
               "-b  --use-bootstrap",
               "-db --disable-battery-saves",
+              "--battery-save PATH",
               "--join-netplay HOST",
               "--start-muted",
               "--debug",

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
@@ -58,6 +58,7 @@ class PackagedLocalNetplayRelaunchSmokeTest {
     val directory = Files.createTempDirectory("local-netplay-relaunch-child")
     val marker = directory.resolve("child.marker")
     val rom = Files.createFile(directory.resolve("local-netplay-relaunch-smoke.gb"))
+    val batterySave = directory.resolve("local-netplay-relaunch-smoke-client1.sav")
     val packagedLauncher = Files.createFile(directory.resolve("Coffee GB.exe"))
     val environment =
         mapOf(
@@ -70,7 +71,8 @@ class PackagedLocalNetplayRelaunchSmokeTest {
         validatePackagedLocalNetplayRelaunchChildIfRequested(
             arrayOf(
                 "--profile=dmg",
-                "--disable-battery-saves",
+                "--battery-save",
+                batterySave.toString(),
                 "--start-muted",
                 "--join-netplay",
                 "127.0.0.1:4567",


### PR DESCRIPTION
## Summary

Local auto-started netplay clients opened battery-backed games with a blank in-memory save. In Donkey Kong Country this leaves the client without the host's unlocked multiplayer progress, so the two instances cannot reach the same link screen.

The launcher now gives each local client an isolated persistent `ROM-clientN.sav`. A missing client save is seeded once from the host save; an existing client save is preserved. The new `--battery-save PATH` launch option routes that exact file through the controller persistence layer without changing the user's normal save destination.

## Verification

- Reproduced the old launcher behavior in a regression test: all children received `--disable-battery-saves` and no host progress.
- Added coverage for first-launch copying, per-client isolation, preserving existing client progress, CLI validation, session storage routing, and packaged relaunch semantics.
- `XDG_DATA_HOME=/tmp/coffee-gb-issue629-xdg /opt/maven/bin/mvn -pl controller,swing -am test` — 1,768 tests passed, 3 skipped.
- Android Java compile passed against controller artifacts built from this checkout.
- Reviewed the reporter's attached before screenshot. This process-launch and persistence fix does not produce a stable automated after screenshot; the behavior is covered by the packaged relaunch and storage tests above.

Fixes #629
