### PR TITLE
Add a generic TV remote for CGB infrared games

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/StateTypeRegistry.kt
@@ -127,6 +127,7 @@ internal object StateTypeRegistry {
           "eu.rekawek.coffeegb.core.gpu.ScalarTimingDmgPixelFifo\$State",
           "eu.rekawek.coffeegb.core.gpu.ScalarTimingColorPixelFifo\$State",
           "eu.rekawek.coffeegb.core.memory.cart.type.Ggb81\$Ggb81State",
+          "eu.rekawek.coffeegb.core.ir.TvRemote\$TvRemoteState",
       )
 
   val legacyRecordClassNames =

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/DetachedState.kt
@@ -939,6 +939,10 @@ internal object DetachedStateAdapter {
 }
 
 internal object StateGraph {
+  private const val INFRARED_PORT_STATE =
+      "eu.rekawek.coffeegb.core.ir.InfraredPort\$InfraredPortState"
+  private const val TV_REMOTE_STATE = "eu.rekawek.coffeegb.core.ir.TvRemote\$TvRemoteState"
+
   private val recordIds by lazy {
     StateTypeRegistry.recordClasses.withIndex().associate { (index, type) -> type to index + 1 }
   }
@@ -981,9 +985,9 @@ internal object StateGraph {
 
   /**
    * Returns the stable wire/hash view of one record without changing the detached value itself.
-   * PERFORMANCE appends only defaultable execution metadata to the historical Sound/GPU records;
-   * when those fields are at their legacy defaults, omit them for canonical encoding and replay
-   * hashing. Non-default metadata, and already-decoded historical prefixes, remain untouched.
+   * New execution metadata and inactive accessory state are append-only. When those fields are at
+   * their historical defaults, omit them for canonical encoding and replay hashing. Non-default
+   * metadata, and already-decoded historical prefixes, remain untouched.
    */
   internal fun canonicalRecordFields(value: RecordState): List<StateField> {
     val fields = value.fields
@@ -1014,6 +1018,14 @@ internal object StateGraph {
             fields.last().value == Int32State(0)) {
           val counter = fields[fields.lastIndex - 3].value
           if (counter == Int32State(-1)) fields.dropLast(4) else fields.dropLast(3)
+        } else {
+          fields
+        }
+      }
+      INFRARED_PORT_STATE -> {
+        if (fields.lastOrNull()?.name == "tvRemoteMemento" &&
+            fields.last().value == idleTvRemoteState()) {
+          fields.dropLast(1)
         } else {
           fields
         }
@@ -1071,6 +1083,12 @@ internal object StateGraph {
       }
     }
 
+    if (typeName == INFRARED_PORT_STATE &&
+        value.fields.size == names.size - 1 &&
+        value.fields.map(StateField::name) == names.dropLast(1)) {
+      return value.fields + StateField("tvRemoteMemento", idleTvRemoteState())
+    }
+
     val gpuType = typeName == "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuState"
     if (!gpuType) {
       return value.fields
@@ -1099,6 +1117,20 @@ internal object StateGraph {
       )
     }
     return value.fields
+  }
+
+  private fun idleTvRemoteState(): RecordState {
+    val typeId = StateTypeRegistry.recordClassNames.indexOf(TV_REMOTE_STATE) + 1
+    check(typeId > 0) { "TV remote state is not registered" }
+    return RecordState(
+        typeId,
+        listOf(
+            StateField("armed", BooleanState(false)),
+            StateField("running", BooleanState(false)),
+            StateField("index", Int32State(0)),
+            StateField("remaining", Int32State(0)),
+        ),
+    )
   }
 
   private class Capture(private val admittedRecordIds: Map<Class<*>, Int>) {

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateSemantics.kt
@@ -485,6 +485,26 @@ internal object StateSemantics {
               }
             }
           })
