### PR TITLE
Prevent autosave races from freezing netplay connections

### DIFF
--- a/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
+++ b/controller/src/main/java/eu/rekawek/coffeegb/controller/state/StateRepository.kt
@@ -30,7 +30,7 @@ import kotlin.concurrent.withLock
  */
 class StateRepository(
     val layout: StateStorageLayout,
-    private val persistence: AtomicFileWriter = AtomicFileWriter.system(),
+    private val persistence: AtomicFileWriter = AtomicFileWriter.inDirectory(layout.gameDirectory),
 ) {
   /**
    * Validates and atomically commits one portable machine state. Metadata failure never rolls back

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/NetplayAutosaveHandoffTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/NetplayAutosaveHandoffTest.kt
@@ -1,0 +1,171 @@
+package eu.rekawek.coffeegb.controller
+
+import eu.rekawek.coffeegb.controller.events.register
+import eu.rekawek.coffeegb.controller.link.LinkMode
+import eu.rekawek.coffeegb.controller.link.LinkedController
+import eu.rekawek.coffeegb.controller.network.Connection.PeerLoadedGameEvent
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettings
+import eu.rekawek.coffeegb.controller.properties.ApplicationSettingsOverrides
+import eu.rekawek.coffeegb.controller.properties.EmulatorProperties
+import eu.rekawek.coffeegb.controller.state.StateRepository
+import eu.rekawek.coffeegb.controller.state.StateWorkspace
+import eu.rekawek.coffeegb.core.events.EventBusImpl
+import eu.rekawek.coffeegb.core.Gameboy.BootstrapMode
+import eu.rekawek.coffeegb.core.hardware.HardwareProfileRegistry
+import eu.rekawek.coffeegb.core.persistence.HandoffAutosaveWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.system.exitProcess
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class NetplayAutosaveHandoffTest {
+  @get:Rule val directory = TemporaryFolder()
+
+  @Test(timeout = 30_000)
+  fun sharedSavesDoNotStrandEitherPeerDuringTheControllerHandoff() {
+    val root = directory.root.toPath()
+    val rom = Path.of("src/test/resources/roms/cpu_instrs.gb").toAbsolutePath()
+    Peer(root, rom, true).use { host ->
+      host.expect("LOADED")
+      // Load the client before holding the host's write, as on the desktop.
+      Peer(root, rom, false).use { client ->
+        client.expect("LOADED")
+        host.proceed()
+        host.expect("CLOSING")
+        host.expect("AUTOSAVE_READY")
+        client.proceed()
+        client.expect("CLOSING")
+        val clientFinishedEarly = client.process.waitFor(300, TimeUnit.MILLISECONDS)
+        host.proceed()
+        host.expect("LINKED_FRAMES_ADVANCED")
+        client.expect("LINKED_FRAMES_ADVANCED")
+        host.assertSuccess()
+        client.assertSuccess()
+        assertFalse(clientFinishedEarly)
+      }
+    }
+    Files.walk(root.resolve("saves")).use { paths ->
+      assertTrue(paths.anyMatch { it.fileName.toString() == "state.cgbstate" })
+    }
+  }
+
+  private class Peer(root: Path, rom: Path, hold: Boolean) : AutoCloseable {
+    val process = ProcessBuilder(
+        Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+        "-cp", System.getProperty("java.class.path"),
+        NetplayAutosavePeer::class.java.name, root.toString(), rom.toString(), hold.toString(),
+    ).redirectError(ProcessBuilder.Redirect.INHERIT).start()
+    private val output = process.inputStream.bufferedReader()
+
+    fun expect(expected: String) = assertEquals(
+        expected, CompletableFuture.supplyAsync { output.readLine() }.get(10, TimeUnit.SECONDS))
+
+    fun proceed() {
+      process.outputStream.write(10)
+      process.outputStream.flush()
+    }
+
+    fun assertSuccess() {
+      assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+      assertEquals(0, process.exitValue())
+    }
+
+    override fun close() {
+      process.destroyForcibly()
+      assertTrue(process.waitFor(5, TimeUnit.SECONDS))
+      output.close()
+    }
+  }
+}
+
+/** Also accepts an authorized local ROM path for a headless desktop-handoff reproduction. */
+object NetplayAutosavePeer {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    try {
+      run(Path.of(args[0]), Path.of(args[1]), args[2].toBoolean())
+      exitProcess(0)
+    } catch (failure: Throwable) {
+      failure.printStackTrace()
+      exitProcess(1)
+    }
+  }
+
+  private fun run(root: Path, rom: Path, hold: Boolean) {
+    val properties = EmulatorProperties(
+        root.resolve("peer-$hold/settings.properties"),
+        overrides = ApplicationSettingsOverrides(
+            hardwareProfile = HardwareProfileRegistry.DMG, bootstrapMode = BootstrapMode.SKIP),
+        debounceMillis = 0,
+    )
+    properties.updateApplicationSettings {
+      it.copy(saves = ApplicationSettings.Saves(
+          directory = root.resolve("saves"),
+          resumePolicy = ApplicationSettings.ResumePolicy.NEVER,
+      ))
+    }
+    val bus = EventBusImpl()
+    val started = LinkedBlockingQueue<Controller.EmulationStartedEvent>()
+    bus.register<Controller.EmulationStartedEvent>(started::add)
+    bus.register<Controller.LoadRomFailedEvent> {
+      System.err.println("ROM load failed (${it.kind}): ${it.technicalDetails}")
+    }
+    val basic = BasicController(
+        bus, properties, null, RomSessionPreparer(), SnapshotManagerFactory.DEFAULT,
+        RewindManager(enabled = false),
+        StateWorkspaceFactory { paths ->
+          StateWorkspace(paths.copy(fallbackLayouts = emptyList())) { layout ->
+            StateRepository(layout, HandoffAutosaveWriter(layout.gameDirectory, hold))
+          }
+        },
+        StateOperationWorkerFactory.DEFAULT,
+    )
+    basic.startController()
+    bus.post(Controller.LoadRomEvent(rom.toFile()))
+    assertNotNull(started.poll(10, TimeUnit.SECONDS))
+    println("LOADED")
+    check(System.`in`.read() != -1)
+    println("CLOSING")
+    val state = assertNotNull(basic.closeWithState())
+    // This is the same state transfer as SwingEmulator.startLinkedController().
+    val localPlayer = if (hold) 0 else 1
+    val linked = LinkedController(bus, properties, null, LinkMode.NORMAL, localPlayer = localPlayer)
+    try {
+      linked.timingTicker.disabled = true
+      bus.post(Controller.LoadRomEvent(state.rom.image, state.state))
+      awaitSessions(linked, 1)
+      val configuration = Controller.createGameboyConfig(properties, state.rom)
+      bus.post(PeerLoadedGameEvent(
+          rom.toFile().readBytes(), null, null, configuration.gameboyType,
+          configuration.bootstrapMode, linked.currentFrame(), player = 1 - localPlayer,
+      ))
+      awaitSessions(linked, 2)
+      val firstFrame = linked.currentFrame()
+      repeat(3) { linked.runFrame() }
+      assertTrue(linked.currentFrame() > firstFrame)
+      println("LINKED_FRAMES_ADVANCED")
+    } finally {
+      linked.close()
+      properties.close()
+      bus.close()
+    }
+  }
+
+  private fun awaitSessions(linked: LinkedController, expected: Int) {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+    while (linked.activeSessionCount() != expected && System.nanoTime() < deadline) {
+      linked.runFrame()
+      Thread.sleep(1)
+    }
+    assertEquals(expected, linked.activeSessionCount())
+  }
+}

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/link/LinkedControllerTest.kt
@@ -335,7 +335,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(directory.resolve("settings-true.properties"))
       Files.deleteIfExists(battery)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -394,7 +394,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(directory.resolve("settings.properties"))
       Files.deleteIfExists(battery)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -441,7 +441,7 @@ class LinkedControllerTest {
       Files.list(directory).use { files ->
         files.forEach { Files.deleteIfExists(it) }
       }
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -1415,7 +1415,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(directory.resolve("settings.properties"))
       Files.deleteIfExists(battery)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -1689,12 +1689,12 @@ class LinkedControllerTest {
     } catch (unsupported: UnsupportedOperationException) {
       Files.deleteIfExists(secret)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
       Assume.assumeNoException("symbolic links are unsupported", unsupported)
     } catch (unsupported: IOException) {
       Files.deleteIfExists(secret)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
       Assume.assumeNoException("symbolic links are unavailable", unsupported)
     }
     val eventBus = EventBusImpl()
@@ -1733,7 +1733,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(battery)
       Files.deleteIfExists(secret)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -1776,7 +1776,7 @@ class LinkedControllerTest {
       properties.close()
       Files.deleteIfExists(slot)
       Files.deleteIfExists(settings)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -1812,7 +1812,7 @@ class LinkedControllerTest {
       properties.close()
       Files.deleteIfExists(slot)
       Files.deleteIfExists(settings)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -2006,7 +2006,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(directory.resolve("settings.properties"))
       Files.deleteIfExists(battery)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -2023,7 +2023,7 @@ class LinkedControllerTest {
     } catch (_: Exception) {
       Files.deleteIfExists(outside)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
       return
     }
     val eventBus = EventBusImpl()
@@ -2057,7 +2057,7 @@ class LinkedControllerTest {
       Files.deleteIfExists(battery)
       Files.deleteIfExists(outside)
       Files.deleteIfExists(rom)
-      Files.deleteIfExists(directory)
+      deleteTestDirectory(directory)
     }
   }
 
@@ -4415,6 +4415,12 @@ class LinkedControllerTest {
       assertEquals(before, sut.captureDetachedState())
     }
     eventBus.close()
+  }
+
+  private fun deleteTestDirectory(directory: Path) {
+    // All fixture controllers are closed before removing their permanent coordination file.
+    Files.deleteIfExists(directory.resolve(".coffeegb.lock"))
+    Files.deleteIfExists(directory)
   }
 
   private companion object {

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/properties/ApplicationSettingsStoreTest.kt
@@ -408,8 +408,9 @@ class ApplicationSettingsStoreTest {
     }
 
     assertTrue(original.contentEquals(Files.readAllBytes(path)))
+    // Recovery still coordinates with other processes without rewriting the settings document.
     Files.list(directory).use { entries ->
-      assertEquals(listOf(path), entries.toList())
+      assertEquals(setOf(path, directory.resolve(".coffeegb.lock")), entries.toList().toSet())
     }
 
     ApplicationSettingsStore(path, debounceMillis = 0).use { store ->
@@ -532,7 +533,9 @@ class ApplicationSettingsStoreTest {
     }
 
     assertTrue(Files.isDirectory(path))
-    Files.list(directory).use { entries -> assertEquals(listOf(path), entries.toList()) }
+    Files.list(directory).use { entries ->
+      assertEquals(setOf(path, directory.resolve(".coffeegb.lock")), entries.toList().toSet())
+    }
   }
 
   @Test

--- a/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateRepositoryTest.kt
+++ b/controller/src/test/java/eu/rekawek/coffeegb/controller/state/StateRepositoryTest.kt
@@ -203,7 +203,7 @@ class StateRepositoryTest {
         .save(ref, fixture.plain, StateSaveMetadata("old", SAVE_TIME))
 
     val result =
-        StateRepository(layout, SelectiveFailureWriter(failMetadata = true))
+        StateRepository(layout, SelectiveFailureWriter(layout.gameDirectory, failMetadata = true))
             .save(
                 ref,
                 fixture.deflated,
@@ -234,7 +234,7 @@ class StateRepositoryTest {
         StateStorageLayout(Files.createTempDirectory("state-repository-thumbnail-failures"))
     val ref = StateRef.Slot(6)
     val repository =
-        StateRepository(layout, SelectiveFailureWriter(failMetadata = true))
+        StateRepository(layout, SelectiveFailureWriter(layout.gameDirectory, failMetadata = true))
     val thumbnail =
         StatePngCodec.encode(
             StateImage(2, 1, intArrayOf(0x112233, 0xaabbcc)).thumbnail())
@@ -324,7 +324,7 @@ class StateRepositoryTest {
     repository.save(ref, fixture.plain, StateSaveMetadata("old", SAVE_TIME))
 
     assertFailsWith<IOException> {
-      StateRepository(layout, SelectiveFailureWriter(failState = true))
+      StateRepository(layout, SelectiveFailureWriter(layout.gameDirectory, failState = true))
           .save(
               ref,
               fixture.deflated,
@@ -736,9 +736,10 @@ class StateRepositoryTest {
   )
 
   private class SelectiveFailureWriter(
+      gameDirectory: Path,
       private val failState: Boolean = false,
       private val failMetadata: Boolean = false,
-  ) : AtomicFileWriter() {
+  ) : AtomicFileWriter(gameDirectory) {
     override fun write(target: Path, intendedBytes: ByteArray) {
       if (failState && target.fileName.toString() == StateStorageLayout.STATE_FILE) {
         throw IOException("injected state disk-full failure")
@@ -746,7 +747,7 @@ class StateRepositoryTest {
       if (failMetadata && target.fileName.toString() == StateStorageLayout.METADATA_FILE) {
         throw IOException("injected metadata read-only failure")
       }
-      AtomicFileWriter.system().write(target, intendedBytes)
+      super.write(target, intendedBytes)
     }
   }
 

--- a/controller/src/test/java/eu/rekawek/coffeegb/core/persistence/HandoffAutosaveWriter.java
+++ b/controller/src/test/java/eu/rekawek/coffeegb/core/persistence/HandoffAutosaveWriter.java
@@ -1,0 +1,17 @@
+package eu.rekawek.coffeegb.core.persistence;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Pauses a real controller autosave at the rename boundary for the separate-process regression. */
+public final class HandoffAutosaveWriter extends AtomicFileWriter {
+    public HandoffAutosaveWriter(Path gameDirectory, boolean hold) {
+        super(new NioFileOperations(), (stage, target, temp) -> {
+            if (hold && target.getFileName().toString().equals("state.cgbstate")
+                    && stage == Stage.AFTER_FORCE_BEFORE_REPLACEMENT) {
+                System.out.println("AUTOSAVE_READY");
+                if (System.in.read() == -1) throw new IOException("parent closed input");
+            }
+        }, gameDirectory);
+    }
+}

--- a/core/src/main/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriter.java
+++ b/core/src/main/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriter.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryStream;
@@ -19,6 +20,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -27,7 +29,8 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>The caller must materialize the complete intended bytes before calling {@link #write}. Reads
  * performed with {@link #read} share the target's lock with writes and run recovery first, so they
- * cannot observe the temporary missing-target interval of the non-atomic fallback.
+ * cannot observe the temporary missing-target interval of the non-atomic fallback. Filesystem locks
+ * also exclude other emulator processes, including readers performing crash recovery.
  */
 public class AtomicFileWriter {
 
@@ -42,6 +45,11 @@ public class AtomicFileWriter {
 
     private static final int MAX_STALE_TEMPS = 32;
 
+    private static final String LOCK_FILE = ".coffeegb.lock";
+
+    private static final ThreadLocal<Set<Path>> HELD_FILE_LOCKS =
+            ThreadLocal.withInitial(HashSet::new);
+
     static {
         for (int i = 0; i < LOCKS.length; i++) {
             LOCKS[i] = new ReentrantLock();
@@ -52,14 +60,27 @@ public class AtomicFileWriter {
 
     private final StageListener stageListener;
 
+    private final Path lockDirectory;
+
     /** Constructor for test subclasses that override the public operations. */
     protected AtomicFileWriter() {
         this(new NioFileOperations(), StageListener.NOOP);
     }
 
+    /** Constructor for test subclasses that retain a repository's storage-root lock scope. */
+    protected AtomicFileWriter(Path directory) {
+        this(new NioFileOperations(), StageListener.NOOP, directory.toAbsolutePath().normalize());
+    }
+
     AtomicFileWriter(FileOperations operations, StageListener stageListener) {
+        this(operations, stageListener, null);
+    }
+
+    AtomicFileWriter(
+            FileOperations operations, StageListener stageListener, Path lockDirectory) {
         this.operations = operations;
         this.stageListener = stageListener;
+        this.lockDirectory = lockDirectory == null ? null : lockDirectory.toAbsolutePath().normalize();
     }
 
     public static AtomicFileWriter system() {
@@ -67,8 +88,18 @@ public class AtomicFileWriter {
     }
 
     /**
-     * Returns whether {@code candidate} names a deterministic recovery backup or temporary file
-     * that this writer may remove while recovering or replacing {@code target}.
+     * Uses one permanent lock in a caller-owned storage root. All accesses to files below that root
+     * must use the same scope. Keeping the lock outside removable state entries allows their
+     * directories to be deleted without unlinking a lock another process may already have open.
+     */
+    public static AtomicFileWriter inDirectory(Path directory) {
+        return new AtomicFileWriter(
+                new NioFileOperations(), StageListener.NOOP, directory.toAbsolutePath().normalize());
+    }
+
+    /**
+     * Returns whether {@code candidate} names a recovery backup, temporary file, or the permanent
+     * coordination file reserved by this writer while recovering or replacing {@code target}.
      *
      * <p>This is a lexical, side-effect-free classification. Callers that accept owner-selected
      * files can use it to reject a source before a transaction could mistake that source for one
@@ -86,6 +117,9 @@ public class AtomicFileWriter {
             return false;
         }
         String candidateName = normalizedCandidate.getFileName().toString();
+        if (candidateName.equalsIgnoreCase(LOCK_FILE)) {
+            return true;
+        }
         String backupName = backupPath(normalizedTarget).getFileName().toString();
         if (candidateName.equalsIgnoreCase(backupName)) {
             return true;
@@ -130,6 +164,11 @@ public class AtomicFileWriter {
             throw new NullPointerException("intendedBytes");
         }
         Path normalized = normalizeTarget(target);
+        if (ownerOnly) {
+            // Reject an untrusted parent before creating even the empty coordination file.
+            operations.createDirectories(normalized.getParent());
+            operations.verifyOwnerOnlyParent(normalized.getParent());
+        }
         withLock(normalized, () -> {
             writeLocked(normalized, intendedBytes, ownerOnly);
             return null;
@@ -445,11 +484,36 @@ public class AtomicFileWriter {
         return LOCKS[(target.hashCode() & Integer.MAX_VALUE) % LOCKS.length];
     }
 
-    private static <T> T withLock(Path target, IoCallable<T> callable) throws IOException {
-        ReentrantLock lock = lock(target);
+    private <T> T withLock(Path target, IoCallable<T> callable) throws IOException {
+        Path directory = lockDirectory == null ? target.getParent() : lockDirectory;
+        if (!target.startsWith(directory)
+                || target.getFileName().toString().equalsIgnoreCase(LOCK_FILE)) {
+            throw new IOException("Persistence target is outside its storage scope or is its lock");
+        }
+        operations.createDirectories(directory);
+        // Physical paths ensure aliases in one JVM use the same monitor before FileChannel.lock().
+        Path lockPath = directory.toRealPath().resolve(LOCK_FILE);
+        ReentrantLock lock = lock(lockPath);
         lock.lock();
         try {
-            return callable.call();
+            Set<Path> held = HELD_FILE_LOCKS.get();
+            if (held.contains(lockPath)) {
+                return callable.call();
+            }
+            refuseNonRegularArtifact(lockPath);
+            // Never delete this file: a waiter may already have its inode open. Replacing it would
+            // let a third process acquire a different lock while the original waiter is running.
+            try (FileChannel channel = operations.openFile(lockPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS);
+                    FileLock ignored = channel.lock(0, 1, false)) {
+                held.add(lockPath);
+                try {
+                    return callable.call();
+                } finally {
+                    held.remove(lockPath);
+                    if (held.isEmpty()) HELD_FILE_LOCKS.remove();
+                }
+            }
         } finally {
             lock.unlock();
         }

--- a/core/src/test/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriterProcessTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriterProcessTest.java
@@ -1,0 +1,166 @@
+package eu.rekawek.coffeegb.core.persistence;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Uses separate JVMs, as desktop netplay peers do when sharing the same Saves directory. */
+public class AtomicFileWriterProcessTest {
+    @Rule public TemporaryFolder directory = new TemporaryFolder();
+
+    @Test(timeout = 20_000)
+    public void anotherProcessCannotRecoverAnActiveAutosaveTemporaryFile() throws Exception {
+        assertConcurrentOperationWaits("read", false);
+    }
+
+    @Test(timeout = 20_000)
+    public void simultaneousAutosaveWritersBothCommitSuccessfully() throws Exception {
+        assertConcurrentOperationWaits("write", false);
+    }
+
+    @Test(timeout = 20_000)
+    public void stateEntriesShareTheLockInTheirGameStorageRoot() throws Exception {
+        assertConcurrentOperationWaits("write", false, true);
+    }
+
+    @Test(timeout = 20_000)
+    public void anotherProcessCannotRestoreAnActiveFallbackBackup() throws Exception {
+        assertConcurrentOperationWaits("read", true);
+    }
+
+    @Test(timeout = 20_000)
+    public void processExitReleasesRecoveryLockAndPreservesTheOldSave() throws Exception {
+        Path target = directory.getRoot().toPath().resolve("autosave.state");
+        Files.writeString(target, "old");
+        try (Peer writer = new Peer(target, "hold-fallback")) {
+            writer.expect("READY");
+            writer.process.destroyForcibly();
+            assertTrue(writer.process.waitFor(5, TimeUnit.SECONDS));
+        }
+        assertEquals("old", AtomicFileWriter.system().read(target, Files::readString));
+        AtomicFileWriter.system().write(target, "retry".getBytes());
+        assertEquals("retry", Files.readString(target));
+    }
+
+    private void assertConcurrentOperationWaits(String operation, boolean fallback) throws Exception {
+        assertConcurrentOperationWaits(operation, fallback, false);
+    }
+
+    private void assertConcurrentOperationWaits(String operation, boolean fallback, boolean scoped)
+            throws Exception {
+        Path root = directory.getRoot().toPath();
+        Path target = root.resolve(scoped ? "states/autosave/state.cgbstate" : "autosave.state");
+        Files.createDirectories(target.getParent());
+        Files.writeString(target, "old");
+        try (Peer writer = new Peer(target, fallback ? "hold-fallback" : "hold", scoped ? root : null)) {
+            writer.expect("READY");
+            try (Peer other = new Peer(target, operation, scoped ? root : null)) {
+                other.expect("STARTED");
+                boolean finishedEarly = other.process.waitFor(300, TimeUnit.MILLISECONDS);
+                writer.release();
+                writer.expect("DONE");
+                writer.assertSuccess();
+                other.expect(operation.equals("read") ? "READ first" : "DONE");
+                other.assertSuccess();
+                assertFalse("another process must wait for the active save, including recovery",
+                        finishedEarly);
+            }
+        }
+        assertEquals(operation.equals("read") ? "first" : "second", Files.readString(target));
+    }
+
+    private static final class Peer implements AutoCloseable {
+        final Process process;
+        final BufferedReader output;
+
+        Peer(Path target, String operation) throws IOException {
+            this(target, operation, null);
+        }
+
+        Peer(Path target, String operation, Path root) throws IOException {
+            process = new ProcessBuilder(
+                    Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                    "-cp", System.getProperty("java.class.path"),
+                    Worker.class.getName(), target.toString(), operation, root == null ? "" : root.toString())
+                    .redirectError(ProcessBuilder.Redirect.INHERIT).start();
+            output = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        }
+
+        void expect(String expected) throws Exception {
+            assertEquals(expected, CompletableFuture.supplyAsync(() -> {
+                try {
+                    return output.readLine();
+                } catch (IOException failure) {
+                    throw new java.io.UncheckedIOException(failure);
+                }
+            }).get(5, TimeUnit.SECONDS));
+        }
+
+        void release() throws IOException {
+            process.getOutputStream().write('\n');
+            process.getOutputStream().flush();
+        }
+
+        void assertSuccess() throws InterruptedException {
+            assertTrue("worker exited", process.waitFor(5, TimeUnit.SECONDS));
+            assertEquals(0, process.exitValue());
+        }
+
+        @Override public void close() throws Exception {
+            process.destroyForcibly();
+            assertTrue(process.waitFor(5, TimeUnit.SECONDS));
+            output.close();
+        }
+    }
+
+    public static class Worker {
+        public static void main(String[] args) throws Exception {
+            Path target = Path.of(args[0]);
+            String operation = args[1];
+            boolean fallback = operation.equals("hold-fallback");
+            AtomicFileWriter.NioFileOperations files = new AtomicFileWriter.NioFileOperations() {
+                @Override public void move(Path source, Path destination, StandardCopyOption... options)
+                        throws IOException {
+                    if (fallback && java.util.Arrays.asList(options).contains(StandardCopyOption.ATOMIC_MOVE)) {
+                        throw new AtomicMoveNotSupportedException("source", "destination", "test fallback");
+                    }
+                    super.move(source, destination, options);
+                }
+            };
+            AtomicFileWriter writer = new AtomicFileWriter(files, (stage, ignored, temp) -> {
+                AtomicFileWriter.Stage heldStage = fallback
+                        ? AtomicFileWriter.Stage.FALLBACK_AFTER_OLD_PRESERVED
+                        : AtomicFileWriter.Stage.AFTER_FORCE_BEFORE_REPLACEMENT;
+                if (operation.startsWith("hold") && stage == heldStage) {
+                    System.out.println("READY");
+                    if (System.in.read() == -1) throw new IOException("parent closed input");
+                }
+            }, args[2].isEmpty() ? null : Path.of(args[2]));
+            if (operation.startsWith("hold")) {
+                writer.write(target, "first".getBytes());
+            } else {
+                System.out.println("STARTED");
+                if (operation.equals("read")) {
+                    System.out.println("READ " + writer.read(target, Files::readString));
+                    return;
+                }
+                writer.write(target, "second".getBytes());
+            }
+            System.out.println("DONE");
+        }
+    }
+}

--- a/core/src/test/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriterTest.java
+++ b/core/src/test/java/eu/rekawek/coffeegb/core/persistence/AtomicFileWriterTest.java
@@ -47,6 +47,7 @@ public class AtomicFileWriterTest {
                     target,
                     directory.resolve(backup.getFileName().toString().toUpperCase())));
             assertTrue(AtomicFileWriter.isTransactionArtifact(target, temp));
+            assertTrue(AtomicFileWriter.isTransactionArtifact(target, directory.resolve(".coffeegb.lock")));
             assertTrue(AtomicFileWriter.isTransactionArtifact(
                     target,
                     directory.resolve((prefix + "ABC.PART").toUpperCase())));
@@ -55,6 +56,42 @@ public class AtomicFileWriterTest {
                     target, directory.resolve(prefix + "123.part.extra")));
             assertFalse(AtomicFileWriter.isTransactionArtifact(
                     target, directory.resolve("other").resolve(temp.getFileName())));
+        });
+    }
+
+    @Test
+    public void nestedRecoveryUsesTheHeldFilesystemLock() throws Exception {
+        withDirectory(directory -> {
+            Path target = directory.resolve("state.bin");
+            AtomicFileWriter writer = AtomicFileWriter.inDirectory(directory);
+            writer.write(target, OLD);
+            Path alias = directory.resolve("alias");
+            Files.createSymbolicLink(alias, directory.toAbsolutePath());
+            assertArrayEquals(OLD, writer.read(target,
+                    path -> AtomicFileWriter.inDirectory(alias)
+                            .read(alias.resolve(path.getFileName()), Files::readAllBytes)));
+        });
+    }
+
+    @Test
+    public void storageScopeRejectsEscapesAndLockReplacement() throws Exception {
+        withDirectory(directory -> {
+            AtomicFileWriter writer = AtomicFileWriter.inDirectory(directory.resolve("game"));
+            expectFailure(() -> writer.write(directory.resolve("outside.bin"), NEW));
+            expectFailure(() -> writer.write(directory.resolve("game/.coffeegb.lock"), NEW));
+            assertFalse(Files.exists(directory.resolve("game")));
+            assertFalse(Files.exists(directory.resolve("outside.bin")));
+        });
+    }
+
+    @Test
+    public void refusesSymlinkedCoordinationFile() throws Exception {
+        withDirectory(directory -> {
+            Path victim = directory.resolve("victim.bin");
+            Files.write(victim, OLD);
+            Files.createSymbolicLink(directory.resolve(".coffeegb.lock"), victim.getFileName());
+            expectFailure(() -> AtomicFileWriter.system().write(directory.resolve("state.bin"), NEW));
+            assertArrayEquals(OLD, Files.readAllBytes(victim));
         });
     }
 


### PR DESCRIPTION
Fixed #665.

Connecting two Coffee GB instances that share a Saves directory can strand the host in PAUSED during the transition to netplay. Each instance closes its standalone controller and writes an autosave; another instance's writer or recent-game preview reader can run recovery at the same time. The old persistence lock covered only one JVM, so recovery could delete the host's active temporary file. Its subsequent rename throws `NoSuchFileException`, which becomes the reported `PersistenceBarrierException` before the linked controller is installed.

Serialize recovery, reads, and replacement across processes using a filesystem lock, while retaining JVM synchronization and reentrant reads. Managed states share a permanent lock in the game storage root, outside deletable autosave/slot/named-state directories. The existing autosave persistence barrier, atomic replacement, and backup recovery remain enforced. Instances sharing Saves must all use the updated writer.

Addresses the connection-time host freeze reported in #665.

Validation:

- Forced overlapping autosaves in two separate JVMs with the pre-fix writer: reproduced the same `BasicController.persistCloseAutosave` exception chain, including `NoSuchFileException: <path>`.
- Repeated with the fix and the local `Master Karateka (Japan).gb`, DMG, SKIP, isolated shared Saves: both autosaves complete, both controllers load two linked machines, and both advance frames. The issue title additionally includes `(En)`; validation used the named local Japan release. This headless check covers controller handoff and frame progress.
- Added process tests for competing readers/writers, fallback backup recovery, process termination, and a real standalone-to-linked controller handoff. Also cover reentrancy through a directory alias and reserved lock-file safety.
- Latest reports across the full core/controller suites and full Swing suite: **4,103 passed, 11 skipped, no remaining failures** (core 2,281 cases; controller 979; Swing 854). No screenshot: the regression asserts the exception boundary and subsequent frame progress directly.

Commands run:

```sh
/opt/maven/bin/mvn -pl swing -am test
/opt/maven/bin/mvn -pl swing -am '-Dtest=AtomicFileWriterTest,AtomicFileWriterProcessTest,LinkedControllerTest,NetplayAutosaveHandoffTest,StateRepositoryTest,ApplicationSettingsStoreTest,%regex[eu/rekawek/coffeegb/swing/.*Test.class]' -Dsurefire.failIfNoSpecifiedTests=false test
/opt/maven/bin/mvn -pl controller -am -Dtest=NetplayAutosaveHandoffTest -Dsurefire.failIfNoSpecifiedTests=false test
```

The first run found ten fixture cleanup/directory-list expectations that needed to allow the persistent lock file. Those expectations were updated; the second command reran every affected class and all Swing tests successfully. The final command verifies the handoff with explicit DMG/SKIP configuration.
