### PR TITLE
Fix Android MBC7 tilt handling and performance

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,6 +26,10 @@ jobs:
         run: sdkmanager --install "platforms;android-36" "build-tools;36.0.0"
       - name: Install same-checkout portable artifacts
         run: mvn -B -pl controller,ui-portable -am install -DskipTests -Dmaven.repo.local="$GITHUB_WORKSPACE/build/android-m2"
+      - name: Test Android profile install wrappers
+        run: |
+          bash ./upload_to_android-test.sh
+          sh ./android/benchmark-device-matrix-test.sh
       - name: Test, lint, and assemble debug and R8 release APKs
         run: >-
           ./android/gradlew -p android --no-daemon

--- a/android/README-benchmark.md
+++ b/android/README-benchmark.md
@@ -14,8 +14,8 @@ cd ..
 
 The `benchmark` build type is signed with the machine-local Android debug key (no repository
 secret). Parent and candidate must use the same certificate and must be distinct final signed APK
-SHA-256 identities. The wrapper verifies the certificate and installs the selected APK; pass the
-resulting signed APK paths to the scheduler.
+SHA-256 identities. The wrapper verifies the certificate and installs the selected APK/profile
+pair; pass the resulting signed APK paths to the scheduler.
 
 The physical scheduler is the primary workflow. It pins exactly one configured Redmi device,
 checks its model/API/UID/signing state, force-stops and reinstalls the selected artifact for every