+      put("eu.rekawek.coffeegb.core.ir.TvRemote\$TvRemoteState",
+          constrained("The fixed NEC envelope has one armed, running, completed, or idle position.") {
+            val armed = it.boolean("armed")
+            val running = it.boolean("running")
+            val index = it.int("index")
+            val remaining = it.int("remaining")
+            it.require(!(armed && running), "cannot be both armed and running")
+            it.range("index", 0, TV_REMOTE_SCHEDULE_SIZE)
+            it.range("remaining", -1, TV_REMOTE_LEADER_BURST_CYCLES)
+            when {
+              armed -> it.require(index == 0 && remaining == 0,
+                  "has an invalid armed pulse position")
+              running -> it.require(index < TV_REMOTE_SCHEDULE_SIZE && remaining > 0,
+                  "has an invalid running pulse position")
+              index == 0 -> it.require(remaining == 0,
+                  "has an invalid idle pulse position")
+              else -> it.require(index == TV_REMOTE_SCHEDULE_SIZE && remaining <= 0,
+                  "has an invalid completed pulse position")
+            }
+          })
 
       // DMA/PPU queues, phase indices, and delayed-write collections.
       put("eu.rekawek.coffeegb.core.memory.Dma\$DmaState",
@@ -1866,6 +1886,8 @@ internal object StateSemantics {
   private const val SGB_DISPLAY_FADE_MASK = 0xff
   private const val SGB_DISPLAY_STATE_ALLOWED_BITS = 0x1ff
   private const val FULL_CHANGER_SCHEDULE_SIZE = 36
+  private const val TV_REMOTE_SCHEDULE_SIZE = 67
+  private const val TV_REMOTE_LEADER_BURST_CYCLES = 37_749
   private const val BARCODE_FRAME_SIZE = 30
   private const val MOBILE_PACKET_DATA_BYTES = 254
   private const val MOBILE_PACKET_BYTES = 262

--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateValueCodec.kt
@@ -333,10 +333,10 @@ internal object StateValueCodec {
   }
 
   /**
-   * StateFile v1/v2 are byte-stable formats.  The PERFORMANCE fields appended to these two
-   * records are transient/defaultable, so released files with their historical prefixes remain
-   * valid and must be retained at their original arity for exact re-encoding.  Restore-time
-   * normalization supplies the omitted values before constructing the live Java record.
+   * StateFile v1/v2 are byte-stable formats. Appended transient/defaultable fields and inactive
+   * accessory state leave released files with their historical prefixes valid. Those prefixes
+   * must be retained at their original arity for exact re-encoding; restore-time normalization
+   * supplies omitted values before constructing the live Java record.
    */
   private fun acceptedFieldInventories(
       type: Class<*>,
@@ -348,6 +348,8 @@ internal object StateValueCodec {
           listOf(names, names.dropLast(2))
       "eu.rekawek.coffeegb.core.gpu.Gpu\$GpuState" ->
           listOf(names, names.dropLast(3), names.dropLast(4))
+      "eu.rekawek.coffeegb.core.ir.InfraredPort\$InfraredPortState" ->
+          listOf(names, names.dropLast(1))
       else -> listOf(names)
     }
   }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateCoverageMatrixTest.kt
@@ -5,6 +5,7 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode
 import eu.rekawek.coffeegb.core.events.EventBusImpl
 import eu.rekawek.coffeegb.core.ir.FullChanger
 import eu.rekawek.coffeegb.core.ir.InfraredPort
+import eu.rekawek.coffeegb.core.ir.TvRemote
 import eu.rekawek.coffeegb.core.state.MachineStateCapture
 import eu.rekawek.coffeegb.core.state.ComponentState
 import eu.rekawek.coffeegb.core.memory.cart.MemoryController
@@ -445,6 +446,24 @@ class StateCoverageMatrixTest {
       infrared.getByte(0xff56)
       assertEquals(completedContinuation, continueInfrared(infrared, 600))
       assertEquals(completedExpected, StateGraph.capture(infrared.captureState()))
+
+      irBus.post(TvRemote.SendSignalEvent())
+      infrared.setByte(0xff56, 0xc0)
+      infrared.getByte(0xff56)
+      repeat(5_000) { infrared.tick() }
+      val activeRemote = StateGraph.capture(infrared.captureState())
+      val remote = activeRemote.record(TV_REMOTE_MEMENTO)
+      assertTrue(!remote.bool("armed"))
+      assertTrue(remote.bool("running"))
+      StateSemantics.validate(StateGraph.restore(activeRemote))
+
+      val expectedRemoteTrace = continueInfrared(infrared, 50_000)
+      val expectedRemote = StateGraph.capture(infrared.captureState())
+      @Suppress("UNCHECKED_CAST")
+      infrared.restoreState(
+          StateGraph.restore(activeRemote) as ComponentState<InfraredPort>)
+      assertEquals(expectedRemoteTrace, continueInfrared(infrared, 50_000))
+      assertEquals(expectedRemote, StateGraph.capture(infrared.captureState()))
     }
   }
 
@@ -852,6 +871,7 @@ class StateCoverageMatrixTest {
         "eu.rekawek.coffeegb.core.memory.cart.type.Mbc7Eeprom\$EepromState"
     const val DATEL_MEMENTO = "eu.rekawek.coffeegb.core.memory.cart.type.Datel\$DatelState"
     const val FULL_CHANGER_MEMENTO = "eu.rekawek.coffeegb.core.ir.FullChanger\$FullChangerState"
+    const val TV_REMOTE_MEMENTO = "eu.rekawek.coffeegb.core.ir.TvRemote\$TvRemoteState"
     val DEFAULT_MAPPER_PROBES = listOf(0x0100, 0x4000, 0x7000, 0x7fe1, 0xa000, 0xa001)
 
     val EXPECTED_MAPPER_FAMILIES =

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/InfraredPort.java
@@ -22,7 +22,8 @@ import eu.rekawek.coffeegb.core.serial.SerialEndpoint;
  * DMG-compatibility mode (reads 0xFF), matching the other CGB-only registers.
  *
  * <p>Received light comes from a pluggable external device. Supported sources are another
- * linked Game Boy and the {@link FullChanger} (Zok Zok Heroes).
+ * linked Game Boy, the {@link FullChanger} (Zok Zok Heroes), and a generic
+ * {@link TvRemote}.
  */
 public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPort> {
 
@@ -35,6 +36,10 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
     private final FullChanger fullChanger = new FullChanger();
 
     private transient boolean fullChangerActive;
+
+    private final TvRemote tvRemote = new TvRemote();
+
+    private transient boolean tvRemoteActive;
 
     private transient InfraredEndpoint endpoint = InfraredEndpoint.NULL_ENDPOINT;
 
@@ -70,6 +75,12 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
             fullChanger.transform(e.characterId());
             fullChangerActive = true;
         }, FullChanger.TransformEvent.class);
+        eventBus.register(e -> {
+            if (gbc && !speedMode.isDmgCompat()) {
+                tvRemote.sendSignal();
+                tvRemoteActive = true;
+            }
+        }, TvRemote.SendSignalEvent.class);
     }
 
     /** Connects RP bit 4 to the CGB link port's serial-input pin. */
