### PR TITLE
Open on-screen menu with Start and Select

### DIFF
--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -273,8 +273,16 @@ internal class SwingProposal3Menu(
       return true
     }
     if (!visible()) {
+      val menuChordPressed =
+          current.contains(Button.START) &&
+              current.contains(Button.SELECT) &&
+              !(gamepadHeld.contains(Button.START) && gamepadHeld.contains(Button.SELECT))
       gamepadHeld.clear()
       gamepadHeld.addAll(current)
+      if (menuChordPressed) {
+        runOnEdt(::openOnEdt)
+        return true
+      }
       return false
     }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
@@ -29,7 +29,7 @@ import org.junit.Test
 class SwingProposal3MenuTest {
 
   @Test
-  fun `start and select remain gameplay input while the menu is hidden`() {
+  fun `start and select chord opens the hidden menu while either button alone remains gameplay input`() {
     val bridge = FakeBridge()
     val releaseCount = AtomicInteger()
     val menu =
@@ -39,11 +39,20 @@ class SwingProposal3MenuTest {
             releaseGameplay = { releaseCount.incrementAndGet() },
         )
 
-    assertFalse(menu.updatePlayerButtons(EnumSet.of(Button.START, Button.SELECT)))
-    assertFalse(menu.visible())
+    assertFalse(menu.updatePlayerButtons(EnumSet.of(Button.SELECT)))
     assertFalse(menu.updatePlayerButtons(emptySet()))
-    assertEquals(0, releaseCount.get())
-    assertTrue(bridge.pauseTransitions.isEmpty())
+
+    assertFalse(menu.updatePlayerButtons(EnumSet.of(Button.START)))
+    assertTrue(menu.updatePlayerButtons(EnumSet.of(Button.START, Button.SELECT)))
+    javax.swing.SwingUtilities.invokeAndWait {}
+
+    assertTrue(menu.visible())
+    assertEquals(MenuRoute.PAUSE_CONSOLE, menu.routeForTest())
+    assertEquals(listOf(true), bridge.pauseTransitions)
+    assertTrue(menu.updatePlayerButtons(emptySet()))
+    javax.swing.SwingUtilities.invokeAndWait {}
+
+    assertEquals(1, releaseCount.get())
   }
 
   @Test


### PR DESCRIPTION
## Summary
- open the portable on-screen menu from the player-one Start+Select chord
- keep Start and Select individually available to gameplay
- cover staggered controller button presses and menu input capture

## Testing
- `/opt/maven/bin/mvn -pl swing -am -Dtest=SwingProposal3MenuTest -Dsurefire.failIfNoSpecifiedTests=false test`