### PR TITLE
Use performance ROM fetches for all mappers

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -1524,8 +1524,6 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !dma.requiresClockTick(false)
                 && !hdma.hasActiveOrPendingTransfer()
                 && hdma.isPerformanceInactiveRequestClockStable()
-                && !cartridgeClocked
-                && !slotCartridgeClocked
                 && serialPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS)
                 && infraredPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
     }
@@ -1542,6 +1540,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
+        if (cartridgeClocked) {
+            span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
+        if (slotCartridgeClocked) {
+            span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+        }
         span = Math.min(span, timer.performanceEpochSpanLimit(span));
         span = Math.min(span, sound.performanceEpochSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
@@ -1648,7 +1652,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
      * Attempts one native-CGB double-speed settled-HALT packet. HALT has no CPU bus work once
      * its entry and wake samples have settled, but the packet still stops before every timer,
      * audio, input, PPU, STAT, DMA, and frame boundary. Unlike the ordinary epoch this path does
-     * not borrow a ROM mapping or change the CPU instruction sequencer.
+     * not borrow a ROM reader or change the CPU instruction sequencer.
      */
     private int tryPerformanceSettledNativeCgbHaltSpan(long remaining) {
         if (remaining <= 0 || !cpu.performanceNativeCgbSettledHaltSpanEligible()
@@ -1656,6 +1660,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return 0;
         }
         int span = (int) Math.min((long) SETTLED_HALT_PERFORMANCE_MAX_SPAN, remaining);
+        if (cartridgeClocked) {
+            span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
+        if (slotCartridgeClocked) {
+            span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
+        }
         span = Math.min(span, timer.performanceEpochSpanLimit(span));
         // This is a settled no-bus HALT transaction, so ordinary compact samples cannot race a
         // deferred CPU sound-register write. Only the synchronous host callback stays scalar.
@@ -1723,14 +1733,18 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && !hdma.holdsHblankSpeedSwitchTail()
                 && !hdma.pausesOamDmaForSpeedSwitchBurst()
                 && !hdma.requiresCpuHdmaPhaseFlags()
-                && hdma.isPerformanceInactiveRequestClockStable()
-                && !cartridgeClocked
-                && !slotCartridgeClocked;
+                && hdma.isPerformanceInactiveRequestClockStable();
     }
 
     private void tickPerformanceSettledNativeCgbHaltSpan(
             int ticks, PerformanceEpochPpuPlan ppuPlan, boolean directRaster,
             boolean steadyRaster) {
+        if (cartridgeClocked) {
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
         timer.tickPerformanceEpochTrusted(ticks);
         sound.tickFrameSequencer(false);
         assert !sound.hasPendingFrameSequencerClock()
@@ -1845,12 +1859,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return 0;
         }
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
-        if (nativeCgbNormalSpeed && cartridgeClocked) {
-            // Native x1 keeps every decoded mapper/RTC access on the scalar boundary.  A
-            // clocked primary cartridge may therefore join only through its independently
-            // proven arithmetic clock horizon; the conservative MemoryController default
-            // rejects unknown clocked hardware here.
+        if (cartridgeClocked) {
+            // Cartridge-control, external-RAM, and RTC accesses stay on the scalar boundary.
+            // A clocked cartridge may join only through its independently proven arithmetic
+            // horizon; the conservative MemoryController default rejects unknown hardware.
             span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
+        }
+        if (slotCartridgeClocked) {
+            span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
         }
         span = Math.min(span, timer.performanceNormalSpeedEpochSpanLimit(span, cgbHardware));
         span = Math.min(span, nativeCgbNormalSpeed || sgb || physicalDmgLcdOffEpoch
@@ -2036,8 +2052,6 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && (lcdEnabled ? !lcdDisabled : lcdOffEpoch && lcdDisabled)
                 && !dma.isTransferInProgress()
                 && !dma.requiresClockTick(false)
-                && (!cartridgeClocked || nativeCgbNormalSpeed)
-                && !slotCartridgeClocked
                 && (!cgbHardware || (!hdma.hasActiveOrPendingTransfer()
                         && !hdma.hasPendingHblankTransfer()
                         && !hdma.isHaltRequestLatched()
@@ -2071,6 +2085,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private void commitPerformanceEpochPeripherals(int ticks) {
         if (ticks <= 0) {
             return;
+        }
+        if (cartridgeClocked) {
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
         timer.tickPerformanceEpochTrusted(ticks);
         sound.tickFrameSequencer(false);
@@ -2149,11 +2169,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             return;
         }
         capturePerformanceEpochEntryStatReadPhase();
-        if (cgbHardware && !speedMode.isDmgCompat() && cartridgeClocked) {
+        if (cartridgeClocked) {
             // Scalar Gameboy.tick() clocks the cartridge before Timer and every other
             // subsystem.  Prefix flushes and the final suffix both pass through this method,
             // preserving that ordering before a fenced mapper/RTC boundary returns scalar.
             cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
         }
         timer.tickPerformanceNormalSpeedEpochTrusted(ticks);
         sound.tickFrameSequencer(false);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -63,15 +63,15 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private final AddressSpace baseAddressSpace;
 
-    /** Immutable typed entrance to the optional native-CGB physical ROM mapping chain. */
+    /** Immutable typed entrance to the optional running-epoch ROM reader chain. */
     private final PerformanceRomAccessProvider performanceRomAccessProvider;
 
     private AddressSpace addressSpace;
 
-    /** Reused CPU-bus observer for the native-CGB coarse PERFORMANCE epoch. */
+    /** Reused CPU-bus observer for coarse running PERFORMANCE epochs. */
     private transient PerformanceEpochBus performanceEpochBus;
 
-    /** Borrowed direct ROM mapping retained only for one bounded native-CGB epoch. */
+    /** Borrowed ROM reader retained only for one bounded running PERFORMANCE epoch. */
     private transient PerformanceRomAccess performanceEpochRomAccess;
 
     private transient AddressSpace performanceEpochTarget;
@@ -268,8 +268,8 @@ public class Cpu implements StatefulComponent<Cpu> {
                     }
                 }
 
-                // Fence the next fetch/operand window before the native epoch may use its
-                // borrowed ROM mapping. Scalar and physical-DMG fetches remain on the base bus.
+                // Fence the next fetch/operand window before the native x2 epoch may use its
+                // borrowed ROM reader.
                 if (!performanceEpochPrefetchSafe()) {
                     performanceEpochTerminal = true;
                     break;
@@ -351,8 +351,8 @@ public class Cpu implements StatefulComponent<Cpu> {
     /**
      * Fixed four-master-dot epoch for native CGB software which remains at normal speed.
      * Address-known ROM reads and work/high-RAM accesses may remain inside the epoch.
-     * CPU-visible peripheral, mapper, cartridge-RAM, and RTC accesses stay scalar so they
-     * retain their position before the owner ticks Sound and the remaining peripherals.
+     * CPU-visible peripheral, cartridge-control, external-RAM, and RTC accesses stay scalar so
+     * they retain their position before the owner ticks Sound and the remaining peripherals.
      */
     public int runNativeCgbNormalSpeedPerformanceEpoch(int maxMasterTicks) {
         return !speedMode.isDmgCompat()
@@ -397,6 +397,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         }
         PerformanceEpochBus bus = performanceEpochBus;
         AddressSpace target = addressSpace;
+        performanceEpochRomAccess = acquirePerformanceEpochRomAccess();
         performanceEpochTarget = target;
         performanceEpochTerminal = false;
         performanceEpochJournalValid = false;
@@ -448,6 +449,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                 }
             }
         } finally {
+            performanceEpochRomAccess = null;
             addressSpace = target;
             performanceEpochActive = false;
             performanceEpochLcdOffVramAccess = false;
@@ -546,7 +548,21 @@ public class Cpu implements StatefulComponent<Cpu> {
      * fetch boundary itself untouched when the next opcode is HALT.
      */
     private boolean performanceNextBoundaryFetchesHalt() {
-        return state == State.OPCODE && readInstructionByte(registers.getPC()) == 0x76;
+        if (state != State.OPCODE) {
+            return false;
+        }
+        int pc = registers.getPC();
+        if (pc >= 0x8000) {
+            return readInstructionByte(pc) == 0x76;
+        }
+        PerformanceRomAccess romAccess = performanceEpochRomAccess;
+        if (romAccess == null) {
+            return true;
+        }
+        int physicalOffset = romAccess.physicalOffset(pc);
+        // A logical mapper read may itself mutate cartridge state. Leave this rare masked-IRQ
+        // boundary scalar instead of peeking and then fetching the same opcode a second time.
+        return physicalOffset < 0 || romAccess.readPhysicalByte(physicalOffset) == 0x76;
     }
 
     private boolean hasImeDisabledRawPendingInterrupt() {
@@ -1330,7 +1346,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         switch (state) {
             case OPCODE:
                 clearState();
-                opcode1 = readInstructionByte(pc);
+                opcode1 = readPerformanceEpochInstructionByte(pc);
                 if (opcode1 == 0xcb) {
                     state = State.EXT_OPCODE;
                 } else if (opcode1 == 0x10) {
@@ -1358,7 +1374,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                 return 0;
 
             case EXT_OPCODE:
-                opcode2 = readInstructionByte(pc);
+                opcode2 = readPerformanceEpochInstructionByte(pc);
                 if (currentOpcode == null) {
                     setCurrentOpcode(Opcodes.EXT_COMMANDS.get(opcode2));
                 }
@@ -1379,7 +1395,7 @@ public class Cpu implements StatefulComponent<Cpu> {
             case OPERAND:
                 boolean fetchedOperand = false;
                 if (operandIndex < currentOperandLength) {
-                    operand[operandIndex++] = readInstructionByte(pc);
+                    operand[operandIndex++] = readPerformanceEpochInstructionByte(pc);
                     registers.incrementPC();
                     fetchedOperand = true;
                     if (operandIndex < currentOperandLength) {
@@ -1431,7 +1447,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                             ? speedSwitchPaddingOpcode
                             : useHdmaArbitrationOpcode
                             ? hdmaArbitrationOpcode
-                            : readInstructionByte(pc);
+                            : readPerformanceEpochInstructionByte(pc);
                     accessedMemory = true;
                     notifyOpcodeFetched(pc, false, opcode1);
                     if (opcode1 == 0xcb) {
@@ -1468,7 +1484,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                         return;
                     }
                     accessedMemory = true;
-                    opcode2 = readInstructionByte(pc);
+                    opcode2 = readPerformanceEpochInstructionByte(pc);
                     if (opcode1 == 0xcb) {
                         notifyOpcodeFetched(debugInstructionPc, true, opcode2);
                     }
@@ -1490,7 +1506,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                             return;
                         }
                         accessedMemory = true;
-                        operand[operandIndex++] = readInstructionByte(pc);
+                        operand[operandIndex++] = readPerformanceEpochInstructionByte(pc);
                         registers.incrementPC();
                     }
                     ops = currentOpcode.getOps();
@@ -1530,7 +1546,8 @@ public class Cpu implements StatefulComponent<Cpu> {
                         // HALT always samples the next opcode. It is normally fetched
                         // again on wake, but a simultaneously acknowledged HDMA request
                         // turns this sample into the held pipeline opcode.
-                        haltPrefetchedOpcode = readInstructionByte(registers.getPC());
+                        haltPrefetchedOpcode = readPerformanceEpochInstructionByte(
+                                registers.getPC());
                         haltOpcodePrefetchValid = false;
                         // committing a pending EI happens even when entering halt, so
                         // "ei; halt" halts with IME=1 (no halt bug, wake dispatches)
@@ -2040,7 +2057,7 @@ public class Cpu implements StatefulComponent<Cpu> {
      * Executes a complete high-frequency instruction transaction after its real
      * opcode fetch. Each additional machine-cycle boundary is charged at native
      * CGB's fixed two-master-dot width. Instruction bytes are fetched in program
-     * order through the epoch's borrowed ROM mapping when available; an unsafe data
+     * order through the epoch's borrowed ROM reader when available; an unsafe data
      * access is left in the canonical RUNNING state for the ordinary epoch sequencer.
      *
      * @return additional master ticks, or {@code -1} when this opcode/budget is not
@@ -2293,7 +2310,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         while (operandIndex < operandLength) {
             performanceEpochElapsed += 4;
             extraTicks += 4;
-            operand[operandIndex++] = readInstructionByte(registers.getPC());
+            operand[operandIndex++] = readPerformanceEpochInstructionByte(registers.getPC());
             registers.incrementPC();
         }
         ops = currentOpcode.getOps();
@@ -3198,13 +3215,13 @@ public class Cpu implements StatefulComponent<Cpu> {
                 : observed.getByte(address, DebugMemoryAccess.EXECUTE);
     }
 
-    /** Acquires one borrowed mapping after the native epoch entrance proof has passed. */
+    /** Acquires one borrowed reader after the running-epoch entrance proof has passed. */
     private PerformanceRomAccess acquirePerformanceEpochRomAccess() {
         PerformanceRomAccessProvider provider = performanceRomAccessProvider;
         return provider == null ? null : provider.acquirePerformanceRomAccess();
     }
 
-    /** Native-CGB epoch-only instruction fetch through its borrowed physical ROM mapping. */
+    /** Running-PERFORMANCE instruction fetch through its borrowed ROM reader. */
     private int readPerformanceEpochInstructionByte(int address) {
         PerformanceRomAccess romAccess = performanceEpochRomAccess;
         if (romAccess != null && address >= 0 && address < 0x8000) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccess.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccess.java
@@ -1,21 +1,35 @@
 package eu.rekawek.coffeegb.core.memory;
 
 /**
- * Borrowed, read-only view of one stable CPU ROM mapping for a bounded PERFORMANCE transaction.
+ * Borrowed ROM reader for one bounded, owner-thread PERFORMANCE transaction.
  *
- * <p>The provider may reuse and mutate the returned object on the next acquisition. Callers must
- * therefore neither retain it beyond their transaction nor assume that a later acquisition has
- * the same bank mapping. ROM contents themselves are immutable.</p>
+ * <p>An access may expose either of two tiers. Immutable mapper backings can return physical
+ * offsets and read those bytes directly. More complex mappers may instead override
+ * {@link #readCpuByte(int)} to preserve transformed data, mutable flash, pass-through routing, or
+ * read-side effects while still bypassing the inert outer bus layers.</p>
+ *
+ * <p>The provider may reuse or mutate the returned object on the next acquisition. Callers must
+ * neither retain it beyond their transaction nor assume that a later acquisition has the same
+ * mapping.</p>
  */
 public interface PerformanceRomAccess {
 
-    /** Returns the immutable ROM-image offset for {@code cpuAddress}, or {@code -1}. */
+    /**
+     * Returns an offset in the mapper's immutable ROM backing, or {@code -1} when the address is
+     * unmapped or this access supplies only authoritative logical CPU reads.
+     */
     int physicalOffset(int cpuAddress);
 
-    /** Reads one immutable ROM-image byte. Implementations return the cartridge open value past EOF. */
+    /**
+     * Reads one immutable mapper-backing byte. Callers use only non-negative offsets returned by
+     * {@link #physicalOffset(int)}; implementations return the cartridge open value past EOF.
+     */
     int readPhysicalByte(int physicalOffset);
 
-    /** Maps and reads one CPU ROM byte, returning {@code -1} when the address is not mapped. */
+    /**
+     * Reads one CPU ROM byte, returning {@code -1} only when the full bus must remain authoritative.
+     * Logical mapper-direct accesses override this method when no physical offset exists.
+     */
     default int readCpuByte(int cpuAddress) {
         int offset = physicalOffset(cpuAddress);
         return offset < 0 ? -1 : readPhysicalByte(offset);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessProvider.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessProvider.java
@@ -1,12 +1,12 @@
 package eu.rekawek.coffeegb.core.memory;
 
-/** Supplies a borrowed ROM mapping only when every bypassed address-space layer is inert. */
+/** Supplies a borrowed ROM reader only when every bypassed address-space layer is inert. */
 public interface PerformanceRomAccessProvider {
 
     /**
-     * Acquires an allocation-free ROM mapping for one bounded PERFORMANCE transaction.
+     * Acquires an allocation-free ROM reader for one bounded PERFORMANCE transaction.
      *
-     * @return a borrowed mapping, or {@code null} when ordinary bus dispatch remains authoritative
+     * @return a borrowed reader, or {@code null} when ordinary bus dispatch remains authoritative
      */
     PerformanceRomAccess acquirePerformanceRomAccess();
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/Cartridge.java
@@ -27,6 +27,9 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     private final MemoryController addressSpace;
 
+    /** Reused exact-reader fallback for mappers without an immutable physical ROM lease. */
+    private final PerformanceRomAccess mapperPerformanceRomAccess;
+
     /** Parser-corrected loaded-image bytes retained for side-effect-free debugger reads. */
     private final int[] debugRom;
 
@@ -80,6 +83,7 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
         this.battery = battery;
         this.debugRom = rom.getRom();
         this.addressSpace = createMemoryController(rom, battery, rtcTimeSource, clockSpec);
+        this.mapperPerformanceRomAccess = new MapperPerformanceRomAccess(addressSpace);
         this.clocked = addressSpace.isClocked();
     }
 
@@ -214,10 +218,18 @@ public class Cartridge implements AddressSpace, StatefulComponent<Cartridge>,
 
     @Override
     public PerformanceRomAccess acquirePerformanceRomAccess() {
-        if (!(addressSpace instanceof PerformanceRomAccessProvider provider)) {
+        // A subclass may override the otherwise transparent cartridge read path. Production
+        // cartridges are exact instances, so derived wrappers must opt in explicitly.
+        if (getClass() != Cartridge.class) {
             return null;
         }
-        return provider.acquirePerformanceRomAccess();
+        if (addressSpace instanceof PerformanceRomAccessProvider provider) {
+            PerformanceRomAccess physicalAccess = provider.acquirePerformanceRomAccess();
+            if (physicalAccess != null) {
+                return physicalAccess;
+            }
+        }
+        return mapperPerformanceRomAccess;
     }
 
     /**

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MapperPerformanceRomAccess.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MapperPerformanceRomAccess.java
@@ -1,0 +1,37 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import java.util.Objects;
+
+/**
+ * Exact logical ROM reader used when a mapper cannot expose one immutable physical mapping.
+ *
+ * <p>This preserves the mapper's own transformations, overlays, mutable flash, pass-through
+ * routing, and read-side effects. The PERFORMANCE entrance proof has already established that the
+ * cartridge's outer bus layers are inert for the bounded transaction.</p>
+ */
+final class MapperPerformanceRomAccess implements PerformanceRomAccess {
+
+    private final MemoryController mapper;
+
+    MapperPerformanceRomAccess(MemoryController mapper) {
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    @Override
+    public int physicalOffset(int cpuAddress) {
+        return -1;
+    }
+
+    @Override
+    public int readPhysicalByte(int physicalOffset) {
+        return 0xff;
+    }
+
+    @Override
+    public int readCpuByte(int cpuAddress) {
+        return cpuAddress >= 0 && cpuAddress < 0x8000
+                ? mapper.getByte(cpuAddress)
+                : -1;
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MemoryController.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/MemoryController.java
@@ -19,6 +19,9 @@ public interface MemoryController extends AddressSpace, StatefulComponent<Memory
      * Returns the largest PERFORMANCE span which can advance this mapper without entering its
      * scalar clock path.  Clocked controllers must opt in explicitly; this conservative default
      * keeps newly added mapper hardware on the exact scheduler until its clock contract is known.
+     * Opting in also certifies that CPU ROM reads commute with the deferred arithmetic clock
+     * advance; cartridge-control, external-RAM, and RTC accesses are pre-fenced or terminate
+     * after an exact committed clock prefix.
      */
     default int performanceQuietSpanLimit(int requested) {
         if (requested <= 0) {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256M.java
@@ -129,6 +129,37 @@ public final class Unlicensed256M implements MemoryController {
     }
 
     @Override
+    public int performanceQuietSpanLimit(int requested) {
+        if (requested <= 0 || debugHooks != null) {
+            return 0;
+        }
+        // The menu has no independent clock. Once a game is selected, delegate to its mapper so
+        // an embedded MBC3 remains eligible without making every multicart tick scalar.
+        return selectedGame == null
+                ? requested
+                : selectedGame.performanceQuietSpanLimit(requested);
+    }
+
+    @Override
+    public boolean tickPerformanceQuietSpan(int ticks) {
+        if (ticks <= 0 || debugHooks != null || performanceQuietSpanLimit(ticks) < ticks) {
+            return false;
+        }
+        if (selectedGame != null) {
+            return selectedGame.tickPerformanceQuietSpan(ticks);
+        }
+        return true;
+    }
+
+    @Override
+    public void tickPerformanceQuietSpanTrusted(int ticks) {
+        if (ticks <= 0 || selectedGame == null) {
+            return;
+        }
+        selectedGame.tickPerformanceQuietSpanTrusted(ticks);
+    }
+
+    @Override
     public void setClockPaused(boolean paused) {
         clockPaused = paused;
         if (selectedGame != null) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.RecordComponent;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 
@@ -511,22 +512,114 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
-    public void clockedMbc3CgbCompatibilityRemainsOutsideRunningEpoch()
+    public void clockedMbc3DmgAndCgbCompatibilityMatchScalarWithRunningEpochCoverage()
             throws Exception {
-        byte[] compatibility = mbc3(dmgRomWramLoop());
-        try (Gameboy cgbCompatibility = new Gameboy.GameboyConfiguration(new Rom(compatibility))
-                     .setHardwareProfile(HardwareProfileRegistry.CGB)
-                     .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
-                     .setExecutionMode(ExecutionMode.PERFORMANCE)
-                     .setPlayerInputSource(PlayerInputSource.RELEASED)
-                     .setRtcTimeSource(() -> 0L)
-                     .setSupportBatterySave(false)
-                     .build()) {
-            cgbCompatibility.runTicks(100_000);
+        for (HardwareProfile profile : new HardwareProfile[] {
+                HardwareProfileRegistry.DMG, HardwareProfileRegistry.CGB}) {
+            byte[] image = mbc3(dmgRomWramLoop());
+            try (Gameboy scalar = clockedMbc3NormalSpeedSession(
+                    image, profile, PlayerInputSnapshot::released);
+                 Gameboy candidate = clockedMbc3NormalSpeedSession(
+                         image, profile, PlayerInputSource.RELEASED)) {
+                for (int chunk = 0; chunk < 20; chunk++) {
+                    assertEquals(profile.id() + " MBC3 frame callback " + chunk,
+                            scalar.runTicks(5_000), candidate.runTicks(5_000));
+                    assertDeepStateEquals(profile.id() + " MBC3 chunk " + chunk,
+                            scalar.captureStateWithoutTimeSource(),
+                            candidate.captureStateWithoutTimeSource());
+                }
 
-            assertTrue(cgbCompatibility.getSpeedMode().isDmgCompat());
-            assertEquals("clocked MBC3 entered CGB-compatibility running epoch",
-                    0L, cgbCompatibility.getPerformanceEpochTicks());
+                assertEquals("custom-source MBC3 oracle unexpectedly entered " + profile.id(),
+                        0L, scalar.getPerformanceEpochTicks());
+                assertTrue(profile.id() + " MBC3 had no running-epoch coverage",
+                        candidate.getPerformanceEpochTicks() > 10_000L);
+            }
+        }
+    }
+
+    @Test
+    public void nativeDoubleSpeedMbc3MatchesScalarWithRunningEpochCoverage()
+            throws Exception {
+        byte[] image = nativeMbc3(doubleSpeedLoop());
+        try (Gameboy scalar = nativeDoubleSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            for (int chunk = 0; chunk < 40; chunk++) {
+                assertEquals("native CGB x2 MBC3 frame callback " + chunk,
+                        scalar.runTicks(5_000), candidate.runTicks(5_000));
+                assertDeepStateEquals("native CGB x2 MBC3 chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            assertEquals(2, candidate.getSpeedMode().getSpeedMode());
+            assertEquals("custom-source MBC3 oracle unexpectedly entered x2 epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native CGB x2 MBC3 had no running-epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000L);
+        }
+    }
+
+    @Test
+    public void nativeDoubleSpeedMbc3SettledHaltMatchesScalarWithBulkCoverage()
+            throws Exception {
+        byte[] image = nativeMbc3(doubleSpeedLoop());
+        image[0x106] = 0x76; // HALT immediately after the speed switch.
+        try (Gameboy scalar = nativeDoubleSpeedMbc3Session(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedMbc3Session(
+                     image, PlayerInputSource.RELEASED)) {
+            assertEquals("native CGB x2 MBC3 HALT setup frame callback",
+                    scalar.runTicks(160_000), candidate.runTicks(160_000));
+            assertEquals(2, candidate.getSpeedMode().getSpeedMode());
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertDeepStateEquals("native CGB x2 MBC3 settled-HALT setup",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("native CGB x2 MBC3 settled-HALT frame callback",
+                    scalar.runTicks(256), candidate.runTicks(256));
+
+            assertEquals("custom-source MBC3 HALT oracle entered a bulk lane",
+                    0L, scalar.getPerformanceBulkTicks());
+            assertTrue("clocked native CGB x2 settled HALT had no substantial packet",
+                    candidate.getPerformanceBulkMaxTicks() > 3);
+            assertDeepStateEquals("native CGB x2 MBC3 settled HALT",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void datelClockedMbc3SlotMatchesScalarAcrossRtcBoundaries()
+            throws Exception {
+        byte[] slotImage = mbc3(nativeCgbMbc3RtcWriteLoop());
+        try (Gameboy scalar = datelMbc3SlotSession(
+                slotImage, PlayerInputSnapshot::released);
+             Gameboy candidate = datelMbc3SlotSession(
+                     slotImage, PlayerInputSource.RELEASED)) {
+            launchDatelSlot(scalar);
+            launchDatelSlot(candidate);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            for (int chunk = 0; chunk < 20; chunk++) {
+                assertEquals("Datel MBC3-slot frame callback " + chunk,
+                        scalar.runTicks(5_000), candidate.runTicks(5_000));
+                assertDeepStateEquals("Datel MBC3-slot chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            assertEquals("custom-source Datel oracle unexpectedly entered epoch lane",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("Datel MBC3 slot had no running-epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 10_000L);
+            assertEquals("slot RTC write/read boundary", 42,
+                    candidate.getAddressSpace().getByte(0xc000));
         }
     }
 
@@ -1589,6 +1682,37 @@ public final class GameboyPerformanceEpochTest {
                 .build();
     }
 
+    private static Gameboy nativeDoubleSpeedMbc3Session(
+            byte[] image, PlayerInputSource inputSource) throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setRtcTimeSource(() -> 0L)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy datelMbc3SlotSession(
+            byte[] slotImage, PlayerInputSource inputSource) throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(datelPerformanceRom()))
+                .setSlotRom(new Rom(slotImage))
+                .setHardwareProfile(HardwareProfileRegistry.CGB)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setRtcTimeSource(() -> 0L)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static void launchDatelSlot(Gameboy gameboy) {
+        gameboy.getAddressSpace().setByte(0x7fe4, 0x11);
+        gameboy.getAddressSpace().setByte(0x7ff4, 0x10);
+        gameboy.runTicks(4);
+    }
+
     private static Gameboy fastForwardCgbCompatibilitySession(PlayerInputSource inputSource)
             throws Exception {
         return new Gameboy.GameboyConfiguration(new Rom(validNonColorRom()))
@@ -1619,6 +1743,19 @@ public final class GameboyPerformanceEpochTest {
                 .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
                 .setExecutionMode(executionMode)
                 .setPlayerInputSource(inputSource)
+                .setSupportBatterySave(false)
+                .build();
+    }
+
+    private static Gameboy clockedMbc3NormalSpeedSession(
+            byte[] image, HardwareProfile profile, PlayerInputSource inputSource)
+            throws Exception {
+        return new Gameboy.GameboyConfiguration(new Rom(image))
+                .setHardwareProfile(profile)
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setExecutionMode(ExecutionMode.PERFORMANCE)
+                .setPlayerInputSource(inputSource)
+                .setRtcTimeSource(() -> 0L)
                 .setSupportBatterySave(false)
                 .build();
     }
@@ -1995,6 +2132,22 @@ public final class GameboyPerformanceEpochTest {
         byte[] image = validNonColorRom();
         image[0x143] = (byte) 0x80;
         updateHeaderChecksum(image);
+        return image;
+    }
+
+    private static byte[] datelPerformanceRom() {
+        byte[] image = new byte[0x20000];
+        image[0x100] = 0x00;
+        image[0x101] = (byte) 0xc3;
+        image[0x102] = 0x50;
+        image[0x103] = 0x01;
+        image[0x104] = 0x44; // Deliberately invalid logo, as on the supported Datel image.
+        byte[] title = "Action Replay V4".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, image, 0x134, title.length);
+        image[0x147] = 0x00;
+        image[0x148] = 0x02;
+        image[0x150] = 0x18;
+        image[0x151] = (byte) 0xfe;
         return image;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -506,6 +506,82 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
+    public void nativeEpochUsesLogicalRomReaderWithoutFallingBackToTheCpuBus() {
+        LogicalLeasedMemory memory = new LogicalLeasedMemory();
+        memory.bytes[0] = 0x3e; // LD A,d8
+        memory.bytes[1] = 0x5a;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+
+        assertEquals(4, cpu.runPerformanceEpoch(4));
+
+        assertEquals(0x5a, cpu.getRegisters().getA());
+        assertEquals(1, memory.leaseAcquisitions);
+        assertEquals(2, memory.logicalReads);
+        assertEquals(0, memory.busReads);
+    }
+
+    @Test
+    public void normalSpeedEpochsUseLogicalRomReaderWithoutFallingBackToTheCpuBus() {
+        for (boolean gbc : new boolean[] {false, true}) {
+            LogicalLeasedMemory memory = new LogicalLeasedMemory();
+            memory.bytes[0] = 0x3e; // LD A,d8
+            memory.bytes[1] = 0x5a;
+            Cpu cpu = new Cpu(memory, new InterruptManager(gbc), null,
+                    new SpeedMode(gbc), new Display(false));
+
+            int elapsed = gbc
+                    ? cpu.runNativeCgbNormalSpeedPerformanceEpoch(8)
+                    : cpu.runPhysicalDmgPerformanceEpoch(8);
+
+            assertEquals(8, elapsed);
+            assertEquals(0x5a, cpu.getRegisters().getA());
+            assertEquals(1, memory.leaseAcquisitions);
+            assertEquals(2, memory.logicalReads);
+            assertEquals(0, memory.busReads);
+        }
+    }
+
+    @Test
+    public void normalSpeedDirectWholeInstructionUsesLogicalRomOperands() {
+        LogicalLeasedMemory memory = new LogicalLeasedMemory();
+        memory.bytes[0] = 0x18; // JR -2
+        memory.bytes[1] = (byte) 0xfe;
+        Cpu cpu = new Cpu(memory, new InterruptManager(false), null,
+                new SpeedMode(false), new Display(false));
+
+        assertEquals(12, cpu.runPhysicalDmgPerformanceEpoch(12));
+
+        assertEquals(0, cpu.getRegisters().getPC());
+        assertEquals(1, memory.leaseAcquisitions);
+        assertEquals(2, memory.logicalReads);
+        assertEquals(0, memory.busReads);
+    }
+
+    @Test
+    public void logicalRomReaderObservesMapperViewChangesFromSafeWritesInTheSameEpoch() {
+        LogicalLeasedMemory memory = new LogicalLeasedMemory();
+        memory.bytes[0] = 0x3e; // LD A,01
+        memory.bytes[1] = 0x01;
+        memory.bytes[2] = (byte) 0xea; // LD (c000),A
+        memory.bytes[3] = 0x00;
+        memory.bytes[4] = (byte) 0xc0;
+        memory.bytes[5] = 0x3e; // stale-view LD A,11
+        memory.bytes[6] = 0x11;
+        System.arraycopy(memory.bytes, 0, memory.changedBytes, 0, memory.bytes.length);
+        memory.changedBytes[5] = 0x3e; // updated-view LD A,77
+        memory.changedBytes[6] = 0x77;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+
+        assertTrue(cpu.runPerformanceEpoch(54) > 0);
+
+        assertTrue(memory.mapperViewChanged);
+        assertEquals(0x77, cpu.getRegisters().getA());
+        assertEquals(0, memory.busReads);
+    }
+
+    @Test
     public void unavailableOrUnmappedRomLeaseFallsBackToAuthoritativeBus() {
         LeasedMemory unavailable = new LeasedMemory(0, 0x4000);
         unavailable.leaseAvailable = false;
@@ -567,7 +643,7 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
-    public void scalarAndPhysicalDmgFetchesNeverAcquireNativeRomLease() {
+    public void scalarFetchDoesNotAcquireLeaseButNormalSpeedEpochDoes() {
         LeasedMemory scalarMemory = new LeasedMemory(0, 0x4000);
         scalarMemory.bytes[0] = 0x00; // NOP on the authoritative bus
         scalarMemory.physicalBytes[0] = 0x76; // HALT only in the lease
@@ -583,16 +659,17 @@ public final class CpuPerformanceEpochTest {
         assertEquals(1, scalarMemory.busReads);
 
         LeasedMemory physicalDmgMemory = new LeasedMemory(0, 0x4000);
-        physicalDmgMemory.bytes[0] = 0x00;
-        physicalDmgMemory.physicalBytes[0] = 0x76;
+        physicalDmgMemory.bytes[0] = 0x76; // HALT only on the authoritative bus
+        physicalDmgMemory.physicalBytes[0] = 0x00; // NOP in the lease
         Cpu physicalDmg = new Cpu(physicalDmgMemory, new InterruptManager(false), null,
                 new SpeedMode(false), new Display(false));
 
         assertEquals(4, physicalDmg.runPhysicalDmgPerformanceEpoch(4));
         assertEquals(Cpu.State.OPCODE, physicalDmg.getState());
         assertEquals(1, physicalDmg.getRegisters().getPC());
-        assertEquals(0, physicalDmgMemory.leaseAcquisitions);
-        assertEquals(1, physicalDmgMemory.busReads);
+        assertEquals(1, physicalDmgMemory.leaseAcquisitions);
+        assertEquals(1, physicalDmgMemory.leaseReads);
+        assertEquals(0, physicalDmgMemory.busReads);
     }
 
     @Test
@@ -690,7 +767,7 @@ public final class CpuPerformanceEpochTest {
     }
 
     @Test
-    public void nativeCgbNormalSpeedRunsOrdinaryCodeUnderImeDisabledRawPendingInterrupt()
+    public void nativeCgbNormalSpeedLeavesUnknownRomFetchScalarUnderRawPendingInterrupt()
             throws Exception {
         ParityMemory directMemory = new ParityMemory();
         ParityMemory scalarMemory = new ParityMemory();
@@ -707,7 +784,7 @@ public final class CpuPerformanceEpochTest {
 
         assertTrue(direct.performanceNativeCgbNormalSpeedEpochEntryEligible());
         int elapsed = direct.runNativeCgbNormalSpeedPerformanceEpoch(54);
-        assertEquals(54, elapsed);
+        assertEquals(3, elapsed);
         for (int tick = 0; tick < elapsed; tick++) {
             scalar.tick();
         }
@@ -716,6 +793,7 @@ public final class CpuPerformanceEpochTest {
         assertDeepEquals("interrupts", scalarInterrupts.captureState(),
                 directInterrupts.captureState());
         assertArrayEquals(scalarMemory.bytes, directMemory.bytes);
+        assertEquals("unknown ROM opcode was speculatively read", 0, directMemory.reads);
     }
 
     @Test
@@ -773,9 +851,9 @@ public final class CpuPerformanceEpochTest {
         CountingMemory retiMemory = new CountingMemory();
         retiMemory.bytes[0] = (byte) 0xd9; // RETI
         Cpu reti = normalSpeedNativeCpu(retiMemory, pendingVBlank());
-        assertEquals(4, reti.runNativeCgbNormalSpeedPerformanceEpoch(4));
-        assertTrue(reti.getState() != Cpu.State.OPCODE);
-        assertEquals("in-flight RETI must remain scalar", 0,
+        assertEquals(3, reti.runNativeCgbNormalSpeedPerformanceEpoch(4));
+        assertEquals(Cpu.State.OPCODE, reti.getState());
+        assertEquals("RETI fetch must remain scalar", 0,
                 reti.runNativeCgbNormalSpeedPerformanceEpoch(54));
     }
 
@@ -1529,6 +1607,64 @@ public final class CpuPerformanceEpochTest {
                 return physicalBytes[physicalOffset] & 0xff;
             }
             return bytes[address & 0xffff] & 0xff;
+        }
+    }
+
+    private static final class LogicalLeasedMemory
+            implements AddressSpace, PerformanceRomAccessProvider {
+
+        private final byte[] bytes = new byte[0x10000];
+        private final byte[] changedBytes = new byte[0x10000];
+        private int leaseAcquisitions;
+        private int logicalReads;
+        private int busReads;
+        private boolean mapperViewChanged;
+
+        private final PerformanceRomAccess lease = new PerformanceRomAccess() {
+            @Override
+            public int physicalOffset(int cpuAddress) {
+                return -1;
+            }
+
+            @Override
+            public int readPhysicalByte(int physicalOffset) {
+                return 0xff;
+            }
+
+            @Override
+            public int readCpuByte(int cpuAddress) {
+                if (cpuAddress < 0 || cpuAddress >= 0x8000) {
+                    return -1;
+                }
+                logicalReads++;
+                return (mapperViewChanged ? changedBytes : bytes)[cpuAddress] & 0xff;
+            }
+        };
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address <= 0xffff;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+            if ((address & 0xffff) == 0xc000) {
+                mapperViewChanged = true;
+            }
+            bytes[address & 0xffff] = (byte) value;
+            changedBytes[address & 0xffff] = (byte) value;
+        }
+
+        @Override
+        public int getByte(int address) {
+            busReads++;
+            return (mapperViewChanged ? changedBytes : bytes)[address & 0xffff] & 0xff;
+        }
+
+        @Override
+        public PerformanceRomAccess acquirePerformanceRomAccess() {
+            leaseAcquisitions++;
+            return lease;
         }
     }
 }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/PerformanceRomAccessTest.java
@@ -223,13 +223,52 @@ public class PerformanceRomAccessTest {
     }
 
     @Test
-    public void nonMbc5CartridgeHasSafeNullFallback() throws IOException {
+    public void basicRomCartridgeUsesReusedExactMapperFallback() throws IOException {
         byte[] rom = new byte[0x8000];
+        rom[0x0000] = 0x21;
+        rom[0x3fff] = 0x43;
+        rom[0x4000] = 0x65;
+        rom[0x7fff] = (byte) 0x87;
         rom[0x0147] = 0x00;
 
         Cartridge cartridge = new Cartridge(new Rom(rom), Battery.NULL_BATTERY);
 
-        assertNull(cartridge.acquirePerformanceRomAccess());
+        PerformanceRomAccess access = cartridge.acquirePerformanceRomAccess();
+        assertNotNull(access);
+        assertSame(access, cartridge.acquirePerformanceRomAccess());
+        assertEquals(-1, access.physicalOffset(0x0000));
+        assertEquals(0xff, access.readPhysicalByte(0));
+        assertEquals(0x21, access.readCpuByte(0x0000));
+        assertEquals(0x43, access.readCpuByte(0x3fff));
+        assertEquals(0x65, access.readCpuByte(0x4000));
+        assertEquals(0x87, access.readCpuByte(0x7fff));
+        assertEquals(-1, access.readCpuByte(-1));
+        assertEquals(-1, access.readCpuByte(0x8000));
+    }
+
+    @Test
+    public void productionCartridgeFallsBackWhenSpecializedMapperDeclines() throws IOException {
+        Cartridge cartridge = new Cartridge(new Rom(mbc5Rom()), Battery.NULL_BATTERY);
+        cartridge.setDebugHooks(new TestDebugHooks());
+
+        PerformanceRomAccess access = cartridge.acquirePerformanceRomAccess();
+
+        assertNotNull(access);
+        assertEquals(-1, access.physicalOffset(0x0000));
+        assertEquals(0x20, access.readCpuByte(0x0000));
+        assertEquals(0x21, access.readCpuByte(0x4000));
+    }
+
+    @Test
+    public void derivedCartridgeStillFailsClosed() throws IOException {
+        Cartridge derived = new Cartridge(new Rom(mbc5Rom()), Battery.NULL_BATTERY) {
+            @Override
+            public int getByte(int address) {
+                return 0x5a;
+            }
+        };
+
+        assertNull(derived.acquirePerformanceRomAccess());
     }
 
     private static Mbc5 plainMbc5() throws IOException {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/MapperPerformanceRomAccessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/MapperPerformanceRomAccessTest.java
@@ -1,0 +1,53 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.memory.PerformanceRomAccess;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapperPerformanceRomAccessTest {
+
+    @Test
+    public void logicalReadsPreserveMapperSideEffectsExactlyOnce() {
+        StatefulRomMapper mapper = new StatefulRomMapper();
+        PerformanceRomAccess access = new MapperPerformanceRomAccess(mapper);
+
+        assertEquals(-1, access.physicalOffset(0x1234));
+        assertEquals(0xff, access.readPhysicalByte(0x1234));
+        assertEquals(0x34, access.readCpuByte(0x1234));
+        assertEquals(0x35, access.readCpuByte(0x1234));
+        assertEquals(2, mapper.reads);
+        assertEquals(-1, access.readCpuByte(-1));
+        assertEquals(-1, access.readCpuByte(0x8000));
+        assertEquals(2, mapper.reads);
+    }
+
+    private static final class StatefulRomMapper implements MemoryController {
+
+        private int reads;
+
+        @Override
+        public boolean accepts(int address) {
+            return address >= 0 && address < 0x8000;
+        }
+
+        @Override
+        public void setByte(int address, int value) {
+        }
+
+        @Override
+        public int getByte(int address) {
+            return (address + reads++) & 0xff;
+        }
+
+        @Override
+        public ComponentState<MemoryController> captureState() {
+            return null;
+        }
+
+        @Override
+        public void restoreState(ComponentState<MemoryController> state) {
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/type/Unlicensed256MTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.core.memory.cart.type;
 
 import eu.rekawek.coffeegb.core.AddressSpace;
+import eu.rekawek.coffeegb.core.TestDebugHooks;
 import eu.rekawek.coffeegb.core.hardware.ClockSpec;
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge;
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class Unlicensed256MTest {
@@ -77,6 +79,52 @@ public class Unlicensed256MTest {
 
         assertEquals(0xc0, mapper.getByte(0x0000));
         assertEquals(0xc3, mapper.getByte(0x4000));
+    }
+
+    @Test
+    public void menuAndSelectedGameAllowPerformanceQuietSpansUntilDebugging() throws IOException {
+        Unlicensed256M mapper = new Unlicensed256M(
+                new Rom(multicartRom()), Battery.NULL_BATTERY);
+
+        assertEquals(64, mapper.performanceQuietSpanLimit(64));
+        assertTrue(mapper.tickPerformanceQuietSpan(64));
+        mapper.tickPerformanceQuietSpanTrusted(64);
+
+        configure(mapper, 0x60, 0xe0, 0x91);
+        assertEquals(64, mapper.performanceQuietSpanLimit(64));
+        assertTrue(mapper.tickPerformanceQuietSpan(64));
+        mapper.tickPerformanceQuietSpanTrusted(64);
+
+        mapper.setDebugHooks(new TestDebugHooks());
+        assertEquals(0, mapper.performanceQuietSpanLimit(64));
+        assertFalse(mapper.tickPerformanceQuietSpan(64));
+    }
+
+    @Test
+    public void selectedMbc3DelegatesPerformanceQuietSpans() throws IOException {
+        Unlicensed256M scalar = new Unlicensed256M(
+                new Rom(multicartRom(0x13)), Battery.NULL_BATTERY,
+                () -> 0L, ClockSpec.LEGACY);
+        Unlicensed256M mapper = new Unlicensed256M(
+                new Rom(multicartRom(0x13)), Battery.NULL_BATTERY,
+                () -> 0L, ClockSpec.LEGACY);
+
+        configure(scalar, 0x60, 0xe0, 0x91);
+        configure(mapper, 0x60, 0xe0, 0x91);
+
+        assertNotNull(mapper.getActiveMbc3());
+        int halfSecond = 2_097_152;
+        assertEquals(halfSecond, mapper.performanceQuietSpanLimit(halfSecond));
+        assertTrue(mapper.tickPerformanceQuietSpan(halfSecond));
+        mapper.tickPerformanceQuietSpanTrusted(halfSecond);
+        for (int tick = 0; tick < 2 * halfSecond; tick++) {
+            scalar.tick();
+        }
+
+        int scalarSeconds = latchedRtcSeconds(scalar);
+        int bulkSeconds = latchedRtcSeconds(mapper);
+        assertEquals(1, bulkSeconds);
+        assertEquals(scalarSeconds, bulkSeconds);
     }
 
     @Test
@@ -158,7 +206,19 @@ public class Unlicensed256MTest {
         mapper.setByte(0x7002, flags);
     }
 
+    private static int latchedRtcSeconds(AddressSpace mapper) {
+        mapper.setByte(0x0000, 0x0a);
+        mapper.setByte(0x4000, 0x08);
+        mapper.setByte(0x6000, 0x00);
+        mapper.setByte(0x6000, 0x01);
+        return mapper.getByte(0xa000);
+    }
+
     private static byte[] multicartRom() {
+        return multicartRom(0x1b);
+    }
+
+    private static byte[] multicartRom(int selectedType) {
         byte[] data = new byte[0x400000];
         for (int bank = 0; bank < data.length / 0x4000; bank++) {
             data[bank * 0x4000] = (byte) bank;
@@ -168,7 +228,7 @@ public class Unlicensed256MTest {
         data[0x0101] = (byte) 0xc3;
         data[0x0102] = 0x00;
         data[0x0103] = 0x40;
-        putHeader(data, 0xc0, "SELECTED", 0x1b, 0x05, 0x03);
+        putHeader(data, 0xc0, "SELECTED", selectedType, 0x05, 0x03);
         return data;
     }
 


### PR DESCRIPTION
## Summary

- Add an allocation-free mapper-direct ROM reader for cartridges without a specialized physical mapping.
- Keep the existing zero-copy MBC5 and MBC7 leases as the preferred path.
- Use the borrowed reader in both normal-speed and double-speed performance epochs.
- Allow proven clocked primary and pass-through cartridges to join epochs while preserving scalar clock order.
- Add quiet-span support for the Unlicensed 256M multicart.

## Correctness safeguards

- BIOS overlays, cheats, active DMA, split MMU ownership, debugging, and derived cartridge wrappers still fail closed.
- Logical reads call the live mapper, preserving banking, overlays, mutable flash, pass-through routing, and read-side effects.
- Each reader is borrowed for one bounded epoch and released before deferred writes are replayed.
- Cartridge-control, external-RAM, and RTC accesses remain fenced or terminate after an exact committed clock prefix.
- Primary and slot cartridge clocks are preflighted and committed in scalar order.

## Performance

A controlled native-CGB double-speed, ROM-fetch-dense CPU benchmark measured:

- Mapper-direct reader: 198.383M ticks/s
- Full bus fallback: 183.732M ticks/s
- Improvement: 7.97%
- Measured allocation: 0 bytes for both paths

The whole-Gameboy benchmark remained neutral at approximately 25.48M ticks/s versus the 25.46M baseline, with allocation unchanged.

## Validation

- `/opt/maven/bin/mvn -pl core test` — 2,008 tests, 0 failures/errors
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` — Mooneye 130 passed; DMG Acid2 and CGB Acid2 passed
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` — 54 passed
- `git diff --check`