### PR TITLE
Fix Yu-Gi-Oh Early Days card graphics

### DIFF
--- a/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/Gameboy.java
@@ -364,6 +364,8 @@ public class Gameboy implements Runnable, StatefulComponent<Gameboy>, Closeable 
         gpu = new Gpu(display, dma, oamRam, vRamTransfer, statRegister, gbc, speedMode,
                 configuration.mealybugDmgBlob,
                 cartridgeProperties.has(CartridgeProperties.Feature.EARLY_CGB_LY_READ_EDGE),
+                cartridgeProperties.has(
+                        CartridgeProperties.Feature.YUGIOH_EARLY_DAYS_CARD_VRAM_WRITES),
                 executionMode, hardwareProfile, configuration.debugHistoryReplay);
         mmu.setGpu(gpu);
         statRegister.init(gpu);

--- a/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/gpu/Gpu.java
@@ -75,6 +75,8 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
 
     private final boolean earlyCgbLyReadEdge;
 
+    private final boolean yugiohEarlyDaysCardVramWrites;
+
     // Construction-time capability supplied by Gameboy.  This is deliberately a positive,
     // profile-filtered permission rather than a raw execution mode: only normal-speed DMG/MGB,
     // SGB/SGB2, ordinary CGB compatibility, and native CGB/CGB0 sessions without history/replay
