### PR TITLE
Restore Android rumble setting

### DIFF
--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AllRouteRendererAndroidTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/AllRouteRendererAndroidTest.java
@@ -69,7 +69,8 @@ public class AllRouteRendererAndroidTest {
         pages.add(AndroidMenuModel.touchPage(AndroidMenuModel.resetTouchDraft(), true));
         pages.add(AndroidMenuModel.controllerPage("PHYSICAL BLUETOOTH GAME CONTROLLER",
                 Map.of(Button.A, "BUTTON A", Button.B, "BUTTON B"), null, false));
-        pages.add(AndroidMenuModel.optionalDevicesPage("rear", "auto", true, List.of()));
+        pages.add(AndroidMenuModel.optionalDevicesPage(
+                "rear", "auto", true, true, List.of()));
         pages.add(AndroidMenuModel.optionPickerPage("OPTION PICKER", List.of(
                 new AndroidMenuModel.ChoiceValue("one", "ONE"),
                 new AndroidMenuModel.ChoiceValue("two", "TWO"),

--- a/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
+++ b/android/app/src/androidTest/java/eu/rekawek/coffeegb/android/MainActivitySmokeTest.java
@@ -539,6 +539,54 @@ public class MainActivitySmokeTest {
     }
 
     @Test
+    public void rumbleControlPersistsAndUpdatesTheBoundRuntimeImmediately() throws Exception {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        AtomicReference<AndroidEmulationRuntime> runtime = new AtomicReference<>();
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            await("runtime binding", () -> {
+                scenario.onActivity(activity -> runtime.set(runtime(activity)));
+                return runtime.get() != null;
+            });
+            scenario.onActivity(activity -> {
+                activity.getPreferences(MainActivity.MODE_PRIVATE).edit()
+                        .putBoolean("devices.rumble", false).commit();
+                runtime(activity).setRumbleEnabled(false);
+                menuController(activity).show(MenuRoute.OPTIONAL_DEVICES);
+            });
+            awaitRoute(scenario, MenuRoute.OPTIONAL_DEVICES);
+            awaitFocused(scenario, "rumble");
+
+            press(instrumentation, KeyEvent.KEYCODE_ENTER, 1);
+            scenario.onActivity(activity -> {
+                assertTrue(activity.getPreferences(MainActivity.MODE_PRIVATE)
+                        .getBoolean("devices.rumble", false));
+                assertTrue(runtime(activity).rumbleEnabledForTesting());
+            });
+
+            runtime.set(null);
+            scenario.recreate();
+            await("runtime rebinding", () -> {
+                scenario.onActivity(activity -> runtime.set(runtime(activity)));
+                return runtime.get() != null;
+            });
+            awaitRoute(scenario, MenuRoute.OPTIONAL_DEVICES);
+            awaitFocused(scenario, "rumble");
+            scenario.onActivity(activity -> {
+                assertTrue(activity.getPreferences(MainActivity.MODE_PRIVATE)
+                        .getBoolean("devices.rumble", false));
+                assertTrue(runtime(activity).rumbleEnabledForTesting());
+            });
+
+            press(instrumentation, KeyEvent.KEYCODE_ENTER, 1);
+            scenario.onActivity(activity -> {
+                assertFalse(activity.getPreferences(MainActivity.MODE_PRIVATE)
+                        .getBoolean("devices.rumble", true));
+                assertFalse(runtime(activity).rumbleEnabledForTesting());
+            });
+        }
+    }
+
+    @Test
     public void deniedCameraPermissionUsesOneOwnerAndStatusSurvivesRecreation()
             throws Exception {
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidEmulationRuntime.java
@@ -428,6 +428,10 @@ public final class AndroidEmulationRuntime implements AutoCloseable {
         rumblePreference.setEnabled(enabled);
     }
 
+    boolean rumbleEnabledForTesting() {
+        return rumblePreference.enabledForTesting();
+    }
+
     /** Calibrates an active MBC7 cartridge to the device's current resting position. */
     void calibrateTilt() {
         if (rejectBenchmarkMutation()) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
@@ -83,14 +83,15 @@ final class AndroidMenuModel {
                 preferredFocusId, MenuPreview.empty());
     }
 
-    static MenuPageSpec optionalDevicesPage(String camera, String gamepad, boolean gps,
-            List<ChoiceValue> gamepadChoices) {
+    static MenuPageSpec optionalDevicesPage(String camera, String gamepad, boolean rumble,
+            boolean gps, List<ChoiceValue> gamepadChoices) {
         return page(MenuRoute.OPTIONAL_DEVICES, "COFFEE GB", "PERIPHERALS", "", "", List.of(),
                 List.of(
+                        checkbox("rumble", "RUMBLE", rumble, true),
                         dropdown("camera", "CAMERA", cameraLabel(camera), true),
                         dropdown("gamepad", "GAMEPAD", gamepadLabel(gamepad, gamepadChoices), true),
                         checkbox("gps", "GPS", gps, true)),
-                "camera", MenuPreview.empty());
+                "rumble", MenuPreview.empty());
     }
 
     static MenuPageSpec optionPickerPage(String title, List<ChoiceValue> choices,
@@ -204,7 +205,8 @@ final class AndroidMenuModel {
 
     static MenuPageSpec optionalDevicesPage(DevicesDraft draft, String status,
             MenuPreview paperPreview) {
-        return optionalDevicesPage(draft.camera() ? "rear" : "off", "auto", false, List.of());
+        return optionalDevicesPage(
+                draft.camera() ? "rear" : "off", "auto", draft.rumble(), false, List.of());
     }
 
     static MenuPageSpec controllerPage(String controllerName, Map<Button, String> labels,

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumblePreference.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidRumblePreference.java
@@ -19,6 +19,10 @@ final class AndroidRumblePreference {
         }
     }
 
+    synchronized boolean enabledForTesting() {
+        return enabled;
+    }
+
     synchronized void attach(Output output) {
         Output checked = Objects.requireNonNull(output, "output");
         checked.setEnabled(enabled);

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -1286,6 +1286,17 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     }
 
     private void handleOptionalDevicesItem(AndroidEmulationRuntime active, String id) {
+        if ("rumble".equals(id)) {
+            SharedPreferences preferences = getPreferences(MODE_PRIVATE);
+            boolean enabled = !preferences.getBoolean("devices.rumble", false);
+            preferences.edit().putBoolean("devices.rumble", enabled).apply();
+            if (active != null) {
+                active.setRumbleEnabled(enabled);
+            }
+            optionalDevicesStatus = enabled ? "RUMBLE ENABLED" : "RUMBLE DISABLED";
+            refreshMenuPages();
+            return;
+        }
         if ("camera".equals(id)) {
             String selected = cameraSelection(getPreferences(MODE_PRIVATE));
             ArrayList<AndroidMenuModel.ChoiceValue> choices = new ArrayList<>(cameraChoices());
@@ -1342,7 +1353,6 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             devicesDraft = loadDevicesDraft();
         }
         switch (id) {
-            case "rumble" -> devicesDraft = devicesDraft.toggleRumble();
             case "live-camera" -> devicesDraft = devicesDraft.toggleCamera();
             case "game-boy-printer" -> devicesDraft = devicesDraft.togglePrinter();
             case "calibrate-tilt" -> {
@@ -2234,6 +2244,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
                         "grey".equals(displayColors(preferences))),
                 AndroidMenuModel.touchPage(touch, controllerAvailable), controllerPage(),
                 AndroidMenuModel.optionalDevicesPage(camera, gamepad,
+                        preferences.getBoolean("devices.rumble", false),
                         preferences.getBoolean(PREF_GPS_ENABLED, false), gamepadChoices),
                 AndroidMenuModel.optionPickerPage(
                         optionSession == null ? "SELECT OPTION" : optionSession.title(),

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
@@ -64,7 +64,7 @@ public class AndroidMenuModelTest {
         assertIds(AndroidMenuModel.optionalDevicesPage(
                         new AndroidMenuModel.DevicesDraft(false, false, false), "READY",
                         MenuPreview.empty()),
-                "camera", "gamepad", "gps");
+                "rumble", "camera", "gamepad", "gps");
         assertIds(AndroidMenuModel.printerPaperPage(MenuPreview.empty(), "READY"),
                 "paper-status");
         assertIds(AndroidMenuModel.systemPage("dmg-games"),
@@ -112,9 +112,9 @@ public class AndroidMenuModelTest {
         assertWidgetTypes(AndroidMenuModel.systemPage("dmg-games"),
                 MenuWidgetType.DROPDOWN, MenuWidgetType.DROPDOWN,
                 MenuWidgetType.DROPDOWN, MenuWidgetType.DROPDOWN);
-                assertWidgetTypes(AndroidMenuModel.optionalDevicesPage(
-                        "rear", "auto", true, List.of()),
-                MenuWidgetType.DROPDOWN, MenuWidgetType.DROPDOWN,
+        assertWidgetTypes(AndroidMenuModel.optionalDevicesPage(
+                        "rear", "auto", true, true, List.of()),
+                MenuWidgetType.CHECKBOX, MenuWidgetType.DROPDOWN, MenuWidgetType.DROPDOWN,
                 MenuWidgetType.CHECKBOX);
         assertWidgetTypes(AndroidMenuModel.touchPage(AndroidMenuModel.resetTouchDraft(), true),
                 MenuWidgetType.CHECKBOX, MenuWidgetType.BUTTON);

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/SettingsSelectionTest.java
@@ -31,11 +31,13 @@ public class SettingsSelectionTest {
                         .map(MenuPageSpec.Item::id).toList());
         assertFalse(AndroidMenuModel.displayPage(false, false).items().get(0).checked());
         assertEquals("", AndroidMenuModel.displayPage(false, false).items().get(0).detail());
-        assertEquals(List.of("camera", "gamepad", "gps"),
-                AndroidMenuModel.optionalDevicesPage("off", "auto", false, List.of())
+        assertEquals(List.of("rumble", "camera", "gamepad", "gps"),
+                AndroidMenuModel.optionalDevicesPage("off", "auto", true, false, List.of())
                         .items().stream().map(MenuPageSpec.Item::id).toList());
-        assertFalse(AndroidMenuModel.optionalDevicesPage("off", "auto", false, List.of())
-                .items().get(2).checked());
+        MenuPageSpec peripherals = AndroidMenuModel.optionalDevicesPage(
+                "off", "auto", true, false, List.of());
+        assertTrue(peripherals.items().get(0).checked());
+        assertFalse(peripherals.items().get(3).checked());
         assertEquals("FAST-FORWARD",
                 AndroidMenuModel.systemPage(
                         "auto", "auto", "fast-forward", "accuracy", "dmg-games")


### PR DESCRIPTION
## Summary

- restore the RUMBLE checkbox on the Android Peripherals page, backed by the existing persisted `devices.rumble` preference
- apply changes to the currently bound runtime immediately and retain them across Activity/runtime recreation
- add menu-model, selection, route-rendering, and Activity smoke regression coverage

## Root cause

The Peripherals redesign in #547 replaced the older device page with Camera, Gamepad, and GPS controls but omitted the existing Rumble control. Rumble remains opt-in and defaults to disabled, so Android users had no way to enable the already-working MBC5 rumble pipeline.

## Verification

- `/opt/maven/bin/mvn -B -pl core -Dtest=Mbc5RumbleTest,CartridgeTypeTest test`
- `ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon -PcoffeeGbMavenRepository=/home/newton/dev/coffee-gb/build/android-m2 :app:check :app:lintDebug :app:assembleDebug :app:assembleRelease`
- focused Android menu/rumble unit tests
- GitHub Android instrumentation passed on API 26 and API 36
- GitHub Java build and all compatibility/integration suites passed
- manually verified on an Android 15 physical device: the option persists, and Pokémon Pinball’s Rumble test produces repeated app-attributed vibration waveforms

## Visual verification

| Before | After enabling Rumble |
| --- | --- |
| ![Peripherals menu without Rumble](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/coffee-gb-peripherals-menu-f0171b60.png) | ![Peripherals menu with Rumble enabled](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/coffee-gb-peripherals-rumble-enabled-06dc517b.png) |

Fixes #645