### PR TITLE
Add desktop input recording and replay playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Default keyboard controls:
 | Pause | <kbd>Space</kbd> |
 | Save / load state | <kbd>F5</kbd> / <kbd>F7</kbd> |
 | Take screenshot | <kbd>F12</kbd> |
-| Start / stop input recording | <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
+| Start input recording | <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
 | Rewind | Hold <kbd>Backspace</kbd> |
 | Toggle fullscreen | <kbd>F11</kbd> |
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ orchestration layer use Kotlin and Java.
 - **High compatibility** across commercial games, unusual cartridges, homebrew,
   demos, and diagnostic ROMs.
 - **Save states and rewind**, including ten save slots, named states, previews,
-  autosave and resume, screenshots, and battery-backed saves.
+  autosave and resume, screenshots, deterministic input recordings, and battery-backed saves.
 - **Easy game loading** with drag and drop and support for `.gb`, `.gbc`, and
   `.rom` files, either directly or from ZIP and 7z archives.
 - **Rollback netplay** for link-cable games, with synchronized infrared
@@ -54,6 +54,7 @@ Default keyboard controls:
 | Pause | <kbd>Space</kbd> |
 | Save / load state | <kbd>F5</kbd> / <kbd>F7</kbd> |
 | Take screenshot | <kbd>F12</kbd> |
+| Start / stop input recording | <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
 | Rewind | Hold <kbd>Backspace</kbd> |
 | Toggle fullscreen | <kbd>F11</kbd> |
 
@@ -65,7 +66,7 @@ keyboard input works without it.
 Use **Game > Manage States…** to choose among the ten save slots, name states,
 preview them, and export them. Autosave and resume settings are under
 **File > Preferences… > Saves & Rewind**. See
-[save states, autosave, screenshots, and rewind](docs/state-management.md) for
+[save states, autosave, screenshots, input recording, and rewind](docs/state-management.md) for
 more details. Pause, save states, and rewind are unavailable during netplay.
 
 ## Compatibility

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -16,6 +16,24 @@ import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkBackend
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkError as BackendNetworkError
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkPhase as BackendNetworkPhase
 import eu.rekawek.coffeegb.controller.mobile.network.MobileAdapterNetworkStatus
+import eu.rekawek.coffeegb.controller.replay.ReplayArtifactResult
+import eu.rekawek.coffeegb.controller.replay.ReplayCompatibilityException
+import eu.rekawek.coffeegb.controller.replay.ReplayFile
+import eu.rekawek.coffeegb.controller.replay.ReplayInitialMode
+import eu.rekawek.coffeegb.controller.replay.ReplayMetadata
+import eu.rekawek.coffeegb.controller.replay.ReplayRecorder
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingException
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingDiscardEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingFailedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingSavedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStartRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStatusEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingRetrySaveEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingOptions
+import eu.rekawek.coffeegb.controller.replay.ReplayRuntime
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
@@ -111,11 +129,13 @@ import eu.rekawek.coffeegb.core.joypad.Button
 import eu.rekawek.coffeegb.core.joypad.ButtonPressEvent
 import eu.rekawek.coffeegb.core.joypad.ButtonReleaseEvent
 import eu.rekawek.coffeegb.core.joypad.JoypadButtonMask
+import eu.rekawek.coffeegb.core.joypad.PlayerInputSnapshot
 import eu.rekawek.coffeegb.core.memory.cart.Cartridge
 import eu.rekawek.coffeegb.core.memory.cart.CartridgeProperties
 import eu.rekawek.coffeegb.core.memory.cart.Rom
 import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryFlush
 import eu.rekawek.coffeegb.core.memory.cart.battery.BatteryPersistenceResult
+import eu.rekawek.coffeegb.core.memory.cart.rtc.VirtualTimeSource
 import eu.rekawek.coffeegb.core.serial.BarcodeBoySerialEndpoint
 import eu.rekawek.coffeegb.core.serial.GameboyPrinterSerialEndpoint
 import eu.rekawek.coffeegb.core.serial.GpsDataSource