@@ -311,13 +313,14 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
                boolean mealybugDmgBlob, boolean earlyCgbLyReadEdge) {
         this(display, dma, oamRam, vRamTransfer, statRegister, gbc, speedMode,
                 mealybugDmgBlob, earlyCgbLyReadEdge,
-                ExecutionMode.ACCURACY, null, false);
+                false, ExecutionMode.ACCURACY, null, false);
     }
 
     public Gpu(Display display, Dma dma, Ram oamRam, VRamTransfer vRamTransfer,
                StatRegister statRegister, boolean gbc,
                eu.rekawek.coffeegb.core.cpu.SpeedMode speedMode,
                boolean mealybugDmgBlob, boolean earlyCgbLyReadEdge,
+               boolean yugiohEarlyDaysCardVramWrites,
                ExecutionMode executionMode, HardwareProfile hardwareProfile,
                boolean debugHistoryReplay) {
         this.statRegister = statRegister;
@@ -328,6 +331,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         this.gbc = gbc;
         this.speedMode = speedMode;
         this.earlyCgbLyReadEdge = earlyCgbLyReadEdge;
+        this.yugiohEarlyDaysCardVramWrites = yugiohEarlyDaysCardVramWrites;
         this.performanceSteadyTiming = executionMode == ExecutionMode.PERFORMANCE
                 && !debugHistoryReplay
                 && (hardwareProfile == HardwareProfileRegistry.DMG
@@ -547,7 +551,7 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         }
         if (!shouldDelayPpuWrite(address, value)) {
             cancelPendingPpuWrites(address);
-            setByteImmediately(address, value);
+            setByteImmediately(address, value, true);
             return;
         }
 
@@ -559,12 +563,16 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         // value also preserves the DMG's separate write-strobe effects (notably the
         // immediate WX "just changed" pulse) while the synchronized value is pending.
         int immediateValue = (value & ~mask) | (current & mask);
-        setByteImmediately(address, immediateValue);
+        setByteImmediately(address, immediateValue, true);
         pendingPpuWrites.add(new PendingPpuWriteRuntime(
                 address, value, mask, getPpuWriteDelayDots(address)));
     }
 
     private void setByteImmediately(int address, int value) {
+        setByteImmediately(address, value, false);
+    }
+
+    private void setByteImmediately(int address, int value, boolean fromCpu) {
         if (address == LYC.getAddress()) {
             statRegister.onLycWrite(r.get(LYC), value);
         }
@@ -600,7 +608,9 @@ public class Gpu implements AddressSpace, StatefulComponent<Gpu> {
         }
         if (videoRam0.accepts(address)) {
             lastCpuVramWriteTick = ticksInLine;
-            if (isVramAvailableForCpu(true)) {
+            if (isVramAvailableForCpu(true)
+                    || (fromCpu && yugiohEarlyDaysCardVramWrites
+                    && address < 0x8500)) {
                 selectedVideoRam().setByte(address, value);
             }
             return;

--- a/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/memory/cart/CartridgeProperties.java
@@ -79,7 +79,8 @@ public final class CartridgeProperties {
         SHIKINJOU_LINK_ROLE_PATCH,
         VOLLEY_FIRE_LINK_ROLE_PATCH,
         HARVEST_MOON_LINK_ROLE_PATCH,
-        IKARI_YOUSAI_2_LINK_ROLE_PATCH
+        IKARI_YOUSAI_2_LINK_ROLE_PATCH,
+        YUGIOH_EARLY_DAYS_CARD_VRAM_WRITES
     }
 
     private static final int[] NINTENDO_LOGO = {
@@ -212,6 +213,9 @@ public final class CartridgeProperties {
             features("Jantaku Boy four-player transition workaround",
                     CartridgeProperties::isJantakuBoyFourPlayer,
                     Feature.JANTAKU_BOY_FOUR_PLAYER_PATCH),
+            features("Yu-Gi-Oh Early Days card tile upload",
+                    CartridgeProperties::isYugiohEarlyDaysCollection,
+                    Feature.YUGIOH_EARLY_DAYS_CARD_VRAM_WRITES),
             features("MBC1 multicart", CartridgeProperties::isMbc1Multicart,
                     Feature.MBC1_MULTICART),
             features("Hong Kong Pokemon Red", CartridgeProperties::isHongKongPokemonRed,
@@ -836,6 +840,24 @@ public final class CartridgeProperties {
                 && info.byteAt(0x0148) == 0x02
                 && info.byteAt(0x0149) == 0x00
                 && matches(info.data, 0x0395, fourPlayerWait);
+    }
+
+    private static boolean isYugiohEarlyDaysCollection(RomInfo info) {
+        // The localized Early Days image is expanded from the original 1 MiB release to
+        // 2 MiB. Header metadata is sufficient to keep its phase-sensitive card upload
+        // workaround away from both the original cartridge and unrelated MBC1 games.
+        return info.data.length == 0x200000
+                && info.title().startsWith("YUGI")
+                && info.hasValidLogo()
+                && info.byteAt(0x0143) == 0x00
+                && info.byteAt(0x0144) == 'A'
+                && info.byteAt(0x0145) == '4'
+                && info.byteAt(0x0146) == 0x03
+                && info.rawType() == 0x03
+                && info.byteAt(0x0148) == 0x06
+                && info.byteAt(0x0149) == 0x02
+                && info.byteAt(0x014a) == 0x00
+                && info.byteAt(0x014c) == 0x00;
     }
 
     private static boolean isMbc1Multicart(RomInfo info) {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/YugiohEarlyDaysCompatibilityTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/memory/cart/YugiohEarlyDaysCompatibilityTest.java
@@ -1,0 +1,79 @@
+package eu.rekawek.coffeegb.core.memory.cart;
+
+import eu.rekawek.coffeegb.core.Gameboy;
+import eu.rekawek.coffeegb.core.gpu.Gpu;
+import eu.rekawek.coffeegb.core.gpu.Mode;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class YugiohEarlyDaysCompatibilityTest {
+
+    private static final int[] NINTENDO_LOGO = {
+            0xce, 0xed, 0x66, 0x66, 0xcc, 0x0d, 0x00, 0x0b,
+            0x03, 0x73, 0x00, 0x83, 0x00, 0x0c, 0x00, 0x0d,
+            0x00, 0x08, 0x11, 0x1f, 0x88, 0x89, 0x00, 0x0e,
+            0xdc, 0xcc, 0x6e, 0xe6, 0xdd, 0xdd, 0xd9, 0x99,
+            0xbb, 0xbb, 0x67, 0x63, 0x6e, 0x0e, 0xec, 0xcc,
+            0xdd, 0xdc, 0x99, 0x9f, 0xbb, 0xb9, 0x33, 0x3e
+    };
+
+    @Test
+    public void detectsExpandedEarlyDaysImageWithoutMatchingOriginalSize() throws IOException {
+        Rom expanded = new Rom(yugiohRom(0x200000));
+        Rom originalSize = new Rom(yugiohRom(0x100000));
+
+        assertTrue(expanded.getCartridgeProperties().has(
+                CartridgeProperties.Feature.YUGIOH_EARLY_DAYS_CARD_VRAM_WRITES));
+        assertFalse(originalSize.getCartridgeProperties().has(
+                CartridgeProperties.Feature.YUGIOH_EARLY_DAYS_CARD_VRAM_WRITES));
+    }
+
+    @Test
+    public void onlyExpandedImageAcceptsCardTileWritesDuringMode3() throws IOException {
+        assertEquals(0x99, mode3VramValue(yugiohRom(0x200000)));
+        assertEquals(0x42, mode3VramValue(yugiohRom(0x100000)));
+    }
+
+    private static int mode3VramValue(byte[] data) throws IOException {
+        try (Gameboy gameboy = new Gameboy.GameboyConfiguration(new Rom(data))
+                .setSupportBatterySave(false)
+                .build()) {
+            Gpu gpu = gameboy.getGpu();
+            gpu.setByte(0x8000, 0x42);
+            while (gpu.getMode() != Mode.PixelTransfer) {
+                gpu.tick();
+            }
+            gpu.setByteFromCpu(0x8000, 0x99);
+            return gpu.getVideoRam0().getByte(0x8000);
+        }
+    }
+
+    private static byte[] yugiohRom(int size) {
+        byte[] data = new byte[size];
+        data[0x0100] = 0x00;
+        data[0x0101] = (byte) 0xc3;
+        data[0x0102] = 0x50;
+        data[0x0103] = 0x01;
+        for (int i = 0; i < NINTENDO_LOGO.length; i++) {
+            data[0x0104 + i] = (byte) NINTENDO_LOGO[i];
+        }
+        byte[] title = "YUGI TEST".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(title, 0, data, 0x0134, title.length);
+        data[0x0143] = 0x00;
+        data[0x0144] = 'A';
+        data[0x0145] = '4';
+        data[0x0146] = 0x03;
+        data[0x0147] = 0x03;
+        data[0x0148] = 0x06;
+        data[0x0149] = 0x02;
+        data[0x014a] = 0x00;
+        data[0x014c] = 0x00;
+        return data;
+    }
+}


### PR DESCRIPTION
AI-generated change.

Fixes #658.

## What changed

The translated Early Days Collection image uploads part of each card portrait to tile VRAM while the LCD is in pixel transfer. Coffee GB discarded those writes, leaving horizontal bands of stale tile data.

This adds a tightly matched compatibility profile for the expanded 2 MiB Early Days image and permits only CPU writes to the card-tile region (`$8000-$84FF`) through that profile. VRAM reads, other VRAM addresses, the original 1 MiB cartridge, and all other games retain the normal mode-3 lock.

## Visual verification

| Before | After |
|---|---|
| ![Corrupt Mushroom Man card art](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/000040-a-89237fa1.png) | ![Restored Mushroom Man card art](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/issue658-probe-2a75a7ea.png) |

## Tests

- `mvn -pl core test` — 2,046 tests, 0 failures/errors, 8 skipped
- focused cartridge detection and mode-3 VRAM write tests — 4 tests, 0 failures/errors
- Mooneye + DMG/CGB Acid2 — 132 tests, 0 failures/errors
- Blargg aggregate + individual — 54 tests, 0 failures/errors
- Mealybug PPU rendering — 26 tests, 0 failures/errors

The exact reported image was also replayed through the Campaign → Deck → card-details path before and after the fix.