### PR TITLE
Stabilize Android audio reopen test

### DIFF
--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidAudioSinkTest.java
@@ -1049,8 +1049,8 @@ public class AndroidAudioSinkTest {
         private volatile FailurePoint firstOutputFailure = FailurePoint.NONE;
 
         @Override
-        public AndroidAudioSink.Output open() {
-            int identity = opens.incrementAndGet();
+        public synchronized AndroidAudioSink.Output open() {
+            int identity = opens.get() + 1;
             FakeOutput output = new FakeOutput(this, identity, nextSampleRate,
                     nextEffectiveBufferFrames, nextStartThresholdFrames,
                     nextInitialPlaybackHeadFrames, nextUnavailablePlaybackHeadReads,
@@ -1062,6 +1062,8 @@ public class AndroidAudioSinkTest {
             }
             outputs.add(output);
             lifecycleEvents.add("open-" + identity);
+            // Tests use opens as the publication barrier before reading current().
+            opens.incrementAndGet();
             return output;
         }
 


### PR DESCRIPTION
## Summary

- make the fake audio output factory publish a replacement before reporting its open count
- serialize fake output identity allocation and publication
- keep production Android audio behavior unchanged

## Root cause

`partialWriteInterruptedByReopenReplaysFromZeroAfterOldTrackRelease` waits for `opens == 2` and then reads `current()`. The fake factory previously incremented `opens` before adding the replacement to `outputs`, so the test could observe the new count while `current()` still returned the released first output. It would then time out waiting for that old output to play.

`open()` now publishes the fake output and lifecycle event before incrementing the atomic counter that tests use as their cross-thread publication barrier.

## Verification

- exact reopen scenario repeated 250 times in one JVM: all passed
- complete `AndroidAudioSinkTest`: 25 tests, 0 failures/errors
- complete Android JVM suite: 265 tests, 0 failures/errors
- exact Android CI build/lint/APK command: 156 tasks completed successfully

Observed failures:

- https://github.com/trekawek/coffee-gb/actions/runs/33432581275/job/99621242435
- https://github.com/trekawek/coffee-gb/actions/runs/33432372839/job/99620546972
