### PR TITLE
Fix Kirby tilt direction and Android frame rate

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,6 +14,7 @@ private val requiredBaselineProfileClassNames = listOf(
     "eu.rekawek.coffeegb.core.Gameboy",
     "eu.rekawek.coffeegb.core.cpu.Cpu",
     "eu.rekawek.coffeegb.core.cpu.Cpu\$PerformanceEpochBus",
+    "eu.rekawek.coffeegb.core.memory.Hdma",
     "eu.rekawek.coffeegb.core.gpu.Gpu",
     "eu.rekawek.coffeegb.core.gpu.StatRegister",
     "eu.rekawek.coffeegb.core.sound.Sound",
@@ -253,7 +254,7 @@ val verifyBaselineProfileSource = tasks.register("verifyBaselineProfileSource") 
     val expected = expectedBaselineProfileRules.joinToString(separator = "\n", postfix = "\n")
     val actual = baselineProfileSource.asFile.readText()
     check(actual == expected) {
-      "src/main/baseline-prof.txt must contain exactly the eight unique reviewed HP rules " +
+      "src/main/baseline-prof.txt must contain exactly the nine unique reviewed HP rules " +
           "in order, with no S flags."
     }
   }

--- a/android/app/src/main/baseline-prof.txt
+++ b/android/app/src/main/baseline-prof.txt
@@ -1,6 +1,7 @@
 HPLeu/rekawek/coffeegb/core/Gameboy;->**(**)**
 HPLeu/rekawek/coffeegb/core/cpu/Cpu;->**(**)**
 HPLeu/rekawek/coffeegb/core/cpu/Cpu$PerformanceEpochBus;->**(**)**
+HPLeu/rekawek/coffeegb/core/memory/Hdma;->**(**)**
 HPLeu/rekawek/coffeegb/core/gpu/Gpu;->**(**)**
 HPLeu/rekawek/coffeegb/core/gpu/StatRegister;->**(**)**
 HPLeu/rekawek/coffeegb/core/sound/Sound;->**(**)**

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidTiltSink.java
@@ -197,9 +197,10 @@ final class AndroidTiltSink implements AutoCloseable {
             calibrated = true;
         }
         // Android reports acceleration in m/s² while the portable MBC7 contract uses g units.
-        // Feeding the raw delta made the emulated sensor roughly 9.8 times too sensitive.
+        // Its gravity-derived horizontal acceleration has the opposite sign from the portable
+        // tilt contract, so invert X after mapping the sensor axes to the display orientation.
         eventBus.post(new AccelerometerEvent(
-                (x - neutralX) / SensorManager.GRAVITY_EARTH,
+                (neutralX - x) / SensorManager.GRAVITY_EARTH,
                 (y - neutralY) / SensorManager.GRAVITY_EARTH));
     }
 

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/EmulationService.java
@@ -34,10 +34,7 @@ public final class EmulationService extends Service implements AudioManager.OnAu
     static void start(Context context, String executionMode) {
         DiagnosticsOptions selected = DiagnosticsOptions.disabled(
                 DiagnosticsOptions.parseExecutionMode(executionMode));
-        nextStartOptions = selected;
-        context.startService(new Intent(context, EmulationService.class)
-                .putExtra(DiagnosticsOptions.EXTRA_EXECUTION_MODE,
-                        DiagnosticsOptions.executionModeValue(selected.executionMode)));
+        context.startService(startIntent(context, selected));
     }
 
     static void start(Context context, DiagnosticsOptions options) {
@@ -61,6 +58,11 @@ public final class EmulationService extends Service implements AudioManager.OnAu
         return checked.benchmarkScenario.externalValue();
     }
 
