### PR TITLE
Fix Dragon Tales HDMA graphics corruption

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -367,7 +367,7 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
                 executionMode, hardwareProfile, configuration.debugHistoryReplay);
         mmu.setGpu(gpu);
         statRegister.init(gpu);
-        hdma = new Hdma(getAddressSpace(), speedMode);
+        hdma = new Hdma(getAddressSpace(), speedMode, gpu::writeSelectedVideoRamForHdma);
         gpu.setHdma(hdma);
         sound = new Sound(timer, speedMode, gbc, clockSpec, executionMode);
         joypad = new Joypad(interruptManager, sgbBus, sgb, configuration.playerInputSource);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -496,6 +496,16 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         videoRam0.setByte(address, value);
     }
 
+    /**
+     * Writes the selected physical VRAM bank through the CGB DMA destination bus.
+     * Unlike CPU writes, an already-granted transfer retains ownership if its block
+     * completion crosses into mode 3.
+     */
+    public void writeSelectedVideoRamForHdma(int address, int value) {
+        materializeSteadyTiming();
+        selectedVideoRam().setByte(address, value);
+    }
+
     /** Core HDMA helper that reads the selected physical bank without exposing its RAM object. */
     public int readSelectedVideoRamForCore(int address) {
         materializeSteadyTiming();

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/Hdma.java
@@ -17,6 +17,12 @@ import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
 public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
 
+    @FunctionalInterface
+    public interface VramWriter {
+
+        void setByte(int address, int value);
+    }
+
     private enum HaltHdmaState {
         LOW,
         HIGH,
@@ -66,6 +72,8 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
     private final AddressSpace addressSpace;
 
     private final SpeedMode speedMode;
+
+    private final VramWriter vramWriter;
 
     private Mode gpuMode;
 
@@ -169,8 +177,13 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
     }
 
     public Hdma(AddressSpace addressSpace, SpeedMode speedMode) {
+        this(addressSpace, speedMode, addressSpace::setByte);
+    }
+
+    public Hdma(AddressSpace addressSpace, SpeedMode speedMode, VramWriter vramWriter) {
         this.addressSpace = addressSpace;
         this.speedMode = speedMode;
+        this.vramWriter = vramWriter;
     }
 
     public long getPpuBusGeneration() {
@@ -227,7 +240,7 @@ public class Hdma implements AddressSpace, StatefulComponent<Hdma> {
         // be visible per byte for HDMA/OAM-DMA bus sharing.
         for (int j = 0; j < 0x10; j++) {
             int destinationAddress = 0x8000 | ((dst + j) & 0x1fff);
-            addressSpace.setByte(destinationAddress, blockData[j]);
+            vramWriter.setByte(destinationAddress, blockData[j]);
             if (debugMemoryHooks) {
                 notifyMemoryAccess(
                         DebugAddressSpace.VIDEO_RAM,

--- a/core/src/test/java/eu/rekawek/coffeegb/core/GameboyHdmaArbitrationTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/GameboyHdmaArbitrationTest.java
@@ -198,6 +198,43 @@ public class GameboyHdmaArbitrationTest {
         }
     }
 
+    @Test
+    public void vramDmaDestinationBypassesCpuMode3Lock() throws IOException {
+        byte[] rom = new byte[0x8000];
+        rom[0x143] = (byte) 0x80;
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(rom))
+                .setBootstrapMode(Gameboy.BootstrapMode.SKIP)
+                .setGameboyType(GameboyType.CGB)
+                .setSupportBatterySave(false)
+                .build()) {
+            AddressSpace bus = gameboy.getAddressSpace();
+            for (int i = 0; i < 0x10; i++) {
+                bus.setByte(0xc100 + i, 0xa0 + i);
+            }
+
+            int guard = 2000;
+            while (guard-- > 0 && (gameboy.getGpu().getMode() != Mode.PixelTransfer
+                    || gameboy.getGpu().getTicksInLine() < 100)) {
+                gameboy.tick();
+            }
+            assertTrue(guard > 0);
+
+            bus.setByte(0xff51, 0xc1);
+            bus.setByte(0xff52, 0);
+            bus.setByte(0xff53, 0);
+            bus.setByte(0xff54, 0);
+            bus.setByte(0xff55, 0);
+            while (gameboy.getHdma().isTransferInProgress()) {
+                gameboy.getHdma().tick();
+            }
+
+            assertEquals(Mode.PixelTransfer, gameboy.getGpu().getMode());
+            for (int i = 0; i < 0x10; i++) {
+                assertEquals(0xa0 + i, gameboy.getGpu().getVideoRam0().getByte(0x8000 + i));
+            }
+        }
+    }
+
     private static final class Fixture implements AutoCloseable {
 
         private final Gameboy gameboy;


### PR DESCRIPTION
Fixes #656.

## What changed

- give CGB VRAM DMA a dedicated destination-bus writer instead of routing completed blocks through CPU VRAM access rules
- retain ordinary CPU mode-3 write locking
- add a regression for a DMA block whose completion occurs during pixel transfer

Dragon Tales starts an HBlank DMA burst late enough that its atomic destination commit crosses into mode 3. The previous shared write path reported the DMA transfer but silently dropped its VRAM writes because the CPU bus was locked, leaving the game's tile data blank.

## Verification

- `/opt/maven/bin/mvn -pl core -Dtest=GameboyHdmaArbitrationTest,HdmaTest test` (62 tests)
- `/opt/maven/bin/mvn -pl core test` (2,045 tests; 8 skipped)
- `/opt/maven/bin/mvn -pl core test -Ptest-gbc-hw,test-mooneye,test-dmgacid2,test-cgbacid2` (353 tests)
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg` (54 tests)
- exact reported European game, authentic CGB boot, frame 1200

| Before | After |
| --- | --- |
| ![Blank green frame before the fix](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Dragon_Tales_Dragon_Wings_Europe_gbc_f1200-0184dd55.png) | ![Dragon Tales title screen after the fix](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/Dragon_Tales_Dragon_Wings_Europe_gbc_f1200-43726874.png) |