@@ -134,6 +154,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.Logger
@@ -431,6 +452,23 @@ class BasicController private constructor(
 
   private var session: Session? = null
 
+  /** The sole live deterministic input recorder. It may be accessed only by [thread]. */
+  private var replayRecording: ActiveReplayRecording? = null
+
+  /** A start request that is waiting for the activation key/gamepad input to be released. */
+  private var armedReplayRecording: ArmedReplayRecording? = null
+
+  /** A finished replay retained until its bounded artifact write succeeds or is explicitly discarded. */
+  private var pendingReplayArtifact: PendingReplayArtifact? = null
+
+  /** Set while the ordinary ROM replacement pipeline constructs a clean boot recorder session. */
+  private var pendingCleanBootReplay: PendingCleanBootReplay? = null
+
+  /** Clean boot sessions never replace the user's normal battery or autosave implicitly. */
+  private var cleanBootReplaySession = false
+
+  private var nextReplayRecordingId = 1L
+
   private var snapshotManager: SnapshotManager? = null
 
   private var stateContext: StateWorkerContext? = null
@@ -539,8 +577,15 @@ class BasicController private constructor(
 
   init {
     require(closeTimeoutMillis > 0) { "Controller close timeout must be positive" }
-    eventQueue.register<AddPatches> { patches.addAll(it.patches) }
-    eventQueue.register<Controller.LoadRomEvent> { requestLoadWithAutosave(properties, it) }
+    eventQueue.register<AddPatches> {
+      finishReplayRecording("Cheats changed")
+      patches.addAll(it.patches)
+    }
+    eventQueue.register<Controller.LoadRomEvent> {
+      cancelPendingCleanBootReplay("Clean-boot input recording was cancelled by another game load.")
+      finishReplayRecording("The game session changed")
+      requestLoadWithAutosave(properties, it)
+    }
     eventQueue.register<Controller.CancelRomOpenEvent> { cancelOpenRequest(it.openRequestId) }
     eventQueue.register<Controller.RetryRomReplacementEvent> { retryPersistence(it.requestId) }
     eventQueue.register<Controller.CancelRomReplacementEvent> { cancelPersistence(it.requestId) }
@@ -556,6 +601,17 @@ class BasicController private constructor(
     eventQueue.register<StateDeleteRequestEvent> { requestStateDelete(it) }
     eventQueue.register<StateExportRequestEvent> { requestStateExport(it) }
     eventQueue.register<StateScreenshotRequestEvent> { requestScreenshot(it) }
+    eventQueue.register<ReplayRecordingStartRequestEvent> { requestReplayRecording(it) }
+    eventQueue.register<ReplayRecordingStopRequestEvent> { stopReplayRecording(it) }
+    eventQueue.register<ReplayRecordingRetrySaveEvent> { retryReplayArtifactSave(it) }
+    eventQueue.register<ReplayRecordingDiscardEvent> { discardReplayArtifact(it) }
+    eventQueue.register<ReplayRecordingCloseBarrierEvent> { event ->
+      try {
+        finishReplayRecording("Coffee GB is closing")
+      } finally {
+        event.completed.countDown()
+      }
+    }
     eventQueue.register<StateOpenFolderRequestEvent> { requestOpenStateFolder(it) }
     eventQueue.register<StateResumeDecisionEvent> { applyResumeDecision(it) }
     eventQueue.register<StatePrepareCloseRequestEvent> { prepareClose(it) }
@@ -586,6 +642,7 @@ class BasicController private constructor(
     }
     eventQueue.register<StateWorkerCompletedEvent> { finishStateWorkerRequest(it) }
     eventQueue.register<Controller.PauseEmulationEvent> {
+      finishReplayRecording("Emulation was paused")
       if (pauseStateBeforeLoading != null) {
         pauseStateBeforeLoading = true
       } else if (pauseStateBeforeResume != null) {
@@ -798,6 +855,17 @@ class BasicController private constructor(
     }
     eventQueue.register<Controller.FlushBatteryEvent> { requestBatteryFlush(it) }
     eventQueue.register<Controller.RewindEvent> {
+      if (replayRecording != null || armedReplayRecording != null || pendingCleanBootReplay != null) {
+        if (it.active) {
+          postReplayRecordingStatus(
+              if (replayRecording != null) ReplayRecordingPhase.RECORDING
+              else ReplayRecordingPhase.ARMING,
+              "Rewind is unavailable while recording inputs.",
+          )
+        }
+        isRewinding = false
+        return@register
+      }
       // Disabled rewind is a real no-work mode: the key cannot freeze forward emulation and
       // runFrame never reaches a machine capture.
       if (rewindManager.enabled && it.active && !isRewinding) {
@@ -817,6 +885,7 @@ class BasicController private constructor(
       session?.gameboy?.requestFrameRenderSuppression(false)
     }
     eventQueue.register<SgbDisplay.SetSgbBorder> {
+      finishReplayRecording("The Super Game Boy border setting changed")
       // The display consumes the same event on its session bus. Keep the configuration identity
       // synchronized at this frame boundary so later portable captures describe the live option.
       session?.config?.let { config ->
@@ -828,6 +897,7 @@ class BasicController private constructor(
       }
     }
     eventQueue.register<Controller.ResetEmulationEvent> {
+      finishReplayRecording("The game was reset")
       if (hasMobileAdapterExternalIo()) {
         postMobileAdapterStateBoundary(Controller.MobileAdapterStateBoundary.RESET)
         disconnectMobileAdapter(Controller.MobileAdapterDisconnectReason.PROTOCOL_RESET)
@@ -845,9 +915,11 @@ class BasicController private constructor(
       }
     }
     eventQueue.register<Controller.StopEmulationEvent> {
+      finishReplayRecording("The game was closed")
       requestStop()
     }
     eventQueue.register<Controller.SetSerialPeripheralEvent> {
+      finishReplayRecording("The link-port device changed")
       selectSerialPeripheral(it.selection)
     }
     eventBus.register<Controller.RefreshMobileAdapterConfigurationEvent> { event ->
@@ -878,6 +950,7 @@ class BasicController private constructor(
       )
     }
     eventQueue.register<Controller.UpdatedSystemMappingEvent> {
+      finishReplayRecording("The system configuration changed")
       session?.config?.let { config ->
         val newProfile = Controller.getHardwareProfile(properties.system, config.rom)
         val newBootstrapMode = properties.system.bootstrapMode
@@ -928,6 +1001,7 @@ class BasicController private constructor(
     finishReplacement()
     finishStop()
     finishBatteryFlush()
+    startArmedReplayRecordingIfReady()
 
     val benchmarkExecutionFrozen =
         properties.overrides.benchmarkPolicyEnabled && benchmarkArmed
@@ -981,6 +1055,7 @@ class BasicController private constructor(
             debugPort == null &&
             debugInstrumentation == null &&
             !debugCheckpointHistory.enabled &&
+            replayRecording == null &&
             !properties.overrides.benchmarkPolicyEnabled &&
             !timingTicker.disabled &&
             timingTicker.hasPacingDebt,
@@ -1022,7 +1097,7 @@ class BasicController private constructor(
             if (trackDebugHistory) {
               tickWithDebugHistory(gameboy, frameTicks)
             } else {
-              gameboy.tick()
+              tickReplayAware(gameboy)
             }
             emulatedTicks++
           }
@@ -1239,7 +1314,7 @@ class BasicController private constructor(
           if (debugCheckpointHistory.enabled) {
             tickWithDebugHistory(gameboy, frameTicks)
           } else {
-            gameboy.tick()
+            tickReplayAware(gameboy)
           }
           debugMasterTick = Math.addExact(debugMasterTick, 1L)
           debugFramePosition++
@@ -1276,7 +1351,7 @@ class BasicController private constructor(
     val retirement = gameboy.debugRetirementSequence
     debugCheckpointHistory.onTickStarted(isEffectivelyPaused())
     try {
-      gameboy.tick()
+      tickReplayAware(gameboy)
     } catch (failure: Throwable) {
       debugCheckpointHistory.abortTick()
       throw failure
@@ -1285,6 +1360,32 @@ class BasicController private constructor(
         gameboy.debugRetirementSequence != retirement,
         frameTicks,
     )
+  }
+
+  /** Keeps recorder ownership in one place so no controller tick path can bypass it. */
+  private fun tickReplayAware(gameboy: Gameboy) {
+    val active = replayRecording
+    if (active == null) {
+      gameboy.tick()
+      return
+    }
+    try {
+      active.recorder.tick()
+      if (active.recorder.frameCount > 0L && active.recorder.frameCount % 60L == 0L &&
+          active.recorder.tickCount % gameboy.clockSpec.controllerTicksPerFrame().toLong() == 0L) {
+        postReplayRecordingStatus(ReplayRecordingPhase.RECORDING)
+      }
+    } catch (failure: Throwable) {
+      replayRecording = null
+      postReplayRecordingFailure(
+          null,
+          active.sessionId,
+          active.mode,
+          "Input recording stopped without a saved file.",
+          replayRecordingDetail(failure),
+          recoverable = false,
+      )
+    }
   }
 
   private fun recordCompletedFrame() {
@@ -2206,6 +2307,7 @@ class BasicController private constructor(
             event.expectedSessionId,
             StateOperation.LOAD,
         ) ?: return
+    finishReplayRecording("A state load begins a new input timeline")
     latestStateRequests[StateOperation.LOAD] = event.requestId
     stateWorker.load(
         context,
@@ -2222,6 +2324,7 @@ class BasicController private constructor(
             event.expectedSessionId,
             StateOperation.LOAD,
         ) ?: return
+    finishReplayRecording("A state load begins a new input timeline")
     latestStateRequests[StateOperation.LOAD] = event.requestId
     val compatibilityManager = snapshotManager
     stateWorker.loadFirst(context, event.requestId, event.ref) {
@@ -2283,6 +2386,347 @@ class BasicController private constructor(
         ) ?: return
     latestStateRequests[StateOperation.SCREENSHOT] = event.requestId
     stateWorker.screenshot(context, event.requestId, event.image)
+  }
+
+  private fun requestReplayRecording(event: ReplayRecordingStartRequestEvent) {
+    if (replayRecording != null || armedReplayRecording != null || pendingReplayArtifact != null) {
+      postReplayRecordingFailure(
+          event.requestId,
+          stateSessionId,
+          event.mode,
+          "An input recording is already active or waiting to be saved.",
+          "Stop the current recording and wait for it to save before starting another one.",
+          recoverable = pendingReplayArtifact != null,
+      )
+      return
+    }
+    val currentSession = session
+    val context = stateContext
+    if (currentSession == null || context == null || event.expectedSessionId != context.sessionId) {
+      postReplayRecordingFailure(
+          event.requestId,
+          context?.sessionId,
+          event.mode,
+          "Input recording is unavailable for this game.",
+          "Keep one standalone game open with a writable save workspace, then try again.",
+          recoverable = false,
+      )
+      return
+    }
+    if (event.mode == ReplayRecordingMode.CLEAN_BOOT) {
+      requestCleanBootReplay(event, currentSession)
+      return
+    }
+    if (isEffectivelyPaused() || isRewinding || debugCheckpointHistory.enabled) {
+      postReplayRecordingFailure(
+          event.requestId,
+          context.sessionId,
+          event.mode,
+          "Input recording must start while normal emulation is running.",
+          "Resume the game, release Rewind, and close reverse-debug history before trying again.",
+          recoverable = false,
+      )
+      return
+    }
+    armedReplayRecording = ArmedReplayRecording(event, context.sessionId)
+    postReplayRecordingStatus(ReplayRecordingPhase.ARMING, "Release controller inputs to start recording.")
+  }
+
+  private fun requestCleanBootReplay(
+      event: ReplayRecordingStartRequestEvent,
+      currentSession: Session,
+  ) {
+    if (currentSession.config.rom.image == null) {
+      postReplayRecordingFailure(
+          event.requestId,
+          stateSessionId,
+          event.mode,
+          "Clean-boot recording is unavailable for this game.",
+          "The current ROM cannot be reopened as an isolated clean session.",
+          recoverable = false,
+      )
+      return
+    }
+    pendingCleanBootReplay =
+        PendingCleanBootReplay(
+            request = event,
+            rtcEpochMillis = ReplayRecordingOptions.DEFAULT_RTC_EPOCH_MILLIS,
+        )
+    postReplayRecordingStatus(
+        ReplayRecordingPhase.ARMING,
+        "Saving the current session, then restarting from a clean boot.",
+    )
+    requestLoadWithAutosave(
+        properties,
+        Controller.LoadRomEvent(
+            image = checkNotNull(currentSession.config.rom.image),
+            persistenceStore = currentPersistenceStore,
+            allowAutosaveResume = false,
+        ),
+    )
+  }
+
+  /** Starts a current-session recorder only after activation input has fully released. */
+  private fun startArmedReplayRecordingIfReady() {
+    val armed = armedReplayRecording ?: return
+    val currentSession = session
+    val context = stateContext
+    if (currentSession == null || context == null || context.sessionId != armed.sessionId) {
+      armedReplayRecording = null
+      postReplayRecordingFailure(
+          armed.request.requestId,
+          context?.sessionId,
+          armed.request.mode,
+          "Input recording could not start.",
+          "The active game changed before recording began.",
+          recoverable = false,
+      )
+      return
+    }
+    if (currentSession.gameboy.sampledPlayerInput != PlayerInputSnapshot.released()) {
+      return
+    }
+    armedReplayRecording = null
+    startReplayRecording(
+        currentSession,
+        context,
+        armed.request.mode,
+        initialMode = ReplayInitialMode.EMBEDDED_SESSION_STATE,
+        includeSensitiveInitialState = armed.request.includeSensitiveInitialState,
+        rtcEpochMillis = ReplayRecordingOptions.DEFAULT_RTC_EPOCH_MILLIS,
+        requestId = armed.request.requestId,
+    )
+  }
+
+  private fun startCleanBootReplayRecordingIfPending(currentSession: Session) {
+    val pending = pendingCleanBootReplay ?: return
+    val context = stateContext ?: return
+    if (replayRecording != null || context.sessionId <= 0L) return
+    pendingCleanBootReplay = null
+    startReplayRecording(
+        currentSession,
+        context,
+        ReplayRecordingMode.CLEAN_BOOT,
+        initialMode = ReplayInitialMode.BOOT_REFERENCE,
+        includeSensitiveInitialState = false,
+        rtcEpochMillis = pending.rtcEpochMillis,
+        requestId = pending.request.requestId,
+    )
+    cleanBootReplaySession = replayRecording?.mode == ReplayRecordingMode.CLEAN_BOOT
+  }
+
+  private fun startReplayRecording(
+      currentSession: Session,
+      context: StateWorkerContext,
+      mode: ReplayRecordingMode,
+      initialMode: ReplayInitialMode,
+      includeSensitiveInitialState: Boolean,
+      rtcEpochMillis: Long,
+      requestId: Long,
+  ) {
+    try {
+      if (initialMode == ReplayInitialMode.EMBEDDED_SESSION_STATE) {
+        ensureReplaySerialEndpoint(currentSession)
+      }
+      val recorder =
+          ReplayRecorder.start(
+              currentSession,
+              ReplayRecordingOptions(
+                  initialMode = initialMode,
+                  includeSensitiveInitialState = includeSensitiveInitialState,
+                  rtcEpochMillis = rtcEpochMillis,
+                  metadata =
+                      ReplayMetadata(
+                          producerVersion = "Coffee GB",
+                          createdAtEpochMillis = System.currentTimeMillis(),
+                      ),
+              ),
+          )
+      replayRecording =
+          ActiveReplayRecording(
+              id = nextReplayRecordingId++,
+              sessionId = context.sessionId,
+              mode = mode,
+              recorder = recorder,
+          )
+      postReplayRecordingStatus(ReplayRecordingPhase.RECORDING)
+    } catch (failure: Throwable) {
+      postReplayRecordingFailure(
+          requestId,
+          context.sessionId,
+          mode,
+          "Input recording could not start.",
+          replayRecordingDetail(failure),
+          recoverable = false,
+      )
+    }
+  }
+
+  /** Normalizes only Coffee GB's inactive default link cable; real peripherals require user action. */
+  private fun ensureReplaySerialEndpoint(currentSession: Session) {
+    if (currentSession.serialEndpoint === SerialEndpoint.NULL_ENDPOINT) return
+    val peer = currentSession.serialEndpoint as? Peer2PeerSerialEndpoint
+    if (serialPeripheralSelection == Controller.SerialPeripheralSelection.PEER_TO_PEER &&
+        peer != null && !peer.isConnected) {
+      selectSerialPeripheral(Controller.SerialPeripheralSelection.NONE)
+      return
+    }
+    throw ReplayCompatibilityException(
+        eu.rekawek.coffeegb.controller.replay.ReplayCompatibilityReason.UNSUPPORTED_SERIAL_PERIPHERAL,
+        "Input recording requires an empty link port. Select None in the Peripherals menu.",
+    )
+  }
+
+  private fun stopReplayRecording(event: ReplayRecordingStopRequestEvent) {
+    val pendingCleanBoot = pendingCleanBootReplay
+    if (pendingCleanBoot != null &&
+        pendingCleanBoot.request.expectedSessionId == event.expectedSessionId) {
+      pendingCleanBootReplay = null
+      cancelPendingRomSwitch()
+      cancelLoadJob()
+      discardReplacement(restorePause = true)
+      postReplayRecordingStatus(
+          ReplayRecordingPhase.IDLE,
+          "Clean-boot input recording was cancelled before it started.",
+      )
+      return
+    }
+    val armed = armedReplayRecording
+    if (armed != null && armed.sessionId == event.expectedSessionId) {
+      armedReplayRecording = null
+      postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "Input recording was cancelled before it started.")
+      return
+    }
+    val active = replayRecording
+    if (active == null || active.sessionId != event.expectedSessionId) {
+      return
+    }
+    finishReplayRecording("Input recording stopped")
+  }
+
+  private fun retryReplayArtifactSave(event: ReplayRecordingRetrySaveEvent) {
+    val pending = pendingReplayArtifact ?: return
+    if (pending.sessionId != event.expectedSessionId) return
+    submitReplayArtifact(pending, "Retrying input recording save")
+  }
+
+  private fun discardReplayArtifact(event: ReplayRecordingDiscardEvent) {
+    val pending = pendingReplayArtifact ?: return
+    if (pending.sessionId != event.expectedSessionId) return
+    pendingReplayArtifact = null
+    postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "Unsaved input recording was discarded.")
+  }
+
+  /** Ends a linear recording before a lifecycle boundary can restore or mutate machine state. */
+  private fun finishReplayRecording(reason: String) {
+    pendingCleanBootReplay?.let {
+      pendingCleanBootReplay = null
+      postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "$reason before clean-boot recording began.")
+    }
+    armedReplayRecording?.let {
+      armedReplayRecording = null
+      postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "$reason before recording began.")
+    }
+    val active = replayRecording ?: return
+    replayRecording = null
+    val completed =
+        try {
+          active.recorder.finish()
+        } catch (failure: ReplayRecordingException) {
+          if (failure.reason == eu.rekawek.coffeegb.controller.replay.ReplayRecordingReason.NO_EXECUTED_TICKS) {
+            active.recorder.close()
+            postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "No input recording was saved.")
+            return
+          }
+          postReplayRecordingFailure(
+              null,
+              active.sessionId,
+              active.mode,
+              "Input recording stopped without a saved file.",
+              replayRecordingDetail(failure),
+              recoverable = false,
+          )
+          return
+        } catch (failure: Throwable) {
+          postReplayRecordingFailure(
+              null,
+              active.sessionId,
+              active.mode,
+              "Input recording stopped without a saved file.",
+              replayRecordingDetail(failure),
+              recoverable = false,
+          )
+          return
+        }
+    val context = stateContext
+    if (context == null) {
+      postReplayRecordingFailure(
+          null,
+          active.sessionId,
+          active.mode,
+          "Input recording could not be saved.",
+          "The game save workspace is no longer available.",
+          recoverable = false,
+      )
+      return
+    }
+    val pending =
+        PendingReplayArtifact(
+            active.id,
+            active.sessionId,
+            active.mode,
+            context,
+            completed,
+            active.recorder.tickCount,
+            active.recorder.frameCount,
+        )
+    pendingReplayArtifact = pending
+    submitReplayArtifact(pending, reason)
+  }
+
+  private fun cancelPendingCleanBootReplay(message: String) {
+    if (pendingCleanBootReplay == null) return
+    pendingCleanBootReplay = null
+    postReplayRecordingStatus(ReplayRecordingPhase.IDLE, message)
+  }
+
+  private fun submitReplayArtifact(pending: PendingReplayArtifact, reason: String) {
+    val requestId = nextInternalStateRequestId()
+    pending.requestId = requestId
+    postReplayRecordingStatus(ReplayRecordingPhase.SAVING, reason)
+    stateWorker.replay(pending.context, requestId, pending.replay)
+  }
+
+  private fun replayRecordingDetail(failure: Throwable): String =
+      when (failure) {
+        is ReplayCompatibilityException, is ReplayRecordingException -> failure.message ?: failure.javaClass.simpleName
+        else -> "The recorder reported ${failure.javaClass.simpleName}."
+      }
+
+  private fun postReplayRecordingStatus(
+      phase: ReplayRecordingPhase,
+      message: String? = null,
+  ) {
+    val active = replayRecording
+    val pending = pendingReplayArtifact
+    val armed = armedReplayRecording
+    val recordingId = active?.id ?: pending?.id
+    val sessionId = active?.sessionId ?: pending?.sessionId ?: armed?.sessionId
+    val mode = active?.mode ?: pending?.mode ?: armed?.request?.mode
+    val ticks = active?.recorder?.tickCount ?: pending?.tickCount ?: 0L
+    val frames = active?.recorder?.frameCount ?: pending?.frameCount ?: 0L
+    eventBus.post(ReplayRecordingStatusEvent(recordingId, sessionId, mode, phase, ticks, frames, message))
+  }
+
+  private fun postReplayRecordingFailure(
+      requestId: Long?,
+      sessionId: Long?,
+      mode: ReplayRecordingMode?,
+      summary: String,
+      detail: String,
+      recoverable: Boolean,
+  ) {
+    eventBus.post(ReplayRecordingFailedEvent(requestId, sessionId, mode, summary, detail, recoverable))
   }
 
   private fun requestOpenStateFolder(event: StateOpenFolderRequestEvent) {
@@ -2377,6 +2821,11 @@ class BasicController private constructor(
     cancelPendingRomSwitch(restorePause = true)
     val currentSession = session
     val context = stateContext
+    if (cleanBootReplaySession && currentSession != null) {
+      // A clean-boot replay session deliberately cannot replace the user's normal autosave.
+      requestLoad(properties, event)
+      return
+    }
     val autosaveRequired = currentSession != null
     if (!autosaveRequired) {
       requestLoad(properties, event)
@@ -2456,6 +2905,10 @@ class BasicController private constructor(
   }
 
   private fun finishStateWorkerRequest(event: StateWorkerCompletedEvent) {
+    if (event.operation == StateOperation.REPLAY_SAVE) {
+      finishReplayArtifactSave(event)
+      return
+    }
     val context = stateContext
     if (context == null ||
         event.context.sessionId != context.sessionId) {
@@ -2565,7 +3018,49 @@ class BasicController private constructor(
             ))
       }
       is StateWorkerResult.Resume -> finishResumeScan(event, result)
+      is StateWorkerResult.Replay -> error("Replay saves are handled above")
       is StateWorkerResult.Failure -> error("Handled above")
+    }
+  }
+
+  private fun finishReplayArtifactSave(event: StateWorkerCompletedEvent) {
+    val pending = pendingReplayArtifact ?: return
+    if (pending.requestId != event.requestId) return
+    when (val result = event.result) {
+      is StateWorkerResult.Replay -> {
+        pendingReplayArtifact = null
+        eventBus.post(
+            ReplayRecordingSavedEvent(
+                pending.id,
+                result.result.path,
+                pending.mode,
+                pending.tickCount,
+                pending.frameCount,
+            ))
+        postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "Input recording saved as ${result.result.path.fileName}.")
+      }
+      is StateWorkerResult.Failure -> {
+        postReplayRecordingStatus(ReplayRecordingPhase.UNSAVED, "Input recording was not saved.")
+        postReplayRecordingFailure(
+            null,
+            pending.sessionId,
+            pending.mode,
+            "Input recording could not be saved.",
+            result.error.detail,
+            recoverable = true,
+        )
+      }
+      else -> {
+        postReplayRecordingStatus(ReplayRecordingPhase.UNSAVED, "Input recording was not saved.")
+        postReplayRecordingFailure(
+            null,
+            pending.sessionId,
+            pending.mode,
+            "Input recording could not be saved.",
+            "The state worker returned an unexpected result.",
+            recoverable = true,
+        )
+      }
     }
   }
 
@@ -2662,6 +3157,7 @@ class BasicController private constructor(
             ))
       }
       StateWorkerPurpose.RESUME_SCAN -> Unit
+      StateWorkerPurpose.REPLAY_SAVE -> error("Replay saves use their own completion path")
     }
   }
 
@@ -2718,6 +3214,7 @@ class BasicController private constructor(
             }
         if (latest) postStateFailure(event.requestId, event.operation, error)
       }
+      StateWorkerPurpose.REPLAY_SAVE -> error("Replay saves use their own completion path")
     }
   }
 
@@ -3199,13 +3696,32 @@ class BasicController private constructor(
     loadJob = null
 
     try {
-      beginReplacement(job, job.task.take())
+      beginReplacement(job, cleanBootPreparedSessionIfRequested(job.task.take()))
     } catch (_: CancellationException) {
       restorePauseStateAfterLoading()
     } catch (e: ExecutionException) {
       reportLoadFailure(job.event, e.cause ?: e)
     } catch (e: Exception) {
       reportLoadFailure(job.event, e)
+    }
+  }
+
+  /** Reuses the ordinary autosave/replacement transaction, but never loads a user battery save. */
+  private fun cleanBootPreparedSessionIfRequested(prepared: PreparedSession): PreparedSession {
+    val pending = pendingCleanBootReplay ?: return prepared
+    return try {
+      val cleanConfig =
+          ReplayRuntime.configuration(
+              prepared.config,
+              VirtualTimeSource(pending.rtcEpochMillis),
+              prepared.config.playerInputSource,
+              ExecutionMode.ACCURACY,
+          )
+      // A CGBR boot reference requires a physically empty port from the first machine tick.
+      serialPeripheralSelection = Controller.SerialPeripheralSelection.NONE
+      PreparedSession.Deferred(cleanConfig, StateIdentity.hashes(cleanConfig), prepared.stateStore)
+    } finally {
+      prepared.discard()
     }
   }
 
@@ -3357,6 +3873,13 @@ class BasicController private constructor(
     pauseStateBeforeLoading = null
     val currentSession = session
     if (currentSession == null) {
+      isPaused = false
+      return
+    }
+
+    if (cleanBootReplaySession) {
+      setPaused(true)
+      stop()
       isPaused = false
       return
     }
@@ -3728,6 +4251,17 @@ class BasicController private constructor(
   }
 
   private fun reportLoadFailure(event: Controller.LoadRomEvent, error: Throwable) {
+    pendingCleanBootReplay?.let { pending ->
+      pendingCleanBootReplay = null
+      postReplayRecordingFailure(
+          pending.request.requestId,
+          stateSessionId.takeIf { it > 0L },
+          ReplayRecordingMode.CLEAN_BOOT,
+          "Clean-boot input recording could not start.",
+          replayRecordingDetail(error),
+          recoverable = false,
+      )
+    }
     LOG.error("Can't load ROM ${event.rom}", error)
     val message = error.message?.takeIf { it.isNotBlank() } ?: error.javaClass.simpleName
     eventBus.post(
@@ -3798,6 +4332,9 @@ class BasicController private constructor(
   }
 
   private fun setDebugPaused(paused: Boolean) {
+    if (paused && !debugPaused) {
+      finishReplayRecording("The debugger paused emulation")
+    }
     if (paused) {
       disableBenchmarkAudioCalendar()
     }
@@ -4482,6 +5019,7 @@ class BasicController private constructor(
       allowAutosaveResume: Boolean = true,
   ) {
     val session = session ?: return
+    cleanBootReplaySession = pendingCleanBootReplay != null
 
     // A newly committed session never inherits the transient host calendar from a replaced
     // machine, even when the controller was already paused and no pause transition is emitted.
@@ -4545,6 +5083,8 @@ class BasicController private constructor(
               )
           null
         }
+
+    startCleanBootReplayRecordingIfPending(session)
 
     if ((properties.overrides.benchmarkPolicyEnabled ||
             session.config.bootstrapMode == Gameboy.BootstrapMode.FAST_FORWARD) &&
@@ -4635,9 +5175,20 @@ class BasicController private constructor(
         throw IllegalStateException("Bootstrap did not reach the cartridge handoff")
       }
       val chunk = minOf(remaining, PRESENTATION_BOOTSTRAP_CHUNK_TICKS.toLong()).toInt()
-      val executed = gameboy.runTicksUntilStop(chunk) {
-        doStop || session !== currentSession || gameboy.isBootstrapReady()
-      }
+      val executed =
+          if (replayRecording != null) {
+            var ticks = 0
+            while (ticks < chunk && !doStop && session === currentSession &&
+                !gameboy.isBootstrapReady()) {
+              tickReplayAware(gameboy)
+              ticks++
+            }
+            ticks
+          } else {
+            gameboy.runTicksUntilStop(chunk) {
+              doStop || session !== currentSession || gameboy.isBootstrapReady()
+            }
+          }
       remaining -= executed.toLong()
       if (executed == 0 && !gameboy.isBootstrapReady()) {
         if (doStop || session !== currentSession) {
@@ -4832,6 +5383,7 @@ class BasicController private constructor(
       closeDeadlineNanos: Long? = null,
   ) {
     val session = session ?: return
+    cleanBootReplaySession = false
     // Stop is also used by terminal close paths that may bypass a visible pause transition.
     // Clear the transient calendar before releasing the machine or its event bus.
     session.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
@@ -4926,6 +5478,7 @@ class BasicController private constructor(
           ))
       return
     }
+    finishReplayRecording("A state load begins a new input timeline")
     val manager = snapshotManager
     if (manager == null) {
       requestStateLoadRef(
@@ -4981,6 +5534,7 @@ class BasicController private constructor(
     // leave an apparently open port whose commands have nobody left to service them.
     debugPort?.close()
     console?.setDebugPort(null)
+    finishReplayRecordingBeforeClose(closeDeadlineNanos)
     doStop = true
     awaitTimingThread(closeDeadlineNanos)
 
@@ -5223,6 +5777,7 @@ class BasicController private constructor(
 
   private fun shouldPersistCloseAutosave(): Boolean =
       !properties.overrides.suppressCloseAutosave &&
+          !cleanBootReplaySession &&
           session?.config?.rom?.file != null &&
           closeAutosaveCompletedSessionId != stateSessionId &&
           closeAutosaveSkippedSessionId != stateSessionId
@@ -5249,6 +5804,46 @@ class BasicController private constructor(
           "Controller timing thread did not stop before the close deadline. " +
               "The running session remains retained and close can be retried.",
           java.io.IOException("Controller timing-thread stop timed out"),
+      )
+    }
+  }
+
+  /**
+   * [ReplayRecorder] is owner-thread confined. Closing must therefore finalize it at a controller
+   * safe point before [doStop] prevents the timing loop from dispatching any more events.
+   */
+  private fun finishReplayRecordingBeforeClose(closeDeadlineNanos: Long) {
+    if (Thread.currentThread() === thread) {
+      finishReplayRecording("Coffee GB is closing")
+      return
+    }
+    if (!thread.isAlive) {
+      if (replayRecording != null || armedReplayRecording != null) {
+        throw closeBarrierFailure(
+            "Input recording could not be finalized because the controller thread is not running.",
+            java.io.IOException("Controller thread stopped before replay finalization"),
+            "input recording",
+        )
+      }
+      return
+    }
+    val completed = CountDownLatch(1)
+    eventBus.post(ReplayRecordingCloseBarrierEvent(completed))
+    val remainingNanos = remainingCloseNanos(closeDeadlineNanos, "input recording finalization")
+    try {
+      if (!completed.await(remainingNanos, TimeUnit.NANOSECONDS)) {
+        throw closeBarrierFailure(
+            "Input recording did not finalize before the close deadline. Close can be retried.",
+            java.io.IOException("Input recording finalization timed out"),
+            "input recording",
+        )
+      }
+    } catch (failure: InterruptedException) {
+      Thread.currentThread().interrupt()
+      throw closeBarrierFailure(
+          "Interrupted while finalizing input recording for close.",
+          failure,
+          "input recording",
       )
     }
   }
@@ -5589,6 +6184,38 @@ class BasicController private constructor(
       val clearPatches: Boolean,
       val task: PreparedLoadTask,
   )
+
+  private data class ArmedReplayRecording(
+      val request: ReplayRecordingStartRequestEvent,
+      val sessionId: Long,
+  )
+
+  private data class ActiveReplayRecording(
+      val id: Long,
+      val sessionId: Long,
+      val mode: ReplayRecordingMode,
+      val recorder: ReplayRecorder,
+  )
+
+  private data class PendingReplayArtifact(
+      val id: Long,
+      val sessionId: Long,
+      val mode: ReplayRecordingMode,
+      val context: StateWorkerContext,
+      val replay: ReplayFile,
+      val tickCount: Long,
+      val frameCount: Long,
+      var requestId: Long = 0L,
+  )
+
+  private data class PendingCleanBootReplay(
+      val request: ReplayRecordingStartRequestEvent,
+      val rtcEpochMillis: Long,
+  )
+
+  private data class ReplayRecordingCloseBarrierEvent(
+      val completed: CountDownLatch,
+  ) : Event
 
   private data class ReplacementJob(
       val requestId: Long,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -5458,6 +5458,12 @@ class BasicController private constructor(
             context?.workspace?.activeGameDirectory(),
             stateUnavailableReason,
         ))
+    // A clean-boot recorder starts before the new session is published so it owns boot tick zero.
+    // Publish its status again after the session event, otherwise the desktop still scopes the
+    // original status to the just-replaced session and cannot enable Stop.
+    replayRecording
+        ?.takeIf { it.sessionId == stateSessionId }
+        ?.let { postReplayRecordingStatus(ReplayRecordingPhase.RECORDING) }
     if (allowAutosaveResume &&
         context != null &&
         properties.saves.resumePolicy !=

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -601,6 +601,9 @@ class BasicController private constructor(
   init {
     require(closeTimeoutMillis > 0) { "Controller close timeout must be positive" }
     eventQueue.register<AddPatches> {
+      // start() republishes this exact controller-owned list to initialize the new core. It is not
+      // a user mutation and must not terminate a recorder that already owns clean-boot tick zero.
+      if (it.patches === patches) return@register
       if (replayPlaybackMutationBlocked("Changing cheats")) return@register
       finishReplayRecording("Cheats changed")
       patches.addAll(it.patches)
@@ -669,7 +672,6 @@ class BasicController private constructor(
     }
     eventQueue.register<StateWorkerCompletedEvent> { finishStateWorkerRequest(it) }
     eventQueue.register<Controller.PauseEmulationEvent> {
-      finishReplayRecording("Emulation was paused")
       if (pauseStateBeforeLoading != null) {
         pauseStateBeforeLoading = true
       } else if (pauseStateBeforeResume != null) {
@@ -844,6 +846,13 @@ class BasicController private constructor(
       benchmarkAudioPolicyProcessed = true
     }
     eventQueue.register<Controller.ResumeEmulationEvent> {
+      if (replayPlaybackCompleted) {
+        postReplayPlaybackStatus(
+            ReplayPlaybackPhase.COMPLETED,
+            "Input playback is complete. Close or reopen the game to play normally.",
+        )
+        return@register
+      }
       if (properties.overrides.benchmarkPolicyEnabled && benchmarkCoreFrozenGate.getAsBoolean()) {
         // The 600th measured core boundary owns the terminal freeze.  A lifecycle/audio resume
         // cannot accidentally create an unmeasured 601st frame before the host collects SF data.
@@ -1101,7 +1110,7 @@ class BasicController private constructor(
     )
     val gameboy = session?.gameboy
     var emulatedTicks = 0
-    if (gameboy != null && !benchmarkExecutionFrozen
+    if (gameboy != null && !benchmarkExecutionFrozen && !replayPlaybackCompleted
         && (rewound || (!isEffectivelyPaused() && !isRewinding))) {
       relinquishDebugBreakpointPauseOwnership()
       val performanceWorkSession =
@@ -2470,7 +2479,8 @@ class BasicController private constructor(
   }
 
   private fun requestReplayRecording(event: ReplayRecordingStartRequestEvent) {
-    if (replayRecording != null || armedReplayRecording != null || pendingReplayArtifact != null) {
+    if (replayRecording != null || armedReplayRecording != null || pendingCleanBootReplay != null ||
+        pendingReplayArtifact != null) {
       postReplayRecordingFailure(
           event.requestId,
           stateSessionId,
@@ -2478,6 +2488,18 @@ class BasicController private constructor(
           "An input recording is already active or waiting to be saved.",
           "Stop the current recording and wait for it to save before starting another one.",
           recoverable = pendingReplayArtifact != null,
+      )
+      return
+    }
+    if (pendingReplayPlayback != null || replayPlayback != null || replayPlaybackCompleted ||
+        replayPlaybackSession) {
+      postReplayRecordingFailure(
+          event.requestId,
+          stateSessionId.takeIf { it > 0L },
+          event.mode,
+          "Input recording is unavailable during input playback.",
+          "Close or reopen the game before starting another recording.",
+          recoverable = false,
       )
       return
     }
@@ -2524,6 +2546,17 @@ class BasicController private constructor(
           event.mode,
           "Clean-boot recording is unavailable for this game.",
           "The current ROM cannot be reopened as an isolated clean session.",
+          recoverable = false,
+      )
+      return
+    }
+    if (patches.isNotEmpty()) {
+      postReplayRecordingFailure(
+          event.requestId,
+          stateSessionId,
+          event.mode,
+          "Clean-boot recording is unavailable while cheats are active.",
+          "Disable cheats or use From current moment so the initial state contains them.",
           recoverable = false,
       )
       return
@@ -2666,6 +2699,7 @@ class BasicController private constructor(
       cancelPendingRomSwitch()
       cancelLoadJob()
       discardReplacement(restorePause = true)
+      restorePauseStateAfterLoading()
       postReplayRecordingStatus(
           ReplayRecordingPhase.IDLE,
           "Clean-boot input recording was cancelled before it started.",
@@ -2709,6 +2743,15 @@ class BasicController private constructor(
       postReplayRecordingStatus(ReplayRecordingPhase.IDLE, "$reason before recording began.")
     }
     val active = replayRecording ?: return
+    val activeGameboy = session?.gameboy
+    // Application pause is not part of the emulated timeline. Normalize an MBC3 clock to the
+    // running state while hashing the final tick, then restore the host's pause ownership. This
+    // keeps a recording stopped from a paused menu replayable without advancing its RTC.
+    val restorePausedRtc =
+        activeGameboy != null && isEffectivelyPaused() && activeGameboy.hasPausedCartridgeRtc()
+    if (restorePausedRtc) {
+      activeGameboy.reanchorCartridgeRtcPause(false)
+    }
     replayRecording = null
     val completed =
         try {
@@ -2738,6 +2781,10 @@ class BasicController private constructor(
               recoverable = false,
           )
           return
+        } finally {
+          if (restorePausedRtc && session?.gameboy === activeGameboy && isEffectivelyPaused()) {
+            activeGameboy.reanchorCartridgeRtcPause(true)
+          }
         }
     val context = stateContext
     if (context == null) {
@@ -2791,9 +2838,12 @@ class BasicController private constructor(
     val active = replayRecording
     val pending = pendingReplayArtifact
     val armed = armedReplayRecording
+    val cleanBoot = pendingCleanBootReplay
     val recordingId = active?.id ?: pending?.id
-    val sessionId = active?.sessionId ?: pending?.sessionId ?: armed?.sessionId
-    val mode = active?.mode ?: pending?.mode ?: armed?.request?.mode
+    val sessionId =
+        active?.sessionId ?: pending?.sessionId ?: armed?.sessionId
+          ?: cleanBoot?.request?.expectedSessionId
+    val mode = active?.mode ?: pending?.mode ?: armed?.request?.mode ?: cleanBoot?.request?.mode
     val ticks = active?.recorder?.tickCount ?: pending?.tickCount ?: 0L
     val frames = active?.recorder?.frameCount ?: pending?.frameCount ?: 0L
     eventBus.post(ReplayRecordingStatusEvent(recordingId, sessionId, mode, phase, ticks, frames, message))
@@ -2807,6 +2857,10 @@ class BasicController private constructor(
       detail: String,
       recoverable: Boolean,
   ) {
+    if (!recoverable && replayRecording == null && armedReplayRecording == null &&
+        pendingCleanBootReplay == null && pendingReplayArtifact == null) {
+      postReplayRecordingStatus(ReplayRecordingPhase.IDLE)
+    }
     eventBus.post(ReplayRecordingFailedEvent(requestId, sessionId, mode, summary, detail, recoverable))
   }
 
@@ -2815,7 +2869,8 @@ class BasicController private constructor(
    * autosave/replacement transaction to present it in an isolated machine.
    */
   private fun requestReplayPlayback(event: ReplayPlaybackLoadRequestEvent) {
-    if (replayRecording != null || armedReplayRecording != null || pendingReplayArtifact != null) {
+    if (replayRecording != null || armedReplayRecording != null || pendingCleanBootReplay != null ||
+        pendingReplayArtifact != null) {
       postReplayPlaybackFailure(
           stateSessionId.takeIf { it > 0L },
           "Stop and save the input recording before loading a replay.",
@@ -4451,8 +4506,10 @@ class BasicController private constructor(
     // Benchmark activation owns an explicit preconditioning pause independently of the user's
     // pre-load playback state. Do not let the loading workflow's `false` restore overwrite the
     // pause established by start(), or the generation-bound scenario start will be rejected.
+    val deterministicReplayReplacement = pendingPlayback != null || pendingCleanBootReplay != null
     val pauseNewSession =
-        properties.overrides.benchmarkPolicyEnabled || pauseStateBeforeLoading == true
+        properties.overrides.benchmarkPolicyEnabled ||
+            (!deterministicReplayReplacement && pauseStateBeforeLoading == true)
 
     // This assignment is the ownership commit. From here on the old session is never resumed:
     // its bus may need deferred cleanup, but it cannot invalidate the fully staged candidate.
@@ -4704,7 +4761,13 @@ class BasicController private constructor(
       // the deterministic input transcript, so no checkpoint spanning this boundary is replayable.
       debugCheckpointHistory.clear(DebugHistoryTruncationReason.NONDETERMINISTIC_IO)
     }
-    gameboy.setCartridgeClockPaused(effectivelyPaused)
+    if (resumedPausedRtc && replayRecording != null) {
+      // Host pause duration has no emulated ticks and therefore cannot appear in an input replay.
+      // Resume the RTC without applying that wall-clock gap while deterministic capture owns it.
+      gameboy.reanchorCartridgeRtcPause(false)
+    } else {
+      gameboy.setCartridgeClockPaused(effectivelyPaused)
+    }
     if (resumedPausedRtc && debugFramePosition == 0 && supportsDebugHistory(currentSession)) {
       try {
         debugCheckpointHistory.recordFrame(currentSession)

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -21,6 +21,12 @@ import eu.rekawek.coffeegb.controller.replay.ReplayCompatibilityException
 import eu.rekawek.coffeegb.controller.replay.ReplayFile
 import eu.rekawek.coffeegb.controller.replay.ReplayInitialMode
 import eu.rekawek.coffeegb.controller.replay.ReplayMetadata
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackFailedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatus
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlayer
 import eu.rekawek.coffeegb.controller.replay.ReplayRecorder
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingException
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingDiscardEvent
@@ -34,6 +40,7 @@ import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingRetrySaveEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingOptions
 import eu.rekawek.coffeegb.controller.replay.ReplayRuntime
+import eu.rekawek.coffeegb.controller.replay.ReplayInputSource
 import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.state.BatteryStorageResolver
@@ -467,6 +474,22 @@ class BasicController private constructor(
   /** Clean boot sessions never replace the user's normal battery or autosave implicitly. */
   private var cleanBootReplaySession = false
 
+  /** A decoded replay waiting for the ordinary autosave/replacement transaction to commit. */
+  private var pendingReplayPlayback: PendingReplayPlayback? = null
+
+  /** The live timeline driver for a session presenting an isolated replay. */
+  private var replayPlayback: ActiveReplayPlayback? = null
+
+  /** Retains the isolated-session boundary after the final checkpoint has paused the display. */
+  private var replayPlaybackCompleted = false
+
+  /**
+   * The currently installed machine is an isolated replay machine. Unlike [replayPlayback], this
+   * remains true after the replay reaches its final checkpoint so close/replacement never tries
+   * to autosave the intentionally state-less playback session.
+   */
+  private var replayPlaybackSession = false
+
   private var nextReplayRecordingId = 1L
 
   private var snapshotManager: SnapshotManager? = null
@@ -578,10 +601,13 @@ class BasicController private constructor(
   init {
     require(closeTimeoutMillis > 0) { "Controller close timeout must be positive" }
     eventQueue.register<AddPatches> {
+      if (replayPlaybackMutationBlocked("Changing cheats")) return@register
       finishReplayRecording("Cheats changed")
       patches.addAll(it.patches)
     }
     eventQueue.register<Controller.LoadRomEvent> {
+      endReplayPlayback("Input playback was cancelled by another game load.")
+      cancelPendingReplayPlayback("Input playback was cancelled by another game load.")
       cancelPendingCleanBootReplay("Clean-boot input recording was cancelled by another game load.")
       finishReplayRecording("The game session changed")
       requestLoadWithAutosave(properties, it)
@@ -605,6 +631,7 @@ class BasicController private constructor(
     eventQueue.register<ReplayRecordingStopRequestEvent> { stopReplayRecording(it) }
     eventQueue.register<ReplayRecordingRetrySaveEvent> { retryReplayArtifactSave(it) }
     eventQueue.register<ReplayRecordingDiscardEvent> { discardReplayArtifact(it) }
+    eventQueue.register<ReplayPlaybackLoadRequestEvent> { requestReplayPlayback(it) }
     eventQueue.register<ReplayRecordingCloseBarrierEvent> { event ->
       try {
         finishReplayRecording("Coffee GB is closing")
@@ -855,13 +882,21 @@ class BasicController private constructor(
     }
     eventQueue.register<Controller.FlushBatteryEvent> { requestBatteryFlush(it) }
     eventQueue.register<Controller.RewindEvent> {
-      if (replayRecording != null || armedReplayRecording != null || pendingCleanBootReplay != null) {
+      if (replayRecording != null || armedReplayRecording != null || pendingCleanBootReplay != null ||
+          replayPlaybackSession || pendingReplayPlayback != null) {
         if (it.active) {
-          postReplayRecordingStatus(
-              if (replayRecording != null) ReplayRecordingPhase.RECORDING
-              else ReplayRecordingPhase.ARMING,
-              "Rewind is unavailable while recording inputs.",
-          )
+          if (replayPlaybackSession || pendingReplayPlayback != null) {
+            postReplayPlaybackStatus(
+                if (pendingReplayPlayback != null) ReplayPlaybackPhase.LOADING else replayPlaybackPhase(),
+                "Rewind is unavailable while playing recorded inputs.",
+            )
+          } else {
+            postReplayRecordingStatus(
+                if (replayRecording != null) ReplayRecordingPhase.RECORDING
+                else ReplayRecordingPhase.ARMING,
+                "Rewind is unavailable while recording inputs.",
+            )
+          }
         }
         isRewinding = false
         return@register
@@ -885,6 +920,7 @@ class BasicController private constructor(
       session?.gameboy?.requestFrameRenderSuppression(false)
     }
     eventQueue.register<SgbDisplay.SetSgbBorder> {
+      if (replayPlaybackMutationBlocked("Changing the Super Game Boy border")) return@register
       finishReplayRecording("The Super Game Boy border setting changed")
       // The display consumes the same event on its session bus. Keep the configuration identity
       // synchronized at this frame boundary so later portable captures describe the live option.
@@ -897,6 +933,7 @@ class BasicController private constructor(
       }
     }
     eventQueue.register<Controller.ResetEmulationEvent> {
+      endReplayPlayback("Input playback was cancelled because the game was reset.")
       finishReplayRecording("The game was reset")
       if (hasMobileAdapterExternalIo()) {
         postMobileAdapterStateBoundary(Controller.MobileAdapterStateBoundary.RESET)
@@ -915,6 +952,7 @@ class BasicController private constructor(
       }
     }
     eventQueue.register<Controller.StopEmulationEvent> {
+      endReplayPlayback("Input playback was stopped because the game was closed.")
       finishReplayRecording("The game was closed")
       requestStop()
     }
@@ -950,6 +988,7 @@ class BasicController private constructor(
       )
     }
     eventQueue.register<Controller.UpdatedSystemMappingEvent> {
+      if (replayPlaybackMutationBlocked("Changing the system configuration")) return@register
       finishReplayRecording("The system configuration changed")
       session?.config?.let { config ->
         val newProfile = Controller.getHardwareProfile(properties.system, config.rom)
@@ -1093,13 +1132,18 @@ class BasicController private constructor(
           gameboy.runTicks(frameTicks)
           emulatedTicks = frameTicks
         } else {
-          repeat(frameTicks) {
+          while (emulatedTicks < frameTicks) {
             if (trackDebugHistory) {
               tickWithDebugHistory(gameboy, frameTicks)
             } else {
-              tickReplayAware(gameboy)
+              if (!tickReplayAware(gameboy)) {
+                break
+              }
             }
             emulatedTicks++
+            if (isEffectivelyPaused() || replayPlaybackCompleted) {
+              break
+            }
           }
         }
       } finally {
@@ -1130,7 +1174,7 @@ class BasicController private constructor(
     if (suppressDebugObservation) {
       syncDebugInstrumentation()
     }
-    if (emulated && !rewound) {
+    if (emulated && !rewound && replayPlayback == null && !replayPlaybackCompleted) {
       recordCompletedFrame()
     }
   }
@@ -1287,6 +1331,9 @@ class BasicController private constructor(
           event is Controller.ResetEmulationEvent ||
           event is Controller.StopEmulationEvent ||
           event is Controller.UpdatedSystemMappingEvent ||
+          event is ReplayRecordingStartRequestEvent ||
+          event is ReplayRecordingStopRequestEvent ||
+          event is ReplayPlaybackLoadRequestEvent ||
           event is StatePrepareCloseRequestEvent ||
           event is StateSkipCloseAutosaveRequestEvent ||
           event is StateResumeDecisionEvent ||
@@ -1363,11 +1410,39 @@ class BasicController private constructor(
   }
 
   /** Keeps recorder ownership in one place so no controller tick path can bypass it. */
-  private fun tickReplayAware(gameboy: Gameboy) {
+  private fun tickReplayAware(gameboy: Gameboy): Boolean {
+    val playback = replayPlayback
+    if (playback != null) {
+      return when (val status = playback.player.step()) {
+        is ReplayPlaybackStatus.Advanced -> true
+        is ReplayPlaybackStatus.Completed -> {
+          replayPlayback = null
+          replayPlaybackCompleted = true
+          setPaused(true)
+          postReplayPlaybackStatus(
+              ReplayPlaybackPhase.COMPLETED,
+              "Input playback completed and is paused. Close or reopen the game to play normally.",
+              playback.sessionId,
+          )
+          true
+        }
+        is ReplayPlaybackStatus.Diverged -> {
+          replayPlayback = null
+          replayPlaybackCompleted = true
+          setPaused(true)
+          postReplayPlaybackFailure(
+              playback.sessionId,
+              "Input playback stopped at a divergent checkpoint.",
+              "The replay no longer matches ${status.divergence.mismatchedSubsystems.joinToString()} at tick ${status.divergence.tick}.",
+          )
+          true
+        }
+      }
+    }
     val active = replayRecording
     if (active == null) {
       gameboy.tick()
-      return
+      return true
     }
     try {
       active.recorder.tick()
@@ -1386,6 +1461,7 @@ class BasicController private constructor(
           recoverable = false,
       )
     }
+    return true
   }
 
   private fun recordCompletedFrame() {
@@ -2213,11 +2289,16 @@ class BasicController private constructor(
       config: Gameboy.GameboyConfiguration,
       prebuiltGameboy: Gameboy? = null,
       stateStore: StateStore? = null,
+      forceEmptySerialPort: Boolean = false,
   ): Session {
     val sessionBus = StagedEventBus(eventBus.fork("main"))
     try {
       val serialEndpoint =
-          createLinkDevice(serialPeripheralSelection, sessionBus, config.clockSpec)
+          if (forceEmptySerialPort) {
+            PreparedSerialEndpoint(SerialEndpoint.NULL_ENDPOINT) {}
+          } else {
+            createLinkDevice(serialPeripheralSelection, sessionBus, config.clockSpec)
+          }
       return Session(
           config,
           sessionBus,
@@ -2729,6 +2810,133 @@ class BasicController private constructor(
     eventBus.post(ReplayRecordingFailedEvent(requestId, sessionId, mode, summary, detail, recoverable))
   }
 
+  /**
+   * Decodes an explicitly selected replay on the bounded I/O worker, then reuses the ordinary
+   * autosave/replacement transaction to present it in an isolated machine.
+   */
+  private fun requestReplayPlayback(event: ReplayPlaybackLoadRequestEvent) {
+    if (replayRecording != null || armedReplayRecording != null || pendingReplayArtifact != null) {
+      postReplayPlaybackFailure(
+          stateSessionId.takeIf { it > 0L },
+          "Stop and save the input recording before loading a replay.",
+          "Only one deterministic recording or playback session can own the emulator at a time.",
+      )
+      return
+    }
+    if (pendingReplayPlayback != null || replayPlayback != null || replayPlaybackCompleted) {
+      postReplayPlaybackFailure(
+          stateSessionId.takeIf { it > 0L },
+          "An input replay is already loading or playing.",
+          "Wait for the active replay to finish, then close or reopen the game before loading another file.",
+      )
+      return
+    }
+    val currentSession = session
+    val context = stateContext
+    if (currentSession == null || context == null || context.sessionId != event.expectedSessionId) {
+      postReplayPlaybackFailure(
+          context?.sessionId,
+          "Input replay is unavailable for this game.",
+          "Open the ROM that belongs to the replay, then try again.",
+      )
+      return
+    }
+    if (currentSession.config.rom.image == null) {
+      postReplayPlaybackFailure(
+          context.sessionId,
+          "Input replay needs a reopenable ROM.",
+          "Open the ROM from a local file, then load the replay again.",
+      )
+      return
+    }
+    val pending = PendingReplayPlayback(event, context.sessionId, currentSession.config)
+    pendingReplayPlayback = pending
+    postReplayPlaybackStatus(ReplayPlaybackPhase.LOADING, "Loading input recording…")
+    stateWorker.replayLoad(context, event.requestId, event.path)
+  }
+
+  private fun finishReplayPlaybackLoad(event: StateWorkerCompletedEvent) {
+    val pending = pendingReplayPlayback ?: return
+    if (pending.request.requestId != event.requestId || pending.sessionId != event.context.sessionId) return
+    when (val result = event.result) {
+      is StateWorkerResult.ReplayLoaded -> {
+        pending.replay = result.replay
+        pending.path = result.path
+        val image = pending.sourceConfiguration.rom.image
+        if (image == null || stateContext?.sessionId != pending.sessionId || session == null) {
+          cancelPendingReplayPlayback("Input playback was cancelled because the active game changed.")
+          return
+        }
+        requestLoadWithAutosave(
+            properties,
+            Controller.LoadRomEvent(
+                image = image,
+                persistenceStore = currentPersistenceStore,
+                allowAutosaveResume = false,
+            ),
+        )
+      }
+      is StateWorkerResult.Failure -> {
+        pendingReplayPlayback = null
+        postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE)
+        postReplayPlaybackFailure(
+            pending.sessionId,
+            "Input recording could not be loaded.",
+            result.error.detail,
+        )
+      }
+      else -> {
+        pendingReplayPlayback = null
+        postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE)
+        postReplayPlaybackFailure(
+            pending.sessionId,
+            "Input recording could not be loaded.",
+            "The replay reader returned an unexpected result.",
+        )
+      }
+    }
+  }
+
+  private fun cancelPendingReplayPlayback(message: String) {
+    val pending = pendingReplayPlayback ?: return
+    pendingReplayPlayback = null
+    postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, message, pending.sessionId)
+  }
+
+  /** Drops the controller-side timeline wrapper; the normal session replacement owns machine close. */
+  private fun endReplayPlayback(message: String) {
+    val active = replayPlayback
+    if (active == null && !replayPlaybackCompleted) return
+    replayPlayback = null
+    replayPlaybackCompleted = false
+    postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, message, active?.sessionId)
+  }
+
+  /** Prevents an isolated replay from silently becoming a non-interactive live session. */
+  private fun replayPlaybackMutationBlocked(action: String): Boolean {
+    if (!replayPlaybackSession) return false
+    postReplayPlaybackStatus(
+        replayPlaybackPhase(),
+        "$action is unavailable during input playback. Close or reopen the game first.",
+    )
+    return true
+  }
+
+  private fun replayPlaybackPhase(): ReplayPlaybackPhase =
+      if (replayPlayback != null) ReplayPlaybackPhase.PLAYING else ReplayPlaybackPhase.COMPLETED
+
+  private fun postReplayPlaybackStatus(
+      phase: ReplayPlaybackPhase,
+      message: String? = null,
+      sessionId: Long? = replayPlayback?.sessionId ?: pendingReplayPlayback?.sessionId,
+  ) {
+    eventBus.post(ReplayPlaybackStatusEvent(sessionId, phase, message))
+  }
+
+  private fun postReplayPlaybackFailure(sessionId: Long?, summary: String, detail: String) {
+    eventBus.post(ReplayPlaybackFailedEvent(sessionId, summary, detail))
+  }
+
   private fun requestOpenStateFolder(event: StateOpenFolderRequestEvent) {
     val context =
         requireStateContext(
@@ -2821,8 +3029,8 @@ class BasicController private constructor(
     cancelPendingRomSwitch(restorePause = true)
     val currentSession = session
     val context = stateContext
-    if (cleanBootReplaySession && currentSession != null) {
-      // A clean-boot replay session deliberately cannot replace the user's normal autosave.
+    if ((cleanBootReplaySession || replayPlaybackSession) && currentSession != null) {
+      // Isolated replay sessions deliberately cannot replace the user's normal autosave.
       requestLoad(properties, event)
       return
     }
@@ -2907,6 +3115,10 @@ class BasicController private constructor(
   private fun finishStateWorkerRequest(event: StateWorkerCompletedEvent) {
     if (event.operation == StateOperation.REPLAY_SAVE) {
       finishReplayArtifactSave(event)
+      return
+    }
+    if (event.operation == StateOperation.REPLAY_LOAD) {
+      finishReplayPlaybackLoad(event)
       return
     }
     val context = stateContext
@@ -3019,6 +3231,7 @@ class BasicController private constructor(
       }
       is StateWorkerResult.Resume -> finishResumeScan(event, result)
       is StateWorkerResult.Replay -> error("Replay saves are handled above")
+      is StateWorkerResult.ReplayLoaded -> error("Replay loads are handled above")
       is StateWorkerResult.Failure -> error("Handled above")
     }
   }
@@ -3158,6 +3371,7 @@ class BasicController private constructor(
       }
       StateWorkerPurpose.RESUME_SCAN -> Unit
       StateWorkerPurpose.REPLAY_SAVE -> error("Replay saves use their own completion path")
+      StateWorkerPurpose.REPLAY_LOAD -> error("Replay loads use their own completion path")
     }
   }
 
@@ -3215,6 +3429,7 @@ class BasicController private constructor(
         if (latest) postStateFailure(event.requestId, event.operation, error)
       }
       StateWorkerPurpose.REPLAY_SAVE -> error("Replay saves use their own completion path")
+      StateWorkerPurpose.REPLAY_LOAD -> error("Replay loads use their own completion path")
     }
   }
 
@@ -3708,6 +3923,37 @@ class BasicController private constructor(
 
   /** Reuses the ordinary autosave/replacement transaction, but never loads a user battery save. */
   private fun cleanBootPreparedSessionIfRequested(prepared: PreparedSession): PreparedSession {
+    val playback = pendingReplayPlayback
+    if (playback != null) {
+      return try {
+        val replay = checkNotNull(playback.replay) { "Replay replacement has no decoded replay" }
+        val isolatedConfig =
+            ReplayRuntime.configuration(
+                prepared.config,
+                VirtualTimeSource(replay.initialConditions.rtcEpochMillis),
+                playback.inputSource,
+                ExecutionMode.ACCURACY,
+            )
+        // A replay owns physical input and starts with a genuinely disconnected link port.
+        serialPeripheralSelection = Controller.SerialPeripheralSelection.NONE
+        if (replay.initialConditions.mode == ReplayInitialMode.EMBEDDED_SESSION_STATE) {
+          PreparedSession.Ready(
+              isolatedConfig,
+              isolatedConfig.forRestore().build(),
+              StateIdentity.hashes(isolatedConfig),
+              prepared.stateStore,
+          )
+        } else {
+          PreparedSession.Deferred(
+              isolatedConfig,
+              StateIdentity.hashes(isolatedConfig),
+              prepared.stateStore,
+          )
+        }
+      } finally {
+        prepared.discard()
+      }
+    }
     val pending = pendingCleanBootReplay ?: return prepared
     return try {
       val cleanConfig =
@@ -3877,7 +4123,7 @@ class BasicController private constructor(
       return
     }
 
-    if (cleanBootReplaySession) {
+    if (cleanBootReplaySession || replayPlaybackSession) {
       setPaused(true)
       stop()
       isPaused = false
@@ -4144,13 +4390,30 @@ class BasicController private constructor(
     var nextSession: Session? = null
     var nextSnapshotManager: SnapshotManager? = null
     var preparedRewindSeed: RewindManager.PreparedSessionSeed? = null
+    var preparedReplayPlayer: ReplayPlayer? = null
+    val pendingPlayback = pendingReplayPlayback
     try {
       // Finish constructing and initializing the candidate before releasing the current session.
       // A core-startup failure must leave the old game available for resume/cancel semantics.
-      nextSession = createSession(job.prepared.config, nextGameboy, job.prepared.stateStore)
+      nextSession =
+          createSession(
+              job.prepared.config,
+              nextGameboy,
+              job.prepared.stateStore,
+              forceEmptySerialPort = pendingPlayback != null,
+          )
       nextGameboy = null
+      if (pendingPlayback != null) {
+        preparedReplayPlayer =
+            ReplayPlayer.openForSession(
+                checkNotNull(pendingPlayback.replay) { "Replay replacement has no decoded replay" },
+                pendingPlayback.sourceConfiguration,
+                checkNotNull(nextSession),
+                pendingPlayback.inputSource,
+            )
+      }
       nextSnapshotManager =
-          if (job.prepared.config.rom.origin.persistencePath(".sn0").isPresent) {
+          if (pendingPlayback == null && job.prepared.config.rom.origin.persistencePath(".sn0").isPresent) {
             snapshotManagerFactory.create(job.prepared.config)
           } else {
             null
@@ -4159,6 +4422,7 @@ class BasicController private constructor(
       // discard this still-staged session and leave the live session/history untouched.
       preparedRewindSeed = rewindManager.prepareSessionSeed(checkNotNull(nextSession))
     } catch (e: Exception) {
+      preparedReplayPlayer = null
       preparedRewindSeed?.discard()
       try {
         nextSession?.discardUnstarted()
@@ -4220,6 +4484,16 @@ class BasicController private constructor(
     }
     playbackSessionGeneration = null
 
+    val activatedReplayPlayer = preparedReplayPlayer
+    if (activatedReplayPlayer != null) {
+      replayPlayback = ActiveReplayPlayback(activatedReplayPlayer, 0L, checkNotNull(pendingPlayback).path)
+      replayPlaybackCompleted = false
+      replayPlaybackSession = true
+      pendingReplayPlayback = null
+    } else {
+      replayPlaybackSession = false
+    }
+
     try {
       committedSession.activate()
       start(job.event.openRequestId, job.event.allowAutosaveResume)
@@ -4231,10 +4505,20 @@ class BasicController private constructor(
       } else {
         setPaused(pauseNewSession)
       }
+      replayPlayback?.let { playback ->
+        playback.sessionId = stateSessionId
+        postReplayPlaybackStatus(
+            ReplayPlaybackPhase.PLAYING,
+            "Playing input recording ${playback.path.fileName}.",
+        )
+      }
     } catch (activationFailure: RuntimeException) {
       // Rolling back would reattach an already stopped/closing machine. Keep the committed
       // candidate retained and paused so the failure is explicit without corrupting ownership.
       LOG.error("ROM ownership committed but candidate activation failed", activationFailure)
+      replayPlayback = null
+      replayPlaybackSession = false
+      pendingReplayPlayback = null
       setPaused(true)
       val message =
           activationFailure.message?.takeIf { it.isNotBlank() }
@@ -4247,10 +4531,26 @@ class BasicController private constructor(
               Controller.RomLoadFailureKind.CORE_STARTUP,
               sanitizedPersistenceDetail(activationFailure),
           ))
+      if (activatedReplayPlayer != null) {
+        postReplayPlaybackFailure(
+            stateSessionId.takeIf { it > 0L },
+            "Input recording could not start playback.",
+            replayRecordingDetail(activationFailure),
+        )
+      }
     }
   }
 
   private fun reportLoadFailure(event: Controller.LoadRomEvent, error: Throwable) {
+    pendingReplayPlayback?.let { pending ->
+      pendingReplayPlayback = null
+      postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, sessionId = pending.sessionId)
+      postReplayPlaybackFailure(
+          pending.sessionId,
+          "Input recording could not start playback.",
+          replayRecordingDetail(error),
+      )
+    }
     pendingCleanBootReplay?.let { pending ->
       pendingCleanBootReplay = null
       postReplayRecordingFailure(
@@ -4524,6 +4824,9 @@ class BasicController private constructor(
       postSerialPeripheralEventSafely(
           Controller.SerialPeripheralSelectionChangedEvent(selection))
       postSerialPeripheralStatus(selection, Controller.SerialPeripheralStatus.DETACHED)
+      return
+    }
+    if (replayPlaybackMutationBlocked("Changing the link-port device")) {
       return
     }
 
@@ -5059,29 +5362,39 @@ class BasicController private constructor(
     closeAutosaveWaivableRequestId = null
     var stateUnavailableReason: StateUserError? = null
     stateContext =
-        try {
-          val identity =
-              StateIdentity.from(
-                  session.config,
-                  checkNotNull(currentRomHashes) {
-                    "Activated session has no precomputed ROM identity"
-                  },
-              )
-          StateWorkerContext(
-              stateSessionId,
-              stateWorkspace(session, identity, properties.applicationSettings.saves),
-              identity,
-              session.config.hardwareProfile.id(),
-          )
-        } catch (failure: Throwable) {
-          LOG.warn("Unable to initialize desktop state storage", failure)
+        if (replayPlayback != null) {
           stateUnavailableReason =
-              stateError(
-                  "State management is unavailable for this game.",
-                  failure,
-                  "Choose a writable Saves directory in Preferences, then retry.",
+              StateUserError(
+                  "Managed states are unavailable during input playback.",
+                  "Replay playback owns an isolated, read-only session so recorded inputs and checkpoints remain deterministic.",
+                  "Close or reopen the game after playback to manage states again.",
               )
           null
+        } else {
+          try {
+            val identity =
+                StateIdentity.from(
+                    session.config,
+                    checkNotNull(currentRomHashes) {
+                      "Activated session has no precomputed ROM identity"
+                    },
+                )
+            StateWorkerContext(
+                stateSessionId,
+                stateWorkspace(session, identity, properties.applicationSettings.saves),
+                identity,
+                session.config.hardwareProfile.id(),
+            )
+          } catch (failure: Throwable) {
+            LOG.warn("Unable to initialize desktop state storage", failure)
+            stateUnavailableReason =
+                stateError(
+                    "State management is unavailable for this game.",
+                    failure,
+                    "Choose a writable Saves directory in Preferences, then retry.",
+                )
+            null
+          }
         }
 
     startCleanBootReplayRecordingIfPending(session)
@@ -5384,6 +5697,10 @@ class BasicController private constructor(
   ) {
     val session = session ?: return
     cleanBootReplaySession = false
+    replayPlayback = null
+    replayPlaybackCompleted = false
+    replayPlaybackSession = false
+    pendingReplayPlayback = null
     // Stop is also used by terminal close paths that may bypass a visible pause transition.
     // Clear the transient calendar before releasing the machine or its event bus.
     session.gameboy.sound.setPerformanceSystemMutedAudioCalendar(false)
@@ -5778,6 +6095,7 @@ class BasicController private constructor(
   private fun shouldPersistCloseAutosave(): Boolean =
       !properties.overrides.suppressCloseAutosave &&
           !cleanBootReplaySession &&
+          !replayPlaybackSession &&
           session?.config?.rom?.file != null &&
           closeAutosaveCompletedSessionId != stateSessionId &&
           closeAutosaveSkippedSessionId != stateSessionId
@@ -6211,6 +6529,21 @@ class BasicController private constructor(
   private data class PendingCleanBootReplay(
       val request: ReplayRecordingStartRequestEvent,
       val rtcEpochMillis: Long,
+  )
+
+  private data class PendingReplayPlayback(
+      val request: ReplayPlaybackLoadRequestEvent,
+      val sessionId: Long,
+      val sourceConfiguration: Gameboy.GameboyConfiguration,
+      val inputSource: ReplayInputSource = ReplayInputSource(),
+      var replay: ReplayFile? = null,
+      var path: java.nio.file.Path = request.path,
+  )
+
+  private data class ActiveReplayPlayback(
+      val player: ReplayPlayer,
+      var sessionId: Long,
+      val path: java.nio.file.Path,
   )
 
   private data class ReplayRecordingCloseBarrierEvent(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -24,6 +24,7 @@ import eu.rekawek.coffeegb.controller.replay.ReplayMetadata
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackFailedEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStopRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatus
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlayer
@@ -635,6 +636,7 @@ class BasicController private constructor(
     eventQueue.register<ReplayRecordingRetrySaveEvent> { retryReplayArtifactSave(it) }
     eventQueue.register<ReplayRecordingDiscardEvent> { discardReplayArtifact(it) }
     eventQueue.register<ReplayPlaybackLoadRequestEvent> { requestReplayPlayback(it) }
+    eventQueue.register<ReplayPlaybackStopRequestEvent> { stopReplayPlayback(it) }
     eventQueue.register<ReplayRecordingCloseBarrierEvent> { event ->
       try {
         finishReplayRecording("Coffee GB is closing")
@@ -1343,6 +1345,7 @@ class BasicController private constructor(
           event is ReplayRecordingStartRequestEvent ||
           event is ReplayRecordingStopRequestEvent ||
           event is ReplayPlaybackLoadRequestEvent ||
+          event is ReplayPlaybackStopRequestEvent ||
           event is StatePrepareCloseRequestEvent ||
           event is StateSkipCloseAutosaveRequestEvent ||
           event is StateResumeDecisionEvent ||
@@ -2958,13 +2961,53 @@ class BasicController private constructor(
     postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, message, pending.sessionId)
   }
 
+  /**
+   * Stops the tape transport without forgetting which file the desktop selected. A pending load
+   * is cancelled in place; an installed replay machine is replaced with the same ROM's ordinary,
+   * interactive clean start so no paused or input-isolated state can leak into normal play.
+   */
+  private fun stopReplayPlayback(event: ReplayPlaybackStopRequestEvent) {
+    val pending = pendingReplayPlayback
+    if (pending != null) {
+      if (event.expectedSessionId != pending.sessionId &&
+          event.expectedSessionId != stateSessionId) {
+        return
+      }
+      pendingReplayPlayback = null
+      cancelPendingRomSwitch(restorePause = false)
+      cancelLoadJob()
+      discardReplacement(restorePause = false)
+      restorePauseStateAfterLoading()
+      postReplayPlaybackStatus(
+          ReplayPlaybackPhase.IDLE,
+          "Input playback stopped.",
+          pending.sessionId,
+      )
+      return
+    }
+
+    if (!replayPlaybackSession || event.expectedSessionId != stateSessionId) return
+    val image = session?.config?.rom?.image ?: return
+    endReplayPlayback("Input playback stopped.", stateSessionId)
+    requestLoad(
+        properties,
+        Controller.LoadRomEvent(
+            image = image,
+            persistenceStore = currentPersistenceStore,
+            allowAutosaveResume = false,
+        ),
+        clearPatches = false,
+        resumeAfterLoad = true,
+    )
+  }
+
   /** Drops the controller-side timeline wrapper; the normal session replacement owns machine close. */
-  private fun endReplayPlayback(message: String) {
+  private fun endReplayPlayback(message: String, sessionId: Long? = null) {
     val active = replayPlayback
     if (active == null && !replayPlaybackCompleted) return
     replayPlayback = null
     replayPlaybackCompleted = false
-    postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, message, active?.sessionId)
+    postReplayPlaybackStatus(ReplayPlaybackPhase.IDLE, message, active?.sessionId ?: sessionId)
   }
 
   /** Prevents an isolated replay from silently becoming a non-interactive live session. */

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/BasicController.kt
@@ -3938,6 +3938,7 @@ class BasicController private constructor(
       properties: EmulatorProperties,
       event: Controller.LoadRomEvent,
       clearPatches: Boolean = true,
+      resumeAfterLoad: Boolean = cleanBootReplaySession || replayPlaybackSession,
   ) {
     if (doStop) {
       return
@@ -3954,7 +3955,7 @@ class BasicController private constructor(
     // request was ignored and also allows the old game to consume input meant for the new one.
     eventBus.post(Controller.RomLoadingEvent(event.rom, event.openRequestId))
     val task = PreparedLoadTask { sessionPreparer.prepare(properties, event) }
-    loadJob = LoadJob(event, clearPatches, task)
+    loadJob = LoadJob(event, clearPatches, resumeAfterLoad, task)
     loadExecutor.execute(task)
   }
 
@@ -4035,6 +4036,7 @@ class BasicController private constructor(
             requestId = nextPersistenceRequestId++,
             event = job.event,
             clearPatches = job.clearPatches,
+            resumeAfterLoad = job.resumeAfterLoad,
             prepared = prepared,
             capture = capture,
             attempt = attempt,
@@ -4506,7 +4508,8 @@ class BasicController private constructor(
     // Benchmark activation owns an explicit preconditioning pause independently of the user's
     // pre-load playback state. Do not let the loading workflow's `false` restore overwrite the
     // pause established by start(), or the generation-bound scenario start will be rejected.
-    val deterministicReplayReplacement = pendingPlayback != null || pendingCleanBootReplay != null
+    val deterministicReplayReplacement =
+        pendingPlayback != null || pendingCleanBootReplay != null || job.resumeAfterLoad
     val pauseNewSession =
         properties.overrides.benchmarkPolicyEnabled ||
             (!deterministicReplayReplacement && pauseStateBeforeLoading == true)
@@ -4561,6 +4564,12 @@ class BasicController private constructor(
         setPaused(true)
       } else {
         setPaused(pauseNewSession)
+      }
+      if (job.resumeAfterLoad) {
+        // start() publishes the session's unpaused baseline before the loading workflow restores
+        // its desired state. Replay recovery intentionally resumes, so repeat that final value to
+        // make it the unambiguous last event for the committed replacement.
+        publishPlaybackState()
       }
       replayPlayback?.let { playback ->
         playback.sessionId = stateSessionId
@@ -5558,10 +5567,10 @@ class BasicController private constructor(
       }
       val chunk = minOf(remaining, PRESENTATION_BOOTSTRAP_CHUNK_TICKS.toLong()).toInt()
       val executed =
-          if (replayRecording != null) {
+          if (replayRecording != null || replayPlayback != null) {
             var ticks = 0
             while (ticks < chunk && !doStop && session === currentSession &&
-                !gameboy.isBootstrapReady()) {
+                !gameboy.isBootstrapReady() && !replayPlaybackCompleted) {
               tickReplayAware(gameboy)
               ticks++
             }
@@ -6569,6 +6578,7 @@ class BasicController private constructor(
   private data class LoadJob(
       val event: Controller.LoadRomEvent,
       val clearPatches: Boolean,
+      val resumeAfterLoad: Boolean,
       val task: PreparedLoadTask,
   )
 
@@ -6623,6 +6633,7 @@ class BasicController private constructor(
       val requestId: Long,
       val event: Controller.LoadRomEvent,
       val clearPatches: Boolean,
+      val resumeAfterLoad: Boolean,
       val prepared: PreparedSession,
       val capture: BatteryFlush,
       var attempt: ReplacementTask?,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayArtifactStore.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayArtifactStore.kt
@@ -1,0 +1,37 @@
+package eu.rekawek.coffeegb.controller.replay
+
+import eu.rekawek.coffeegb.controller.state.ExclusiveFileWriter
+import eu.rekawek.coffeegb.controller.state.ExclusiveWriteRecovery
+import java.nio.file.Path
+import java.time.Clock
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+data class ReplayArtifactResult(
+    val path: Path,
+    val size: Int,
+    val recovery: ExclusiveWriteRecovery,
+)
+
+/** Writes one complete, bounded CGBR artifact without overwriting an existing recording. */
+class ReplayArtifactStore(
+    private val directory: Path,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+  fun save(replay: ReplayFile): ReplayArtifactResult {
+    val encoded = ReplayCodec.encode(replay)
+    val written =
+        ExclusiveFileWriter.collisionSafe(
+            directory,
+            "coffee-gb-${FILE_TIME.format(clock.instant())}",
+            "cgbreplay",
+            encoded,
+        )
+    return ReplayArtifactResult(written.path, encoded.size, written.recovery)
+  }
+
+  private companion object {
+    val FILE_TIME: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("uuuuMMdd-HHmmss-SSS").withZone(ZoneOffset.UTC)
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayPlayer.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayPlayer.kt
@@ -250,18 +250,7 @@ class ReplayPlayer private constructor(
               restoreImmediately = replay.initialConditions.mode == ReplayInitialMode.EMBEDDED_SESSION_STATE,
           )
       try {
-        if (embeddedState != null) {
-          ReplayCompatibility.applyEmbeddedState(embeddedState, session)
-        }
-        return ReplayPlayer(
-            replay,
-            HeadlessMachineSession(
-                session,
-                replay.initialConditions.initialTick,
-                replay.initialConditions.initialFrame,
-            ),
-            inputSource,
-        )
+        return openForSession(replay, configuration, session, inputSource, embeddedState)
       } catch (failure: Throwable) {
         try {
           session.close()
@@ -270,6 +259,44 @@ class ReplayPlayer private constructor(
         }
         throw failure
       }
+    }
+
+    /**
+     * Binds the validated timeline to a session owned by an interactive controller. The caller
+     * owns that session's lifecycle; unlike [open], this helper never closes it on failure.
+     */
+    internal fun openForSession(
+        replay: ReplayFile,
+        sourceConfiguration: Gameboy.GameboyConfiguration,
+        session: Session,
+        inputSource: ReplayInputSource,
+        validatedEmbeddedState: StateFile? = null,
+    ): ReplayPlayer {
+      ReplayCompatibility.validateIdentity(replay.identity, sourceConfiguration)
+      ReplayCompatibility.validatePlayback(sourceConfiguration)
+      if (replay.initialConditions.initialTick != 0L ||
+          replay.initialConditions.initialFrame != 0L) {
+        throw ReplayPlaybackException(
+            ReplayPlaybackReason.INVALID_INITIAL_POSITION,
+            "CGBR v1 playback requires a frame-aligned zero-based initial position",
+        )
+      }
+      validateTimelineShape(replay, sourceConfiguration.clockSpec.controllerTicksPerFrame())
+      val embeddedState =
+          validatedEmbeddedState
+              ?: replay.embeddedState?.let { ReplayCompatibility.validateEmbeddedState(it, sourceConfiguration) }
+      if (embeddedState != null) {
+        ReplayCompatibility.applyEmbeddedState(embeddedState, session)
+      }
+      return ReplayPlayer(
+          replay,
+          HeadlessMachineSession(
+              session,
+              replay.initialConditions.initialTick,
+              replay.initialConditions.initialFrame,
+          ),
+          inputSource,
+      )
     }
 
     private fun validateTimelineShape(

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
@@ -1,0 +1,111 @@
+package eu.rekawek.coffeegb.controller.replay
+
+import eu.rekawek.coffeegb.core.events.Event
+import java.nio.file.Path
+
+/** Desktop-facing choices for creating one deterministic CGBR replay. */
+enum class ReplayRecordingMode {
+  /** Capture the current session, including its portable machine state. */
+  CURRENT_SESSION,
+
+  /** Start a fresh, battery-isolated machine and record from its first tick. */
+  CLEAN_BOOT,
+}
+
+enum class ReplayRecordingPhase {
+  IDLE,
+  ARMING,
+  RECORDING,
+  SAVING,
+  UNSAVED,
+}
+
+/** A consent-bound request from a presentation surface. */
+data class ReplayRecordingStartRequestEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+    val mode: ReplayRecordingMode,
+    /** Required only when [mode] captures an in-progress portable state. */
+    val includeSensitiveInitialState: Boolean,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay recording request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay recording session ID must be positive" }
+    require(mode != ReplayRecordingMode.CURRENT_SESSION || includeSensitiveInitialState) {
+      "Current-session replay recording requires explicit sensitive-state consent"
+    }
+  }
+}
+
+data class ReplayRecordingStopRequestEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay recording request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay recording session ID must be positive" }
+  }
+}
+
+/** Requests persistence of the exact immutable replay retained after a recoverable write failure. */
+data class ReplayRecordingRetrySaveEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay retry request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay retry session ID must be positive" }
+  }
+}
+
+/** Explicitly discards a completed replay that could not be saved. */
+data class ReplayRecordingDiscardEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay discard request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay discard session ID must be positive" }
+  }
+}
+
+/** Authoritative, generation-scoped recording status. */
+data class ReplayRecordingStatusEvent(
+    val recordingId: Long?,
+    val sessionId: Long?,
+    val mode: ReplayRecordingMode?,
+    val phase: ReplayRecordingPhase,
+    val tickCount: Long = 0,
+    val frameCount: Long = 0,
+    val message: String? = null,
+) : Event {
+  init {
+    require(tickCount >= 0) { "Replay recording tick count cannot be negative" }
+    require(frameCount >= 0) { "Replay recording frame count cannot be negative" }
+    if (phase == ReplayRecordingPhase.IDLE) {
+      require(recordingId == null && mode == null) { "Idle replay recording cannot retain a job" }
+    }
+  }
+}
+
+data class ReplayRecordingSavedEvent(
+    val recordingId: Long,
+    val path: Path,
+    val mode: ReplayRecordingMode,
+    val tickCount: Long,
+    val frameCount: Long,
+) : Event
+
+data class ReplayRecordingFailedEvent(
+    val recordingId: Long?,
+    val sessionId: Long?,
+    val mode: ReplayRecordingMode?,
+    val summary: String,
+    val detail: String,
+    val recoverable: Boolean,
+) : Event {
+  init {
+    require(summary.isNotBlank()) { "Replay recording failure summary cannot be blank" }
+    require(detail.isNotBlank()) { "Replay recording failure detail cannot be blank" }
+  }
+}

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
@@ -20,6 +20,14 @@ enum class ReplayRecordingPhase {
   UNSAVED,
 }
 
+/** Lifecycle summary for an isolated deterministic replay being presented by the desktop. */
+enum class ReplayPlaybackPhase {
+  IDLE,
+  LOADING,
+  PLAYING,
+  COMPLETED,
+}
+
 /** A consent-bound request from a presentation surface. */
 data class ReplayRecordingStartRequestEvent(
     val requestId: Long,
@@ -66,6 +74,37 @@ data class ReplayRecordingDiscardEvent(
   init {
     require(requestId > 0) { "Replay discard request ID must be positive" }
     require(expectedSessionId > 0) { "Replay discard session ID must be positive" }
+  }
+}
+
+/** Requests that a bounded CGBR file be decoded and played with the currently open matching ROM. */
+data class ReplayPlaybackLoadRequestEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+    val path: Path,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay playback request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay playback session ID must be positive" }
+  }
+}
+
+/** Authoritative replay-playback state, scoped to the normal game session that initiated it. */
+data class ReplayPlaybackStatusEvent(
+    val sessionId: Long?,
+    val phase: ReplayPlaybackPhase,
+    val message: String? = null,
+) : Event
+
+/** A bounded decode, identity, or deterministic-checkpoint failure while loading a replay. */
+data class ReplayPlaybackFailedEvent(
+    val sessionId: Long?,
+    val summary: String,
+    val detail: String,
+) : Event {
+  init {
+    require(summary.isNotBlank()) { "Replay playback failure summary cannot be blank" }
+    require(detail.isNotBlank()) { "Replay playback failure detail cannot be blank" }
   }
 }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/replay/ReplayRecordingEvents.kt
@@ -89,6 +89,17 @@ data class ReplayPlaybackLoadRequestEvent(
   }
 }
 
+/** Stops loading or presenting a replay while retaining the selected file in the desktop UI. */
+data class ReplayPlaybackStopRequestEvent(
+    val requestId: Long,
+    val expectedSessionId: Long,
+) : Event {
+  init {
+    require(requestId > 0) { "Replay playback request ID must be positive" }
+    require(expectedSessionId > 0) { "Replay playback session ID must be positive" }
+  }
+}
+
 /** Authoritative replay-playback state, scoped to the normal game session that initiated it. */
 data class ReplayPlaybackStatusEvent(
     val sessionId: Long?,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateOperationWorker.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateOperationWorker.kt
@@ -3,7 +3,9 @@ package eu.rekawek.coffeegb.controller.state
 import eu.rekawek.coffeegb.controller.CompatibilitySnapshot
 import eu.rekawek.coffeegb.controller.replay.ReplayArtifactResult
 import eu.rekawek.coffeegb.controller.replay.ReplayArtifactStore
+import eu.rekawek.coffeegb.controller.replay.ReplayCodec
 import eu.rekawek.coffeegb.controller.replay.ReplayFile
+import eu.rekawek.coffeegb.controller.replay.ReplayLimits
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import java.io.IOException
@@ -23,6 +25,7 @@ internal enum class StateWorkerPurpose {
   AUTOSAVE_STOP,
   AUTOSAVE_CLOSE,
   REPLAY_SAVE,
+  REPLAY_LOAD,
   RESUME_SCAN,
 }
 
@@ -70,6 +73,12 @@ internal sealed interface StateWorkerResult {
   data class Screenshot(val result: StateScreenshotResult) : StateWorkerResult
 
   data class Replay(val result: ReplayArtifactResult) : StateWorkerResult
+
+  /** A fully decoded, bounded replay selected from an explicit desktop file chooser. */
+  data class ReplayLoaded(
+      val path: Path,
+      val replay: ReplayFile,
+  ) : StateWorkerResult
 
   data class Folder(
       val path: Path,
@@ -245,6 +254,23 @@ internal class StateOperationWorker(
         StateWorkerResult.Replay(ReplayArtifactStore(context.workspace.paths.replaysDirectory).save(replay))
       }
 
+  /** Reads a user-selected CGBR file off both the EDT and the emulation owner thread. */
+  fun replayLoad(
+      context: StateWorkerContext,
+      requestId: Long,
+      path: Path,
+  ) =
+      submit(context, requestId, StateOperation.REPLAY_LOAD, StateWorkerPurpose.REPLAY_LOAD) {
+        val normalized = path.toAbsolutePath().normalize()
+        val attributes = Files.readAttributes(normalized, java.nio.file.attribute.BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+        require(attributes.isRegularFile) { "Selected replay is not a regular file" }
+        require(!Files.isSymbolicLink(normalized)) { "Selected replay must not be a symbolic link" }
+        require(attributes.size() <= ReplayLimits.MAX_FILE_BYTES.toLong()) {
+          "Selected replay exceeds ${ReplayLimits.MAX_FILE_BYTES} bytes"
+        }
+        StateWorkerResult.ReplayLoaded(normalized, ReplayCodec.decode(Files.readAllBytes(normalized)))
+      }
+
   fun openFolder(context: StateWorkerContext, requestId: Long) =
       submit(context, requestId, StateOperation.OPEN_FOLDER, StateWorkerPurpose.MANUAL) {
         val directory = context.workspace.activeGameDirectory().toAbsolutePath().normalize()
@@ -360,6 +386,7 @@ internal class StateOperationWorker(
           StateOperation.EXPORT -> "State could not be exported."
           StateOperation.SCREENSHOT -> "Screenshot could not be saved."
           StateOperation.REPLAY_SAVE -> "Input recording could not be saved."
+          StateOperation.REPLAY_LOAD -> "Input recording could not be loaded."
           StateOperation.OPEN_FOLDER -> "Save folder could not be prepared."
           StateOperation.PREPARE_CLOSE -> "Close autosave could not be completed."
         }
@@ -387,6 +414,8 @@ internal class StateOperationWorker(
           StateOperation.REPLAY_SAVE ->
               "Check that the configured save directory is writable and has free space. " +
                   "The finished input recording remains available for retry."
+          StateOperation.REPLAY_LOAD ->
+            "Select a regular .cgbreplay file that matches the currently open ROM, then retry."
           StateOperation.LOAD, StateOperation.RESUME ->
             "Keep the running game open, inspect or export the state, and delete it only if it " +
                 "is no longer needed."
@@ -438,7 +467,9 @@ private data class StateQueuedWork(
           StateWorkerPurpose.AUTOSAVE_ROM_SWITCH,
           StateWorkerPurpose.AUTOSAVE_STOP,
           StateWorkerPurpose.REPLAY_SAVE -> 1
-          StateWorkerPurpose.MANUAL, StateWorkerPurpose.RESUME_SCAN -> 2
+          StateWorkerPurpose.MANUAL,
+          StateWorkerPurpose.REPLAY_LOAD,
+          StateWorkerPurpose.RESUME_SCAN -> 2
         }
 
   val coalescingKey: Pair<Long, StateOperation>?

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateOperationWorker.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateOperationWorker.kt
@@ -1,6 +1,9 @@
 package eu.rekawek.coffeegb.controller.state
 
 import eu.rekawek.coffeegb.controller.CompatibilitySnapshot
+import eu.rekawek.coffeegb.controller.replay.ReplayArtifactResult
+import eu.rekawek.coffeegb.controller.replay.ReplayArtifactStore
+import eu.rekawek.coffeegb.controller.replay.ReplayFile
 import eu.rekawek.coffeegb.core.events.Event
 import eu.rekawek.coffeegb.core.events.EventBus
 import java.io.IOException
@@ -19,6 +22,7 @@ internal enum class StateWorkerPurpose {
   AUTOSAVE_ROM_SWITCH,
   AUTOSAVE_STOP,
   AUTOSAVE_CLOSE,
+  REPLAY_SAVE,
   RESUME_SCAN,
 }
 
@@ -64,6 +68,8 @@ internal sealed interface StateWorkerResult {
   ) : StateWorkerResult
 
   data class Screenshot(val result: StateScreenshotResult) : StateWorkerResult
+
+  data class Replay(val result: ReplayArtifactResult) : StateWorkerResult
 
   data class Folder(
       val path: Path,
@@ -229,6 +235,16 @@ internal class StateOperationWorker(
                 .save(image, context.hardwareProfileId))
       }
 
+  /** Encodes one immutable, bounded deterministic replay away from the emulation owner. */
+  fun replay(
+      context: StateWorkerContext,
+      requestId: Long,
+      replay: ReplayFile,
+  ) =
+      submit(context, requestId, StateOperation.REPLAY_SAVE, StateWorkerPurpose.REPLAY_SAVE) {
+        StateWorkerResult.Replay(ReplayArtifactStore(context.workspace.paths.replaysDirectory).save(replay))
+      }
+
   fun openFolder(context: StateWorkerContext, requestId: Long) =
       submit(context, requestId, StateOperation.OPEN_FOLDER, StateWorkerPurpose.MANUAL) {
         val directory = context.workspace.activeGameDirectory().toAbsolutePath().normalize()
@@ -343,6 +359,7 @@ internal class StateOperationWorker(
           StateOperation.DELETE -> "State could not be deleted."
           StateOperation.EXPORT -> "State could not be exported."
           StateOperation.SCREENSHOT -> "Screenshot could not be saved."
+          StateOperation.REPLAY_SAVE -> "Input recording could not be saved."
           StateOperation.OPEN_FOLDER -> "Save folder could not be prepared."
           StateOperation.PREPARE_CLOSE -> "Close autosave could not be completed."
         }
@@ -367,6 +384,9 @@ internal class StateOperationWorker(
           StateOperation.SAVE, StateOperation.AUTOSAVE, StateOperation.SCREENSHOT ->
             "Check that the configured save directory is writable and has free space. " +
                 "The previous complete state was preserved."
+          StateOperation.REPLAY_SAVE ->
+              "Check that the configured save directory is writable and has free space. " +
+                  "The finished input recording remains available for retry."
           StateOperation.LOAD, StateOperation.RESUME ->
             "Keep the running game open, inspect or export the state, and delete it only if it " +
                 "is no longer needed."
@@ -415,7 +435,9 @@ private data class StateQueuedWork(
     get() =
         when (purpose) {
           StateWorkerPurpose.AUTOSAVE_CLOSE -> 0
-          StateWorkerPurpose.AUTOSAVE_ROM_SWITCH, StateWorkerPurpose.AUTOSAVE_STOP -> 1
+          StateWorkerPurpose.AUTOSAVE_ROM_SWITCH,
+          StateWorkerPurpose.AUTOSAVE_STOP,
+          StateWorkerPurpose.REPLAY_SAVE -> 1
           StateWorkerPurpose.MANUAL, StateWorkerPurpose.RESUME_SCAN -> 2
         }
 

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateStorageLayout.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateStorageLayout.kt
@@ -21,6 +21,9 @@ class StateStorageLayout(gameDirectory: Path) {
 
   val screenshotsDirectory: Path = contained(this.gameDirectory.resolve(SCREENSHOTS_DIRECTORY))
 
+  /** Deterministic input replays are distinct from state snapshots and future media recordings. */
+  val replaysDirectory: Path = contained(this.gameDirectory.resolve(REPLAYS_DIRECTORY))
+
   val batteryFile: Path = contained(this.gameDirectory.resolve(BATTERY_FILE))
 
   init {
@@ -64,6 +67,7 @@ class StateStorageLayout(gameDirectory: Path) {
     const val NAMED_DIRECTORY = "named"
     const val AUTOSAVE_DIRECTORY = "autosave"
     const val SCREENSHOTS_DIRECTORY = "screenshots"
+    const val REPLAYS_DIRECTORY = "replays"
     const val BATTERY_FILE = "battery.sav"
     const val STATE_FILE = "state.cgbstate"
     const val METADATA_FILE = "metadata.properties"

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateStorageResolver.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateStorageResolver.kt
@@ -9,6 +9,7 @@ data class StateStoragePaths(
     val layout: StateStorageLayout,
     val screenshotsDirectory: Path,
     val fallbackLayouts: List<StateStorageLayout>,
+    val replaysDirectory: Path = layout.replaysDirectory,
 )
 
 /**
@@ -73,6 +74,7 @@ object StateStorageResolver {
         layout,
         layout.gameDirectory.resolve(SCREENSHOTS_DIRECTORY).toAbsolutePath().normalize(),
         fallbacks,
+        layout.gameDirectory.resolve(REPLAYS_DIRECTORY).toAbsolutePath().normalize(),
     )
   }
 
@@ -95,4 +97,5 @@ object StateStorageResolver {
   const val DEFAULT_DIRECTORY = ".coffee-gb"
   const val GAMES_DIRECTORY = "games"
   const val SCREENSHOTS_DIRECTORY = "screenshots"
+  const val REPLAYS_DIRECTORY = "replays"
 }

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateUxEvents.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateUxEvents.kt
@@ -12,6 +12,7 @@ enum class StateOperation {
   DELETE,
   EXPORT,
   SCREENSHOT,
+  REPLAY_SAVE,
   OPEN_FOLDER,
   AUTOSAVE,
   RESUME,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateUxEvents.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateUxEvents.kt
@@ -13,6 +13,7 @@ enum class StateOperation {
   EXPORT,
   SCREENSHOT,
   REPLAY_SAVE,
+  REPLAY_LOAD,
   OPEN_FOLDER,
   AUTOSAVE,
   RESUME,

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateWorkspace.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateWorkspace.kt
@@ -164,6 +164,7 @@ class StateWorkspace(
       buildList {
         add(paths.layout.gameDirectory)
         add(paths.screenshotsDirectory)
+        add(paths.replaysDirectory)
         paths.fallbackLayouts.forEach { add(it.gameDirectory) }
       }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -49,10 +49,12 @@ class BasicControllerInputRecordingTest {
     val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
     val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
     val playback = LinkedBlockingQueue<ReplayPlaybackStatusEvent>()
+    val playbackStates = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
     eventBus.register<StateUxSessionEvent>(sessions::add)
     eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
     eventBus.register<ReplayRecordingSavedEvent>(saved::add)
     eventBus.register<ReplayPlaybackStatusEvent>(playback::add)
+    eventBus.register<Controller.SessionPlaybackStateEvent>(playbackStates::add)
     val controller = BasicController(eventBus, properties, null)
     controller.startController()
     try {
@@ -71,6 +73,17 @@ class BasicControllerInputRecordingTest {
           await(statuses) { it.phase == ReplayRecordingPhase.RECORDING }.phase,
       )
 
+      eventBus.post(Controller.RewindEvent(true))
+      assertEquals(
+          ReplayRecordingPhase.RECORDING,
+          await(statuses) { it.message?.contains("Rewind is unavailable") == true }.phase,
+      )
+
+      playbackStates.clear()
+      eventBus.post(Controller.PauseEmulationEvent())
+      assertTrue(await(playbackStates) { it.paused }.paused)
+      eventBus.post(Controller.ResumeEmulationEvent())
+      assertTrue(!await(playbackStates) { !it.paused }.paused)
       eventBus.post(Controller.RewindEvent(true))
       assertEquals(
           ReplayRecordingPhase.RECORDING,
@@ -128,15 +141,20 @@ class BasicControllerInputRecordingTest {
     val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
     val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
     val playback = LinkedBlockingQueue<ReplayPlaybackStatusEvent>()
+    val playbackStates = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
     eventBus.register<StateUxSessionEvent>(sessions::add)
     eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
     eventBus.register<ReplayRecordingSavedEvent>(saved::add)
     eventBus.register<ReplayPlaybackStatusEvent>(playback::add)
+    eventBus.register<Controller.SessionPlaybackStateEvent>(playbackStates::add)
     val controller = BasicController(eventBus, properties, null)
     controller.startController()
     try {
       eventBus.post(Controller.LoadRomEvent(rom))
       val session = await(sessions) { it.available }
+
+      eventBus.post(Controller.PauseEmulationEvent())
+      assertTrue(await(playbackStates) { it.paused }.paused)
 
       eventBus.post(
           ReplayRecordingStartRequestEvent(
@@ -146,6 +164,18 @@ class BasicControllerInputRecordingTest {
               includeSensitiveInitialState = false,
           ))
       val recording = await(statuses) { it.phase == ReplayRecordingPhase.RECORDING }
+      eventBus.post(Controller.RewindEvent(true))
+      assertTrue(
+          await(statuses) { it.message?.contains("Rewind is unavailable") == true }.tickCount > 0L)
+
+      playbackStates.clear()
+      eventBus.post(Controller.PauseEmulationEvent())
+      assertTrue(await(playbackStates) { it.paused }.paused)
+      eventBus.post(Controller.RewindEvent(true))
+      assertEquals(
+          ReplayRecordingPhase.RECORDING,
+          await(statuses) { it.message?.contains("Rewind is unavailable") == true }.phase,
+      )
       eventBus.post(
           ReplayRecordingStopRequestEvent(
               2,

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -1,0 +1,162 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.replay.ReplayCodec
+import eu.rekawek.coffeegb.controller.replay.ReplayInitialMode
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingSavedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStartRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStatusEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
+import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Comparator
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class BasicControllerInputRecordingTest {
+  @Test
+  fun `current-session recording persists an embedded replay and rejects rewind`() {
+    val directory = Files.createTempDirectory("controller-input-recording")
+    val rom = directory.resolve("game.gb").toFile().also { ROM.copyTo(it) }
+    val properties =
+        EmulatorProperties(directory.resolve("settings.properties"), debounceMillis = 0).also {
+          it.updateApplicationSettings { settings ->
+            settings.copy(
+                saves =
+                    ApplicationSettings.Saves(
+                        directory = directory.resolve("saves"),
+                        resumePolicy = ApplicationSettings.ResumePolicy.NEVER,
+                    ))
+          }
+        }
+    val eventBus = EventBusImpl()
+    val sessions = LinkedBlockingQueue<StateUxSessionEvent>()
+    val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
+    val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
+    eventBus.register<StateUxSessionEvent>(sessions::add)
+    eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
+    eventBus.register<ReplayRecordingSavedEvent>(saved::add)
+    val controller = BasicController(eventBus, properties, null)
+    controller.startController()
+    try {
+      eventBus.post(Controller.LoadRomEvent(rom))
+      val session = await(sessions) { it.available }
+
+      eventBus.post(
+          ReplayRecordingStartRequestEvent(
+              1,
+              session.sessionId,
+              ReplayRecordingMode.CURRENT_SESSION,
+              includeSensitiveInitialState = true,
+          ))
+      assertEquals(
+          ReplayRecordingPhase.RECORDING,
+          await(statuses) { it.phase == ReplayRecordingPhase.RECORDING }.phase,
+      )
+
+      eventBus.post(Controller.RewindEvent(true))
+      assertEquals(
+          ReplayRecordingPhase.RECORDING,
+          await(statuses) { it.message?.contains("Rewind is unavailable") == true }.phase,
+      )
+
+      eventBus.post(ReplayRecordingStopRequestEvent(2, session.sessionId))
+      val artifact = assertNotNull(saved.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val replay = ReplayCodec.decode(Files.readAllBytes(artifact.path))
+      assertEquals(ReplayInitialMode.EMBEDDED_SESSION_STATE, replay.initialConditions.mode)
+      assertNotNull(replay.embeddedState)
+      assertTrue(artifact.path.parent.fileName.toString() == "replays")
+    } finally {
+      controller.close()
+      eventBus.close()
+      properties.close()
+      deleteTree(directory)
+    }
+  }
+
+  @Test
+  fun `clean-boot recording persists no session state`() {
+    val directory = Files.createTempDirectory("controller-clean-boot-recording")
+    val rom = directory.resolve("game.gb").toFile().also { ROM.copyTo(it) }
+    val properties =
+        EmulatorProperties(directory.resolve("settings.properties"), debounceMillis = 0).also {
+          it.updateApplicationSettings { settings ->
+            settings.copy(
+                saves =
+                    ApplicationSettings.Saves(
+                        directory = directory.resolve("saves"),
+                        resumePolicy = ApplicationSettings.ResumePolicy.NEVER,
+                    ))
+          }
+        }
+    val eventBus = EventBusImpl()
+    val sessions = LinkedBlockingQueue<StateUxSessionEvent>()
+    val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
+    val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
+    eventBus.register<StateUxSessionEvent>(sessions::add)
+    eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
+    eventBus.register<ReplayRecordingSavedEvent>(saved::add)
+    val controller = BasicController(eventBus, properties, null)
+    controller.startController()
+    try {
+      eventBus.post(Controller.LoadRomEvent(rom))
+      val session = await(sessions) { it.available }
+
+      eventBus.post(
+          ReplayRecordingStartRequestEvent(
+              1,
+              session.sessionId,
+              ReplayRecordingMode.CLEAN_BOOT,
+              includeSensitiveInitialState = false,
+          ))
+      val recording = await(statuses) { it.phase == ReplayRecordingPhase.RECORDING }
+      eventBus.post(
+          ReplayRecordingStopRequestEvent(
+              2,
+              assertNotNull(recording.sessionId),
+          ))
+
+      val artifact = assertNotNull(saved.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      val replay = ReplayCodec.decode(Files.readAllBytes(artifact.path))
+      assertEquals(ReplayInitialMode.BOOT_REFERENCE, replay.initialConditions.mode)
+      assertEquals(null, replay.embeddedState)
+    } finally {
+      controller.close()
+      eventBus.close()
+      properties.close()
+      deleteTree(directory)
+    }
+  }
+
+  private fun <T> await(queue: LinkedBlockingQueue<T>, predicate: (T) -> Boolean): T {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
+    while (System.nanoTime() < deadline) {
+      val value = queue.poll(100, TimeUnit.MILLISECONDS) ?: continue
+      if (predicate(value)) return value
+    }
+    throw AssertionError("Timed out waiting for expected event")
+  }
+
+  private fun deleteTree(path: Path) {
+    if (!Files.exists(path)) return
+    Files.walk(path).use { stream ->
+      stream.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+    }
+  }
+
+  private companion object {
+    val ROM = Paths.get("src/test/resources/roms", "cpu_instrs.gb").toFile()
+    const val TIMEOUT_SECONDS = 10L
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -15,6 +15,7 @@ import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStartRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStatusEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
 import eu.rekawek.coffeegb.controller.state.StateUxSessionEvent
+import eu.rekawek.coffeegb.core.Gameboy
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import java.nio.file.Files
 import java.nio.file.Path
@@ -114,6 +115,7 @@ class BasicControllerInputRecordingTest {
         EmulatorProperties(directory.resolve("settings.properties"), debounceMillis = 0).also {
           it.updateApplicationSettings { settings ->
             settings.copy(
+                advanced = settings.advanced.copy(bootstrapMode = Gameboy.BootstrapMode.NORMAL),
                 saves =
                     ApplicationSettings.Saves(
                         directory = directory.resolve("saves"),
@@ -125,9 +127,11 @@ class BasicControllerInputRecordingTest {
     val sessions = LinkedBlockingQueue<StateUxSessionEvent>()
     val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
     val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
+    val playback = LinkedBlockingQueue<ReplayPlaybackStatusEvent>()
     eventBus.register<StateUxSessionEvent>(sessions::add)
     eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
     eventBus.register<ReplayRecordingSavedEvent>(saved::add)
+    eventBus.register<ReplayPlaybackStatusEvent>(playback::add)
     val controller = BasicController(eventBus, properties, null)
     controller.startController()
     try {
@@ -152,6 +156,21 @@ class BasicControllerInputRecordingTest {
       val replay = ReplayCodec.decode(Files.readAllBytes(artifact.path))
       assertEquals(ReplayInitialMode.BOOT_REFERENCE, replay.initialConditions.mode)
       assertEquals(null, replay.embeddedState)
+
+      eventBus.post(
+          ReplayPlaybackLoadRequestEvent(
+              3,
+              assertNotNull(recording.sessionId),
+              artifact.path,
+          ))
+      assertEquals(
+          ReplayPlaybackPhase.PLAYING,
+          await(playback) { it.phase == ReplayPlaybackPhase.PLAYING }.phase,
+      )
+      assertEquals(
+          ReplayPlaybackPhase.COMPLETED,
+          await(playback) { it.phase == ReplayPlaybackPhase.COMPLETED }.phase,
+      )
     } finally {
       controller.close()
       eventBus.close()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -5,6 +5,9 @@ import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
 import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
 import eu.rekawek.coffeegb.controller.replay.ReplayCodec
 import eu.rekawek.coffeegb.controller.replay.ReplayInitialMode
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingSavedEvent
@@ -44,9 +47,11 @@ class BasicControllerInputRecordingTest {
     val sessions = LinkedBlockingQueue<StateUxSessionEvent>()
     val statuses = LinkedBlockingQueue<ReplayRecordingStatusEvent>()
     val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
+    val playback = LinkedBlockingQueue<ReplayPlaybackStatusEvent>()
     eventBus.register<StateUxSessionEvent>(sessions::add)
     eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
     eventBus.register<ReplayRecordingSavedEvent>(saved::add)
+    eventBus.register<ReplayPlaybackStatusEvent>(playback::add)
     val controller = BasicController(eventBus, properties, null)
     controller.startController()
     try {
@@ -77,6 +82,22 @@ class BasicControllerInputRecordingTest {
       assertEquals(ReplayInitialMode.EMBEDDED_SESSION_STATE, replay.initialConditions.mode)
       assertNotNull(replay.embeddedState)
       assertTrue(artifact.path.parent.fileName.toString() == "replays")
+
+      eventBus.post(ReplayPlaybackLoadRequestEvent(3, session.sessionId, artifact.path))
+      assertEquals(
+          ReplayPlaybackPhase.PLAYING,
+          await(playback) { it.phase == ReplayPlaybackPhase.PLAYING }.phase,
+      )
+      assertEquals(
+          ReplayPlaybackPhase.COMPLETED,
+          await(playback) { it.phase == ReplayPlaybackPhase.COMPLETED }.phase,
+      )
+
+      eventBus.post(Controller.RewindEvent(true))
+      assertEquals(
+          ReplayPlaybackPhase.COMPLETED,
+          await(playback) { it.message?.contains("Rewind is unavailable") == true }.phase,
+      )
     } finally {
       controller.close()
       eventBus.close()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -24,6 +24,7 @@ import java.util.Comparator
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.junit.Test
@@ -121,14 +122,14 @@ class BasicControllerInputRecordingTest {
   }
 
   @Test
-  fun `clean-boot recording persists no session state`() {
+  fun `fast-forward clean-boot recording survives pause and desktop playback`() {
     val directory = Files.createTempDirectory("controller-clean-boot-recording")
     val rom = directory.resolve("game.gb").toFile().also { ROM.copyTo(it) }
     val properties =
         EmulatorProperties(directory.resolve("settings.properties"), debounceMillis = 0).also {
           it.updateApplicationSettings { settings ->
             settings.copy(
-                advanced = settings.advanced.copy(bootstrapMode = Gameboy.BootstrapMode.NORMAL),
+                advanced = settings.advanced.copy(bootstrapMode = Gameboy.BootstrapMode.FAST_FORWARD),
                 saves =
                     ApplicationSettings.Saves(
                         directory = directory.resolve("saves"),
@@ -142,11 +143,13 @@ class BasicControllerInputRecordingTest {
     val saved = LinkedBlockingQueue<ReplayRecordingSavedEvent>()
     val playback = LinkedBlockingQueue<ReplayPlaybackStatusEvent>()
     val playbackStates = LinkedBlockingQueue<Controller.SessionPlaybackStateEvent>()
+    val started = LinkedBlockingQueue<Controller.EmulationStartedEvent>()
     eventBus.register<StateUxSessionEvent>(sessions::add)
     eventBus.register<ReplayRecordingStatusEvent>(statuses::add)
     eventBus.register<ReplayRecordingSavedEvent>(saved::add)
     eventBus.register<ReplayPlaybackStatusEvent>(playback::add)
     eventBus.register<Controller.SessionPlaybackStateEvent>(playbackStates::add)
+    eventBus.register<Controller.EmulationStartedEvent>(started::add)
     val controller = BasicController(eventBus, properties, null)
     controller.startController()
     try {
@@ -201,6 +204,16 @@ class BasicControllerInputRecordingTest {
           ReplayPlaybackPhase.COMPLETED,
           await(playback) { it.phase == ReplayPlaybackPhase.COMPLETED }.phase,
       )
+
+      // Reset is the recovery route after either completion or checkpoint divergence. It must
+      // replace the input-isolated replay machine with a normal, running session.
+      started.clear()
+      playbackStates.clear()
+      eventBus.post(Controller.ResetEmulationEvent())
+      val resetGeneration =
+          assertNotNull(await(started) { it.sessionGeneration != null }.sessionGeneration)
+      await(playbackStates) { it.sessionGeneration == resetGeneration }
+      assertFalse(await(playbackStates) { it.sessionGeneration == resetGeneration }.paused)
     } finally {
       controller.close()
       eventBus.close()

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/BasicControllerInputRecordingTest.kt
@@ -7,6 +7,7 @@ import eu.rekawek.coffeegb.controller.replay.ReplayCodec
 import eu.rekawek.coffeegb.controller.replay.ReplayInitialMode
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStopRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
@@ -167,6 +168,8 @@ class BasicControllerInputRecordingTest {
               includeSensitiveInitialState = false,
           ))
       val recording = await(statuses) { it.phase == ReplayRecordingPhase.RECORDING }
+      // Leave enough post-boot tape for Stop to be exercised while playback is still active.
+      Thread.sleep(350)
       eventBus.post(Controller.RewindEvent(true))
       assertTrue(
           await(statuses) { it.message?.contains("Rewind is unavailable") == true }.tickCount > 0L)
@@ -196,6 +199,30 @@ class BasicControllerInputRecordingTest {
               assertNotNull(recording.sessionId),
               artifact.path,
           ))
+      val playing = await(playback) { it.phase == ReplayPlaybackPhase.PLAYING }
+
+      // Tape Stop must replace the input-isolated replay machine with a normal, running session
+      // while the desktop retains the selected file for another Play from the beginning.
+      started.clear()
+      playbackStates.clear()
+      sessions.clear()
+      eventBus.post(
+          ReplayPlaybackStopRequestEvent(
+              4,
+              assertNotNull(playing.sessionId),
+          ))
+      assertEquals(
+          ReplayPlaybackPhase.IDLE,
+          await(playback) { it.phase == ReplayPlaybackPhase.IDLE }.phase,
+      )
+      val restoredGeneration =
+          assertNotNull(await(started) { it.sessionGeneration != null }.sessionGeneration)
+      val restoredSession = await(sessions) { it.available }
+      assertFalse(
+          await(playbackStates) { it.sessionGeneration == restoredGeneration }.paused)
+
+      playback.clear()
+      eventBus.post(ReplayPlaybackLoadRequestEvent(5, restoredSession.sessionId, artifact.path))
       assertEquals(
           ReplayPlaybackPhase.PLAYING,
           await(playback) { it.phase == ReplayPlaybackPhase.PLAYING }.phase,
@@ -204,16 +231,6 @@ class BasicControllerInputRecordingTest {
           ReplayPlaybackPhase.COMPLETED,
           await(playback) { it.phase == ReplayPlaybackPhase.COMPLETED }.phase,
       )
-
-      // Reset is the recovery route after either completion or checkpoint divergence. It must
-      // replace the input-isolated replay machine with a normal, running session.
-      started.clear()
-      playbackStates.clear()
-      eventBus.post(Controller.ResetEmulationEvent())
-      val resetGeneration =
-          assertNotNull(await(started) { it.sessionGeneration != null }.sessionGeneration)
-      await(playbackStates) { it.sessionGeneration == resetGeneration }
-      assertFalse(await(playbackStates) { it.sessionGeneration == resetGeneration }.paused)
     } finally {
       controller.close()
       eventBus.close()

--- a/docs/replay-format-v1.md
+++ b/docs/replay-format-v1.md
@@ -93,7 +93,10 @@ or boot-ROM bytes, filesystem paths, host names, user names, network credentials
 Playback clones only immutable ROM and hardware choices. It replaces live controls with
 `ReplayInputSource`, wall time with `VirtualTimeSource`, serial and infrared with empty endpoints,
 and battery persistence with disabled/null storage. Replay v1 has no pause/reset/external-I/O event,
-so recording code must end or discard a recording before any such lifecycle boundary.
+so recording code must end or discard a recording before reset or external-I/O lifecycle boundaries.
+An application pause may retain a recorder because it executes no emulated ticks; cartridge RTC
+wall time must be frozen across that interval, and a final checkpoint taken while paused must be
+normalized to the running RTC state expected after its last recorded tick.
 
 ## Input timing
 

--- a/docs/replay-format-v1.md
+++ b/docs/replay-format-v1.md
@@ -98,6 +98,11 @@ An application pause may retain a recorder because it executes no emulated ticks
 wall time must be frozen across that interval, and a final checkpoint taken while paused must be
 normalized to the running RTC state expected after its last recorded tick.
 
+Fast-forward bootstrap ticks are part of a boot-reference replay timeline. Interactive playback
+must advance that bootstrap through `ReplayPlayer`, just as recording advances it through
+`ReplayRecorder`; advancing the machine directly would leave the player's tick counter behind the
+machine and shift every later checkpoint.
+
 ## Input timing
 
 Replay ticks are zero-based executed master-tick indices. Input and checkpoint ticks are limited to

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -1,4 +1,4 @@
-# Managed states, autosave, screenshots, and rewind
+# Managed states, autosave, screenshots, input recording, and rewind
 
 Coffee GB's desktop state browser extends the same ten slots used by the quick-save shortcuts with
 named states, previews, autosave/resume, export, and recovery reporting. All disk access is performed
@@ -72,6 +72,7 @@ states/
   named/<UUID>/
   autosave/
 screenshots/
+replays/
 ```
 
 `battery.sav` is used when a Saves directory is configured, including a distinct hash namespace for
@@ -156,6 +157,31 @@ uses the operating system's default opener without blocking the Swing event thre
 and metadata are bounded before decoding. Embedded metadata is limited
 to UTC capture time, hardware-profile ID, and `Coffee GB` as the software name. It deliberately
 contains no ROM title, filename, path, or hash.
+
+## Input recording and rewind
+
+Choose **Screen > Start Input Recording…** (or press <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>)
+to create a deterministic `.cgbreplay` controller-input recording. The dialog deliberately starts
+with no selected mode:
+
+- **From current moment** embeds the current portable machine state so recording can begin where
+  play is now. It requires an explicit acknowledgement because that state can contain emulator
+  memory and cartridge RAM/save data. It never contains ROM bytes, ROM paths, or host paths.
+- **Restart from clean boot** saves the ordinary session first, then starts a battery-isolated clean
+  boot with an empty link port. It records from the first emulated tick and includes no machine or
+  cartridge save state. That clean session continues to avoid reading or writing the ordinary
+  battery/autosave files until the game is loaded normally again.
+
+The command becomes **Stop Input Recording** while active. The recorder writes the finished artifact
+away from both the emulation and Swing threads to `replays/` as
+`coffee-gb-YYYYMMDD-HHmmss-SSS[-N].cgbreplay`; collisions never overwrite an existing file. CLI
+playback is documented in [headless-cli.md](headless-cli.md).
+
+Replay v1 represents one forward input timeline. Rewind is therefore disabled while a recording is
+arming or active; it becomes available again after stopping. State loads, reset, ROM changes, pause,
+peripheral changes, and closing finish the recording before their lifecycle boundary. Linked play,
+real serial/infrared devices, host-time/sensor cartridges, reverse debugging, and paused execution
+are rejected with an actionable reason.
 
 ## Rewind bounds
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -170,7 +170,8 @@ with no selected mode:
 - **Restart from clean boot** saves the ordinary session first, then starts a battery-isolated clean
   boot with an empty link port. It records from the first emulated tick and includes no machine or
   cartridge save state. That clean session continues to avoid reading or writing the ordinary
-  battery/autosave files until the game is loaded normally again.
+  battery/autosave files until the game is loaded normally again. Active cheats must be disabled;
+  use **From current moment** when their state needs to be part of the recording.
 
 **Game > Input Recording > Stop Input Recording** is enabled while capture is arming or active. The recorder writes the finished artifact
 away from both the emulation and Swing threads to `replays/` as
@@ -184,10 +185,14 @@ at the final matching checkpoint; close or reopen the game to return to normal p
 also documented in [headless-cli.md](headless-cli.md).
 
 Replay v1 represents one forward input timeline. Rewind is therefore disabled while a recording is
-arming or active; it becomes available again after stopping. State loads, reset, ROM changes, pause,
-peripheral changes, and closing finish the recording before their lifecycle boundary. Linked play,
-real serial/infrared devices, host-time/sensor cartridges, reverse debugging, and paused execution
-are rejected with an actionable reason.
+arming or active; it becomes available again after stopping. Pausing suspends capture without adding
+an emulated tick, and **Stop Input Recording** remains available while paused. Resuming continues the
+same input timeline; cartridge RTC wall time is frozen across that pause. A clean-boot recording or
+loaded playback always starts its replacement session running, even when the previous session was
+paused. State loads, reset, ROM changes, peripheral changes, debugger pauses, and closing finish the
+recording before their lifecycle boundary. Linked play, real serial/infrared devices,
+host-time/sensor cartridges, reverse debugging, and starting a current-session recording while
+paused are rejected with an actionable reason.
 
 ## Rewind bounds
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -172,10 +172,16 @@ with no selected mode:
   cartridge save state. That clean session continues to avoid reading or writing the ordinary
   battery/autosave files until the game is loaded normally again.
 
-The command becomes **Stop Input Recording** while active. The recorder writes the finished artifact
+**Screen > Stop Input Recording** is enabled while capture is arming or active. The recorder writes the finished artifact
 away from both the emulation and Swing threads to `replays/` as
-`coffee-gb-YYYYMMDD-HHmmss-SSS[-N].cgbreplay`; collisions never overwrite an existing file. CLI
-playback is documented in [headless-cli.md](headless-cli.md).
+`coffee-gb-YYYYMMDD-HHmmss-SSS[-N].cgbreplay`; collisions never overwrite an existing file.
+
+To play one, open the matching ROM and choose **Screen > Load Input Recording…**. Coffee GB reads
+and validates the selected bounded `.cgbreplay` off the Swing and emulation threads, autosaves the
+currently open session, then presents the recording in an isolated, read-only session. Live inputs,
+battery saves, peripherals, managed states, and rewind are disabled during playback. Playback pauses
+at the final matching checkpoint; close or reopen the game to return to normal play. CLI playback is
+also documented in [headless-cli.md](headless-cli.md).
 
 Replay v1 represents one forward input timeline. Rewind is therefore disabled while a recording is
 arming or active; it becomes available again after stopping. State loads, reset, ROM changes, pause,

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -160,7 +160,7 @@ contains no ROM title, filename, path, or hash.
 
 ## Input recording and rewind
 
-Choose **Screen > Start Input Recording…** (or press <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>)
+Choose **Game > Input Recording > Start Input Recording** (or press <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>)
 to create a deterministic `.cgbreplay` controller-input recording. The dialog deliberately starts
 with no selected mode:
 
@@ -172,11 +172,11 @@ with no selected mode:
   cartridge save state. That clean session continues to avoid reading or writing the ordinary
   battery/autosave files until the game is loaded normally again.
 
-**Screen > Stop Input Recording** is enabled while capture is arming or active. The recorder writes the finished artifact
+**Game > Input Recording > Stop Input Recording** is enabled while capture is arming or active. The recorder writes the finished artifact
 away from both the emulation and Swing threads to `replays/` as
 `coffee-gb-YYYYMMDD-HHmmss-SSS[-N].cgbreplay`; collisions never overwrite an existing file.
 
-To play one, open the matching ROM and choose **Screen > Load Input Recording…**. Coffee GB reads
+To play one, open the matching ROM and choose **Game > Input Recording > Load Input Recording**. Coffee GB reads
 and validates the selected bounded `.cgbreplay` off the Swing and emulation threads, autosaves the
 currently open session, then presents the recording in an isolated, read-only session. Live inputs,
 battery saves, peripherals, managed states, and rewind are disabled during playback. Playback pauses

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -181,8 +181,9 @@ To play one, open the matching ROM and choose **Game > Input Recording > Load In
 and validates the selected bounded `.cgbreplay` off the Swing and emulation threads, autosaves the
 currently open session, then presents the recording in an isolated, read-only session. Live inputs,
 battery saves, peripherals, managed states, and rewind are disabled during playback. Playback pauses
-at the final matching checkpoint; close or reopen the game to return to normal play. CLI playback is
-also documented in [headless-cli.md](headless-cli.md).
+at the final matching checkpoint. If playback completes or a checkpoint diverges, **Reset** or
+reopen the game to replace the isolated replay machine with a normal, running session. CLI playback
+is also documented in [headless-cli.md](headless-cli.md).
 
 Replay v1 represents one forward input timeline. Rewind is therefore disabled while a recording is
 arming or active; it becomes available again after stopping. Pausing suspends capture without adding

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -589,11 +589,11 @@ private fun commandMetadata(command: DesktopCommand): DesktopActionMetadata =
       DesktopCommand.SCREENSHOT ->
           DesktopActionMetadata("Screenshot", "Save a screenshot of the current game")
       DesktopCommand.INPUT_RECORDING ->
-          DesktopActionMetadata("Start Input Recording…", "Record controller input for deterministic replay")
+          DesktopActionMetadata("Start Input Recording", "Record controller input for deterministic replay")
       DesktopCommand.STOP_INPUT_RECORDING ->
           DesktopActionMetadata("Stop Input Recording", "Stop and save the active input recording")
       DesktopCommand.LOAD_INPUT_RECORDING ->
-          DesktopActionMetadata("Load Input Recording…", "Play a deterministic CGBR input recording")
+          DesktopActionMetadata("Load Input Recording", "Play a deterministic CGBR input recording")
       DesktopCommand.SHOW_COMMAND_BAR ->
           DesktopActionMetadata("Show Command Bar", "Show the game command bar in a window")
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -523,8 +523,7 @@ internal class DesktopActionRegistry(
         DesktopCommand.STOP_INPUT_RECORDING ->
             (state.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
                 state.inputRecordingPhase == ReplayRecordingPhase.RECORDING) &&
-                state.gameLoaded &&
-                !state.sessionBusy
+                state.gameLoaded
         DesktopCommand.LOAD_INPUT_RECORDING ->
             state.gameLoaded &&
                 state.inputRecordingPhase == ReplayRecordingPhase.IDLE &&

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.core.memory.cart.RomOrigin
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
 import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import eu.rekawek.coffeegb.ui.menu.PlayTimeTracker
@@ -34,6 +35,8 @@ internal enum class DesktopCommand {
   FULLSCREEN,
   SCREENSHOT,
   INPUT_RECORDING,
+  STOP_INPUT_RECORDING,
+  LOAD_INPUT_RECORDING,
   SHOW_COMMAND_BAR,
 }
 
@@ -52,6 +55,7 @@ internal data class DesktopCommandPresentation(
     val commandBarVisible: Boolean = true,
     val exactWindowScaleOne: Boolean = false,
     val inputRecordingPhase: ReplayRecordingPhase = ReplayRecordingPhase.IDLE,
+    val inputPlaybackPhase: ReplayPlaybackPhase = ReplayPlaybackPhase.IDLE,
 ) {
   init {
     require(stateSlot in 0..9)
@@ -78,6 +82,8 @@ internal data class DesktopCommandHandlers(
     val setCommandBarVisible: (Boolean) -> Unit,
     val selectStateSlot: (Int) -> Unit,
     val inputRecording: () -> Unit = {},
+    val stopInputRecording: () -> Unit = {},
+    val loadInputRecording: () -> Unit = {},
     /** Opens one entry selected from the portable Recent Games page. */
     val openRecentGame: ((PortableMenuRecentGame) -> Unit)? = null,
     val preferencesForCategory: ((PreferencesCategory) -> Unit)? = null,
@@ -297,16 +303,6 @@ internal class DesktopActionRegistry(
         Action.NAME,
         if (presentation.muted) "Unmute" else "Mute",
     )
-    actions.getValue(DesktopCommand.INPUT_RECORDING).putValue(
-        Action.NAME,
-        when (presentation.inputRecordingPhase) {
-          ReplayRecordingPhase.IDLE -> "Start Input Recording…"
-          ReplayRecordingPhase.ARMING,
-          ReplayRecordingPhase.RECORDING -> "Stop Input Recording"
-          ReplayRecordingPhase.SAVING -> "Saving Input Recording…"
-          ReplayRecordingPhase.UNSAVED -> "Input Recording Needs Saving"
-        },
-    )
     stateSlotActions.forEachIndexed { slot, action ->
       action.isEnabled = presentation.stateCommandsAvailable && !presentation.sessionBusy
       action.putValue(Action.SELECTED_KEY, slot == presentation.stateSlot)
@@ -488,6 +484,8 @@ internal class DesktopActionRegistry(
       DesktopCommand.FULLSCREEN -> handlers.setFullscreen(!presentation.fullscreen)
       DesktopCommand.SCREENSHOT -> handlers.screenshot()
       DesktopCommand.INPUT_RECORDING -> handlers.inputRecording()
+      DesktopCommand.STOP_INPUT_RECORDING -> handlers.stopInputRecording()
+      DesktopCommand.LOAD_INPUT_RECORDING -> handlers.loadInputRecording()
       DesktopCommand.SHOW_COMMAND_BAR ->
           handlers.setCommandBarVisible(!presentation.commandBarVisible)
     }
@@ -516,12 +514,22 @@ internal class DesktopActionRegistry(
         DesktopCommand.SCREENSHOT -> state.stateBrowserAvailable && !state.sessionBusy
         DesktopCommand.INPUT_RECORDING ->
             when (state.inputRecordingPhase) {
-              ReplayRecordingPhase.IDLE -> state.stateBrowserAvailable && !state.sessionBusy
-              ReplayRecordingPhase.ARMING,
-              ReplayRecordingPhase.RECORDING -> state.gameLoaded && !state.sessionBusy
-              ReplayRecordingPhase.SAVING,
-              ReplayRecordingPhase.UNSAVED -> false
+              ReplayRecordingPhase.IDLE ->
+                  state.stateBrowserAvailable &&
+                      state.inputPlaybackPhase == ReplayPlaybackPhase.IDLE &&
+                      !state.sessionBusy
+              else -> false
             }
+        DesktopCommand.STOP_INPUT_RECORDING ->
+            (state.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
+                state.inputRecordingPhase == ReplayRecordingPhase.RECORDING) &&
+                state.gameLoaded &&
+                !state.sessionBusy
+        DesktopCommand.LOAD_INPUT_RECORDING ->
+            state.gameLoaded &&
+                state.inputRecordingPhase == ReplayRecordingPhase.IDLE &&
+                state.inputPlaybackPhase == ReplayPlaybackPhase.IDLE &&
+                !state.sessionBusy
         DesktopCommand.FULLSCREEN -> !state.sessionBusy
       }
 
@@ -531,9 +539,6 @@ internal class DesktopActionRegistry(
         DesktopCommand.MUTE -> state.muted
         DesktopCommand.FULLSCREEN -> state.fullscreen
         DesktopCommand.SHOW_COMMAND_BAR -> state.commandBarVisible
-        DesktopCommand.INPUT_RECORDING ->
-            state.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
-                state.inputRecordingPhase == ReplayRecordingPhase.RECORDING
         else -> false
       }
 }
@@ -585,6 +590,10 @@ private fun commandMetadata(command: DesktopCommand): DesktopActionMetadata =
           DesktopActionMetadata("Screenshot", "Save a screenshot of the current game")
       DesktopCommand.INPUT_RECORDING ->
           DesktopActionMetadata("Start Input Recording…", "Record controller input for deterministic replay")
+      DesktopCommand.STOP_INPUT_RECORDING ->
+          DesktopActionMetadata("Stop Input Recording", "Stop and save the active input recording")
+      DesktopCommand.LOAD_INPUT_RECORDING ->
+          DesktopActionMetadata("Load Input Recording…", "Play a deterministic CGBR input recording")
       DesktopCommand.SHOW_COMMAND_BAR ->
           DesktopActionMetadata("Show Command Bar", "Show the game command bar in a window")
     }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.core.memory.cart.RomOrigin
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
 import eu.rekawek.coffeegb.ui.menu.MenuPreview
 import eu.rekawek.coffeegb.ui.menu.PlayTimeTracker
 import java.awt.Toolkit
@@ -32,6 +33,7 @@ internal enum class DesktopCommand {
   MUTE,
   FULLSCREEN,
   SCREENSHOT,
+  INPUT_RECORDING,
   SHOW_COMMAND_BAR,
 }
 
@@ -49,6 +51,7 @@ internal data class DesktopCommandPresentation(
     val fullscreen: Boolean = false,
     val commandBarVisible: Boolean = true,
     val exactWindowScaleOne: Boolean = false,
+    val inputRecordingPhase: ReplayRecordingPhase = ReplayRecordingPhase.IDLE,
 ) {
   init {
     require(stateSlot in 0..9)
@@ -74,6 +77,7 @@ internal data class DesktopCommandHandlers(
     val screenshot: () -> Unit,
     val setCommandBarVisible: (Boolean) -> Unit,
     val selectStateSlot: (Int) -> Unit,
+    val inputRecording: () -> Unit = {},
     /** Opens one entry selected from the portable Recent Games page. */
     val openRecentGame: ((PortableMenuRecentGame) -> Unit)? = null,
     val preferencesForCategory: ((PreferencesCategory) -> Unit)? = null,
@@ -293,6 +297,16 @@ internal class DesktopActionRegistry(
         Action.NAME,
         if (presentation.muted) "Unmute" else "Mute",
     )
+    actions.getValue(DesktopCommand.INPUT_RECORDING).putValue(
+        Action.NAME,
+        when (presentation.inputRecordingPhase) {
+          ReplayRecordingPhase.IDLE -> "Start Input Recording…"
+          ReplayRecordingPhase.ARMING,
+          ReplayRecordingPhase.RECORDING -> "Stop Input Recording"
+          ReplayRecordingPhase.SAVING -> "Saving Input Recording…"
+          ReplayRecordingPhase.UNSAVED -> "Input Recording Needs Saving"
+        },
+    )
     stateSlotActions.forEachIndexed { slot, action ->
       action.isEnabled = presentation.stateCommandsAvailable && !presentation.sessionBusy
       action.putValue(Action.SELECTED_KEY, slot == presentation.stateSlot)
@@ -473,6 +487,7 @@ internal class DesktopActionRegistry(
       DesktopCommand.MUTE -> handlers.setMuted(!presentation.muted)
       DesktopCommand.FULLSCREEN -> handlers.setFullscreen(!presentation.fullscreen)
       DesktopCommand.SCREENSHOT -> handlers.screenshot()
+      DesktopCommand.INPUT_RECORDING -> handlers.inputRecording()
       DesktopCommand.SHOW_COMMAND_BAR ->
           handlers.setCommandBarVisible(!presentation.commandBarVisible)
     }
@@ -499,6 +514,14 @@ internal class DesktopActionRegistry(
         DesktopCommand.MANAGE_STATES,
         DesktopCommand.OPEN_SAVE_FOLDER,
         DesktopCommand.SCREENSHOT -> state.stateBrowserAvailable && !state.sessionBusy
+        DesktopCommand.INPUT_RECORDING ->
+            when (state.inputRecordingPhase) {
+              ReplayRecordingPhase.IDLE -> state.stateBrowserAvailable && !state.sessionBusy
+              ReplayRecordingPhase.ARMING,
+              ReplayRecordingPhase.RECORDING -> state.gameLoaded && !state.sessionBusy
+              ReplayRecordingPhase.SAVING,
+              ReplayRecordingPhase.UNSAVED -> false
+            }
         DesktopCommand.FULLSCREEN -> !state.sessionBusy
       }
 
@@ -508,6 +531,9 @@ internal class DesktopActionRegistry(
         DesktopCommand.MUTE -> state.muted
         DesktopCommand.FULLSCREEN -> state.fullscreen
         DesktopCommand.SHOW_COMMAND_BAR -> state.commandBarVisible
+        DesktopCommand.INPUT_RECORDING ->
+            state.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
+                state.inputRecordingPhase == ReplayRecordingPhase.RECORDING
         else -> false
       }
 }
@@ -557,6 +583,8 @@ private fun commandMetadata(command: DesktopCommand): DesktopActionMetadata =
           DesktopActionMetadata("Full Screen", "Enter or leave full screen")
       DesktopCommand.SCREENSHOT ->
           DesktopActionMetadata("Screenshot", "Save a screenshot of the current game")
+      DesktopCommand.INPUT_RECORDING ->
+          DesktopActionMetadata("Start Input Recording…", "Record controller input for deterministic replay")
       DesktopCommand.SHOW_COMMAND_BAR ->
           DesktopActionMetadata("Show Command Bar", "Show the game command bar in a window")
     }
@@ -592,6 +620,11 @@ internal class DesktopShortcutRegistry(
             DesktopCommand.LOAD_STATE to KeyStroke.getKeyStroke(KeyEvent.VK_F7, 0),
             DesktopCommand.FULLSCREEN to KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0),
             DesktopCommand.SCREENSHOT to KeyStroke.getKeyStroke(KeyEvent.VK_F12, 0),
+            DesktopCommand.INPUT_RECORDING to
+                KeyStroke.getKeyStroke(
+                    KeyEvent.VK_R,
+                    platformMenuMask or InputEvent.SHIFT_DOWN_MASK,
+                ),
         )
     val activeKeys = mutableSetOf<KeyStroke>()
     shortcuts =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopActions.kt
@@ -513,13 +513,7 @@ internal class DesktopActionRegistry(
         DesktopCommand.OPEN_SAVE_FOLDER,
         DesktopCommand.SCREENSHOT -> state.stateBrowserAvailable && !state.sessionBusy
         DesktopCommand.INPUT_RECORDING ->
-            when (state.inputRecordingPhase) {
-              ReplayRecordingPhase.IDLE ->
-                  state.stateBrowserAvailable &&
-                      state.inputPlaybackPhase == ReplayPlaybackPhase.IDLE &&
-                      !state.sessionBusy
-              else -> false
-            }
+            state.gameLoaded
         DesktopCommand.STOP_INPUT_RECORDING ->
             (state.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
                 state.inputRecordingPhase == ReplayRecordingPhase.RECORDING) &&
@@ -588,7 +582,7 @@ private fun commandMetadata(command: DesktopCommand): DesktopActionMetadata =
       DesktopCommand.SCREENSHOT ->
           DesktopActionMetadata("Screenshot", "Save a screenshot of the current game")
       DesktopCommand.INPUT_RECORDING ->
-          DesktopActionMetadata("Start Input Recording", "Record controller input for deterministic replay")
+          DesktopActionMetadata("Input Recording", "Open input recording and playback controls")
       DesktopCommand.STOP_INPUT_RECORDING ->
           DesktopActionMetadata("Stop Input Recording", "Stop and save the active input recording")
       DesktopCommand.LOAD_INPUT_RECORDING ->

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
@@ -81,6 +81,7 @@ internal fun desktopShortcutGuide(
                   DesktopShortcutGuideRow("Select state slot", stateSlotShortcut),
                   mainRow("Full Screen", DesktopCommand.FULLSCREEN),
                   mainRow("Screenshot", DesktopCommand.SCREENSHOT),
+                  mainRow("Start / stop input recording", DesktopCommand.INPUT_RECORDING),
               ),
       ),
       DesktopShortcutGuideGroup(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
@@ -81,7 +81,7 @@ internal fun desktopShortcutGuide(
                   DesktopShortcutGuideRow("Select state slot", stateSlotShortcut),
                   mainRow("Full Screen", DesktopCommand.FULLSCREEN),
                   mainRow("Screenshot", DesktopCommand.SCREENSHOT),
-                  mainRow("Start / stop input recording", DesktopCommand.INPUT_RECORDING),
+                  mainRow("Start input recording", DesktopCommand.INPUT_RECORDING),
               ),
       ),
       DesktopShortcutGuideGroup(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopHelpDialogs.kt
@@ -81,7 +81,7 @@ internal fun desktopShortcutGuide(
                   DesktopShortcutGuideRow("Select state slot", stateSlotShortcut),
                   mainRow("Full Screen", DesktopCommand.FULLSCREEN),
                   mainRow("Screenshot", DesktopCommand.SCREENSHOT),
-                  mainRow("Start input recording", DesktopCommand.INPUT_RECORDING),
+                  mainRow("Input recording", DesktopCommand.INPUT_RECORDING),
               ),
       ),
       DesktopShortcutGuideGroup(

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
@@ -419,6 +419,7 @@ internal class DesktopCommandBar(
             DesktopCommand.NETPLAY,
             DesktopCommand.FULLSCREEN,
             DesktopCommand.SCREENSHOT,
+            DesktopCommand.INPUT_RECORDING,
             DesktopCommand.MANAGE_STATES,
         )
         .forEach { command -> overflowMenu.add(JMenuItem(actions[command])) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
@@ -420,6 +420,8 @@ internal class DesktopCommandBar(
             DesktopCommand.FULLSCREEN,
             DesktopCommand.SCREENSHOT,
             DesktopCommand.INPUT_RECORDING,
+            DesktopCommand.STOP_INPUT_RECORDING,
+            DesktopCommand.LOAD_INPUT_RECORDING,
             DesktopCommand.MANAGE_STATES,
         )
         .forEach { command -> overflowMenu.add(JMenuItem(actions[command])) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopMainPanel.kt
@@ -420,8 +420,6 @@ internal class DesktopCommandBar(
             DesktopCommand.FULLSCREEN,
             DesktopCommand.SCREENSHOT,
             DesktopCommand.INPUT_RECORDING,
-            DesktopCommand.STOP_INPUT_RECORDING,
-            DesktopCommand.LOAD_INPUT_RECORDING,
             DesktopCommand.MANAGE_STATES,
         )
         .forEach { command -> overflowMenu.add(JMenuItem(actions[command])) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
@@ -219,6 +219,9 @@ internal class DesktopUiCoordinator(
     update { it.copy(commands = it.commands.copy(stateSlot = slot)) }
   }
 
+  fun inputRecording(phase: eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase) =
+      update { it.copy(commands = it.commands.copy(inputRecordingPhase = phase)) }
+
   fun netplaySummary(summary: String) {
     require(summary.isNotBlank())
     update { it.copy(netplaySummary = summary) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/DesktopUiCoordinator.kt
@@ -222,6 +222,9 @@ internal class DesktopUiCoordinator(
   fun inputRecording(phase: eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase) =
       update { it.copy(commands = it.commands.copy(inputRecordingPhase = phase)) }
 
+  fun inputPlayback(phase: eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase) =
+      update { it.copy(commands = it.commands.copy(inputPlaybackPhase = phase)) }
+
   fun netplaySummary(summary: String) {
     require(summary.isNotBlank())
     update { it.copy(netplaySummary = summary) }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/InputRecordingWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/InputRecordingWindow.kt
@@ -56,9 +56,30 @@ internal fun inputRecordingControlState(
   )
 }
 
+internal class InputReplaySelection {
+  var path: Path? = null
+    private set
+
+  fun loadAndPlay(
+      selected: Path?,
+      onSelected: () -> Unit,
+      playReplay: (Path) -> Unit,
+  ): Boolean {
+    val replay = selected ?: return false
+    path = replay
+    onSelected()
+    playReplay(replay)
+    return true
+  }
+
+  fun selectRecorded(replay: Path) {
+    path = replay
+  }
+}
+
 /** Modeless, emoji-only tape controls for deterministic input capture and playback. */
 internal class InputRecordingWindow(
-    owner: Window,
+    private val owner: Window,
     private val chooseReplay: () -> Path?,
     private val playReplay: (Path) -> Unit,
     private val setPlaybackPaused: (Boolean) -> Unit,
@@ -96,29 +117,30 @@ internal class InputRecordingWindow(
         pack()
       }
 
-  private var selectedReplay: Path? = null
+  private val replaySelection = InputReplaySelection()
   private var presentation = DesktopCommandPresentation()
   private var shown = false
 
   init {
     requireEdt("Input recording window construction")
-    eject.addActionListener {
-      chooseReplay()?.let { selected ->
-        selectedReplay = selected
-        render(presentation)
-      }
+    eject.onTapeAction {
+      replaySelection.loadAndPlay(
+          chooseReplay(),
+          onSelected = { render(presentation) },
+          playReplay = playReplay,
+      )
     }
-    playPause.addActionListener {
+    playPause.onTapeAction {
       when (presentation.inputPlaybackPhase) {
-        ReplayPlaybackPhase.IDLE -> selectedReplay?.let(playReplay)
+        ReplayPlaybackPhase.IDLE -> replaySelection.path?.let(playReplay)
         ReplayPlaybackPhase.PLAYING -> setPlaybackPaused(!presentation.paused)
         ReplayPlaybackPhase.LOADING,
         ReplayPlaybackPhase.COMPLETED -> Unit
       }
     }
-    stop.addActionListener { stopTransport() }
-    record.addActionListener { startRecording(ReplayRecordingMode.CURRENT_SESSION) }
-    resetRecord.addActionListener { startRecording(ReplayRecordingMode.CLEAN_BOOT) }
+    stop.onTapeAction(stopTransport)
+    record.onTapeAction { startRecording(ReplayRecordingMode.CURRENT_SESSION) }
+    resetRecord.onTapeAction { startRecording(ReplayRecordingMode.CLEAN_BOOT) }
     render(presentation)
   }
 
@@ -135,7 +157,7 @@ internal class InputRecordingWindow(
   fun render(next: DesktopCommandPresentation) {
     requireEdt("Input recording window update")
     presentation = next
-    val controls = inputRecordingControlState(next, selectedReplay != null)
+    val controls = inputRecordingControlState(next, replaySelection.path != null)
     eject.isEnabled = controls.ejectEnabled
     playPause.isEnabled = controls.playPauseEnabled
     stop.isEnabled = controls.stopEnabled
@@ -148,12 +170,37 @@ internal class InputRecordingWindow(
           next.paused -> "Resume input playback"
           else -> "Pause input playback"
         }
-    dialog.title = selectedReplay?.fileName?.let { "$BASE_TITLE — $it" } ?: BASE_TITLE
+    dialog.title = replaySelection.path?.fileName?.let { "$BASE_TITLE — $it" } ?: BASE_TITLE
+  }
+
+  fun selectRecordedReplay(path: Path) {
+    requireEdt("Recorded input replay selection")
+    replaySelection.selectRecorded(path)
+    render(presentation)
   }
 
   override fun close() {
     requireEdt("Input recording window closing")
     dialog.dispose()
+  }
+
+  private fun JButton.onTapeAction(action: () -> Unit) {
+    addActionListener {
+      try {
+        action()
+      } finally {
+        restoreEmulatorFocus()
+      }
+    }
+  }
+
+  private fun restoreEmulatorFocus() {
+    SwingUtilities.invokeLater {
+      if (owner.isDisplayable) {
+        owner.toFront()
+        owner.requestFocus()
+      }
+    }
   }
 
   private companion object {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/InputRecordingWindow.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/InputRecordingWindow.kt
@@ -1,0 +1,176 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import java.awt.Dialog
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Window
+import java.awt.event.KeyEvent
+import java.nio.file.Path
+import javax.swing.AbstractAction
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JDialog
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+import javax.swing.SwingUtilities
+import javax.swing.WindowConstants
+
+internal data class InputRecordingControlState(
+    val ejectEnabled: Boolean,
+    val playPauseEnabled: Boolean,
+    val stopEnabled: Boolean,
+    val recordEnabled: Boolean,
+    val resetRecordEnabled: Boolean,
+)
+
+internal fun inputRecordingControlState(
+    presentation: DesktopCommandPresentation,
+    replaySelected: Boolean,
+): InputRecordingControlState {
+  val transportIdle =
+      presentation.inputRecordingPhase == ReplayRecordingPhase.IDLE &&
+          presentation.inputPlaybackPhase == ReplayPlaybackPhase.IDLE
+  val ordinarySessionReady =
+      presentation.gameLoaded &&
+          presentation.stateCommandsAvailable &&
+          !presentation.sessionBusy
+  val playbackControllable =
+      presentation.gameLoaded &&
+          presentation.inputPlaybackPhase == ReplayPlaybackPhase.PLAYING &&
+          !presentation.sessionBusy
+  val recordingActive =
+      presentation.inputRecordingPhase == ReplayRecordingPhase.ARMING ||
+          presentation.inputRecordingPhase == ReplayRecordingPhase.RECORDING
+  val playbackActive = presentation.inputPlaybackPhase != ReplayPlaybackPhase.IDLE
+  return InputRecordingControlState(
+      ejectEnabled = ordinarySessionReady && transportIdle,
+      playPauseEnabled =
+          playbackControllable || (ordinarySessionReady && transportIdle && replaySelected),
+      stopEnabled = presentation.gameLoaded && (recordingActive || playbackActive),
+      recordEnabled = ordinarySessionReady && transportIdle && !presentation.paused,
+      resetRecordEnabled = ordinarySessionReady && transportIdle,
+  )
+}
+
+/** Modeless, emoji-only tape controls for deterministic input capture and playback. */
+internal class InputRecordingWindow(
+    owner: Window,
+    private val chooseReplay: () -> Path?,
+    private val playReplay: (Path) -> Unit,
+    private val setPlaybackPaused: (Boolean) -> Unit,
+    private val stopTransport: () -> Unit,
+    private val startRecording: (ReplayRecordingMode) -> Unit,
+) : AutoCloseable {
+  private val eject = tapeButton("⏏️", "Load input recording")
+  private val playPause = tapeButton("⏯️", "Play input recording")
+  private val stop = tapeButton("⏹️", "Stop input recording or playback")
+  private val record = tapeButton("🔴", "Record from current moment")
+  private val resetRecord = tapeButton("🔄️ 🔴", "Reset and record from boot", 82)
+  private val dialog =
+      JDialog(owner, BASE_TITLE, Dialog.ModalityType.MODELESS).apply {
+        defaultCloseOperation = WindowConstants.HIDE_ON_CLOSE
+        contentPane =
+            JPanel(FlowLayout(FlowLayout.CENTER, 8, 8)).apply {
+              border = BorderFactory.createEmptyBorder(4, 4, 4, 4)
+              add(eject)
+              add(playPause)
+              add(stop)
+              add(record)
+              add(resetRecord)
+            }
+        rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+            .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "hide")
+        rootPane.actionMap.put(
+            "hide",
+            object : AbstractAction() {
+              override fun actionPerformed(event: java.awt.event.ActionEvent) {
+                isVisible = false
+              }
+            },
+        )
+        isResizable = false
+        pack()
+      }
+
+  private var selectedReplay: Path? = null
+  private var presentation = DesktopCommandPresentation()
+  private var shown = false
+
+  init {
+    requireEdt("Input recording window construction")
+    eject.addActionListener {
+      chooseReplay()?.let { selected ->
+        selectedReplay = selected
+        render(presentation)
+      }
+    }
+    playPause.addActionListener {
+      when (presentation.inputPlaybackPhase) {
+        ReplayPlaybackPhase.IDLE -> selectedReplay?.let(playReplay)
+        ReplayPlaybackPhase.PLAYING -> setPlaybackPaused(!presentation.paused)
+        ReplayPlaybackPhase.LOADING,
+        ReplayPlaybackPhase.COMPLETED -> Unit
+      }
+    }
+    stop.addActionListener { stopTransport() }
+    record.addActionListener { startRecording(ReplayRecordingMode.CURRENT_SESSION) }
+    resetRecord.addActionListener { startRecording(ReplayRecordingMode.CLEAN_BOOT) }
+    render(presentation)
+  }
+
+  fun show() {
+    requireEdt("Input recording window opening")
+    if (!shown) {
+      dialog.setLocationRelativeTo(dialog.owner)
+      shown = true
+    }
+    dialog.isVisible = true
+    dialog.toFront()
+  }
+
+  fun render(next: DesktopCommandPresentation) {
+    requireEdt("Input recording window update")
+    presentation = next
+    val controls = inputRecordingControlState(next, selectedReplay != null)
+    eject.isEnabled = controls.ejectEnabled
+    playPause.isEnabled = controls.playPauseEnabled
+    stop.isEnabled = controls.stopEnabled
+    record.isEnabled = controls.recordEnabled
+    resetRecord.isEnabled = controls.resetRecordEnabled
+    playPause.toolTipText =
+        when {
+          next.inputPlaybackPhase != ReplayPlaybackPhase.PLAYING ->
+              "Play input recording from beginning"
+          next.paused -> "Resume input playback"
+          else -> "Pause input playback"
+        }
+    dialog.title = selectedReplay?.fileName?.let { "$BASE_TITLE — $it" } ?: BASE_TITLE
+  }
+
+  override fun close() {
+    requireEdt("Input recording window closing")
+    dialog.dispose()
+  }
+
+  private companion object {
+    const val BASE_TITLE = "Input Recording"
+
+    fun tapeButton(emoji: String, accessibleName: String, width: Int = 54): JButton =
+        JButton(emoji).apply {
+          preferredSize = Dimension(width, 46)
+          minimumSize = preferredSize
+          toolTipText = accessibleName
+          accessibleContext.accessibleName = accessibleName
+        }
+
+    fun requireEdt(operation: String) {
+      check(SwingUtilities.isEventDispatchThread()) {
+        "$operation must run on the Event Dispatch Thread"
+      }
+    }
+  }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
@@ -1,6 +1,15 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingFailedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingDiscardEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingMode
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingSavedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStartRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStatusEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingRetrySaveEvent
 import eu.rekawek.coffeegb.controller.state.StateBrowserCatalog
 import eu.rekawek.coffeegb.controller.state.StateBrowserEntry
 import eu.rekawek.coffeegb.controller.state.StateCatalogReadyEvent
@@ -53,14 +62,20 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import javax.swing.AbstractAction
 import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.ButtonGroup
 import javax.swing.ImageIcon
 import javax.swing.JButton
+import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.JFileChooser
 import javax.swing.JFrame
 import javax.swing.JLabel
+import javax.swing.JOptionPane
 import javax.swing.JPanel
+import javax.swing.JRadioButton
 import javax.swing.JScrollPane
 import javax.swing.JSplitPane
 import javax.swing.JTable
@@ -96,6 +111,7 @@ internal class StateUxDesktopController(
     onSlotLoadAvailability: (slot: Int, available: Boolean) -> Unit = { _, _ -> },
     private val onPortableCatalog: (StateBrowserCatalog, Set<Int>) -> Unit = { _, _ -> },
     private val onRememberResumeDecision: (resume: Boolean) -> Unit = {},
+    private val onInputRecordingPhase: (ReplayRecordingPhase) -> Unit = {},
     private val dialogFactory: DesktopDialogFactory = DesktopDialogFactory(),
 ) : AutoCloseable {
   private val eventBus = rootEventBus.fork("desktop-state-ux")
@@ -121,6 +137,7 @@ internal class StateUxDesktopController(
               },
       )
   private var pendingClose: PendingClose? = null
+  private var inputRecordingPhase = ReplayRecordingPhase.IDLE
   private var closed = false
   private val slotLoadAvailability =
       StateSlotLoadAvailabilityTracker(
@@ -304,6 +321,65 @@ internal class StateUxDesktopController(
         finishClosePreparation(event)
       }
     }
+    eventBus.register<ReplayRecordingStatusEvent> { event ->
+      onEdt {
+        if (closed) return@onEdt
+        event.sessionId?.let { sessionId ->
+          if (!isCurrent(sessionId)) return@onEdt
+        }
+        inputRecordingPhase = event.phase
+        onInputRecordingPhase(event.phase)
+        if (event.phase == ReplayRecordingPhase.ARMING) {
+          event.message?.let { message -> onDesktopStatus(message, null) }
+        }
+      }
+    }
+    eventBus.register<ReplayRecordingSavedEvent> { event ->
+      onEdt {
+        if (closed) return@onEdt
+        inputRecordingPhase = ReplayRecordingPhase.IDLE
+        onInputRecordingPhase(ReplayRecordingPhase.IDLE)
+        onDesktopStatus(
+            "Input recording saved as ${event.path.fileName}. Use Open Save Folder to reveal it.",
+            DesktopCommand.OPEN_SAVE_FOLDER,
+        )
+      }
+    }
+    eventBus.register<ReplayRecordingFailedEvent> { event ->
+      onEdt {
+        if (closed) return@onEdt
+        event.sessionId?.let { sessionId ->
+          if (!isCurrent(sessionId)) return@onEdt
+        }
+        if (event.recoverable) {
+          val session = currentSession ?: return@onEdt
+          when (
+              JOptionPane.showOptionDialog(
+                  owner,
+                  "${event.summary}\n\n${event.detail}",
+                  "Input recording was not saved",
+                  JOptionPane.DEFAULT_OPTION,
+                  JOptionPane.ERROR_MESSAGE,
+                  null,
+                  arrayOf("Retry Save", "Discard Recording"),
+                  "Retry Save",
+              )) {
+            0 -> eventBus.post(ReplayRecordingRetrySaveEvent(nextRequestId(), session.sessionId))
+            1 -> eventBus.post(ReplayRecordingDiscardEvent(nextRequestId(), session.sessionId))
+          }
+          return@onEdt
+        }
+        showStateError(
+            owner,
+            StateUserError(
+                event.summary,
+                event.detail,
+                if (event.recoverable) "Keep the game open and retry saving the recording."
+                else "Keep the game open and start a new recording after resolving this issue.",
+            ),
+        )
+      }
+    }
   }
 
   fun showBrowser() {
@@ -355,6 +431,96 @@ internal class StateUxDesktopController(
         }
     if (!isCurrent(expectedSessionId)) return
     eventBus.post(StateScreenshotRequestEvent(nextRequestId(), expectedSessionId, image))
+  }
+
+  fun toggleInputRecording() {
+    requireEdt("Input recording request")
+    if (closed) return
+    when (inputRecordingPhase) {
+      ReplayRecordingPhase.ARMING,
+      ReplayRecordingPhase.RECORDING -> {
+        val session = currentSession ?: return
+        eventBus.post(ReplayRecordingStopRequestEvent(nextRequestId(), session.sessionId))
+      }
+      ReplayRecordingPhase.IDLE -> startInputRecording()
+      ReplayRecordingPhase.SAVING ->
+          onDesktopStatus("Input recording is being saved. Please wait.", null)
+      ReplayRecordingPhase.UNSAVED ->
+          onDesktopStatus("Input recording needs saving before another recording can start.", null)
+    }
+  }
+
+  private fun startInputRecording() {
+    if (!requireAvailableSession()) return
+    val expectedSessionId = checkNotNull(currentSession).sessionId
+    val choice = showInputRecordingModeDialog() ?: return
+    if (!isCurrent(expectedSessionId)) return
+    eventBus.post(
+        ReplayRecordingStartRequestEvent(
+            nextRequestId(),
+            expectedSessionId,
+            choice,
+            includeSensitiveInitialState = choice == ReplayRecordingMode.CURRENT_SESSION,
+        ))
+  }
+
+  /** No option is preselected: choosing the privacy-sensitive mode is always deliberate. */
+  private fun showInputRecordingModeDialog(): ReplayRecordingMode? {
+    val current = JRadioButton("From current moment")
+    val cleanBoot = JRadioButton("Restart from clean boot")
+    val consent =
+        JCheckBox(
+            "I understand this file includes the current emulator and cartridge save state.",
+        ).apply { isEnabled = false }
+    ButtonGroup().apply {
+      add(current)
+      add(cleanBoot)
+    }
+    current.addActionListener { consent.isEnabled = true }
+    cleanBoot.addActionListener {
+      consent.isSelected = false
+      consent.isEnabled = false
+    }
+    val panel =
+        JPanel().apply {
+          layout = BoxLayout(this, BoxLayout.Y_AXIS)
+          add(JLabel("Choose how to begin input recording:"))
+          add(Box.createVerticalStrut(10))
+          add(current)
+          add(
+              JLabel(
+                  "  Continues now. The replay includes emulator memory and cartridge RAM/save data, but never ROM bytes or paths."))
+          add(consent)
+          add(Box.createVerticalStrut(10))
+          add(cleanBoot)
+          add(
+              JLabel(
+                  "  Restarts in a battery-isolated clean boot. The replay and session contain no save state."))
+        }
+    val result =
+        JOptionPane.showOptionDialog(
+            owner,
+            panel,
+            "Start Input Recording",
+            JOptionPane.DEFAULT_OPTION,
+            JOptionPane.QUESTION_MESSAGE,
+            null,
+            arrayOf("Start Recording", "Cancel"),
+            "Cancel",
+        )
+    if (result != 0) return null
+    return when {
+      current.isSelected && consent.isSelected -> ReplayRecordingMode.CURRENT_SESSION
+      cleanBoot.isSelected -> ReplayRecordingMode.CLEAN_BOOT
+      current.isSelected -> {
+        onDesktopStatus("Confirm the current-session data notice before recording.", null)
+        null
+      }
+      else -> {
+        onDesktopStatus("Choose a recording mode before starting.", null)
+        null
+      }
+    }
   }
 
   fun saveSlot(slot: Int) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
@@ -10,6 +10,10 @@ import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStartRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStatusEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingStopRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingRetrySaveEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackFailedEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
 import eu.rekawek.coffeegb.controller.state.StateBrowserCatalog
 import eu.rekawek.coffeegb.controller.state.StateBrowserEntry
 import eu.rekawek.coffeegb.controller.state.StateCatalogReadyEvent
@@ -112,6 +116,7 @@ internal class StateUxDesktopController(
     private val onPortableCatalog: (StateBrowserCatalog, Set<Int>) -> Unit = { _, _ -> },
     private val onRememberResumeDecision: (resume: Boolean) -> Unit = {},
     private val onInputRecordingPhase: (ReplayRecordingPhase) -> Unit = {},
+    private val onInputPlaybackPhase: (ReplayPlaybackPhase) -> Unit = {},
     private val dialogFactory: DesktopDialogFactory = DesktopDialogFactory(),
 ) : AutoCloseable {
   private val eventBus = rootEventBus.fork("desktop-state-ux")
@@ -138,6 +143,7 @@ internal class StateUxDesktopController(
       )
   private var pendingClose: PendingClose? = null
   private var inputRecordingPhase = ReplayRecordingPhase.IDLE
+  private var inputPlaybackPhase = ReplayPlaybackPhase.IDLE
   private var closed = false
   private val slotLoadAvailability =
       StateSlotLoadAvailabilityTracker(
@@ -380,6 +386,46 @@ internal class StateUxDesktopController(
         )
       }
     }
+    eventBus.register<ReplayPlaybackStatusEvent> { event ->
+      onEdt {
+        if (closed) return@onEdt
+        event.sessionId?.let { sessionId ->
+          if (!isCurrent(sessionId)) return@onEdt
+        }
+        inputPlaybackPhase = event.phase
+        onInputPlaybackPhase(event.phase)
+        event.message?.let { message ->
+          onDesktopStatus(
+              message,
+              if (event.phase == ReplayPlaybackPhase.COMPLETED) DesktopCommand.CLOSE_GAME else null,
+          )
+        }
+      }
+    }
+    eventBus.register<ReplayPlaybackFailedEvent> { event ->
+      onEdt {
+        if (closed) return@onEdt
+        event.sessionId?.let { sessionId ->
+          if (!isCurrent(sessionId)) return@onEdt
+        }
+        // A decode/identity failure leaves the ordinary session available, so retry is safe.
+        // Once replacement has committed, however, the isolated replay machine has no live input
+        // source or state workspace; keep commands disabled until the user closes or reopens it.
+        val phase =
+            if (currentSession?.available == false) ReplayPlaybackPhase.COMPLETED
+            else ReplayPlaybackPhase.IDLE
+        inputPlaybackPhase = phase
+        onInputPlaybackPhase(phase)
+        showStateError(
+            owner,
+            StateUserError(
+                event.summary,
+                event.detail,
+                "Keep the matching ROM open and select another recording, or reopen the game after playback.",
+            ),
+        )
+      }
+    }
   }
 
   fun showBrowser() {
@@ -433,24 +479,55 @@ internal class StateUxDesktopController(
     eventBus.post(StateScreenshotRequestEvent(nextRequestId(), expectedSessionId, image))
   }
 
-  fun toggleInputRecording() {
+  fun startInputRecording() {
     requireEdt("Input recording request")
     if (closed) return
-    when (inputRecordingPhase) {
-      ReplayRecordingPhase.ARMING,
-      ReplayRecordingPhase.RECORDING -> {
-        val session = currentSession ?: return
-        eventBus.post(ReplayRecordingStopRequestEvent(nextRequestId(), session.sessionId))
-      }
-      ReplayRecordingPhase.IDLE -> startInputRecording()
-      ReplayRecordingPhase.SAVING ->
+    when {
+      inputPlaybackPhase != ReplayPlaybackPhase.IDLE ->
+          onDesktopStatus("Input playback is active. Close or reopen the game before recording again.", null)
+      inputRecordingPhase == ReplayRecordingPhase.IDLE -> requestInputRecordingStart()
+      inputRecordingPhase == ReplayRecordingPhase.SAVING ->
           onDesktopStatus("Input recording is being saved. Please wait.", null)
-      ReplayRecordingPhase.UNSAVED ->
+      inputRecordingPhase == ReplayRecordingPhase.UNSAVED ->
           onDesktopStatus("Input recording needs saving before another recording can start.", null)
+      else -> onDesktopStatus("Input recording is already active. Use Stop Input Recording.", null)
     }
   }
 
-  private fun startInputRecording() {
+  fun stopInputRecording() {
+    requireEdt("Input recording stop request")
+    if (closed) return
+    if (inputRecordingPhase != ReplayRecordingPhase.ARMING &&
+        inputRecordingPhase != ReplayRecordingPhase.RECORDING) {
+      onDesktopStatus("No input recording is active.", null)
+      return
+    }
+    val session = currentSession ?: return
+    eventBus.post(ReplayRecordingStopRequestEvent(nextRequestId(), session.sessionId))
+  }
+
+  fun loadInputRecording() {
+    requireEdt("Input recording playback request")
+    if (closed || inputPlaybackPhase != ReplayPlaybackPhase.IDLE ||
+        inputRecordingPhase != ReplayRecordingPhase.IDLE || !requireAvailableSession()) {
+      return
+    }
+    val session = checkNotNull(currentSession)
+    val initialDirectory = session.gameDirectory?.resolve("replays")?.takeIf { java.nio.file.Files.isDirectory(it) }
+        ?: session.gameDirectory
+    val chooser = JFileChooser(initialDirectory?.toFile()).apply {
+      dialogTitle = "Load Input Recording"
+      fileSelectionMode = JFileChooser.FILES_ONLY
+      isAcceptAllFileFilterUsed = false
+      addChoosableFileFilter(FileNameExtensionFilter("Coffee GB input recordings (*.cgbreplay)", "cgbreplay"))
+    }
+    if (chooser.showOpenDialog(owner) != JFileChooser.APPROVE_OPTION) return
+    val selected = chooser.selectedFile?.toPath() ?: return
+    if (!isCurrent(session.sessionId)) return
+    eventBus.post(ReplayPlaybackLoadRequestEvent(nextRequestId(), session.sessionId, selected))
+  }
+
+  private fun requestInputRecordingStart() {
     if (!requireAvailableSession()) return
     val expectedSessionId = checkNotNull(currentSession).sessionId
     val choice = showInputRecordingModeDialog() ?: return

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
@@ -421,7 +421,7 @@ internal class StateUxDesktopController(
             StateUserError(
                 event.summary,
                 event.detail,
-                "Keep the matching ROM open and select another recording, or reopen the game after playback.",
+                "Reset or reopen the game to return to normal play, then select another recording.",
             ),
         )
       }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.swing
 
+import eu.rekawek.coffeegb.controller.Controller
 import eu.rekawek.coffeegb.controller.events.register
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingFailedEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingDiscardEvent
@@ -13,6 +14,7 @@ import eu.rekawek.coffeegb.controller.replay.ReplayRecordingRetrySaveEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackFailedEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackLoadRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStopRequestEvent
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackStatusEvent
 import eu.rekawek.coffeegb.controller.state.StateBrowserCatalog
 import eu.rekawek.coffeegb.controller.state.StateBrowserEntry
@@ -68,7 +70,6 @@ import javax.swing.AbstractAction
 import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.BoxLayout
-import javax.swing.ButtonGroup
 import javax.swing.ImageIcon
 import javax.swing.JButton
 import javax.swing.JCheckBox
@@ -79,7 +80,6 @@ import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JOptionPane
 import javax.swing.JPanel
-import javax.swing.JRadioButton
 import javax.swing.JScrollPane
 import javax.swing.JSplitPane
 import javax.swing.JTable
@@ -421,7 +421,7 @@ internal class StateUxDesktopController(
             StateUserError(
                 event.summary,
                 event.detail,
-                "Reset or reopen the game to return to normal play, then select another recording.",
+                "Press Stop in Input Recording to return to normal play, then select another recording.",
             ),
         )
       }
@@ -479,125 +479,129 @@ internal class StateUxDesktopController(
     eventBus.post(StateScreenshotRequestEvent(nextRequestId(), expectedSessionId, image))
   }
 
-  fun startInputRecording() {
+  fun startInputRecording(mode: ReplayRecordingMode) {
     requireEdt("Input recording request")
     if (closed) return
     when {
       inputPlaybackPhase != ReplayPlaybackPhase.IDLE ->
-          onDesktopStatus("Input playback is active. Close or reopen the game before recording again.", null)
-      inputRecordingPhase == ReplayRecordingPhase.IDLE -> requestInputRecordingStart()
+          onDesktopStatus("Stop input playback before recording again.", null)
+      inputRecordingPhase == ReplayRecordingPhase.IDLE -> requestInputRecordingStart(mode)
       inputRecordingPhase == ReplayRecordingPhase.SAVING ->
           onDesktopStatus("Input recording is being saved. Please wait.", null)
       inputRecordingPhase == ReplayRecordingPhase.UNSAVED ->
           onDesktopStatus("Input recording needs saving before another recording can start.", null)
-      else -> onDesktopStatus("Input recording is already active. Use Stop Input Recording.", null)
+      else -> onDesktopStatus("Input recording is already active. Press Stop to save it.", null)
     }
   }
 
+  /** Stops whichever tape transport currently owns the emulator. */
   fun stopInputRecording() {
-    requireEdt("Input recording stop request")
+    requireEdt("Input recording transport stop request")
     if (closed) return
-    if (inputRecordingPhase != ReplayRecordingPhase.ARMING &&
-        inputRecordingPhase != ReplayRecordingPhase.RECORDING) {
-      onDesktopStatus("No input recording is active.", null)
-      return
-    }
     val session = currentSession ?: return
-    eventBus.post(ReplayRecordingStopRequestEvent(nextRequestId(), session.sessionId))
+    when {
+      inputRecordingPhase == ReplayRecordingPhase.ARMING ||
+          inputRecordingPhase == ReplayRecordingPhase.RECORDING ->
+          eventBus.post(ReplayRecordingStopRequestEvent(nextRequestId(), session.sessionId))
+      inputPlaybackPhase != ReplayPlaybackPhase.IDLE ->
+          eventBus.post(ReplayPlaybackStopRequestEvent(nextRequestId(), session.sessionId))
+      else -> onDesktopStatus("No input recording or playback is active.", null)
+    }
   }
 
+  /** Legacy command bridge: select a tape and immediately play it. */
   fun loadInputRecording() {
+    chooseInputRecording()?.let(::playInputRecording)
+  }
+
+  /** Opens the tape chooser without starting playback. */
+  fun chooseInputRecording(): Path? {
+    requireEdt("Input recording file selection")
+    if (closed || inputPlaybackPhase != ReplayPlaybackPhase.IDLE ||
+        inputRecordingPhase != ReplayRecordingPhase.IDLE || !requireAvailableSession()) return null
+    val session = checkNotNull(currentSession)
+    val initialDirectory =
+        session.gameDirectory?.resolve("replays")?.takeIf { java.nio.file.Files.isDirectory(it) }
+            ?: session.gameDirectory
+    val chooser =
+        JFileChooser(initialDirectory?.toFile()).apply {
+          dialogTitle = "Load Input Recording"
+          fileSelectionMode = JFileChooser.FILES_ONLY
+          isAcceptAllFileFilterUsed = false
+          addChoosableFileFilter(
+              FileNameExtensionFilter(
+                  "Coffee GB input recordings (*.cgbreplay)",
+                  "cgbreplay",
+              ))
+        }
+    if (chooser.showOpenDialog(owner) != JFileChooser.APPROVE_OPTION) return null
+    val selected = chooser.selectedFile?.toPath() ?: return null
+    return selected.takeIf { isCurrent(session.sessionId) }
+  }
+
+  /** Starts the already-selected tape from its beginning. */
+  fun playInputRecording(path: Path) {
     requireEdt("Input recording playback request")
     if (closed || inputPlaybackPhase != ReplayPlaybackPhase.IDLE ||
-        inputRecordingPhase != ReplayRecordingPhase.IDLE || !requireAvailableSession()) {
-      return
-    }
+        inputRecordingPhase != ReplayRecordingPhase.IDLE || !requireAvailableSession()) return
     val session = checkNotNull(currentSession)
-    val initialDirectory = session.gameDirectory?.resolve("replays")?.takeIf { java.nio.file.Files.isDirectory(it) }
-        ?: session.gameDirectory
-    val chooser = JFileChooser(initialDirectory?.toFile()).apply {
-      dialogTitle = "Load Input Recording"
-      fileSelectionMode = JFileChooser.FILES_ONLY
-      isAcceptAllFileFilterUsed = false
-      addChoosableFileFilter(FileNameExtensionFilter("Coffee GB input recordings (*.cgbreplay)", "cgbreplay"))
-    }
-    if (chooser.showOpenDialog(owner) != JFileChooser.APPROVE_OPTION) return
-    val selected = chooser.selectedFile?.toPath() ?: return
-    if (!isCurrent(session.sessionId)) return
-    eventBus.post(ReplayPlaybackLoadRequestEvent(nextRequestId(), session.sessionId, selected))
+    eventBus.post(ReplayPlaybackLoadRequestEvent(nextRequestId(), session.sessionId, path))
   }
 
-  private fun requestInputRecordingStart() {
+  fun setInputPlaybackPaused(paused: Boolean) {
+    requireEdt("Input playback pause request")
+    if (closed || inputPlaybackPhase != ReplayPlaybackPhase.PLAYING) return
+    eventBus.post(
+        if (paused) Controller.PauseEmulationEvent() else Controller.ResumeEmulationEvent())
+  }
+
+  private fun requestInputRecordingStart(mode: ReplayRecordingMode) {
     if (!requireAvailableSession()) return
     val expectedSessionId = checkNotNull(currentSession).sessionId
-    val choice = showInputRecordingModeDialog() ?: return
+    if (mode == ReplayRecordingMode.CURRENT_SESSION && !confirmCurrentSessionRecording()) return
     if (!isCurrent(expectedSessionId)) return
     eventBus.post(
         ReplayRecordingStartRequestEvent(
             nextRequestId(),
             expectedSessionId,
-            choice,
-            includeSensitiveInitialState = choice == ReplayRecordingMode.CURRENT_SESSION,
+            mode,
+            includeSensitiveInitialState = mode == ReplayRecordingMode.CURRENT_SESSION,
         ))
   }
 
-  /** No option is preselected: choosing the privacy-sensitive mode is always deliberate. */
-  private fun showInputRecordingModeDialog(): ReplayRecordingMode? {
-    val current = JRadioButton("From current moment")
-    val cleanBoot = JRadioButton("Restart from clean boot")
+  /** Current-session tapes embed memory and cartridge data, so the red button confirms consent. */
+  private fun confirmCurrentSessionRecording(): Boolean {
     val consent =
         JCheckBox(
             "I understand this file includes the current emulator and cartridge save state.",
-        ).apply { isEnabled = false }
-    ButtonGroup().apply {
-      add(current)
-      add(cleanBoot)
-    }
-    current.addActionListener { consent.isEnabled = true }
-    cleanBoot.addActionListener {
-      consent.isSelected = false
-      consent.isEnabled = false
-    }
+        )
     val panel =
         JPanel().apply {
           layout = BoxLayout(this, BoxLayout.Y_AXIS)
-          add(JLabel("Choose how to begin input recording:"))
+          add(JLabel("Record from the current moment?"))
           add(Box.createVerticalStrut(10))
-          add(current)
           add(
               JLabel(
-                  "  Continues now. The replay includes emulator memory and cartridge RAM/save data, but never ROM bytes or paths."))
+                  "The replay includes emulator memory and cartridge RAM/save data, " +
+                      "but never ROM bytes or paths."))
+          add(Box.createVerticalStrut(6))
           add(consent)
-          add(Box.createVerticalStrut(10))
-          add(cleanBoot)
-          add(
-              JLabel(
-                  "  Restarts in a battery-isolated clean boot. The replay and session contain no save state."))
         }
     val result =
         JOptionPane.showOptionDialog(
             owner,
             panel,
-            "Start Input Recording",
+            "Record from Current Moment",
             JOptionPane.DEFAULT_OPTION,
             JOptionPane.QUESTION_MESSAGE,
             null,
-            arrayOf("Start Recording", "Cancel"),
-            "Cancel",
+            arrayOf("🔴", "✖️"),
+            "✖️",
         )
-    if (result != 0) return null
-    return when {
-      current.isSelected && consent.isSelected -> ReplayRecordingMode.CURRENT_SESSION
-      cleanBoot.isSelected -> ReplayRecordingMode.CLEAN_BOOT
-      current.isSelected -> {
-        onDesktopStatus("Confirm the current-session data notice before recording.", null)
-        null
-      }
-      else -> {
-        onDesktopStatus("Choose a recording mode before starting.", null)
-        null
-      }
+    if (result == 0 && !consent.isSelected) {
+      onDesktopStatus("Confirm the current-session data notice before recording.", null)
     }
+    return result == 0 && consent.isSelected
   }
 
   fun saveSlot(slot: Int) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/StateUxDesktopController.kt
@@ -68,11 +68,8 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import javax.swing.AbstractAction
 import javax.swing.BorderFactory
-import javax.swing.Box
-import javax.swing.BoxLayout
 import javax.swing.ImageIcon
 import javax.swing.JButton
-import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.JFileChooser
@@ -118,6 +115,7 @@ internal class StateUxDesktopController(
     private val onInputRecordingPhase: (ReplayRecordingPhase) -> Unit = {},
     private val onInputPlaybackPhase: (ReplayPlaybackPhase) -> Unit = {},
     private val dialogFactory: DesktopDialogFactory = DesktopDialogFactory(),
+    private val onInputRecordingSaved: (Path) -> Unit = {},
 ) : AutoCloseable {
   private val eventBus = rootEventBus.fork("desktop-state-ux")
   private val requestIds = AtomicLong()
@@ -345,6 +343,7 @@ internal class StateUxDesktopController(
         if (closed) return@onEdt
         inputRecordingPhase = ReplayRecordingPhase.IDLE
         onInputRecordingPhase(ReplayRecordingPhase.IDLE)
+        onInputRecordingSaved(event.path)
         onDesktopStatus(
             "Input recording saved as ${event.path.fileName}. Use Open Save Folder to reveal it.",
             DesktopCommand.OPEN_SAVE_FOLDER,
@@ -558,7 +557,6 @@ internal class StateUxDesktopController(
   private fun requestInputRecordingStart(mode: ReplayRecordingMode) {
     if (!requireAvailableSession()) return
     val expectedSessionId = checkNotNull(currentSession).sessionId
-    if (mode == ReplayRecordingMode.CURRENT_SESSION && !confirmCurrentSessionRecording()) return
     if (!isCurrent(expectedSessionId)) return
     eventBus.post(
         ReplayRecordingStartRequestEvent(
@@ -567,41 +565,6 @@ internal class StateUxDesktopController(
             mode,
             includeSensitiveInitialState = mode == ReplayRecordingMode.CURRENT_SESSION,
         ))
-  }
-
-  /** Current-session tapes embed memory and cartridge data, so the red button confirms consent. */
-  private fun confirmCurrentSessionRecording(): Boolean {
-    val consent =
-        JCheckBox(
-            "I understand this file includes the current emulator and cartridge save state.",
-        )
-    val panel =
-        JPanel().apply {
-          layout = BoxLayout(this, BoxLayout.Y_AXIS)
-          add(JLabel("Record from the current moment?"))
-          add(Box.createVerticalStrut(10))
-          add(
-              JLabel(
-                  "The replay includes emulator memory and cartridge RAM/save data, " +
-                      "but never ROM bytes or paths."))
-          add(Box.createVerticalStrut(6))
-          add(consent)
-        }
-    val result =
-        JOptionPane.showOptionDialog(
-            owner,
-            panel,
-            "Record from Current Moment",
-            JOptionPane.DEFAULT_OPTION,
-            JOptionPane.QUESTION_MESSAGE,
-            null,
-            arrayOf("🔴", "✖️"),
-            "✖️",
-        )
-    if (result == 0 && !consent.isSelected) {
-      onDesktopStatus("Confirm the current-session data notice before recording.", null)
-    }
-    return result == 0 && consent.isSelected
   }
 
   fun saveSlot(slot: Int) {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -316,6 +316,11 @@ class SwingGui private constructor(
                 desktopUiCoordinator.inputRecording(phase)
               }
             },
+            onInputPlaybackPhase = { phase ->
+              if (::desktopUiCoordinator.isInitialized) {
+                desktopUiCoordinator.inputPlayback(phase)
+              }
+            },
             dialogFactory = desktopDialogFactory,
         )
     debuggerController =
@@ -433,7 +438,9 @@ class SwingGui private constructor(
                 },
                 setFullscreen = displayController::setFullscreen,
                 screenshot = stateUxController::takeScreenshot,
-                inputRecording = stateUxController::toggleInputRecording,
+                inputRecording = stateUxController::startInputRecording,
+                stopInputRecording = stateUxController::stopInputRecording,
+                loadInputRecording = stateUxController::loadInputRecording,
                 setCommandBarVisible = ::setCommandBarVisible,
                 selectStateSlot = { slot ->
                   desktopUiCoordinator.stateSlot(slot)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -311,6 +311,11 @@ class SwingGui private constructor(
                         ))
               }
             },
+            onInputRecordingPhase = { phase ->
+              if (::desktopUiCoordinator.isInitialized) {
+                desktopUiCoordinator.inputRecording(phase)
+              }
+            },
             dialogFactory = desktopDialogFactory,
         )
     debuggerController =
@@ -428,6 +433,7 @@ class SwingGui private constructor(
                 },
                 setFullscreen = displayController::setFullscreen,
                 screenshot = stateUxController::takeScreenshot,
+                inputRecording = stateUxController::toggleInputRecording,
                 setCommandBarVisible = ::setCommandBarVisible,
                 selectStateSlot = { slot ->
                   desktopUiCoordinator.stateSlot(slot)

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -324,6 +324,11 @@ class SwingGui private constructor(
                 desktopUiCoordinator.inputPlayback(phase)
               }
             },
+            onInputRecordingSaved = { path ->
+              if (::inputRecordingWindow.isInitialized) {
+                inputRecordingWindow.selectRecordedReplay(path)
+              }
+            },
             dialogFactory = desktopDialogFactory,
         )
     inputRecordingWindow =

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingGui.kt
@@ -116,6 +116,8 @@ class SwingGui private constructor(
 
   private lateinit var stateUxController: StateUxDesktopController
 
+  private lateinit var inputRecordingWindow: InputRecordingWindow
+
   private lateinit var debuggerController: DesktopDebuggerController
 
   private lateinit var netplayWindow: NetplayWindowHost
@@ -170,6 +172,7 @@ class SwingGui private constructor(
           runDesktopEdtStep(debuggerController::close)
           runDesktopEdtStep(netplayWindow::close)
           runDesktopEdtStep(mobileAdapterWindow::close)
+          runDesktopEdtStep(inputRecordingWindow::close)
           runDesktopEdtStep(stateUxController::close)
           recentGamePreviewLoader.close()
           console?.stop()
@@ -323,6 +326,15 @@ class SwingGui private constructor(
             },
             dialogFactory = desktopDialogFactory,
         )
+    inputRecordingWindow =
+        InputRecordingWindow(
+            owner = mainWindow,
+            chooseReplay = stateUxController::chooseInputRecording,
+            playReplay = stateUxController::playInputRecording,
+            setPlaybackPaused = stateUxController::setInputPlaybackPaused,
+            stopTransport = stateUxController::stopInputRecording,
+            startRecording = stateUxController::startInputRecording,
+        )
     debuggerController =
         DesktopDebuggerController(
             mainWindow,
@@ -388,6 +400,7 @@ class SwingGui private constructor(
           { runDesktopEdtStep(debuggerController::close) },
           { runDesktopEdtStep(netplayWindow::close) },
           { runDesktopEdtStep(mobileAdapterWindow::close) },
+          { runDesktopEdtStep(inputRecordingWindow::close) },
           {
             if (::desktopUiStateController.isInitialized) {
               runDesktopEdtStep(desktopUiStateController::close)
@@ -438,7 +451,7 @@ class SwingGui private constructor(
                 },
                 setFullscreen = displayController::setFullscreen,
                 screenshot = stateUxController::takeScreenshot,
-                inputRecording = stateUxController::startInputRecording,
+                inputRecording = inputRecordingWindow::show,
                 stopInputRecording = stateUxController::stopInputRecording,
                 loadInputRecording = stateUxController::loadInputRecording,
                 setCommandBarVisible = ::setCommandBarVisible,
@@ -545,7 +558,10 @@ class SwingGui private constructor(
                               "System appearance is active for this launch.")
                     },
             ),
-            desktopMainPanel::render,
+            { presentation ->
+              desktopMainPanel.render(presentation)
+              inputRecordingWindow.render(presentation.commands)
+            },
         )
     desktopPlaybackState = DesktopPlaybackState(desktopUiCoordinator::paused)
     desktopUiCoordinator.publish()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -611,7 +611,9 @@ internal class SwingMenu(
     screenshot.mnemonic = KeyEvent.VK_T
     screenMenu.insert(screenshot, 1)
     screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING]), 2)
-    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 3)
+    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.STOP_INPUT_RECORDING]), 3)
+    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.LOAD_INPUT_RECORDING]), 4)
+    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 5)
     screenMenu.addSeparator()
     screenMenu.add(
         JMenuItem("More Display Settings…").apply {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -610,7 +610,8 @@ internal class SwingMenu(
     val screenshot = JMenuItem(desktopActions[DesktopCommand.SCREENSHOT])
     screenshot.mnemonic = KeyEvent.VK_T
     screenMenu.insert(screenshot, 1)
-    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 2)
+    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING]), 2)
+    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 3)
     screenMenu.addSeparator()
     screenMenu.add(
         JMenuItem("More Display Settings…").apply {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -413,6 +413,13 @@ internal class SwingMenu(
     manageStates.mnemonic = KeyEvent.VK_M
     gameMenu.add(manageStates)
 
+    val inputRecording = JMenu("Input Recording")
+    inputRecording.mnemonic = KeyEvent.VK_I
+    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING]))
+    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.STOP_INPUT_RECORDING]))
+    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.LOAD_INPUT_RECORDING]))
+    gameMenu.add(inputRecording)
+
     gameMenu.addSeparator()
     val cheats = JMenuItem("Cheats…")
     cheats.accessibleContext.accessibleDescription =
@@ -610,10 +617,7 @@ internal class SwingMenu(
     val screenshot = JMenuItem(desktopActions[DesktopCommand.SCREENSHOT])
     screenshot.mnemonic = KeyEvent.VK_T
     screenMenu.insert(screenshot, 1)
-    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING]), 2)
-    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.STOP_INPUT_RECORDING]), 3)
-    screenMenu.insert(JMenuItem(desktopActions[DesktopCommand.LOAD_INPUT_RECORDING]), 4)
-    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 5)
+    screenMenu.insert(JCheckBoxMenuItem(desktopActions[DesktopCommand.SHOW_COMMAND_BAR]), 2)
     screenMenu.addSeparator()
     screenMenu.add(
         JMenuItem("More Display Settings…").apply {

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -413,11 +413,8 @@ internal class SwingMenu(
     manageStates.mnemonic = KeyEvent.VK_M
     gameMenu.add(manageStates)
 
-    val inputRecording = JMenu("Input Recording")
+    val inputRecording = JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING])
     inputRecording.mnemonic = KeyEvent.VK_I
-    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.INPUT_RECORDING]))
-    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.STOP_INPUT_RECORDING]))
-    inputRecording.add(JMenuItem(desktopActions[DesktopCommand.LOAD_INPUT_RECORDING]))
     gameMenu.add(inputRecording)
 
     gameMenu.addSeparator()

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -786,6 +786,7 @@ internal class SwingProposal3Menu(
                 item("import-state-0", "IMPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
                 item("export-state-0", "EXPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
                 item("export-screenshot", "EXPORT NATIVE SCREENSHOT", enabled(DesktopCommand.SCREENSHOT)),
+                item("input-recording", "INPUT RECORDING", enabled(DesktopCommand.INPUT_RECORDING)),
                 item("preview-printer-paper", "PRINTER PAPER", printerHasPaper),
                 item("back", "BACK", true),
             )
@@ -793,7 +794,7 @@ internal class SwingProposal3Menu(
           page(
               "DATA & MEDIA",
               "DATA DECK",
-              listOf("BATTERY SAVE  READY", "STATE SLOT 0  READY", "SCREENSHOT  PNG"),
+              listOf("BATTERY SAVE  READY", "STATE SLOT 0  READY", "INPUT RECORDING"),
               dataItems,
               preferredFocus = "export-screenshot",
           )
@@ -1122,6 +1123,7 @@ internal class SwingProposal3Menu(
           when (id) {
             "import-state-0", "export-state-0" -> runCommandAndHide(DesktopCommand.MANAGE_STATES)
             "export-screenshot" -> runCommandAndHide(DesktopCommand.SCREENSHOT)
+            "input-recording" -> runCommandAndHide(DesktopCommand.INPUT_RECORDING)
             "preview-printer-paper" -> openRoute(MenuRoute.PRINTER_PAPER)
             "back" -> back()
           }

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingProposal3Menu.kt
@@ -786,7 +786,9 @@ internal class SwingProposal3Menu(
                 item("import-state-0", "IMPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
                 item("export-state-0", "EXPORT STATE SLOT 0", enabled(DesktopCommand.MANAGE_STATES)),
                 item("export-screenshot", "EXPORT NATIVE SCREENSHOT", enabled(DesktopCommand.SCREENSHOT)),
-                item("input-recording", "INPUT RECORDING", enabled(DesktopCommand.INPUT_RECORDING)),
+                item("start-input-recording", "START INPUT RECORDING", enabled(DesktopCommand.INPUT_RECORDING)),
+                item("stop-input-recording", "STOP INPUT RECORDING", enabled(DesktopCommand.STOP_INPUT_RECORDING)),
+                item("load-input-recording", "LOAD INPUT RECORDING", enabled(DesktopCommand.LOAD_INPUT_RECORDING)),
                 item("preview-printer-paper", "PRINTER PAPER", printerHasPaper),
                 item("back", "BACK", true),
             )
@@ -1123,7 +1125,9 @@ internal class SwingProposal3Menu(
           when (id) {
             "import-state-0", "export-state-0" -> runCommandAndHide(DesktopCommand.MANAGE_STATES)
             "export-screenshot" -> runCommandAndHide(DesktopCommand.SCREENSHOT)
-            "input-recording" -> runCommandAndHide(DesktopCommand.INPUT_RECORDING)
+            "start-input-recording" -> runCommandAndHide(DesktopCommand.INPUT_RECORDING)
+            "stop-input-recording" -> runCommandAndHide(DesktopCommand.STOP_INPUT_RECORDING)
+            "load-input-recording" -> runCommandAndHide(DesktopCommand.LOAD_INPUT_RECORDING)
             "preview-printer-paper" -> openRoute(MenuRoute.PRINTER_PAPER)
             "back" -> back()
           }

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -1,5 +1,6 @@
 package eu.rekawek.coffeegb.swing
 
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
 import java.awt.event.ActionEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -269,6 +270,48 @@ class DesktopActionsTest {
     assertTrue(
         shortcuts[DesktopCommand.OPEN_ROM]!!.modifiers and InputEvent.CTRL_DOWN_MASK != 0)
     assertEquals(10, shortcuts.stateSlotShortcuts.size)
+  }
+
+  @Test
+  fun `input recording command tracks recorder lifecycle and keeps its modified shortcut`() {
+    val calls = mutableListOf<String>()
+    val registry = DesktopActionRegistry(handlers(calls).copy(inputRecording = { calls += "record" }))
+
+    registry.update(
+        DesktopCommandPresentation(
+            gameLoaded = true,
+            stateBrowserAvailable = true,
+            inputRecordingPhase = ReplayRecordingPhase.IDLE,
+        ))
+    assertEquals("Start Input Recording…", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
+    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    registry[DesktopCommand.INPUT_RECORDING].actionPerformed(event())
+
+    registry.update(
+        DesktopCommandPresentation(
+            gameLoaded = true,
+            inputRecordingPhase = ReplayRecordingPhase.RECORDING,
+        ))
+    assertEquals("Stop Input Recording", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
+    assertEquals(true, registry[DesktopCommand.INPUT_RECORDING].getValue(Action.SELECTED_KEY))
+    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+
+    registry.update(
+        DesktopCommandPresentation(
+            gameLoaded = true,
+            inputRecordingPhase = ReplayRecordingPhase.SAVING,
+        ))
+    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertEquals(listOf("record"), calls)
+
+    val shortcuts =
+        DesktopShortcutRegistry(
+            gameplayKeyCodes = listOf(KeyEvent.VK_R),
+            platformMenuMask = InputEvent.CTRL_DOWN_MASK,
+        )
+    assertEquals(KeyEvent.VK_R, shortcuts[DesktopCommand.INPUT_RECORDING]?.keyCode)
+    assertTrue(
+        shortcuts[DesktopCommand.INPUT_RECORDING]!!.modifiers and InputEvent.SHIFT_DOWN_MASK != 0)
   }
 
   private fun registry(calls: MutableList<String>): DesktopActionRegistry =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -291,7 +291,7 @@ class DesktopActionsTest {
             stateBrowserAvailable = true,
             inputRecordingPhase = ReplayRecordingPhase.IDLE,
         ))
-    assertEquals("Start Input Recording…", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
+    assertEquals("Start Input Recording", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
     assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertFalse(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
     assertTrue(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -1,6 +1,7 @@
 package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
 import java.awt.event.ActionEvent
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -273,9 +274,16 @@ class DesktopActionsTest {
   }
 
   @Test
-  fun `input recording command tracks recorder lifecycle and keeps its modified shortcut`() {
+  fun `input recording exposes separate start stop and playback commands`() {
     val calls = mutableListOf<String>()
-    val registry = DesktopActionRegistry(handlers(calls).copy(inputRecording = { calls += "record" }))
+    val registry =
+        DesktopActionRegistry(
+            handlers(calls).copy(
+                inputRecording = { calls += "start-recording" },
+                stopInputRecording = { calls += "stop-recording" },
+                loadInputRecording = { calls += "load-recording" },
+            ),
+        )
 
     registry.update(
         DesktopCommandPresentation(
@@ -285,6 +293,8 @@ class DesktopActionsTest {
         ))
     assertEquals("Start Input Recording…", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
     assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertFalse(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
+    assertTrue(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
     registry[DesktopCommand.INPUT_RECORDING].actionPerformed(event())
 
     registry.update(
@@ -292,9 +302,10 @@ class DesktopActionsTest {
             gameLoaded = true,
             inputRecordingPhase = ReplayRecordingPhase.RECORDING,
         ))
-    assertEquals("Stop Input Recording", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
-    assertEquals(true, registry[DesktopCommand.INPUT_RECORDING].getValue(Action.SELECTED_KEY))
-    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertTrue(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
+    assertFalse(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
+    registry[DesktopCommand.STOP_INPUT_RECORDING].actionPerformed(event())
 
     registry.update(
         DesktopCommandPresentation(
@@ -302,7 +313,17 @@ class DesktopActionsTest {
             inputRecordingPhase = ReplayRecordingPhase.SAVING,
         ))
     assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
-    assertEquals(listOf("record"), calls)
+    assertFalse(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
+
+    registry.update(
+        DesktopCommandPresentation(
+            gameLoaded = true,
+            stateBrowserAvailable = true,
+            inputPlaybackPhase = ReplayPlaybackPhase.PLAYING,
+        ))
+    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertFalse(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
+    assertEquals(listOf("start-recording", "stop-recording"), calls)
 
     val shortcuts =
         DesktopShortcutRegistry(

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -301,6 +301,7 @@ class DesktopActionsTest {
         DesktopCommandPresentation(
             gameLoaded = true,
             inputRecordingPhase = ReplayRecordingPhase.RECORDING,
+            sessionBusy = true,
         ))
     assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertTrue(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/DesktopActionsTest.kt
@@ -274,7 +274,7 @@ class DesktopActionsTest {
   }
 
   @Test
-  fun `input recording exposes separate start stop and playback commands`() {
+  fun `input recording window command remains reachable throughout tape activity`() {
     val calls = mutableListOf<String>()
     val registry =
         DesktopActionRegistry(
@@ -291,7 +291,7 @@ class DesktopActionsTest {
             stateBrowserAvailable = true,
             inputRecordingPhase = ReplayRecordingPhase.IDLE,
         ))
-    assertEquals("Start Input Recording", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
+    assertEquals("Input Recording", registry[DesktopCommand.INPUT_RECORDING].getValue(Action.NAME))
     assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertFalse(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
     assertTrue(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
@@ -303,7 +303,7 @@ class DesktopActionsTest {
             inputRecordingPhase = ReplayRecordingPhase.RECORDING,
             sessionBusy = true,
         ))
-    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertTrue(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
     assertFalse(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
     registry[DesktopCommand.STOP_INPUT_RECORDING].actionPerformed(event())
@@ -313,7 +313,7 @@ class DesktopActionsTest {
             gameLoaded = true,
             inputRecordingPhase = ReplayRecordingPhase.SAVING,
         ))
-    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertFalse(registry[DesktopCommand.STOP_INPUT_RECORDING].isEnabled)
 
     registry.update(
@@ -322,7 +322,7 @@ class DesktopActionsTest {
             stateBrowserAvailable = true,
             inputPlaybackPhase = ReplayPlaybackPhase.PLAYING,
         ))
-    assertFalse(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
+    assertTrue(registry[DesktopCommand.INPUT_RECORDING].isEnabled)
     assertFalse(registry[DesktopCommand.LOAD_INPUT_RECORDING].isEnabled)
     assertEquals(listOf("start-recording", "stop-recording"), calls)
 

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/InputRecordingWindowTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/InputRecordingWindowTest.kt
@@ -2,11 +2,44 @@ package eu.rekawek.coffeegb.swing
 
 import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
 import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import java.nio.file.Path
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Test
 
 class InputRecordingWindowTest {
+  @Test
+  fun `loading a replay selects and immediately plays it`() {
+    val selection = InputReplaySelection()
+    val selected = Path.of("loaded.cgbreplay")
+    val actions = mutableListOf<String>()
+
+    assertTrue(
+        selection.loadAndPlay(
+            selected,
+            onSelected = { actions += "selected" },
+            playReplay = { actions += "played:$it" },
+        ))
+
+    assertEquals(selected, selection.path)
+    assertEquals(listOf("selected", "played:$selected"), actions)
+  }
+
+  @Test
+  fun `saved recording replaces the previously loaded replay without starting playback`() {
+    val selection = InputReplaySelection()
+    val loaded = Path.of("loaded.cgbreplay")
+    val recorded = Path.of("recorded.cgbreplay")
+    val played = mutableListOf<Path>()
+    selection.loadAndPlay(loaded, onSelected = {}, playReplay = played::add)
+
+    selection.selectRecorded(recorded)
+
+    assertEquals(recorded, selection.path)
+    assertEquals(listOf(loaded), played)
+  }
+
   @Test
   fun `idle transport enables tape selection and both recording modes`() {
     val presentation =

--- a/swing/src/test/java/eu/rekawek/coffeegb/swing/InputRecordingWindowTest.kt
+++ b/swing/src/test/java/eu/rekawek/coffeegb/swing/InputRecordingWindowTest.kt
@@ -1,0 +1,87 @@
+package eu.rekawek.coffeegb.swing
+
+import eu.rekawek.coffeegb.controller.replay.ReplayPlaybackPhase
+import eu.rekawek.coffeegb.controller.replay.ReplayRecordingPhase
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class InputRecordingWindowTest {
+  @Test
+  fun `idle transport enables tape selection and both recording modes`() {
+    val presentation =
+        DesktopCommandPresentation(
+            gameLoaded = true,
+            stateCommandsAvailable = true,
+        )
+
+    val empty = inputRecordingControlState(presentation, replaySelected = false)
+    assertTrue(empty.ejectEnabled)
+    assertFalse(empty.playPauseEnabled)
+    assertFalse(empty.stopEnabled)
+    assertTrue(empty.recordEnabled)
+    assertTrue(empty.resetRecordEnabled)
+
+    val loaded = inputRecordingControlState(presentation, replaySelected = true)
+    assertTrue(loaded.playPauseEnabled)
+  }
+
+  @Test
+  fun `recording and playback expose only their applicable transport controls`() {
+    val recording =
+        inputRecordingControlState(
+            DesktopCommandPresentation(
+                gameLoaded = true,
+                inputRecordingPhase = ReplayRecordingPhase.RECORDING,
+            ),
+            replaySelected = true,
+        )
+    assertTrue(recording.stopEnabled)
+    assertFalse(recording.ejectEnabled)
+    assertFalse(recording.playPauseEnabled)
+    assertFalse(recording.recordEnabled)
+    assertFalse(recording.resetRecordEnabled)
+
+    val playback =
+        inputRecordingControlState(
+            DesktopCommandPresentation(
+                gameLoaded = true,
+                inputPlaybackPhase = ReplayPlaybackPhase.PLAYING,
+            ),
+            replaySelected = true,
+        )
+    assertTrue(playback.playPauseEnabled)
+    assertTrue(playback.stopEnabled)
+    assertFalse(playback.ejectEnabled)
+    assertFalse(playback.recordEnabled)
+    assertFalse(playback.resetRecordEnabled)
+
+    val completed =
+        inputRecordingControlState(
+            DesktopCommandPresentation(
+                gameLoaded = true,
+                inputPlaybackPhase = ReplayPlaybackPhase.COMPLETED,
+                paused = true,
+            ),
+            replaySelected = true,
+        )
+    assertTrue(completed.stopEnabled)
+    assertFalse(completed.playPauseEnabled)
+  }
+
+  @Test
+  fun `paused ordinary game can reset and record but cannot record current state`() {
+    val controls =
+        inputRecordingControlState(
+            DesktopCommandPresentation(
+                gameLoaded = true,
+                stateCommandsAvailable = true,
+                paused = true,
+            ),
+            replaySelected = false,
+        )
+
+    assertFalse(controls.recordEnabled)
+    assertTrue(controls.resetRecordEnabled)
+  }
+}


### PR DESCRIPTION
## Summary

- add deterministic input recording from the current session or a clean boot
- add replay loading, playback, pause, stop, and desktop tape controls
- integrate replay persistence with state storage and lifecycle handling
- streamline tape controls with immediate recording, autoplay after loading, focus restoration, and automatic selection of the latest recording

## Testing

- /opt/maven/bin/mvn -pl swing -am -Dtest=InputRecordingWindowTest -Dsurefire.failIfNoSpecifiedTests=false test