### PR TITLE
Align packaged netplay save-policy smoke

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/packaging/NativePackageVerifier.java
@@ -407,7 +407,7 @@ public final class NativePackageVerifier {
                 requireOutput(evidence, "profile=dmg", "packaged local netplay relaunch profile");
                 requireOutput(
                         evidence,
-                        "battery-saves=false",
+                        "battery-save=isolated",
                         "packaged local netplay relaunch battery policy");
                 requireOutput(
                         evidence,

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/PackagedLocalNetplayRelaunchSmokeTest.kt
@@ -86,6 +86,7 @@ class PackagedLocalNetplayRelaunchSmokeTest {
     assertTrue(evidence.startsWith("Coffee GB local netplay relaunch OK:"))
     assertTrue(evidence.contains("pid=1234"))
     assertTrue(evidence.contains("profile=dmg"))
+    assertTrue(evidence.contains("battery-save=isolated"))
     assertTrue(evidence.contains("audio=muted"))
     assertTrue(evidence.contains("join=127.0.0.1:4567"))
 


### PR DESCRIPTION
## Summary

- update the native-package verifier to expect the isolated battery-save policy emitted by local netplay relaunches
- cover the policy evidence in `PackagedLocalNetplayRelaunchSmokeTest`

## Release context

The Coffee GB 2.0.9 release workflow exposed this stale assertion on its Windows package job after the persistent local-netplay save change landed. The packaged relaunch and Maven tests succeeded, but verification still expected the former `battery-saves=false` marker.

Failed run: https://github.com/trekawek/coffee-gb/actions/runs/33445537032

## Testing

- `/opt/maven/bin/mvn -pl swing -am -Dtest=PackagedLocalNetplayRelaunchSmokeTest -Dsurefire.failIfNoSpecifiedTests=false test`