@@ -92,6 +103,9 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
             // double speed so a game sees the same delays regardless of its speed setting
             fullChangerActive = fullChanger.tick(speedMode.getSpeedMode());
         }
+        if (tvRemoteActive) {
+            tvRemoteActive = tvRemote.tick(speedMode.getSpeedMode());
+        }
         if (debugHooks != null) {
             notifyDebugSignalChange();
         }
@@ -99,12 +113,13 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
 
     /**
      * Returns the exact idle CGB IR span. External infrared endpoints, non-quiet serial inputs,
-     * and the FullChanger are deliberately fail-closed: their callbacks or pulse edges must
-     * remain visible in the scalar ordering.
+     * and emulated infrared accessories are deliberately fail-closed: their callbacks or pulse
+     * edges must remain visible in the scalar ordering.
      */
     public int performanceQuietSpanLimit(int requested) {
         if (requested <= 0 || !gbc || speedMode.getSpeedMode() != 1
                 || fullChangerActive
+                || tvRemoteActive
                 || endpoint != InfraredEndpoint.NULL_ENDPOINT
                 || !serialEndpoint.canTickPerformanceQuietSpan(requested)
                 || debugHooks != null) {
@@ -117,6 +132,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
     public int performanceSettledHaltSpanLimit(int requested) {
         if (requested <= 0 || !gbc || speedMode.getSpeedMode() != 1
                 || fullChangerActive
+                || tvRemoteActive
                 || endpoint != InfraredEndpoint.NULL_ENDPOINT
                 || !serialEndpoint.canTickPerformanceQuietSpan(requested)
                 || debugHooks != null) {
@@ -137,7 +153,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         if (ticks <= 0) {
             return;
         }
-        // The packet preflight proves an inactive FullChanger, null IR endpoint, and quiet serial
+        // The packet preflight proves inactive IR accessories, a null endpoint, and quiet serial
         // input. There is no arithmetic state to advance, so the trusted commit is a no-op.
     }
 
@@ -147,6 +163,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
                 && speedMode.getSpeedMode() == 2
                 && requested > 0
                 && !fullChangerActive
+                && !tvRemoteActive
                 && endpoint == InfraredEndpoint.NULL_ENDPOINT
                 && serialEndpoint.canTickPerformanceQuietSpan(requested)
                 && debugHooks == null;
@@ -154,7 +171,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
 
     /** The idle epoch has no IR state to advance. */
     public void tickPerformanceEpochIdle(int ticks) {
-        // Intentionally empty: the null endpoint and inactive FullChanger were preflighted.
+        // Intentionally empty: the null endpoint and inactive IR accessories were preflighted.
     }
 
     @Override
@@ -177,6 +194,7 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         // an armed device starts transmitting at a poll of the register, so the polling
         // loop observes the first pulse from its beginning
         fullChanger.onRpRead();
+        tvRemote.onRpRead();
         notifyDebugSignalChange();
         // Bits 2, 3 and 5 are pulled high. Bit 4 is not unused on CGB hardware: it
         // exposes link-port pin 4 as a raw digital input for software UARTs.
@@ -189,21 +207,21 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         // light source. In the normal $C0 receive mode it is active-low only
         // while infrared light is present.
         if (readMode == 0x80
-                || (readMode == 0xc0 && (fullChanger.isLightOn() || endpoint.isLightOn()))) {
+                || (readMode == 0xc0 && receivedLight())) {
             result &= ~0x02;
         }
         return result;
     }
 
     /**
-     * Captures RP and its physical inputs without calling {@code FullChanger.onRpRead()}.
-     * Ordinary FF56 reads intentionally arm/advance some infrared peripherals.
+     * Captures RP and its physical inputs without polling emulated infrared accessories.
+     * Ordinary FF56 reads intentionally start an armed accessory transmission.
      */
     public DebugHardwareInspection.Infrared captureDebugInfraredInspection(boolean available) {
         if (!available) {
             return new DebugHardwareInspection.Infrared(false, -1, false, false, false);
         }
-        boolean receivedLight = fullChanger.isLightOn() || endpoint.isLightOn();
+        boolean receivedLight = receivedLight();
         boolean serialInputHigh = serialEndpoint.isSerialInputHigh();
         int result = rp | 0x2c | 0x02;
         if (serialInputHigh) {
@@ -219,12 +237,13 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
 
     @Override
     public ComponentState<InfraredPort> captureState() {
-        return new InfraredPortState(rp, fullChanger.captureState());
+        return new InfraredPortState(rp, fullChanger.captureState(), tvRemote.captureState());
     }
 
     @Override
     public ComponentState<InfraredPort> captureState(MachineStateCapture capture) {
-        return new InfraredPortState(rp, fullChanger.captureState(capture));
+        return new InfraredPortState(
+                rp, fullChanger.captureState(capture), tvRemote.captureState(capture));
     }
 
     @Override
@@ -236,6 +255,8 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
         endpoint.setLightOn((rp & 0x01) != 0);
         fullChanger.restoreState(mem.fullChangerMemento);
         fullChangerActive = fullChanger.isActive();
+        tvRemote.restoreState(mem.tvRemoteMemento);
+        tvRemoteActive = tvRemote.isActive();
         alignDebugSignal();
     }
 
@@ -267,16 +288,25 @@ public class InfraredPort implements AddressSpace, StatefulComponent<InfraredPor
 
     private int getDebugSignal() {
         int localOutput = rp & 0x01;
-        int receivedLight = fullChanger.isLightOn() || endpoint.isLightOn() ? 0x02 : 0;
+        int receivedLight = receivedLight() ? 0x02 : 0;
         return localOutput | receivedLight;
     }
 
-    private record InfraredPortState(int rp, ComponentState<FullChanger> fullChangerMemento)
+    private boolean receivedLight() {
+        return fullChanger.isLightOn() || tvRemote.isLightOn() || endpoint.isLightOn();
+    }
+
+    private record InfraredPortState(
+            int rp,
+            ComponentState<FullChanger> fullChangerMemento,
+            ComponentState<TvRemote> tvRemoteMemento)
             implements ComponentState<InfraredPort> {
     }
 
     /** Importer-only compatibility record for released local snapshots. */
-    private record InfraredPortMemento(int rp, Memento<FullChanger> fullChangerMemento)
+    private record InfraredPortMemento(
+            int rp,
+            Memento<FullChanger> fullChangerMemento)
             implements Memento<InfraredPort> {
     }
 }

--- a/core/src/main/java/eu/rekawek/coffeegb/core/ir/TvRemote.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/ir/TvRemote.java
@@ -1,0 +1,139 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.events.Event;
+import eu.rekawek.coffeegb.core.memento.Memento;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import eu.rekawek.coffeegb.core.state.MachineStateCapture;
+import eu.rekawek.coffeegb.core.state.StatefulComponent;
+
+/**
+ * A generic NEC television-remote transmission for games that use the CGB infrared sensor.
+ *
+ * <p>The receiver sees the demodulated carrier envelope: a 9 ms leader burst and 4.5 ms
+ * space, followed by 32 LSB-first bits. Each bit starts with a 562.5 us burst; a zero has a
+ * 562.5 us space and a one a 1.6875 ms space. The frame carries the conventional address,
+ * inverse-address, command, and inverse-command bytes. A user action arms the remote and the
+ * first RP read starts it, so a polling loop observes the leader from its beginning.
+ */
+public class TvRemote implements StatefulComponent<TvRemote> {
+
+    /** The player points a generic television remote at the CGB and presses a button. */
+    public record SendSignalEvent() implements Event {
+    }
+
+    // Durations in CGB CPU T-cycles at normal speed, rounded from the NEC timings.
+    static final int LEADER_BURST_CYCLES = 37_749;
+
+    static final int LEADER_SPACE_CYCLES = 18_874;
+
+    static final int BIT_BURST_CYCLES = 2_359;
+
+    static final int ZERO_SPACE_CYCLES = 2_359;
+
+    static final int ONE_SPACE_CYCLES = 7_078;
+
+    // A valid, deterministic NEC frame. Games generally classify the envelope rather than the
+    // particular key; complements make the frame acceptable to decoders that validate bytes.
+    private static final int ADDRESS = 0x00;
+
+    private static final int COMMAND = 0x10;
+
+    private static final int[] SCHEDULE = buildSchedule();
+
+    private boolean armed;
+
+    private boolean running;
+
+    private int index;
+
+    private int remaining;
+
+    /** Queues one complete NEC frame, replacing any pending or running frame. */
+    public void sendSignal() {
+        armed = true;
+        running = false;
+        index = 0;
+        remaining = 0;
+    }
+
+    void onRpRead() {
+        if (armed) {
+            armed = false;
+            running = true;
+            index = 0;
+            remaining = SCHEDULE[0];
+        }
+    }
+
+    boolean tick(int cycles) {
+        if (!running) {
+            return armed;
+        }
+        remaining -= cycles;
+        while (remaining <= 0) {
+            if (++index >= SCHEDULE.length) {
+                running = false;
+                return false;
+            }
+            remaining += SCHEDULE[index];
+        }
+        return true;
+    }
+
+    boolean isActive() {
+        return armed || running;
+    }
+
+    boolean isLightOn() {
+        return running && (index & 1) == 0;
+    }
+
+    private static int[] buildSchedule() {
+        int[] schedule = new int[2 + 32 * 2 + 1];
+        int offset = 0;
+        schedule[offset++] = LEADER_BURST_CYCLES;
+        schedule[offset++] = LEADER_SPACE_CYCLES;
+        int frame = ADDRESS
+                | ((~ADDRESS & 0xff) << 8)
+                | (COMMAND << 16)
+                | ((~COMMAND & 0xff) << 24);
+        for (int bit = 0; bit < 32; bit++) {
+            schedule[offset++] = BIT_BURST_CYCLES;
+            schedule[offset++] = (frame & (1 << bit)) == 0
+                    ? ZERO_SPACE_CYCLES
+                    : ONE_SPACE_CYCLES;
+        }
+        schedule[offset] = BIT_BURST_CYCLES;
+        return schedule;
+    }
+
+    @Override
+    public ComponentState<TvRemote> captureState() {
+        return new TvRemoteState(armed, running, index, remaining);
+    }
+
+    @Override
+    public ComponentState<TvRemote> captureState(MachineStateCapture capture) {
+        return captureState();
+    }
+
+    @Override
+    public void restoreState(ComponentState<TvRemote> state) {
+        if (!(state instanceof TvRemoteState mem)) {
+            throw new IllegalArgumentException("Invalid state type");
+        }
+        armed = mem.armed;
+        running = mem.running;
+        index = mem.index;
+        remaining = mem.remaining;
+    }
+
+    private record TvRemoteState(boolean armed, boolean running, int index, int remaining)
+            implements ComponentState<TvRemote> {
+    }
+
+    /** Importer-only compatibility record for released local snapshots. */
+    private record TvRemoteMemento(boolean armed, boolean running, int index, int remaining)
+            implements Memento<TvRemote> {
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/ir/TvRemoteTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/ir/TvRemoteTest.java
@@ -1,0 +1,102 @@
+package eu.rekawek.coffeegb.core.ir;
+
+import eu.rekawek.coffeegb.core.cpu.SpeedMode;
+import eu.rekawek.coffeegb.core.events.EventBusImpl;
+import eu.rekawek.coffeegb.core.state.ComponentState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TvRemoteTest {
+
+    private final SpeedMode speedMode = new SpeedMode(true);
+
+    private final InfraredPort port = new InfraredPort(true, speedMode);
+
+    @Test
+    public void sendsValidNecFrameAfterFirstRpPoll() {
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        port.init(bus);
+        port.setByte(0xff56, 0xc0);
+        bus.post(new TvRemote.SendSignalEvent());
+
+        int[] durations = captureEnvelope();
+        assertEquals(TvRemote.LEADER_BURST_CYCLES, durations[0]);
+        assertEquals(TvRemote.LEADER_SPACE_CYCLES, durations[1]);
+
+        int frame = 0;
+        for (int bit = 0; bit < 32; bit++) {
+            assertEquals(TvRemote.BIT_BURST_CYCLES, durations[2 + bit * 2]);
+            int space = durations[3 + bit * 2];
+            if (space == TvRemote.ONE_SPACE_CYCLES) {
+                frame |= 1 << bit;
+            } else {
+                assertEquals(TvRemote.ZERO_SPACE_CYCLES, space);
+            }
+        }
+        assertEquals(TvRemote.BIT_BURST_CYCLES, durations[66]);
+
+        int address = frame & 0xff;
+        int inverseAddress = frame >> 8 & 0xff;
+        int command = frame >> 16 & 0xff;
+        int inverseCommand = frame >> 24 & 0xff;
+        assertEquals(0x00, address);
+        assertEquals(0x10, command);
+        assertEquals(0xff, address ^ inverseAddress);
+        assertEquals(0xff, command ^ inverseCommand);
+    }
+
+    @Test
+    public void stateRoundTripContinuesSameEnvelope() {
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        port.init(bus);
+        port.setByte(0xff56, 0xc0);
+        bus.post(new TvRemote.SendSignalEvent());
+        port.getByte(0xff56);
+        for (int i = 0; i < TvRemote.LEADER_BURST_CYCLES + 1234; i++) {
+            port.tick();
+        }
+        ComponentState<InfraredPort> state = port.captureState();
+
+        InfraredPort restored = new InfraredPort(true, speedMode);
+        restored.restoreState(state);
+        for (int i = 0; i < 150_000; i++) {
+            assertEquals(port.getByte(0xff56), restored.getByte(0xff56));
+            port.tick();
+            restored.tick();
+        }
+    }
+
+    @Test
+    public void ignoresRemoteActionInDmgCompatibilityMode() {
+        speedMode.setDmgCompat(true);
+        EventBusImpl bus = new EventBusImpl(null, null, false);
+        port.init(bus);
+        bus.post(new TvRemote.SendSignalEvent());
+
+        speedMode.setDmgCompat(false);
+        port.setByte(0xff56, 0xc0);
+        assertEquals(false, isLightOn());
+    }
+
+    private int[] captureEnvelope() {
+        int[] durations = new int[67];
+        boolean lightOn = isLightOn(); // the first read starts the leader burst
+        assertEquals(true, lightOn);
+        for (int segment = 0; segment < durations.length; segment++) {
+            int ticks = 0;
+            do {
+                port.tick();
+                ticks++;
+            } while (isLightOn() == lightOn && ticks < 100_000);
+            durations[segment] = ticks;
+            lightOn = !lightOn;
+        }
+        assertEquals(false, isLightOn());
+        return durations;
+    }
+
+    private boolean isLightOn() {
+        return (port.getByte(0xff56) & 0x02) == 0;
+    }
+}

--- a/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
+++ b/swing/src/main/java/eu/rekawek/coffeegb/swing/SwingMenu.kt
@@ -15,6 +15,7 @@ import eu.rekawek.coffeegb.core.genie.AddPatches
 import eu.rekawek.coffeegb.core.genie.CheatDatabase
 import eu.rekawek.coffeegb.core.genie.PatchFactory
 import eu.rekawek.coffeegb.core.ir.FullChanger
+import eu.rekawek.coffeegb.core.ir.TvRemote
 import eu.rekawek.coffeegb.swing.io.DesktopCameraSource
 import eu.rekawek.coffeegb.swing.io.WebcamCameraSource
 import java.awt.Component
@@ -534,6 +535,14 @@ internal class SwingMenu(
           },
       )
     }
+
+    val tvRemote = JMenuItem("Send TV Remote Signal")
+    tvRemote.accessibleContext.accessibleDescription =
+        "Send a generic NEC television-remote signal to the Game Boy Color infrared sensor"
+    peripheralsMenu.add(tvRemote)
+    tvRemote.isEnabled = false
+    enableWhenEmulationActive(tvRemote)
+    tvRemote.addActionListener { eventBus.post(TvRemote.SendSignalEvent()) }
 
     val scanBarcode = JMenuItem("Barcode Boy…")
     scanBarcode.accessibleContext.accessibleDescription =


### PR DESCRIPTION
Fixes #657

## Summary
- add a stateful generic NEC television-remote transmitter to the CGB RP input
- start an armed frame on the first RP poll so the leader pulse is observed from its beginning
- preserve in-flight frames in portable save states while keeping released state files and replay hashes byte-compatible
- keep IR pulse edges out of performance-mode bulk spans
- add **Peripherals → Send TV Remote Signal** to the desktop UI

## Protocol
The transmitter sends the demodulated NEC envelope: a 9 ms leader, 4.5 ms space, then a conventional 32-bit address/inverse-address/command/inverse-command frame with 562.5 us bursts and 0/1 spaces. This targets the valid-TV-remote behavior discussed in the linked GBE+ reports, while also providing the on/off edges accepted by games that only detect arbitrary IR activity.

## State compatibility
The TV remote record is appended to the portable type registry. Idle accessory state is omitted from the canonical representation, and historical `InfraredPortState` prefixes restore with an idle remote. The released legacy memento schema remains unchanged. Semantic validation constrains every armed, running, completed, and idle pulse position.

## Verification
- full Maven reactor (`mvn -B package`): all 7 modules successful
- core: 2,046 tests, 0 failures, 8 skipped
- controller: 968 tests, 0 failures, 2 skipped
- Swing: 854 tests, 0 failures, 1 skipped
- focused portable-state/replay/link regression set: 102 controller tests, 0 failures
- focused IR tests: 15 tests, 0 failures
- Mooneye + dmg-acid2 + cgb-acid2: 132 tests, 0 failures
- Blargg aggregate + individual: 54 tests, 0 failures

The regression decodes the emitted envelope, verifies exact NEC timings and complementary bytes, checks DMG-compatibility gating, proves save-state continuation mid-frame, and exercises active remote capture/restore through the portable state graph.