### PR TITLE
Improve on-screen menu usability

### DIFF
--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/AndroidMenuModel.java
@@ -68,7 +68,7 @@ final class AndroidMenuModel {
     static MenuPageSpec pausePage(String title, String elapsed, boolean batterySaveActive,
             boolean runtimeAvailable, MenuPreview preview) {
         return page(MenuRoute.PAUSE_CONSOLE, "COFFEE GB", "", "", title,
-                List.of("PLAY TIME", elapsed,
+                List.of("PLAY TIME " + elapsed,
                         batterySaveActive ? "BATTERY SAVE ACTIVE" : "NO BATTERY SAVE"),
                 List.of(
                         button("save-state", "SAVE STATE", "", runtimeAvailable),
@@ -82,10 +82,10 @@ final class AndroidMenuModel {
     }
 
     static MenuPageSpec resetConfirmationPage() {
-        return page(MenuRoute.CONFIRM_ACTION, "COFFEE GB", "CONFIRM ACTION", "", "RESET GAME",
+        return page(MenuRoute.CONFIRM_ACTION, "COFFEE GB", "RESET GAME?", "", "RESET GAME",
                 List.of("UNSAVED PROGRESS MAY BE LOST"),
                 List.of(
-                        button("confirm", "CONFIRM", "", true),
+                        button("confirm", "RESET GAME", "", true),
                         button("cancel", "CANCEL", "", true)),
                 "cancel", MenuPreview.empty());
     }

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/CoffeeGbSurfaceView.java
@@ -21,8 +21,13 @@ import android.view.SurfaceView;
 import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
 import eu.rekawek.coffeegb.android.menu.MenuRenderer;
 import eu.rekawek.coffeegb.ui.menu.MenuKey;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerGesture;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
 import eu.rekawek.coffeegb.ui.menu.MenuRoute;
 import eu.rekawek.coffeegb.ui.menu.MenuTouchInput;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuPoint;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor;
 import eu.rekawek.coffeegb.core.joypad.Button;
 
 import java.util.ArrayList;
@@ -74,6 +79,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             new LinkedHashMap<>(3, 0.75f, true);
     private final MenuRenderer menuRenderer = new MenuRenderer();
     private final Set<Integer> menuTouchPointers = new HashSet<>();
+    private final MenuPointerGesture menuPointerGesture = new MenuPointerGesture();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final AtomicLong transientRevision = new AtomicLong();
     private final Runnable menuAnimationFrame = new Runnable() {
@@ -164,6 +170,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
      * an already-cleared snapshot leaves the retained game frame and renderer asleep.
      */
     public void clearMenuPresentation() {
+        menuPointerGesture.cancel();
         if (!requiresMenuInvalidationOnClear(menuPresentation)) {
             return;
         }
@@ -271,6 +278,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
 
     /** Installs the input bridge used to consume skin controls while the menu is visible. */
     public void setMenuInput(MenuTouchInput input) {
+        menuPointerGesture.cancel();
         MenuTouchInput previous = menuInput;
         if (previous != null) {
             previous.releaseAllPointers();
@@ -317,6 +325,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             menuTouchPointers.clear();
         }
         input = null;
+        menuPointerGesture.cancel();
         stopRenderer();
     }
 
@@ -333,6 +342,7 @@ public final class CoffeeGbSurfaceView extends SurfaceView
         }
         if (menu != null && (menuVisible || menuPointer)) {
             if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_OUTSIDE) {
+                menuPointerGesture.cancel();
                 menu.releaseAllPointers();
                 synchronized (menuTouchPointers) {
                     menuTouchPointers.clear();
@@ -344,6 +354,13 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                 synchronized (menuTouchPointers) {
                     menuTouchPointers.remove(actionPointerId);
                 }
+                MenuPointerTarget target = menuPointerGesture.release(actionPointerId,
+                        menuVisible ? menuTargetAt(event.getX(event.getActionIndex()),
+                                event.getY(event.getActionIndex())) : null).orElse(null);
+                if (target != null) {
+                    performClick();
+                    menu.activateTarget(target);
+                }
                 return true;
             }
             if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN
@@ -351,7 +368,12 @@ public final class CoffeeGbSurfaceView extends SurfaceView
                 if (menuVisible) {
                     for (int index = 0; index < event.getPointerCount(); index++) {
                         int pointerId = event.getPointerId(index);
-                        menu.updatePointer(pointerId, menuKeysAt(event.getX(index), event.getY(index)));
+                        if (action != MotionEvent.ACTION_MOVE && index == event.getActionIndex()) {
+                            menuPointerGesture.press(pointerId,
+                                    menuTargetAt(event.getX(index), event.getY(index)));
+                        }
+                        menu.updatePointer(pointerId, menuPointerGesture.captured(pointerId)
+                                ? List.of() : menuKeysAt(event.getX(index), event.getY(index)));
                         synchronized (menuTouchPointers) {
                             menuTouchPointers.add(pointerId);
                         }
@@ -390,6 +412,41 @@ public final class CoffeeGbSurfaceView extends SurfaceView
             return true;
         }
         return super.onTouchEvent(event);
+    }
+
+    @Override
+    public boolean performClick() {
+        super.performClick();
+        return true;
+    }
+
+    private MenuPointerTarget menuTargetAt(float viewX, float viewY) {
+        MenuPresentation presentation = menuPresentation;
+        int width = getWidth();
+        int height = getHeight();
+        if (presentation == null || !presentation.visible() || width <= 0 || height <= 0) {
+            return null;
+        }
+        RasterSkin skin = skinFor(width, height);
+        RectF display = skin.displayBounds(skin.transform(width, height));
+        int left = Math.round(display.left);
+        int top = Math.round(display.top);
+        int apertureWidth = Math.round(display.right) - left;
+        int apertureHeight = Math.round(display.bottom) - top;
+        return menuTargetAt(presentation, left, top, apertureWidth, apertureHeight, viewX, viewY);
+    }
+
+    /** Uses the same rounded aperture and aspect fit as MenuRenderer's draw placement. */
+    static MenuPointerTarget menuTargetAt(MenuPresentation presentation, int left, int top,
+            int apertureWidth, int apertureHeight, float viewX, float viewY) {
+        if (apertureWidth < 2 || apertureHeight < 2) {
+            return null;
+        }
+        return MenuViewport.fit(apertureWidth, apertureHeight)
+                .viewToSource(new MenuPoint(viewX - left, viewY - top))
+                .flatMap(point -> Proposal3MenuCompositor.hitTest(presentation,
+                        (int) point.x(), (int) point.y()))
+                .orElse(null);
     }
 
     private List<MenuKey> menuKeysAt(float x, float y) {

--- a/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
+++ b/android/app/src/main/java/eu/rekawek/coffeegb/android/MainActivity.java
@@ -882,7 +882,8 @@ public final class MainActivity extends Activity implements RuntimeObserver {
         AndroidStateSlot selected = stateSlot(slot);
         MenuPreview preview = selected == null ? MenuPreview.empty() : selected.preview();
         List<String> sideLines = stateSavedAtLines(selected);
-        if (presentation.preview() == preview && presentation.sideLines().equals(sideLines)) {
+        if (presentation.preview() == preview && presentation.sideLines().equals(sideLines)
+                && presentation.footerHints().get(1).equals(statePrimaryHint(selected))) {
             return false;
         }
         String focusId = focused.id();
@@ -2775,12 +2776,20 @@ public final class MainActivity extends Activity implements RuntimeObserver {
     private MenuPageSpec statePage(MenuPreview preview, String preferredFocus) {
         List<MenuPageSpec.Item> items = stateMenuItems(stateSlots);
         String mode = stateMenuMode == StateMenuMode.SAVE ? "SAVE" : "LOAD";
+        AndroidStateSlot selected = stateSlot(preferredFocus == null
+                ? StateRef.MIN_SLOT : parseSlot(preferredFocus.replace("slot:", "")));
         return new MenuPageSpec(MenuRoute.SAVE_STATES, "COFFEE GB", mode + " STATES", "", "",
-                stateSavedAtLines(stateSlot(preferredFocus == null
-                        ? StateRef.MIN_SLOT : parseSlot(preferredFocus.replace("slot:", "")))),
+                stateSavedAtLines(selected),
                 items, 1,
-                List.of("D-PAD MOVE", "A " + mode, "B BACK"),
+                List.of("D-PAD MOVE", statePrimaryHint(selected), "B BACK"),
                 preferredFocus == null ? "slot:" + StateRef.MIN_SLOT : preferredFocus, preview);
+    }
+
+    private String statePrimaryHint(AndroidStateSlot selected) {
+        if (stateMenuMode == StateMenuMode.SAVE) {
+            return "A SAVE";
+        }
+        return selected != null && selected.loadable() ? "A LOAD" : "";
     }
 
     private MenuPageSpec recentGamesPage() {
@@ -2824,7 +2833,7 @@ public final class MainActivity extends Activity implements RuntimeObserver {
             // The reusable button detail distinguishes a persisted state from an empty but still
             // focusable slot without requiring a save-state-specific asset.
             items.add(MenuPageSpec.Item.button("slot:" + index, "SLOT " + index,
-                    used ? "SAVED" : "", true));
+                    used ? "SAVED" : "EMPTY", true));
         }
         return List.copyOf(items);
     }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidMenuModelTest.java
@@ -54,7 +54,7 @@ public class AndroidMenuModelTest {
         assertFalse(page.items().stream().anyMatch(item -> item.id().equals("resume")
                 || item.id().equals("fullscreen")));
         assertTrue(page.items().stream().allMatch(item -> item.detail().isEmpty()));
-        assertEquals(List.of("PLAY TIME", "12:34", "BATTERY SAVE ACTIVE"), page.sideLines());
+        assertEquals(List.of("PLAY TIME 12:34", "BATTERY SAVE ACTIVE"), page.sideLines());
 
         MenuPageSpec unavailable = AndroidMenuModel.pausePage(
                 "NO GAME", "00:00", false, false, MenuPreview.empty());
@@ -62,11 +62,12 @@ public class AndroidMenuModelTest {
     }
 
     @Test
-    public void resetConfirmationUsesPlainConfirmAndCancelRows() {
+    public void resetConfirmationNamesTheActionAndFocusesCancel() {
         MenuPageSpec page = AndroidMenuModel.resetConfirmationPage();
 
-        assertEquals("CONFIRM ACTION", page.context());
+        assertEquals("RESET GAME?", page.context());
         assertIds(page, "confirm", "cancel");
+        assertEquals("RESET GAME", page.items().get(0).label());
         assertTrue(page.items().stream().allMatch(item -> item.detail().isEmpty()));
         assertEquals("cancel", page.preferredFocusId());
     }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/AndroidStateSlotTest.java
@@ -73,7 +73,7 @@ public class AndroidStateSlotTest {
         assertEquals(10, items.size());
         assertEquals("slot:0", items.get(0).id());
         assertEquals("slot:9", items.get(9).id());
-        assertEquals("", items.get(0).detail());
+        assertEquals("EMPTY", items.get(0).detail());
         assertEquals("SAVED", items.get(StateRef.MAX_SLOT).detail());
         assertTrue(items.stream().allMatch(eu.rekawek.coffeegb.ui.menu.MenuPageSpec.Item::enabled));
     }

--- a/android/app/src/test/java/eu/rekawek/coffeegb/android/MenuPointerTouchTest.java
+++ b/android/app/src/test/java/eu/rekawek/coffeegb/android/MenuPointerTouchTest.java
@@ -1,0 +1,65 @@
+package eu.rekawek.coffeegb.android;
+
+import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuPageSpec;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerGesture;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
+import eu.rekawek.coffeegb.ui.menu.MenuRoute;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuPoint;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+public class MenuPointerTouchTest {
+
+    @Test
+    public void touchUsesTheSkinsOffsetApertureAndReleaseMustMatchThePressedRow() {
+        MenuController controller = new MenuController(new MenuController.Listener() {
+            @Override
+            public void onPresentation(MenuPresentation presentation) {
+            }
+
+            @Override
+            public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+            }
+
+            @Override
+            public void onHeaderSelected(MenuRoute route) {
+            }
+        });
+        controller.setPages(List.of(new MenuPageSpec(MenuRoute.SETTINGS, "SETTINGS", "",
+                "", "", List.of(), List.of(
+                        MenuPageSpec.Item.button("audio", "AUDIO", "", true),
+                        MenuPageSpec.Item.button("display", "DISPLAY", "", true)),
+                1, List.of("D-PAD MOVE", "A CHOOSE", "B BACK"))));
+        controller.show(MenuRoute.SETTINGS);
+        MenuPresentation presentation = controller.presentation();
+        MenuViewport viewport = MenuViewport.fit(800, 600);
+        MenuPoint first = viewport.sourceToView(600, 150);
+        MenuPoint second = viewport.sourceToView(600, 230);
+        MenuPointerTarget firstTarget = hit(presentation, first);
+        MenuPointerTarget secondTarget = hit(presentation, second);
+        assertEquals("audio", firstTarget.itemId());
+        assertEquals("display", secondTarget.itemId());
+        assertNull(CoffeeGbSurfaceView.menuTargetAt(presentation, 100, 200, 800, 600, 105, 350));
+        assertNull(CoffeeGbSurfaceView.menuTargetAt(presentation, 100, 200, 800, 600, 99, 350));
+
+        MenuPointerGesture gesture = new MenuPointerGesture();
+        gesture.press(7, firstTarget);
+        assertFalse(gesture.release(7, secondTarget).isPresent());
+        gesture.press(7, secondTarget);
+        assertEquals(secondTarget, gesture.release(7, secondTarget).orElseThrow());
+        assertFalse(gesture.release(7, secondTarget).isPresent());
+    }
+
+    private static MenuPointerTarget hit(MenuPresentation presentation, MenuPoint point) {
+        return CoffeeGbSurfaceView.menuTargetAt(presentation, 100, 200, 800, 600,
+                (float) point.x() + 100, (float) point.y() + 200);
+    }
+}

--- a/doc/ui-ux-review.md
+++ b/doc/ui-ux-review.md
@@ -1,0 +1,62 @@
+# On-screen menu UX review
+
+Reviewed the shared desktop/Android menu renderer, every route in its visual gallery, and the
+host navigation and input code. This is a heuristic/code review with rendered-screen inspection,
+not a study with representative users.
+
+The existing interface has a coherent retro identity, consistent screen geometry, large menu
+rows, and a focus arrow that does not rely on color alone. The main problems were readability,
+misleading interaction cues, and missing feedback.
+
+## Improvements implemented
+
+| Priority | Finding | Improvement |
+| --- | --- | --- |
+| High | Rows look interactive but ignore direct mouse clicks and screen taps. | Share hit testing with the rendered row layout; activate on release over the same target. Add clickable previous/next page arrows for file browsing. Borders, dividers, disabled entries, and unused rows stay inert. |
+| High | Word spaces are narrower than the bitmap lettering, visually joining words. | Use consistent, wider runtime word spacing across all five text sizes while retaining the licensed glyph assets. |
+| High | Long labels and dropdown values are truncated or crowded together. | Wrap longer labels to two lines. Align every label to the same inset and place crowded dropdowns on two lines without shrinking text. |
+| High | Volume says “A Choose”, but A does nothing; other controls have the same generic hint. | Show “L/R Adjust”, “A Toggle”, “A Open”, or “A Select” for the focused control. Slider track clicks adjust one step toward the pointer. |
+| High | Empty load slots show no status and advertise a load action that does nothing. | Label them “Empty” and hide the load hint until an occupied slot is selected. Keep empty slots available for saving. |
+| Medium | Root Library advertises Back even when it cannot close. | Derive Back availability from the actual menu stack and host policy; hide the unavailable button glyph as well as its text. |
+| Medium | Empty Recent Games offers no next step; unavailable history can select the wrong preview. | Explain how to open a ROM and select a readable entry, or a safe status row when none are readable. |
+| Medium | Generic “Confirm” obscures what a destructive action will do. | Name the action in both the question and button; keep Cancel initially selected. |
+| Medium | Empty menu rows look like additional controls. | Draw dividers only for occupied rows and scroll indicators. |
+| Medium | A wrapped game title can push battery-save status below the four-line caption. | Put the play-time label and elapsed time on one line. |
+
+## Basis for the review
+
+The review uses visibility of status, familiar language, consistency, recognition, user control,
+error prevention, and reduced visual clutter from
+[Nielsen Norman Group's usability heuristics](https://www.nngroup.com/articles/ten-usability-heuristics/).
+These principles support truthful hints, specific action labels, visible save status, and controls
+that behave as their appearance suggests.
+
+[W3C contrast guidance](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+uses 4.5:1 for ordinary text. Existing foreground/background colors already exceed that benchmark:
+the minimum contrast across each packaged widget texture is 9.00:1 for ordinary rows, 8.63:1 for
+selected rows, and 8.88:1 for paper surfaces. The palette therefore stays unchanged.
+
+[W3C target-size guidance](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
+uses a 24 by 24 CSS-pixel minimum with specified exceptions. It is a useful reference for this
+native UI, not a claim of WCAG conformance. A 72-pixel row scales to about 25 pixels when the
+924-pixel menu is displayed at 320 pixels wide; text at that size still needs device-level review.
+
+## Validation and remaining limits
+
+The gallery can be regenerated with `CommonMenuGalleryMain`. It includes every route plus long
+dropdown values, long labels and filenames, overflow lists, empty load slots, root Library, and
+a wrapped pause title. Automated tests cover geometry and clipping, text metrics, focus and
+navigation, empty states, and pointer activation/cancellation.
+
+Validation passed: 101 portable UI tests, 63 targeted Swing tests (including real mouse-event
+dispatch), and 24 Android JVM tests. The final paging addition was covered by the portable suite.
+Android Java and test code compiled against the updated shared module; live device gestures were
+not instrumented. Local visual evidence is generated under `ui-portable/target/ux-review/`.
+
+The interface still uses a fixed raster layout and controller-style A/B hints. A responsive small
+screen layout, keyboard-specific key labels, screen-reader semantics, slider dragging, and
+unbounded long-caption handling need separate design work. This pass preserves the existing
+save-overwrite behavior. A full accessibility audit would also need assistive-technology and
+physical-device testing.
+
+No new artwork was needed: the changes reuse the existing frame, textures, and illustrations.

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingEmulator.kt
@@ -293,6 +293,7 @@ class SwingEmulator(
                 },
             )
     portableMenu = installedMenu
+    display.setMenuPointerInput(installedMenu)
     playerInput.setMenuCapture(portableMenu)
     return installedMenu
   }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -4,11 +4,13 @@ import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.memory.cart.RomSourceSnapshot
 import eu.rekawek.coffeegb.swing.io.DesktopMenuInputCapture
 import eu.rekawek.coffeegb.swing.io.DesktopMenuKeyboardInput
+import eu.rekawek.coffeegb.swing.io.DesktopMenuPointerInput
 import eu.rekawek.coffeegb.ui.menu.MenuController
 import eu.rekawek.coffeegb.ui.menu.MenuKey
 import eu.rekawek.coffeegb.ui.menu.MenuPageLayout
 import eu.rekawek.coffeegb.ui.menu.MenuPageSpec
 import eu.rekawek.coffeegb.ui.menu.MenuPagination
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget
 import eu.rekawek.coffeegb.ui.menu.PauseMenuSnapshot
 import eu.rekawek.coffeegb.ui.menu.MenuPresentation
 import eu.rekawek.coffeegb.ui.menu.MenuPreview
@@ -17,6 +19,7 @@ import eu.rekawek.coffeegb.ui.menu.MenuWidgetType
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame
 import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor
 import java.util.EnumSet
+import java.util.Optional
 import java.nio.file.Path
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -56,7 +59,8 @@ internal class SwingProposal3Menu(
     private val capturePausePreview: () -> MenuPreview = { MenuPreview.empty() },
     private val romFileBrowser: DesktopRomFileBrowser = DesktopRomFileBrowser(),
     private val fileBrowserExecutor: Executor = FILE_BROWSER_EXECUTOR,
-) : DesktopMenuInputCapture, DesktopMenuKeyboardInput, DesktopArchiveSelectionHost {
+) : DesktopMenuInputCapture, DesktopMenuKeyboardInput, DesktopMenuPointerInput,
+    DesktopArchiveSelectionHost {
 
   private enum class StateMenuMode { SAVE, LOAD }
 
@@ -306,6 +310,17 @@ internal class SwingProposal3Menu(
       if (!visible() || romDialogOpen.get()) break
     }
     return true
+  }
+
+  override fun targetAt(sourceX: Int, sourceY: Int): Optional<MenuPointerTarget> {
+    if (romDialogOpen.get()) return Optional.empty()
+    return Proposal3MenuCompositor.hitTest(controller.presentation(), sourceX, sourceY)
+  }
+
+  override fun activateTarget(target: MenuPointerTarget): Boolean {
+    if (romDialogOpen.get()) return true
+    refreshPrinterPageBeforeInput()
+    return controller.activateTarget(target)
   }
 
   override fun onKeyDown(key: MenuKey, repeat: Boolean): Boolean {
@@ -562,8 +577,7 @@ internal class SwingProposal3Menu(
             "",
             snapshot.romTitle(),
             listOf(
-                "PLAY TIME",
-                snapshot.formattedPlayTime(),
+                "PLAY TIME ${snapshot.formattedPlayTime()}",
                 if (snapshot.batterySaveActive()) "BATTERY SAVE ACTIVE" else "NO BATTERY SAVE",
             ),
             listOf(
@@ -593,7 +607,7 @@ internal class SwingProposal3Menu(
               MenuPageSpec.Item.button(
                   "slot-$slot",
                   "SLOT $slot",
-                  if (catalog.firstOrNull { it.index == slot }?.loadable == true) "SAVED" else "",
+                  if (catalog.firstOrNull { it.index == slot }?.loadable == true) "SAVED" else "EMPTY",
                   true,
               )
             }
@@ -612,7 +626,11 @@ internal class SwingProposal3Menu(
             preferredFocus = focused,
             headerAction = "",
             preview = preview,
-            footerHints = listOf("D-PAD MOVE", "A $mode", "B BACK"),
+            footerHints = listOf(
+                "D-PAD MOVE",
+                if (stateMenuMode == StateMenuMode.SAVE || focusedSlot?.loadable == true) "A $mode" else "",
+                "B BACK",
+            ),
         )
       }
 
@@ -987,11 +1005,11 @@ internal class SwingProposal3Menu(
         requireNotNull(action) { "Confirmation route requires a pending action" }
         val actionLabel = action.confirmationLabel()
         page(
-            "CONFIRM ACTION",
+            "$actionLabel?",
             actionLabel,
             listOf("UNSAVED PROGRESS MAY BE LOST"),
             listOf(
-                MenuPageSpec.Item.button("confirm", "CONFIRM", "", true),
+                MenuPageSpec.Item.button("confirm", actionLabel, "", true),
                 MenuPageSpec.Item.button("cancel", "CANCEL", "", true),
             ),
             preferredFocus = "cancel",
@@ -1672,7 +1690,11 @@ internal class SwingProposal3Menu(
       val desiredSideLines = portableStateSavedAt(focusedSlot?.savedAt)
           ?.let { listOf(it) }
           ?: emptyList()
-      if (presentation.preview() !== desiredPreview || presentation.sideLines() != desiredSideLines) {
+      val desiredAction =
+          if (stateMenuMode == StateMenuMode.SAVE) "A SAVE"
+          else if (focusedSlot?.loadable == true) "A LOAD" else ""
+      if (presentation.preview() !== desiredPreview || presentation.sideLines() != desiredSideLines ||
+          presentation.footerHints().getOrNull(1) != desiredAction) {
         controller.setPage(pageFor(MenuRoute.SAVE_STATES, commands.menuState()))
         return
       }
@@ -1684,7 +1706,7 @@ internal class SwingProposal3Menu(
           focusedId?.removePrefix("recent:")?.toIntOrNull()?.let { commands.recentGames().getOrNull(it) }
       val desiredPreview = selected?.let(::recentPreview) ?: MenuPreview.empty()
       val desiredSideLines =
-          if (selected == null) emptyList()
+          if (selected == null) listOf("GO BACK AND CHOOSE OPEN ROM")
           else listOf("LAST PLAYED: ${recentLastPlayed(selected)}")
       if (presentation.preview() !== desiredPreview || presentation.sideLines() != desiredSideLines) {
         controller.setPage(pageFor(MenuRoute.RECENT_GAMES, commands.menuState()))

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuPointerInput.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/DesktopMenuPointerInput.java
@@ -1,0 +1,13 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
+
+import java.util.Optional;
+
+/** Semantic pointer bridge for the portable menu's canonical source coordinates. */
+public interface DesktopMenuPointerInput {
+
+    Optional<MenuPointerTarget> targetAt(int sourceX, int sourceY);
+
+    boolean activateTarget(MenuPointerTarget target);
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/io/SwingDisplay.java
@@ -13,12 +13,16 @@ import eu.rekawek.coffeegb.core.gpu.Display;
 import eu.rekawek.coffeegb.core.rumble.RumbleEvent;
 import eu.rekawek.coffeegb.core.sgb.SgbDisplay;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerGesture;
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuArgbFrame;
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuRect;
 import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -89,6 +93,10 @@ public class SwingDisplay extends JPanel implements Runnable {
 
     private volatile String persistentNotificationText;
 
+    private DesktopMenuPointerInput menuPointerInput;
+
+    private final MenuPointerGesture menuPointerGesture = new MenuPointerGesture();
+
     public SwingDisplay(DisplayProperties properties, EventBus eventBus, String callerId) {
         super();
         requireEventDispatchThread("SwingDisplay construction");
@@ -105,6 +113,32 @@ public class SwingDisplay extends JPanel implements Runnable {
         this.scaleMode = initialScaleMode(properties);
         setBlending(properties.getBlending());
         setColorCorrection(properties.getColorCorrection());
+
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent event) {
+                if (SwingUtilities.isLeftMouseButton(event)) {
+                    menuPointerGesture.press(0, menuTargetAt(event.getX(), event.getY()));
+                    if (menuOverlay.visible()) {
+                        requestFocusInWindow();
+                        event.consume();
+                    }
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                if (!SwingUtilities.isLeftMouseButton(event)) {
+                    return;
+                }
+                MenuPointerTarget released = menuPointerGesture.release(0,
+                        menuTargetAt(event.getX(), event.getY())).orElse(null);
+                if (released != null) {
+                    menuPointerInput.activateTarget(released);
+                    event.consume();
+                }
+            }
+        });
 
         eventBus.register(this::onDmgFrame, Display.DmgFrameReadyEvent.class, callerId);
         eventBus.register(this::onGbcFrame, Display.GbcFrameReadyEvent.class, callerId);
@@ -399,7 +433,26 @@ public class SwingDisplay extends JPanel implements Runnable {
     /** Installs one immutable portable Proposal 3 frame over the display. */
     public void setMenuOverlay(MenuArgbFrame frame) {
         menuOverlay.setFrame(frame);
+        if (frame == null) {
+            menuPointerGesture.cancel();
+        }
         requestRepaint();
+    }
+
+    /** Installs the semantic pointer bridge; menu geometry stays in the portable compositor. */
+    public void setMenuPointerInput(DesktopMenuPointerInput input) {
+        requireEventDispatchThread("Menu pointer installation");
+        menuPointerGesture.cancel();
+        menuPointerInput = input;
+    }
+
+    private MenuPointerTarget menuTargetAt(int viewX, int viewY) {
+        if (!menuOverlay.visible() || menuPointerInput == null || getWidth() < 2 || getHeight() < 2) {
+            return null;
+        }
+        return MenuViewport.fit(getWidth(), getHeight()).viewToSource(viewX, viewY)
+                .flatMap(point -> menuPointerInput.targetAt((int) point.x(), (int) point.y()))
+                .orElse(null);
     }
 
     /** Clears the portable menu overlay and exposes the emulator frame again. */

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/SwingProposal3MenuTest.kt
@@ -142,6 +142,7 @@ class SwingProposal3MenuTest {
           menu.visibleItemIdsForTest(),
       )
       assertEquals("open-rom", menu.focusedItemIdForTest())
+      assertEquals(listOf("D-PAD MOVE", "A CHOOSE", ""), menu.presentationForTest().footerHints())
       press(menu, MenuKey.DOWN)
       press(menu, MenuKey.A)
       assertEquals(MenuRoute.RECENT_GAMES, menu.routeForTest())
@@ -958,8 +959,9 @@ class SwingProposal3MenuTest {
       press(menu, MenuKey.A)
 
       assertEquals(MenuRoute.CONFIRM_ACTION, menu.routeForTest())
-      assertEquals("CONFIRM ACTION", menu.presentationForTest().context())
+      assertEquals("RESET GAME?", menu.presentationForTest().context())
       assertEquals(listOf("confirm", "cancel"), menu.visibleItemIdsForTest())
+      assertEquals("RESET GAME", menu.presentationForTest().items().first().label())
       assertTrue(menu.presentationForTest().items().all { it.detail().isEmpty() })
       assertEquals("cancel", menu.focusedItemIdForTest())
       press(menu, MenuKey.UP)
@@ -1010,6 +1012,7 @@ class SwingProposal3MenuTest {
       press(menu, MenuKey.A)
       assertEquals(MenuRoute.AUDIO, menu.routeForTest())
       assertEquals("volume", menu.focusedItemIdForTest())
+      assertEquals(listOf("L/R ADJUST", "", "B BACK"), menu.presentationForTest().footerHints())
       assertEquals(listOf("volume", "mute-audio"), menu.visibleItemIdsForTest())
       assertEquals(
           listOf(MenuWidgetType.SLIDER, MenuWidgetType.CHECKBOX),
@@ -1023,6 +1026,7 @@ class SwingProposal3MenuTest {
       assertEquals(MenuRoute.AUDIO, menu.routeForTest())
       press(menu, MenuKey.DOWN)
       assertEquals("mute-audio", menu.focusedItemIdForTest())
+      assertEquals(listOf("D-PAD MOVE", "A TOGGLE", "B BACK"), menu.presentationForTest().footerHints())
       press(menu, MenuKey.A)
       assertTrue(bridge.muted)
       val toggledMute = menu.presentationForTest().items().single { it.id() == "mute-audio" }
@@ -1346,6 +1350,8 @@ class SwingProposal3MenuTest {
       press(menu, MenuKey.A)
       assertEquals(MenuRoute.SAVE_STATES, menu.routeForTest())
       assertEquals("slot-0", menu.focusedItemIdForTest())
+      assertEquals("EMPTY", menu.presentationForTest().items().first().detail())
+      assertEquals("A SAVE", menu.presentationForTest().footerHints()[1])
 
       press(menu, MenuKey.A)
       assertEquals(0, bridge.savedSlot)
@@ -1376,13 +1382,20 @@ class SwingProposal3MenuTest {
       press(menu, MenuKey.DOWN)
       press(menu, MenuKey.A)
       assertEquals(MenuRoute.SAVE_STATES, menu.routeForTest())
+      assertEquals("EMPTY", menu.presentationForTest().items().first().detail())
+      assertEquals("", menu.presentationForTest().footerHints()[1])
 
       repeat(9) { press(menu, MenuKey.DOWN) }
       assertEquals("slot-9", menu.focusedItemIdForTest())
+      assertEquals("A LOAD", menu.presentationForTest().footerHints()[1])
       assertEquals(
           "SAVED",
           menu.presentationForTest().items().single { it.id() == "slot-9" }.detail(),
       )
+      press(menu, MenuKey.UP)
+      assertEquals("", menu.presentationForTest().footerHints()[1])
+      press(menu, MenuKey.DOWN)
+      assertEquals("A LOAD", menu.presentationForTest().footerHints()[1])
       press(menu, MenuKey.A)
     }
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingMenuPointerTest.java
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/io/SwingMenuPointerTest.java
@@ -1,0 +1,90 @@
+package eu.rekawek.coffeegb.swing.io;
+
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties;
+import eu.rekawek.coffeegb.core.events.EventBus;
+import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuPageSpec;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
+import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
+import eu.rekawek.coffeegb.ui.menu.MenuRoute;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuPoint;
+import eu.rekawek.coffeegb.ui.menu.artwork.MenuViewport;
+import eu.rekawek.coffeegb.ui.menu.artwork.Proposal3MenuCompositor;
+import org.junit.Test;
+
+import javax.swing.SwingUtilities;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class SwingMenuPointerTest {
+
+    @Test
+    public void scaledMenuClickActivatesClickedRowAndRejectsBarsAndMismatchedRelease()
+            throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            List<String> selected = new ArrayList<>();
+            SwingDisplay display = new SwingDisplay(new EmulatorProperties().getDisplay(),
+                    EventBus.NULL_EVENT_BUS, "pointer-test");
+            display.setSize(1600, 900);
+            Proposal3MenuCompositor compositor = new Proposal3MenuCompositor();
+            MenuController controller = new MenuController(new MenuController.Listener() {
+                @Override
+                public void onPresentation(MenuPresentation presentation) {
+                    display.setMenuOverlay(compositor.compose(presentation).orElse(null));
+                }
+
+                @Override
+                public void onItemSelected(MenuRoute route, String id, boolean secondary) {
+                    selected.add(id);
+                }
+
+                @Override
+                public void onHeaderSelected(MenuRoute route) {
+                }
+            });
+            controller.setPages(List.of(new MenuPageSpec(MenuRoute.SETTINGS, "SETTINGS", "",
+                    "", "", List.of(), List.of(
+                            MenuPageSpec.Item.button("audio", "AUDIO", "", true),
+                            MenuPageSpec.Item.button("display", "DISPLAY", "", true)),
+                    1, List.of("D-PAD MOVE", "A CHOOSE", "B BACK"))));
+            controller.show(MenuRoute.SETTINGS);
+            display.setMenuPointerInput(new DesktopMenuPointerInput() {
+                @Override
+                public Optional<MenuPointerTarget> targetAt(int sourceX, int sourceY) {
+                    return Proposal3MenuCompositor.hitTest(controller.presentation(), sourceX, sourceY);
+                }
+
+                @Override
+                public boolean activateTarget(MenuPointerTarget target) {
+                    return controller.activateTarget(target);
+                }
+            });
+
+            MenuViewport viewport = MenuViewport.fit(display.getWidth(), display.getHeight());
+            MenuPoint first = viewport.sourceToView(600, 150);
+            MenuPoint second = viewport.sourceToView(600, 230);
+            pointer(display, MouseEvent.MOUSE_PRESSED, second);
+            assertEquals(List.of(), selected);
+            pointer(display, MouseEvent.MOUSE_RELEASED, second);
+            assertEquals(List.of("display"), selected);
+            pointer(display, MouseEvent.MOUSE_PRESSED, first);
+            pointer(display, MouseEvent.MOUSE_RELEASED, second);
+            pointer(display, MouseEvent.MOUSE_PRESSED, new MenuPoint(20, 200));
+            pointer(display, MouseEvent.MOUSE_RELEASED, new MenuPoint(20, 200));
+            pointer(display, MouseEvent.MOUSE_PRESSED, first);
+            controller.hide();
+            controller.show(MenuRoute.SETTINGS);
+            pointer(display, MouseEvent.MOUSE_RELEASED, first);
+            assertEquals(List.of("display"), selected);
+        });
+    }
+
+    private static void pointer(SwingDisplay display, int event, MenuPoint point) {
+        display.dispatchEvent(new MouseEvent(display, event, 0L, 0,
+                (int) point.x(), (int) point.y(), 1, false, MouseEvent.BUTTON1));
+    }
+}

--- a/ui-portable/README.md
+++ b/ui-portable/README.md
@@ -42,6 +42,9 @@ font size.
 All four types use the same row bounds and `Proposal3GlyphAtlas.Role.MEDIUM` item typography.
 Checkboxes use the typed `Item.checkbox(id, label, checked, enabled)` state; their display text is
 only the label, so hosts do not encode or render `ON`/`OFF` strings.
+Long labels can use two lines within the same row. Dropdowns use a second line when the label and
+value would otherwise collide. Unused slots have no dividers, distinguishing blank space from
+actual controls.
 `Proposal3WidgetSkins` supplies only three route-neutral surface textures:
 
 ```
@@ -113,6 +116,8 @@ The selected-output digest and checked-in result are the stable provenance recor
 The Small, Notice, Medium, Display, and SemiBold bitmap atlases under `proposal3/overlay/` come from
 the project's licensed ByteBounce source. The TTF is build-time-only and does not ship. Source and
 atlas digests plus role metrics are recorded in `overlay/ByteBounce-licensed-source.txt`.
+Runtime word spaces use a full glyph advance for readability; this does not alter the source atlas
+recipe or the PNGs.
 
 Regenerate them with:
 
@@ -147,6 +152,14 @@ cross-products and deterministic floor rounding. It centers the content, assigns
 pixels to the right/bottom bars, and rejects letterbox pixels plus half-open right/bottom edges
 during inverse input mapping. Desktop and Android use this same placement rather than reflowing
 the template.
+
+`Proposal3MenuCompositor.hitTest` shares the renderer's visible-slot geometry. Desktop clicks and
+Android taps inverse-map through `MenuViewport`, then use `MenuPointerGesture` to activate only
+when press and release resolve to the same target. Footer targets follow their current hints;
+unavailable actions, separators, and blank rows have no target. Slider track clicks adjust one
+step toward the pointer. Keyboard and gamepad navigation remain available.
+
+See [the UX review](../doc/ui-ux-review.md) for findings, changes, sources, and remaining limits.
 
 Useful verification commands:
 

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuController.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuController.java
@@ -42,7 +42,7 @@ public final class MenuController implements MenuTouchInput {
 
     public MenuPresentation presentation() {
         synchronized (lock) {
-            return state.presentation();
+            return presentationLocked();
         }
     }
 
@@ -60,7 +60,7 @@ public final class MenuController implements MenuTouchInput {
             MenuPage page = MenuPage.from(spec);
             pages.put(spec.route(), page);
             state = MenuReducer.replacePage(state, page);
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -76,7 +76,7 @@ public final class MenuController implements MenuTouchInput {
                     state, page, focusedItemId);
             pages.put(spec.route(), page);
             state = replacement;
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -91,7 +91,7 @@ public final class MenuController implements MenuTouchInput {
                 pages.put(spec.route(), page);
                 state = MenuReducer.replacePage(state, page);
             }
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -101,7 +101,7 @@ public final class MenuController implements MenuTouchInput {
         synchronized (lock) {
             state = MenuReducer.show(state, page(route));
             clearTransientInputsLocked(true);
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -110,7 +110,7 @@ public final class MenuController implements MenuTouchInput {
         MenuPresentation next;
         synchronized (lock) {
             state = MenuReducer.push(state, page(route));
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -147,7 +147,7 @@ public final class MenuController implements MenuTouchInput {
                 state = MenuReducer.restore(routePages, focus);
             }
             clearTransientInputsLocked(true);
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -179,9 +179,21 @@ public final class MenuController implements MenuTouchInput {
      * no gameplay surface to reveal underneath it.</p>
      */
     public void setRootDismissAllowed(boolean allowed) {
+        MenuPresentation next;
         synchronized (lock) {
+            if (rootDismissAllowed == allowed) {
+                return;
+            }
             rootDismissAllowed = allowed;
+            // Hosts commonly configure this policy while constructing their menu controller,
+            // before the view hierarchy exists. The next visible presentation will carry the
+            // policy, while an already visible menu still receives an immediate refresh.
+            if (!state.visible()) {
+                return;
+            }
+            next = presentationLocked();
         }
+        notifyPresentation(next);
     }
 
     public void back() {
@@ -197,7 +209,7 @@ public final class MenuController implements MenuTouchInput {
             if (!state.visible()) {
                 clearTransientInputsLocked(false);
             }
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -210,7 +222,7 @@ public final class MenuController implements MenuTouchInput {
             }
             state = MenuReducer.hide(state);
             clearTransientInputsLocked(false);
-            next = state.presentation();
+            next = presentationLocked();
         }
         notifyPresentation(next);
     }
@@ -252,6 +264,34 @@ public final class MenuController implements MenuTouchInput {
             return false;
         }
         onKeyUp(MenuKey.B);
+        return true;
+    }
+
+    /** Activates a released click or tap after checking it still belongs to the visible page. */
+    @Override
+    public boolean activateTarget(MenuPointerTarget target) {
+        Objects.requireNonNull(target, "target");
+        Transition transition;
+        synchronized (lock) {
+            if (!state.visible() || state.route() != target.route()) {
+                return false;
+            }
+            if (target.itemId() != null) {
+                int index = state.page().enabledIndex(target.itemId());
+                if (index < 0) {
+                    return false;
+                }
+                state = MenuReducer.focus(state, target.itemId());
+                if (state.page().items().get(index).adjustable() && target.key() == MenuKey.A) {
+                    transition = new Transition(presentationLocked(), null);
+                } else {
+                    transition = activateLocked(target.key());
+                }
+            } else {
+                transition = activateLocked(target.key());
+            }
+        }
+        notifyTransition(transition.presentation, transition.event);
         return true;
     }
 
@@ -362,6 +402,13 @@ public final class MenuController implements MenuTouchInput {
         }
     }
 
+    private MenuPresentation presentationLocked() {
+        MenuPresentation presentation = state.presentation();
+        return state.depth() == 1 && !rootDismissAllowed
+                && !backIntercepted && !rootBackIntercepted
+                        ? presentation.withoutBackHint() : presentation;
+    }
+
     private boolean visibleInternal() {
         synchronized (lock) {
             return state.visible();
@@ -382,7 +429,7 @@ public final class MenuController implements MenuTouchInput {
             case UP, DOWN -> {
                 if (state.route() == MenuRoute.FILE_BROWSER
                         && state.page().layout() == MenuPageLayout.FULL_WIDTH_LIST) {
-                    return new Transition(state.presentation(), Event.row(
+                    return new Transition(presentationLocked(), Event.row(
                             state.route(), key == MenuKey.UP ? -1 : 1));
                 }
                 state = MenuReducer.move(state, key == MenuKey.UP
@@ -391,7 +438,7 @@ public final class MenuController implements MenuTouchInput {
             case LEFT, RIGHT -> {
                 MenuItem item = state.page().items().get(state.focusedIndex());
                 if (item.enabled() && item.adjustable()) {
-                    return new Transition(state.presentation(), Event.adjust(
+                    return new Transition(presentationLocked(), Event.adjust(
                             state.route(), item.id(), key == MenuKey.LEFT ? -1 : 1));
                 }
                 MenuPage page = state.page();
@@ -400,7 +447,7 @@ public final class MenuController implements MenuTouchInput {
                     int targetIndex = pagination.pageIndex()
                             + (key == MenuKey.LEFT ? -1 : 1);
                     if (targetIndex >= 0 && targetIndex < pagination.pageCount()) {
-                        return new Transition(state.presentation(), Event.page(
+                        return new Transition(presentationLocked(), Event.page(
                                 state.route(), targetIndex));
                     }
                 }
@@ -409,10 +456,10 @@ public final class MenuController implements MenuTouchInput {
             }
             case B -> {
                 if (backIntercepted || (state.stack().size() == 1 && rootBackIntercepted)) {
-                    return new Transition(state.presentation(), Event.back(state.route()));
+                    return new Transition(presentationLocked(), Event.back(state.route()));
                 }
                 if (state.stack().size() == 1 && !rootDismissAllowed) {
-                    return new Transition(state.presentation(), null);
+                    return new Transition(presentationLocked(), null);
                 }
                 state = MenuReducer.back(state);
                 if (!state.visible()) {
@@ -422,14 +469,14 @@ public final class MenuController implements MenuTouchInput {
             case A, START -> {
                 MenuItem item = state.page().items().get(state.focusedIndex());
                 if (item.enabled()) {
-                    return new Transition(state.presentation(), Event.item(
+                    return new Transition(presentationLocked(), Event.item(
                             state.route(), item.id(), false));
                 }
             }
             case SECONDARY -> {
                 MenuItem item = state.page().items().get(state.focusedIndex());
                 if (item.enabled() && item.secondaryId() != null) {
-                    return new Transition(state.presentation(), Event.item(
+                    return new Transition(presentationLocked(), Event.item(
                             state.route(), item.secondaryId(), true));
                 }
             }
@@ -437,7 +484,7 @@ public final class MenuController implements MenuTouchInput {
             // the distinct delete/remap route used by rows that explicitly declare one.
             case SELECT -> { }
         }
-        return new Transition(state.presentation(), null);
+        return new Transition(presentationLocked(), null);
     }
 
     private boolean heldByOtherSourceLocked(MenuKey key) {

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPageSpec.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPageSpec.java
@@ -48,7 +48,7 @@ public final class MenuPageSpec {
         RecentGame selected = null;
         if (selectedId != null) {
             for (RecentGame game : copied) {
-                if (selectedId.equals(game.id())) {
+                if (selectedId.equals(game.id()) && game.enabled()) {
                     selected = game;
                     break;
                 }
@@ -74,9 +74,10 @@ public final class MenuPageSpec {
                 selectedId = "recent-games-status";
             }
         }
-        List<String> sideLines = selected == null || selected.lastPlayed().isBlank()
-                ? List.of()
-                : List.of("LAST PLAYED: " + selected.lastPlayed());
+        List<String> sideLines = selected == null
+                ? List.of("GO BACK AND CHOOSE OPEN ROM")
+                : selected.lastPlayed().isBlank() ? List.of()
+                        : List.of("LAST PLAYED: " + selected.lastPlayed());
         MenuPreview preview = selected == null ? MenuPreview.empty() : selected.preview();
         List<String> footer = "recent-games-status".equals(selectedId)
                 ? List.of("", "", "B BACK")

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPages.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPages.java
@@ -17,7 +17,7 @@ final class MenuPages {
         }
         return switch (route) {
             case PAUSE_CONSOLE -> page(route, "COFFEE GB", "", "", "",
-                    List.of("PLAY TIME", "00:00", "NO BATTERY SAVE"),
+                    List.of("PLAY TIME 00:00", "NO BATTERY SAVE"),
                     items(
                             button("save-state", "SAVE STATE"),
                             button("load-state", "LOAD STATE"),
@@ -112,9 +112,9 @@ final class MenuPages {
                             button("storage", "NO BROAD STORAGE ACCESS"),
                             button("live-camera", "CAMERA ONLY WHEN ENABLED"),
                             button("source-notices", "SOURCE & THIRD-PARTY NOTICES")));
-            case CONFIRM_ACTION -> page(route, "COFFEE GB", "CONFIRM ACTION", "", "RESET GAME",
+            case CONFIRM_ACTION -> page(route, "COFFEE GB", "RESET GAME?", "", "RESET GAME",
                     List.of("UNSAVED PROGRESS MAY BE LOST"),
-                    items(button("confirm", "CONFIRM"),
+                    items(button("confirm", "RESET GAME"),
                             button("cancel", "CANCEL")), 1, DEFAULT_HINTS,
                     "cancel", MenuPreview.empty());
         };
@@ -128,17 +128,17 @@ final class MenuPages {
         String context = load ? "LOAD STATES" : "SAVE STATES";
         return page(MenuRoute.SAVE_STATES, "COFFEE GB", context, "", "", List.of(),
                 items(
-                        button("slot-0", "SLOT 0"),
-                        button("slot-1", "SLOT 1"),
-                        button("slot-2", "SLOT 2"),
-                        button("slot-3", "SLOT 3"),
-                        button("slot-4", "SLOT 4"),
-                        button("slot-5", "SLOT 5"),
-                        button("slot-6", "SLOT 6"),
-                        button("slot-7", "SLOT 7"),
-                        button("slot-8", "SLOT 8"),
-                        button("slot-9", "SLOT 9")),
-                1, List.of("D-PAD MOVE", "A " + (load ? "LOAD" : "SAVE"), "B BACK"),
+                        button("slot-0", "SLOT 0", "EMPTY"),
+                        button("slot-1", "SLOT 1", "EMPTY"),
+                        button("slot-2", "SLOT 2", "EMPTY"),
+                        button("slot-3", "SLOT 3", "EMPTY"),
+                        button("slot-4", "SLOT 4", "EMPTY"),
+                        button("slot-5", "SLOT 5", "EMPTY"),
+                        button("slot-6", "SLOT 6", "EMPTY"),
+                        button("slot-7", "SLOT 7", "EMPTY"),
+                        button("slot-8", "SLOT 8", "EMPTY"),
+                        button("slot-9", "SLOT 9", "EMPTY")),
+                1, List.of("D-PAD MOVE", load ? "" : "A SAVE", "B BACK"),
                 "slot-0", MenuPreview.empty());
     }
 

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPointerGesture.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPointerGesture.java
@@ -1,0 +1,31 @@
+package eu.rekawek.coffeegb.ui.menu;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** UI-thread gesture state: a pointer activates only the target on which it was pressed. */
+public final class MenuPointerGesture {
+
+    private final Map<Integer, MenuPointerTarget> pressed = new HashMap<>();
+
+    public void press(int pointerId, MenuPointerTarget target) {
+        pressed.remove(pointerId);
+        if (target != null) {
+            pressed.put(pointerId, target);
+        }
+    }
+
+    public boolean captured(int pointerId) {
+        return pressed.containsKey(pointerId);
+    }
+
+    public Optional<MenuPointerTarget> release(int pointerId, MenuPointerTarget target) {
+        MenuPointerTarget start = pressed.remove(pointerId);
+        return start != null && start.equals(target) ? Optional.of(start) : Optional.empty();
+    }
+
+    public void cancel() {
+        pressed.clear();
+    }
+}

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPointerTarget.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPointerTarget.java
@@ -1,0 +1,12 @@
+package eu.rekawek.coffeegb.ui.menu;
+
+import java.util.Objects;
+
+/** A semantic target retained between pointer press and release, independent of host scaling. */
+public record MenuPointerTarget(MenuRoute route, String itemId, MenuKey key) {
+
+    public MenuPointerTarget {
+        Objects.requireNonNull(route, "route");
+        Objects.requireNonNull(key, "key");
+    }
+}

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPresentation.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuPresentation.java
@@ -110,7 +110,30 @@ public final class MenuPresentation {
     }
 
     public List<String> footerHints() {
-        return footerHints;
+        if (!visible || focusedIndex < 0 || footerHints.size() < 3
+                || !"A CHOOSE".equals(footerHints.get(1))) {
+            return footerHints;
+        }
+        Item focused = items.get(focusedIndex);
+        return switch (focused.widgetType()) {
+            case SLIDER -> List.of("L/R ADJUST", "", footerHints.get(2));
+            case CHECKBOX -> List.of(footerHints.get(0),
+                    route == MenuRoute.OPTION_PICKER ? "A SELECT" : "A TOGGLE",
+                    footerHints.get(2));
+            case DROPDOWN -> List.of(footerHints.get(0), "A OPEN", footerHints.get(2));
+            case BUTTON -> footerHints;
+        };
+    }
+
+    /** Removes a root Back hint when the host has no underlying surface to return to. */
+    MenuPresentation withoutBackHint() {
+        if (!visible || footerHints.size() < 3 || footerHints.get(2).isEmpty()) {
+            return this;
+        }
+        ArrayList<String> hints = new ArrayList<>(footerHints);
+        hints.set(2, "");
+        return new MenuPresentation(visible, route, title, context, headerAction, sideHeading,
+                sideLines, items, focusedIndex, columns, hints, preview, layout, pagination);
     }
 
     public MenuPreview preview() {

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuReducer.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuReducer.java
@@ -175,6 +175,23 @@ final class MenuReducer {
         return MenuState.withStack(stack);
     }
 
+    /** Focuses one enabled row on the current page without changing any parent-page focus. */
+    static MenuState focus(MenuState state, String itemId) {
+        if (state == null || itemId == null) {
+            throw new IllegalArgumentException("state and item id are required");
+        }
+        if (!state.visible()) {
+            return state;
+        }
+        int next = state.page().enabledIndex(itemId);
+        if (next < 0 || next == state.focusedIndex()) {
+            return state;
+        }
+        ArrayList<MenuState.Frame> stack = new ArrayList<>(state.stack());
+        stack.set(stack.size() - 1, new MenuState.Frame(state.page(), next));
+        return MenuState.withStack(stack);
+    }
+
     private static int nextEnabledIndex(MenuPage page, int current, MenuCommand.Direction direction) {
         if (page.columns() == 1 && (direction == MenuCommand.Direction.LEFT
                 || direction == MenuCommand.Direction.RIGHT)) {

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuTouchInput.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/MenuTouchInput.java
@@ -7,6 +7,11 @@ public interface MenuTouchInput {
 
     boolean visible();
 
+    /** Activates a row or navigation control after a pointer is released over its press target. */
+    default boolean activateTarget(MenuPointerTarget target) {
+        return false;
+    }
+
     void updatePointer(int pointerId, Collection<MenuKey> keys);
 
     void releasePointer(int pointerId);

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3GlyphAtlas.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3GlyphAtlas.java
@@ -20,8 +20,8 @@ final class Proposal3GlyphAtlas {
     static final String CHARACTERS =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .:/&-_%?+()[]!,'";
     enum Role {
-        // These advances are part of the licensed atlas recipe recorded beside the PNGs. Keep
-        // them in sync so glyphs retain their intended spacing when a role is reused.
+        // These are the source metrics from the licensed atlas recipe recorded beside the PNGs.
+        // Runtime word spacing below is deliberately wider for readable menu labels.
         SMALL(22, 36, 11, 5),
         NOTICE(28, 36, 15, 7),
         MEDIUM(36, 36, 19, 8),
@@ -31,13 +31,13 @@ final class Proposal3GlyphAtlas {
         private final int cellWidth;
         private final int cellHeight;
         private final int advance;
-        private final int spaceAdvance;
+        private final int sourceSpaceAdvance;
 
         Role(int cellWidth, int cellHeight, int advance, int spaceAdvance) {
             this.cellWidth = cellWidth;
             this.cellHeight = cellHeight;
             this.advance = advance;
-            this.spaceAdvance = spaceAdvance;
+            this.sourceSpaceAdvance = spaceAdvance;
         }
 
         int width() {
@@ -50,6 +50,13 @@ final class Proposal3GlyphAtlas {
 
         int cellHeight() {
             return cellHeight;
+        }
+
+        int spaceAdvance() {
+            // The bitmap ink extends beyond the glyph advance, so the source font's narrow
+            // spaces make adjacent words look joined. Use at least one full advance for a
+            // word boundary, consistently in painting, fitting, and alignment.
+            return Math.max(sourceSpaceAdvance, advance);
         }
     }
 
@@ -121,7 +128,7 @@ final class Proposal3GlyphAtlas {
     }
 
     int advance(Role role, char value) {
-        return value == ' ' ? role.spaceAdvance : role.advance;
+        return value == ' ' ? role.spaceAdvance() : role.advance;
     }
 
     int measure(String value) {

--- a/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositor.java
+++ b/ui-portable/src/main/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositor.java
@@ -1,6 +1,8 @@
 package eu.rekawek.coffeegb.ui.menu.artwork;
 
 import eu.rekawek.coffeegb.ui.menu.MenuPresentation;
+import eu.rekawek.coffeegb.ui.menu.MenuKey;
+import eu.rekawek.coffeegb.ui.menu.MenuPointerTarget;
 import eu.rekawek.coffeegb.ui.menu.MenuPreview;
 import eu.rekawek.coffeegb.ui.menu.MenuPageLayout;
 import eu.rekawek.coffeegb.ui.menu.MenuRoute;
@@ -27,8 +29,8 @@ public final class Proposal3MenuCompositor {
     /** One font role for every item label and item value. */
     private static final Proposal3GlyphAtlas.Role ITEM_ROLE = Proposal3GlyphAtlas.Role.MEDIUM;
     private static final Proposal3GlyphAtlas.Role FOOTER_ROLE = Proposal3GlyphAtlas.Role.MEDIUM;
-    private static final int TITLE_EXTRA_WORD_SPACING = 18;
-    private static final MenuRect FOOTER_MOVE = new MenuRect(73, 660, 226, 56);
+    private static final int TITLE_EXTRA_WORD_SPACING = 0;
+    private static final MenuRect FOOTER_MOVE = new MenuRect(35, 660, 292, 56);
     private static final MenuRect FOOTER_CHOOSE = new MenuRect(458, 670, 123, 48);
     private static final MenuRect FOOTER_BACK = new MenuRect(722, 670, 184, 48);
     private static final int DISABLED_TEXT = 0xff89927b;
@@ -57,6 +59,66 @@ public final class Proposal3MenuCompositor {
 
     Proposal3MenuCompositor(LongSupplier nanoTime) {
         this.nanoTime = Objects.requireNonNull(nanoTime, "nanoTime");
+    }
+
+    /**
+     * Resolves a pointer in canonical frame coordinates against the same slots we paint.
+     * Hosts inverse-map their viewport first; borders, separators and empty rows are inert.
+     */
+    public static Optional<MenuPointerTarget> hitTest(MenuPresentation presentation, int x, int y) {
+        Objects.requireNonNull(presentation, "presentation");
+        if (!presentation.visible()) {
+            return Optional.empty();
+        }
+        List<VisibleSlot> slots = visibleSlots(presentation.items(), presentation.focusedIndex());
+        for (int index = 0; index < slots.size(); index++) {
+            MenuRect row = presentation.layout() == MenuPageLayout.FULL_WIDTH_LIST
+                    ? MenuScreenTemplate.fullWidthOptionRow(index)
+                    : MenuScreenTemplate.optionRow(index);
+            if (!row.contains(x, y)) {
+                continue;
+            }
+            VisibleSlot slot = slots.get(index);
+            if (slot.arrow != Arrow.NONE) {
+                int direction = slot.arrow == Arrow.UP ? 1 : -1;
+                for (int anchorIndex = index + direction;
+                        anchorIndex >= 0 && anchorIndex < slots.size(); anchorIndex += direction) {
+                    VisibleSlot anchor = slots.get(anchorIndex);
+                    if (anchor.item != null && anchor.item.enabled()) {
+                        return Optional.of(new MenuPointerTarget(presentation.route(),
+                                anchor.item.id(), slot.arrow == Arrow.UP ? MenuKey.UP : MenuKey.DOWN));
+                    }
+                }
+                return Optional.empty();
+            }
+            if (slot.item == null || !slot.item.enabled()) {
+                return Optional.empty();
+            }
+            MenuKey key = MenuKey.A;
+            if (slot.item.adjustable() && x >= row.x() + 192) {
+                int progress = slot.item.progress() >= 0 ? slot.item.progress()
+                        : parsePercent(slot.item.detail());
+                int thumbCenter = row.x() + 202 + 156 * progress / 100;
+                key = x < thumbCenter ? MenuKey.LEFT : MenuKey.RIGHT;
+            }
+            return Optional.of(new MenuPointerTarget(presentation.route(), slot.item.id(), key));
+        }
+        List<String> hints = presentation.footerHints();
+        if (isPagedList(presentation) && FOOTER_MOVE.contains(x, y)) {
+            boolean previous = x < FOOTER_MOVE.x() + FOOTER_MOVE.width() / 2;
+            int page = presentation.pagination().pageIndex() + (previous ? -1 : 1);
+            if (page >= 0 && page < presentation.pagination().pageCount()) {
+                return Optional.of(new MenuPointerTarget(presentation.route(), null,
+                        previous ? MenuKey.LEFT : MenuKey.RIGHT));
+            }
+        }
+        if (!valueAt(hints, 1).isEmpty() && new MenuRect(350, 659, 240, 61).contains(x, y)) {
+            return Optional.of(new MenuPointerTarget(presentation.route(), null, MenuKey.A));
+        }
+        if (!valueAt(hints, 2).isEmpty() && new MenuRect(610, 659, 296, 61).contains(x, y)) {
+            return Optional.of(new MenuPointerTarget(presentation.route(), null, MenuKey.B));
+        }
+        return Optional.empty();
     }
 
     /** Returns a detached canonical frame, or empty when the presentation is hidden. */
@@ -338,8 +400,14 @@ public final class Proposal3MenuCompositor {
         List<MenuRect> dividers = fullWidth
                 ? MenuScreenTemplate.FULL_WIDTH_OPTION_DIVIDERS
                 : MenuScreenTemplate.OPTION_DIVIDERS;
-        for (MenuRect divider : dividers) {
-            raster.fill(divider, DIVIDER);
+        for (int index = 0; index < dividers.size(); index++) {
+            MenuRect divider = dividers.get(index);
+            VisibleSlot slot = visible.get(index);
+            if (slot.item != null || slot.arrow != Arrow.NONE) {
+                raster.fill(divider, DIVIDER);
+            } else {
+                raster.paintWidget(skins().surface(Proposal3WidgetSkins.Surface.DARK), divider);
+            }
         }
     }
 
@@ -373,8 +441,7 @@ public final class Proposal3MenuCompositor {
             raster.drawClippedText(atlas(), ITEM_ROLE, item.label(), label, textColor,
                     marqueeOffset);
         } else {
-            raster.drawText(atlas(), ITEM_ROLE, item.label(), label, textColor,
-                    MenuRaster.HorizontalAlignment.LEFT);
+            drawRowLabel(raster, item.label(), label, textColor);
         }
         if (detail) {
             raster.drawText(atlas(), ITEM_ROLE, item.detail(),
@@ -387,22 +454,25 @@ public final class Proposal3MenuCompositor {
     private void drawDropdown(MenuRaster raster, MenuRect row, MenuPresentation.Item item,
             int textColor) {
         String valueText = display(item.detail());
-        int availableLeft = row.x() + 20;
+        int availableLeft = row.x() + 38;
         int availableRight = row.right() - TRAILING_CONTENT_RIGHT_INSET;
-        int gap = 4;
-        int fieldWidth = Math.min(262,
-                Math.max(103, atlas().renderedWidth(ITEM_ROLE, valueText) + 27));
-        int labelWidth = Math.max(80, availableRight - availableLeft - gap - fieldWidth);
-        raster.drawText(atlas(), ITEM_ROLE, item.label(),
-                new MenuRect(availableLeft, row.y(), labelWidth, row.height()), textColor,
+        int gap = 16;
+        int fieldWidth = Math.min(availableRight - availableLeft,
+                Math.max(103, atlas().renderedWidth(ITEM_ROLE, valueText) + 39));
+        int labelWidth = availableRight - availableLeft - gap - fieldWidth;
+        boolean stacked = atlas().renderedWidth(ITEM_ROLE, display(item.label())) > labelWidth;
+        MenuRect label = stacked
+                ? new MenuRect(availableLeft, row.y(), availableRight - availableLeft, 36)
+                : new MenuRect(availableLeft, row.y(), labelWidth, row.height());
+        raster.drawText(atlas(), ITEM_ROLE, item.label(), label, textColor,
                 MenuRaster.HorizontalAlignment.LEFT);
-        MenuRect field = new MenuRect(availableLeft + labelWidth + gap, row.y() + 10,
-                fieldWidth, row.height() - 20);
+        MenuRect field = new MenuRect(availableRight - fieldWidth,
+                row.y() + (stacked ? 36 : 10), fieldWidth, stacked ? 36 : row.height() - 20);
         raster.fill(field, MenuRaster.INK);
         raster.fill(new MenuRect(field.x() + 3, field.y() + 3, field.width() - 6,
                 field.height() - 6), DROPDOWN_FILL);
         raster.drawText(atlas(), ITEM_ROLE, valueText,
-                new MenuRect(field.x() + 4, field.y(), field.width() - 27, field.height()),
+                new MenuRect(field.x() + 8, field.y(), field.width() - 35, field.height()),
                 MenuRaster.INK, MenuRaster.HorizontalAlignment.LEFT);
         drawDownChevron(raster, field.right() - 14, field.y() + field.height() / 2,
                 MenuRaster.INK);
@@ -413,10 +483,9 @@ public final class Proposal3MenuCompositor {
         MenuRect checkbox = new MenuRect(
                 row.right() - TRAILING_CONTENT_RIGHT_INSET - 36, row.y() + 18, 36, 36);
         int labelLeft = row.x() + 38;
-        raster.drawText(atlas(), ITEM_ROLE, item.label(),
+        drawRowLabel(raster, item.label(),
                 new MenuRect(labelLeft, row.y(), checkbox.x() - 16 - labelLeft, row.height()),
-                textColor,
-                MenuRaster.HorizontalAlignment.LEFT);
+                textColor);
         raster.drawCheckbox(checkbox, item.checked());
     }
 
@@ -439,12 +508,75 @@ public final class Proposal3MenuCompositor {
         String move = valueAt(hints, 0);
         String choose = stripButton(valueAt(hints, 1), "A");
         String back = stripButton(valueAt(hints, 2), "B");
-        raster.drawText(atlas(), FOOTER_ROLE, move, FOOTER_MOVE, MenuRaster.INK,
-                MenuRaster.HorizontalAlignment.CENTER);
+        // Button glyphs are part of the original template. Remove unavailable actions along
+        // with their labels, so an empty state or a root page does not advertise an inert key.
+        if (choose.isEmpty()) {
+            raster.paintWidget(skins().surface(Proposal3WidgetSkins.Surface.PAPER),
+                    new MenuRect(355, 665, 230, 52));
+        }
+        if (back.isEmpty()) {
+            raster.paintWidget(skins().surface(Proposal3WidgetSkins.Surface.PAPER),
+                    new MenuRect(620, 665, 280, 52));
+        }
+        if (isPagedList(presentation)) {
+            int page = presentation.pagination().pageIndex();
+            int pages = presentation.pagination().pageCount();
+            raster.drawText(atlas(), FOOTER_ROLE, "PAGE " + (page + 1) + "/" + pages,
+                    new MenuRect(FOOTER_MOVE.x() + 30, FOOTER_MOVE.y(),
+                            FOOTER_MOVE.width() - 60, FOOTER_MOVE.height()),
+                    MenuRaster.INK, MenuRaster.HorizontalAlignment.CENTER);
+            drawPageArrow(raster, FOOTER_MOVE.x() + 6, false,
+                    page > 0 ? MenuRaster.INK : DISABLED_TEXT);
+            drawPageArrow(raster, FOOTER_MOVE.right() - 24, true,
+                    page + 1 < pages ? MenuRaster.INK : DISABLED_TEXT);
+        } else {
+            raster.drawText(atlas(), FOOTER_ROLE, move, FOOTER_MOVE, MenuRaster.INK,
+                    MenuRaster.HorizontalAlignment.CENTER);
+        }
         raster.drawText(atlas(), FOOTER_ROLE, choose, FOOTER_CHOOSE, MenuRaster.INK,
                 MenuRaster.HorizontalAlignment.LEFT);
         raster.drawText(atlas(), FOOTER_ROLE, back, FOOTER_BACK, MenuRaster.INK,
                 MenuRaster.HorizontalAlignment.LEFT);
+    }
+
+    private static boolean isPagedList(MenuPresentation presentation) {
+        return presentation.layout() == MenuPageLayout.FULL_WIDTH_LIST
+                && presentation.pagination().pageCount() > 1;
+    }
+
+    private static void drawPageArrow(MenuRaster raster, int left, boolean right, int color) {
+        for (int x = 0; x < MenuRaster.FOCUS_ARROW_WIDTH; x++) {
+            int height = Math.max(2, MenuRaster.FOCUS_ARROW_HEIGHT - 2 * ((x + 1) / 2));
+            int targetX = right ? left + x : left + MenuRaster.FOCUS_ARROW_WIDTH - 1 - x;
+            raster.fill(new MenuRect(targetX, 688 - height / 2, 1, height), color);
+        }
+    }
+
+    /** Keep short labels on one line and use the row's second line before truncating words. */
+    private void drawRowLabel(MenuRaster raster, String value, MenuRect bounds, int color) {
+        String text = display(value);
+        if (atlas().renderedWidth(ITEM_ROLE, text) <= bounds.width()) {
+            raster.drawText(atlas(), ITEM_ROLE, text, bounds, color,
+                    MenuRaster.HorizontalAlignment.LEFT);
+            return;
+        }
+        int split = text.lastIndexOf(' ');
+        while (split > 0
+                && atlas().renderedWidth(ITEM_ROLE, text.substring(0, split)) > bounds.width()) {
+            split = text.lastIndexOf(' ', split - 1);
+        }
+        if (split <= 0) {
+            raster.drawText(atlas(), ITEM_ROLE, text, bounds, color,
+                    MenuRaster.HorizontalAlignment.LEFT);
+            return;
+        }
+        int lineHeight = bounds.height() / 2;
+        raster.drawText(atlas(), ITEM_ROLE, text.substring(0, split),
+                new MenuRect(bounds.x(), bounds.y(), bounds.width(), lineHeight), color,
+                MenuRaster.HorizontalAlignment.LEFT);
+        raster.drawText(atlas(), ITEM_ROLE, text.substring(split + 1),
+                new MenuRect(bounds.x(), bounds.y() + lineHeight, bounds.width(), lineHeight),
+                color, MenuRaster.HorizontalAlignment.LEFT);
     }
 
     private static List<VisibleSlot> visibleSlots(List<MenuPresentation.Item> items,

--- a/ui-portable/src/main/resources/eu/rekawek/coffeegb/ui/menu/artwork/proposal3/overlay/ByteBounce-licensed-source.txt
+++ b/ui-portable/src/main/resources/eu/rekawek/coffeegb/ui/menu/artwork/proposal3/overlay/ByteBounce-licensed-source.txt
@@ -34,3 +34,12 @@ SHA-256: b99d64929933538a958881be776ef3ffa7b79cde7b96d501c4b9c00de90aad02
 SemiBold atlas: 768x192
 Cell: 48x48; glyph advance: 27; space advance: 9
 SHA-256: a895052d22f63c87d72dd64fb693f11d48c679538013aec3ffeea8ed278c5ef5
+
+Runtime typography adjustment
+-----------------------------
+
+The metrics above describe the source rasterization recipe. The menu compositor
+uses a full glyph advance for spaces to keep word boundaries readable despite
+the bitmap glyphs' overhang: Small 11, Notice 15, Medium 19, Display 20, and
+SemiBold 27 pixels. This adjustment applies consistently to painting and text
+measurement in Proposal3GlyphAtlas; it does not change the packaged PNGs.

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/MenuControllerTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/MenuControllerTest.java
@@ -32,12 +32,109 @@ public class MenuControllerTest {
         assertEquals("recent-games-status", empty.items().get(0).id());
         assertEquals("NO RECENT GAMES", empty.items().get(0).label());
         assertEquals(List.of("", "", "B BACK"), empty.footerHints());
+        assertEquals(List.of("GO BACK AND CHOOSE OPEN ROM"), empty.sideLines());
 
         MenuPageSpec unavailable = MenuPageSpec.recentGames(List.of(
                 new MenuPageSpec.RecentGame("missing", "MISSING.GB", "LAST WEEK", false,
                         MenuPreview.empty())), null);
         assertEquals("recent-games-status", unavailable.preferredFocusId());
         assertEquals("NO READABLE RECENT GAMES", unavailable.items().get(1).label());
+    }
+
+    @Test
+    public void unavailableRecentSelectionFallsBackToAnEnabledEntryAndItsPreview() {
+        MenuPreview preview = MenuPreview.ready(1, 1, new int[] {0xff123456});
+        MenuPageSpec.RecentGame missing = new MenuPageSpec.RecentGame(
+                "missing", "MISSING.GB", "LAST WEEK", false, MenuPreview.empty());
+        MenuPageSpec spec = MenuPageSpec.recentGames(List.of(missing,
+                new MenuPageSpec.RecentGame("available", "AVAILABLE.GB", "TODAY", true,
+                        preview)), "missing");
+
+        assertEquals("available", spec.preferredFocusId());
+        assertEquals(preview, spec.preview());
+        assertEquals(List.of("LAST PLAYED: TODAY"), spec.sideLines());
+
+        MenuPageSpec unavailable = MenuPageSpec.recentGames(List.of(missing), "missing");
+        assertEquals("recent-games-status", unavailable.preferredFocusId());
+        assertEquals(List.of("", "", "B BACK"), unavailable.footerHints());
+    }
+
+    @Test
+    public void footerFollowsTheFocusedControlAndPreservesExplicitActionHints() {
+        MenuController controller = new MenuController(new Events());
+        controller.show(MenuRoute.AUDIO);
+        assertEquals(List.of("L/R ADJUST", "", "B BACK"),
+                controller.presentation().footerHints());
+
+        controller.onKeyDown(MenuKey.DOWN, false);
+        controller.onKeyUp(MenuKey.DOWN);
+        assertEquals(List.of("D-PAD MOVE", "A TOGGLE", "B BACK"),
+                controller.presentation().footerHints());
+
+        controller.show(MenuRoute.SYSTEM);
+        assertEquals(List.of("D-PAD MOVE", "A OPEN", "B BACK"),
+                controller.presentation().footerHints());
+        controller.show(MenuRoute.OPTION_PICKER);
+        assertEquals(List.of("D-PAD MOVE", "A SELECT", "B BACK"),
+                controller.presentation().footerHints());
+        controller.show(MenuRoute.SAVE_STATES);
+        assertEquals(List.of("D-PAD MOVE", "A SAVE", "B BACK"),
+                controller.presentation().footerHints());
+    }
+
+    @Test
+    public void pointerActivatesTheClickedRowAndPreservesParentFocus() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.show(MenuRoute.SETTINGS);
+        controller.push(MenuRoute.SETTINGS);
+
+        assertTrue(controller.activateTarget(new MenuPointerTarget(
+                MenuRoute.SETTINGS, "audio", MenuKey.A)));
+
+        assertEquals(List.of("audio:false"), events.items);
+        assertEquals("audio", controller.snapshot().frames().get(1).focusedItemId());
+        assertEquals("system", controller.snapshot().frames().get(0).focusedItemId());
+        assertTrue(controller.activateTarget(new MenuPointerTarget(
+                MenuRoute.SETTINGS, null, MenuKey.B)));
+        assertEquals(1, controller.snapshot().frames().size());
+    }
+
+    @Test
+    public void pointerIgnoresHiddenStaleDisabledAndRemovedRows() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        MenuPointerTarget audio = new MenuPointerTarget(MenuRoute.SETTINGS, "audio", MenuKey.A);
+        assertFalse(controller.activateTarget(audio));
+        controller.show(MenuRoute.AUDIO);
+        assertFalse(controller.activateTarget(audio));
+        controller.setPage(page(MenuRoute.SETTINGS, 1, List.of(
+                item("system", "SYSTEM", true, null),
+                item("audio", "AUDIO", false, null))));
+        controller.show(MenuRoute.SETTINGS);
+        assertFalse(controller.activateTarget(audio));
+        assertFalse(controller.activateTarget(new MenuPointerTarget(
+                MenuRoute.SETTINGS, "missing", MenuKey.A)));
+        assertEquals("system", controller.snapshot().frames().get(0).focusedItemId());
+        assertTrue(events.items.isEmpty());
+    }
+
+    @Test
+    public void pointerSliderFocusAndAdjustmentUseSeparateActions() {
+        Events events = new Events();
+        MenuController controller = new MenuController(events);
+        controller.show(MenuRoute.AUDIO);
+        controller.activateTarget(new MenuPointerTarget(MenuRoute.AUDIO, "mute-audio", MenuKey.A));
+        events.items.clear();
+
+        assertTrue(controller.activateTarget(new MenuPointerTarget(
+                MenuRoute.AUDIO, "volume", MenuKey.A)));
+        assertEquals("volume", controller.snapshot().frames().get(0).focusedItemId());
+        assertTrue(events.items.isEmpty());
+        assertTrue(events.adjustments.isEmpty());
+        assertTrue(controller.activateTarget(new MenuPointerTarget(
+                MenuRoute.AUDIO, "volume", MenuKey.RIGHT)));
+        assertEquals(List.of("volume:1"), events.adjustments);
     }
 
     @Test
@@ -359,16 +456,20 @@ public class MenuControllerTest {
         controller.setRootDismissAllowed(false);
         controller.show(MenuRoute.LIBRARY);
 
+        assertEquals(List.of("D-PAD MOVE", "A CHOOSE", ""),
+                controller.presentation().footerHints());
         assertTrue(controller.dispatchBackEdge());
         assertTrue(controller.visible());
         assertEquals(MenuRoute.LIBRARY, controller.route());
 
         controller.push(MenuRoute.SETTINGS);
+        assertEquals("B BACK", controller.presentation().footerHints().get(2));
         assertTrue(controller.dispatchBackEdge());
         assertTrue(controller.visible());
         assertEquals(MenuRoute.LIBRARY, controller.route());
 
         controller.setRootDismissAllowed(true);
+        assertEquals("B BACK", controller.presentation().footerHints().get(2));
         assertTrue(controller.dispatchBackEdge());
         assertFalse(controller.visible());
     }
@@ -451,7 +552,7 @@ public class MenuControllerTest {
     }
 
     @Test
-    public void statePageVariantsUseExactCopyAndOnlyFourPrimarySlotRows() {
+    public void statePageVariantsKeepTenSlotsAndOnlyOfferSaveForEmptySlots() {
         MenuPage save = MenuPages.statePage(false);
         MenuPage load = MenuPages.statePage(true);
 
@@ -465,27 +566,28 @@ public class MenuControllerTest {
         assertEquals("COFFEE GB", load.title());
         assertEquals("LOAD STATES", load.context());
         assertEquals("", load.headerAction());
-        assertEquals(List.of("D-PAD MOVE", "A LOAD", "B BACK"), load.footerHints());
+        assertEquals(List.of("D-PAD MOVE", "", "B BACK"), load.footerHints());
 
         List<String> expectedSlots = List.of("slot-0", "slot-1", "slot-2", "slot-3",
                 "slot-4", "slot-5", "slot-6", "slot-7", "slot-8", "slot-9");
         assertEquals(expectedSlots, save.items().stream().map(MenuItem::id).toList());
         assertEquals(expectedSlots, load.items().stream().map(MenuItem::id).toList());
         assertTrue(save.items().stream().allMatch(item -> item.enabled()
-                && item.detail().isEmpty() && item.secondaryId() == null));
+                && item.detail().equals("EMPTY") && item.secondaryId() == null));
         assertTrue(load.items().stream().allMatch(item -> item.enabled()
-                && item.detail().isEmpty() && item.secondaryId() == null));
+                && item.detail().equals("EMPTY") && item.secondaryId() == null));
     }
 
     @Test
     public void confirmationDefaultsUseTheSingleVerticalRailAndBReturnsToParent() {
         MenuPage confirmation = MenuPages.forRoute(MenuRoute.CONFIRM_ACTION);
         assertEquals(1, confirmation.columns());
-        assertEquals("CONFIRM ACTION", confirmation.context());
+        assertEquals("RESET GAME?", confirmation.context());
         assertEquals(List.of("UNSAVED PROGRESS MAY BE LOST"), confirmation.sideLines());
         assertEquals("", confirmation.headerAction());
         assertEquals(List.of("confirm", "cancel"),
                 confirmation.items().stream().map(MenuItem::id).toList());
+        assertEquals("RESET GAME", confirmation.items().get(0).label());
         assertTrue(confirmation.items().stream().allMatch(item -> item.detail().isEmpty()));
         assertEquals("cancel", confirmation.items().get(confirmation.initialFocusIndex()).id());
 

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/MenuPointerGestureTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/MenuPointerGestureTest.java
@@ -1,0 +1,52 @@
+package eu.rekawek.coffeegb.ui.menu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MenuPointerGestureTest {
+
+    @Test
+    public void matchingReleaseActivatesExactlyOnceAndKeepsOtherPointersIndependent() {
+        MenuPointerGesture gesture = new MenuPointerGesture();
+        MenuPointerTarget first = new MenuPointerTarget(MenuRoute.SETTINGS, "audio", MenuKey.A);
+        MenuPointerTarget second = new MenuPointerTarget(MenuRoute.SETTINGS, "display", MenuKey.A);
+
+        gesture.press(10, first);
+        gesture.press(20, second);
+        assertEquals(first, gesture.release(10, first).orElseThrow());
+        assertFalse(gesture.release(10, first).isPresent());
+        assertTrue(gesture.captured(20));
+        assertEquals(second, gesture.release(20, second).orElseThrow());
+    }
+
+    @Test
+    public void releaseOverAnotherRowOrAfterNavigationDoesNotActivate() {
+        MenuPointerGesture gesture = new MenuPointerGesture();
+        MenuPointerTarget first = new MenuPointerTarget(MenuRoute.SETTINGS, "audio", MenuKey.A);
+        gesture.press(1, first);
+        assertFalse(gesture.release(1,
+                new MenuPointerTarget(MenuRoute.SETTINGS, "display", MenuKey.A)).isPresent());
+
+        gesture.press(1, first);
+        assertFalse(gesture.release(1,
+                new MenuPointerTarget(MenuRoute.AUDIO, "audio", MenuKey.A)).isPresent());
+        assertFalse(gesture.captured(1));
+    }
+
+    @Test
+    public void cancellationAndReleaseOutsideTheMenuDiscardThePress() {
+        MenuPointerGesture gesture = new MenuPointerGesture();
+        MenuPointerTarget target = new MenuPointerTarget(MenuRoute.SETTINGS, "audio", MenuKey.A);
+
+        gesture.press(1, target);
+        assertFalse(gesture.release(1, null).isPresent());
+        gesture.press(1, target);
+        gesture.cancel();
+        assertFalse(gesture.release(1, target).isPresent());
+        gesture.press(1, null);
+        assertFalse(gesture.release(1, target).isPresent());
+    }
+}

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/PortableSettingsContractTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/PortableSettingsContractTest.java
@@ -49,7 +49,8 @@ public class PortableSettingsContractTest {
         Proposal3GlyphAtlas atlas = Proposal3GlyphAtlas.load();
         assertEquals("medium glyph advance must match the packaged atlas recipe", 19,
                 atlas.advance(Proposal3GlyphAtlas.Role.MEDIUM, 'A'));
-        assertEquals("medium space advance must match the packaged atlas recipe", 8,
+        // The source recipe's 8-pixel spaces are widened at runtime for readable word gaps.
+        assertEquals("medium spaces must use a full glyph advance in the menu", 19,
                 atlas.advance(Proposal3GlyphAtlas.Role.MEDIUM, ' '));
     }
 

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/CommonMenuGalleryMain.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/CommonMenuGalleryMain.java
@@ -82,6 +82,29 @@ public final class CommonMenuGalleryMain {
         controller.show(MenuRoute.SYSTEM);
         write(compositor.compose(controller.presentation()).orElseThrow(),
                 new File(directory, "19-system_fast_forward.png"));
+
+        controller.setRootDismissAllowed(false);
+        controller.show(MenuRoute.LIBRARY);
+        write(compositor.compose(controller.presentation()).orElseThrow(),
+                new File(directory, "20-library_root.png"));
+        controller.setRootDismissAllowed(true);
+
+        controller.setPage(new MenuPageSpec(MenuRoute.SAVE_STATES, "COFFEE GB", "LOAD STATES",
+                "", "", List.of(), List.of(
+                        MenuPageSpec.Item.button("slot-0", "SLOT 0", "EMPTY", true),
+                        MenuPageSpec.Item.button("slot-1", "SLOT 1", "SAVED", true)),
+                1, List.of("D-PAD MOVE", "", "B BACK"), "slot-0", MenuPreview.empty()));
+        controller.show(MenuRoute.SAVE_STATES);
+        write(compositor.compose(controller.presentation()).orElseThrow(),
+                new File(directory, "21-load_empty.png"));
+
+        controller.setPage(new MenuPageSpec(MenuRoute.PAUSE_CONSOLE, "COFFEE GB", "", "",
+                "A LONG GAME TITLE", List.of("PLAY TIME 01:24", "BATTERY SAVE ACTIVE"),
+                List.of(MenuPageSpec.Item.button("resume", "RESUME", "", true)), 1,
+                List.of("D-PAD MOVE", "A CHOOSE", "B RESUME"), "resume", MenuPreview.empty()));
+        controller.show(MenuRoute.PAUSE_CONSOLE);
+        write(compositor.compose(controller.presentation()).orElseThrow(),
+                new File(directory, "22-pause_long_title.png"));
     }
 
     private static void write(MenuArgbFrame frame, File target) throws Exception {

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3GlyphAtlasTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3GlyphAtlasTest.java
@@ -1,0 +1,67 @@
+package eu.rekawek.coffeegb.ui.menu.artwork;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Proposal3GlyphAtlasTest {
+
+    private static final int WIDTH = MenuArtworkCatalog.PACKAGED_WIDTH;
+    private static final int HEIGHT = MenuArtworkCatalog.PACKAGED_HEIGHT;
+
+    @Test
+    public void wordBoundariesRemainVisibleBeyondWideGlyphOverhangs() throws Exception {
+        Proposal3GlyphAtlas atlas = Proposal3GlyphAtlas.load();
+
+        for (Proposal3GlyphAtlas.Role role : Proposal3GlyphAtlas.Role.values()) {
+            int glyph = atlas.index('M');
+            int left = atlas.cellWidth(role);
+            int right = 0;
+            for (int x = 0; x < atlas.cellWidth(role); x++) {
+                for (int y = 0; y < atlas.cellHeight(role); y++) {
+                    if ((atlas.pixel(role, glyph, x, y) >>> 24) != 0) {
+                        left = Math.min(left, x);
+                        right = Math.max(right, x + 1);
+                    }
+                }
+            }
+
+            int visibleWordGap = atlas.measure(role, "M ") + left - right;
+            assertTrue(role + " joins words across wide glyphs",
+                    visibleWordGap >= (atlas.advance(role, 'M') + 1) / 2);
+        }
+    }
+
+    @Test
+    public void measuredMultiwordLabelsKeepAllInkWhenFittedAndRightAligned() throws Exception {
+        Proposal3GlyphAtlas atlas = Proposal3GlyphAtlas.load();
+
+        for (Proposal3GlyphAtlas.Role role : Proposal3GlyphAtlas.Role.values()) {
+            for (String label : List.of("D-PAD MOVE", "SAVE STATES", "LCD GHOSTING")) {
+                MenuRaster reference = new MenuRaster(new int[WIDTH * HEIGHT]);
+                MenuRaster fitted = new MenuRaster(new int[WIDTH * HEIGHT]);
+                reference.drawText(atlas, role, label, new MenuRect(10, 10, 450, 72),
+                        MenuRaster.PAPER_TEXT, MenuRaster.HorizontalAlignment.LEFT);
+                fitted.drawText(atlas, role, label,
+                        new MenuRect(500, 10, atlas.renderedWidth(role, label), 72),
+                        MenuRaster.PAPER_TEXT, MenuRaster.HorizontalAlignment.RIGHT);
+
+                assertEquals(role + " clipped or shortened " + label,
+                        paintedPixels(reference), paintedPixels(fitted));
+            }
+        }
+    }
+
+    private static int paintedPixels(MenuRaster raster) {
+        int count = 0;
+        for (int pixel : raster.pixels()) {
+            if (pixel != 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositorTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3MenuCompositorTest.java
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.ui.menu.artwork;
 
 import eu.rekawek.coffeegb.ui.menu.MenuController;
+import eu.rekawek.coffeegb.ui.menu.MenuKey;
 import eu.rekawek.coffeegb.ui.menu.MenuPageLayout;
 import eu.rekawek.coffeegb.ui.menu.MenuPageSpec;
 import eu.rekawek.coffeegb.ui.menu.MenuPagination;
@@ -28,6 +29,70 @@ public class Proposal3MenuCompositorTest {
     private static final int HEIGHT = MenuArtworkCatalog.PACKAGED_HEIGHT;
     private static final List<String> FOOTER =
             List.of("D-PAD MOVE", "A CHOOSE", "B BACK");
+
+    @Test
+    public void pointersResolvePaintedItemsAndScrollAnchorsButNeverEmptyRowsOrDividers() {
+        MenuPresentation shortList = presentation(MenuRoute.SETTINGS, "SETTINGS", "", List.of(),
+                List.of(button("first", "FIRST"),
+                        MenuPageSpec.Item.button("disabled", "DISABLED", "", false)),
+                "first", MenuPreview.empty());
+        assertEquals("first", Proposal3MenuCompositor.hitTest(shortList, 500, 150)
+                .orElseThrow().itemId());
+        for (int[] point : List.of(new int[]{500, 193}, new int[]{500, 220},
+                new int[]{500, 300}, new int[]{420, 150}, new int[]{920, 150})) {
+            assertTrue(Proposal3MenuCompositor.hitTest(shortList, point[0], point[1]).isEmpty());
+        }
+
+        MenuPresentation start = presentation(MenuRoute.SAVE_STATES, "SAVE STATES", "", List.of(),
+                buttons(13, 0), "item-0", MenuPreview.empty());
+        var down = Proposal3MenuCompositor.hitTest(start, 660, 600).orElseThrow();
+        assertEquals("item-5", down.itemId());
+        assertEquals(MenuKey.DOWN, down.key());
+        MenuPresentation end = presentation(MenuRoute.SAVE_STATES, "SAVE STATES", "", List.of(),
+                buttons(13, 0), "item-12", MenuPreview.empty());
+        var up = Proposal3MenuCompositor.hitTest(end, 660, 150).orElseThrow();
+        assertEquals("item-7", up.itemId());
+        assertEquals(MenuKey.UP, up.key());
+
+        List<MenuPageSpec.Item> unavailableEdge = new ArrayList<>(buttons(13, 0));
+        unavailableEdge.set(5, MenuPageSpec.Item.button("item-5", "UNAVAILABLE", "", false));
+        MenuPresentation disabled = presentation(MenuRoute.RECENT_GAMES, "RECENT", "", List.of(),
+                unavailableEdge, "item-0", MenuPreview.empty());
+        assertEquals("scrolling must not anchor on an unavailable row", "item-4",
+                Proposal3MenuCompositor.hitTest(disabled, 660, 600).orElseThrow().itemId());
+    }
+
+    @Test
+    public void pointersUseFullWidthRowsAndOnlyAdvertisedFooterActions() {
+        MenuPresentation wide = fullWidthPresentation(List.of(button("rom", "GAME.GBC")),
+                "rom", MenuPagination.singlePage());
+        assertEquals("rom", Proposal3MenuCompositor.hitTest(wide, 40, 150)
+                .orElseThrow().itemId());
+        MenuPresentation firstPage = fullWidthPresentation(List.of(button("rom", "GAME.GBC")),
+                "rom", new MenuPagination(0, 3));
+        assertTrue(Proposal3MenuCompositor.hitTest(firstPage, 70, 690).isEmpty());
+        assertEquals(MenuKey.RIGHT, Proposal3MenuCompositor.hitTest(firstPage, 290, 690)
+                .orElseThrow().key());
+        MenuPresentation lastPage = fullWidthPresentation(List.of(button("rom", "GAME.GBC")),
+                "rom", new MenuPagination(2, 3));
+        assertEquals(MenuKey.LEFT, Proposal3MenuCompositor.hitTest(lastPage, 70, 690)
+                .orElseThrow().key());
+        assertTrue(Proposal3MenuCompositor.hitTest(lastPage, 290, 690).isEmpty());
+        MenuController controller = new MenuController(new NoopListener());
+        controller.show(MenuRoute.AUDIO);
+        assertTrue("A is inert for a slider", Proposal3MenuCompositor.hitTest(
+                controller.presentation(), 480, 690).isEmpty());
+        assertEquals(MenuKey.LEFT, Proposal3MenuCompositor.hitTest(
+                controller.presentation(), 630, 150).orElseThrow().key());
+        assertEquals(MenuKey.RIGHT, Proposal3MenuCompositor.hitTest(
+                controller.presentation(), 800, 150).orElseThrow().key());
+        controller.setRootDismissAllowed(false);
+        controller.show(MenuRoute.LIBRARY);
+        assertTrue("root Back is unavailable", Proposal3MenuCompositor.hitTest(
+                controller.presentation(), 760, 690).isEmpty());
+        controller.hide();
+        assertTrue(Proposal3MenuCompositor.hitTest(controller.presentation(), 500, 150).isEmpty());
+    }
 
     @Test
     public void everyRouteProducesOneCanonical924By736Frame() {
@@ -281,13 +346,13 @@ public class Proposal3MenuCompositorTest {
         MenuRect value = new MenuRect(row.x() + 376, row.y(), 88, row.height());
         assertTrue("100% was rendered as an ellipsis",
                 differences(oneHundred, ellipsis, value) > 0);
-        MenuRect field = new MenuRect(row.right() - 20 - 262, row.y() + 10, 262,
-                row.height() - 20);
+        MenuRect field = new MenuRect(row.x() + 38, row.y() + 36,
+                row.width() - 58, 36);
         assertTrue("FAST-FORWARD was rendered as an ellipsis",
                 differences(dropdown, dropdownEllipsis, field) > 0);
 
         int fieldRight = row.right() - 20;
-        int fieldCenterY = row.y() + 10 + (row.height() - 20) / 2;
+        int fieldCenterY = row.y() + 54;
         assertEquals("dropdown chevron touched the field border", MenuRaster.PAPER,
                 dropdown[(fieldCenterY - 2) * WIDTH + fieldRight - 4]);
         assertEquals(MenuRaster.INK,

--- a/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3UnavailableRouteTest.java
+++ b/ui-portable/src/test/java/eu/rekawek/coffeegb/ui/menu/artwork/Proposal3UnavailableRouteTest.java
@@ -54,7 +54,8 @@ public class Proposal3UnavailableRouteTest {
         MenuRect secondRow = MenuScreenTemplate.optionRow(1);
         assertTrue("explicit action did not occupy the second reusable row",
                 differences(status, action, secondRow) > 0);
-        assertEqualOutside(status, action, secondRow);
+        assertEqualOutside(status, action, new MenuRect(secondRow.x(), secondRow.y(),
+                secondRow.width(), secondRow.height() + MenuScreenTemplate.OPTION_DIVIDER_HEIGHT));
     }
 
     private static MenuPresentation statusOnly(MenuRoute route) {


### PR DESCRIPTION
## What changed

The shared Coffee GB on-screen menus now communicate state and controls more clearly and behave consistently on desktop and Android.

- Added direct mouse and touch activation with press/release target matching, including file-browser paging.
- Improved bitmap text spacing and wrapping for long labels and dropdown values.
- Made footer hints contextual for sliders, toggles, dropdowns, save/load, and root navigation.
- Added explicit empty save-slot status and useful empty recent-games guidance.
- Made reset confirmations name the action and retain Cancel as the safe initial choice.
- Added a heuristic UX review with rendered visual evidence and accessibility notes.

## Validation

- `mvn -pl ui-portable test` — 101 tests passed.
- `mvn -pl swing -am -Dtest=SwingProposal3MenuTest,SwingMenuPointerTest,DesktopInputRouterTest -Dsurefire.failIfNoSpecifiedTests=false test -q` — 63 tests passed.
- Android targeted JVM tests — 27 tests passed.

The Android validation compiles and runs the menu/model tests; live device gesture instrumentation is not included in this local check.