+    static boolean benchmarkModeExtraValue(DiagnosticsOptions options) {
+        DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
+        return checked.enabled;
+    }
+
     static String audioPolicyExtraValue(DiagnosticsOptions options) {
         DiagnosticsOptions checked = options == null ? DiagnosticsOptions.disabled() : options;
         return checked.audioPolicy.externalValue();
@@ -73,7 +75,8 @@ public final class EmulationService extends Service implements AudioManager.OnAu
 
     private static Intent populateStartIntent(Intent intent, DiagnosticsOptions checked) {
         nextStartOptions = checked;
-        return intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK, checked.enabled)
+        return intent.putExtra(DiagnosticsOptions.EXTRA_BENCHMARK,
+                        benchmarkModeExtraValue(checked))
                 .putExtra(DiagnosticsOptions.EXTRA_HARDWARE,
                         checked.hardware.externalValue())
                 .putExtra(DiagnosticsOptions.EXTRA_AUDIO, checked.audioOutput)

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidTiltSinkTest.java
@@ -27,7 +27,7 @@ public class AndroidTiltSinkTest {
         input.sample(7, 13);
         assertSample(samples.get(0), 0, 0);
         assertSample(samples.get(1),
-                2 / SensorManager.GRAVITY_EARTH,
+                -2 / SensorManager.GRAVITY_EARTH,
                 3 / SensorManager.GRAVITY_EARTH);
 
         orientation.rotation = Surface.ROTATION_90;
@@ -35,7 +35,7 @@ public class AndroidTiltSinkTest {
         input.sample(8, 14);
         assertSample(samples.get(2), 0, 0);
         assertSample(samples.get(3),
-                -1 / SensorManager.GRAVITY_EARTH,
+                1 / SensorManager.GRAVITY_EARTH,
                 1 / SensorManager.GRAVITY_EARTH);
 
         orientation.rotation = Surface.ROTATION_180;
@@ -43,7 +43,7 @@ public class AndroidTiltSinkTest {
         input.sample(9, 16);
         assertSample(samples.get(4), 0, 0);
         assertSample(samples.get(5),
-                -1 / SensorManager.GRAVITY_EARTH,
+                1 / SensorManager.GRAVITY_EARTH,
                 -2 / SensorManager.GRAVITY_EARTH);
 
         orientation.rotation = Surface.ROTATION_270;
@@ -51,8 +51,40 @@ public class AndroidTiltSinkTest {
         input.sample(11, 19);
         assertSample(samples.get(6), 0, 0);
         assertSample(samples.get(7),
-                3 / SensorManager.GRAVITY_EARTH,
+                -3 / SensorManager.GRAVITY_EARTH,
                 -2 / SensorManager.GRAVITY_EARTH);
+    }
+
+    @Test
+    public void loweringDisplayRightEdgeProducesPositiveHorizontalTiltForEveryRotation() {
+        EventBusImpl events = new EventBusImpl(null, null, false);
+        List<AccelerometerEvent> samples = new ArrayList<>();
+        events.register(samples::add, AccelerometerEvent.class);
+        FakeInput input = new FakeInput(true);
+        FakeOrientation orientation = new FakeOrientation(Surface.ROTATION_0);
+        AndroidTiltSink sink = new AndroidTiltSink(events, input, orientation);
+
+        int[] rotations = {
+                Surface.ROTATION_0,
+                Surface.ROTATION_90,
+                Surface.ROTATION_180,
+                Surface.ROTATION_270
+        };
+        float gravity = SensorManager.GRAVITY_EARTH;
+        float[][] rightEdgeDownDeltas = {
+                {-gravity, 0},
+                {0, gravity},
+                {gravity, 0},
+                {0, -gravity}
+        };
+
+        sink.setCartridgeActive(true);
+        for (int i = 0; i < rotations.length; i++) {
+            orientation.rotation = rotations[i];
+            input.sample(0, 0);
+            input.sample(rightEdgeDownDeltas[i][0], rightEdgeDownDeltas[i][1]);
+            assertSample(samples.get(samples.size() - 1), 1, 0);
+        }
     }
 
     @Test
@@ -68,7 +100,7 @@ public class AndroidTiltSinkTest {
         input.sample(0, 0);
         input.sample(SensorManager.GRAVITY_EARTH, -SensorManager.GRAVITY_EARTH);
 
-        assertSample(samples.get(1), 1, -1);
+        assertSample(samples.get(1), -1, -1);
     }
 
     @Test
@@ -92,7 +124,7 @@ public class AndroidTiltSinkTest {
         assertEquals(2, samples.size());
         assertSample(samples.get(0), 0, 0);
         assertSample(samples.get(1),
-                5 / SensorManager.GRAVITY_EARTH,
+                -5 / SensorManager.GRAVITY_EARTH,
                 3 / SensorManager.GRAVITY_EARTH);
         sink.close();
         assertEquals(2, input.stops);
@@ -122,11 +154,11 @@ public class AndroidTiltSinkTest {
         input.sample(5, 9);
 
         assertSample(samples.get(1),
-                2 / SensorManager.GRAVITY_EARTH,
+                -2 / SensorManager.GRAVITY_EARTH,
                 3 / SensorManager.GRAVITY_EARTH);
         assertSample(samples.get(2), 0, 0);
         assertSample(samples.get(3),
-                1 / SensorManager.GRAVITY_EARTH,
+                -1 / SensorManager.GRAVITY_EARTH,
                 2 / SensorManager.GRAVITY_EARTH);
     }
 

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/EmulationServiceTest.java
@@ -3,8 +3,16 @@ package eu.rekawek.coffeegb.android;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class EmulationServiceTest {
+
+    @Test
+    public void ordinaryStartWireExplicitlyDisablesBenchmarkMode() {
+        assertFalse(EmulationService.benchmarkModeExtraValue(
+                DiagnosticsOptions.disabled(
+                        eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)));
+    }
 
     @Test
     public void startWireForwardsBenchmarkScenarioToken() {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/RomSessionPreparer.kt
@@ -251,7 +251,7 @@ internal class RuntimeWarmupCache(
         val rom = config.rom
         if (config.slotRom != null ||
             rom.cartridgeProperties.mapper != Mapper.STANDARD ||
-            !isOrdinaryNonRtcCartridge(rom.type)) {
+            !isRuntimeWarmupCartridge(rom.type)) {
           return null
         }
         if (flavor == RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1
@@ -415,6 +415,10 @@ internal class RuntimeWarmupCache(
     internal val shared = RuntimeWarmupCache()
   }
 }
+
+// MBC7 is safe for the service-free disposable run, but remains outside reusable boot templates.
+private fun isRuntimeWarmupCartridge(type: CartridgeType): Boolean =
+    isOrdinaryNonRtcCartridge(type) || type.isMbc7
 
 private fun isOrdinaryNonRtcCartridge(type: CartridgeType): Boolean =
     type == CartridgeType.ROM ||

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/RomSessionPreparerTest.kt
@@ -235,7 +235,7 @@ class RomSessionPreparerTest {
   }
 
   @Test
-  fun runtimeWarmupOnlyAcceptsFreshOrdinarySkipCartridges() {
+  fun runtimeWarmupSharesBootstrapModesButRejectsSlotsRtcAndNonStandardMappers() {
     val executor = RecordingWarmupExecutor()
     val cache = RuntimeWarmupCache(8, executor)
 
@@ -248,6 +248,34 @@ class RomSessionPreparerTest {
 
     assertEquals(1, executor.calls.size)
     assertEquals(1, cache.size)
+  }
+
+  @Test
+  fun cgbMbc7IsEligibleForShadowMeasuredRuntimeWarmup() {
+    val executor = RecordingWarmupExecutor()
+    val cache = RuntimeWarmupCache(2, executor)
+    val config =
+        skipConfig(mbc7CgbImage())
+            .setHardwareProfile(HardwareProfileRegistry.CGB)
+            .setExecutionMode(eu.rekawek.coffeegb.core.ExecutionMode.PERFORMANCE)
+
+    assertTrue(config.rom.type.isMbc7)
+    assertTrue(cache.warm(config, RuntimeWarmupFlavor.SHADOW_MEASURED_EXACT_V1) {})
+    assertEquals(1, executor.calls.size)
+    assertEquals(1, cache.size)
+  }
+
+  @Test
+  fun mbc7RemainsIneligibleForBootStateCache() {
+    val cache = BootStateCache(2)
+    val config =
+        skipConfig(mbc7CgbImage())
+            .setHardwareProfile(HardwareProfileRegistry.CGB)
+            .setBootstrapMode(BootstrapMode.FAST_FORWARD)
+
+    assertTrue(config.rom.type.isMbc7)
+    assertNull(cache.getOrCreate(config))
+    assertEquals(0, cache.size)
   }
 
   @Test
@@ -518,6 +546,12 @@ class RomSessionPreparerTest {
   private fun mbc5Image(): RomImage = RomImage.memory(mbc5Bytes(), "mbc5.gb")
 
   private fun mbc5Bytes(): ByteArray = ROM.readBytes().also { it[0x147] = 0x19 }
+
+  private fun mbc7CgbImage(): RomImage =
+      RomImage.memory(
+          cgbNativeImage().bytes().also { it[0x147] = 0x22 },
+          "mbc7-cgb.gb",
+      )
 
   private fun nonStandardMapperImage(): RomImage =
       RomImage.memory(ROM.readBytes().also { it[0x147] = 0x00 }, "oversized-rom.gb")

--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -229,8 +229,13 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     private transient long performanceBulkTicks;
 
-    /** Largest settled-HALT PERFORMANCE packet in this session (diagnostic only). */
+    /** Largest all-subsystem PERFORMANCE packet in this session (diagnostic only). */
     private transient int performanceBulkMaxTicks;
+
+    /** Native-CGB HDMA-owned data-interior diagnostics; absent from portable state. */
+    private transient long performanceHdmaOwnedSpanCount;
+
+    private transient long performanceHdmaOwnedTicks;
 
     /** Bounded coarse CPU-epoch diagnostics; absent from portable state. */
     private transient long performanceEpochCount;
@@ -267,6 +272,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
     private transient boolean performanceEpochDirectRaster;
 
     private transient boolean performanceEpochSteadyRaster;
+
+    /** Exact native-CGB PPU/STAT replay selected for the current CPU epoch. */
+    private transient boolean performanceEpochStatReplay;
+
+    /** Closed-form STAT endpoint selected inside the exact-replay contract. */
+    private transient boolean performanceEpochStatAggregate;
 
     private transient IntConsumer performanceEpochPrefixCommitter;
 
@@ -1037,7 +1048,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         try {
             while (remaining > 0 && !stop.getAsBoolean()
                     && isNativeCgbPerformanceEpochTopology()) {
-                int committed = tryPerformanceEpoch(remaining);
+                int committed = tryPerformanceNativeCgbHdmaOwnedDataSpan(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+                committed = tryPerformanceEpoch(remaining);
                 if (committed > 0) {
                     remaining -= committed;
                     continue;
@@ -1216,7 +1232,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         long remaining = ticks;
         try {
             while (remaining > 0 && isNativeCgbPerformanceEpochTopology()) {
-                int committed = tryPerformanceEpoch(remaining);
+                int committed = tryPerformanceNativeCgbHdmaOwnedDataSpan(remaining);
+                if (committed > 0) {
+                    remaining -= committed;
+                    continue;
+                }
+                committed = tryPerformanceEpoch(remaining);
                 if (committed > 0) {
                     remaining -= committed;
                     continue;
@@ -1522,10 +1543,105 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 && gpu.isLcdEnabled()
                 && !dma.isTransferInProgress()
                 && !dma.requiresClockTick(false)
-                && !hdma.hasActiveOrPendingTransfer()
-                && hdma.isPerformanceInactiveRequestClockStable()
+                && hdma.isPerformanceNativeCgbRunningEpochStable()
                 && serialPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS)
                 && infraredPort.performanceEpochIdle(Cpu.PERFORMANCE_EPOCH_MAX_TICKS);
+    }
+
+    /**
+     * Advances the remaining source-read interior of one already-owned native-CGB HBlank burst.
+     * HDMA tick 32 remains on the scalar scheduler so its atomic VRAM publication, request reset,
+     * and held-opcode release keep their established whole-machine ordering.
+     */
+    private int tryPerformanceNativeCgbHdmaOwnedDataSpan(long remaining) {
+        if (remaining <= 0
+                || !hdma.isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                || !isNativeCgbPerformanceEpochTopology()
+                || warmResetRequested
+                || speedSwitchTailTicks != 0
+                || debugHistoryReplay
+                || debugInstrumentation != null
+                || debugRetirementTrackingActive
+                || !cpu.performanceHdmaOwnedBlockCpuFrozenEligible()
+                || cpu.hasPendingPeripheralSample()
+                || dma.isTransferInProgress()
+                || dma.requiresClockTick(false)) {
+            return 0;
+        }
+        PerformanceRomAccess romAccess =
+                hdma.requiresPerformanceNativeCgbOwnedHblankRomAccess()
+                        ? gameGenie.acquirePerformanceRomAccess()
+                        : null;
+        int requested = (int) Math.min((long) Integer.MAX_VALUE, remaining);
+        int span = hdma.performanceNativeCgbOwnedHblankDataSpanLimit(requested, romAccess);
+        if (span <= 0
+                || cartridgeClocked && cartridge.performanceQuietSpanLimit(span) < span
+                || slotCartridgeClocked && slotCartridge.performanceQuietSpanLimit(span) < span
+                || timer.performanceEpochSpanLimit(span) < span
+                || sound.performanceQuietSpanLimit(span) < span
+                || joypad.performanceSettledHaltSpanLimit(span) < span
+                || !serialPort.performanceEpochIdle(span)
+                || !infraredPort.performanceEpochIdle(span)
+                || gpu.performanceNativeCgbOwnedHblankDataSpanLimit(span) < span
+                || statRegister.performanceSettledHaltSpanLimit(span) < span) {
+            return 0;
+        }
+
+        // Input/reset publication is the only host-side mutation admitted by this scheduler.
+        // Keep those volatile/state guards adjacent to the trusted packet commit.
+        if (warmResetRequested
+                || speedSwitchTailTicks != 0
+                || !cpu.performanceHdmaOwnedBlockCpuFrozenEligible()
+                || !hdma.isPerformanceNativeCgbOwnedHblankDataStable(romAccess)
+                || hdma.performanceNativeCgbOwnedHblankDataSpanLimit(
+                        span, romAccess) != span
+                || dma.isTransferInProgress()
+                || dma.requiresClockTick(false)
+                || !serialPort.performanceEpochIdle(span)
+                || !infraredPort.performanceEpochIdle(span)
+                || !joypad.isPerformanceQuietSpanStillEligible()) {
+            return 0;
+        }
+
+        tickPerformanceNativeCgbHdmaOwnedDataSpan(
+                span, cpu.getStatReadPhaseFlags(), romAccess);
+        performanceBulkSpanCount++;
+        performanceBulkTicks += span;
+        performanceBulkMaxTicks = Math.max(performanceBulkMaxTicks, span);
+        performanceHdmaOwnedSpanCount++;
+        performanceHdmaOwnedTicks += span;
+        return span;
+    }
+
+    /** Commits one preflighted no-CPU/no-OAM-DMA HDMA source-read packet. */
+    private void tickPerformanceNativeCgbHdmaOwnedDataSpan(
+            int ticks, int entryStatReadPhaseFlags, PerformanceRomAccess romAccess) {
+        if (cartridgeClocked) {
+            cartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        if (slotCartridgeClocked) {
+            slotCartridge.tickPerformanceQuietSpanTrusted(ticks);
+        }
+        statRegister.capturePerformanceNoCpuReadPhaseTrusted(entryStatReadPhaseFlags);
+        timer.tickPerformanceEpochTrusted(ticks);
+        sound.tickFrameSequencer(false);
+        assert !sound.hasPendingFrameSequencerClock()
+                : "frame sequencer edge crossed an HDMA-owned PERFORMANCE span";
+        sound.commitFrameSequencerClock();
+        sound.tickPerformanceQuietSpan(ticks);
+        serialPort.tickPerformanceEpochIdle(ticks);
+        infraredPort.tickPerformanceEpochIdle(ticks);
+        joypad.tickPerformanceQuietSpanTrusted(ticks);
+
+        // The source is side-effect-free WRAM or immutable leased ROM, OAM DMA is inactive, and
+        // the direct line is already in HBlank, so the ordered source reads commute with these
+        // independently preflighted peripheral advances.
+        hdma.advancePerformanceNativeCgbOwnedHblankDataTrusted(ticks, romAccess);
+        gpu.advancePerformanceNativeCgbOwnedHblankDataSpanTrusted(ticks);
+        statRegister.tickPerformanceQuietSpanTrusted(ticks);
+        hdma.onGpuTiming(gpu.getLine(), gpu.getTicksInLine(),
+                gpu.isStatModeLatchRephasedBySpeedSwitch());
+        cpu.latchHdmaHaltOpcode(hdma.isHaltRequestLatched());
     }
 
     /**
@@ -1539,6 +1655,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 || !canStartPerformanceEpoch()) {
             return 0;
         }
+        boolean armedHblankWait = hdma.isPerformanceArmedHblankWaitStable();
         int span = (int) Math.min((long) Cpu.PERFORMANCE_EPOCH_MAX_TICKS, remaining);
         if (cartridgeClocked) {
             span = Math.min(span, cartridge.performanceQuietSpanLimit(span));
@@ -1547,7 +1664,9 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
             span = Math.min(span, slotCartridge.performanceQuietSpanLimit(span));
         }
         span = Math.min(span, timer.performanceEpochSpanLimit(span));
-        span = Math.min(span, sound.performanceEpochSpanLimit(span));
+        span = Math.min(span, armedHblankWait
+                ? sound.performanceFencedEpochSpanLimit(span)
+                : sound.performanceEpochSpanLimit(span));
         span = Math.min(span, joypad.performanceSettledHaltSpanLimit(span));
 
         PerformanceEpochPpuPlan ppuPlan;
@@ -1568,15 +1687,25 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         if (span <= 0) {
             return 0;
         }
-
         int statSpan = statRegister.performanceSettledHaltSpanLimit(span);
+        boolean statReplay = false;
+        boolean statAggregate = false;
         if (statSpan == 0) {
-            if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
-                return 0;
+            int replaySpan =
+                    statRegister.performanceNativeCgbCheckpointReplaySpanLimit(span);
+            if (replaySpan == 0) {
+                if (warmResetRequested || !joypad.isPerformanceQuietSpanStillEligible()) {
+                    return 0;
+                }
+                return -span;
             }
-            return -span;
+            span = Math.min(span, replaySpan);
+            statReplay = true;
+            statAggregate =
+                    statRegister.performanceNativeCgbCheckpointAggregateSpanLimit(span) >= span;
+        } else {
+            span = Math.min(span, statSpan);
         }
-        span = Math.min(span, statSpan);
         if (span <= 0) {
             return 0;
         }
@@ -1589,6 +1718,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochSteadyRaster = !performanceEpochDirectRaster
                 && gpu.isPerformanceSteadyCursorActive();
         performanceEpochPpuPlan = ppuPlan;
+        performanceEpochStatReplay = statReplay;
+        performanceEpochStatAggregate = statAggregate;
         performanceEpochPrefixCommitted = 0;
         if (performanceEpochPrefixCommitter == null) {
             performanceEpochPrefixCommitter = this::commitPerformanceEpochPrefix;
@@ -1596,7 +1727,11 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         cpu.setPerformanceEpochPrefixCommitter(performanceEpochPrefixCommitter);
         int elapsed;
         try {
-            elapsed = cpu.runPerformanceEpoch(span);
+            elapsed = statReplay
+                    ? cpu.runNativeCgbStatReplayPerformanceEpoch(span)
+                    : armedHblankWait
+                    ? cpu.runNativeCgbArmedHblankWaitPerformanceEpoch(span)
+                    : cpu.runNativeCgbPerformanceEpoch(span);
         } finally {
             cpu.setPerformanceEpochPrefixCommitter(null);
         }
@@ -2101,20 +2236,36 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         serialPort.tickPerformanceEpochIdle(ticks);
         infraredPort.tickPerformanceEpochIdle(ticks);
         joypad.tickPerformanceQuietSpanTrusted(ticks);
-        hdma.advancePerformanceInactiveRequestClockTrusted(ticks);
+        hdma.advancePerformanceNativeCgbRunningEpochClockTrusted(ticks);
 
-        switch (performanceEpochPpuPlan) {
+        if (performanceEpochStatReplay && !performanceEpochStatAggregate) {
+            // The CPU runner fences every decoded access and HALT. Replay the exact post-GPU
+            // STAT evaluator dot-for-dot so internal latches remain identical while the CPU
+            // cannot observe LY/STAT/IF or skip an interrupt acceptance boundary.
+            for (int i = 0; i < ticks; i++) {
+                gpu.tick();
+                statRegister.tickNativeCgbPerformancePostGpu();
+            }
+        } else switch (performanceEpochPpuPlan) {
             case SGB_IDLE -> throw new IllegalStateException(
                     "native-CGB epoch has an SGB PPU plan");
             case TRUSTED_RASTER -> {
                 gpu.advancePerformanceEpochQuietSpanTrusted(
                         ticks, performanceEpochDirectRaster, performanceEpochSteadyRaster);
-                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                if (performanceEpochStatAggregate) {
+                    statRegister.advancePerformanceNativeCgbCheckpointAggregateSpanTrusted(ticks);
+                } else {
+                    statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                }
                 performanceEpochRasterFastTicks += ticks;
             }
             case MODE2_BULK -> {
                 gpu.advancePerformanceMode2QuietSpanTrusted(ticks);
-                statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                if (performanceEpochStatAggregate) {
+                    statRegister.advancePerformanceNativeCgbCheckpointAggregateSpanTrusted(ticks);
+                } else {
+                    statRegister.tickPerformanceQuietSpanTrusted(ticks);
+                }
                 performanceEpochMode2ReplayTicks += ticks;
                 performanceEpochMode2BulkTicks += ticks;
             }
@@ -2124,7 +2275,12 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 // and STAT state are published dot-for-dot before the scalar hand-off tick.
                 for (int i = 0; i < ticks; i++) {
                     gpu.tick();
-                    statRegister.tick();
+                    if (!performanceEpochStatAggregate) {
+                        statRegister.tick();
+                    }
+                }
+                if (performanceEpochStatAggregate) {
+                    statRegister.advancePerformanceNativeCgbCheckpointAggregateSpanTrusted(ticks);
                 }
                 performanceEpochMode2ReplayTicks += ticks;
             }
@@ -2532,6 +2688,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceBulkSpanCount = 0L;
         performanceBulkTicks = 0L;
         performanceBulkMaxTicks = 0;
+        performanceHdmaOwnedSpanCount = 0L;
+        performanceHdmaOwnedTicks = 0L;
         performanceEpochCount = 0L;
         performanceEpochTicks = 0L;
         performanceEpochMaxTicks = 0;
@@ -2541,6 +2699,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         performanceEpochLcdOffTicks = 0L;
         performanceEpochSgbIdleTicks = 0L;
         performanceEpochPpuPlan = PerformanceEpochPpuPlan.NONE;
+        performanceEpochStatReplay = false;
+        performanceEpochStatAggregate = false;
         cpu.resetPerformanceEpochTelemetry();
     }
 
@@ -2554,9 +2714,17 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         return performanceBulkTicks;
     }
 
-    /** Largest settled-HALT PERFORMANCE packet in the current session. */
+    /** Largest all-subsystem PERFORMANCE packet in the current session. */
     public int getPerformanceBulkMaxTicks() {
         return performanceBulkMaxTicks;
+    }
+
+    public long getPerformanceHdmaOwnedSpanCount() {
+        return performanceHdmaOwnedSpanCount;
+    }
+
+    public long getPerformanceHdmaOwnedTicks() {
+        return performanceHdmaOwnedTicks;
     }
 
     public long getPerformanceEpochCount() {
@@ -2585,6 +2753,14 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
 
     public long getPerformanceEpochLcdOffTicks() {
         return performanceEpochLcdOffTicks;
+    }
+
+    public long getPerformanceEpochFenceAttemptCount() {
+        return cpu.getPerformanceEpochFenceAttemptCount();
+    }
+
+    public long getPerformanceEpochCartWindowFenceAttemptCount() {
+        return cpu.getPerformanceEpochCartWindowFenceAttemptCount();
     }
 
     public long getPerformanceEpochSgbIdleTicks() {

--- a/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/cpu/Cpu.java
@@ -94,6 +94,12 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     private transient long performanceEpochTerminalAccesses;
 
+    /** Unsafe decoded or delegated memory boundaries reached by attempted epochs. */
+    private transient long performanceEpochFenceAttemptCount;
+
+    /** Fence-attempt subset whose resolved address was in the cartridge RAM/RTC window. */
+    private transient long performanceEpochCartWindowFenceAttemptCount;
+
     private transient IntConsumer performanceEpochPrefixCommitter;
 
     private transient int performanceEpochElapsed;
@@ -102,6 +108,9 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     /** Epoch-local proof that LCD-off CGB VRAM is an unobserved direct memory plane. */
     private transient boolean performanceEpochLcdOffVramAccess;
+
+    /** Epoch-local proof that native-CGB FF44 cannot change before the owner commits. */
+    private transient boolean performanceEpochStableLyRead;
 
     private transient DebugCpuAddressSpace debugAddressSpace;
 
@@ -233,6 +242,40 @@ public class Cpu implements StatefulComponent<Cpu> {
      * @return master ticks consumed by the CPU epoch
      */
     public int runPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceEpoch(maxMasterTicks, false, false);
+    }
+
+    /**
+     * Native-CGB x2 epoch whose owner has intersected the packet with the invariant STAT
+     * horizon. That horizon also proves the CPU-visible LY value cannot change, so FF44 reads
+     * may use the canonical bus without terminating the packet. All other IO remains fenced.
+     */
+    public int runNativeCgbPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceEpoch(maxMasterTicks, false, true);
+    }
+
+    /**
+     * Native-CGB x2 running epoch used only while HBlank DMA is armed between bursts. Unsafe
+     * decoded memory cycles remain scalar so LCDC/HDMA control writes cannot cross the owner's
+     * HDMA callback, and HALT remains scalar so its request-latch timing is sampled per dot.
+     * The same owner-proven STAT horizon permits stable FF44 reads.
+     */
+    public int runNativeCgbArmedHblankWaitPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceEpoch(maxMasterTicks, true, true);
+    }
+
+    /**
+     * Native-CGB x2 checkpoint-replay epoch. Every decoded memory boundary and HALT stays on
+     * the scalar scheduler: unlike the ordinary invariant-STAT lease, FF44 is not stable while
+     * the owner replays the PPU/STAT dots exactly.
+     */
+    public int runNativeCgbStatReplayPerformanceEpoch(int maxMasterTicks) {
+        return runPerformanceEpoch(maxMasterTicks, true, false);
+    }
+
+    private int runPerformanceEpoch(
+            int maxMasterTicks, boolean fenceDecodedMemoryAndHalt,
+            boolean allowStableLyRead) {
         if (maxMasterTicks <= 0 || !performanceEpochEntryEligible()) {
             return 0;
         }
@@ -257,6 +300,7 @@ public class Cpu implements StatefulComponent<Cpu> {
             performanceEpochElapsed = 0;
             performanceEpochPrefixTicks = 0;
             performanceEpochActive = true;
+            performanceEpochStableLyRead = allowStableLyRead;
             bus.resetForEpoch(target);
             addressSpace = bus;
             while (elapsed < requested) {
@@ -270,7 +314,11 @@ public class Cpu implements StatefulComponent<Cpu> {
 
                 // Fence the next fetch/operand window before the native x2 epoch may use its
                 // borrowed ROM reader.
-                if (!performanceEpochPrefetchSafe()) {
+                if (!performanceEpochPrefetchSafe()
+                        || fenceDecodedMemoryAndHalt
+                        && (performanceNextBoundaryFetchesHalt()
+                        || !performanceDecodedMemoryBoundarySafe(
+                        true, false, allowStableLyRead))) {
                     performanceEpochTerminal = true;
                     break;
                 }
@@ -294,6 +342,7 @@ public class Cpu implements StatefulComponent<Cpu> {
             performanceEpochRomAccess = null;
             addressSpace = target;
             performanceEpochActive = false;
+            performanceEpochStableLyRead = false;
             performanceEpochAccesses += bus.accesses();
             performanceEpochTerminalAccesses += bus.terminalAccesses();
             performanceEpochTicks += elapsed;
@@ -428,7 +477,7 @@ public class Cpu implements StatefulComponent<Cpu> {
                         && performanceNextBoundaryFetchesHalt()
                         || fenceDecodedMemoryCycles
                         && !performanceDecodedMemoryBoundarySafe(
-                        allowResolvedSafeDecodedAccess, allowLcdOffVramAccess)) {
+                        allowResolvedSafeDecodedAccess, allowLcdOffVramAccess, false)) {
                     performanceEpochTerminal = true;
                     break;
                 }
@@ -470,7 +519,8 @@ public class Cpu implements StatefulComponent<Cpu> {
      * machine-cycle tick, so the complete group is classified before any part may run.
      */
     private boolean performanceDecodedMemoryBoundarySafe(
-            boolean allowResolvedSafeDecodedAccess, boolean allowLcdOffVramAccess) {
+            boolean allowResolvedSafeDecodedAccess, boolean allowLcdOffVramAccess,
+            boolean allowStableLyRead) {
         if (state != State.RUNNING || currentExecutionOps == null) {
             return true;
         }
@@ -478,20 +528,25 @@ public class Cpu implements StatefulComponent<Cpu> {
             Op op = currentExecutionOps[i];
             if (allowResolvedSafeDecodedAccess
                     && op.causesOemBug(registers, opContext) != null) {
+                recordPerformanceEpochFenceAttempt();
                 return false;
             }
             if (currentOpAccessesMemory[i]) {
                 if (!allowResolvedSafeDecodedAccess) {
+                    recordPerformanceEpochFenceAttempt();
                     return false;
                 }
                 Integer address = op.resolveMemoryAddress(registers, operand, opContext);
                 if (address == null) {
                     if (!op.isInternalMemoryCycle()) {
+                        recordPerformanceEpochFenceAttempt();
                         return false;
                     }
                 } else if (currentOpWritesMemory[i]
                         ? !isPerformanceEpochSafeWrite(address, allowLcdOffVramAccess)
-                        : !isPerformanceEpochSafeRead(address, allowLcdOffVramAccess)) {
+                        : !isPerformanceEpochSafeRead(
+                        address, allowLcdOffVramAccess, allowStableLyRead)) {
+                    recordPerformanceEpochFenceAttempt(address);
                     return false;
                 }
             }
@@ -503,9 +558,10 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     private static boolean isPerformanceEpochSafeRead(
-            int address, boolean allowLcdOffVramAccess) {
+            int address, boolean allowLcdOffVramAccess, boolean allowStableLyRead) {
         return PerformanceEpochBus.isSafeRead(address)
-                || allowLcdOffVramAccess && PerformanceEpochBus.isVideoRam(address);
+                || allowLcdOffVramAccess && PerformanceEpochBus.isVideoRam(address)
+                || allowStableLyRead && (address & 0xffff) == 0xff44;
     }
 
     private static boolean isPerformanceEpochSafeWrite(
@@ -515,7 +571,8 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     private boolean isPerformanceEpochSafeRead(int address) {
-        return isPerformanceEpochSafeRead(address, performanceEpochLcdOffVramAccess);
+        return isPerformanceEpochSafeRead(
+                address, performanceEpochLcdOffVramAccess, performanceEpochStableLyRead);
     }
 
     private boolean isPerformanceEpochSafeWrite(int address) {
@@ -704,11 +761,25 @@ public class Cpu implements StatefulComponent<Cpu> {
         performanceEpochTerminal = true;
     }
 
+    private void recordPerformanceEpochFenceAttempt() {
+        performanceEpochFenceAttemptCount++;
+    }
+
+    private void recordPerformanceEpochFenceAttempt(int address) {
+        performanceEpochFenceAttemptCount++;
+        int normalized = address & 0xffff;
+        if (normalized >= 0xa000 && normalized <= 0xbfff) {
+            performanceEpochCartWindowFenceAttemptCount++;
+        }
+    }
+
     public void resetPerformanceEpochTelemetry() {
         performanceEpochCount = 0L;
         performanceEpochTicks = 0L;
         performanceEpochAccesses = 0L;
         performanceEpochTerminalAccesses = 0L;
+        performanceEpochFenceAttemptCount = 0L;
+        performanceEpochCartWindowFenceAttemptCount = 0L;
     }
 
     public long getPerformanceEpochCount() {
@@ -725,6 +796,14 @@ public class Cpu implements StatefulComponent<Cpu> {
 
     public long getPerformanceEpochTerminalAccesses() {
         return performanceEpochTerminalAccesses;
+    }
+
+    public long getPerformanceEpochFenceAttemptCount() {
+        return performanceEpochFenceAttemptCount;
+    }
+
+    public long getPerformanceEpochCartWindowFenceAttemptCount() {
+        return performanceEpochCartWindowFenceAttemptCount;
     }
 
     /**
@@ -865,6 +944,10 @@ public class Cpu implements StatefulComponent<Cpu> {
                 || speedMode.getSpeedMode() != 1) {
             return false;
         }
+        return hasOnlyDurableOrdinaryHaltWakeStatPhase();
+    }
+
+    private boolean hasOnlyDurableOrdinaryHaltWakeStatPhase() {
         int flags = getStatReadPhaseFlags();
         int allowed = STAT_READ_PHASE_ORDINARY_HALT_WAKE
                 | STAT_READ_PHASE_ONE_CYCLE_ORDINARY_HALT_WAKE;
@@ -2243,7 +2326,10 @@ public class Cpu implements StatefulComponent<Cpu> {
 
         opContext = context;
         opIndex = runningOp;
-        if (read ? !PerformanceEpochBus.isSafeRead(address)
+        boolean directStableLyRead = opcode == 0xf0
+                && performanceEpochStableLyRead
+                && address == 0xff44;
+        if (read ? !PerformanceEpochBus.isSafeRead(address) && !directStableLyRead
                 : !PerformanceEpochBus.isSafeWrite(address)) {
             return extraTicks;
         }
@@ -3568,6 +3654,35 @@ public class Cpu implements StatefulComponent<Cpu> {
     }
 
     /**
+     * Whether an HDMA-owned native-CGB x2 data interior may keep the CPU completely frozen.
+     * The scalar arbiter has already fetched and decoded the next opcode; the transfer releases
+     * that held pipeline only on its separately scalar block-completion tick.
+     */
+    public boolean performanceHdmaOwnedBlockCpuFrozenEligible() {
+        return speedMode.isGbc()
+                && !speedMode.isDmgCompat()
+                && speedMode.getSpeedMode() == 2
+                && debugAddressSpace == null
+                && debugHooks == null
+                && debugRetirementTracker == null
+                && hdmaOpcodePrefetched
+                && (state == State.OPERAND
+                || state == State.EXT_OPCODE && opcode1 != 0x10)
+                && clockCycle >= 0 && clockCycle <= 3
+                && haltEntrySampleTicks == 0
+                && !haltBugMode
+                && !phasedPpuInputHigh
+                && !fastPhasedPpuDispatch
+                && !hdmaArbitrationOpcodeValid
+                && !haltOpcodePrefetchValid
+                && !speedSwitchPaddingReplayValid
+                && hasOnlyDurableOrdinaryHaltWakeStatPhase()
+                && !interruptManager.hasPpuTickSignals()
+                && !interruptManager.isInterruptEnablePending()
+                && !interruptManager.hasRawPendingEnabledInterrupt();
+    }
+
+    /**
      * Whether the CPU side of an HDMA request slot is still in progress. Besides an
      * already decoded instruction, the latter half of an opcode cycle owns the slot
      * until the arbiter performs its one authoritative opcode fetch.
@@ -3830,6 +3945,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         public int getByte(int address) {
             accesses++;
             if (!owner.isPerformanceEpochSafeRead(address)) {
+                owner.recordPerformanceEpochFenceAttempt(address);
                 terminalAccesses++;
                 owner.markPerformanceEpochTerminal();
                 owner.flushPerformanceEpochPrefix();
@@ -3841,6 +3957,7 @@ public class Cpu implements StatefulComponent<Cpu> {
         public void setByte(int address, int value) {
             accesses++;
             if (!owner.isPerformanceEpochSafeWrite(address)) {
+                owner.recordPerformanceEpochFenceAttempt(address);
                 int a = address & 0xffff;
                 if (!owner.speedMode.isGbc() && a >= 0xfe00 && a <= 0xfeff) {
                     // DMG OAM writes must observe the corruption-suppression latch and access

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -1160,11 +1160,11 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         return Math.max(0, limit);
     }
 
-    /** Native-CGB coarse epoch horizon; HDMA is unconditionally part of this contract. */
+    /** Native-CGB coarse epoch horizon; the next HBlank/HDMA request edge remains scalar. */
     public int performanceEpochSpanLimit(int requested) {
         if (requested <= 0 || !lcdEnabled || dma == null || dma.isTransferInProgress()
                 || dma.ownsOamForPpu() || dma.hasPpuOamOwnershipTransitionThisTick()
-                || hdma == null || hdma.hasActiveOrPendingTransfer()) {
+                || hdma == null || !hdma.isPerformanceNativeCgbRunningEpochStable()) {
             return 0;
         }
         if (!performanceScanlineEnabled || !performanceScanlineCapable
@@ -1177,9 +1177,8 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         }
         int limit;
         if (mode == Mode.PixelTransfer) {
-            // Direct rendered mode 3 is the only mode-3 cursor admitted here.  Unlike the
-            // older scheduler horizon, this coarse transaction cannot yet advance HDMA's
-            // HBlank-request synchronizer, so even an armed transfer remains fail-closed.
+            // Direct rendered mode 3 is the only mode-3 cursor admitted here. Stop before its
+            // HBlank hand-off so an armed transfer's request synchronizer remains scalar.
             if (!performanceScanlineCursor
                     || ticksInLine + 1 >= performanceScanlineEndTick) {
                 return 0;
@@ -1199,6 +1198,33 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             return 0;
         }
         return Math.min(requested, Math.max(0, limit));
+    }
+
+    /**
+     * HBlank-only horizon for the data interior of an HDMA burst which already owns the CPU bus.
+     * The direct compositor has emptied both pixel pipelines, and the returned span stays before
+     * both the scanline edge and HDMA's separately scalar atomic destination commit.
+     */
+    public int performanceNativeCgbOwnedHblankDataSpanLimit(int requested) {
+        if (requested <= 0
+                || !gbc || dmgCompatValue || speedModeValue != 2
+                || !lcdEnabled || firstLine || line < 0 || line >= 144
+                || mode != Mode.HBlank || !performanceScanlineLine
+                || !performanceScanlineEnabled || !performanceScanlineCapable
+                || performanceObservationBlocked || mutablePpuStateExposed
+                || debugHooks != null || !pendingPpuWrites.isEmpty()
+                || r.hasPendingConflictLatches() || lcdc.hasPendingConflictLatches()
+                || !lcdc.isPerformanceQuietSpanFixedPoint()
+                || !isPerformanceNativeCgbIdleOutput()
+                || !bootCompatibilityResolved
+                || dma == null || dma.isTransferInProgress() || dma.ownsOamForPpu()
+                || dma.hasPpuOamOwnershipTransitionThisTick()
+                || hdma == null
+                || !hdma.isPerformanceNativeCgbOwnedHblankDataStructurallyStable()) {
+            return 0;
+        }
+        int lineLength = firstLine ? 455 : 456;
+        return Math.min(requested, Math.max(0, lineLength - ticksInLine - 1));
     }
 
     /**
@@ -1323,7 +1349,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                 || phase != oamSearchPhase || performanceScanlineCursor
                 || performanceScanlineLine || dma == null || dma.isTransferInProgress()
                 || dma.ownsOamForPpu() || dma.hasPpuOamOwnershipTransitionThisTick()
-                || hdma == null || hdma.hasActiveOrPendingTransfer()) {
+                || hdma == null || !hdma.isPerformanceNativeCgbRunningEpochStable()) {
             return 0;
         }
         if (!performanceScanlineEnabled || !performanceScanlineCapable
@@ -1673,6 +1699,18 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
             timingGeneration += ticks;
             performanceScanlineFastTicks += ticks;
         }
+    }
+
+    /** Applies a preflighted direct-line HBlank data span without crossing its mode/line edge. */
+    public void advancePerformanceNativeCgbOwnedHblankDataSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        advancePerformanceNativeCgbIdleOutputSpanTrusted(ticks);
+        ticksInLine += ticks;
+        timingGeneration += ticks;
+        performanceScanlineFastTicks += ticks;
+        cpuLyReadAcrossLineEdge = false;
     }
 
     /** Physical-DMG trusted epoch commit with canonical empty output-clock advancement. */

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/StatRegister.java
@@ -993,6 +993,142 @@ public class StatRegister implements AddressSpace, StatefulComponent<StatRegiste
     }
 
     /**
+     * Returns a bounded native-CGB x2 span for which the CPU may run against its frozen
+     * peripheral view while the owner replays every PPU/STAT dot exactly.
+     *
+     * <p>This is deliberately narrower than the scalar evaluator: only a fully settled,
+     * LYC-only source with mutually consistent register copies is admitted. The equality line,
+     * its preceding comparator line, and all frame/VBlank handoffs stay scalar. Callers must
+     * additionally fence every decoded memory boundary (including FF41/FF44/FF0F) and HALT.</p>
+     */
+    public int performanceNativeCgbCheckpointReplaySpanLimit(int requested) {
+        if (requested <= 0 || !gbc || statEvaluationDirty
+                || enableBits != 0x40
+                || lycIrqStatSource != 0x40
+                || lycIrqStatLatch != 0x40
+                || modeIrqStatLatch != 0x40
+                || mode0IrqStatLatch != 0x40
+                || lycIrqValueSource != lycIrqValueLatch
+                || lycIrqValueSource != modeIrqLycLatch
+                || lycIrqValueSource != mode0IrqLycLatch
+                || pendingModeIrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingModeIrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqStatClock != NO_LYC_IRQ_EVENT
+                || pendingMode0IrqLycClock != NO_LYC_IRQ_EVENT
+                || pendingCgbMode0Interrupt
+                || pendingCgbMode1Interrupt
+                || pendingCgbMode2Interrupt
+                || pendingCgbMode2LateReplay
+                || pendingCgbMode2PublicationClock != NO_LYC_IRQ_EVENT
+                || pendingCgbFrameMode2Interrupt
+                || retractableCgbMode2Interrupt
+                || releaseTailLycCpuAcceptance
+                || pendingLycWriteIrq != NO_LYC_IRQ_EVENT
+                || pendingLycComparatorIrq != NO_LYC_IRQ_EVENT
+                || interruptManager.hasPpuTickSignals()) {
+            return 0;
+        }
+        refreshGpuTiming();
+        int currentLine = timing.line;
+        int lyc = lycIrqValueSource;
+        if (!timing.nativeDoubleSpeed || !timing.lcdEnabled || timing.firstLine
+                || currentLine < 1 || currentLine > 142
+                || currentLine == lyc || currentLine + 1 == lyc) {
+            return 0;
+        }
+
+        int lineLength = timing.firstLine ? 455 : 456;
+        int limit = Math.min(requested, lineLength - timing.ticksInLine - 1);
+        if (nextLycIrqEvent != NO_LYC_IRQ_EVENT) {
+            long distance = nextLycIrqEvent - lycIrqClock;
+            if (distance <= 1) {
+                return 0;
+            }
+            limit = Math.min(limit,
+                    (int) Math.min((long) Integer.MAX_VALUE, distance - 1));
+        }
+        return Math.max(0, limit);
+    }
+
+    /**
+     * Returns the LYC-only checkpoint subwindows whose scalar replay has a closed-form state
+     * transition.  At an ordinary visible-line start, mode 0/1/2 are all low and only the
+     * dot-2 HALT-wake release can occur.  In the line tail, mode 2 rises at dot 448 and native
+     * double speed registers the already-proven non-matching LY at dot 454.  The mid-line
+     * mode-0 checkpoints retain exact replay.
+     *
+     * <p>The broad replay proof remains authoritative.  These additional guards require the
+     * readable and interrupt coincidence planes, shared level, comparator signal, and window
+     * history to be canonical before replacing the per-dot evaluator.  The caller must retain
+     * the replay runner's every-memory-boundary and HALT fences and commit one of GPU's already
+     * preflighted raster/mode-2 plans before applying the trusted endpoint below.</p>
+     */
+    public int performanceNativeCgbCheckpointAggregateSpanLimit(int requested) {
+        int limit = performanceNativeCgbCheckpointReplaySpanLimit(requested);
+        if (limit <= 0) {
+            return 0;
+        }
+        int ticksInLine = timing.ticksInLine;
+        boolean lineStart = ticksInLine <= 12;
+        boolean lineTail = ticksInLine >= 447;
+        if (!lineStart && !lineTail) {
+            return 0;
+        }
+        if (registers.get(LYC) != lycIrqValueSource
+                || registeredLy != timing.visibleLy
+                || coincidence || intCoincidence || intLine
+                || lycWriteSuppressed
+                || suppressedLycIrqLine != -1
+                || modeBlockedLycIrqLine != -1
+                || lycComparatorSignal
+                || pendingCgbMode2IfHighAtCapture
+                || cgbMode2CapturedAtLineEdge) {
+            return 0;
+        }
+        if (lineStart) {
+            if (previousMode0Window || previousMode1Window || previousMode2Window) {
+                return 0;
+            }
+        } else if (!previousMode0Window || previousMode1Window
+                || previousMode2Window != (ticksInLine >= 448)) {
+            return 0;
+        }
+        return limit;
+    }
+
+    /** Applies one prefix of a preflighted native-CGB LYC-only checkpoint transaction. */
+    public void advancePerformanceNativeCgbCheckpointAggregateSpanTrusted(int ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        int endTicksInLine = gpu.getTicksInLine();
+        int startTicksInLine = endTicksInLine - ticks;
+        if (startTicksInLine < 0
+                || !(endTicksInLine <= 79
+                || startTicksInLine >= 447 && endTicksInLine <= 455)) {
+            throw new IllegalStateException(
+                    "STAT aggregate left its preflighted checkpoint window");
+        }
+
+        interruptManager.finishLcdcReadMaskWindowAndClearCpuReadInterruptPreview(ticks);
+        lycIrqClock += ticks;
+        clearCpuStatReadPhase();
+
+        refreshGpuTiming();
+        previousMode0Window = timing.mode0IntWindow;
+        previousMode1Window = timing.mode1IntWindow;
+        previousMode2Window = timing.mode2IntWindow;
+        if (startTicksInLine < CGB_DOUBLE_TAIL_LATCH
+                && endTicksInLine >= CGB_DOUBLE_TAIL_LATCH) {
+            registeredLy = timing.visibleLy;
+        }
+        if (startTicksInLine < timing.cpuMachineCycleDots
+                && endTicksInLine >= timing.cpuMachineCycleDots) {
+            interruptManager.releaseHaltWake(InterruptType.LCDC);
+        }
+    }
+
+    /**
      * Returns the full SGB/SGB2 LCD-off span when STAT has no live publication residue.
      * The LCD-off DMG comparator is frozen, so {@code nextLycIrqEvent} is deliberately not
      * consulted here; only pending writes, captures, and PPU-to-CPU signals can still publish.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -780,6 +780,186 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
     }
 
     /**
+     * Whether a native-CGB double-speed running epoch may borrow the quiet interval between
+     * HBlank-DMA bursts. The programmed transfer remains armed, but neither request clock nor
+     * any CPU/HDMA arbitration state can change until the GPU publishes the next HBlank edge.
+     * That edge is deliberately left to the scalar scheduler by the GPU epoch horizons.
+     */
+    public boolean isPerformanceArmedHblankWaitStable() {
+        return speedMode.isGbc()
+                && !speedMode.isDmgCompat()
+                && speedMode.getSpeedMode() == 2
+                && transferInProgress
+                && hblankTransfer
+                && lcdEnabled
+                && tick < 0
+                && hblankRequestTicks < 0
+                && hblankRequestAge == 0
+                && nextHblankRequestTicks < 0
+                && nextHblankRequestAge == 0
+                && !stopAfterCurrentBlock
+                && !preserveLengthAfterCurrentBlock
+                && !speedSwitchInProgress
+                && !speedSwitchStartedWithoutRequest
+                && !pauseOamDmaForSpeedSwitchBurst
+                && wakeRequestArbitration == WakeRequestArbitration.NONE
+                && !cpuHalted
+                && !haltEnteredThisTick
+                && !requestOverlappedCpuWrite
+                && !interruptEntryWonArbitration
+                && cpuRequestArbitration == CpuRequestArbitration.NONE
+                && !cpuRequestAllowsLateInterrupt
+                && !haltOpcodeRequestLatched
+                && sourceBusSample == null;
+    }
+
+    /**
+     * Whether the native-CGB x2 scheduler has a structurally stable, already-owned HBlank data
+     * interior. The source may be either one side-effect-free WRAM block or one ROM block whose
+     * immutable physical mapping still has to be proven by a bounded
+     * {@link PerformanceRomAccess} lease. The atomic tick-32 VRAM commit remains scalar.
+     */
+    public boolean isPerformanceNativeCgbOwnedHblankDataStructurallyStable() {
+        return transferInProgress
+                && hblankTransfer
+                && tick >= 0 && tick < 31
+                && speedMode.isGbc()
+                && !speedMode.isDmgCompat()
+                && speedMode.getSpeedMode() == 2
+                && lcdEnabled
+                && gpuMode == Mode.HBlank
+                && gpuLine >= 0 && gpuLine < 144
+                && hblankRequestTicks == 0
+                && hblankRequestAge > 0
+                && nextHblankRequestTicks < 0
+                && nextHblankRequestAge == 0
+                && cpuRequestArbitration == CpuRequestArbitration.DMA
+                && wakeRequestArbitration == WakeRequestArbitration.NONE
+                && !cpuRequestAllowsLateInterrupt
+                && !cpuHalted
+                && !haltEnteredThisTick
+                && !haltOpcodeRequestLatched
+                && !requestOverlappedCpuWrite
+                && !interruptEntryWonArbitration
+                && !stopAfterCurrentBlock
+                && !preserveLengthAfterCurrentBlock
+                && !speedSwitchInProgress
+                && !speedSwitchStartedWithoutRequest
+                && !pauseOamDmaForSpeedSwitchBurst
+                && sourceBusSample == null
+                && debugHooks == null
+                && !debugMemoryHooks
+                && (src & 0x0f) == 0
+                && (src >= 0x0000 && src <= 0x7ff0
+                || src >= 0xc000 && src <= 0xdff0);
+    }
+
+    /** Existing lease-free WRAM tier retained for callers which do not borrow cartridge data. */
+    public boolean isPerformanceNativeCgbOwnedHblankDataStable() {
+        return isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                && isPerformanceOwnedHblankWramSource();
+    }
+
+    /** Whether this structurally stable packet needs an immutable ROM mapping lease. */
+    public boolean requiresPerformanceNativeCgbOwnedHblankRomAccess() {
+        return isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                && isPerformanceOwnedRomSource();
+    }
+
+    /** WRAM plus an exactly mapped immutable-ROM tier for the native-CGB owner. */
+    public boolean isPerformanceNativeCgbOwnedHblankDataStable(
+            PerformanceRomAccess romAccess) {
+        return isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                && (isPerformanceOwnedHblankWramSource()
+                || hasCompletePerformanceOwnedPhysicalRomBlock(romAccess));
+    }
+
+    private boolean isPerformanceOwnedHblankWramSource() {
+        return src >= 0xc000 && src <= 0xdff0;
+    }
+
+    private boolean isPerformanceOwnedRomSource() {
+        return src >= 0x0000 && src <= 0x7ff0;
+    }
+
+    /**
+     * Proves every byte separately: the generic physical lease does not promise that adjacent
+     * CPU addresses have adjacent backing offsets, even though ordinary MBC5/MBC7 mappings do.
+     */
+    private boolean hasCompletePerformanceOwnedPhysicalRomBlock(
+            PerformanceRomAccess romAccess) {
+        if (romAccess == null || !isPerformanceOwnedRomSource()) {
+            return false;
+        }
+        for (int j = 0; j < 0x10; j++) {
+            if (romAccess.physicalOffset(src + j) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the complete remaining data-only prefix through internal tick 31, or zero when the
+     * request cannot consume that whole prefix. Tick 32 is the observable destination commit and
+     * is intentionally excluded.
+     */
+    public int performanceNativeCgbOwnedHblankDataSpanLimit(int requested) {
+        return performanceNativeCgbOwnedHblankDataSpanLimit(requested, null);
+    }
+
+    /** Immutable-ROM-aware counterpart using one owner-thread lease for the whole transaction. */
+    public int performanceNativeCgbOwnedHblankDataSpanLimit(
+            int requested, PerformanceRomAccess romAccess) {
+        if (requested <= 0 || !isPerformanceNativeCgbOwnedHblankDataStable(romAccess)) {
+            return 0;
+        }
+        int remainingDataTicks = 31 - tick;
+        return requested >= remainingDataTicks ? remainingDataTicks : 0;
+    }
+
+    /** Applies one preflighted WRAM-source data prefix without publishing transient bus samples. */
+    public void advancePerformanceNativeCgbOwnedHblankDataTrusted(int ticks) {
+        advancePerformanceNativeCgbOwnedHblankDataTrusted(ticks, null);
+    }
+
+    /**
+     * Applies one preflighted WRAM/immutable-ROM data prefix. ROM bytes retain the scalar odd-slot
+     * ordering, but bypass inert outer bus layers through the same bounded physical lease.
+     */
+    public void advancePerformanceNativeCgbOwnedHblankDataTrusted(
+            int ticks, PerformanceRomAccess romAccess) {
+        if (ticks <= 0
+                || performanceNativeCgbOwnedHblankDataSpanLimit(ticks, romAccess) != ticks) {
+            throw new IllegalStateException(
+                    "HDMA burst is not stable for a native-CGB PERFORMANCE data span");
+        }
+        boolean physicalRomSource = isPerformanceOwnedRomSource();
+        int endTick = tick + ticks;
+        ppuBusGeneration += ticks;
+        for (int sourceTick = tick + 1; sourceTick <= endTick; sourceTick++) {
+            if ((sourceTick & 1) == 0) {
+                continue;
+            }
+            int j = sourceTick >> 1;
+            int sourceAddress = (src + j) & 0xffff;
+            blockData[j] = physicalRomSource
+                    ? romAccess.readPhysicalByte(romAccess.physicalOffset(sourceAddress))
+                    : readSourceByte(sourceAddress);
+            sourceBytesTransferred++;
+        }
+        tick = endTick;
+        hblankRequestAge += ticks;
+        sourceBusSample = null;
+    }
+
+    /** Stable HDMA clock contract used only by the native-CGB x2 running epoch. */
+    public boolean isPerformanceNativeCgbRunningEpochStable() {
+        return isPerformanceInactiveRequestClockStable()
+                || isPerformanceArmedHblankWaitStable();
+    }
+
+    /**
      * Replays the arithmetic part of {@link #advanceHblankRequest()} for a preflighted inactive
      * packet. Zero clocks age once per scalar dot; negative clocks remain invariant.
      */
@@ -793,6 +973,21 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
         }
         if (nextHblankRequestTicks == 0) {
             nextHblankRequestAge += ticks;
+        }
+    }
+
+    /**
+     * Native-CGB x2 counterpart of {@link #advancePerformanceInactiveRequestClockTrusted(int)}.
+     * An armed HBlank wait has two negative request clocks, so its trusted commit is a no-op;
+     * inactive zero clocks retain their established scalar-equivalent age arithmetic.
+     */
+    public void advancePerformanceNativeCgbRunningEpochClockTrusted(int ticks) {
+        if (ticks < 0 || !isPerformanceNativeCgbRunningEpochStable()) {
+            throw new IllegalStateException(
+                    "HDMA request clock is not stable for a native-CGB PERFORMANCE span");
+        }
+        if (isPerformanceInactiveRequestClockStable()) {
+            advancePerformanceInactiveRequestClockTrusted(ticks);
         }
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyPerformanceEpochTest.java
@@ -11,11 +11,13 @@ import eu.rekawek.coffeegb.core.joypad.PlayerInputSource;
 import eu.rekawek.coffeegb.core.memory.Hdma;
 import eu.rekawek.coffeegb.core.memory.cart.Rom;
 import eu.rekawek.coffeegb.core.sgb.Commands;
+import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.RecordComponent;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -65,7 +67,7 @@ public final class GameboyPerformanceEpochTest {
             long candidateFrames = 0;
             // The speed-switch preamble is about 130k master ticks. The alternating NR50
             // loop then writes every 20 double-speed master ticks, walking every phase of the
-            // 55-dot compact-output cadence and repeatedly terminating unfenced epochs.
+            // 55-dot compact-output cadence.
             for (int chunk = 0; chunk < 60; chunk++) {
                 scalarFrames += scalar.runTicks(5_000);
                 candidateFrames += candidate.runTicks(5_000);
@@ -1586,6 +1588,642 @@ public final class GameboyPerformanceEpochTest {
     }
 
     @Test
+    public void nativeCgbDoubleSpeedArmedHblankWaitMatchesScalarAcrossMultipleBurstsAndRestore()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "armed HBlank DMA");
+            startHblankDmaPair(scalar, candidate, 0x83);
+            assertTrue(candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertDeepStateEquals("armed HBlank DMA initial wait",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("armed HBlank DMA first-burst frame callbacks",
+                    scalar.runTicks(350), candidate.runTicks(350));
+
+            Hdma.HdmaState firstWait = (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertTrue("multi-block HBlank DMA did not remain armed",
+                    firstWait.transferInProgress() && firstWait.hblankTransfer());
+            assertEquals("first HBlank DMA block did not advance the source", 0xc010,
+                    firstWait.src());
+            assertEquals("post-burst request clock was not idle", -1,
+                    firstWait.hblankRequestTicks());
+            assertTrue("post-burst wait did not reopen the native x2 lease",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertTrue("armed HBlank wait had no coarse epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0);
+            assertDeepStateEquals("armed HBlank DMA after first burst",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            assertEquals("armed HBlank DMA uninterrupted frame callbacks",
+                    scalar.runTicks(1_300), candidate.runTicks(1_300));
+            assertFalse("multi-block HBlank DMA did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertDeepStateEquals("armed HBlank DMA uninterrupted completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.restoreStateSilently(scalarCheckpoint);
+            candidate.restoreStateSilently(candidateCheckpoint);
+            assertTrue("restored HBlank DMA wait lost its native x2 lease",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertEquals("armed HBlank DMA restored frame callbacks",
+                    scalar.runTicks(1_300), candidate.runTicks(1_300));
+            assertFalse("restored multi-block HBlank DMA did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertDeepStateEquals("armed HBlank DMA restored completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedArmedHblankWaitCrossesCompactSamplesWithScalarParity()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "armed HBlank audio fence");
+
+            int guard = 0;
+            boolean crossingEntry = false;
+            while (!crossingEntry && guard++ < 400_000) {
+                if (candidate.getCpu().performanceEpochEntryEligible()
+                        && candidate.getGpu().getMode() == Mode.OamSearch
+                        && candidate.getGpu().getTicksInLine() >= 12
+                        && candidate.getGpu().getTicksInLine() <= 20
+                        // One ordinary quiet dot remains before the compact sample tick.
+                        && candidate.getSound().performanceEpochSpanLimit(54) == 1
+                        // The same sample is not the synchronous host-buffer callback.
+                        && candidate.getSound().performanceFencedEpochSpanLimit(54) == 54) {
+                    var scalarProbe = scalar.captureState();
+                    var candidateProbe = candidate.captureState();
+                    startHblankDmaPair(scalar, candidate, 0xff);
+                    scalar.resetPerformanceBulkCounters();
+                    candidate.resetPerformanceBulkCounters();
+                    assertEquals("armed HBlank audio crossing probe frame callback",
+                            scalar.runTicks(2), candidate.runTicks(2));
+                    assertDeepStateEquals("armed HBlank audio crossing probe",
+                            scalar.captureStateWithoutTimeSource(),
+                            candidate.captureStateWithoutTimeSource());
+                    crossingEntry = candidate.getPerformanceEpochMaxTicks() >= 2;
+                    if (crossingEntry) {
+                        break;
+                    }
+                    scalar.restoreStateSilently(scalarProbe);
+                    candidate.restoreStateSilently(candidateProbe);
+                }
+                assertEquals("armed HBlank audio alignment frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertTrue("test did not find a fenced epoch crossing a non-callback sample",
+                    crossingEntry);
+
+            assertTrue("crossing HBlank DMA did not retain its armed wait",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertDeepStateEquals("armed HBlank audio-fence checkpoint",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            // State records are intentionally cheap restoration snapshots, not persistent
+            // values: restored array members may become live component storage. Give every
+            // matrix row its own one-shot checkpoint.
+            List<ComponentState<Gameboy>> scalarCheckpoints = new ArrayList<>(109);
+            List<ComponentState<Gameboy>> candidateCheckpoints = new ArrayList<>(109);
+            for (int checkpoint = 0; checkpoint < 109; checkpoint++) {
+                scalarCheckpoints.add(scalar.captureState());
+                candidateCheckpoints.add(candidate.captureState());
+            }
+
+            // Every possible owner budget immediately after the proven crossing must remain
+            // equal; the crossing probe above is the narrow regression assertion.
+            for (int caseIndex = 0; caseIndex < 54; caseIndex++) {
+                int budget = caseIndex == 0 ? 2 : caseIndex == 1 ? 1 : caseIndex + 1;
+                scalar.restoreStateSilently(scalarCheckpoints.get(caseIndex));
+                candidate.restoreStateSilently(candidateCheckpoints.get(caseIndex));
+                scalar.resetPerformanceBulkCounters();
+                candidate.resetPerformanceBulkCounters();
+
+                assertEquals("armed HBlank audio budget " + budget + " frame callback",
+                        scalar.runTicks(budget), candidate.runTicks(budget));
+                assertDeepStateEquals("armed HBlank audio budget " + budget,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            // Shift the checkpoint through the complete 55-dot compact-audio calendar. For each
+            // phase, run two dots beyond the old unfenced horizon so every boundary ordering is
+            // compared against the scalar whole-machine oracle.
+            boolean[] visitedHorizon = new boolean[55];
+            for (int offset = 0; offset < 55; offset++) {
+                scalar.restoreStateSilently(scalarCheckpoints.get(54 + offset));
+                candidate.restoreStateSilently(candidateCheckpoints.get(54 + offset));
+                assertEquals("armed HBlank audio phase " + offset + " setup frame callback",
+                        scalar.runTicks(offset), candidate.runTicks(offset));
+                int oldHorizon = candidate.getSound().performanceEpochSpanLimit(54);
+                assertEquals("armed HBlank audio phase " + offset + " horizon",
+                        scalar.getSound().performanceEpochSpanLimit(54), oldHorizon);
+                visitedHorizon[oldHorizon] = true;
+
+                scalar.resetPerformanceBulkCounters();
+                candidate.resetPerformanceBulkCounters();
+                int budget = oldHorizon + 2;
+                assertEquals("armed HBlank audio phase " + offset + " frame callback",
+                        scalar.runTicks(budget), candidate.runTicks(budget));
+                assertDeepStateEquals("armed HBlank audio phase " + offset,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+            for (int horizon = 0; horizon < visitedHorizon.length; horizon++) {
+                assertTrue("compact-audio horizon was not covered: " + horizon,
+                        visitedHorizon[horizon]);
+            }
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedOwnedHblankWramDataMatchesScalarThroughCommitAndRestore()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "owned HBlank WRAM data");
+            startHblankDmaPair(scalar, candidate, 0xc000, 0x82);
+            advancePairToOwnedHblankDataTickZero(scalar, candidate,
+                    "owned HBlank WRAM data");
+
+            int sourceBeforePrefix =
+                    ((Hdma.HdmaState) candidate.getHdma().captureState()).src();
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("owned HBlank data-prefix frame callbacks",
+                    scalar.runTicks(31), candidate.runTicks(31));
+            assertEquals("owned HBlank path did not consume the complete data prefix", 31L,
+                    candidate.getPerformanceHdmaOwnedTicks());
+            assertEquals("owned HBlank path split one preflighted data prefix", 1L,
+                    candidate.getPerformanceHdmaOwnedSpanCount());
+            assertEquals("owned HBlank prefix crossed the scalar destination commit", 31,
+                    ((Hdma.HdmaState) candidate.getHdma().captureState()).tick());
+            assertDeepStateEquals("owned HBlank data prefix",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("owned HBlank scalar commit frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            Hdma.HdmaState committed =
+                    (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertEquals("owned HBlank scalar commit did not advance the source",
+                    (sourceBeforePrefix + 0x10) & 0xffff, committed.src());
+            assertFalse("owned HBlank scalar commit retained the frozen-CPU lease",
+                    candidate.getCpu().performanceHdmaOwnedBlockCpuFrozenEligible());
+            assertDeepStateEquals("owned HBlank scalar destination commit",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("owned HBlank uninterrupted completion frame callbacks",
+                    scalar.runTicks(1_300), candidate.runTicks(1_300));
+            assertFalse("owned HBlank multi-block transfer did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertTrue("later owned HBlank bursts had no packet coverage",
+                    candidate.getPerformanceHdmaOwnedSpanCount() > 1L);
+            assertDeepStateEquals("owned HBlank uninterrupted completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.restoreStateSilently(scalarCheckpoint);
+            candidate.restoreStateSilently(candidateCheckpoint);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("owned HBlank restored completion frame callbacks",
+                    scalar.runTicks(1_332), candidate.runTicks(1_332));
+            assertFalse("restored owned HBlank multi-block transfer did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertTrue("restored owned HBlank bursts had no packet coverage",
+                    candidate.getPerformanceHdmaOwnedTicks() > 0L);
+            assertDeepStateEquals("owned HBlank restored completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedOwnedHblankPhysicalRomDataMatchesScalarThroughRestore()
+            throws Exception {
+        byte[] image = nativeMbc7(doubleSpeedLoop());
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "owned HBlank physical ROM data");
+            startHblankDmaPair(scalar, candidate, 0x4000, 0x82);
+            advancePairToOwnedHblankDataTickZero(scalar, candidate,
+                    "owned HBlank physical ROM data", true);
+
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("owned HBlank ROM data-prefix frame callbacks",
+                    scalar.runTicks(31), candidate.runTicks(31));
+            assertEquals("immutable ROM source did not enter the owned-HDMA packet", 31L,
+                    candidate.getPerformanceHdmaOwnedTicks());
+            assertEquals("immutable ROM prefix was split", 1L,
+                    candidate.getPerformanceHdmaOwnedSpanCount());
+            assertDeepStateEquals("owned HBlank physical ROM data prefix",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("owned HBlank ROM scalar commit frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertFalse("ROM block commit retained the frozen-CPU lease",
+                    candidate.getCpu().performanceHdmaOwnedBlockCpuFrozenEligible());
+            assertDeepStateEquals("owned HBlank physical ROM scalar commit",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.restoreStateSilently(scalarCheckpoint);
+            candidate.restoreStateSilently(candidateCheckpoint);
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("restored ROM-source HBlank DMA frame callbacks",
+                    scalar.runTicks(1_332), candidate.runTicks(1_332));
+            assertFalse("restored ROM-source HBlank DMA did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertTrue("restored ROM-source bursts had no packet coverage",
+                    candidate.getPerformanceHdmaOwnedTicks() > 0L);
+            assertDeepStateEquals("restored owned HBlank physical ROM completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedOwnedHblankDataRejectsUnsafeSourcesAndOamDma()
+            throws Exception {
+        assertOwnedHblankDataStaysScalar(0x4000, false, "ROM source");
+        assertOwnedHblankDataStaysScalar(0xc000, true, "OAM-DMA overlap");
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedLyPollingMatchesScalarAcrossLinesAndRestore()
+            throws Exception {
+        byte[] image = nativeDoubleSpeedLyPollingLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "native x2 FF44 polling");
+            int startLine = candidate.getGpu().getLine();
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            int[] chunks = {73, 911, 457, 1_003};
+            long scalarFrames = 0;
+            long candidateFrames = 0;
+            for (int chunk : chunks) {
+                scalarFrames += scalar.runTicks(chunk);
+                candidateFrames += candidate.runTicks(chunk);
+                assertDeepStateEquals("native x2 FF44 polling chunk " + chunk,
+                        scalar.captureStateWithoutTimeSource(),
+                        candidate.captureStateWithoutTimeSource());
+            }
+
+            assertEquals("native x2 FF44 polling frame callbacks",
+                    scalarFrames, candidateFrames);
+            assertNotEquals("native x2 FF44 polling did not cross a scanline",
+                    startLine, candidate.getGpu().getLine());
+            assertEquals("custom-source FF44 oracle unexpectedly entered an epoch",
+                    0L, scalar.getPerformanceEpochTicks());
+            assertTrue("native x2 FF44 polling had no epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertEquals("stable FF44 read terminated a native x2 epoch", 0L,
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertEquals("stable FF44 read recorded a native x2 fence", 0L,
+                    candidate.getPerformanceEpochFenceAttemptCount());
+
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            assertEquals("native x2 FF44 uninterrupted frame callbacks",
+                    scalar.runTicks(1_379), candidate.runTicks(1_379));
+            assertDeepStateEquals("native x2 FF44 uninterrupted continuation",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.restoreStateSilently(scalarCheckpoint);
+            candidate.restoreStateSilently(candidateCheckpoint);
+            assertEquals("native x2 FF44 restored frame callbacks",
+                    scalar.runTicks(1_379), candidate.runTicks(1_379));
+            assertDeepStateEquals("native x2 FF44 restored continuation",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedArmedHblankLyPollingMatchesScalarAcrossBurstsAndRestore()
+            throws Exception {
+        byte[] image = nativeDoubleSpeedLyPollingLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "armed HBlank FF44 polling");
+            startHblankDmaPair(scalar, candidate, 0x83);
+            assertTrue("FF44 fixture did not start in an armed HBlank wait",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals("armed HBlank FF44 first-burst frame callbacks",
+                    scalar.runTicks(350), candidate.runTicks(350));
+            assertTrue("armed HBlank FF44 wait had no epoch coverage",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertEquals("armed stable FF44 read reached the terminal bus", 0L,
+                    candidate.getCpu().getPerformanceEpochTerminalAccesses());
+            assertEquals("armed stable FF44 read recorded a decoded fence", 0L,
+                    candidate.getPerformanceEpochFenceAttemptCount());
+            assertTrue("FF44 polling transfer did not remain armed after its first burst",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertDeepStateEquals("armed HBlank FF44 after first burst",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            var scalarCheckpoint = scalar.captureState();
+            var candidateCheckpoint = candidate.captureState();
+            assertEquals("armed HBlank FF44 uninterrupted frame callbacks",
+                    scalar.runTicks(1_300), candidate.runTicks(1_300));
+            assertFalse("armed HBlank FF44 transfer did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertDeepStateEquals("armed HBlank FF44 uninterrupted completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.restoreStateSilently(scalarCheckpoint);
+            candidate.restoreStateSilently(candidateCheckpoint);
+            assertTrue("restored FF44 polling wait lost its armed lease",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertEquals("armed HBlank FF44 restored frame callbacks",
+                    scalar.runTicks(1_300), candidate.runTicks(1_300));
+            assertFalse("restored armed HBlank FF44 transfer did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertEquals("restored armed FF44 read recorded a decoded fence", 0L,
+                    candidate.getPerformanceEpochFenceAttemptCount());
+            assertDeepStateEquals("armed HBlank FF44 restored completion",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedStatHorizonKeepsLyTransitionWindowsScalar()
+            throws Exception {
+        byte[] image = nativeDoubleSpeedLyPollingLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "native x2 FF44 transition horizon");
+            advancePairToOddVisibleLineDot(scalar, candidate, 447,
+                    "native x2 FF44 line-tail horizon");
+            int line = candidate.getGpu().getLine();
+            assertEquals("FF44 tail fixture did not select an odd line", 1, line & 1);
+            assertEquals("FF44 changed before its rephased tail slot", line,
+                    candidate.getAddressSpace().getByte(0xff44));
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            while (candidate.getGpu().getTicksInLine() < 450) {
+                assertEquals("FF44 pre-ripple frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertEquals("STAT horizon admitted the dot-447..449 tail", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertEquals(line, candidate.getAddressSpace().getByte(0xff44));
+
+            assertEquals("FF44 ripple frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("rephased odd-line FF44 ripple", line & (line + 1),
+                    candidate.getAddressSpace().getByte(0xff44));
+            assertEquals("FF44 ripple slot entered an epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+
+            assertEquals("FF44 main-edge frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("native x2 FF44 did not advance at dot 452", line + 1,
+                    candidate.getAddressSpace().getByte(0xff44));
+            assertEquals("FF44 dot-452 edge entered an epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("native x2 FF44 ordinary-line edge",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            advancePairToRasterDot(scalar, candidate, 153, 0,
+                    "native x2 FF44 line-153 horizon");
+            assertEquals(153, candidate.getAddressSpace().getByte(0xff44));
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("FF44 line-153 reset frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("rephased native x2 FF44 did not reset at dot 1", 0,
+                    candidate.getAddressSpace().getByte(0xff44));
+            while (candidate.getGpu().getTicksInLine() < 13) {
+                assertEquals("FF44 line-153 startup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertEquals("STAT horizon admitted the line-153 reset/startup window", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("native x2 FF44 line-153 edge",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            int lcdc = scalar.getAddressSpace().getByte(0xff40);
+            assertEquals(lcdc, candidate.getAddressSpace().getByte(0xff40));
+            for (Gameboy gameboy : new Gameboy[]{scalar, candidate}) {
+                gameboy.getAddressSpace().setByte(0xff40, lcdc & 0x7f);
+                gameboy.getAddressSpace().setByte(0xff40, lcdc | 0x80);
+            }
+            advancePairToRasterDot(scalar, candidate, 153, 0,
+                    "LCD-restarted native x2 FF44 line-153 horizon");
+            assertEquals(153, candidate.getAddressSpace().getByte(0xff44));
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("unrephased FF44 line-153 dot-1 frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("unrephased native x2 FF44 reset too early", 153,
+                    candidate.getAddressSpace().getByte(0xff44));
+            assertEquals("unrephased FF44 line-153 reset frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals("unrephased native x2 FF44 did not reset at dot 2", 0,
+                    candidate.getAddressSpace().getByte(0xff44));
+            while (candidate.getGpu().getTicksInLine() < 13) {
+                assertEquals("unrephased FF44 line-153 startup frame callback",
+                        scalar.runTicks(1), candidate.runTicks(1));
+            }
+            assertEquals("STAT horizon admitted the unrephased line-153 startup window", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("unrephased native x2 FF44 line-153 edge",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedLycOnlyCheckpointReplayMatchesScalarAtLineStartAndTail()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "native x2 LYC-only checkpoint replay");
+            for (Gameboy gameboy : new Gameboy[]{scalar, candidate}) {
+                gameboy.getAddressSpace().setByte(0xff45, 72);
+                gameboy.getAddressSpace().setByte(0xff41, 0x40);
+            }
+
+            advancePairToRasterDot(scalar, candidate, 10, 447,
+                    "native x2 LYC-only line tail");
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("LYC-only tail frame callbacks",
+                    scalar.runTicks(8), candidate.runTicks(8));
+            assertEquals("scalar oracle entered an epoch", 0L,
+                    scalar.getPerformanceEpochTicks());
+            assertTrue("dot-447 STAT checkpoint did not enter the replay lane",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertTrue("line-tail STAT replay did not reuse the trusted raster transaction",
+                    candidate.getPerformanceEpochRasterFastTicks() > 0L);
+            assertDeepStateEquals("LYC-only tail replay",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            assertEquals("line rollover frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals(11, candidate.getGpu().getLine());
+            assertEquals(0, candidate.getGpu().getTicksInLine());
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("LYC-only line-start frame callbacks",
+                    scalar.runTicks(13), candidate.runTicks(13));
+            assertTrue("dot-0 STAT checkpoint did not enter the replay lane",
+                    candidate.getPerformanceEpochTicks() > 0L);
+            assertTrue("line-start STAT replay did not reuse the mode-2 bulk transaction",
+                    candidate.getPerformanceEpochMode2BulkTicks() > 0L);
+            assertDeepStateEquals("LYC-only line-start replay",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedArmedHblankRequestEdgeRemainsScalar()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "armed HBlank request edge");
+            startHblankDmaPair(scalar, candidate, 0x81);
+            scalar.getGpu().setPerformanceScanlineEnabled(true);
+            candidate.getGpu().setPerformanceScanlineEnabled(true);
+
+            int guard = 0;
+            while (!isAtArmedHblankRequestEdge(scalar, candidate) && guard++ < 456) {
+                assertEquals("armed HBlank request-edge setup frame callback",
+                        scalar.tick(), candidate.tick());
+            }
+            assertTrue("test did not reach the reserved HBlank request edge", guard < 456);
+            assertEquals(-1, ((Hdma.HdmaState) candidate.getHdma().captureState())
+                    .hblankRequestTicks());
+            assertDeepStateEquals("before reserved HBlank request edge",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("reserved HBlank request-edge frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+
+            Hdma.HdmaState request = (Hdma.HdmaState) candidate.getHdma().captureState();
+            assertEquals(Mode.HBlank, candidate.getGpu().getMode());
+            assertEquals("HBlank edge did not arm the three-dot synchronizer", 3,
+                    request.hblankRequestTicks());
+            assertEquals("HBlank request edge crossed a native x2 epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("after reserved HBlank request edge",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedArmedHblankControlWritesRemainScalar()
+            throws Exception {
+        assertArmedHblankControlWriteRemainsScalar(0x40, 0x00, "LCDC off");
+        assertArmedHblankControlWriteRemainsScalar(0x55, 0x00, "HDMA cancel");
+    }
+
+    @Test
+    public void nativeCgbDoubleSpeedArmedHblankHaltRemainsScalar()
+            throws Exception {
+        byte[] image = doubleSpeedLoop();
+        image[0x200] = 0x76; // HALT
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate,
+                    "armed HBlank HALT");
+            startHblankDmaPair(scalar, candidate, 0x83);
+            scalar.getCpu().getRegisters().setPC(0x0200);
+            candidate.getCpu().getRegisters().setPC(0x0200);
+            assertTrue(candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertDeepStateEquals("before armed HBlank HALT",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals("armed HBlank HALT frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+
+            assertEquals(Cpu.State.HALTED, candidate.getCpu().getState());
+            assertEquals("HALT crossed the armed-HDMA native x2 epoch", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertDeepStateEquals("after scalar armed HBlank HALT",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    @Test
     public void cgbCompatibilityMeasuredWindowRetainsEpochLane() throws Exception {
         try (Gameboy gameboy = cgbCompatibilitySession(
                 dmgRomWramLoop(), PlayerInputSource.RELEASED, ExecutionMode.PERFORMANCE)) {
@@ -1670,6 +2308,250 @@ public final class GameboyPerformanceEpochTest {
                 .setExecutionMode(ExecutionMode.PERFORMANCE)
                 .setSupportBatterySave(false)
                 .build();
+    }
+
+    private static void advancePairToNativeDoubleSpeedMode2EpochEntry(
+            Gameboy scalar, Gameboy candidate, String label) {
+        int guard = 0;
+        while (!(candidate.getSpeedMode().getSpeedMode() == 2
+                && candidate.getCpu().getState() == Cpu.State.OPCODE
+                && candidate.getCpu().getDebugMachineCycle() == 1
+                && candidate.getCpu().performanceEpochEntryEligible()
+                && !candidate.getGpu().isFirstLine()
+                && candidate.getGpu().getLine() < 144
+                && candidate.getGpu().getMode() == Mode.OamSearch
+                && candidate.getGpu().getTicksInLine() >= 12
+                && candidate.getGpu().getTicksInLine() <= 40)
+                && guard++ < 400_000) {
+            assertEquals(label + " setup frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue(label + " did not reach a native x2 mode-2 entry", guard < 400_000);
+        assertDeepStateEquals(label + " native x2 mode-2 entry",
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static void advancePairToEarlyNativeDoubleSpeedVblank(
+            Gameboy scalar, Gameboy candidate, String label) {
+        int guard = 0;
+        while (!(candidate.getSpeedMode().getSpeedMode() == 2
+                && !candidate.getGpu().isFirstLine()
+                && candidate.getGpu().getMode() == Mode.VBlank
+                && candidate.getGpu().getLine() == 145
+                && candidate.getGpu().getTicksInLine() >= 12
+                && candidate.getGpu().getTicksInLine() <= 28)
+                && guard++ < 400_000) {
+            assertEquals(label + " setup frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue(label + " did not reach early native x2 VBlank", guard < 400_000);
+        assertDeepStateEquals(label + " early native x2 VBlank",
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static void startHblankDmaPair(
+            Gameboy scalar, Gameboy candidate, int control) {
+        startHblankDmaPair(scalar, candidate, 0xc000, control);
+    }
+
+    private static void startHblankDmaPair(
+            Gameboy scalar, Gameboy candidate, int source, int control) {
+        for (Gameboy gameboy : new Gameboy[]{scalar, candidate}) {
+            AddressSpace bus = gameboy.getAddressSpace();
+            // SKIP boot begins with an already-enabled GPU and therefore has no LCD transition
+            // from which Gameboy would otherwise publish this mirror to HDMA.
+            gameboy.getHdma().onLcdSwitch(gameboy.getGpu().isLcdEnabled());
+            for (int offset = 0; offset < 0x40; offset++) {
+                bus.setByte(0xc000 + offset, (offset * 37 + 0x19) & 0xff);
+            }
+            bus.setByte(0xff51, source >>> 8);
+            bus.setByte(0xff52, source & 0xf0);
+            bus.setByte(0xff53, 0x00);
+            bus.setByte(0xff54, 0x00);
+            bus.setByte(0xff55, control);
+        }
+    }
+
+    private static void advancePairToOwnedHblankDataTickZero(
+            Gameboy scalar, Gameboy candidate, String label) {
+        advancePairToOwnedHblankDataTickZero(scalar, candidate, label, false);
+    }
+
+    private static void advancePairToOwnedHblankDataTickZero(
+            Gameboy scalar, Gameboy candidate, String label, boolean allowPhysicalRom) {
+        int guard = 0;
+        while (!isOwnedHblankDataTickZero(candidate, allowPhysicalRom)
+                && guard++ < 456 * 4) {
+            assertEquals(label + " setup frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        Hdma.HdmaState hdma = (Hdma.HdmaState) candidate.getHdma().captureState();
+        assertTrue(label + " did not reach an admissible first data tick: tick="
+                        + hdma.tick() + " line=" + candidate.getGpu().getLine()
+                        + " dot=" + candidate.getGpu().getTicksInLine()
+                        + " hdma="
+                        + (allowPhysicalRom
+                        ? candidate.getHdma()
+                                .isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                        : candidate.getHdma()
+                                .isPerformanceNativeCgbOwnedHblankDataStable())
+                        + " cpu="
+                        + candidate.getCpu().performanceHdmaOwnedBlockCpuFrozenEligible(),
+                guard < 456 * 4);
+        assertTrue(label + " did not retain a frozen prefetched opcode",
+                candidate.getCpu().performanceHdmaOwnedBlockCpuFrozenEligible());
+        assertDeepStateEquals(label + " tick-zero entry",
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static boolean isOwnedHblankDataTickZero(Gameboy gameboy) {
+        return isOwnedHblankDataTickZero(gameboy, false);
+    }
+
+    private static boolean isOwnedHblankDataTickZero(
+            Gameboy gameboy, boolean allowPhysicalRom) {
+        Hdma.HdmaState hdma = (Hdma.HdmaState) gameboy.getHdma().captureState();
+        return hdma.tick() == 0
+                && (allowPhysicalRom
+                ? gameboy.getHdma()
+                        .isPerformanceNativeCgbOwnedHblankDataStructurallyStable()
+                : gameboy.getHdma().isPerformanceNativeCgbOwnedHblankDataStable())
+                && gameboy.getCpu().performanceHdmaOwnedBlockCpuFrozenEligible();
+    }
+
+    private static void assertOwnedHblankDataStaysScalar(
+            int source, boolean startOamDma, String label) throws Exception {
+        byte[] image = doubleSpeedLoop();
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate, label);
+            startHblankDmaPair(scalar, candidate, source, 0x80);
+            if (startOamDma) {
+                scalar.getAddressSpace().setByte(0xff46, 0xc0);
+                candidate.getAddressSpace().setByte(0xff46, 0xc0);
+            }
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+
+            assertEquals(label + " frame callbacks",
+                    scalar.runTicks(350), candidate.runTicks(350));
+            assertFalse(label + " HBlank transfer did not complete",
+                    candidate.getHdma().hasActiveOrPendingTransfer());
+            assertEquals(label + " entered the owned-HDMA packet", 0L,
+                    candidate.getPerformanceHdmaOwnedTicks());
+            assertDeepStateEquals(label,
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
+    }
+
+    private static void advancePairToOddVisibleLineDot(
+            Gameboy scalar, Gameboy candidate, int targetDot, String label) {
+        int guard = 0;
+        while (!(candidate.getGpu().getLine() < 144
+                && (candidate.getGpu().getLine() & 1) != 0
+                && candidate.getGpu().getTicksInLine() == targetDot)
+                && guard++ < 456 * 3) {
+            assertEquals(label + " frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue(label + " did not reach an odd visible line dot " + targetDot,
+                guard < 456 * 3);
+        assertDeepStateEquals(label,
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static void advancePairToRasterDot(
+            Gameboy scalar, Gameboy candidate, int targetLine, int targetDot, String label) {
+        int guard = 0;
+        while (!(candidate.getGpu().getLine() == targetLine
+                && candidate.getGpu().getTicksInLine() == targetDot)
+                && guard++ < 456 * 155) {
+            assertEquals(label + " frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+        }
+        assertTrue(label + " did not reach line " + targetLine + " dot " + targetDot,
+                guard < 456 * 155);
+        assertDeepStateEquals(label,
+                scalar.captureStateWithoutTimeSource(),
+                candidate.captureStateWithoutTimeSource());
+    }
+
+    private static boolean isAtArmedHblankRequestEdge(
+            Gameboy scalar, Gameboy candidate) {
+        if (candidate.getGpu().getMode() != Mode.PixelTransfer
+                || !candidate.getGpu().isPerformanceScanlineCursorActive()
+                || !candidate.getHdma().isPerformanceArmedHblankWaitStable()) {
+            return false;
+        }
+        int scalarLimit = scalar.getGpu().performanceEpochSpanLimit(1);
+        int candidateLimit = candidate.getGpu().performanceEpochSpanLimit(1);
+        assertEquals("armed HBlank request-edge horizon", scalarLimit, candidateLimit);
+        return candidateLimit == 0;
+    }
+
+    private static void assertArmedHblankControlWriteRemainsScalar(
+            int register, int value, String label) throws Exception {
+        byte[] image = doubleSpeedLoop();
+        image[0x200] = (byte) 0xe0; // LDH (a8),A
+        image[0x201] = (byte) register;
+        image[0x202] = 0x18; // JR 0202
+        image[0x203] = (byte) 0xfe;
+        try (Gameboy scalar = nativeDoubleSpeedSession(
+                image, PlayerInputSnapshot::released);
+             Gameboy candidate = nativeDoubleSpeedSession(
+                     image, PlayerInputSource.RELEASED)) {
+            advancePairToNativeDoubleSpeedMode2EpochEntry(scalar, candidate, label);
+            startHblankDmaPair(scalar, candidate, 0x83);
+            for (Gameboy gameboy : new Gameboy[]{scalar, candidate}) {
+                gameboy.getCpu().getRegisters().setA(value);
+                gameboy.getCpu().getRegisters().setPC(0x0200);
+            }
+
+            int guard = 0;
+            while (!(candidate.getCpu().getState() == Cpu.State.RUNNING
+                    && candidate.getCpu().getDebugOpcode() == 0xe0
+                    && candidate.getCpu().getRegisters().getPC() == 0x0202
+                    && candidate.getCpu().getDebugMachineCycle() == 1)
+                    && guard++ < 32) {
+                assertEquals(label + " decode frame callback",
+                        scalar.tick(), candidate.tick());
+            }
+            assertTrue(label + " did not reach the decoded write boundary", guard < 32);
+            assertTrue(label + " lost the armed HBlank wait before the write",
+                    candidate.getHdma().isPerformanceArmedHblankWaitStable());
+            assertDeepStateEquals(label + " before decoded write",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+
+            scalar.resetPerformanceBulkCounters();
+            candidate.resetPerformanceBulkCounters();
+            assertEquals(label + " write frame callback",
+                    scalar.runTicks(1), candidate.runTicks(1));
+            assertEquals(label + " crossed the decoded epoch fence", 0L,
+                    candidate.getPerformanceEpochTicks());
+            assertEquals(label + " did not exercise the armed decoded-memory fence", 1L,
+                    candidate.getPerformanceEpochFenceAttemptCount());
+            if (register == 0x40) {
+                assertFalse("LCDC-off write did not disable the GPU",
+                        candidate.getGpu().isLcdEnabled());
+                assertEquals("LCDC-off write did not release the armed HDMA request", 0,
+                        ((Hdma.HdmaState) candidate.getHdma().captureState())
+                                .hblankRequestTicks());
+            } else {
+                assertFalse("HDMA5 write did not cancel the armed transfer",
+                        candidate.getHdma().hasActiveOrPendingTransfer());
+            }
+            assertDeepStateEquals(label + " after scalar write",
+                    scalar.captureStateWithoutTimeSource(),
+                    candidate.captureStateWithoutTimeSource());
+        }
     }
 
     private static Gameboy nativeDoubleSpeedSession(
@@ -2166,6 +3048,11 @@ public final class GameboyPerformanceEpochTest {
         return nativeColor(mbc3(image));
     }
 
+    private static byte[] nativeMbc7(byte[] image) {
+        image[0x147] = 0x22; // MBC7 + sensor + EEPROM
+        return nativeColor(image);
+    }
+
     private static void updateHeaderChecksum(byte[] image) {
         int checksum = 0;
         for (int address = 0x134; address <= 0x14c; address++) {
@@ -2186,6 +3073,15 @@ public final class GameboyPerformanceEpochTest {
         image[0x107] = 0x06;
         image[0x108] = 0x01;
         image[0x143] = (byte) 0x80;
+        return image;
+    }
+
+    private static byte[] nativeDoubleSpeedLyPollingLoop() {
+        byte[] image = doubleSpeedLoop();
+        image[0x106] = (byte) 0xf0; // LDH A,(FF44)
+        image[0x107] = 0x44;
+        image[0x108] = 0x18; // JR 0106
+        image[0x109] = (byte) 0xfc;
         return image;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPerformanceEpochTest.java
@@ -41,7 +41,287 @@ public final class CpuPerformanceEpochTest {
         assertEquals(1, memory.writes);
         assertEquals(0xff40, memory.lastWriteAddress);
         assertEquals(1, cpu.getPerformanceEpochTerminalAccesses());
+        assertEquals(1L, cpu.getPerformanceEpochFenceAttemptCount());
+        assertEquals(0L, cpu.getPerformanceEpochCartWindowFenceAttemptCount());
         assertTrue("journal is one-shot", !cpu.replayPerformanceEpochJournal());
+    }
+
+    @Test
+    public void nativeCgbEpochAdmitsStableLyReadWithScalarParityAtEveryBudget()
+            throws Exception {
+        assertStableLyReadEpochMatchesScalar(false);
+    }
+
+    @Test
+    public void armedHblankWaitEpochAdmitsStableLyReadWithScalarParityAtEveryBudget()
+            throws Exception {
+        assertStableLyReadEpochMatchesScalar(true);
+    }
+
+    @Test
+    public void stableLyReadLeaseDoesNotLeakIntoPlainEpoch() {
+        for (boolean armed : new boolean[]{false, true}) {
+            LeasedMemory memory = new LeasedMemory(0, 0x4000);
+            memory.bytes[0] = (byte) 0xf0; // LDH A,(FF44), under the native-CGB lease
+            memory.bytes[1] = 0x44;
+            memory.bytes[2] = (byte) 0xf0; // LDH A,(FF44), through the plain API
+            memory.bytes[3] = 0x44;
+            System.arraycopy(memory.bytes, 0, memory.physicalBytes, 0, 4);
+            memory.bytes[0xff44] = 0x66;
+            Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                    doubleSpeed(), new Display(false));
+
+            int leasedElapsed = armed
+                    ? cpu.runNativeCgbArmedHblankWaitPerformanceEpoch(6)
+                    : cpu.runNativeCgbPerformanceEpoch(6);
+            String path = armed ? "armed HBlank wait" : "native CGB";
+            assertEquals(path + " did not finish its leased FF44 read", 6, leasedElapsed);
+            assertEquals(path + " did not read FF44", 1, memory.busReads);
+            assertEquals(0L, cpu.getPerformanceEpochTerminalAccesses());
+            assertEquals(0L, cpu.getPerformanceEpochFenceAttemptCount());
+
+            cpu.resetPerformanceEpochTelemetry();
+            int plainElapsed = cpu.runPerformanceEpoch(54);
+
+            assertEquals(path + " leaked its stable-LY lease into the plain API", 6,
+                    plainElapsed);
+            assertEquals(path + " plain API did not delegate exactly one FF44 read", 2,
+                    memory.busReads);
+            assertEquals(0x66, cpu.getRegisters().getA());
+            assertEquals(4, cpu.getRegisters().getPC());
+            assertEquals(Cpu.State.OPCODE, cpu.getState());
+            assertEquals(1L, cpu.getPerformanceEpochTerminalAccesses());
+            assertEquals(1L, cpu.getPerformanceEpochFenceAttemptCount());
+            assertFalse(cpu.hasPerformanceEpochJournal());
+        }
+    }
+
+    @Test
+    public void armedHblankWaitEpochKeepsOtherPpuIoAndLyWritesBeforeTheBus()
+            throws Exception {
+        String[] labels = {"FF41 read", "FF45 read", "FF44 write", "FF44 RMW"};
+        int[][] programs = {
+                {0xf0, 0x41},       // LDH A,(FF41)
+                {0xf0, 0x45},       // LDH A,(FF45)
+                {0xe0, 0x44},       // LDH (FF44),A
+                {0x34}              // INC (HL), with HL=FF44
+        };
+        int[] addresses = {0xff41, 0xff45, 0xff44, 0xff44};
+
+        for (int index = 0; index < labels.length; index++) {
+            LeasedMemory directMemory = new LeasedMemory(0, 0x4000);
+            ParityMemory scalarMemory = new ParityMemory();
+            for (int offset = 0; offset < programs[index].length; offset++) {
+                directMemory.bytes[offset] = (byte) programs[index][offset];
+                directMemory.physicalBytes[offset] = (byte) programs[index][offset];
+                scalarMemory.bytes[offset] = (byte) programs[index][offset];
+            }
+            directMemory.bytes[addresses[index]] = 0x23;
+            scalarMemory.bytes[addresses[index]] = 0x23;
+
+            InterruptManager directInterrupts = new InterruptManager(true);
+            InterruptManager scalarInterrupts = new InterruptManager(true);
+            Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            direct.getRegisters().setA(0x45);
+            direct.getRegisters().setHL(0xff44);
+            scalar.restoreState(direct.captureState());
+            scalarInterrupts.restoreState(directInterrupts.captureState());
+
+            int elapsed = direct.runNativeCgbArmedHblankWaitPerformanceEpoch(54);
+            assertTrue(labels[index] + " safe prefix made no progress", elapsed > 0);
+            for (int tick = 0; tick < elapsed; tick++) {
+                scalar.tick();
+            }
+
+            assertDeepEquals(labels[index] + " CPU boundary",
+                    scalar.captureState(), direct.captureState());
+            assertDeepEquals(labels[index] + " interrupt boundary",
+                    scalarInterrupts.captureState(), directInterrupts.captureState());
+            assertArrayEquals(labels[index] + " memory",
+                    scalarMemory.bytes, directMemory.bytes);
+            assertEquals(labels[index] + " crossed its decoded read", 0,
+                    directMemory.busReads);
+            assertEquals(labels[index] + " changed the target byte", 0x23,
+                    directMemory.bytes[addresses[index]] & 0xff);
+            assertFalse(labels[index] + " was journaled",
+                    direct.hasPerformanceEpochJournal());
+            assertEquals(labels[index] + " delegated a terminal access", 0L,
+                    direct.getPerformanceEpochTerminalAccesses());
+            assertEquals(labels[index] + " did not record one decoded fence", 1L,
+                    direct.getPerformanceEpochFenceAttemptCount());
+            assertEquals(Cpu.State.RUNNING, direct.getState());
+        }
+    }
+
+    @Test
+    public void statReplayEpochKeepsLyReadBeforeTheBusAfterASafePrefix()
+            throws Exception {
+        LeasedMemory directMemory = new LeasedMemory(0, 0x4000);
+        ParityMemory scalarMemory = new ParityMemory();
+        int[] program = {0x00, 0xf0, 0x44}; // NOP; LDH A,(FF44)
+        for (int offset = 0; offset < program.length; offset++) {
+            directMemory.bytes[offset] = (byte) program[offset];
+            directMemory.physicalBytes[offset] = (byte) program[offset];
+            scalarMemory.bytes[offset] = (byte) program[offset];
+        }
+        directMemory.bytes[0xff44] = 0x23;
+        scalarMemory.bytes[0xff44] = 0x23;
+        InterruptManager directInterrupts = new InterruptManager(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                doubleSpeed(), new Display(false));
+        Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                doubleSpeed(), new Display(false));
+        scalar.restoreState(direct.captureState());
+        scalarInterrupts.restoreState(directInterrupts.captureState());
+
+        int elapsed = direct.runNativeCgbStatReplayPerformanceEpoch(54);
+        assertTrue("safe NOP prefix made no progress", elapsed > 0);
+        for (int tick = 0; tick < elapsed; tick++) {
+            scalar.tick();
+        }
+
+        assertDeepEquals("STAT replay CPU boundary",
+                scalar.captureState(), direct.captureState());
+        assertDeepEquals("STAT replay interrupt boundary",
+                scalarInterrupts.captureState(), directInterrupts.captureState());
+        assertEquals("STAT replay crossed the FF44 read", 0, directMemory.busReads);
+        assertEquals("STAT replay did not record the FF44 fence", 1L,
+                direct.getPerformanceEpochFenceAttemptCount());
+        assertEquals(0L, direct.getPerformanceEpochTerminalAccesses());
+        assertFalse(direct.hasPerformanceEpochJournal());
+    }
+
+    @Test
+    public void statReplayEpochLeavesHaltOnTheZeroDotScalarBoundary()
+            throws Exception {
+        LeasedMemory memory = new LeasedMemory(0, 0x4000);
+        memory.bytes[0] = 0x00;
+        memory.bytes[1] = 0x76;
+        memory.physicalBytes[0] = 0x00;
+        memory.physicalBytes[1] = 0x76;
+        InterruptManager interrupts = new InterruptManager(true);
+        Cpu cpu = new Cpu(memory, interrupts, null, doubleSpeed(), new Display(false));
+        assertTrue(cpu.runNativeCgbStatReplayPerformanceEpoch(54) > 0);
+        assertEquals(1, cpu.getRegisters().getPC());
+        var cpuState = cpu.captureState();
+        var interruptState = interrupts.captureState();
+
+        assertEquals(0, cpu.runNativeCgbStatReplayPerformanceEpoch(54));
+        assertDeepEquals("zero-dot STAT replay HALT CPU", cpuState, cpu.captureState());
+        assertDeepEquals("zero-dot STAT replay HALT interrupts",
+                interruptState, interrupts.captureState());
+    }
+
+    @Test
+    public void armedHblankWaitEpochStopsBeforeLcdcAndHdmaControlWrites()
+            throws Exception {
+        int[] addresses = {0xff40, 0xff55};
+        for (int address : addresses) {
+            LeasedMemory directMemory = new LeasedMemory(0, 0x4000);
+            ParityMemory scalarMemory = new ParityMemory();
+            int[] program = {0xe0, address & 0xff}; // LDH (a8),A
+            for (int offset = 0; offset < program.length; offset++) {
+                directMemory.bytes[offset] = (byte) program[offset];
+                directMemory.physicalBytes[offset] = (byte) program[offset];
+                scalarMemory.bytes[offset] = (byte) program[offset];
+            }
+            directMemory.bytes[address] = 0x12;
+            scalarMemory.bytes[address] = 0x12;
+
+            InterruptManager directInterrupts = new InterruptManager(true);
+            InterruptManager scalarInterrupts = new InterruptManager(true);
+            Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            direct.getRegisters().setA(0x34);
+            scalar.restoreState(direct.captureState());
+            scalarInterrupts.restoreState(directInterrupts.captureState());
+
+            int elapsed = direct.runNativeCgbArmedHblankWaitPerformanceEpoch(54);
+            assertTrue("0x" + Integer.toHexString(address) + " prefix made no progress",
+                    elapsed > 0);
+            for (int tick = 0; tick < elapsed; tick++) {
+                scalar.tick();
+            }
+
+            assertDeepEquals("0x" + Integer.toHexString(address) + " CPU boundary",
+                    scalar.captureState(), direct.captureState());
+            assertDeepEquals("0x" + Integer.toHexString(address) + " interrupt boundary",
+                    scalarInterrupts.captureState(), directInterrupts.captureState());
+            assertEquals("unsafe write crossed the decoded fence", 0x12,
+                    directMemory.bytes[address] & 0xff);
+            assertFalse("unsafe write was journaled", direct.hasPerformanceEpochJournal());
+            assertEquals("decoded fence delegated an access", 0L,
+                    direct.getPerformanceEpochTerminalAccesses());
+            assertEquals(Cpu.State.RUNNING, direct.getState());
+        }
+    }
+
+    @Test
+    public void armedHblankWaitEpochStopsBeforeHaltAfterASafePrefix()
+            throws Exception {
+        LeasedMemory directMemory = new LeasedMemory(0, 0x4000);
+        ParityMemory scalarMemory = new ParityMemory();
+        directMemory.bytes[0] = 0x00; // NOP
+        directMemory.bytes[1] = 0x76; // HALT
+        directMemory.physicalBytes[0] = 0x00;
+        directMemory.physicalBytes[1] = 0x76;
+        scalarMemory.bytes[0] = 0x00;
+        scalarMemory.bytes[1] = 0x76;
+        InterruptManager directInterrupts = new InterruptManager(true);
+        InterruptManager scalarInterrupts = new InterruptManager(true);
+        Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                doubleSpeed(), new Display(false));
+        Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                doubleSpeed(), new Display(false));
+        scalar.restoreState(direct.captureState());
+        scalarInterrupts.restoreState(directInterrupts.captureState());
+
+        int elapsed = direct.runNativeCgbArmedHblankWaitPerformanceEpoch(54);
+        assertTrue("safe NOP prefix made no progress", elapsed > 0);
+        for (int tick = 0; tick < elapsed; tick++) {
+            scalar.tick();
+        }
+        assertDeepEquals("CPU before HALT", scalar.captureState(), direct.captureState());
+        assertDeepEquals("interrupts before HALT", scalarInterrupts.captureState(),
+                directInterrupts.captureState());
+        assertEquals(1, direct.getRegisters().getPC());
+        assertEquals(Cpu.State.OPCODE, direct.getState());
+
+        var cpuState = direct.captureState();
+        var interruptState = directInterrupts.captureState();
+        assertEquals("HALT fetch must remain on the zero-dot scalar boundary", 0,
+                direct.runNativeCgbArmedHblankWaitPerformanceEpoch(54));
+        assertDeepEquals("zero-dot HALT CPU", cpuState, direct.captureState());
+        assertDeepEquals("zero-dot HALT interrupts", interruptState,
+                directInterrupts.captureState());
+    }
+
+    @Test
+    public void doubleSpeedCartWindowFenceAttemptIsClassifiedAndReset() {
+        CountingMemory memory = new CountingMemory();
+        memory.bytes[0] = 0x7e; // LD A,(HL)
+        memory.bytes[0xa000] = 0x66;
+        Cpu cpu = new Cpu(memory, new InterruptManager(true), null,
+                doubleSpeed(), new Display(false));
+        cpu.getRegisters().setHL(0xa000);
+
+        int elapsed = cpu.runPerformanceEpoch(54);
+
+        assertTrue(elapsed > 0);
+        assertEquals(1, memory.reads[0xa000]);
+        assertEquals(1L, cpu.getPerformanceEpochTerminalAccesses());
+        assertEquals(1L, cpu.getPerformanceEpochFenceAttemptCount());
+        assertEquals(1L, cpu.getPerformanceEpochCartWindowFenceAttemptCount());
+
+        cpu.resetPerformanceEpochTelemetry();
+        assertEquals(0L, cpu.getPerformanceEpochFenceAttemptCount());
+        assertEquals(0L, cpu.getPerformanceEpochCartWindowFenceAttemptCount());
     }
 
     @Test
@@ -714,6 +994,7 @@ public final class CpuPerformanceEpochTest {
         assertEquals(1, memory.reads[0xff44]);
         assertEquals(0x66, cpu.getRegisters().getA());
         assertEquals(1, cpu.getPerformanceEpochTerminalAccesses());
+        assertEquals(1L, cpu.getPerformanceEpochFenceAttemptCount());
         assertFalse(cpu.hasPerformanceEpochJournal());
     }
 
@@ -969,6 +1250,11 @@ public final class CpuPerformanceEpochTest {
                     pair.direct.getRegisters().getA());
             assertEquals(labels[index] + " delegated a terminal read", 0L,
                     pair.direct.getPerformanceEpochTerminalAccesses());
+            assertEquals(labels[index] + " did not record its decoded fence", 1L,
+                    pair.direct.getPerformanceEpochFenceAttemptCount());
+            assertEquals(labels[index] + " cart-window classification", index == 2 || index == 3
+                            ? 1L : 0L,
+                    pair.direct.getPerformanceEpochCartWindowFenceAttemptCount());
         }
 
         CpuPair mapper = newNativeNormalSpeedPair(0xea, 0x00, 0x20); // LD (2000),A
@@ -980,6 +1266,10 @@ public final class CpuPerformanceEpochTest {
                 mapper.directMemory.writes);
         assertEquals("mapper-control fence delegated a terminal write", 0L,
                 mapper.direct.getPerformanceEpochTerminalAccesses());
+        assertEquals("mapper-control decoded fence was not recorded", 1L,
+                mapper.direct.getPerformanceEpochFenceAttemptCount());
+        assertEquals("mapper-control write was misclassified as a cart-window fence", 0L,
+                mapper.direct.getPerformanceEpochCartWindowFenceAttemptCount());
     }
 
     @Test
@@ -1009,6 +1299,62 @@ public final class CpuPerformanceEpochTest {
         interrupts.setByte(0xffff, 1);
         interrupts.requestInterrupt(InterruptManager.InterruptType.VBlank);
         return interrupts;
+    }
+
+    private static void assertStableLyReadEpochMatchesScalar(boolean armed)
+            throws Exception {
+        String path = armed ? "armed HBlank wait" : "native CGB";
+        for (int budget = 1; budget <= 54; budget++) {
+            LeasedMemory directMemory = new LeasedMemory(0, 0x4000);
+            CountingMemory scalarMemory = new CountingMemory();
+            int[] program = {
+                    0xf0, 0x44,       // LDH A,(FF44)
+                    0x18, 0xfc        // JR back to the FF44 read
+            };
+            for (int offset = 0; offset < program.length; offset++) {
+                directMemory.bytes[offset] = (byte) program[offset];
+                directMemory.physicalBytes[offset] = (byte) program[offset];
+                scalarMemory.bytes[offset] = (byte) program[offset];
+            }
+            directMemory.bytes[0xff44] = 0x66;
+            scalarMemory.bytes[0xff44] = 0x66;
+
+            InterruptManager directInterrupts = new InterruptManager(true);
+            InterruptManager scalarInterrupts = new InterruptManager(true);
+            Cpu direct = new Cpu(directMemory, directInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            Cpu scalar = new Cpu(scalarMemory, scalarInterrupts, null,
+                    doubleSpeed(), new Display(false));
+            scalar.restoreState(direct.captureState());
+            scalarInterrupts.restoreState(directInterrupts.captureState());
+
+            int elapsed = armed
+                    ? direct.runNativeCgbArmedHblankWaitPerformanceEpoch(budget)
+                    : direct.runNativeCgbPerformanceEpoch(budget);
+            String boundary = path + " budget " + budget;
+            assertEquals(boundary + " stopped at a stable FF44 read", budget, elapsed);
+            for (int tick = 0; tick < elapsed; tick++) {
+                scalar.tick();
+            }
+
+            assertDeepEquals(boundary + " CPU",
+                    scalar.captureState(), direct.captureState());
+            assertDeepEquals(boundary + " interrupts",
+                    scalarInterrupts.captureState(), directInterrupts.captureState());
+            assertArrayEquals(boundary + " memory", scalarMemory.bytes, directMemory.bytes);
+            assertEquals(boundary + " FF44 read count",
+                    scalarMemory.reads[0xff44], directMemory.busReads);
+            if (budget >= 6) {
+                assertTrue(boundary + " did not execute FF44", directMemory.busReads > 0);
+                assertEquals(0x66, direct.getRegisters().getA());
+            }
+            assertEquals(boundary + " FF44 read was terminal", 0L,
+                    direct.getPerformanceEpochTerminalAccesses());
+            assertEquals(boundary + " FF44 read recorded a fence", 0L,
+                    direct.getPerformanceEpochFenceAttemptCount());
+            assertFalse(boundary + " FF44 read created a journal",
+                    direct.hasPerformanceEpochJournal());
+        }
     }
 
     private static Cpu normalSpeedNativeCpu(

--- a/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/cpu/CpuPpuInterruptTimingTest.java
@@ -530,6 +530,32 @@ public class CpuPpuInterruptTimingTest {
     }
 
     @Test
+    public void ownedHdmaBlockRequiresAnOrdinaryFrozenDoubleSpeedOpcode() {
+        Harness ordinary = new Harness(true);
+        ordinary.enableDoubleSpeed();
+        ordinary.memory.setByte(PROGRAM, 0x06); // LD B,d8
+        ordinary.cpu.prefetchOpcodeForHdma();
+
+        assertTrue(ordinary.cpu.performanceHdmaOwnedBlockCpuFrozenEligible());
+        ordinary.cpu.releaseHdmaPrefetchedOpcode();
+        assertFalse(ordinary.cpu.performanceHdmaOwnedBlockCpuFrozenEligible());
+
+        Harness prefetchedStop = new Harness(true);
+        prefetchedStop.enableDoubleSpeed();
+        prefetchedStop.memory.setByte(PROGRAM, 0x10); // STOP prefix
+        prefetchedStop.cpu.prefetchOpcodeForHdma();
+        assertFalse(prefetchedStop.cpu.performanceHdmaOwnedBlockCpuFrozenEligible());
+
+        Harness pendingInterrupt = new Harness(true);
+        pendingInterrupt.enableDoubleSpeed();
+        pendingInterrupt.memory.setByte(PROGRAM, 0x06);
+        pendingInterrupt.cpu.prefetchOpcodeForHdma();
+        pendingInterrupt.enable(LCDC);
+        pendingInterrupt.interrupts.requestInterrupt(LCDC);
+        assertFalse(pendingInterrupt.cpu.performanceHdmaOwnedBlockCpuFrozenEligible());
+    }
+
+    @Test
     public void hdmaArbitrationFetchIsTheOnlyOpcodeBusRead() {
         for (int opcode : new int[] {0x04, 0x76}) { // INC B; HALT
             Harness h = new Harness(true);

--- a/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/gpu/StatRegisterTest.java
@@ -228,6 +228,191 @@ public class StatRegisterTest {
     }
 
     @Test
+    public void nativeCgbCheckpointReplayAdmitsOnlyNonTargetVisibleLineWindows() {
+        Fixture lineStart = settledNativeLycOnlyFixture(10, 0, 72);
+        assertEquals(54,
+                lineStart.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+        assertEquals(54,
+                lineStart.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+
+        Fixture lineTail = settledNativeLycOnlyFixture(10, 447, 72);
+        assertEquals("tail must stop before the line rollover", 8,
+                lineTail.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+        assertEquals("canonical tail has a closed-form endpoint", 8,
+                lineTail.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+        assertEquals(0, lineTail.stat.performanceNativeCgbCheckpointReplaySpanLimit(0));
+
+        Fixture midLine = settledNativeLycOnlyFixture(10, 100, 72);
+        assertEquals("mid-line checkpoints retain exact replay", 0,
+                midLine.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+
+        Fixture normalSpeed = new Fixture(true, false);
+        normalSpeed.gpu.setByte(GpuRegister.LYC.getAddress(), 72);
+        normalSpeed.stat.setByte(StatRegister.ADDRESS, 0x40);
+        normalSpeed.advanceTo(10, 0);
+        assertEquals("normal-speed CGB", 0,
+                normalSpeed.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+
+        assertEquals("LYC equality line", 0,
+                settledNativeLycOnlyFixture(72, 0, 72).stat
+                        .performanceNativeCgbCheckpointReplaySpanLimit(54));
+        assertEquals("preceding comparator line", 0,
+                settledNativeLycOnlyFixture(71, 447, 72).stat
+                        .performanceNativeCgbCheckpointReplaySpanLimit(54));
+        assertEquals("VBlank handoff line", 0,
+                settledNativeLycOnlyFixture(143, 0, 72).stat
+                        .performanceNativeCgbCheckpointReplaySpanLimit(54));
+    }
+
+    @Test
+    public void nativeCgbCheckpointReplayRejectsPendingAndMismatchedStatPlanes()
+            throws Exception {
+        for (String field : new String[]{
+                "lycIrqStatSource", "lycIrqStatLatch", "modeIrqStatLatch",
+                "mode0IrqStatLatch", "lycIrqValueLatch", "modeIrqLycLatch",
+                "mode0IrqLycLatch"}) {
+            Fixture mismatch = settledNativeLycOnlyFixture(10, 0, 72);
+            setIntField(mismatch.stat, field, 0);
+            assertEquals(field, 0,
+                    mismatch.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+        }
+
+        for (String field : new String[]{
+                "pendingModeIrqStatClock", "pendingModeIrqLycClock",
+                "pendingMode0IrqStatClock", "pendingMode0IrqLycClock",
+                "pendingCgbMode2PublicationClock", "pendingLycWriteIrq",
+                "pendingLycComparatorIrq"}) {
+            Fixture pending = settledNativeLycOnlyFixture(10, 0, 72);
+            setLongField(pending.stat, field, longField(pending.stat, "lycIrqClock") + 1);
+            assertEquals(field, 0,
+                    pending.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+        }
+
+        for (String field : new String[]{
+                "pendingCgbMode0Interrupt", "pendingCgbMode1Interrupt",
+                "pendingCgbMode2Interrupt", "pendingCgbMode2LateReplay",
+                "pendingCgbFrameMode2Interrupt", "retractableCgbMode2Interrupt",
+                "releaseTailLycCpuAcceptance"}) {
+            Fixture pending = settledNativeLycOnlyFixture(10, 0, 72);
+            setBooleanField(pending.stat, field, true);
+            assertEquals(field, 0,
+                    pending.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+        }
+
+        Fixture dirty = settledNativeLycOnlyFixture(10, 0, 72);
+        dirty.gpu.setByteFromCpu(GpuRegister.SCX.getAddress(), 1);
+        assertEquals("dirty evaluator", 0,
+                dirty.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+
+        Fixture signalled = settledNativeLycOnlyFixture(10, 0, 72);
+        signalled.interrupts.requestInterrupt(LCDC);
+        signalled.interrupts.clearInterrupt(LCDC);
+        assertTrue(signalled.interrupts.hasPpuTickSignals());
+        assertEquals("PPU signal", 0,
+                signalled.stat.performanceNativeCgbCheckpointReplaySpanLimit(54));
+    }
+
+    @Test
+    public void nativeCgbCheckpointReplayMatchesScalarAtLineStartAndTail() {
+        int[][] windows = {{10, 0, 13}, {10, 447, 8}};
+        for (int[] window : windows) {
+            Fixture scalar = settledNativeLycOnlyFixture(window[0], window[1], 72);
+            Fixture replay = settledNativeLycOnlyFixture(window[0], window[1], 72);
+            int span = replay.stat.performanceNativeCgbCheckpointReplaySpanLimit(window[2]);
+            assertEquals(window[0] + ":" + window[1], window[2], span);
+
+            for (int dot = 0; dot < span; dot++) {
+                scalar.gpu.tick();
+                scalar.stat.tick();
+                replay.gpu.tick();
+                replay.stat.tickNativeCgbPerformancePostGpu();
+            }
+
+            assertEquals("GPU line", scalar.gpu.getLine(), replay.gpu.getLine());
+            assertEquals("GPU dot", scalar.gpu.getTicksInLine(), replay.gpu.getTicksInLine());
+            assertEquals("STAT state", scalar.stat.captureState(), replay.stat.captureState());
+            assertEquals("interrupt state", scalar.interrupts.captureState(),
+                    replay.interrupts.captureState());
+        }
+    }
+
+    @Test
+    public void nativeCgbCheckpointAggregateRejectsNonCanonicalEndpointPlanes()
+            throws Exception {
+        for (String field : new String[]{
+                "coincidence", "intCoincidence", "intLine", "lycWriteSuppressed",
+                "lycComparatorSignal", "pendingCgbMode2IfHighAtCapture",
+                "cgbMode2CapturedAtLineEdge", "previousMode0Window",
+                "previousMode1Window", "previousMode2Window"}) {
+            Fixture nonCanonical = settledNativeLycOnlyFixture(10, 0, 72);
+            setBooleanField(nonCanonical.stat, field, true);
+            assertEquals(field, 0,
+                    nonCanonical.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+        }
+
+        for (String field : new String[]{"suppressedLycIrqLine", "modeBlockedLycIrqLine"}) {
+            Fixture nonCanonical = settledNativeLycOnlyFixture(10, 0, 72);
+            setIntField(nonCanonical.stat, field, 7);
+            assertEquals(field, 0,
+                    nonCanonical.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+        }
+
+        Fixture wrongRegisteredLy = settledNativeLycOnlyFixture(10, 0, 72);
+        setIntField(wrongRegisteredLy.stat, "registeredLy", 9);
+        assertEquals("registered LY", 0,
+                wrongRegisteredLy.stat.performanceNativeCgbCheckpointAggregateSpanLimit(54));
+
+        Fixture tail = settledNativeLycOnlyFixture(10, 447, 72);
+        setBooleanField(tail.stat, "previousMode0Window", false);
+        assertEquals("tail mode-0 history", 0,
+                tail.stat.performanceNativeCgbCheckpointAggregateSpanLimit(8));
+    }
+
+    @Test
+    public void nativeCgbCheckpointAggregateMatchesScalarAcrossPartialPrefixes() {
+        int[][] windows = {
+                {1, 0, 54}, {10, 6, 54}, {142, 12, 54},
+                {10, 447, 8}, {10, 451, 4}
+        };
+        for (int[] window : windows) {
+            Fixture scalar = settledNativeLycOnlyFixture(window[0], window[1], 72);
+            Fixture aggregate = settledNativeLycOnlyFixture(window[0], window[1], 72);
+            int span = aggregate.stat
+                    .performanceNativeCgbCheckpointAggregateSpanLimit(window[2]);
+            assertEquals(window[0] + ":" + window[1], window[2], span);
+
+            for (int dot = 0; dot < span; dot++) {
+                scalar.gpu.tick();
+                scalar.stat.tick();
+            }
+            int remaining = span;
+            int prefix = 1;
+            while (remaining > 0) {
+                int chunk = Math.min(remaining, prefix);
+                for (int dot = 0; dot < chunk; dot++) {
+                    aggregate.gpu.tick();
+                }
+                aggregate.stat
+                        .advancePerformanceNativeCgbCheckpointAggregateSpanTrusted(chunk);
+                remaining -= chunk;
+                prefix = prefix == 5 ? 1 : prefix + 1;
+            }
+
+            assertEquals("GPU line", scalar.gpu.getLine(), aggregate.gpu.getLine());
+            assertEquals("GPU dot", scalar.gpu.getTicksInLine(),
+                    aggregate.gpu.getTicksInLine());
+            assertEquals("STAT state", scalar.stat.captureState(),
+                    aggregate.stat.captureState());
+            assertEquals("interrupt state", scalar.interrupts.captureState(),
+                    aggregate.interrupts.captureState());
+            assertEquals("STAT readback", scalar.stat.getByte(StatRegister.ADDRESS),
+                    aggregate.stat.getByte(StatRegister.ADDRESS));
+            assertEquals("LY readback", scalar.gpu.getByte(GpuRegister.LY.getAddress()),
+                    aggregate.gpu.getByte(GpuRegister.LY.getAddress()));
+        }
+    }
+
+    @Test
     public void performanceSgbLcdOffSpanRejectsEveryLiveStatPublicationPlane()
             throws Exception {
         Fixture settled = settledDmgLcdOffFixture();
@@ -3073,6 +3258,13 @@ public class StatRegisterTest {
         field.setBoolean(stat, value);
     }
 
+    private static void setIntField(StatRegister stat, String name, int value)
+            throws Exception {
+        Field field = StatRegister.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.setInt(stat, value);
+    }
+
     private static Fixture settledDmgLcdOffFixture() {
         Fixture fixture = new Fixture(false);
         fixture.gpu.setByte(0xff40, 0);
@@ -3086,6 +3278,14 @@ public class StatRegisterTest {
         Fixture fixture = new Fixture(true);
         fixture.advanceTo(1, 100);
         assertFalse(fixture.gpu.isStatEventCheckpoint());
+        return fixture;
+    }
+
+    private static Fixture settledNativeLycOnlyFixture(int line, int ticksInLine, int lyc) {
+        Fixture fixture = new Fixture(true, true);
+        fixture.gpu.setByte(GpuRegister.LYC.getAddress(), lyc);
+        fixture.stat.setByte(StatRegister.ADDRESS, 0x40);
+        fixture.advanceTo(line, ticksInLine);
         return fixture;
     }
 

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/HdmaTest.java
@@ -76,6 +76,273 @@ public class HdmaTest {
     }
 
     @Test
+    public void nativeCgbEpochMayBorrowOnlyTheStableWaitBetweenHblankBursts() {
+        Fixture fixture = new Fixture(2);
+        fixture.hdma.onLcdSwitch(true);
+        fixture.hdma.onGpuTiming(1, 0);
+        fixture.hdma.onGpuUpdate(Mode.OamSearch);
+        fixture.startTransfer(0x81);
+
+        assertTrue(fixture.hdma.isPerformanceArmedHblankWaitStable());
+        assertTrue(fixture.hdma.isPerformanceNativeCgbRunningEpochStable());
+        Hdma.HdmaState initialWait = hdmaState(fixture);
+        fixture.hdma.advancePerformanceNativeCgbRunningEpochClockTrusted(54);
+        assertSameHdmaState(initialWait, hdmaState(fixture));
+
+        fixture.hdma.onGpuTiming(1, 248);
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        assertEquals(3, hdmaState(fixture).hblankRequestTicks());
+        assertFalse(fixture.hdma.isPerformanceNativeCgbRunningEpochStable());
+        fixture.advanceHblankRequest(1);
+        assertEquals(2, hdmaState(fixture).hblankRequestTicks());
+        fixture.advanceHblankRequest(1);
+        assertEquals(1, hdmaState(fixture).hblankRequestTicks());
+        fixture.advanceHblankRequest(1);
+        assertEquals(0, hdmaState(fixture).hblankRequestTicks());
+        assertFalse(fixture.hdma.isPerformanceArmedHblankWaitStable());
+
+        fixture.hdma.resolveCpuRequest(false, false);
+        int guard = 0;
+        while (!fixture.hdma.tick() && guard++ < 64) {
+            // Complete exactly one 16-byte burst.
+        }
+        assertTrue("first HBlank burst did not complete", guard < 64);
+        assertEquals(0xa0, fixture.memory.getByte(0x8000));
+        assertTrue("second block was not left armed",
+                fixture.hdma.hasPendingHblankTransfer());
+        assertTrue("post-burst wait did not reopen the native x2 lease",
+                fixture.hdma.isPerformanceArmedHblankWaitStable());
+
+        fixture.hdma.onGpuUpdate(Mode.OamSearch);
+        assertTrue("armed wait should span OAM search",
+                fixture.hdma.isPerformanceArmedHblankWaitStable());
+        fixture.hdma.onGpuUpdate(Mode.PixelTransfer);
+        assertTrue("armed wait should span pixel transfer",
+                fixture.hdma.isPerformanceArmedHblankWaitStable());
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        assertEquals(3, hdmaState(fixture).hblankRequestTicks());
+        assertFalse("next HBlank edge must close the lease",
+                fixture.hdma.isPerformanceNativeCgbRunningEpochStable());
+    }
+
+    @Test
+    public void nativeCgbOwnedWramDataInteriorMatchesScalarAndLeavesCommitScalar() {
+        Fixture scalar = ownedHblankDataFixture(0xc800);
+        Fixture bulk = ownedHblankDataFixture(0xc800);
+
+        int span = bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(64);
+        assertEquals(31, span);
+        assertEquals("a partial budget must leave the whole interior scalar", 0,
+                bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(span - 1));
+        for (int i = 0; i < span; i++) {
+            assertFalse(scalar.hdma.tick());
+            scalar.hdma.consumeSourceBusSample();
+            scalar.hdma.advanceHblankRequest();
+        }
+        bulk.hdma.advancePerformanceNativeCgbOwnedHblankDataTrusted(span);
+
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals(scalar.hdma.getPpuBusGeneration(), bulk.hdma.getPpuBusGeneration());
+        assertEquals("tick-32 destination publication must not be folded into the packet", 0,
+                bulk.memory.getByte(0x8000));
+        assertEquals(0, bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(1));
+
+        assertTrue(scalar.hdma.tick());
+        scalar.hdma.consumeSourceBusSample();
+        scalar.hdma.advanceHblankRequest();
+        assertTrue(bulk.hdma.tick());
+        bulk.hdma.consumeSourceBusSample();
+        bulk.hdma.advanceHblankRequest();
+
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals(scalar.hdma.getPpuBusGeneration(), bulk.hdma.getPpuBusGeneration());
+        for (int i = 0; i < 0x10; i++) {
+            assertEquals(0x40 + i, bulk.memory.getByte(0x8000 + i));
+        }
+    }
+
+    @Test
+    public void nativeCgbOwnedRomDataInteriorMatchesScalarThroughPhysicalLease() {
+        Fixture scalar = ownedHblankDataFixture(0x4000);
+        Fixture bulk = ownedHblankDataFixture(0x4000);
+        int[] physicalReads = {0};
+        PerformanceRomAccess physicalRom = new PerformanceRomAccess() {
+            @Override
+            public int physicalOffset(int cpuAddress) {
+                return cpuAddress >= 0 && cpuAddress < 0x8000 ? cpuAddress : -1;
+            }
+
+            @Override
+            public int readPhysicalByte(int physicalOffset) {
+                assertEquals("physical ROM reads lost their source-slot order",
+                        0x4000 + physicalReads[0]++, physicalOffset);
+                return bulk.memory.getByte(physicalOffset);
+            }
+        };
+
+        int span = bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(64, physicalRom);
+        assertEquals(31, span);
+        assertEquals("ROM must not enter the lease-free WRAM tier", 0,
+                bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(64));
+        for (int i = 0; i < span; i++) {
+            assertFalse(scalar.hdma.tick());
+            scalar.hdma.consumeSourceBusSample();
+            scalar.hdma.advanceHblankRequest();
+        }
+        bulk.hdma.advancePerformanceNativeCgbOwnedHblankDataTrusted(span, physicalRom);
+
+        assertEquals("the complete ROM block was not sampled exactly once", 0x10,
+                physicalReads[0]);
+        assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+        assertEquals(scalar.hdma.getPpuBusGeneration(), bulk.hdma.getPpuBusGeneration());
+        assertEquals("tick-32 destination publication must remain scalar", 0,
+                bulk.memory.getByte(0x8000));
+    }
+
+    @Test
+    public void nativeCgbOwnedRomDataRequiresAllSixteenImmutablePhysicalOffsets() {
+        Fixture fixture = ownedHblankDataFixture(0x7ff0);
+        PerformanceRomAccess completePhysicalRom = physicalRomAccess(fixture.memory, -1);
+        PerformanceRomAccess physicalRomWithHole = physicalRomAccess(fixture.memory, 0x7ff8);
+        PerformanceRomAccess logicalOnlyRom = new PerformanceRomAccess() {
+            @Override
+            public int physicalOffset(int cpuAddress) {
+                return -1;
+            }
+
+            @Override
+            public int readPhysicalByte(int physicalOffset) {
+                throw new AssertionError("logical-only ROM must remain scalar");
+            }
+
+            @Override
+            public int readCpuByte(int cpuAddress) {
+                return fixture.memory.getByte(cpuAddress);
+            }
+        };
+
+        assertTrue(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStructurallyStable());
+        assertTrue(fixture.hdma.requiresPerformanceNativeCgbOwnedHblankRomAccess());
+        assertFalse(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStable());
+        assertTrue(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStable(completePhysicalRom));
+        assertFalse(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStable(null));
+        assertFalse(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStable(logicalOnlyRom));
+        assertFalse(fixture.hdma.isPerformanceNativeCgbOwnedHblankDataStable(physicalRomWithHole));
+        assertEquals(0,
+                fixture.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(31, logicalOnlyRom));
+        assertEquals(0,
+                fixture.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(
+                        31, physicalRomWithHole));
+    }
+
+    @Test
+    public void nativeCgbOwnedDataInteriorAdmitsOnlyAlignedWramOrRomSourceBlocks() {
+        assertTrue(ownedHblankDataFixture(0xc000).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStable());
+        assertTrue(ownedHblankDataFixture(0xdff0).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStable());
+        assertTrue(ownedHblankDataFixture(0x0000).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStructurallyStable());
+        assertTrue(ownedHblankDataFixture(0x7ff0).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStructurallyStable());
+        assertFalse(ownedHblankDataFixture(0xbff0).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStructurallyStable());
+        assertFalse(ownedHblankDataFixture(0xe000).hdma
+                .isPerformanceNativeCgbOwnedHblankDataStructurallyStable());
+    }
+
+    @Test
+    public void nativeCgbOwnedWramDataInteriorMatchesScalarFromEveryDataTick() {
+        for (int scalarPrefix = 0; scalarPrefix < 31; scalarPrefix++) {
+            Fixture scalar = ownedHblankDataFixture(0xcf00);
+            Fixture bulk = ownedHblankDataFixture(0xcf00);
+            for (int i = 0; i < scalarPrefix; i++) {
+                assertFalse(scalar.hdma.tick());
+                scalar.hdma.consumeSourceBusSample();
+                scalar.hdma.advanceHblankRequest();
+                assertFalse(bulk.hdma.tick());
+                bulk.hdma.consumeSourceBusSample();
+                bulk.hdma.advanceHblankRequest();
+            }
+
+            int span = 31 - scalarPrefix;
+            for (int i = 0; i < span; i++) {
+                assertFalse(scalar.hdma.tick());
+                scalar.hdma.consumeSourceBusSample();
+                scalar.hdma.advanceHblankRequest();
+            }
+            assertEquals(span,
+                    bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(span));
+            bulk.hdma.advancePerformanceNativeCgbOwnedHblankDataTrusted(span);
+
+            assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+            assertEquals(scalar.hdma.getPpuBusGeneration(), bulk.hdma.getPpuBusGeneration());
+        }
+    }
+
+    @Test
+    public void nativeCgbOwnedPhysicalRomDataInteriorMatchesScalarFromEveryDataTick() {
+        for (int scalarPrefix = 0; scalarPrefix < 31; scalarPrefix++) {
+            Fixture scalar = ownedHblankDataFixture(0x4000);
+            Fixture bulk = ownedHblankDataFixture(0x4000);
+            PerformanceRomAccess physicalRom = physicalRomAccess(bulk.memory, -1);
+            for (int i = 0; i < scalarPrefix; i++) {
+                assertFalse(scalar.hdma.tick());
+                scalar.hdma.consumeSourceBusSample();
+                scalar.hdma.advanceHblankRequest();
+                assertFalse(bulk.hdma.tick());
+                bulk.hdma.consumeSourceBusSample();
+                bulk.hdma.advanceHblankRequest();
+            }
+
+            int span = 31 - scalarPrefix;
+            for (int i = 0; i < span; i++) {
+                assertFalse(scalar.hdma.tick());
+                scalar.hdma.consumeSourceBusSample();
+                scalar.hdma.advanceHblankRequest();
+            }
+            assertEquals(span,
+                    bulk.hdma.performanceNativeCgbOwnedHblankDataSpanLimit(
+                            span, physicalRom));
+            bulk.hdma.advancePerformanceNativeCgbOwnedHblankDataTrusted(
+                    span, physicalRom);
+
+            assertSameHdmaState(hdmaState(scalar), hdmaState(bulk));
+            assertEquals(scalar.hdma.getPpuBusGeneration(), bulk.hdma.getPpuBusGeneration());
+        }
+    }
+
+    @Test
+    public void restoredArmedHblankWaitRetainsTheNativeCgbEpochLease() {
+        Fixture original = new Fixture(2);
+        original.hdma.onLcdSwitch(true);
+        original.hdma.onGpuTiming(7, 120);
+        original.hdma.onGpuUpdate(Mode.PixelTransfer);
+        original.startTransfer(0x82);
+        assertTrue(original.hdma.isPerformanceArmedHblankWaitStable());
+
+        Fixture restored = new Fixture(2);
+        restored.hdma.restoreState(original.hdma.captureState());
+
+        assertTrue(restored.hdma.isPerformanceArmedHblankWaitStable());
+        restored.hdma.advancePerformanceNativeCgbRunningEpochClockTrusted(31);
+        assertSameHdmaState(hdmaState(original), hdmaState(restored));
+    }
+
+    @Test
+    public void normalSpeedArmedHblankWaitRemainsOutsideTheNativeCgbEpochLease() {
+        Fixture fixture = new Fixture(1);
+        fixture.hdma.onLcdSwitch(true);
+        fixture.hdma.onGpuTiming(3, 120);
+        fixture.hdma.onGpuUpdate(Mode.PixelTransfer);
+        fixture.startTransfer(0x81);
+
+        assertTrue(fixture.hdma.hasPendingHblankTransfer());
+        assertFalse(fixture.hdma.isPerformanceArmedHblankWaitStable());
+        assertFalse(fixture.hdma.isPerformanceNativeCgbRunningEpochStable());
+    }
+
+    @Test
     public void runningEpochHaltReconciliationExcludesOnlyTheTerminalCurrentAge() {
         Fixture scalar = new Fixture();
         Fixture bulk = new Fixture();
@@ -488,6 +755,41 @@ public class HdmaTest {
         fixture.hdma.onGpuUpdate(Mode.HBlank);
         fixture.hdma.onGpuTiming(1, 249);
         return fixture;
+    }
+
+    private Fixture ownedHblankDataFixture(int source) {
+        Fixture fixture = new Fixture(2);
+        for (int i = 0; i < 0x10; i++) {
+            fixture.memory.setByte((source + i) & 0xffff, 0x40 + i);
+        }
+        fixture.hdma.setByte(0xff51, source >>> 8);
+        fixture.hdma.setByte(0xff52, source & 0xf0);
+        fixture.hdma.onLcdSwitch(true);
+        fixture.hdma.onGpuTiming(1, 248);
+        fixture.hdma.onGpuUpdate(Mode.HBlank);
+        fixture.startTransfer(0x80);
+        fixture.hdma.resolveCpuRequest(false, false);
+        while (hdmaState(fixture).tick() < 0) {
+            assertFalse(fixture.hdma.tick());
+            fixture.hdma.consumeSourceBusSample();
+            fixture.hdma.advanceHblankRequest();
+        }
+        return fixture;
+    }
+
+    private PerformanceRomAccess physicalRomAccess(Ram memory, int missingCpuAddress) {
+        return new PerformanceRomAccess() {
+            @Override
+            public int physicalOffset(int cpuAddress) {
+                return cpuAddress >= 0 && cpuAddress < 0x8000
+                        && cpuAddress != missingCpuAddress ? cpuAddress : -1;
+            }
+
+            @Override
+            public int readPhysicalByte(int physicalOffset) {
+                return memory.getByte(physicalOffset);
+            }
+        };
     }
 
     private Hdma.HdmaState hdmaState(Fixture fixture) {


### PR DESCRIPTION
## Summary

- invert Android's horizontal accelerometer axis after display-rotation mapping so Kirby tilts in the physical direction of the phone
- include MBC7 in disposable runtime warmup and add HDMA to the Android baseline profile
- extend bounded native-CGB double-speed epochs across armed HBlank-DMA waits, including proven-stable LY reads
- batch already-owned HBlank-DMA source reads and aggregate safe LYC-only STAT checkpoints while leaving observable transfer, interrupt, HALT, and line-boundary edges scalar
- keep ordinary Android service starts explicitly outside benchmark mode

## Device performance

Measured on the connected Redmi from a fresh Level 1-1 start with native CGB hardware, canonical audio, presentation rendering, and 600 measured frames:

- original: **23.118 FPS**
- final immediate run: **59.182 ready FPS / 59.166 submitted FPS**
- final settled repeat: **59.290 ready FPS / 59.262 submitted FPS**
- native content target: **59.7275 Hz**
- steady 60-frame intervals after frame 180: **59.597–60.107 FPS**, ending at **59.766 FPS**

The full-window result includes the first post-arm second at 55.851 FPS; subsequent intervals remain locked to native cadence. Both final runs delivered 600/600 ready and submitted frames with zero dropped, duplicate, late, or corrupt frames. The settled run used 9,489 ms of controller CPU time at 93.541% utilization; `thermal_worst=0`.

## Correctness safeguards

- the new scheduler paths require PERFORMANCE mode on native CGB double speed and fail closed to scalar execution
- decoded I/O/control accesses, HALT, HDMA publication, interrupt edges, and unsafe mapper accesses remain scalar
- differential tests cover partial epochs, every HDMA data tick, ROM and WRAM sources, STAT checkpoint windows, control-write fences, and state restoration

## Verification

- `/opt/maven/bin/mvn -pl core test` — 2,044 tests, 0 failures/errors, 8 skipped
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2` — 132 tests passed
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` — 54 tests passed
- focused controller tests — 59 passed
- Android debug and benchmark JVM suites — 288/288 passed in each variant
- final R8 benchmark APK built and installed with its `.dm` baseline profile; runtime reported `status=speed-profile reason=install-dm`
- `git diff --check`
