### PR TITLE
Fix Razor Freestyle Scooter multiplayer link

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
@@ -75,6 +75,11 @@ internal object LinkedFrameStepper {
             first.heldButtons == second.heldButtons
     if (!sameTimingPhase && !mirroredFastInputActivation) return null
 
+    val mirroredFastInternalTransfer =
+        bothInternal &&
+            first.gameboy.isFastSerialClockSelectedForActiveTransfer &&
+            second.gameboy.isFastSerialClockSelectedForActiveTransfer
+
     return when {
       bothInternal -> {
         val ticks =
@@ -82,10 +87,13 @@ internal object LinkedFrameStepper {
                 clockSpec.controllerTicksPerFrame().toLong(),
                 INTERNAL_COLLISION_ESCAPE_FRAMES.toLong(),
             )
-        advanceUnilaterally(second, ticks)
+        val advanced =
+            advanceUnilaterally(second, ticks) {
+              mirroredFastInternalTransfer && second.gameboy.isExternalClockTransferActive
+            }
         LOG.atDebug().log(
             "Resolved mirrored internal-clock link election with a {}-tick P2 lead",
-            ticks,
+            advanced,
         )
         SymmetryBreak.INTERNAL_CLOCK_COLLISION
       }

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
@@ -16,6 +16,41 @@ import org.junit.Test
 class LinkedFrameStepperTest {
 
   @Test
+  fun mirroredCgbFastInternalMastersStopWhenOnePeerBecomesTheListener() {
+    val electionRom =
+        StateCodecTestSupport.rom(cgb = true).also { bytes ->
+          // LD A,$82; LDH ($02),A; LD A,$01; LDH ($80),A; JR -2
+          // The marker distinguishes the listener transition from an oversized fixed lead.
+          byteArrayOf(
+                  0x3e,
+                  0x82.toByte(),
+                  0xe0.toByte(),
+                  0x02,
+                  0x3e,
+                  0x01,
+                  0xe0.toByte(),
+                  0x80.toByte(),
+                  0x18,
+                  0xfe.toByte(),
+              )
+              .copyInto(bytes, destinationOffset = 0x100)
+        }
+    PairFixture(GameboyType.CGB, electionRom).use { fixture ->
+      fixture.armBoth(0x83)
+
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.INTERNAL_CLOCK_COLLISION,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+      assertTrue(fixture.first.gameboy.isInternalClockTransferActive)
+      assertTrue(fixture.second.gameboy.isExternalClockTransferActive)
+      assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+      assertTrue(dividerDelta(fixture.second, fixture.first) > 0)
+      assertEquals(0, fixture.second.gameboy.addressSpace.getByte(0xff80))
+    }
+  }
+
+  @Test
   fun mirroredInternalMastersReceiveOneDeterministicP2PhaseEscape() {
     PairFixture().use { fixture ->
       fixture.armBoth(0x81)
@@ -164,7 +199,10 @@ class LinkedFrameStepperTest {
     return (aheadDivider - behindDivider) and 0xffff
   }
 
-  private class PairFixture(hardware: GameboyType = GameboyType.DMG) : AutoCloseable {
+  private class PairFixture(
+      hardware: GameboyType = GameboyType.DMG,
+      rom: ByteArray = StateCodecTestSupport.rom(cgb = hardware == GameboyType.CGB),
+  ) : AutoCloseable {
     val firstEndpoint = Peer2PeerSerialEndpoint()
     val secondEndpoint = Peer2PeerSerialEndpoint()
     val first: Session
@@ -176,12 +214,12 @@ class LinkedFrameStepperTest {
       firstEndpoint.init(secondEndpoint)
       val firstConfig =
           StateCodecTestSupport.configuration(
-              bytes = StateCodecTestSupport.rom(cgb = hardware == GameboyType.CGB),
+              bytes = rom.clone(),
               hardware = hardware,
           )
       val secondConfig =
           StateCodecTestSupport.configuration(
-              bytes = StateCodecTestSupport.rom(cgb = hardware == GameboyType.CGB),
+              bytes = rom.clone(),
               hardware = hardware,
           )
       first = Session(firstConfig, EventBusImpl(null, null, false), null, firstEndpoint)

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/Peer2PeerSerialEndpoint.java
@@ -7,6 +7,7 @@ import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
 
 public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponent<SerialEndpoint> {
 
@@ -19,6 +20,9 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
     private int bitIndex = 7;
 
     private int linkPlayerIndex = -1;
+
+    /** Transient wiring to the peer's serial shift register, installed during Gameboy init. */
+    private transient IntUnaryOperator externalClockReceiver;
 
     /** Pairs two endpoints before session installation; this is not a concurrent hot-plug API. */
     public void init(Peer2PeerSerialEndpoint peer) {
@@ -68,11 +72,18 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
         if (peer == null) {
             return -1;
         }
+        // New peer transfers deliver external clock edges synchronously. Retain this drain only
+        // so a released snapshot containing an old deferred edge can still finish its byte.
         if (bitsReceived.get() == 0) {
             return -1;
         }
         bitsReceived.decrementAndGet();
         return shift();
+    }
+
+    @Override
+    public void setExternalClockReceiver(IntUnaryOperator receiver) {
+        externalClockReceiver = receiver;
     }
 
     @Override
@@ -97,12 +108,29 @@ public class Peer2PeerSerialEndpoint implements SerialEndpoint, StatefulComponen
         return shift();
     }
 
+    @Override
+    public int exchangeBit(int outgoingBit) {
+        if (peer == null) {
+            return 1;
+        }
+        IntUnaryOperator receiver = peer.externalClockReceiver;
+        if (receiver == null) {
+            // Preserve the legacy deferred exchange for direct endpoint users and old snapshots.
+            return sendBit();
+        }
+        return receiver.applyAsInt(outgoingBit & 1);
+    }
+
     private int shift() {
         var bit = BitUtils.getBit(peer.sb, bitIndex) ? 1 : 0;
+        advanceBitIndex();
+        return bit;
+    }
+
+    private void advanceBitIndex() {
         if (--bitIndex == -1) {
             bitIndex = 7;
         }
-        return bit;
     }
 
     @Override

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialEndpoint.java
@@ -3,6 +3,8 @@ package eu.rekawek.coffeegb.core.serial;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import eu.rekawek.coffeegb.core.state.StatefulComponent;
 
+import java.util.function.IntUnaryOperator;
+
 public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
 
     /** Stable zero-based player index for an in-process link, or {@code -1}. */
@@ -102,6 +104,14 @@ public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
     }
 
     /**
+     * Binds the owning serial port's external-clock exchange. In-process peer cables invoke this
+     * function synchronously on the clock master's falling edge; it returns the current outgoing
+     * data bit before shifting the supplied incoming bit. Device endpoints may ignore it.
+     */
+    default void setExternalClockReceiver(IntUnaryOperator receiver) {
+    }
+
+    /**
      * Returns the received byte.
      */
     default int recvByte() {
@@ -117,6 +127,14 @@ public interface SerialEndpoint extends StatefulComponent<SerialEndpoint> {
      * Sends following SB bit. Returns the received bit.
      */
     int sendBit();
+
+    /**
+     * Exchanges one bit while this Game Boy supplies the clock. Endpoints which do not model an
+     * in-process peer retain the legacy {@link #sendBit()} contract.
+     */
+    default int exchangeBit(int outgoingBit) {
+        return sendBit();
+    }
 
     /**
      * Sends the SB bit and returns the received byte.

--- a/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/serial/SerialPort.java
@@ -59,7 +59,10 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
     }
 
     public void init(SerialEndpoint serialEndpoint) {
+        this.serialEndpoint.setExternalTransfer(false);
+        this.serialEndpoint.setExternalClockReceiver(null);
         this.serialEndpoint = serialEndpoint;
+        serialEndpoint.setExternalClockReceiver(this::exchangeExternalClockBit);
     }
 
     /** True when the raw SC register has armed a transfer using this port's clock. */
@@ -280,7 +283,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
             // lead in addition to Gambatte's four-clock peripheral window.
             int acknowledgeWindow = gbc ? 8 : 3;
             if (clocksToCompletion <= acknowledgeWindow) {
-                shiftBit(serialEndpoint.sendBit());
+                shiftInternalBit();
             }
         }
 
@@ -308,7 +311,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
         if (precedingStageHigh) {
             serialClockSignal = !serialClockSignal;
             if (!serialClockSignal) {
-                shiftBit(serialEndpoint.sendBit());
+                shiftInternalBit();
             }
         }
     }
@@ -330,7 +333,7 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
             if (oldPhase == flipClocks - 1) {
                 serialClockSignal = !serialClockSignal;
                 if (!serialClockSignal) {
-                    shiftBit(serialEndpoint.sendBit());
+                    shiftInternalBit();
                 }
             }
         }
@@ -354,6 +357,22 @@ public class SerialPort implements AddressSpace, StatefulComponent<SerialPort> {
             interruptManager.requestInterruptBeforeHaltWake(InterruptManager.InterruptType.Serial);
             LOG.atDebug().log("[{}] Received sb = {}", this.hashCode(), Integer.toBinaryString(sb));
         }
+    }
+
+    private void shiftInternalBit() {
+        shiftBit(serialEndpoint.exchangeBit((sb >>> 7) & 1));
+    }
+
+    private int exchangeExternalClockBit(int incomingBit) {
+        if ((sc & 0x80) == 0) {
+            return 0;
+        }
+        if ((sc & 0x01) != 0) {
+            return 1;
+        }
+        int outgoingBit = (sb >>> 7) & 1;
+        shiftBit(incomingBit);
+        return outgoingBit;
     }
 
     private boolean isColorMode() {

--- a/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/serial/SerialPortTest.java
@@ -5,6 +5,8 @@ import eu.rekawek.coffeegb.core.cpu.SpeedMode;
 import eu.rekawek.coffeegb.core.state.ComponentState;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -30,6 +32,238 @@ public class SerialPortTest {
         serialPort.setByte(0xff02, 0x01);
         assertFalse(serialPort.isInternalClockTransferActive());
         assertFalse(serialPort.isExternalClockTransferActive());
+    }
+
+    @Test
+    public void peerClockShiftsAnExternalPortSynchronously() {
+        InterruptManager firstInterrupts = new InterruptManager(true);
+        InterruptManager secondInterrupts = new InterruptManager(true);
+        SerialPort firstPort = new SerialPort(firstInterrupts, true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(secondInterrupts, true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0xa5);
+        secondPort.setByte(0xff01, 0x3c);
+        secondPort.setByte(0xff02, 0x82);
+        firstPort.setByte(0xff02, 0x83);
+
+        int remainingTicks = 1024;
+        while (firstPort.isInternalClockTransferActive() && remainingTicks-- > 0) {
+            firstPort.tick();
+        }
+
+        assertTrue("serial transfer did not complete", remainingTicks > 0);
+        assertEquals(0x3c, firstPort.getByte(0xff01));
+        assertEquals(0xa5, secondPort.getByte(0xff01));
+        assertFalse(secondPort.isExternalClockTransferActive());
+        assertTrue(firstInterrupts.isInterruptFlagSet(InterruptManager.InterruptType.Serial));
+        assertTrue(secondInterrupts.isInterruptFlagSet(InterruptManager.InterruptType.Serial));
+    }
+
+    @Test
+    public void peerCableUsesTheLiveShiftRegisterOnAConsecutiveTransfer() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0xa5);
+        secondPort.setByte(0xff01, 0x3c);
+        secondPort.setByte(0xff02, 0x82);
+        firstPort.setByte(0xff02, 0x83);
+
+        tickUntilComplete(firstPort);
+        assertEquals(0x3c, firstPort.getByte(0xff01));
+        assertEquals(0xa5, secondPort.getByte(0xff01));
+
+        // Reverse the clock roles without rewriting SB. Each peer must transmit the byte that
+        // actually occupies its shift register after the previous transfer.
+        firstPort.setByte(0xff02, 0x82);
+        secondPort.setByte(0xff02, 0x83);
+        tickUntilComplete(secondPort);
+
+        assertEquals(0xa5, firstPort.getByte(0xff01));
+        assertEquals(0x3c, secondPort.getByte(0xff01));
+    }
+
+    @Test
+    public void peerExchangeContinuesAfterBothPortsRestoreMidByte() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0xa5);
+        secondPort.setByte(0xff01, 0x3c);
+        secondPort.setByte(0xff02, 0x82);
+        firstPort.setByte(0xff02, 0x83);
+        for (int i = 0; i < 52; i++) {
+            firstPort.tick();
+        }
+        assertEquals(3, firstPort.captureDebugSerialInspection().receivedBits());
+        assertEquals(3, secondPort.captureDebugSerialInspection().receivedBits());
+        ComponentState<SerialPort> firstPortState = firstPort.captureState();
+        ComponentState<SerialPort> secondPortState = secondPort.captureState();
+        ComponentState<SerialEndpoint> firstEndpointState = firstEndpoint.captureState();
+        ComponentState<SerialEndpoint> secondEndpointState = secondEndpoint.captureState();
+
+        tickUntilComplete(firstPort);
+        int expectedFirst = firstPort.getByte(0xff01);
+        int expectedSecond = secondPort.getByte(0xff01);
+
+        // Controller state restore applies both machines before their endpoint payloads.
+        firstPort.restoreState(firstPortState);
+        secondPort.restoreState(secondPortState);
+        firstEndpoint.restoreState(firstEndpointState);
+        secondEndpoint.restoreState(secondEndpointState);
+        tickUntilComplete(firstPort);
+
+        assertEquals(expectedFirst, firstPort.getByte(0xff01));
+        assertEquals(expectedSecond, secondPort.getByte(0xff01));
+        assertEquals(0x3c, expectedFirst);
+        assertEquals(0xa5, expectedSecond);
+    }
+
+    @Test
+    public void replacingAnEndpointDisconnectsTheOldCableCallback() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0x55);
+        firstPort.setByte(0xff02, 0x82);
+
+        firstPort.init(SerialEndpoint.NULL_ENDPOINT);
+        secondPort.setByte(0xff01, 0x80);
+        secondPort.setByte(0xff02, 0x83);
+        for (int i = 0; i < 20; i++) {
+            secondPort.tick();
+        }
+
+        assertEquals(0x55, firstPort.getByte(0xff01));
+        assertEquals(0, firstPort.captureDebugSerialInspection().receivedBits());
+    }
+
+    @Test
+    public void dormantPeerSuppliesZeroWithoutReceivingOrReplayingAClock() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0xa5);
+        secondPort.setByte(0xff01, 0xff);
+        firstPort.setByte(0xff02, 0x83);
+
+        int remainingTicks = 1024;
+        while (firstPort.isInternalClockTransferActive() && remainingTicks-- > 0) {
+            firstPort.tick();
+        }
+        secondPort.setByte(0xff02, 0x82);
+        for (int i = 0; i < 32; i++) {
+            secondPort.tick();
+        }
+
+        assertEquals(0x00, firstPort.getByte(0xff01));
+        assertEquals(0xff, secondPort.getByte(0xff01));
+        assertTrue(secondPort.isExternalClockTransferActive());
+        assertEquals(0, secondPort.captureDebugSerialInspection().receivedBits());
+    }
+
+    @Test
+    public void internallyClockedPeerSuppliesOneWithoutReceivingTheOtherClock() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        firstPort.setByte(0xff01, 0x00);
+        secondPort.setByte(0xff01, 0x00);
+        firstPort.setByte(0xff02, 0x83);
+        secondPort.setByte(0xff02, 0x83);
+
+        for (int i = 0; i < 20; i++) {
+            firstPort.tick();
+        }
+
+        assertEquals(0x01, firstPort.getByte(0xff01));
+        assertEquals(1, firstPort.captureDebugSerialInspection().receivedBits());
+        assertEquals(0x00, secondPort.getByte(0xff01));
+        assertEquals(0, secondPort.captureDebugSerialInspection().receivedBits());
+    }
+
+    @Test
+    public void restoringAnExternalTransferPreservesThePeerCableRole() {
+        SerialPort firstPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        SerialPort secondPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        Peer2PeerSerialEndpoint firstEndpoint = new Peer2PeerSerialEndpoint();
+        Peer2PeerSerialEndpoint secondEndpoint = new Peer2PeerSerialEndpoint();
+        firstEndpoint.init(secondEndpoint);
+        firstPort.init(firstEndpoint);
+        secondPort.init(secondEndpoint);
+        secondPort.setByte(0xff01, 0x00);
+        secondPort.setByte(0xff02, 0x82);
+        ComponentState<SerialPort> externalState = secondPort.captureState();
+        secondPort.setByte(0xff02, 0x02);
+        secondPort.restoreState(externalState);
+        firstPort.setByte(0xff01, 0x80);
+        firstPort.setByte(0xff02, 0x83);
+
+        for (int i = 0; i < 20; i++) {
+            firstPort.tick();
+        }
+
+        assertEquals(1, secondPort.captureDebugSerialInspection().receivedBits());
+        assertEquals(0x01, secondPort.getByte(0xff01));
+    }
+
+    @Test
+    public void nonPeerEndpointReceivesOnlyTheCpuWrittenByte() {
+        AtomicInteger received = new AtomicInteger(-1);
+        SerialPort serialPort = new SerialPort(
+                new InterruptManager(true), true, new SpeedMode(true));
+        serialPort.init(new ByteReceivingSerialEndpoint(received::set));
+        serialPort.setByte(0xff01, 0xa5);
+        serialPort.setByte(0xff02, 0x83);
+
+        tickUntilComplete(serialPort);
+
+        assertEquals(0xa5, received.get());
+        assertEquals(0xff, serialPort.getByte(0xff01));
+    }
+
+    private static void tickUntilComplete(SerialPort clockMaster) {
+        int remainingTicks = 1024;
+        while (clockMaster.isInternalClockTransferActive() && remainingTicks-- > 0) {
+            clockMaster.tick();
+        }
+        assertTrue("serial transfer did not complete", remainingTicks > 0);
     }
 
     @Test