@@ -32,6 +32,11 @@ adjacent parent/candidate runs in 12 randomized seven-row blocks:
   --execution-mode accuracy \
   --output-dir /path/to/private-report-dir
 ```
+
+Keep each Gradle-generated install-time baseline profile beside its signed APK with the same
+stem (`parent-signed.dm` and `candidate-signed.dm`). The runner installs each APK/DM pair in one
+data-preserving transaction and rejects a run unless ART reports both `status=speed-profile` and
+`reason=install-dm`.
 
 `--execution-mode` accepts `accuracy` (the default) or `performance`. Run the matrix separately
 for each mode; the app emits the selected strategy as `execution_mode` in both `matrix_run` and

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -474,6 +474,30 @@ androidComponents {
                 }
               }
             }
+            val installProfiles = apk.parentFile.resolve("baselineProfiles")
+                .walkTopDown()
+                .filter { candidate -> candidate.isFile && candidate.extension == "dm" }
+                .toList()
+            check(installProfiles.size == 2) {
+              "${apk.name} requires exactly two API-ranged install profiles: $installProfiles"
+            }
+            installProfiles.forEach { profile ->
+              check(profile.nameWithoutExtension == apk.nameWithoutExtension) {
+                "${profile.name} must share the APK stem ${apk.nameWithoutExtension}"
+              }
+              ZipFile(profile).use { archive ->
+                val entries = archive.entries().asSequence()
+                    .filterNot { entry -> entry.isDirectory }
+                    .map { entry -> entry.name to entry.size }
+                    .toList()
+                check(entries.size == 2
+                    && entries.map { entry -> entry.first }.toSet()
+                        == setOf("primary.prof", "primary.profm")
+                    && entries.all { entry -> entry.second > 0L }) {
+                  "${profile.name} must contain only non-empty primary.prof and primary.profm"
+                }
+              }
+            }
           }
         }
       }

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/FixtureRomProvider.java
@@ -29,9 +29,12 @@ public final class FixtureRomProvider extends ContentProvider {
             "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-cgb.gbc");
     static final Uri SGB_URI = Uri.parse(
             "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-sgb.gb");
+    static final Uri TILT_URI = Uri.parse(
+            "content://eu.rekawek.coffeegb.android.test.fixture/ci-smoke-tilt.gbc");
     private static final String DISPLAY_NAME = "coffee-gb-ci-smoke.gb";
     private static final String SECOND_DISPLAY_NAME = "coffee-gb-ci-smoke-cgb.gbc";
     private static final String SGB_DISPLAY_NAME = "coffee-gb-ci-smoke-sgb.gb";
+    private static final String TILT_DISPLAY_NAME = "coffee-gb-ci-smoke-tilt.gbc";
     private static final int ROM_SIZE = 0x8000;
     private static final byte[] NINTENDO_LOGO = {
             (byte) 0xce, (byte) 0xed, 0x66, 0x66, (byte) 0xcc, 0x0d, 0x00, 0x0b,
@@ -79,8 +82,10 @@ public final class FixtureRomProvider extends ContentProvider {
             try (FileOutputStream output = new FileOutputStream(fixture)) {
                 output.write(fixtureBytes(
                         uri.equals(SECOND_URI) ? "CI SMOKE CGB"
-                                : uri.equals(SGB_URI) ? "CI SMOKE SGB" : "CI SMOKE",
-                        uri.equals(SECOND_URI), uri.equals(SGB_URI)));
+                                : uri.equals(SGB_URI) ? "CI SMOKE SGB"
+                                : uri.equals(TILT_URI) ? "CI SMOKE TILT" : "CI SMOKE",
+                        uri.equals(SECOND_URI) || uri.equals(TILT_URI),
+                        uri.equals(SGB_URI), uri.equals(TILT_URI)));
             }
             return ParcelFileDescriptor.open(fixture, ParcelFileDescriptor.MODE_READ_ONLY);
         } catch (IOException failure) {
@@ -104,7 +109,8 @@ public final class FixtureRomProvider extends ContentProvider {
     }
 
     private static void assertFixture(Uri uri) {
-        if (!URI.equals(uri) && !SECOND_URI.equals(uri) && !SGB_URI.equals(uri)) {
+        if (!URI.equals(uri) && !SECOND_URI.equals(uri) && !SGB_URI.equals(uri)
+                && !TILT_URI.equals(uri)) {
             throw new IllegalArgumentException("Unknown CI fixture");
         }
     }
@@ -112,10 +118,12 @@ public final class FixtureRomProvider extends ContentProvider {
     private static String displayName(Uri uri) {
         assertFixture(uri);
         return uri.equals(SECOND_URI) ? SECOND_DISPLAY_NAME
-                : uri.equals(SGB_URI) ? SGB_DISPLAY_NAME : DISPLAY_NAME;
+                : uri.equals(SGB_URI) ? SGB_DISPLAY_NAME
+                : uri.equals(TILT_URI) ? TILT_DISPLAY_NAME : DISPLAY_NAME;
     }
 
-    private static byte[] fixtureBytes(String fixtureTitle, boolean cgb, boolean sgb) {
+    private static byte[] fixtureBytes(
+            String fixtureTitle, boolean cgb, boolean sgb, boolean tilt) {
         byte[] rom = new byte[ROM_SIZE];
         rom[0x0100] = (byte) 0xc3; // JP 0x0150
         rom[0x0101] = 0x50;
@@ -125,7 +133,7 @@ public final class FixtureRomProvider extends ContentProvider {
         System.arraycopy(title, 0, rom, 0x0134, title.length);
         rom[0x0143] = cgb ? (byte) 0x80 : 0x00;
         rom[0x0146] = sgb ? (byte) 0x03 : 0x00;
-        rom[0x0147] = 0x00; // ROM only
+        rom[0x0147] = (byte) (tilt ? 0x22 : 0x00); // MBC7 or ROM only
         rom[0x0148] = 0x00; // 32 KiB
         rom[0x0149] = 0x00; // no RAM
         int checksum = 0;

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -2,6 +2,7 @@ package eu.rekawek.coffeegb.android;
 
 import android.app.Instrumentation;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -26,6 +27,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,6 +41,106 @@ import static org.junit.Assert.assertTrue;
 /** Exercises the bound runtime through Activity recreation and a visibility transition. */
 @RunWith(AndroidJUnit4.class)
 public class MainActivitySmokeTest {
+
+    @Test
+    public void mbc7OrientationLockSurvivesRecreationResetAndReplacement() throws Exception {
+        AtomicReference<AndroidEmulationRuntime> runtime = new AtomicReference<>();
+        AtomicReference<Integer> originalOrientation = new AtomicReference<>();
+        List<RuntimeState> transitions = new CopyOnWriteArrayList<>();
+        RuntimeObserver transitionObserver = transitions::add;
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            await("runtime binding", () -> {
+                scenario.onActivity(activity -> {
+                    runtime.set(runtime(activity));
+                    originalOrientation.compareAndSet(null, activity.getRequestedOrientation());
+                });
+                return runtime.get() != null;
+            });
+            runtime.get().addObserver(transitionObserver);
+
+            runtime.get().openRom(FixtureRomProvider.TILT_URI, 0);
+            await("tilt fixture running", () -> runtime.get().state().phase()
+                    == RuntimeState.Phase.RUNNING
+                    && runtime.get().state().tiltOrientationLocked());
+            awaitActivityOrientation(scenario, true, ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+
+            scenario.recreate();
+            awaitActivityOrientation(scenario, true, ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+            // Rebinding after Activity recreation deliberately leaves a live game paused until
+            // the user resumes it. Establish a playing session before exercising reset semantics.
+            runtime.get().resume();
+            await("tilt fixture resumed after recreation", () ->
+                    runtime.get().state().phase() == RuntimeState.Phase.RUNNING
+                            && runtime.get().state().tiltOrientationLocked());
+
+            long beforeReset = runtime.get().state().sessionGeneration();
+            transitions.clear();
+            runtime.get().reset();
+            await("tilt fixture reset", () -> runtime.get().state().phase()
+                    == RuntimeState.Phase.RUNNING
+                    && runtime.get().state().sessionGeneration() > beforeReset);
+            awaitActivityOrientation(scenario, true, ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+            assertFalse("reset transition must publish at least one presentation state",
+                    transitions.isEmpty());
+            assertFalse("MBC7 reset must not publish an unlocked presentation state",
+                    transitions.stream().anyMatch(state -> !state.tiltOrientationLocked()));
+
+            long beforeSystemReload = runtime.get().state().sessionGeneration();
+            transitions.clear();
+            runtime.get().setSystemSelection("execution-mode", "accuracy");
+            await("tilt fixture reloaded after active system setting", () ->
+                    runtime.get().state().phase() == RuntimeState.Phase.RUNNING
+                            && runtime.get().state().sessionGeneration() > beforeSystemReload);
+            awaitActivityOrientation(scenario, true, ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+            assertFalse("system reload must publish at least one presentation state",
+                    transitions.isEmpty());
+            assertFalse("active MBC7 system reload must not publish an unlocked state",
+                    transitions.stream().anyMatch(state -> !state.tiltOrientationLocked()));
+
+            long beforeReplacement = runtime.get().state().sessionGeneration();
+            transitions.clear();
+            runtime.get().openRom(FixtureRomProvider.TILT_URI, 0);
+            await("tilt fixture replaced by tilt fixture", () -> runtime.get().state().phase()
+                    == RuntimeState.Phase.RUNNING
+                    && runtime.get().state().sessionGeneration() > beforeReplacement);
+            awaitActivityOrientation(scenario, true, ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+            assertFalse("replacement must publish at least one presentation state",
+                    transitions.isEmpty());
+            assertFalse("MBC7 replacement must not publish an unlocked presentation state",
+                    transitions.stream().anyMatch(state -> !state.tiltOrientationLocked()));
+
+            long beforeNormal = runtime.get().state().sessionGeneration();
+            runtime.get().openRom(FixtureRomProvider.URI, 0);
+            await("tilt fixture replaced by normal fixture", () -> runtime.get().state().phase()
+                    == RuntimeState.Phase.RUNNING
+                    && runtime.get().state().sessionGeneration() > beforeNormal
+                    && !runtime.get().state().tiltOrientationLocked());
+            awaitActivityOrientation(scenario, false, originalOrientation.get());
+
+            long beforeModeRestore = runtime.get().state().sessionGeneration();
+            runtime.get().setSystemSelection("execution-mode", "performance");
+            await("execution mode restored after orientation test", () ->
+                    runtime.get().state().phase() == RuntimeState.Phase.RUNNING
+                            && runtime.get().state().sessionGeneration() > beforeModeRestore);
+        } finally {
+            if (runtime.get() != null) {
+                runtime.get().removeObserver(transitionObserver);
+                runtime.get().stop();
+            }
+        }
+    }
+
+    private static void awaitActivityOrientation(
+            ActivityScenario<MainActivity> scenario, boolean locked, int orientation)
+            throws Exception {
+        await("Activity orientation presentation", () -> {
+            AtomicBoolean matched = new AtomicBoolean();
+            scenario.onActivity(activity -> matched.set(
+                    observedState(activity).tiltOrientationLocked() == locked
+                            && activity.getRequestedOrientation() == orientation));
+            return matched.get();
+        });
+    }
 
     @Test
     public void romPickerUsesTrustedExtensionFilterWhenTheDeviceProvidesOne() {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
 
     <application
         android:allowBackup="false"
+        android:appCategory="game"
         android:icon="@mipmap/ic_launcher"
         android:label="Coffee GB"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -124,7 +124,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             new BenchmarkAudioLifecycleGate();
     /** Owner-thread fence invalidating every scheduled scenario/audio poll on replacement. */
     private long benchmarkScenarioCompletionEpoch;
+    private final AndroidRumblePreference rumblePreference = new AndroidRumblePreference();
     private volatile AndroidRumbleSink rumble;
+    private AndroidRumblePreference.Output rumblePreferenceOutput;
     private volatile AndroidTiltSink tilt;
     private volatile AndroidCameraSource camera;
     private volatile AndroidGpsSource gps;
@@ -154,8 +156,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
     private final AndroidStateSaveCompletionTracker stateSaveCompletions =
             new AndroidStateSaveCompletionTracker();
     private long activeOpenRequestId;
-    private long tiltOpenRequestId;
-    private boolean tiltRequiredForOpenRequest;
+    private volatile long controllerInstanceGeneration;
+    private final TiltSessionLifecycle tiltSession = new TiltSessionLifecycle();
     private long cameraOpenRequestId;
     private boolean cameraRequiredForOpenRequest;
     private long nextFlushRequestId;
@@ -423,10 +425,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         if (rejectBenchmarkMutation()) {
             return;
         }
-        AndroidRumbleSink activeRumble = rumble;
-        if (activeRumble != null) {
-            activeRumble.setEnabled(enabled);
-        }
+        rumblePreference.setEnabled(enabled);
     }
 
     /** Calibrates an active MBC7 cartridge to the device's current resting position. */
@@ -670,7 +669,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             return;
         }
         submit(() -> {
-            if (controller != null && activeLayout != null) {
+            if (controller != null && activeLayout != null && tiltSession.hasActiveSession()) {
+                tiltSession.beginRequestedAnonymousReloadTransition();
                 if (releaseMenuPause) {
                     preparePlayingReplacement();
                 }
@@ -1321,6 +1321,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeRomTitle = "";
             activeBatterySave = false;
             activeSessionGeneration = 0L;
+            tiltSession.clear();
             clearPauseMenuSnapshotInternal();
             frames.clearToDefaultPresentation();
             lifecycle.released();
@@ -1507,6 +1508,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void createController() {
         eventBus = new EventBusImpl();
+        final long callbackControllerGeneration = ++controllerInstanceGeneration;
         eventBus.register(
                 (StateOperationCompletedEvent event) -> {
                     if (event.getOperation() == StateOperation.SAVE
@@ -1547,7 +1549,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             diagnostics.audioStats(new AndroidAudioSink.AudioStats(0, 0, 0, 0));
         }
         audio.start();
-        rumble = new AndroidRumbleSink(context, eventBus, false);
+        AndroidRumbleSink createdRumble = new AndroidRumbleSink(context, eventBus, false);
+        AndroidRumblePreference.Output createdRumbleOutput = createdRumble::setEnabled;
+        rumblePreference.attach(createdRumbleOutput);
+        rumblePreferenceOutput = createdRumbleOutput;
+        rumble = createdRumble;
         tilt = new AndroidTiltSink(context, eventBus);
         camera = new AndroidCameraSource(context);
         camera.setLens(cameraLens);
@@ -1690,15 +1696,41 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 Controller.BenchmarkGameplayScenarioCompletedEvent.class);
         eventBus.register(
                 (Controller.RomLoadingEvent event) -> submit(() -> {
+                    if (!controllerLoadCallbackMatches(callbackControllerGeneration,
+                            controllerInstanceGeneration, activeLayout != null)) {
+                        return;
+                    }
                     if (event.getOpenRequestId() != null
                             && event.getOpenRequestId() == activeOpenRequestId) {
                         publish(RuntimeState.Phase.LOADING, "Loading selected ROM…", List.of(),
+                                false, true, state.flushPending());
+                    } else if (event.getOpenRequestId() == null
+                            && !tiltSession.openTransitionPending()) {
+                        // Reset and system-setting reloads are controller-owned and have no host
+                        // request id. RomLoading proves that a setting change actually requires a
+                        // reload; irrelevant selectors produce no transition to clean up.
+                        tiltSession.beginObservedAnonymousReloadTransition();
+                        publish(RuntimeState.Phase.LOADING, "Reloading current ROM…", List.of(),
                                 false, true, state.flushPending());
                     }
                 }),
                 Controller.RomLoadingEvent.class);
         eventBus.register(
+                (Controller.RomLoadingCancelledEvent event) -> {
+                    if (event.getOpenRequestId() != null) {
+                        submit(() -> {
+                            if (callbackControllerGeneration == controllerInstanceGeneration) {
+                                tiltSession.openCancelled(event.getOpenRequestId());
+                            }
+                        });
+                    }
+                },
+                Controller.RomLoadingCancelledEvent.class);
+        eventBus.register(
                 (Controller.EmulationStartedEvent event) -> {
+                    if (callbackControllerGeneration != controllerInstanceGeneration) {
+                        return;
+                    }
                     // This callback runs synchronously on the controller thread. Keep the CPU
                     // sample and adaptive session ownership on that thread instead of the runtime
                     // owner executor.
@@ -1706,85 +1738,110 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     performanceBoost.onSessionStarted(executionMode);
                     AndroidPerformanceBoost.apply(executionMode);
                     submit(() -> {
-                    boolean requestedOpen = event.getOpenRequestId() != null
-                            && event.getOpenRequestId() == activeOpenRequestId;
-                    // Reset reloads the current cartridge without a host open-request id. Its
-                    // session generation is authoritative and must replace the just-ended one;
-                    // otherwise its following metadata event would be rejected as stale.
-                    boolean resetReload = isResetReload(event.getOpenRequestId(), activeLayout != null,
-                            event.getSessionGeneration(), activeSessionGeneration);
-                    if (requestedOpen || resetReload) {
-                        activeRomTitle = event.getRomName();
-                        activeBatterySave = false;
-                        activeSessionGeneration = event.getSessionGeneration() == null ? 0L
-                                : event.getSessionGeneration();
-                        diagnostics.beginSession(activeSessionGeneration);
-                        restartPlaybackTimerOnNextPublish = true;
-                        clearPauseMenuSnapshotInternal();
-                        AndroidTiltSink activeTilt = tilt;
-                        if (activeTilt != null) {
-                            activeTilt.setCartridgeActive(tiltOpenRequestId
-                                    == activeOpenRequestId && tiltRequiredForOpenRequest);
+                        if (callbackControllerGeneration != controllerInstanceGeneration) {
+                            return;
                         }
-                        AndroidCameraSource activeCamera = camera;
-                        if (activeCamera != null) {
-                            activeCamera.setCartridgeActive(cameraOpenRequestId
-                                    == activeOpenRequestId && cameraRequiredForOpenRequest);
-                        }
-                        if (currentSource != null && !diagnostics.enabled()) {
-                            NativeFrameStore.Snapshot recentFrame = frames.snapshot();
-                            persistActiveRecentGame(recentFrame);
-                            if (recentFrame == null) {
-                                scheduleRecentPreview(currentSource, activeOpenRequestId, 0);
+                        TiltSessionLifecycle.OpenStart openStart = event.getOpenRequestId() != null
+                                ? tiltSession.openStarted(event.getOpenRequestId())
+                                : new TiltSessionLifecycle.OpenStart(false, false, false);
+                        // Reset reloads the current cartridge without a host open-request id. Its
+                        // session generation is authoritative and must replace the just-ended one;
+                        // otherwise its following metadata event would be rejected as stale.
+                        boolean anonymousReload = isResetReload(event.getOpenRequestId(),
+                                activeLayout != null, event.getSessionGeneration(),
+                                activeSessionGeneration);
+                        TiltSessionLifecycle.AnonymousStart anonymousStart = anonymousReload
+                                ? tiltSession.anonymousStarted()
+                                : new TiltSessionLifecycle.AnonymousStart(false, false, false);
+                        boolean supersededStart = (openStart.accepted()
+                                && !openStart.completesCurrentTransition())
+                                || (anonymousStart.accepted()
+                                        && !anonymousStart.completesCurrentTransition());
+                        if (supersededStart) {
+                            AndroidTiltSink activeTilt = tilt;
+                            if (activeTilt != null) {
+                                activeTilt.setCartridgeActive(openStart.accepted()
+                                        ? openStart.sensorActive()
+                                        : anonymousStart.sensorActive());
                             }
+                            return;
                         }
-                        lifecycle.activated(lifecycleCommands());
-                        if (printerEnabled) {
-                            eventBus.post(new Controller.SetPrinterEvent(true));
-                        }
-                        if (gpsEnabled) {
-                            eventBus.post(new Controller.SetGpsReceiverEvent(true));
-                        }
-                        boolean configuredScenario = diagnostics.enabled()
-                                && benchmarkScenario.enabled();
-                        if (configuredScenario) {
-                            benchmarkScenario.beginSession(activeSessionGeneration);
-                            if (!input.beginBenchmarkScenario()) {
-                                benchmarkScenario.resetSession();
-                                diagnostics.invalidateSession();
-                                publishBenchmarkScenarioInputFailure();
-                                return;
+                        if (openStart.accepted() || anonymousStart.accepted()) {
+                            activeRomTitle = event.getRomName();
+                            activeBatterySave = false;
+                            activeSessionGeneration = event.getSessionGeneration() == null ? 0L
+                                    : event.getSessionGeneration();
+                            diagnostics.beginSession(activeSessionGeneration);
+                            restartPlaybackTimerOnNextPublish = true;
+                            clearPauseMenuSnapshotInternal();
+                            AndroidTiltSink activeTilt = tilt;
+                            boolean sessionUsesTilt = openStart.accepted()
+                                    ? openStart.sensorActive()
+                                    : anonymousStart.sensorActive();
+                            if (activeTilt != null) {
+                                activeTilt.setCartridgeActive(sessionUsesTilt);
                             }
-                            eventBus.post(new Controller.BenchmarkGameplayScenarioStartEvent(
-                                    activeSessionGeneration,
-                                    benchmarkScenario.endpointFrameForTesting()));
-                            eventBus.post(new Controller.ResumeEmulationEvent());
-                        } else if (benchmarkNoScenarioAudioPreArmRequired(
-                                diagnostics.enabled(), diagnosticsOptions.audioOutput,
-                                diagnosticsOptions.benchmarkScenario,
-                                diagnosticsOptions.audioPolicy)) {
-                            if (!startBenchmarkNoScenarioAudioPreArm(activeSessionGeneration)) {
-                                invalidateBenchmarkSession(false);
-                                publish(RuntimeState.Phase.FAILED,
-                                        "Benchmark audio output could not be prepared.",
-                                        List.of(), false, true, false);
-                                return;
+                            AndroidCameraSource activeCamera = camera;
+                            if (activeCamera != null) {
+                                activeCamera.setCartridgeActive(cameraOpenRequestId
+                                        == activeOpenRequestId && cameraRequiredForOpenRequest);
                             }
-                        } else {
-                            diagnostics.emulationStarted(activeSessionGeneration);
+                            if (currentSource != null && !diagnostics.enabled()) {
+                                NativeFrameStore.Snapshot recentFrame = frames.snapshot();
+                                persistActiveRecentGame(recentFrame);
+                                if (recentFrame == null) {
+                                    scheduleRecentPreview(currentSource, activeOpenRequestId, 0);
+                                }
+                            }
+                            lifecycle.activated(lifecycleCommands());
+                            if (printerEnabled) {
+                                eventBus.post(new Controller.SetPrinterEvent(true));
+                            }
+                            if (gpsEnabled) {
+                                eventBus.post(new Controller.SetGpsReceiverEvent(true));
+                            }
+                            boolean configuredScenario = diagnostics.enabled()
+                                    && benchmarkScenario.enabled();
+                            if (configuredScenario) {
+                                benchmarkScenario.beginSession(activeSessionGeneration);
+                                if (!input.beginBenchmarkScenario()) {
+                                    benchmarkScenario.resetSession();
+                                    diagnostics.invalidateSession();
+                                    publishBenchmarkScenarioInputFailure();
+                                    return;
+                                }
+                                eventBus.post(new Controller.BenchmarkGameplayScenarioStartEvent(
+                                        activeSessionGeneration,
+                                        benchmarkScenario.endpointFrameForTesting()));
+                                eventBus.post(new Controller.ResumeEmulationEvent());
+                            } else if (benchmarkNoScenarioAudioPreArmRequired(
+                                    diagnostics.enabled(), diagnosticsOptions.audioOutput,
+                                    diagnosticsOptions.benchmarkScenario,
+                                    diagnosticsOptions.audioPolicy)) {
+                                if (!startBenchmarkNoScenarioAudioPreArm(activeSessionGeneration)) {
+                                    invalidateBenchmarkSession(false);
+                                    publish(RuntimeState.Phase.FAILED,
+                                            "Benchmark audio output could not be prepared.",
+                                            List.of(), false, true, false);
+                                    return;
+                                }
+                            } else {
+                                diagnostics.emulationStarted(activeSessionGeneration);
+                            }
+                            boolean benchmarkPaused = diagnostics.enabled() && !configuredScenario;
+                            publish(benchmarkPaused ? RuntimeState.Phase.PAUSED
+                                            : RuntimeState.Phase.RUNNING,
+                                    "Loaded " + event.getRomName()
+                                            + ". App-private saves are ready.",
+                                    List.of(), true, benchmarkPaused, false);
                         }
-                        boolean benchmarkPaused = diagnostics.enabled() && !configuredScenario;
-                        publish(benchmarkPaused ? RuntimeState.Phase.PAUSED
-                                        : RuntimeState.Phase.RUNNING,
-                                "Loaded " + event.getRomName() + ". App-private saves are ready.",
-                                List.of(), true, benchmarkPaused, false);
-                    }
                     });
                 },
                 Controller.EmulationStartedEvent.class);
         eventBus.register(
                 (Controller.SessionPresentationEvent event) -> submit(() -> {
-                    if (activeLayout == null) {
+                    if (callbackControllerGeneration != controllerInstanceGeneration
+                            || activeLayout == null) {
                         return;
                     }
                     Long eventGeneration = event.getSessionGeneration();
@@ -1803,12 +1860,21 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 Controller.SessionPresentationEvent.class);
         eventBus.register(
                 (Controller.EmulationStoppedEvent event) -> {
+                    if (callbackControllerGeneration != controllerInstanceGeneration) {
+                        return;
+                    }
                     // The BasicController thread survives between sessions; do not let a prior
                     // PERFORMANCE session leave its scheduler hint on an idle/Accuracy session.
                     performanceBoost.onSessionStopped();
                     AndroidPerformanceBoost.apply(ExecutionMode.ACCURACY);
                     submit(() -> {
-                        if (!closed.get()) {
+                        if (!closed.get()
+                                && callbackControllerGeneration == controllerInstanceGeneration) {
+                            boolean keepTiltSensor = tiltSession.stopped();
+                            AndroidTiltSink activeTilt = tilt;
+                            if (activeTilt != null) {
+                                activeTilt.setCartridgeActive(keepTiltSensor);
+                            }
                             invalidateBenchmarkSession(false);
                             if (!diagnostics.enabled()) {
                                 persistActiveRecentGame(frames.snapshot());
@@ -1822,18 +1888,36 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                 Controller.EmulationStoppedEvent.class);
         eventBus.register(
                 (Controller.LoadRomFailedEvent event) -> submit(() -> {
-                    if (event.getOpenRequestId() != null
-                            && event.getOpenRequestId() == activeOpenRequestId) {
-                        invalidateBenchmarkSession(false);
-                        if (!diagnostics.enabled()) {
-                            new RecentSafDocuments(context).removeGame(currentSource,
-                                    activeCandidateToken, activeArchiveEntryName,
-                                    activeArchiveEntryOccurrence);
-                        }
-                        publish(RuntimeState.Phase.FAILED,
-                                "Coffee GB could not load the selected ROM.",
-                                List.of(), false, true, false);
+                    if (callbackControllerGeneration != controllerInstanceGeneration) {
+                        return;
                     }
+                    boolean keepTiltSensor;
+                    if (event.getOpenRequestId() != null) {
+                        TiltSessionLifecycle.OpenFailure failure = tiltSession.openFailed(
+                                event.getOpenRequestId());
+                        if (!failure.currentTransition()) {
+                            return;
+                        }
+                        keepTiltSensor = failure.sensorActive();
+                    } else {
+                        if (!tiltSession.anonymousReloadPending()) {
+                            return;
+                        }
+                        keepTiltSensor = tiltSession.anonymousFailed();
+                    }
+                    AndroidTiltSink activeTilt = tilt;
+                    if (activeTilt != null) {
+                        activeTilt.setCartridgeActive(keepTiltSensor);
+                    }
+                    invalidateBenchmarkSession(false);
+                    if (!diagnostics.enabled()) {
+                        new RecentSafDocuments(context).removeGame(currentSource,
+                                activeCandidateToken, activeArchiveEntryName,
+                                activeArchiveEntryOccurrence);
+                    }
+                    publish(RuntimeState.Phase.FAILED,
+                            "Coffee GB could not load the selected ROM.",
+                            List.of(), false, true, false);
                 }),
                 Controller.LoadRomFailedEvent.class);
         // The desktop ASK policy emits a prompt before restoring a managed close autosave.
@@ -2024,6 +2108,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
 
     private void activateSnapshot(RomSourceSnapshot snapshot, long token, Uri source,
             RecentSafDocuments.Entry recent, boolean releaseMenuPause) {
+        long tiltTransitionRequestId = 0L;
         try {
             RomSourceSnapshot.ArchiveCandidate candidate = token
                     == RomSourceSnapshot.ArchiveCandidate.DIRECT_TOKEN ? null
@@ -2074,8 +2159,9 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeArchiveEntryOccurrence = candidate == null ? -1 : candidate.entryOccurrence();
             activeRomHash = hash;
             activeOpenRequestId = ++nextOpenRequestId;
-            tiltOpenRequestId = activeOpenRequestId;
-            tiltRequiredForOpenRequest = !diagnostics.enabled() && rom.getType().isMbc7();
+            boolean tiltRequired = !diagnostics.enabled() && rom.getType().isMbc7();
+            tiltSession.beginOpenTransition(activeOpenRequestId, tiltRequired);
+            tiltTransitionRequestId = activeOpenRequestId;
             cameraOpenRequestId = activeOpenRequestId;
             cameraRequiredForOpenRequest = !diagnostics.enabled() && (rom.getType().isPocketCamera()
                     || rom.getCartridgeProperties().getMapper() == CartridgeProperties.Mapper.POCKET_CAMERA);
@@ -2087,6 +2173,14 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             controllerEventBus().post(new Controller.LoadRomEvent(
                     image, null, persistenceStore, activeOpenRequestId, !diagnostics.enabled()));
         } catch (Exception failure) {
+            if (tiltTransitionRequestId != 0L) {
+                TiltSessionLifecycle.OpenFailure tiltFailure = tiltSession.openFailed(
+                        tiltTransitionRequestId);
+                AndroidTiltSink activeTilt = tilt;
+                if (tiltFailure.currentTransition() && activeTilt != null) {
+                    activeTilt.setCartridgeActive(tiltFailure.sensorActive());
+                }
+            }
             if (recent == null) {
                 if (!diagnostics.enabled()) {
                     forgetRevokedPermission(source);
@@ -2389,6 +2483,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         EventBus activeBus = eventBus;
         AndroidAudioSink activeAudio = audio;
         AndroidRumbleSink activeRumble = rumble;
+        AndroidRumblePreference.Output activeRumbleOutput = rumblePreferenceOutput;
         AndroidTiltSink activeTilt = tilt;
         AndroidCameraSource activeCamera = camera;
         AndroidGpsSource activeGps = gps;
@@ -2396,6 +2491,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         controller = null;
         eventBus = null;
         audio = null;
+        rumblePreference.detach(activeRumbleOutput);
+        rumblePreferenceOutput = null;
         rumble = null;
         tilt = null;
         camera = null;
@@ -2422,6 +2519,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeStateSessionId = 0L;
             pendingStateRequests.clear();
             stateSaveCompletions.clear();
+            controllerInstanceGeneration++;
             return true;
         }
         try {
@@ -2450,6 +2548,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             activeStateSessionId = 0L;
             pendingStateRequests.clear();
             stateSaveCompletions.clear();
+            controllerInstanceGeneration++;
             return true;
         } catch (RuntimeException failure) {
             // The synchronized boost owner can be disarmed safely even if controller shutdown
@@ -2459,6 +2558,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             controller = active;
             eventBus = activeBus;
             audio = activeAudio;
+            if (activeRumbleOutput != null) {
+                rumblePreference.attach(activeRumbleOutput);
+            }
+            rumblePreferenceOutput = activeRumbleOutput;
             rumble = activeRumble;
             tilt = activeTilt;
             camera = activeCamera;
@@ -2703,6 +2806,8 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         synchronized (presentationLock) {
             boolean activeSession = phase == RuntimeState.Phase.RUNNING
                     || phase == RuntimeState.Phase.PAUSED;
+            boolean tiltOrientationLocked = !diagnostics.enabled()
+                    && tiltSession.orientationLocked(phase);
             String romTitle = activeSession ? activeRomTitle : "";
             long sessionGeneration = activeSession ? activeSessionGeneration : 0L;
             long playTimeNanos = updatePlayTime(phase, sessionGeneration);
@@ -2712,6 +2817,7 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
                     activeSession && activeBatterySave,
                     sessionGeneration,
                     playTimeNanos,
+                    tiltOrientationLocked,
                     Math.addExact(state.generation(), 1));
             state = next;
         }
@@ -2757,6 +2863,11 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
             Long eventSessionGeneration, long activeSessionGeneration) {
         return openRequestId == null && hasActiveLayout && eventSessionGeneration != null
                 && eventSessionGeneration > activeSessionGeneration;
+    }
+
+    static boolean controllerLoadCallbackMatches(
+            long callbackGeneration, long activeGeneration, boolean hasActiveLayout) {
+        return callbackGeneration == activeGeneration && hasActiveLayout;
     }
 
     /** Shared fail-closed generation gate for synchronous and owner-queued benchmark events. */

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumblePreference.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumblePreference.java
@@ -1,0 +1,33 @@
+package eu.rekawek.coffeegb.android;
+
+import java.util.Objects;
+
+/** Atomically retains the host preference while Android rumble outputs are replaced. */
+final class AndroidRumblePreference {
+
+    interface Output {
+        void setEnabled(boolean enabled);
+    }
+
+    private boolean enabled;
+    private Output output;
+
+    synchronized void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        if (output != null) {
+            output.setEnabled(enabled);
+        }
+    }
+
+    synchronized void attach(Output output) {
+        Output checked = Objects.requireNonNull(output, "output");
+        checked.setEnabled(enabled);
+        this.output = checked;
+    }
+
+    synchronized void detach(Output output) {
+        if (this.output == output) {
+            this.output = null;
+        }
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
@@ -196,7 +196,11 @@ final class AndroidTiltSink implements AutoCloseable {
             calibrationRotation = rotation;
             calibrated = true;
         }
-        eventBus.post(new AccelerometerEvent(x - neutralX, y - neutralY));
+        // Android reports acceleration in m/s² while the portable MBC7 contract uses g units.
+        // Feeding the raw delta made the emulated sensor roughly 9.8 times too sensitive.
+        eventBus.post(new AccelerometerEvent(
+                (x - neutralX) / SensorManager.GRAVITY_EARTH,
+                (y - neutralY) / SensorManager.GRAVITY_EARTH));
     }
 
     private void startIfNeeded() {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -118,6 +118,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private View menuButton;
     private AndroidEmulationRuntime runtime;
     private AndroidEmulationRuntime observedRuntime;
+    private TiltOrientationLock tiltOrientationLock;
     private long observedGeneration = -1L;
     private boolean bound;
     private InputManager inputManager;
@@ -298,6 +299,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             pendingBenchmarkArm.clear();
             bound = false;
             observedState = RuntimeState.stopped();
+            if (tiltOrientationLock != null) {
+                tiltOrientationLock.setActive(false);
+            }
             stateCatalogGeneration++;
             stateSlotsLoading = false;
             stateSlots = List.of();
@@ -331,6 +335,17 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        tiltOrientationLock = new TiltOrientationLock(new TiltOrientationLock.Host() {
+            @Override
+            public int requestedOrientation() {
+                return getRequestedOrientation();
+            }
+
+            @Override
+            public void requestOrientation(int orientation) {
+                setRequestedOrientation(orientation);
+            }
+        });
         diagnosticsOptions = BuildConfig.DIAGNOSTICS_ENABLED
                 ? DiagnosticsOptions.fromIntent(getIntent()) : DiagnosticsOptions.disabled();
         if (diagnosticsOptions.enabled) {
@@ -529,6 +544,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     @Override
     protected void onDestroy() {
         lifecycleGeneration++;
+        if (tiltOrientationLock != null) {
+            tiltOrientationLock.setActive(false);
+        }
         if (printerContinuationPreferences != null) {
             printerContinuationPreferences.unregisterOnSharedPreferenceChangeListener(
                     printerContinuationListener);
@@ -2615,6 +2633,9 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private void applyState(RuntimeState state) {
         if (state.generation() < observedGeneration) {
             return;
+        }
+        if (tiltOrientationLock != null) {
+            tiltOrientationLock.setActive(state.tiltOrientationLocked());
         }
         long previousSessionGeneration = observedState.sessionGeneration();
         if (diagnosticsOptions.enabled

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeState.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/RuntimeState.java
@@ -20,6 +20,7 @@ public record RuntimeState(
         boolean batterySaveActive,
         long sessionGeneration,
         long playTimeNanos,
+        boolean tiltOrientationLocked,
         long generation) {
 
     public RuntimeState {
@@ -36,6 +37,15 @@ public record RuntimeState(
         if (generation < 0) {
             throw new IllegalArgumentException("generation must not be negative");
         }
+    }
+
+    /** Compatibility constructor for callers predating session-scoped tilt presentation. */
+    public RuntimeState(Phase phase, String message, List<Selection> selections,
+            boolean transferReady, boolean paused, boolean flushPending, String romTitle,
+            boolean batterySaveActive, long sessionGeneration, long playTimeNanos,
+            long generation) {
+        this(phase, message, selections, transferReady, paused, flushPending,
+                romTitle, batterySaveActive, sessionGeneration, playTimeNanos, false, generation);
     }
 
     /** Compatibility constructor for callers that do not expose an active session. */

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/TiltOrientationLock.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/TiltOrientationLock.java
@@ -1,0 +1,37 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.pm.ActivityInfo;
+
+import java.util.Objects;
+
+/** Keeps the current display orientation stable for the lifetime of an active tilt session. */
+final class TiltOrientationLock {
+
+    interface Host {
+        int requestedOrientation();
+
+        void requestOrientation(int orientation);
+    }
+
+    private final Host host;
+    private boolean active;
+    private int restoreOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+
+    TiltOrientationLock(Host host) {
+        this.host = Objects.requireNonNull(host, "host");
+    }
+
+    void setActive(boolean active) {
+        if (this.active == active) {
+            return;
+        }
+        if (active) {
+            int previous = host.requestedOrientation();
+            host.requestOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
+            restoreOrientation = previous;
+        } else {
+            host.requestOrientation(restoreOrientation);
+        }
+        this.active = active;
+    }
+}

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/TiltSessionLifecycle.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/TiltSessionLifecycle.java
@@ -1,0 +1,173 @@
+package eu.rekawek.coffeegb.android;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Tracks tilt ownership across staged controller replacements and their asynchronous events. */
+final class TiltSessionLifecycle {
+
+    /** Superseded requests remain until their start, failure, or cancellation event arrives. */
+    private final Map<Long, Boolean> openRequests = new HashMap<>();
+    private long pendingOpenRequestId;
+    private boolean pendingOpenUsesTilt;
+    private boolean anonymousReloadPending;
+    private boolean activeSessionKnown;
+    private boolean activeSessionUsesTilt;
+    private boolean stoppedSessionKnown;
+    private boolean stoppedSessionUsesTilt;
+
+    void beginOpenTransition(long requestId, boolean usesTilt) {
+        if (requestId <= 0L) {
+            throw new IllegalArgumentException("requestId must be positive");
+        }
+        openRequests.put(requestId, usesTilt);
+        pendingOpenRequestId = requestId;
+        pendingOpenUsesTilt = usesTilt;
+        anonymousReloadPending = false;
+    }
+
+    /** A direct reset is the newest host intent and supersedes any still-staged document open. */
+    void beginRequestedAnonymousReloadTransition() {
+        pendingOpenRequestId = 0L;
+        pendingOpenUsesTilt = false;
+        anonymousReloadPending = true;
+    }
+
+    /** A controller loading event may be stale, so it cannot supersede a newer document open. */
+    void beginObservedAnonymousReloadTransition() {
+        if (pendingOpenRequestId == 0L) {
+            anonymousReloadPending = true;
+        }
+    }
+
+    boolean openTransitionPending() {
+        return pendingOpenRequestId != 0L;
+    }
+
+    boolean anonymousReloadPending() {
+        return anonymousReloadPending;
+    }
+
+    /** True only after a controller session has actually committed and before it stops. */
+    boolean hasActiveSession() {
+        return activeSessionKnown;
+    }
+
+    /** Accepts either the current document open or a superseded open that became live first. */
+    OpenStart openStarted(long requestId) {
+        Boolean usesTilt = openRequests.remove(requestId);
+        if (usesTilt == null) {
+            return new OpenStart(false, false, activeSessionUsesTilt);
+        }
+        activeSessionKnown = true;
+        activeSessionUsesTilt = usesTilt;
+        stoppedSessionKnown = false;
+        boolean currentTransition = requestId == pendingOpenRequestId
+                || (pendingOpenRequestId == 0L && !anonymousReloadPending);
+        if (requestId == pendingOpenRequestId) {
+            pendingOpenRequestId = 0L;
+            pendingOpenUsesTilt = false;
+        }
+        return new OpenStart(true, currentTransition, activeSessionUsesTilt);
+    }
+
+    /**
+     * Accepts a controller-owned reset/system reload. A superseded anonymous reload may become
+     * the temporary live session without taking ownership away from a newer document open.
+     */
+    AnonymousStart anonymousStarted() {
+        boolean currentTransition = anonymousReloadPending;
+        if (!currentTransition && !(pendingOpenRequestId != 0L && stoppedSessionKnown)) {
+            return new AnonymousStart(false, false, activeSessionUsesTilt);
+        }
+        if (stoppedSessionKnown) {
+            activeSessionUsesTilt = stoppedSessionUsesTilt;
+        }
+        activeSessionKnown = true;
+        stoppedSessionKnown = false;
+        if (currentTransition) {
+            anonymousReloadPending = false;
+        }
+        return new AnonymousStart(true, currentTransition, activeSessionUsesTilt);
+    }
+
+    /** Ends committed ownership while optionally keeping the sensor warm across a tilt handoff. */
+    boolean stopped() {
+        boolean transitionUsesTilt = pendingOpenRequestId != 0L
+                ? pendingOpenUsesTilt : anonymousReloadPending && activeSessionUsesTilt;
+        boolean keepSensor = activeSessionKnown && activeSessionUsesTilt && transitionUsesTilt;
+        stoppedSessionKnown = activeSessionKnown;
+        stoppedSessionUsesTilt = activeSessionUsesTilt;
+        activeSessionKnown = false;
+        activeSessionUsesTilt = false;
+        return keepSensor;
+    }
+
+    /** Completes a failed current open without disturbing a newer or unrelated transition. */
+    OpenFailure openFailed(long requestId) {
+        if (openRequests.remove(requestId) == null) {
+            return new OpenFailure(false, activeSessionUsesTilt);
+        }
+        boolean currentTransition = requestId == pendingOpenRequestId
+                || (pendingOpenRequestId == 0L && !anonymousReloadPending);
+        if (requestId == pendingOpenRequestId) {
+            pendingOpenRequestId = 0L;
+            pendingOpenUsesTilt = false;
+        }
+        if (!currentTransition) {
+            return new OpenFailure(false, activeSessionUsesTilt);
+        }
+        stoppedSessionKnown = false;
+        return new OpenFailure(true, activeSessionUsesTilt);
+    }
+
+    /** Cancels the current anonymous transition and returns any retained live-session capability. */
+    boolean anonymousFailed() {
+        anonymousReloadPending = false;
+        stoppedSessionKnown = false;
+        return activeSessionUsesTilt;
+    }
+
+    void openCancelled(long requestId) {
+        openRequests.remove(requestId);
+        if (requestId == pendingOpenRequestId) {
+            pendingOpenRequestId = 0L;
+            pendingOpenUsesTilt = false;
+        }
+    }
+
+    void clear() {
+        openRequests.clear();
+        pendingOpenRequestId = 0L;
+        pendingOpenUsesTilt = false;
+        anonymousReloadPending = false;
+        activeSessionKnown = false;
+        activeSessionUsesTilt = false;
+        stoppedSessionKnown = false;
+    }
+
+    boolean orientationLocked(RuntimeState.Phase phase) {
+        if (pendingOpenRequestId == 0L && !anonymousReloadPending) {
+            return activeSessionKnown && activeSessionUsesTilt;
+        }
+        boolean transitionUsesTilt = pendingOpenRequestId != 0L
+                ? pendingOpenUsesTilt
+                : stoppedSessionKnown ? stoppedSessionUsesTilt : activeSessionUsesTilt;
+        return transitionUsesTilt
+                && (phase == RuntimeState.Phase.LOADING
+                        || phase == RuntimeState.Phase.STOPPED
+                        || phase == RuntimeState.Phase.RUNNING
+                        || phase == RuntimeState.Phase.PAUSED);
+    }
+
+    record OpenStart(boolean accepted, boolean completesCurrentTransition,
+            boolean sensorActive) {
+    }
+
+    record AnonymousStart(boolean accepted, boolean completesCurrentTransition,
+            boolean sensorActive) {
+    }
+
+    record OpenFailure(boolean currentTransition, boolean sensorActive) {
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntimeTest.java
@@ -51,6 +51,13 @@ public class AndroidEmulationRuntimeTest {
     }
 
     @Test
+    public void staleControllerLoadingCannotResurrectAStoppedRuntimeShell() {
+        assertTrue(AndroidEmulationRuntime.controllerLoadCallbackMatches(4L, 4L, true));
+        assertFalse(AndroidEmulationRuntime.controllerLoadCallbackMatches(3L, 4L, true));
+        assertFalse(AndroidEmulationRuntime.controllerLoadCallbackMatches(4L, 4L, false));
+    }
+
+    @Test
     public void benchmarkEndpointAndAckMustBelongToOneCurrentPresentedSession() {
         assertTrue(AndroidEmulationRuntime.benchmarkSessionMatches(12L, 12L, 12L, 12L));
         assertFalse(AndroidEmulationRuntime.benchmarkSessionMatches(11L, 12L, 12L, 12L));

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidRumblePreferenceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidRumblePreferenceTest.java
@@ -1,0 +1,47 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AndroidRumblePreferenceTest {
+
+    @Test
+    public void preferenceSetDuringConstructionAppliesWhenTheOutputAttaches() {
+        AndroidRumblePreference preference = new AndroidRumblePreference();
+        FakeOutput constructedButNotAttached = new FakeOutput();
+
+        preference.setEnabled(true);
+        preference.attach(constructedButNotAttached);
+
+        assertEquals(List.of(true), constructedButNotAttached.values);
+    }
+
+    @Test
+    public void recreationRetainsTheLatestPreferenceWithoutTouchingTheDetachedOutput() {
+        AndroidRumblePreference preference = new AndroidRumblePreference();
+        FakeOutput first = new FakeOutput();
+        preference.attach(first);
+        preference.setEnabled(true);
+        preference.detach(first);
+
+        preference.setEnabled(false);
+        FakeOutput replacement = new FakeOutput();
+        preference.attach(replacement);
+
+        assertEquals(List.of(false, true), first.values);
+        assertEquals(List.of(false), replacement.values);
+    }
+
+    private static final class FakeOutput implements AndroidRumblePreference.Output {
+        private final List<Boolean> values = new ArrayList<>();
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            values.add(enabled);
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.android;
 
 import android.view.Surface;
+import android.hardware.SensorManager;
 import eu.rekawek.coffeegb.core.events.EventBusImpl;
 import eu.rekawek.coffeegb.core.memory.cart.type.AccelerometerEvent;
 import org.junit.Test;
@@ -25,13 +26,49 @@ public class AndroidTiltSinkTest {
         input.sample(5, 10);
         input.sample(7, 13);
         assertSample(samples.get(0), 0, 0);
-        assertSample(samples.get(1), 2, 3);
+        assertSample(samples.get(1),
+                2 / SensorManager.GRAVITY_EARTH,
+                3 / SensorManager.GRAVITY_EARTH);
 
         orientation.rotation = Surface.ROTATION_90;
         input.sample(7, 13);
         input.sample(8, 14);
         assertSample(samples.get(2), 0, 0);
-        assertSample(samples.get(3), -1, 1);
+        assertSample(samples.get(3),
+                -1 / SensorManager.GRAVITY_EARTH,
+                1 / SensorManager.GRAVITY_EARTH);
+
+        orientation.rotation = Surface.ROTATION_180;
+        input.sample(8, 14);
+        input.sample(9, 16);
+        assertSample(samples.get(4), 0, 0);
+        assertSample(samples.get(5),
+                -1 / SensorManager.GRAVITY_EARTH,
+                -2 / SensorManager.GRAVITY_EARTH);
+
+        orientation.rotation = Surface.ROTATION_270;
+        input.sample(9, 16);
+        input.sample(11, 19);
+        assertSample(samples.get(6), 0, 0);
+        assertSample(samples.get(7),
+                3 / SensorManager.GRAVITY_EARTH,
+                -2 / SensorManager.GRAVITY_EARTH);
+    }
+
+    @Test
+    public void convertsAndroidMetersPerSecondSquaredToGravityUnits() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        List<AccelerometerEvent> samples = new ArrayList<>();
+        events.register(samples::add, AccelerometerEvent.class);
+        FakeInput input = new FakeInput(true);
+        AndroidTiltSink sink = new AndroidTiltSink(events, input,
+                () -> Surface.ROTATION_0);
+
+        sink.setCartridgeActive(true);
+        input.sample(0, 0);
+        input.sample(SensorManager.GRAVITY_EARTH, -SensorManager.GRAVITY_EARTH);
+
+        assertSample(samples.get(1), 1, -1);
     }
 
     @Test
@@ -54,7 +91,9 @@ public class AndroidTiltSinkTest {
         assertEquals(1, input.stops);
         assertEquals(2, samples.size());
         assertSample(samples.get(0), 0, 0);
-        assertSample(samples.get(1), 5, 3);
+        assertSample(samples.get(1),
+                5 / SensorManager.GRAVITY_EARTH,
+                3 / SensorManager.GRAVITY_EARTH);
         sink.close();
         assertEquals(2, input.stops);
 
@@ -82,9 +121,13 @@ public class AndroidTiltSinkTest {
         input.sample(4, 7);
         input.sample(5, 9);
 
-        assertSample(samples.get(1), 2, 3);
+        assertSample(samples.get(1),
+                2 / SensorManager.GRAVITY_EARTH,
+                3 / SensorManager.GRAVITY_EARTH);
         assertSample(samples.get(2), 0, 0);
-        assertSample(samples.get(3), 1, 2);
+        assertSample(samples.get(3),
+                1 / SensorManager.GRAVITY_EARTH,
+                2 / SensorManager.GRAVITY_EARTH);
     }
 
     private static void assertSample(AccelerometerEvent sample, double x, double y) {

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/TiltOrientationLockTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/TiltOrientationLockTest.java
@@ -1,0 +1,67 @@
+package eu.rekawek.coffeegb.android;
+
+import android.content.pm.ActivityInfo;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TiltOrientationLockTest {
+
+    @Test
+    public void locksOnceAndRestoresThePreviousActivityPolicy() {
+        FakeHost host = new FakeHost(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+        TiltOrientationLock lock = new TiltOrientationLock(host);
+
+        lock.setActive(true);
+        lock.setActive(true);
+        lock.setActive(false);
+        lock.setActive(false);
+
+        assertEquals(List.of(
+                ActivityInfo.SCREEN_ORIENTATION_LOCKED,
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE), host.requests);
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE,
+                host.requestedOrientation());
+    }
+
+    @Test
+    public void aLaterSessionCapturesItsOwnRestoreOrientation() {
+        FakeHost host = new FakeHost(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        TiltOrientationLock lock = new TiltOrientationLock(host);
+
+        lock.setActive(true);
+        lock.setActive(false);
+        host.orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+        lock.setActive(true);
+        lock.setActive(false);
+
+        assertEquals(List.of(
+                ActivityInfo.SCREEN_ORIENTATION_LOCKED,
+                ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED,
+                ActivityInfo.SCREEN_ORIENTATION_LOCKED,
+                ActivityInfo.SCREEN_ORIENTATION_PORTRAIT), host.requests);
+    }
+
+    private static final class FakeHost implements TiltOrientationLock.Host {
+        private final List<Integer> requests = new ArrayList<>();
+        private int orientation;
+
+        private FakeHost(int orientation) {
+            this.orientation = orientation;
+        }
+
+        @Override
+        public int requestedOrientation() {
+            return orientation;
+        }
+
+        @Override
+        public void requestOrientation(int orientation) {
+            requests.add(orientation);
+            this.orientation = orientation;
+        }
+    }
+}

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/TiltSessionLifecycleTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/TiltSessionLifecycleTest.java
@@ -1,0 +1,215 @@
+package eu.rekawek.coffeegb.android;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TiltSessionLifecycleTest {
+
+    @Test
+    public void resetDuringInitialOpenCannotSupersedeTheOnlyPendingStart() {
+        TiltSessionLifecycle lifecycle = new TiltSessionLifecycle();
+        lifecycle.beginOpenTransition(1L, true);
+
+        assertFalse("a selected layout is not yet a committed controller session",
+                lifecycle.hasActiveSession());
+        // AndroidEmulationRuntime.reset() therefore does not begin or post an anonymous reload.
+        TiltSessionLifecycle.OpenStart start = lifecycle.openStarted(1L);
+
+        assertTrue(start.accepted());
+        assertTrue(start.completesCurrentTransition());
+        assertTrue(start.sensorActive());
+        assertFalse(lifecycle.anonymousReloadPending());
+        assertTrue(lifecycle.hasActiveSession());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.RUNNING));
+    }
+
+    @Test
+    public void stagedReplacementFailureRetainsTheStillLiveTiltSession() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginOpenTransition(2L, false);
+
+        TiltSessionLifecycle.OpenFailure failure = lifecycle.openFailed(2L);
+
+        assertTrue(failure.currentTransition());
+        assertTrue(failure.sensorActive());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void committedReplacementFailureReleasesTheStoppedTiltSession() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginOpenTransition(2L, true);
+
+        assertTrue("sensor remains registered during a tilt-to-tilt ownership handoff",
+                lifecycle.stopped());
+        TiltSessionLifecycle.OpenFailure failure = lifecycle.openFailed(2L);
+
+        assertTrue(failure.currentTransition());
+        assertFalse(failure.sensorActive());
+        assertFalse(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void successfulTiltReplacementStaysLockedAcrossTheStoppedState() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginOpenTransition(2L, true);
+
+        assertTrue(lifecycle.stopped());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.STOPPED));
+        TiltSessionLifecycle.OpenStart start = lifecycle.openStarted(2L);
+
+        assertTrue(start.accepted());
+        assertTrue(start.completesCurrentTransition());
+        assertTrue(start.sensorActive());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.RUNNING));
+    }
+
+    @Test
+    public void anonymousSystemReloadRestoresTheSameActiveTiltCapability() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginRequestedAnonymousReloadTransition();
+
+        assertTrue(lifecycle.stopped());
+        TiltSessionLifecycle.AnonymousStart start = lifecycle.anonymousStarted();
+
+        assertTrue(start.accepted());
+        assertTrue(start.completesCurrentTransition());
+        assertTrue(start.sensorActive());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.RUNNING));
+    }
+
+    @Test
+    public void newerOpenRetainsASupersededAnonymousReloadWhenTheOpenFails() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginRequestedAnonymousReloadTransition();
+        lifecycle.beginOpenTransition(2L, false);
+
+        assertFalse(lifecycle.stopped());
+        TiltSessionLifecycle.AnonymousStart staleStart = lifecycle.anonymousStarted();
+        TiltSessionLifecycle.OpenFailure failure = lifecycle.openFailed(2L);
+
+        assertTrue(staleStart.accepted());
+        assertFalse(staleStart.completesCurrentTransition());
+        assertTrue(staleStart.sensorActive());
+        assertTrue(failure.currentTransition());
+        assertTrue("the failed newer open retains the controller's temporary reload session",
+                failure.sensorActive());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void anonymousReloadUsesRetainedTiltSessionAfterNormalOpenFails() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginOpenTransition(2L, false);
+        assertTrue(lifecycle.openFailed(2L).sensorActive());
+
+        lifecycle.beginRequestedAnonymousReloadTransition();
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.LOADING));
+        assertTrue(lifecycle.stopped());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.STOPPED));
+        assertTrue(lifecycle.anonymousStarted().sensorActive());
+    }
+
+    @Test
+    public void anonymousReloadDoesNotInheritTiltFromFailedTiltCandidate() {
+        TiltSessionLifecycle lifecycle = activeSession(false);
+        lifecycle.beginOpenTransition(2L, true);
+        assertFalse(lifecycle.openFailed(2L).sensorActive());
+
+        lifecycle.beginRequestedAnonymousReloadTransition();
+        assertFalse(lifecycle.orientationLocked(RuntimeState.Phase.LOADING));
+        assertFalse(lifecycle.stopped());
+        assertFalse(lifecycle.orientationLocked(RuntimeState.Phase.STOPPED));
+        assertFalse(lifecycle.anonymousStarted().sensorActive());
+    }
+
+    @Test
+    public void supersededTiltOpenBecomesLiveWhenNewerNormalOpenFails() {
+        TiltSessionLifecycle lifecycle = activeSession(false);
+        lifecycle.beginOpenTransition(2L, true);
+        lifecycle.beginOpenTransition(3L, false);
+
+        assertFalse(lifecycle.stopped());
+        TiltSessionLifecycle.OpenStart staleStart = lifecycle.openStarted(2L);
+        TiltSessionLifecycle.OpenFailure failure = lifecycle.openFailed(3L);
+
+        assertTrue(staleStart.accepted());
+        assertFalse(staleStart.completesCurrentTransition());
+        assertTrue(staleStart.sensorActive());
+        assertTrue(failure.currentTransition());
+        assertTrue(failure.sensorActive());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void supersededNormalOpenBecomesLiveWhenNewerTiltOpenFails() {
+        TiltSessionLifecycle lifecycle = activeSession(true);
+        lifecycle.beginOpenTransition(2L, false);
+        lifecycle.beginOpenTransition(3L, true);
+
+        assertTrue(lifecycle.stopped());
+        TiltSessionLifecycle.OpenStart staleStart = lifecycle.openStarted(2L);
+        TiltSessionLifecycle.OpenFailure failure = lifecycle.openFailed(3L);
+
+        assertTrue(staleStart.accepted());
+        assertFalse(staleStart.completesCurrentTransition());
+        assertFalse(staleStart.sensorActive());
+        assertTrue(failure.currentTransition());
+        assertFalse(failure.sensorActive());
+        assertFalse(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void newerResetRetainsACommittedSupersededOpenWhenResetFails() {
+        TiltSessionLifecycle lifecycle = activeSession(false);
+        lifecycle.beginOpenTransition(2L, true);
+        lifecycle.beginRequestedAnonymousReloadTransition();
+
+        assertFalse(lifecycle.stopped());
+        TiltSessionLifecycle.OpenStart staleOpen = lifecycle.openStarted(2L);
+
+        assertTrue(staleOpen.accepted());
+        assertFalse(staleOpen.completesCurrentTransition());
+        assertTrue(staleOpen.sensorActive());
+        assertTrue(lifecycle.anonymousFailed());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.FAILED));
+    }
+
+    @Test
+    public void observedStaleAnonymousLoadCannotSupersedeNewerOpen() {
+        TiltSessionLifecycle lifecycle = activeSession(false);
+        lifecycle.beginOpenTransition(2L, true);
+
+        lifecycle.beginObservedAnonymousReloadTransition();
+
+        assertTrue(lifecycle.openTransitionPending());
+        assertFalse(lifecycle.anonymousReloadPending());
+        assertTrue(lifecycle.orientationLocked(RuntimeState.Phase.LOADING));
+    }
+
+    @Test
+    public void supersededOpenIsPromotedIfTheNewerRequestIsCancelled() {
+        TiltSessionLifecycle lifecycle = activeSession(false);
+        lifecycle.beginOpenTransition(2L, true);
+        lifecycle.beginOpenTransition(3L, false);
+        lifecycle.openCancelled(3L);
+
+        lifecycle.stopped();
+        TiltSessionLifecycle.OpenStart start = lifecycle.openStarted(2L);
+
+        assertTrue(start.accepted());
+        assertTrue(start.completesCurrentTransition());
+        assertTrue(start.sensorActive());
+    }
+
+    private static TiltSessionLifecycle activeSession(boolean usesTilt) {
+        TiltSessionLifecycle lifecycle = new TiltSessionLifecycle();
+        lifecycle.beginOpenTransition(1L, usesTilt);
+        TiltSessionLifecycle.OpenStart start = lifecycle.openStarted(1L);
+        assertTrue(start.accepted());
+        assertTrue(start.completesCurrentTransition());
+        return lifecycle;
+    }
+}

--- a/android/benchmark-device-matrix-test.sh
+++ b/android/benchmark-device-matrix-test.sh
@@ -11,8 +11,12 @@ trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
 parent=$tmp/parent.apk
 candidate=$tmp/candidate.apk
+parent_dm=$tmp/parent.dm
+candidate_dm=$tmp/candidate.dm
 printf 'parent-signed-by-test\n' >"$parent"
 printf 'candidate-signed-by-test\n' >"$candidate"
+printf 'parent-profile-for-test\n' >"$parent_dm"
+printf 'candidate-profile-for-test\n' >"$candidate_dm"
 
 parent_hash=1111111111111111111111111111111111111111111111111111111111111111
 candidate_hash=2222222222222222222222222222222222222222222222222222222222222222
@@ -77,7 +81,14 @@ fi
 shift 2
 command=${1:-}
 if [ "$command" = get-state ]; then echo device; exit 0; fi
-if [ "$command" = install ]; then echo Success; exit 0; fi
+if [ "$command" = install-multiple ]; then
+  [ "$#" -eq 6 ] && [ "$2" = -r ] && [ "$3" = -d ] && [ "$4" = --no-streaming ] \
+    || exit 1
+  case "$5" in *.apk) : ;; *) exit 1 ;; esac
+  [ "$6" = "${5%.apk}.dm" ] && [ -s "$5" ] && [ -s "$6" ] || exit 1
+  echo Success
+  exit 0
+fi
 if [ "$command" = logcat ]; then
   if [ "${2:-}" = -c ]; then
     : >"$log"
@@ -151,6 +162,8 @@ if [ "$sub" = dumpsys ]; then
       echo 'ApplicationInfo{eu.rekawek.coffeegb.android flags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ] privateFlags=[ DIRECT_BOOT_AWARE ]}'
       if [ "$mode" = profile_missing ]; then
         echo 'arm64: [status=verify] [reason=install]'
+      elif [ "$mode" = profile_stale ]; then
+        echo 'arm64: [status=speed-profile] [reason=bg-dexopt]'
       else
         echo 'arm64: [status=speed-profile] [reason=install-dm]'
       fi
@@ -483,8 +496,12 @@ force_stop_count=$(awk '/^force-stop$/ { count++ } END { print count + 0 }' "$re
 [ "$force_stop_count" -eq 168 ] || { echo "expected 168 force-stops, got $force_stop_count" >&2; exit 1; }
 arm_count=$(awk '/^arm / { count++ } END { print count + 0 }' "$records")
 [ "$arm_count" -eq 168 ] || { echo "expected 168 singleTop arms, got $arm_count" >&2; exit 1; }
-install_count=$(grep -c -- ' install -r -d --no-streaming ' "$calls" || true)
-[ "$install_count" -eq 168 ] || { echo "expected 168 data-preserving installs, got $install_count" >&2; exit 1; }
+install_count=$(grep -c -- ' install-multiple -r -d --no-streaming ' "$calls" || true)
+[ "$install_count" -eq 168 ] || { echo "expected 168 profiled data-preserving installs, got $install_count" >&2; exit 1; }
+parent_profile_count=$(grep -c -- " $parent $parent_dm" "$calls" || true)
+[ "$parent_profile_count" -eq 84 ] || { echo "expected 84 parent APK/DM installs, got $parent_profile_count" >&2; exit 1; }
+candidate_profile_count=$(grep -c -- " $candidate $candidate_dm" "$calls" || true)
+[ "$candidate_profile_count" -eq 84 ] || { echo "expected 84 candidate APK/DM installs, got $candidate_profile_count" >&2; exit 1; }
 awk '
   /^launch / {
     launch_no++
@@ -641,9 +658,16 @@ grep -q -- '--es coffee_gb_audio_policy silent-pcm-relaxed-apu-v1' "$calls" || {
   exit 1
 }
 
+: >"$calls"
+mv "$candidate_dm" "$candidate_dm.missing"
+expect_failure missing_dm
+[ ! -s "$calls" ] || { echo 'missing DM reached adb instead of failing preflight' >&2; exit 1; }
+mv "$candidate_dm.missing" "$candidate_dm"
+
 expect_failure wrong_device
 expect_failure unsigned
 expect_failure profile_missing
+expect_failure profile_stale
 expect_failure layer
 expect_failure timeout
 expect_failure privacy

--- a/android/benchmark-device-matrix.sh
+++ b/android/benchmark-device-matrix.sh
@@ -51,6 +51,7 @@ GATE_SCRIPT=${COFFEE_GB_M2_GATE_SCRIPT:-$SCRIPT_DIR/surface-timestats-gate.sh}
 
 usage() {
   echo "usage: benchmark-device-matrix.sh --parent-apk <signed.apk> --candidate-apk <signed.apk>" >&2
+  echo "       Each APK requires a same-stem install-time profile beside it: <signed.dm>" >&2
   echo "       --color-slot <0..9> --non-color-slot <0..9>" >&2
   echo "       [--execution-mode accuracy|performance] [--audio-policy canonical|silent-pcm-v1|silent-pcm-relaxed-apu-v1]" >&2
   echo "       [--output-dir <dir>]" >&2
@@ -191,6 +192,12 @@ case "$non_color_slot" in 0|1|2|3|4|5|6|7|8|9) : ;; *) fatal "non-color catalog 
 
 [ -f "$parent_apk" ] && [ -r "$parent_apk" ] || fatal "parent APK is not a readable regular file"
 [ -f "$candidate_apk" ] && [ -r "$candidate_apk" ] || fatal "candidate APK is not a readable regular file"
+case "$parent_apk" in *.apk) : ;; *) fatal "parent APK path must end in .apk" ;; esac
+case "$candidate_apk" in *.apk) : ;; *) fatal "candidate APK path must end in .apk" ;; esac
+parent_dm=${parent_apk%.apk}.dm
+candidate_dm=${candidate_apk%.apk}.dm
+[ -s "$parent_dm" ] && [ -r "$parent_dm" ] || fatal "parent DM is not a readable non-empty regular file"
+[ -s "$candidate_dm" ] && [ -r "$candidate_dm" ] || fatal "candidate DM is not a readable non-empty regular file"
 
 if [ -n "$output_dir" ]; then
   if [ -e "$output_dir" ] && [ ! -d "$output_dir" ]; then
@@ -550,8 +557,8 @@ save_display_settings() {
 
 # Verify once, then again before each measured side.  No stay/power setting is silently changed:
 # a plugged device with the corresponding stay-on bit and low_power=0 is an eligibility condition.
-# No package manager/data reset is ever issued; install -r is the only installation form and
-# preserves the app-owned catalog.
+# No package manager/data reset is ever issued; install-multiple -r preserves the app-owned
+# catalog while installing the APK and its matching baseline-profile companion atomically.
 check_host_environment
 save_display_settings
 
@@ -592,11 +599,17 @@ verify_installed_profile() {
       line=$0
       gsub(/[][]/, " ", line)
       fields=split(line, token, /[[:space:]]+/)
-      for (i = 1; i <= fields; i++) if (token[i] == "status=speed-profile") found=1
+      status=0
+      reason=0
+      for (i = 1; i <= fields; i++) {
+        if (token[i] == "status=speed-profile") status=1
+        if (token[i] == "reason=install-dm") reason=1
+      }
+      if (status && reason) found=1
     }
     END { exit(found ? 0 : 1) }
   ' "$tmp_dir/package-dump"; then
-    fatal "installed benchmark package is not ART-compiled with status=speed-profile"
+    fatal "installed benchmark package does not report status=speed-profile reason=install-dm"
   fi
 }
 
@@ -1032,15 +1045,16 @@ run_one() {
     "$first_side" "$execution_mode" "$rate"
 
   adb_shell_checked am force-stop "$PACKAGE"
-  if ! adb_capture "$tmp_dir/install" install -r -d --no-streaming "$apk"; then
-    fatal "selected signed APK installation failed"
+  dm=${apk%.apk}.dm
+  if ! adb_capture "$tmp_dir/install" install-multiple -r -d --no-streaming "$apk" "$dm"; then
+    fatal "selected signed APK and DM installation failed"
   fi
   if ! awk 'tolower($0) ~ /(^|[^a-z])success([^a-z]|$)/ { ok=1 } END { exit(ok ? 0 : 1) }' \
       "$tmp_dir/install"; then
     fatal "selected signed APK installation was not confirmed"
   fi
-  # Verify the environment after installation and before the visible launch; install -r never
-  # receives a clear-data flag, so app-owned recent data remains intact.
+  # Verify the environment after installation and before the visible launch; install-multiple -r
+  # never receives a clear-data flag, so app-owned recent data remains intact.
   pin_display_rate "$rate"
   check_host_environment
   resolve_uid

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeType.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeType.java
@@ -99,7 +99,12 @@ public enum CartridgeType {
     }
 
     public boolean isRumble() {
-        return nameContainsSegment("RUMBLE");
+        // The legacy 0x22 header label includes RUMBLE, but retail MBC7 boards expose only an
+        // accelerometer and EEPROM. Among standardized header values, only MBC5 types 0x1c-0x1e
+        // have a cartridge motor output.
+        return this == ROM_MBC5_RUMBLE
+                || this == ROM_MBC5_RUMBLE_SRAM
+                || this == ROM_MBC5_RUMBLE_SRAM_BATTERY;
     }
 
     private boolean nameContainsSegment(String segment) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Mbc7.java
@@ -2,7 +2,10 @@ package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.memento.Memento;
 
+import eu.rekawek.coffeegb.core.debug.DebugHooks;
 import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccessProvider;
 import eu.rekawek.coffeegb.core.state.MachineStateCapture;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController;
@@ -14,7 +17,7 @@ import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
  * Used by Kirby's Tilt 'n' Tumble.
  * Features ROM banking, accelerometer (sensor), and EEPROM.
  */
-public class Mbc7 implements MemoryController {
+public class Mbc7 implements MemoryController, PerformanceRomAccessProvider {
 
     private final int romBanks;
 
@@ -35,6 +38,12 @@ public class Mbc7 implements MemoryController {
     private int latchState = 0;
 
     private final Mbc7Eeprom eeprom;
+
+    private transient DebugHooks debugHooks;
+
+    /** Reused snapshot; a caller borrows it only until its bounded transaction completes. */
+    private final Mbc7PerformanceRomAccess performanceRomAccess =
+            new Mbc7PerformanceRomAccess();
 
     public Mbc7(Rom rom, Battery battery) {
         this.cartridge = rom.getRom();
@@ -117,6 +126,22 @@ public class Mbc7 implements MemoryController {
         }
     }
 
+    @Override
+    public void setDebugHooks(DebugHooks hooks) {
+        debugHooks = hooks;
+    }
+
+    @Override
+    public PerformanceRomAccess acquirePerformanceRomAccess() {
+        // Derived boards may add mapping semantics outside plain MBC7. Debug sessions retain the
+        // ordinary mapper path so instrumentation remains authoritative.
+        if (getClass() != Mbc7.class || debugHooks != null) {
+            return null;
+        }
+        performanceRomAccess.upperWindowBase = (selectedRomBank % romBanks) * 0x4000;
+        return performanceRomAccess;
+    }
+
     private void writeEeprom(int value) {
         eeprom.write(value);
     }
@@ -131,6 +156,39 @@ public class Mbc7 implements MemoryController {
             return cartridge[cartOffset];
         } else {
             return 0xff;
+        }
+    }
+
+    private final class Mbc7PerformanceRomAccess implements PerformanceRomAccess {
+
+        private int upperWindowBase;
+
+        @Override
+        public int physicalOffset(int cpuAddress) {
+            if (cpuAddress < 0 || cpuAddress >= 0x8000) {
+                return -1;
+            }
+            return cpuAddress < 0x4000
+                    ? cpuAddress
+                    : upperWindowBase + cpuAddress - 0x4000;
+        }
+
+        @Override
+        public int readPhysicalByte(int physicalOffset) {
+            return physicalOffset >= 0 && physicalOffset < cartridge.length
+                    ? cartridge[physicalOffset]
+                    : 0xff;
+        }
+
+        @Override
+        public int readCpuByte(int cpuAddress) {
+            if (cpuAddress < 0 || cpuAddress >= 0x8000) {
+                return -1;
+            }
+            int physicalOffset = cpuAddress < 0x4000
+                    ? cpuAddress
+                    : upperWindowBase + cpuAddress - 0x4000;
+            return physicalOffset < cartridge.length ? cartridge[physicalOffset] : 0xff;
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
@@ -12,6 +12,7 @@ import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.memory.cart.battery.Battery;
 import eu.rekawek.coffeegb.core.memory.cart.type.Mbc5;
+import eu.rekawek.coffeegb.core.memory.cart.type.Mbc7;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,6 +24,83 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 public class PerformanceRomAccessTest {
+
+    @Test
+    public void plainMbc7LeaseSnapshotsBothWindowsAndIsReused() throws IOException {
+        Mbc7 mapper = plainMbc7();
+
+        PerformanceRomAccess lease = mapper.acquirePerformanceRomAccess();
+
+        assertNotNull(lease);
+        assertEquals(0x20, lease.readCpuByte(0x0000));
+        assertEquals(0x40, lease.readCpuByte(0x3fff));
+        assertEquals(0x21, lease.readCpuByte(0x4000));
+        assertEquals(0x41, lease.readCpuByte(0x7fff));
+        assertEquals(0x80, lease.readCpuByte(0x0100));
+        assertEquals(0x81, lease.readCpuByte(0x4100));
+        assertEquals(0x0100, lease.physicalOffset(0x0100));
+        assertEquals(0x4100, lease.physicalOffset(0x4100));
+        assertEquals(-1, lease.physicalOffset(0x8000));
+        assertEquals(-1, lease.readCpuByte(-1));
+        assertEquals(0xff, lease.readPhysicalByte(Integer.MAX_VALUE));
+
+        mapper.setByte(0x2000, 0x03);
+        assertEquals("borrowed mapping remains stable until reacquisition",
+                0x81, lease.readCpuByte(0x4100));
+
+        PerformanceRomAccess reacquired = mapper.acquirePerformanceRomAccess();
+        assertSame("plain MBC7 acquisition must not allocate", lease, reacquired);
+        assertEquals(0x83, reacquired.readCpuByte(0x4100));
+        assertEquals(0xc100, reacquired.physicalOffset(0x4100));
+    }
+
+    @Test
+    public void plainMbc7LeaseFailsClosedForDerivedMapperAndDebugHooks() throws IOException {
+        Mbc7 derivedMapper = new Mbc7(new Rom(mbc7Rom()), Battery.NULL_BATTERY) {
+        };
+        assertNull(derivedMapper.acquirePerformanceRomAccess());
+
+        Mbc7 debuggedMapper = plainMbc7();
+        debuggedMapper.setDebugHooks(new TestDebugHooks());
+        assertNull(debuggedMapper.acquirePerformanceRomAccess());
+    }
+
+    @Test
+    public void mbc7LeaseUsesNinthBankBitModuloAndOpenBusForPartialFinalBank()
+            throws IOException {
+        byte[] rom = new byte[0x9000];
+        rom[0x0000] = 0x50;
+        rom[0x8000] = 0x52;
+        rom[0x8fff] = 0x5f;
+        rom[0x0147] = 0x22;
+        rom[0x0148] = 0x00;
+        Mbc7 mapper = new Mbc7(new Rom(rom), Battery.NULL_BATTERY);
+
+        mapper.setByte(0x2000, 0x02);
+        PerformanceRomAccess partialBank = mapper.acquirePerformanceRomAccess();
+        assertEquals(0x52, partialBank.readCpuByte(0x4000));
+        assertEquals(0x5f, partialBank.readCpuByte(0x4fff));
+        assertEquals(0xff, partialBank.readCpuByte(0x5000));
+        assertEquals(0x9000, partialBank.physicalOffset(0x5000));
+
+        mapper.setByte(0x3000, 0x01);
+        PerformanceRomAccess ninthBitBank = mapper.acquirePerformanceRomAccess();
+        assertSame(partialBank, ninthBitBank);
+        assertEquals("0x102 wraps over the physical three-bank image to bank zero",
+                0x50, ninthBitBank.readCpuByte(0x4000));
+        assertEquals(0x0000, ninthBitBank.physicalOffset(0x4000));
+    }
+
+    @Test
+    public void productionCartridgeExposesPlainMbc7Lease() throws IOException {
+        Cartridge cartridge = new Cartridge(new Rom(mbc7Rom()), Battery.NULL_BATTERY);
+
+        PerformanceRomAccess lease = cartridge.acquirePerformanceRomAccess();
+
+        assertNotNull(lease);
+        assertEquals(0x20, lease.readCpuByte(0x0000));
+        assertEquals(0x21, lease.readCpuByte(0x4000));
+    }
 
     @Test
     public void plainMbc5LeaseSnapshotsBothWindowsAndIsReused() throws IOException {
@@ -158,14 +236,29 @@ public class PerformanceRomAccessTest {
         return new Mbc5(new Rom(mbc5Rom()), Battery.NULL_BATTERY);
     }
 
+    private static Mbc7 plainMbc7() throws IOException {
+        return new Mbc7(new Rom(mbc7Rom()), Battery.NULL_BATTERY);
+    }
+
+    private static byte[] mbc7Rom() {
+        byte[] rom = bankedRom();
+        rom[0x0147] = 0x22;
+        return rom;
+    }
+
     private static byte[] mbc5Rom() {
+        byte[] rom = bankedRom();
+        rom[0x0147] = 0x19;
+        return rom;
+    }
+
+    private static byte[] bankedRom() {
         byte[] rom = new byte[0x40000];
         for (int bank = 0; bank < 16; bank++) {
             rom[bank * 0x4000] = (byte) (0x20 + bank);
             rom[bank * 0x4000 + 0x3fff] = (byte) (0x40 + bank);
             rom[bank * 0x4000 + 0x0100] = (byte) (0x80 + bank);
         }
-        rom[0x0147] = 0x19;
         rom[0x0148] = 0x04;
         return rom;
     }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeTypeTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeTypeTest.java
@@ -1,0 +1,19 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CartridgeTypeTest {
+
+    @Test
+    public void onlyMbc5MotorCartridgesReportRumbleCapability() {
+        assertTrue(CartridgeType.ROM_MBC5_RUMBLE.isRumble());
+        assertTrue(CartridgeType.ROM_MBC5_RUMBLE_SRAM.isRumble());
+        assertTrue(CartridgeType.ROM_MBC5_RUMBLE_SRAM_BATTERY.isRumble());
+
+        assertFalse(CartridgeType.ROM_MBC7_SENSOR_RUMBLE_RAM_BATTERY.isRumble());
+        assertFalse(CartridgeType.ROM_MBC5_RAM_BATTERY.isRumble());
+    }
+}

--- a/upload_to_android-test.sh
+++ b/upload_to_android-test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+subject="$source_root/upload_to_android.sh"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/coffee-gb-upload-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+
+fake_repo="$test_root/repo"
+fake_sdk="$test_root/sdk"
+fake_home="$test_root/home"
+fake_bin="$test_root/bin"
+calls="$test_root/adb.calls"
+
+mkdir -p "$fake_repo/android" "$fake_sdk/build-tools/36.0.0" \
+  "$fake_home/.android" "$fake_bin"
+cp -- "$subject" "$fake_repo/upload_to_android.sh"
+chmod 700 "$fake_repo/upload_to_android.sh"
+printf '<project/>\n' >"$fake_repo/pom.xml"
+printf 'fixture key\n' >"$fake_home/.android/debug.keystore"
+
+cat >"$fake_bin/mvn" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+cat >"$fake_sdk/build-tools/36.0.0/zipalign" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$#" -eq 5 && "$1" == -f && "$2" == -p && "$3" == 4 ]]
+cp -- "$4" "$5"
+STUB
+
+cat >"$fake_sdk/build-tools/36.0.0/apksigner" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  verify)
+    exit 0
+    ;;
+  sign)
+    shift
+    output=
+    input=
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == --out ]]; then
+        output="$2"
+        shift 2
+      else
+        input="$1"
+        shift
+      fi
+    done
+    [[ -n "$output" && -f "$input" ]]
+    cp -- "$input" "$output"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+
+cat >"$fake_bin/adb" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_CALLS:?}"
+if [[ "${1:-}" == shell && "${2:-}" == getprop \
+    && "${3:-}" == ro.build.version.sdk ]]; then
+  printf '%s\n' "${FAKE_API:?}"
+  exit 0
+fi
+if [[ "${1:-}" == install-multiple ]]; then
+  [[ "$#" -eq 4 && "$2" == -r && "$3" == *.apk \
+    && "$4" == "${3%.apk}.dm" && -s "$3" && -s "$4" ]]
+  echo Success
+  exit 0
+fi
+if [[ "${1:-}" == install ]]; then
+  [[ "$#" -eq 3 && "$2" == -r && "$3" == *.apk && -s "$3" ]]
+  echo Success
+  exit 0
+fi
+exit 1
+STUB
+
+cat >"$fake_repo/android/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *:app:assembleBenchmark*)
+    variant=benchmark
+    apk_name=app-benchmark.apk
+    ;;
+  *:app:assembleRelease*)
+    variant=release
+    apk_name=app-release-unsigned.apk
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+output="${FAKE_REPO:?}/android/app/build/outputs/apk/$variant"
+mkdir -p "$output/baselineProfiles/0" "$output/baselineProfiles/1"
+printf 'fixture %s apk\n' "$variant" >"$output/$apk_name"
+if [[ "${FAKE_MISSING_DM:-0}" != 1 ]]; then
+  if [[ "${FAKE_EMPTY_DM:-0}" == 1 ]]; then
+    : >"$output/baselineProfiles/0/${apk_name%.apk}.dm"
+  else
+    printf 'api31 %s profile\n' "$variant" \
+      >"$output/baselineProfiles/0/${apk_name%.apk}.dm"
+  fi
+  printf 'api28 %s profile\n' "$variant" \
+    >"$output/baselineProfiles/1/${apk_name%.apk}.dm"
+fi
+if [[ "${FAKE_BAD_METADATA:-0}" == 1 ]]; then
+  printf '{"baselineProfiles": []}\n' >"$output/output-metadata.json"
+  exit 0
+fi
+extra=
+if [[ "${FAKE_AMBIGUOUS_METADATA:-0}" == 1 ]]; then
+  mkdir -p "$output/baselineProfiles/2"
+  printf 'ambiguous %s profile\n' "$variant" \
+    >"$output/baselineProfiles/2/${apk_name%.apk}.dm"
+  extra=',
+    {
+      "minApi": 31,
+      "maxApi": 2147483647,
+      "baselineProfiles": [
+        "baselineProfiles/2/'"${apk_name%.apk}"'.dm"
+      ]
+    }'
+fi
+cat >"$output/output-metadata.json" <<JSON
+{
+  "baselineProfiles": [
+    {
+      "minApi": 28,
+      "maxApi": 30,
+      "baselineProfiles": [
+        "baselineProfiles/1/${apk_name%.apk}.dm"
+      ]
+    },
+    {
+      "minApi": 31,
+      "maxApi": 2147483647,
+      "baselineProfiles": [
+        "baselineProfiles/0/${apk_name%.apk}.dm"
+      ]
+    }$extra
+  ]
+}
+JSON
+STUB
+
+chmod 700 "$fake_bin/mvn" "$fake_bin/adb" "$fake_repo/android/gradlew" \
+  "$fake_sdk/build-tools/36.0.0/zipalign" \
+  "$fake_sdk/build-tools/36.0.0/apksigner"
+
+reset_fixture() {
+  rm -rf "$fake_repo/android/app" "$fake_repo/build"
+  : >"$calls"
+}
+
+run_subject() {
+  local api="$1"
+  local variant="$2"
+  shift 2
+  HOME="$fake_home" ANDROID_SDK_ROOT="$fake_sdk" MAVEN_BIN="$fake_bin/mvn" \
+    ADB_BIN="$fake_bin/adb" FAKE_REPO="$fake_repo" FAKE_CALLS="$calls" \
+    FAKE_API="$api" "$@" "$fake_repo/upload_to_android.sh" "$variant" \
+    >"$test_root/$variant-$api.stdout" 2>"$test_root/$variant-$api.stderr"
+}
+
+assert_profiled_install() {
+  local variant="$1"
+  local profile_marker="$2"
+  local final_stem
+  if [[ "$variant" == benchmark ]]; then
+    final_stem=coffee-gb-benchmark-qa-r8
+  else
+    final_stem=coffee-gb-qa-r8
+  fi
+  local output="$fake_repo/android/app/build/outputs/apk/$variant"
+  [[ -s "$output/$final_stem.apk" && -s "$output/$final_stem.dm" ]]
+  grep -q "$profile_marker" "$output/$final_stem.dm"
+  grep -Fxq "install-multiple -r $output/$final_stem.apk $output/$final_stem.dm" "$calls"
+}
+
+reset_fixture
+run_subject 35 benchmark env
+assert_profiled_install benchmark api31
+
+reset_fixture
+run_subject 35 release env
+assert_profiled_install release api31
+
+reset_fixture
+run_subject 29 benchmark env
+assert_profiled_install benchmark api28
+
+reset_fixture
+run_subject 27 release env
+release_apk="$fake_repo/android/app/build/outputs/apk/release/coffee-gb-qa-r8.apk"
+grep -Fxq "install -r $release_apk" "$calls"
+if grep -q '^install-multiple ' "$calls"; then
+  echo 'API 27 unexpectedly attempted an install-time profile' >&2
+  exit 1
+fi
+
+expect_profile_failure() {
+  local mode_name="$1"
+  local mode_variable="$2"
+  reset_fixture
+  set +e
+  run_subject 35 benchmark env "$mode_variable=1"
+  local status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || {
+    echo "$mode_name profile fixture unexpectedly installed" >&2
+    exit 1
+  }
+  if grep -q '^install' "$calls"; then
+    echo "$mode_name profile fixture reached adb installation" >&2
+    exit 1
+  fi
+}
+
+expect_profile_failure empty FAKE_EMPTY_DM
+expect_profile_failure missing FAKE_MISSING_DM
+expect_profile_failure malformed FAKE_BAD_METADATA
+expect_profile_failure ambiguous FAKE_AMBIGUOUS_METADATA
+
+bash -n "$subject"
+echo 'upload_to_android profile install fixture: PASS'

--- a/upload_to_android.sh
+++ b/upload_to_android.sh
@@ -67,6 +67,42 @@ version_is_newer() {
   return 1
 }
 
+baseline_profile_for_api() {
+  local metadata="$1"
+  local device_api="$2"
+
+  awk -v api="$device_api" '
+    /"minApi"[[:space:]]*:/ {
+      value=$0
+      sub(/^.*:/, "", value)
+      gsub(/[^0-9]/, "", value)
+      min_api=value + 0
+    }
+    /"maxApi"[[:space:]]*:/ {
+      value=$0
+      sub(/^.*:/, "", value)
+      gsub(/[^0-9]/, "", value)
+      max_api=value + 0
+    }
+    /"baselineProfiles\/[^"[:space:]]+[.]dm"/ {
+      path=$0
+      sub(/^[^"]*"/, "", path)
+      sub(/".*/, "", path)
+      if (api >= min_api && api <= max_api) {
+        matches++
+        selected=path
+      }
+    }
+    END {
+      if (matches == 1) {
+        print selected
+        exit 0
+      }
+      exit 1
+    }
+  ' "$metadata"
+}
+
 script_path="${BASH_SOURCE[0]}"
 script_dir="$(cd -- "$(dirname -- "$script_path")" && pwd -P)"
 repo_root="$script_dir"
@@ -177,7 +213,29 @@ else
   "$apksigner_bin" verify --verbose "$signed_apk"
 fi
 
-echo "Installing the $build_variant QA APK with adb -r (app data preserved)"
-"$adb_bin" install -r "$signed_apk"
+device_api="$("$adb_bin" shell getprop ro.build.version.sdk | tr -d '\r')"
+[[ "$device_api" =~ ^[0-9]+$ ]] || die "device returned an invalid Android API level"
+profile_metadata="$apk_dir/output-metadata.json"
+[[ -f "$profile_metadata" ]] || die "Android build did not produce output metadata: $profile_metadata"
 
-echo "Installed $signed_apk"
+if relative_profile="$(baseline_profile_for_api "$profile_metadata" "$device_api")"; then
+  case "$relative_profile" in
+    /*|../*|*/../*|*/..) die "Android build reported an unsafe baseline-profile path" ;;
+  esac
+  generated_profile="$apk_dir/$relative_profile"
+  [[ -s "$generated_profile" ]] \
+    || die "Android build did not produce the selected baseline profile: $generated_profile"
+  signed_profile="${signed_apk%.apk}.dm"
+  cp -- "$generated_profile" "$signed_profile"
+  echo "Installing the $build_variant QA APK and API $device_api baseline profile (app data preserved)"
+  "$adb_bin" install-multiple -r "$signed_apk" "$signed_profile"
+  echo "Installed $signed_apk and $signed_profile"
+elif ((device_api < 28)); then
+  # AGP does not emit install-time DM artifacts for every supported legacy Android version.
+  # The bundled ProfileInstaller can still install the embedded profile after first launch.
+  echo "Installing the $build_variant QA APK with adb -r (no API $device_api install-time profile available)"
+  "$adb_bin" install -r "$signed_apk"
+  echo "Installed $signed_apk"
+else
+  die "Android build metadata did not select exactly one baseline profile for API $device_api"
+fi


### PR DESCRIPTION
## Summary

Kirby's Android issues had several independent causes:

- Android accelerometer values were passed as m/s² although the MBC7 contract uses g units, making tilt roughly 9.8× too sensitive.
- Device rotation could change the control axes during a tilt-enabled session.
- MBC7 ROM fetches remained on the generic mapper/MMU path.
- AGP generated install-time baseline profiles, but the upload and benchmark scripts installed only the APK, leaving tested builds without the `.dm` profile.
- The app was not categorized as a game.

## Rumble clarification

Kirby's Tilt 'n' Tumble should not rumble. Retail MBC7 cartridges contain an accelerometer and EEPROM but no vibration motor or rumble register, despite the legacy cartridge-type label containing `RUMBLE` ([board inventory](https://gbhwdb.gekkio.fi/cartridges/CGB-KTNE-0/endrift-1.html), [MBC7 register map](https://gbdev.io/pandocs/MBC7.html)).

This change limits the rumble capability to the genuine MBC5 rumble types. It also preserves the Android rumble preference across sink and controller recreation for games that actually support rumble.

## Implementation

- Normalize calibrated, rotation-corrected accelerometer deltas with `SensorManager.GRAVITY_EARTH`.
- Lock the current screen orientation while a tilt cartridge owns the session, track that ownership across pauses, reloads, replacements, failures, and activity recreation, and restore the prior orientation afterward.
- Add allocation-free `PerformanceRomAccessProvider` support for plain MBC7 cartridges, while retaining the ordinary mapper path for debugging and derived implementations.
- Mark the Android application with `android:appCategory="game"`.
- Select the API-compatible AGP `.dm` artifact from `output-metadata.json`, rename it to the signed APK stem, and install both atomically while preserving app data.
- Make the device-matrix harness require and verify `status=speed-profile reason=install-dm`.
- Verify release and benchmark builds contain exactly two valid API-ranged install profiles.
- Add regression coverage for tilt scaling and lifecycle, orientation locking, rumble state/capabilities, MBC7 performance access, and profile installation.

## Isolated performance measurement

A CPU-pinned Java 21 headless Kirby A/B used a 600-frame warm-up and 1,500 frame-equivalents per measurement, comparing this implementation with an equivalent build where only the new MBC7 direct-ROM lease was disabled.

After the cold pair, the repeat pairs showed about **6.6% higher CPU throughput** and **6.2% less CPU time**; the aggregate across all three alternating pairs was **8.8% higher throughput**. Every run produced identical frame and tick endpoints.

This isolates mapper-fetch cost. It excludes Android rendering, audio, sensors, and scripted active gameplay, so it is not an end-to-end device FPS claim.

## Verification

- `/opt/maven/bin/mvn -pl core clean test` — **BUILD SUCCESS**; 1,996 tests, 0 failures/errors, 8 skipped.
- From `android/`: `ANDROID_HOME=/opt/android-sdk ./gradlew -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease :app:assembleBenchmark` — **BUILD SUCCESSFUL**; 157 actionable tasks.
- Focused lifecycle/unit tests and `:app:compileDebugAndroidTestJavaWithJavac` — passed. Instrumentation was compiled but not run on a device.
- `bash upload_to_android-test.sh` — `upload_to_android profile install fixture: PASS`.
- `sh android/benchmark-device-matrix-test.sh` — `benchmark device matrix hermetic fixture: PASS`.
