### PR TITLE
Resolve mirrored fast-link input elections

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
@@ -63,7 +63,17 @@ internal object LinkedFrameStepper {
     val secondEndpoint = second.serialEndpoint as? Peer2PeerSerialEndpoint ?: return null
     if (!firstEndpoint.isConnected || !secondEndpoint.isConnected) return null
     if (!firstEndpoint.hasSameTransferState(secondEndpoint)) return null
-    if (!first.gameboy.hasSameLinkTimingPhase(second.gameboy)) return null
+    val sameTimingPhase = first.gameboy.hasSameLinkTimingPhase(second.gameboy)
+    // A passive fast-listener collision already received its one-tick phase nudge. Matching live
+    // input can begin a later software election from that deliberately unequal phase; recognize
+    // it as a new bounded escape without widening ordinary passive-listener scheduling.
+    val mirroredFastInputActivation =
+        bothExternal &&
+            first.gameboy.isFastSerialClockSelectedForActiveTransfer &&
+            second.gameboy.isFastSerialClockSelectedForActiveTransfer &&
+            first.heldButtons.isNotEmpty() &&
+            first.heldButtons == second.heldButtons
+    if (!sameTimingPhase && !mirroredFastInputActivation) return null
 
     return when {
       bothInternal -> {
@@ -81,7 +91,8 @@ internal object LinkedFrameStepper {
       }
       bothExternal -> {
         val limit =
-            if (first.gameboy.isFastSerialClockSelectedForActiveTransfer) {
+            if (first.gameboy.isFastSerialClockSelectedForActiveTransfer &&
+                !mirroredFastInputActivation) {
               FAST_EXTERNAL_ELECTION_PHASE_TICKS
             } else {
               Math.multiplyExact(

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.controller.state.StateCodecTestSupport
 import eu.rekawek.coffeegb.core.GameboyType
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.hardware.ClockSpec
+import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -94,6 +95,46 @@ class LinkedFrameStepperTest {
       assertTrue(fixture.first.gameboy.isFastSerialClockSelectedForActiveTransfer)
       assertTrue(fixture.second.gameboy.isFastSerialClockSelectedForActiveTransfer)
       assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+    }
+  }
+
+  @Test
+  fun mirroredCgbFastInputCanStartANewElectionAfterThePassivePhaseLead() {
+    PairFixture(GameboyType.CGB).use { fixture ->
+      fixture.armBoth(0x82)
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.EXTERNAL_CLOCK_DEADLOCK,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+      assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+
+      fixture.first.heldButtons = setOf(Button.A)
+      fixture.second.heldButtons = setOf(Button.A)
+
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.EXTERNAL_CLOCK_DEADLOCK,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+
+      val expectedLead = 1L + 2L * fixture.clockSpec.controllerTicksPerFrame()
+      assertEquals(expectedLead.toInt() and 0xffff, dividerDelta(fixture.first, fixture.second))
+    }
+  }
+
+  @Test
+  fun unequalFastInputDoesNotBypassTheTimingPhaseGuard() {
+    PairFixture(GameboyType.CGB).use { fixture ->
+      fixture.armBoth(0x82)
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.EXTERNAL_CLOCK_DEADLOCK,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+      fixture.first.heldButtons = setOf(Button.A)
+      fixture.second.heldButtons = setOf(Button.B)
+
+      assertNull(
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

- recognize identical, nonempty live input on two CGB fast external listeners as a new mirrored role election
- retain the existing one-tick escape for passive fast-listener collisions
- keep unequal-input and ordinary unequal-phase sessions behind the existing timing-phase guard

## Root cause

Metal Gear Solid enters a passive fast-listener state before the players select `CONNECTION START`. The existing deadlock escape gives that mirrored listener collision a one-tick phase lead. When both players then press the same button together, the game starts a later software election from that deliberately unequal phase, but the strict timing-phase guard rejects the new election. The peers consequently remain mirrored and can stall at `NOW CONNECTING....` or split into waiting/failure screens.

The new condition is deliberately narrow: both endpoints must still expose the same external-transfer state, both must select the CGB fast clock, and both sessions must hold the same nonempty input. That reuses the bounded two-frame election escape for this new active election while leaving passive and unequal-input scheduling unchanged.

## Verification

- Reproduced with the authorized local `Metal Gear Solid (USA)` ROM: simultaneous `CONNECTION START` stalled on current `master`; small phase offsets also reproduced the reported waiting/failure split.
- Replayed the same simultaneous path after the fix: both machines reached the weapon-select screen.
- Added focused coverage for a fast active election after the passive one-tick lead and for rejecting unequal live input.
- `mvn -pl controller -am -Dtest=LinkedFrameStepperTest -Dsurefire.failIfNoSpecifiedTests=false test` — 7 tests, 0 failures/errors.
- `mvn -pl controller -am test` — core 1,991 tests (0 failures/errors; 8 skipped), controller 962 tests (0 failures/errors; 2 skipped).

As a hardware-model cross-check, two SameBoy instances driven with identical oscillator timing and simultaneous selection also remained mirrored. This supports the inference that independent physical console phases normally break this symmetry and that a deterministic dual-emulator scheduler must supply a bounded separation when it hosts both peers.

The commercial-game result frames were inspected locally and were not uploaded.

Fixes #631