### PR DESCRIPTION
AI-generated change.

Fixes #663.

## Problem

Razor Freestyle Scooter starts both native-CGB instances in the same fast internal-clock role. Coffee GB broke that mirrored election with a fixed unilateral lead, but the in-process link cable still exchanged deferred bits from a cached SB value. The second instance could become an external-clock listener during that lead and then receive stale/replayed link traffic, leaving Multi-Player unavailable.

## Fix

- Exchange peer bits synchronously on each falling serial-clock edge, sampling the peer's live shift register.
- Apply the peer port's current SC role when a clock edge arrives: an external listener shifts immediately, while inactive and internally-clocked peers do not consume the edge.
- Preserve the legacy endpoint methods and serialized state shape for non-peer devices and released snapshots.
- Stop the native-CGB fast mirrored-election lead as soon as player 2 becomes the listener, while retaining the existing bounded fallback for slower games.

The serial-role behavior follows [SameBoy's link implementation](https://github.com/LIJI32/SameBoy/blob/213a12ce93d66b105a113debd9396306066a7cfc/Core/gb.c#L1348-L1379). The [game manual](https://www.gamesdatabase.org/Media/SYSTEM/Nintendo_Game_Boy_Color/Manual/formated/Razor_Freestyle_Scooter_-_2001_-_Crave_Entertainment.pdf) documents Multi-Player as an ordinary Link Mode option, with no startup workaround.

## Visual verification

| Before | After |
| --- | --- |
| ![Multi-Player unavailable](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/multi_selected-p1-b80fcbfc.png) | ![Multi-Player Racing and Trick Mode menu](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/after-a180-f3315-p1-2cdbd23c.png) |

Two linked ACCURACY sessions reached the Racing / Trick Mode menu and remained linked through frame 3,535. PERFORMANCE sessions also retained their player-specific LINK ESTABLISHED screens through frame 400.

## Verification

- `/opt/maven/bin/mvn -pl controller -am test`: 2,058 core tests and 969 controller tests; 0 failures or errors.
- `/opt/maven/bin/mvn -pl core test -Ptest-mooneye,test-dmgacid2,test-cgbacid2`: 132/132 passed.
- `/opt/maven/bin/mvn -pl core test -Ptest-blargg-individual,test-blargg`: 54/54 passed.
- Added focused coverage for synchronous peer exchange, consecutive transfers, mid-byte state restore, endpoint replacement, inactive/internal/external peer roles, non-peer endpoint behavior, and the fast mirrored-election transition.
