### PR TITLE
Fix simultaneous 2P connection in Mach Go Go Go

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepper.kt
@@ -7,13 +7,13 @@ import eu.rekawek.coffeegb.core.serial.Peer2PeerSerialEndpoint
 import org.slf4j.LoggerFactory
 
 /**
- * Advances one linked controller frame while resolving an otherwise perfectly mirrored software
- * role election. Real consoles never reach a link handshake with identical CPU, DIV, PPU, and
- * serial phase; two emulated copies can, and then both ROMs can make the same master/slave choice.
+ * Advances one linked controller frame while resolving competing software clock-role elections.
+ * Matching internal-clock requests can collide even after the machines have acquired different
+ * CPU, DIV, PPU, and serial phases, for example when both players confirm the same menu choice.
  *
- * The escape is deliberately conditional and deterministic. Ordinary asymmetric links retain the
- * exact scalar P1-then-P2 schedule, while rollback replay observes the same canonical-player
- * decision as live execution regardless of which player is local.
+ * The escape is conditional and deterministic. A master and listener retain the exact scalar
+ * P1-then-P2 schedule; passive external listeners still require a mirrored election. Rollback
+ * replay observes the same canonical-player decision regardless of which player is local.
  */
 internal object LinkedFrameStepper {
 
@@ -73,7 +73,11 @@ internal object LinkedFrameStepper {
             second.gameboy.isFastSerialClockSelectedForActiveTransfer &&
             first.heldButtons.isNotEmpty() &&
             first.heldButtons == second.heldButtons
-    if (!sameTimingPhase && !mirroredFastInputActivation) return null
+    // Two masters sending the same byte are a clock collision even with unequal machine
+    // phases. Requiring identical phases here misses menu confirmations whose handshake is
+    // delayed until after the input was released (Mach Go Go Go). The matching endpoint state
+    // above keeps different-byte traffic out of this election escape.
+    if (!sameTimingPhase && !bothInternal && !mirroredFastInputActivation) return null
 
     val mirroredFastInternalTransfer =
         bothInternal &&

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedFrameStepperTest.kt
@@ -69,7 +69,7 @@ class LinkedFrameStepperTest {
       assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
       assertNull(
           LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
-          "the resulting machine phase is the persisted one-shot marker",
+          "the completed contender no longer conflicts with the remaining master",
       )
     }
   }
@@ -174,10 +174,45 @@ class LinkedFrameStepperTest {
   }
 
   @Test
-  fun unequalMachineOrCablePhaseDoesNotTriggerAnEscape() {
+  fun matchingInternalRequestsResolveAfterTheirMachinePhasesHaveDiverged() {
+    PairFixture().use { fixture ->
+      // A passive startup already separated the machines. The user has released the menu
+      // confirmation by the time its delayed handshake begins, so no held input identifies it.
+      fixture.armBoth(0x80)
+      LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec)
+      fixture.armBoth(0x81)
+      assertFalse(fixture.first.gameboy.hasSameLinkTimingPhase(fixture.second.gameboy))
+      assertTrue(fixture.first.heldButtons.isEmpty())
+      assertTrue(fixture.second.heldButtons.isEmpty())
+      val before = dividerDelta(fixture.second, fixture.first)
+
+      assertEquals(
+          LinkedFrameStepper.SymmetryBreak.INTERNAL_CLOCK_COLLISION,
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+
+      val expectedLead = 13L * fixture.clockSpec.controllerTicksPerFrame()
+      assertEquals(
+          (before + expectedLead.toInt()) and 0xffff,
+          dividerDelta(fixture.second, fixture.first),
+      )
+      assertNull(LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec))
+    }
+  }
+
+  @Test
+  fun unequalPassivePhasesOrDifferentOutgoingBytesDoNotTriggerAnEscape() {
     PairFixture().use { fixture ->
       fixture.first.gameboy.tick()
+      fixture.armBoth(0x80)
+      assertNull(
+          LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
+      )
+    }
+
+    PairFixture().use { fixture ->
       fixture.armBoth(0x81)
+      fixture.second.gameboy.addressSpace.setByte(0xff01, 0x34)
       assertNull(
           LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
       )
@@ -189,6 +224,17 @@ class LinkedFrameStepperTest {
       assertNull(
           LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec),
       )
+    }
+  }
+
+  @Test
+  fun masterAndListenerKeepTheirExistingSchedule() {
+    PairFixture().use { fixture ->
+      fixture.armBoth(0x81)
+      fixture.second.gameboy.addressSpace.setByte(0xff02, 0x80)
+      val before = dividerDelta(fixture.second, fixture.first)
+      assertNull(LinkedFrameStepper.breakMirroredRoleElection(fixture.sessions, fixture.clockSpec))
+      assertEquals(before, dividerDelta(fixture.second, fixture.first))
     }
   }
 


### PR DESCRIPTION
Mach Go Go Go can fail to enter 2P Battle when both players confirm together. Its delayed handshake starts after the buttons have been released: both machines select the internal serial clock, send the same request, and eventually return to listening. Coffee GB's existing link-election escape required identical CPU/DIV/PPU/serial phases, so it missed this collision once earlier execution had separated the machines.

Resolve matching-byte internal-clock collisions even when the machine phases differ, using the existing bounded, deterministic player-2 lead. The endpoint-state check still excludes different outgoing bytes. Normal master/listener transfers and the timing guard for passive external listeners retain their existing behavior. This is a controller scheduling correction; the serial hardware model and the game's code are unchanged.

The investigation also established a prerequisite: this game rejects 2P Battle before any handshake if the saved car record is empty. Complete a solo race and choose **きろくする (Record)** on each machine, then return to the title menu. With those records, confirming on one machine already worked; simultaneous confirmation exposed the scheduler defect addressed here.

Validation:

- `/opt/maven/bin/mvn -q -pl controller -am test -Dtest=LinkedFrameStepperTest -Dsurefire.failIfNoSpecifiedTests=false`: 10 tests passed. The new delayed-election regression fails against the previous scheduler with `Expected INTERNAL_CLOCK_COLLISION, actual null`; the other nine tests pass there. Coverage also checks different-byte traffic, passive unequal phases, and ordinary master/listener transfers.
- `/opt/maven/bin/mvn -q -pl controller -am test`: core 2,273 tests (8 skipped), controller 980 tests (2 skipped), zero failures/errors.
- `/opt/maven/bin/mvn -q -pl core test-compile surefire:test@integration-test-mooneye surefire:test@integration-test-dmgacid2 surefire:test@integration-test-cgbacid2 surefire:test@integration-test-blargg-individual surefire:test@integration-test-blargg -Ptest-mooneye,test-dmgacid2,test-cgbacid2,test-blargg-individual,test-blargg`: all 186 tests passed.
- Two locally linked DMG machines, SKIP boot, same in-memory saved-car/menu state: hold A on both for 8 controller frames, release, then advance 500 frames. Before: both remain at the title menu. After: both reach course selection; confirming a course proceeds to level selection. The before/after runs restore the same pair state and change only the scheduler implementation.

Fixes #666.

| Before | After |
| --- | --- |
| ![2P Battle remains at the title menu](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/before_f12755_p1-4e0465a5.png) | ![Connected at course selection](https://github.com/trekawek/gitshot-images/releases/download/_gitshot/after_f13263_p1-55b63549.png) |

Screenshots: *Mach Go Go Go* (1997, TOMY), demonstrating Coffee GB compatibility.
